### PR TITLE
GetSpoInfoFromSiteUrl Fixes

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -100,9 +100,9 @@ namespace Tests.UnitTests
             const string expectedResult = "https://contoso.sharepoint.com/sites/site/Shared%20Documents/";
 
             const string input = "https://contoso.sharepoint.com/sites/site/Shared Documents/";
-            Assert.IsFalse(StringUtils.IsValidAbsoluteUrl(input));
+            Assert.IsFalse(Uri.IsWellFormedUriString(input, UriKind.Absolute));
             Assert.IsTrue(StringUtils.ConvertSharePointUrl(input) == expectedResult);
-            Assert.IsTrue(StringUtils.IsValidAbsoluteUrl(expectedResult));
+            Assert.IsTrue(Uri.IsWellFormedUriString(expectedResult, UriKind.Absolute));
 
         }
         [TestMethod]

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
@@ -1,6 +1,7 @@
 ﻿using Common.DataUtils.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -51,7 +52,17 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
             var logs = new WebActivityReportSet();
 
             // A report download can have multiple reports in a Json array.
-            var allReportsData = Newtonsoft.Json.Linq.JArray.Parse(jSonBody);
+            JArray allReportsData = null;
+            try
+            {
+                allReportsData = JArray.Parse(jSonBody);
+            }
+            catch (JsonReaderException)
+            {
+                _telemetry.LogWarning($"Invalid JSon body '{jSonBody}' for URL '{newUri}'. Ignoring");
+                return new WebActivityReportSet();
+            }
+
             var reportsArray = allReportsData.Children();
             foreach (var reportItem in reportsArray)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -91,7 +91,7 @@ namespace WebJob.Office365ActivityImporter
                 telemetry.LogInformation($"Starting activity import for {spFilterList.OrgUrlConfigs.Count} url filters");
 
                 // Start new O365 activity download session
-                const int MAX_IMPORTS_PER_BATCH = 100000;
+                const int MAX_IMPORTS_PER_BATCH = 20000;
                 var importer = new ActivityWebImporter(configuredSettings, telemetry, MAX_IMPORTS_PER_BATCH);
 
                 var sqlAdaptor = new ActivityReportSqlPersistenceManager(spFilterList, telemetry, configuredSettings);


### PR DESCRIPTION
GetSpoInfoFromSiteUrl uses site ID when drive can't be loaded with URL. Reduced MAX_IMPORTS_PER_BATCH to 20k as 100k caused SQL resource errors with some queries