### PR TITLE
PR: Analytics runbooks are scheduled at incorrect times

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
@@ -97,12 +97,12 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
             // Schedules
             _logger.LogInformation($"Creating/updating automation schedules for '{_config.ResourceName}'...");
 
-            var nextSunday1pm = Next(DateTime.UtcNow.AddHours(13), DayOfWeek.Sunday);
-            var nextSunday6pm = Next(DateTime.UtcNow.AddHours(13), DayOfWeek.Sunday);
-            var nextSunday11pm = Next(DateTime.UtcNow.AddHours(13), DayOfWeek.Sunday);
+            var nextSunday1pm = NextSundayAt(13, DateTimeKind.Utc);
+            var nextSunday6pm = NextSundayAt(18, DateTimeKind.Utc);
+            var nextSunday11pm = NextSundayAt(23, DateTimeKind.Utc);
             var nextSunday1pmSchedule = new AutomationScheduleCreateOrUpdateContent("Weekly Sunday 1pm", nextSunday1pm, AutomationScheduleFrequency.Week) { Interval = BinaryData.FromString("1") };
-            var nextSunday6pmSchedule = new AutomationScheduleCreateOrUpdateContent("Weekly Sunday 6pm", nextSunday1pm, AutomationScheduleFrequency.Week) { Interval = BinaryData.FromString("1") };
-            var nextSunday11pmSchedule = new AutomationScheduleCreateOrUpdateContent("Weekly Sunday 11pm", nextSunday1pm, AutomationScheduleFrequency.Week) { Interval = BinaryData.FromString("1") };
+            var nextSunday6pmSchedule = new AutomationScheduleCreateOrUpdateContent("Weekly Sunday 6pm", nextSunday6pm, AutomationScheduleFrequency.Week) { Interval = BinaryData.FromString("1") };
+            var nextSunday11pmSchedule = new AutomationScheduleCreateOrUpdateContent("Weekly Sunday 11pm", nextSunday11pm, AutomationScheduleFrequency.Week) { Interval = BinaryData.FromString("1") };
 
             var schedules = automationAccount.GetAutomationSchedules();
             await schedules.CreateOrUpdateAsync(WaitUntil.Completed, nextSunday1pmSchedule.Name, nextSunday1pmSchedule);
@@ -131,6 +131,19 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
             if (target <= start)
                 target += 7;
             return from.AddDays(target - start);
+        }
+
+        /// <summary>
+        /// Returns a DateTime object for the next Sunday at a specific time
+        /// </summary>
+        /// <param name="hour"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public static DateTime NextSundayAt(int hour24, DateTimeKind kind = DateTimeKind.Local)
+        {
+            var now = kind == DateTimeKind.Utc ? DateTime.UtcNow : DateTime.Now;
+            var nextSunday = Next(now, DayOfWeek.Sunday);
+            return new DateTime(nextSunday.Year, nextSunday.Month, nextSunday.Day, hour24, 0, 0, kind);
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -3,6 +3,7 @@ using App.ControlPanel.Engine.Entities;
 using App.ControlPanel.Engine.InstallerTasks;
 using App.ControlPanel.Engine.InstallerTasks.Adoptify;
 using App.ControlPanel.Engine.InstallerTasks.Adoptify.Models;
+using App.ControlPanel.Engine.InstallerTasks.Tasks;
 using App.ControlPanel.Engine.Models;
 using App.ControlPanel.Engine.SharePointModelBuilder;
 using App.ControlPanel.Engine.SharePointModelBuilder.ValueLookups;
@@ -541,6 +542,59 @@ namespace Tests.UnitTests
 
                 await job.Install();
             }
+        }
+
+        [TestMethod]
+        public void Automation_Next_Tuesday()
+        {
+            var thisDayWasTuesday = new DateTime(2024, 7, 23, 1, 0, 0, DateTimeKind.Utc);
+            var aSunday = AutomationAccountTask.Next(thisDayWasTuesday, DayOfWeek.Sunday);
+            Assert.IsTrue(aSunday.DayOfWeek == DayOfWeek.Sunday);
+            Assert.IsTrue(aSunday == new DateTime(2024, 7, 28, 1, 0, 0, DateTimeKind.Utc));
+        }
+
+        [TestMethod]
+        public void Automation_Next_Sunday()
+        {
+            var thisDayWasSunday = new DateTime(2024, 7, 28, 1, 0, 0, DateTimeKind.Utc);
+            var aSunday = AutomationAccountTask.Next(thisDayWasSunday, DayOfWeek.Sunday);
+            Assert.IsTrue(aSunday.DayOfWeek == DayOfWeek.Sunday);
+            Assert.IsTrue(aSunday == new DateTime(2024, 8, 4, 1, 0, 0, DateTimeKind.Utc));
+        }
+
+        [TestMethod]
+        public void Automation_Next_Sunday_Midnight()
+        {
+            var thisDayWasSunday = new DateTime(2024, 7, 28, 0, 0, 0, DateTimeKind.Utc);
+            var aSunday = AutomationAccountTask.Next(thisDayWasSunday, DayOfWeek.Sunday);
+            Assert.IsTrue(aSunday.DayOfWeek == DayOfWeek.Sunday);
+            Assert.IsTrue(aSunday == new DateTime(2024, 8, 4, 0, 0, 0, DateTimeKind.Utc));
+        }
+
+        [TestMethod]
+        public void Automation_NextSundayAt_UTC()
+        {
+            var now = DateTime.UtcNow;
+            var nextSunday = AutomationAccountTask.Next(now, DayOfWeek.Sunday);
+            
+            var nextSunday1pm = AutomationAccountTask.NextSundayAt(13);
+            Assert.IsTrue(nextSunday1pm.DayOfWeek == DayOfWeek.Sunday);
+            Assert.IsTrue(nextSunday1pm.Hour == 13);
+            Assert.IsTrue(nextSunday1pm.Minute == 0);
+            Assert.IsTrue(nextSunday1pm.Date == nextSunday.Date);
+        }
+
+        [TestMethod]
+        public void Automation_NextSundayAt_Local()
+        {
+            var now = DateTime.Now;
+            var nextSunday = AutomationAccountTask.Next(now, DayOfWeek.Sunday);
+
+            var nextSunday4pm = AutomationAccountTask.NextSundayAt(16);
+            Assert.IsTrue(nextSunday4pm.DayOfWeek == DayOfWeek.Sunday);
+            Assert.IsTrue(nextSunday4pm.Hour == 16);
+            Assert.IsTrue(nextSunday4pm.Minute == 0);
+            Assert.IsTrue(nextSunday4pm.Date == nextSunday.Date);
         }
     }
 


### PR DESCRIPTION
Runbooks schedules should be created at specific times but all are created at the same time.

Fix:
- Use the proper times when creating/updating the runbook schedules.
