### PR TITLE
Optional filtering by Entra ID Groups

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 using static App.ControlPanel.Engine.Models.AutodetectedSqlAndFtpDetails;
 
 namespace App.ControlPanel.Engine
@@ -308,7 +309,10 @@ namespace App.ControlPanel.Engine
 
             var graphClient = new Microsoft.Graph.GraphServiceClient(auth.Creds);
 
-            var teamsUserUsageLoader = new TeamsUserUsageLoader(new WebJob.Office365ActivityImporter.Engine.Graph.ManualGraphCallClient(auth, telemetry), telemetry);
+            var teamsUserUsageLoader = new TeamsUserUsageLoader(new WebJob.Office365ActivityImporter.Engine.Graph.ManualGraphCallClient(auth, telemetry), 
+                new NoUsersHaveGroupsUserGroupsCache(_logger),
+                new Common.Entities.Config.UserGroupsFilterModel(string.Empty),
+                telemetry);
 
             // Usage reports
             if (Config.SolutionConfig.ImportTaskSettings.GraphUsageReports)

--- a/src/AnalyticsEngine/Common/DataUtils/ConsoleApp.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/ConsoleApp.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
-using System.Configuration;
 
 namespace DataUtils
 {
@@ -35,34 +34,16 @@ namespace DataUtils
             }
         }
 
-        public static void PrintStartupAndLoggingConfig(ILogger logger)
+        public static void PrintStartupAndLoggingConfig(string efConnectionString, string buildLabel, string userGroupsFilterString, ILogger logger)
         {
-            if (logger is null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
 
-            var buildLabel = ConfigurationManager.AppSettings["BuildLabel"];
             logger.LogInformation($"Office 365 Advanced Analytics engine START: '{buildLabel}'.");
-
-            string efConnectionString = ConfigurationManager.ConnectionStrings["SPOInsightsEntities"].ConnectionString;
             var sqlConnectionInfo = new System.Data.SqlClient.SqlConnectionStringBuilder(efConnectionString);
             logger.LogInformation($"Destination SQL Server='{sqlConnectionInfo.DataSource}', DB='{sqlConnectionInfo.InitialCatalog}'.");
-
-            bool loggingEnabled = ConfigurationManager.AppSettings["ImportLogging"] == "True";
-#if DEBUG
-            loggingEnabled = true;
-#endif
-
-            if (loggingEnabled)
+            if (!string.IsNullOrEmpty(userGroupsFilterString))
             {
-                logger.LogInformation("Import logging is ENABLED.");
-            }
-            else
-            {
-                logger.LogInformation("Import logging is disabled. Add key 'ImportLogging' value 'True' to configuration to enable full logging.");
+                logger.LogWarning($"WARNING: User groups import filter configured: '{userGroupsFilterString}'. Will not import data for users not in those groups");
             }
         }
-
     }
 }

--- a/src/AnalyticsEngine/Common/DataUtils/JobTimer.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/JobTimer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using static DataUtils.AnalyticsLogger;

--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -20,6 +20,7 @@ namespace Common.Entities.Config
             this.AppInsightsApiKey = ConfigurationManager.AppSettings["AppInsightsApiKey"];
             this.AppInsightsAppId = ConfigurationManager.AppSettings["AppInsightsAppId"];
 
+            this.BuildLabel = ConfigurationManager.AppSettings["BuildLabel"];
 
             this.ClientID = ConfigurationManager.AppSettings.Get("ClientID");
             this.ClientSecret = ConfigurationManager.AppSettings.Get("ClientSecret");
@@ -76,7 +77,7 @@ namespace Common.Entities.Config
             }
         }
 
-
+        public string BuildLabel { get; set; }
         public string AppInsightsContainerName { get; set; }
         public string AppInsightsApiKey { get; set; }
         public string AppInsightsAppId { get; set; }

--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -28,6 +28,9 @@ namespace Common.Entities.Config
             this.AADInstance = ConfigurationManager.AppSettings.Get("AADInstance");
             this.KeyVaultUrl = ConfigurationManager.AppSettings.Get("KeyVaultUrl");
 
+            // New: UserGroupsFilter (optional)
+            this.UserGroupsFilter = ConfigurationManager.AppSettings.Get("UserGroupsFilter");
+
             var useClientCertificate = ConfigurationManager.AppSettings.Get("UseClientCertificate");
             if (!string.IsNullOrEmpty(useClientCertificate))
             {
@@ -132,5 +135,10 @@ namespace Common.Entities.Config
         public string StatsApiUrl { get; set; } = null;
 
         public AppConnectionStrings ConnectionStrings { get; set; } = null;
+
+        /// <summary>
+        /// Optional filter for user groups
+        /// </summary>
+        public string UserGroupsFilter { get; set; }
     }
 }

--- a/src/AnalyticsEngine/Common/Entities/Config/UserGroupsFilterModel.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/UserGroupsFilterModel.cs
@@ -12,6 +12,7 @@ namespace Common.Entities.Config
     {
         public List<string> Patterns { get; }
 
+        public UserGroupsFilterModel() : this(string.Empty) { }
         public UserGroupsFilterModel(string filterString)
         {
             if (string.IsNullOrWhiteSpace(filterString))

--- a/src/AnalyticsEngine/Common/Entities/Config/UserGroupsFilterModel.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/UserGroupsFilterModel.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Common.Entities.Config
+{
+    /// <summary>
+    /// Model to represent and match Entra ID group names from a filter string.
+    /// </summary>
+    public class UserGroupsFilterModel
+    {
+        public List<string> Patterns { get; }
+
+        public UserGroupsFilterModel(string filterString)
+        {
+            if (string.IsNullOrWhiteSpace(filterString))
+            {
+                Patterns = new List<string>();
+            }
+            else
+            {
+                Patterns = filterString.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(p => p.Trim())
+                    .Where(p => !string.IsNullOrEmpty(p))
+                    .ToList();
+            }
+        }
+
+        /// <summary>
+        /// Checks if the given group name matches any filter pattern (supports * wildcard).
+        /// </summary>
+        public bool Matches(string groupName)
+        {
+            if (string.IsNullOrEmpty(groupName) || Patterns.Count == 0)
+                return false;
+
+            foreach (var pattern in Patterns)
+            {
+                var regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+                if (Regex.IsMatch(groupName, regexPattern, RegexOptions.IgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Config\AppConfig.cs" />
     <Compile Include="Config\AppConnectionStrings.cs" />
     <Compile Include="Config\ImportConfig.cs" />
+    <Compile Include="Config\UserGroupsFilterModel.cs" />
     <Compile Include="Entities\AuditLog\CopilotEvents.cs" />
     <Compile Include="Entities\OnlineMeeting.cs" />
     <Compile Include="Entities\UsageReports\AppPlatformUserActivityLog.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImporterTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImporterTests.cs
@@ -21,6 +21,7 @@ using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace Tests.UnitTests
 {
@@ -146,7 +147,8 @@ namespace Tests.UnitTests
             var oneDriveEvent = DataGenerators.GetRandomSharePointLog();
             oneDriveEvent.Workload = ActivityImportConstants.WORKLOAD_OD;
             hits.Add(oneDriveEvent);
-            var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), AnalyticsLogger.ConsoleOnlyTracer(), new AppConfig());
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(logger), logger, new AppConfig());
 
             await hits.CommitAllToSQL(sqlPersist);
 
@@ -181,7 +183,8 @@ namespace Tests.UnitTests
 
                 // Save
                 int preSPLogsInsertSPEventsCount = db.sharepoint_events.Count();
-                var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), AnalyticsLogger.ConsoleOnlyTracer(), new AppConfig());
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(logger), logger, new AppConfig());
                 await sharePointLogs.CommitAllToSQL(sqlPersist);
 
                 // Validate new count
@@ -248,7 +251,8 @@ namespace Tests.UnitTests
 
                 // Save
                 int preSPLogsInsertSPEventsCount = db.AuditEventsCommon.Count();
-                var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), AnalyticsLogger.ConsoleOnlyTracer(), new AppConfig());
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(logger), logger, new AppConfig());
                 await otherLogs.CommitAllToSQL(sqlPersist);
 
                 // Validate new events count
@@ -442,7 +446,9 @@ Event found in API, doesn't find it in cache, assumes it's a new ignored event, 
             using (var db = new AnalyticsEntitiesContext())
             {
                 int preInsertCount = db.sharepoint_events.Count();
-                var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), AnalyticsLogger.ConsoleOnlyTracer(), new AppConfig());
+
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(logger), logger, new AppConfig());
 
                 // Create content-set for two different-but-same-id activities
                 TestActivityReportSet duplicateContent = new TestActivityReportSet() { randomActivity, duplicateIdRandomActivity };
@@ -557,7 +563,9 @@ Event found in API, doesn't find it in cache, assumes it's a new ignored event, 
 
                 // Save
                 var tempCache = ActivityImportCache.GetEmptyCache();
-                var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), AnalyticsLogger.ConsoleOnlyTracer(), new AppConfig());
+
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var sqlPersist = new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(logger), logger, new AppConfig());
 
                 var s = await hitsActivity.CommitAllToSQL(sqlPersist);
 
@@ -657,7 +665,9 @@ Event found in API, doesn't find it in cache, assumes it's a new ignored event, 
                 var importer = new ActivityWebImporter(fakeClient, s, telemetry);
 
                 // Download all the things & get stats.
-                var stats = await importer.LoadReportsAndSave(new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), telemetry, s));
+
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var stats = await importer.LoadReportsAndSave(new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(logger), logger, new AppConfig()));
 
                 var contentMetaDataLoader = new WebContentMetaDataLoader(telemetry, fakeClient, s);
 

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/MockUserGroupsCache.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/MockUserGroupsCache.cs
@@ -18,7 +18,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
             _mockGroups = mockGroups ?? new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         }
 
-        protected override Task<List<string>> LoadGroupsFromGraphAsync(string upn)
+        protected override Task<List<string>> LoadGroupsFromExternalAsync(string upn)
         {
             if (_mockGroups.TryGetValue(upn, out var groups))
                 return Task.FromResult(groups);

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/MockUserGroupsCache.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/MockUserGroupsCache.cs
@@ -1,0 +1,28 @@
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    public class MockUserGroupsCache : UserGroupsCache
+    {
+        private readonly Dictionary<string, List<string>> _mockGroups;
+
+        public MockUserGroupsCache(Dictionary<string, List<string>> mockGroups, ILogger logger = null)
+            : base(logger)
+        {
+            _mockGroups = mockGroups ?? new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        protected override Task<List<string>> LoadGroupsFromGraphAsync(string upn)
+        {
+            if (_mockGroups.TryGetValue(upn, out var groups))
+                return Task.FromResult(groups);
+            return Task.FromResult(new List<string>());
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphImportTests.cs
@@ -35,7 +35,7 @@ namespace Tests.UnitTests
         {
             const int users = 10000;
             var l = new FakeUserAppLoader(AnalyticsLogger.ConsoleOnlyTracer(), users);
-            var updates = await l.LoadAndSave();
+            var updates = await l.LoadAndSave(new NoUsersHaveGroupsUserGroupsCache(AnalyticsLogger.ConsoleOnlyTracer()), new UserGroupsFilterModel());
             Assert.IsTrue(updates == users);
         }
 
@@ -56,7 +56,7 @@ namespace Tests.UnitTests
             await userUpdater.InsertAndUpdateDatabaseUsersFromGraph();
 
             var updater = new UserAppLogUpdater(telemetry, new AppConfig());
-            var sucess = await updater.UpdateUserInstalledApps(graphClient);
+            var sucess = await updater.UpdateUserInstalledApps(graphClient, new NoUsersHaveGroupsUserGroupsCache(telemetry), new UserGroupsFilterModel());
             Assert.IsTrue(sucess);
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
@@ -9,6 +9,7 @@ using Tests.UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.Graph;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace Tests.UnitTests
 {
@@ -58,10 +59,14 @@ namespace Tests.UnitTests
             var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
             var authConfig = new AppConfig();
 
-            var graphImporter = new GraphImporter(telemetry, authConfig);
             var graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(telemetry, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
+            await graphAppIndentityOAuthContext.InitClientCredential();
 
-            await graphImporter.GetAndSaveActivityReportsMultiThreaded(1, new ManualGraphCallClient(graphAppIndentityOAuthContext, telemetry));
+            var graphClient = new Microsoft.Graph.GraphServiceClient(graphAppIndentityOAuthContext.Creds);
+            var graphImporter = new GraphImporter(telemetry, new NoUsersHaveGroupsUserGroupsCache(telemetry), graphAppIndentityOAuthContext, graphClient, authConfig);
+
+            await graphImporter.GetAndSaveActivityReportsMultiThreaded(1, new ManualGraphCallClient(graphAppIndentityOAuthContext, telemetry), 
+                new NoUsersHaveGroupsUserGroupsCache(telemetry), new UserGroupsFilterModel());
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/Program.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/Program.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace Tests.UnitTests
 {
@@ -36,7 +37,7 @@ namespace Tests.UnitTests
             var t = new JobTimer(telemetry, "Soyve");
             t.Start();
             Console.WriteLine("Saving data...");
-            await testLoader.LoadReportsAndSave(new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), telemetry, new AppConfig()));
+            await testLoader.LoadReportsAndSave(new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(telemetry), telemetry, new AppConfig()));
 
             t.StopAndPrintElapsed();
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="CopilotTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeCopilotEventAdaptor.cs" />
     <Compile Include="FakeLoaderClasses\FakeAggregateWeeklyUsageReportLoader.cs" />
+    <Compile Include="FakeLoaderClasses\MockUserGroupsCache.cs" />
     <Compile Include="TestsAppConfig.cs" />
     <Compile Include="UsageStatsTests.cs" />
     <Compile Include="DataUtilsTests.cs" />
@@ -129,6 +130,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="TeamsTests.cs" />
     <Compile Include="StreamTests.cs" />
+    <Compile Include="UserGroupsCacheTests.cs" />
     <Compile Include="UserGroupsFilterModelTests.cs" />
     <Compile Include="UserLookupTests.cs" />
   </ItemGroup>

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="TeamsTests.cs" />
     <Compile Include="StreamTests.cs" />
+    <Compile Include="UserGroupsFilterModelTests.cs" />
     <Compile Include="UserLookupTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AnalyticsEngine/Tests.UnitTests/UserGroupsCacheTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserGroupsCacheTests.cs
@@ -1,0 +1,50 @@
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class UserGroupsCacheTests
+    {
+        [TestMethod]
+        public async Task IsInGroupsFilter_ReturnsTrue_WhenUserInMatchingGroup()
+        {
+            // Arrange
+            var mockGroups = new Dictionary<string, List<string>>
+            {
+                { "user1@contoso.com", new List<string> { "Finance", "HR" } }
+            };
+            var cache = new MockUserGroupsCache(mockGroups);
+            var filter = new UserGroupsFilterModel("Fin*;IT");
+
+            // Act
+            var result = await cache.IsInGroupsFilter("user1@contoso.com", filter);
+
+            // Assert
+            Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public async Task IsInGroupsFilter_ReturnsFalse_WhenUserNotInMatchingGroup()
+        {
+            // Arrange
+            var mockGroups = new Dictionary<string, List<string>>
+            {
+                { "user2@contoso.com", new List<string> { "Marketing", "Sales" } }
+            };
+            var cache = new MockUserGroupsCache(mockGroups);
+            var filter = new UserGroupsFilterModel("Fin*;IT");
+
+            // Act
+            var result = await cache.IsInGroupsFilter("user2@contoso.com", filter);
+
+            // Assert
+            Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsFalse(result);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/UserGroupsCacheTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserGroupsCacheTests.cs
@@ -1,10 +1,8 @@
 using Common.Entities.Config;
-using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace Tests.UnitTests
 {
@@ -45,6 +43,27 @@ namespace Tests.UnitTests
 
             // Assert
             Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public async Task IsInGroupsFilter_ReturnsTrue_WhenNoFilterConfigured()
+        {
+            // Arrange
+            var mockGroups = new Dictionary<string, List<string>>
+            {
+                { "user1@contoso.com", new List<string> { "Finance", "HR" } },
+                { "user2@contoso.com", new List<string> { "Marketing", "Sales" } },
+                { "user3@contoso.com", new List<string> { "IT", "Support" } }
+            };
+            var cache = new MockUserGroupsCache(mockGroups);
+            var filter = new UserGroupsFilterModel(); // No filter configured
+
+            // Act & Assert
+            foreach (var user in mockGroups.Keys)
+            {
+                var result = await cache.IsInGroupsFilter(user, filter);
+                Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsTrue(result, $"Expected true for user {user} when no filter is configured.");
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/UserGroupsFilterModelTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserGroupsFilterModelTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Common.Entities.Config;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class UserGroupsFilterModelTests
+    {
+        [TestMethod]
+        public void Patterns_AreSplitCorrectly()
+        {
+            var filter = new UserGroupsFilterModel("GroupA;GroupB;GroupC*");
+            Assert.AreEqual(3, filter.Patterns.Count);
+            Assert.AreEqual("GroupA", filter.Patterns[0]);
+            Assert.AreEqual("GroupB", filter.Patterns[1]);
+            Assert.AreEqual("GroupC*", filter.Patterns[2]);
+        }
+
+        [TestMethod]
+        public void Matches_ExactMatch_ReturnsTrue()
+        {
+            var filter = new UserGroupsFilterModel("GroupA;GroupB");
+            Assert.IsTrue(filter.Matches("GroupA"));
+            Assert.IsTrue(filter.Matches("GroupB"));
+            Assert.IsFalse(filter.Matches("GroupC"));
+        }
+
+        [TestMethod]
+        public void Matches_WildcardMatch_ReturnsTrue()
+        {
+            var filter = new UserGroupsFilterModel("Group*");
+            Assert.IsTrue(filter.Matches("GroupA"));
+            Assert.IsTrue(filter.Matches("Group123"));
+            Assert.IsFalse(filter.Matches("OtherGroup"));
+        }
+
+        [TestMethod]
+        public void Matches_EmptyOrNull_ReturnsFalse()
+        {
+            var filter = new UserGroupsFilterModel("");
+            Assert.IsFalse(filter.Matches("GroupA"));
+            Assert.IsFalse(filter.Matches(""));
+            Assert.IsFalse(filter.Matches(null));
+        }
+
+        [TestMethod]
+        public void Matches_MixedPatterns()
+        {
+            var filter = new UserGroupsFilterModel("Admin*;*Users;*Test*");
+            Assert.IsTrue(filter.Matches("AdminGroup"));
+            Assert.IsTrue(filter.Matches("PowerUsers"));
+            Assert.IsTrue(filter.Matches("MyTestGroup"));
+            Assert.IsFalse(filter.Matches("RandomGroup"));
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/Program.cs
@@ -155,25 +155,15 @@ namespace WebJob.AppInsightsImporter
         /// Output the config and check it's good.
         /// </summary>
         /// <returns>If the config is valid</returns>
-        private static bool ValidateAndPrintConfig(AppConfig config, ILogger telemetry)
+        private static bool ValidateAndPrintConfig(AppConfig settings, ILogger telemetry)
         {
-            ConsoleApp.PrintStartupAndLoggingConfig(telemetry);
+            ConsoleApp.PrintStartupAndLoggingConfig(settings.ConnectionStrings.DatabaseConnectionString, settings.BuildLabel, settings.UserGroupsFilter, telemetry);
 
             // Have config object test
 
-            var accountName = StringUtils.FindValueForProp(config.ConnectionStrings.DatabaseConnectionString, "AccountName");
+            settings.ConnectionStrings.TestSQLSettings(telemetry);
 
-            string efConnectionString = System.Configuration.ConfigurationManager.ConnectionStrings["SPOInsightsEntities"].ConnectionString;
-            var sqlConnectionInfo = new System.Data.SqlClient.SqlConnectionStringBuilder(efConnectionString);
-
-            telemetry.LogInformation("Configured values:");
-            //pIIConfig.PrintConfig(telemetry);     // PII anonisation is broken for the time being in this project, but nobody uses it anyway...
-
-            telemetry.LogInformation($"Destination SQL Server configuration: \ndata source='{sqlConnectionInfo.DataSource}', initial catalog='{sqlConnectionInfo.InitialCatalog}'");
-
-            config.ConnectionStrings.TestSQLSettings(telemetry);
-
-            if (string.IsNullOrEmpty(config.AppInsightsApiKey))
+            if (string.IsNullOrEmpty(settings.AppInsightsApiKey))
             {
                 telemetry.LogInformation("Critical: no Application Insights API key found - can't continue. Run the latest installer again to reset configuration.");
                 return false;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Abstract.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Abstract.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Entities.Config;
 using DataUtils;
 using DataUtils.Http;
+using Microsoft.Extensions.Logging;
 
 namespace WebJob.Office365ActivityImporter.Engine
 {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 using WebJob.Office365ActivityImporter.Engine.Properties;
 
 namespace WebJob.Office365ActivityImporter.Engine
@@ -24,17 +25,21 @@ namespace WebJob.Office365ActivityImporter.Engine
     public class ActivityReportSqlPersistenceManager : IActivityReportPersistenceManager
     {
         private readonly AuditFilterConfig _filterConfig;
+        private readonly UserGroupsCache _userGroupsCache;
         private readonly ILogger _telemetry;
         private readonly AppConfig _appConfig;
         private string _defaultConnectionString = null;
+        private UserGroupsFilterModel _userGroupsFilter = null;
 
         private static SemaphoreSlim _sqlSaveSemaphore = new SemaphoreSlim(1);      // Make sure we're only saving one thread at a time
 
-        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, ILogger telemetry, AppConfig appConfig)
+        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger telemetry, AppConfig appConfig)
         {
             _filterConfig = filterConfig;
+            _userGroupsCache = userGroupsCache;
             _telemetry = telemetry;
             _appConfig = appConfig;
+            _userGroupsFilter = new UserGroupsFilterModel(appConfig.UserGroupsFilter);
         }
 
         /// <summary>
@@ -113,11 +118,18 @@ namespace WebJob.Office365ActivityImporter.Engine
                     var result = SaveResultEnum.NotSaved;
                     if (_filterConfig.InScope(abtractLog))
                     {
-                        logsToInsert.Rows.Add(new AuditLogTempEntity(abtractLog, abtractLog.UserId));
+                        if (await _userGroupsCache.IsInGroupsFilter(abtractLog.UserId, _userGroupsFilter))
+                        {
+                            logsToInsert.Rows.Add(new AuditLogTempEntity(abtractLog, abtractLog.UserId));
 
-                        // Remember we've done this one now
-                        cache.RememberProcessedEvent(abtractLog);
-                        result = SaveResultEnum.Imported;
+                            // Remember we've done this one now
+                            cache.RememberProcessedEvent(abtractLog);
+                            result = SaveResultEnum.Imported;
+                        }
+                        else
+                        {
+                            _telemetry.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
+                        }
                     }
                     else
                     {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -128,6 +128,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                         }
                         else
                         {
+                            result = SaveResultEnum.UserOutOfScope;
                             _telemetry.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
                         }
                     }
@@ -135,7 +136,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                     {
                         // No URL
                         cache.RememberNewlyIgnoredEvent(abtractLog);
-                        result = SaveResultEnum.OutOfScope;
+                        result = SaveResultEnum.UrlOutOfScope;
                     }
 
                     // Update stats
@@ -145,8 +146,9 @@ namespace WebJob.Office365ActivityImporter.Engine
                         listOfActivitiesSavedToSQL.Add(abtractLog);
                     }
                     else if (result == SaveResultEnum.ProcessedAlready) stats.ProcessedAlready++;
-                    else if (result == SaveResultEnum.OutOfScope) stats.URLsOutOfScope++;
-                    else throw new InvalidOperationException("Unexpected save result");
+                    else if (result == SaveResultEnum.UrlOutOfScope) stats.URLsOutOfScope++;
+                    else if (result == SaveResultEnum.UserOutOfScope) stats.UsersOutOfScope++;
+                    else _telemetry.LogError($"Unexpected log result for log {abtractLog.Id}");
 
                     processedIds.Add(abtractLog.Id);
                 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
@@ -12,6 +12,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
         public int Imported { get; set; }
         public int ProcessedAlready { get; set; }
         public int URLsOutOfScope { get; set; }
+        public int UsersOutOfScope { get; set; }
         public int DownloadErrors { get; set; }
         public int Total { get; set; }
 
@@ -36,6 +37,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
                 $"Imported successfully: {this.Imported.ToString("n0")}, " +
                 $"already processed: {this.ProcessedAlready.ToString("n0")}, " +
                 $"URLs out of scope (orgs table): {this.URLsOutOfScope.ToString("n0")}, " +
+                $"users out of scope: {this.UsersOutOfScope.ToString("n0")}, " +
                 $"errors: {this.DownloadErrors.ToString("n0")}, " +
                 $"total: {this.Total.ToString("n0")}";
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CommonAuditLogContent.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CommonAuditLogContent.cs
@@ -127,6 +127,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
         NotSaved = 0,           // Default
         ProcessedAlready = 1,   // Event ignored previously
         Imported = 2,           // Already imported
-        OutOfScope = 3          // Not to be imported. Usually because the SharePoint URL is for a site we don't care about.
+        UrlOutOfScope = 3,          // Not to be imported. Usually because the SharePoint URL is for a site we don't care about.
+        UserOutOfScope = 4,          // Not to be imported. Usually because the user is outside group filter
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -13,6 +13,7 @@ using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReport
 using WebJob.Office365ActivityImporter.Engine.Graph.Teams;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
@@ -21,30 +22,29 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     public class GraphImporter : AbstractApiLoader
     {
+        private readonly UserGroupsCache _userGroupsCache;
         private readonly GraphAppIndentityOAuthContext _graphAppIndentityOAuthContext;
-        private GraphServiceClient _graphClient = null;
+        private readonly GraphServiceClient _graphClient;
 
-        public GraphImporter(AnalyticsLogger telemetry, AppConfig settings) : base(telemetry, settings)
+        public GraphImporter(AnalyticsLogger telemetry, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings) 
+            : base(telemetry, settings)
         {
-            _graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(telemetry, _settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
-
+            _userGroupsCache = userGroupsCache;
+            _graphAppIndentityOAuthContext = graphAppIndentityOAuthContext;
+            _graphClient = graphClient;
         }
 
-        async Task InitAuth()
-        {
-            await _graphAppIndentityOAuthContext.InitClientCredential();
-            _graphClient = new GraphServiceClient(_graphAppIndentityOAuthContext.Creds);
-            _graphClient.HttpProvider.OverallTimeout = TimeSpan.FromHours(1);
-        }
 
         /// <summary>
         /// Main entry-point
         /// </summary>
         public async Task GetAndSaveAllGraphData(AppConfig settings)
         {
-            await InitAuth();
             var auth = new GraphAppIndentityOAuthContext(_telemetry, _settings.ClientID, _settings.TenantGUID.ToString(), _settings.ClientSecret, _settings.KeyVaultUrl, _settings.UseClientCertificate);
             var httpClient = new ManualGraphCallClient(auth, _telemetry);
+            var userGroupsFilter = new UserGroupsFilterModel(_settings.UserGroupsFilter);
+
+            var graphUserGroupsCache = new GraphUserGroupsCache(httpClient, _telemetry);
 
             if (settings.ImportJobSettings.GraphUsersMetadata)
             {
@@ -59,7 +59,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 userMetadaTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
             }
             else
-                _telemetry.LogInformation("Skipping user metadata import");
+                _telemetry.LogInformation("Skipping user metadata import", graphUserGroupsCache);
 
 
             using (var db = new AnalyticsEntitiesContext())
@@ -71,13 +71,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     userAppsTimer.Start();
                     var userAppsLogUpdater = new UserAppLogUpdater(_telemetry, _settings);
 
-                    await userAppsLogUpdater.UpdateUserInstalledApps(_graphClient);
+                    await userAppsLogUpdater.UpdateUserInstalledApps(_graphClient, graphUserGroupsCache, userGroupsFilter);
 
                     // Track finished event 
                     userAppsTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
                 }
                 else
-                    _telemetry.LogInformation("Skipping user Teams apps import");
+                    _telemetry.LogInformation("Skipping user Teams apps import", graphUserGroupsCache);
 
 
                 if (settings.ImportJobSettings.GraphUsageReports)
@@ -86,7 +86,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     usageActivityTimer.Start();
 
                     // Global user activity report. Each thread creates own context.
-                    var imported = await GetAndSaveActivityReportsMultiThreaded(settings.DaysBeforeNowToDownload, httpClient);
+                    var imported = await GetAndSaveActivityReportsMultiThreaded(settings.DaysBeforeNowToDownload, httpClient, graphUserGroupsCache, userGroupsFilter);
 
                     // Track finished event 
                     if (imported)
@@ -95,7 +95,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     }
                 }
                 else
-                    _telemetry.LogInformation("Skipping usage reports import");
+                    _telemetry.LogInformation("Skipping usage reports import", graphUserGroupsCache);
 
                 if (settings.ImportJobSettings.GraphTeams)
                 {
@@ -111,20 +111,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     teamsTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
                 }
                 else
-                    _telemetry.LogInformation("Skipping Teams import");
+                    _telemetry.LogInformation("Skipping Teams import", graphUserGroupsCache);
 
             }
         }
 
 
-        public async Task<bool> GetAndSaveActivityReportsMultiThreaded(int daysBackMax, ManualGraphCallClient client)
+        public async Task<bool> GetAndSaveActivityReportsMultiThreaded(int daysBackMax, ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel)
         {
-            await InitAuth();
             var MIN_WAIT = TimeSpan.FromDays(1);
 
             DateTime? lastImportedDate = null;
             UserActivityLastImportedRedisSingleDateLoader lastImportedDateLoader = null;
-            if (_settings.ConnectionStrings.RedisConnectionString != null)
+            if (!string.IsNullOrEmpty(_settings.ConnectionStrings.RedisConnectionString))
             {
                 lastImportedDateLoader = new UserActivityLastImportedRedisSingleDateLoader(_settings.ConnectionStrings.RedisConnectionString);
 
@@ -159,34 +158,34 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 var lookupIdCache = new ConcurrentLookupDbIdsCache();
 
                 // Daily imports
-                var teamsUserUsageLoader = new TeamsUserUsageLoader(client, _telemetry);
+                var teamsUserUsageLoader = new TeamsUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(teamsUserUsageLoader, daysBackMax, "Teams user activity", _telemetry, lookupIdCache));
 
-                var teamsUserDeviceLoader = new TeamsUserDeviceLoader(client, _telemetry);
+                var teamsUserDeviceLoader = new TeamsUserDeviceLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(teamsUserDeviceLoader, daysBackMax, "Teams user device", _telemetry, lookupIdCache));
 
-                var outlookLoader = new OutlookUserActivityLoader(client, _telemetry);
+                var outlookLoader = new OutlookUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(outlookLoader, daysBackMax, "Outlook activity", _telemetry, lookupIdCache));
 
-                var oneDriveUsageLoader = new OneDriveUsageLoader(client, _telemetry);
+                var oneDriveUsageLoader = new OneDriveUsageLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUsageLoader, daysBackMax, "OneDrive usage", _telemetry, lookupIdCache));
 
-                var oneDriveUserActivityLoader = new OneDriveUserActivityLoader(client, _telemetry);
+                var oneDriveUserActivityLoader = new OneDriveUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUserActivityLoader, daysBackMax, "OneDrive activity", _telemetry, lookupIdCache));
 
-                var sharePointUserActivityLoader = new SharePointUserActivityLoader(client, _telemetry);
+                var sharePointUserActivityLoader = new SharePointUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(sharePointUserActivityLoader, daysBackMax, "SharePoint user activity", _telemetry, lookupIdCache));
 
-                var yammerUserActivityLoader = new YammerUserUsageLoader(client, _telemetry);
+                var yammerUserActivityLoader = new YammerUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(yammerUserActivityLoader, daysBackMax, "Yammer user activity", _telemetry, lookupIdCache));
 
                 var yammerGroupsActivityLoader = new YammerGroupUsageLoader(client, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(yammerGroupsActivityLoader, daysBackMax, "Yammer group activity", _telemetry, lookupIdCache));
 
-                var yammerDeviceActivityLoader = new YammerDeviceUsageLoader(client, _telemetry);
+                var yammerDeviceActivityLoader = new YammerDeviceUsageLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(yammerDeviceActivityLoader, daysBackMax, "Yammer device activity", _telemetry, lookupIdCache));
 
-                var userPlatActivityLoader = new AppPlatformUserActivityLoader(client, _telemetry);
+                var userPlatActivityLoader = new AppPlatformUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
                 importTasks.Add(LoadAndSaveDailyImportReport(userPlatActivityLoader, daysBackMax, "Apps & platform activity", _telemetry, lookupIdCache));
 
                 // Weekly imports

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
@@ -14,13 +14,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     {
         public TeamTokenManager(O365Team team, AppConfig appConfig, ILogger logger)
         {
-            if (appConfig.ConnectionStrings.RedisConnectionString != null)
+            if (!string.IsNullOrEmpty(appConfig.ConnectionStrings.RedisConnectionString))
             {
                 this.CacheConnectionManager = CacheConnectionManager.GetConnectionManager(appConfig.ConnectionStrings.RedisConnectionString);
             }
             else
             {
-                logger.LogWarning("No redis connection string found in app config. No caching will be done.");
+                logger.LogWarning("No redis connection string found in config. No deep Teams analytics will be possible.");
             }
             this.Team = team;
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Entities;
 using Common.Entities.ActivityReports;
+using Common.Entities.Config;
 using Common.Entities.LookupCaches;
 using DataUtils;
 using Microsoft.Extensions.Logging;
@@ -9,6 +10,7 @@ using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
@@ -88,6 +90,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 // Look through Graph results & compare with already saved reports for this date
                 foreach (var reportPage in LoadedReportPages[dateTime])
                 {
+                    // Usually we're checking if the user is in scope (Entra ID group memembership for group filter)
+                    var isInScope = await IdInScope(reportPage.LookupFieldValue);
+                    if (!isInScope)
+                    {
+                        Telemetry.LogInformation($"Skipping {reportPage.LookupFieldValue} as not in scope");
+                        continue;   // Skip this record
+                    }
+
                     // Do we have a cached ID for the lookup?
                     int? lookupId = null;
                     lock (userEmailToDbIdCache)     // Lock between import threads
@@ -159,6 +169,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 
             await lookupCache.DB.SaveChangesAsync();
         }
+
+        protected virtual Task<bool> IdInScope(string lookupId)
+        {
+            // Default implementation assumes all IDs are in scope
+            // Override this method to filter out IDs that should not be processed
+            return Task.FromResult(true);
+        }
+
         protected abstract long CountActivity(TUserActivityUserDetail activityPage);
         protected abstract void PopulateReportSpecificMetadata(TReportDbType newRecord, TUserActivityUserDetail activityPage);
 
@@ -179,8 +197,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         where TReportDbType : AbstractUsageActivityLog, new()
         where TUserActivityUserDetail : AbstractActivityRecord<Common.Entities.User>
     {
-        internal AbstractUserDailyActivityLoader(ManualGraphCallClient client, ILogger telemetry) : base(client, telemetry)
+        private readonly UserGroupsCache _graphUserGroupsCache;
+        private readonly UserGroupsFilterModel _userGroupsFilterModel;
+
+        internal AbstractUserDailyActivityLoader(ManualGraphCallClient client, UserGroupsCache graphUserGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry) : base(client, telemetry)
         {
+            _graphUserGroupsCache = graphUserGroupsCache;
+            _userGroupsFilterModel = userGroupsFilterModel;
+        }
+
+        protected override async Task<bool> IdInScope(string upn)
+        {
+            return await _graphUserGroupsCache.IsInGroupsFilter(upn, _userGroupsFilterModel);
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AppPlatformUserActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AppPlatformUserActivityLoader.cs
@@ -1,17 +1,19 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     // https://learn.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-beta
     public class AppPlatformUserActivityLoader : AbstractUserDailyActivityLoader<AppPlatformUserActivityLog, AppPlatformUserActivityDetail>
     {
-        public AppPlatformUserActivityLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public AppPlatformUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OneDriveUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OneDriveUsageLoader.cs
@@ -1,17 +1,19 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveusageaccountdetail?view=graph-rest-beta
     public class OneDriveUsageLoader : AbstractUserDailyActivityLoader<OneDriveUsageLog, OneDriveUsageDetail>
     {
-        public OneDriveUsageLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public OneDriveUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
         protected override void PopulateReportSpecificMetadata(OneDriveUsageLog todaysLog, OneDriveUsageDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OneDriveUserActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OneDriveUserActivityLoader.cs
@@ -1,17 +1,19 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveactivityuserdetail?view=graph-rest-beta
     public class OneDriveUserActivityLoader : AbstractUserDailyActivityLoader<OneDriveUserActivityLog, OneDriveUserActivityDetail>
     {
-        public OneDriveUserActivityLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public OneDriveUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
         protected override void PopulateReportSpecificMetadata(OneDriveUserActivityLog todaysLog, OneDriveUserActivityDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OutlookUserActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OutlookUserActivityLoader.cs
@@ -1,16 +1,18 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     public class OutlookUserActivityLoader : AbstractUserDailyActivityLoader<OutlookUsageActivityLog, OutlookUserActivityUserDetail>
     {
-        public OutlookUserActivityLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public OutlookUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
         protected override void PopulateReportSpecificMetadata(OutlookUsageActivityLog todaysLog, OutlookUserActivityUserDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/SharePointUserActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/SharePointUserActivityLoader.cs
@@ -1,17 +1,19 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveactivityuserdetail?view=graph-rest-beta
     public class SharePointUserActivityLoader : AbstractUserDailyActivityLoader<SharePointUserActivityLog, SharePointUserActivityDetail>
     {
-        public SharePointUserActivityLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public SharePointUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
         protected override void PopulateReportSpecificMetadata(SharePointUserActivityLog todaysLog, SharePointUserActivityDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserDeviceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserDeviceLoader.cs
@@ -1,9 +1,11 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
@@ -12,8 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     /// </summary>
     public class TeamsUserDeviceLoader : AbstractUserDailyActivityLoader<GlobalTeamsUserDeviceUsageLog, TeamsDeviceUsageUserDetail>
     {
-        public TeamsUserDeviceLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public TeamsUserDeviceLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserUsageLoader.cs
@@ -1,16 +1,18 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     public class TeamsUserUsageLoader : AbstractUserDailyActivityLoader<GlobalTeamsUserUsageLog, TeamsUserActivityUserDetail>
     {
-        public TeamsUserUsageLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public TeamsUserUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
         protected override void PopulateReportSpecificMetadata(GlobalTeamsUserUsageLog todaysLog, TeamsUserActivityUserDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerDeviceUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerDeviceUsageLoader.cs
@@ -1,9 +1,11 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
@@ -12,8 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     /// </summary>
     public class YammerDeviceUsageLoader : AbstractUserDailyActivityLoader<YammerDeviceActivityLog, YammerDeviceActivityDetail>
     {
-        public YammerDeviceUsageLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public YammerDeviceUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
         protected override void PopulateReportSpecificMetadata(YammerDeviceActivityLog todaysLog, YammerDeviceActivityDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerUserUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerUserUsageLoader.cs
@@ -1,9 +1,11 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
@@ -12,8 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     /// </summary>
     public class YammerUserUsageLoader : AbstractUserDailyActivityLoader<YammerUserActivityLog, YammerUserActivityUserDetail>
     {
-        public YammerUserUsageLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public YammerUserUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
+            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
         {
         }
         protected override void PopulateReportSpecificMetadata(YammerUserActivityLog todaysLog, YammerUserActivityUserDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserGroupsCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserGroupsCache.cs
@@ -1,4 +1,3 @@
-using Common.Entities.Config;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System;
@@ -20,7 +19,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         }
 
-        protected override async Task<List<string>> LoadGroupsFromGraphAsync(string upn)
+        protected override async Task<List<string>> LoadGroupsFromExternalAsync(string upn)
         {
             var result = new List<string>();
             try
@@ -42,6 +41,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User
                 _logger?.LogError(ex, $"Failed to load groups for user '{upn}'");
             }
             return result;
+        }
+    }
+
+    public class NoUsersHaveGroupsUserGroupsCache : UserGroupsCache
+    {
+        public NoUsersHaveGroupsUserGroupsCache(ILogger logger) : base(logger)
+        {
+        }
+
+        protected override Task<List<string>> LoadGroupsFromExternalAsync(string upn)
+        {
+            // Simulate no groups for any user
+            return Task.FromResult(new List<string>());
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserGroupsCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserGroupsCache.cs
@@ -1,0 +1,47 @@
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.User
+{
+    /// <summary>
+    /// Loads Entra ID group memberships for users from Microsoft Graph.
+    /// </summary>
+    public class GraphUserGroupsCache : UserGroupsCache
+    {
+        private readonly ManualGraphCallClient _httpClient;
+
+        public GraphUserGroupsCache(ManualGraphCallClient httpClient, ILogger logger)
+            : base(logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        }
+
+        protected override async Task<List<string>> LoadGroupsFromGraphAsync(string upn)
+        {
+            var result = new List<string>();
+            try
+            {
+                string url = $"https://graph.microsoft.com/v1.0/users/{Uri.EscapeDataString(upn)}/memberOf?$select=displayName";
+                var response = await _httpClient.GetAsyncWithThrottleRetries<JObject>(url);
+                if (response != null && response["value"] is JArray arr)
+                {
+                    foreach (var group in arr)
+                    {
+                        var displayName = group["displayName"]?.ToString();
+                        if (!string.IsNullOrEmpty(displayName))
+                            result.Add(displayName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, $"Failed to load groups for user '{upn}'");
+            }
+            return result;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/AbstractUserAppLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/AbstractUserAppLoader.cs
@@ -1,4 +1,5 @@
-﻿using DataUtils;
+﻿using Common.Entities.Config;
+using DataUtils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,7 +32,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
 
         public abstract Task Save(Dictionary<string, List<APPTYPE>> usersAndApps);
 
-        public async Task<int> LoadAndSave()
+        public async Task<int> LoadAndSave(UserGroupsCache userGroupsCache, UserGroupsFilterModel filter)
         {
             var timer = new JobTimer(_telemetry, "User Apps load");
             timer.Start();
@@ -45,6 +46,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
             {
                 if (StringUtils.IsEmail(usersEmailResult))
                 {
+                    // Check if the user is in the filter
+                    if (filter != null && !await userGroupsCache.IsInGroupsFilter(usersEmailResult, filter))
+                    {
+                        _telemetry.LogInformation($"User Apps Load - '{usersEmailResult}' is not in the filter groups, skipping...");
+                        continue;
+                    }
                     usersEmailsToUpdate.Add(usersEmailResult);
                 }
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/UserAppLogUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/UserAppLogUpdater.cs
@@ -3,6 +3,7 @@ using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
 using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 using WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
@@ -16,13 +17,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         {
         }
 
-        public async Task<bool> UpdateUserInstalledApps(GraphServiceClient graphClient)
+        public async Task<bool> UpdateUserInstalledApps(GraphServiceClient graphClient, UserGroupsCache graphUserGroupsCache, UserGroupsFilterModel filter)
         {
             using (var db = new AnalyticsEntitiesContext())
             {
                 var l = new GraphAndSqlUserAppLoader(db, _telemetry, graphClient);
 
-                await l.LoadAndSave();
+                await l.LoadAndSave(graphUserGroupsCache, filter);
 
                 return true;
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserGroupsCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserGroupsCache.cs
@@ -32,7 +32,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User
             if (_userGroupsCache.TryGetValue(upn, out var cachedGroups))
                 return cachedGroups;
 
-            var groups = await LoadGroupsFromGraphAsync(upn);
+            List<string> groups = null;
+            try
+            {
+                groups = await LoadGroupsFromExternalAsync(upn);
+            }
+            catch (Exception)
+            {
+                _logger.LogWarning($"Failed to load groups for user {upn}. Returning empty list.");
+                groups = new List<string>();
+            }
             _userGroupsCache[upn] = groups;
             return groups;
         }
@@ -40,7 +49,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User
         /// <summary>
         /// Implement this to load group display names for a user from the desired source.
         /// </summary>
-        protected abstract Task<List<string>> LoadGroupsFromGraphAsync(string upn);
+        protected abstract Task<List<string>> LoadGroupsFromExternalAsync(string upn);
 
         /// <summary>
         /// Returns true if any of the user's groups match the filter.
@@ -50,6 +59,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User
             if (filter == null)
                 throw new ArgumentNullException(nameof(filter));
             var groups = await GetGroupsForUserAsync(upn);
+
+            if (filter.Patterns.Count == 0)
+            {
+                return true; // No filter patterns means all groups match
+            }
             return groups.Any(g => filter.Matches(g));
         }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserGroupsCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserGroupsCache.cs
@@ -1,0 +1,56 @@
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.User
+{
+    /// <summary>
+    /// Abstract cache for Entra ID group memberships for users by UPN.
+    /// </summary>
+    public abstract class UserGroupsCache
+    {
+        protected readonly ILogger _logger;
+        private readonly ConcurrentDictionary<string, List<string>> _userGroupsCache = new ConcurrentDictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        protected UserGroupsCache(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Loads the group display names for a user (by UPN) from cache or underlying loader.
+        /// </summary>
+        public async Task<IReadOnlyList<string>> GetGroupsForUserAsync(string upn)
+        {
+            if (string.IsNullOrWhiteSpace(upn))
+                throw new ArgumentNullException(nameof(upn));
+
+            if (_userGroupsCache.TryGetValue(upn, out var cachedGroups))
+                return cachedGroups;
+
+            var groups = await LoadGroupsFromGraphAsync(upn);
+            _userGroupsCache[upn] = groups;
+            return groups;
+        }
+
+        /// <summary>
+        /// Implement this to load group display names for a user from the desired source.
+        /// </summary>
+        protected abstract Task<List<string>> LoadGroupsFromGraphAsync(string upn);
+
+        /// <summary>
+        /// Returns true if any of the user's groups match the filter.
+        /// </summary>
+        public async Task<bool> IsInGroupsFilter(string upn, UserGroupsFilterModel filter)
+        {
+            if (filter == null)
+                throw new ArgumentNullException(nameof(filter));
+            var groups = await GetGroupsForUserAsync(upn);
+            return groups.Any(g => filter.Matches(g));
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -37,7 +37,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
 
             IDeltaValueProvider deltaProvider = null;
-            if (settings.ConnectionStrings.RedisConnectionString != null)
+            if (!string.IsNullOrEmpty(settings.ConnectionStrings.RedisConnectionString))
             {
                 deltaProvider = new RedisProcessDeltaValueProvider(settings, telemetry);
                 telemetry.LogInformation($"User import - using Redis for delta token cache.");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -150,12 +150,14 @@
     <Compile Include="Graph\UsageReports\YammerUserUsageLoader.cs" />
     <Compile Include="Graph\UsageReports\TeamsUserUsageLoader.cs" />
     <Compile Include="Graph\UserActivityLastImportedRedisSingleDateLoader.cs" />
+    <Compile Include="Graph\User\GraphUserGroupsCache.cs" />
     <Compile Include="Graph\User\GraphUserLoader.cs" />
     <Compile Include="Graph\User\UserApps\AbstractUserAppLoader.cs" />
     <Compile Include="Graph\User\UserApps\GraphAndSqlUserAppLoader.cs" />
     <Compile Include="Graph\User\UserApps\Models.cs" />
     <Compile Include="Graph\User\UserApps\UserAppLogUpdater.cs" />
     <Compile Include="Graph\User\UserGraphResponse.cs" />
+    <Compile Include="Graph\User\UserGroupsCache.cs" />
     <Compile Include="Graph\User\UserMetadataCache.cs" />
     <Compile Include="Graph\User\UserMetadataUpdater.cs" />
     <Compile Include="Graph\User\UserTeamApp.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -138,13 +138,14 @@ namespace WebJob.Office365ActivityImporter
             {
                 var importCycleTimer = new JobTimer(telemetry, Process.GetCurrentProcess().ProcessName);
                 importCycleTimer.Start();
+                var tasks = new ProgramTasks(telemetry, configuredSettings);
 
                 // Start listening for SB messages & register notifications web-hook with Graph 
                 if (webHookUrl != null && configuredSettings.ImportJobSettings.Calls)
                 {
                     try
                     {
-                        await ProgramTasks.ProcessCallQueueAndWebhook(configuredSettings, webHookUrl, telemetry);
+                        await tasks.ProcessCallQueueAndWebhook(webHookUrl);
                     }
                     catch (Exception ex)
                     {
@@ -160,7 +161,7 @@ namespace WebJob.Office365ActivityImporter
                 try
                 {
                     // Get Teams & user data
-                    await ProgramTasks.GetGraphTeamsAndUserData(telemetry, configuredSettings);
+                    await tasks.GetGraphTeamsAndUserData();
                 }
                 catch (Exception ex)
                 {
@@ -178,7 +179,7 @@ namespace WebJob.Office365ActivityImporter
                     try
                     {
 #endif
-                    await ProgramTasks.DownloadActivityData(configuredSettings, telemetry);
+                    await tasks.DownloadActivityData();
 #if !DEBUG
                     }
                     catch (Exception ex)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -205,7 +205,7 @@ namespace WebJob.Office365ActivityImporter
                 using (var db = new AnalyticsEntitiesContext())
                 {
                     var sqlUsageBuilder = new SqlUsageStatsBuilder(db, telemetry, configuredSettings.TenantGUID);
-                    if (configuredSettings.ConnectionStrings.RedisConnectionString != null)
+                    if (!string.IsNullOrEmpty(configuredSettings.ConnectionStrings.RedisConnectionString))
                     {
                         var redisDatesAdaptor = new RedisStatsDatesLoader(configuredSettings);
 
@@ -259,7 +259,7 @@ namespace WebJob.Office365ActivityImporter
         /// </summary>
         private static void PrintStartupDetails(AppConfig settings, ILogger telemetry)
         {
-            ConsoleApp.PrintStartupAndLoggingConfig(telemetry);
+            ConsoleApp.PrintStartupAndLoggingConfig(settings.ConnectionStrings.DatabaseConnectionString, settings.BuildLabel, settings.UserGroupsFilter, telemetry);
 
             var efConnectionString = ConfigurationManager.ConnectionStrings["SPOInsightsEntities"].ConnectionString;
             var sqlConnectionInfo = new System.Data.SqlClient.SqlConnectionStringBuilder(efConnectionString);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -91,6 +91,8 @@ namespace WebJob.Office365ActivityImporter
             _graphClient.HttpProvider.OverallTimeout = TimeSpan.FromHours(1);
             _manualGraphCallClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _telemetry);
             _graphUserGroupsCache = new GraphUserGroupsCache(_manualGraphCallClient, _telemetry);
+
+
             _isInitialized = true;
 
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -2,6 +2,7 @@
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
 using System;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine;
@@ -9,6 +10,7 @@ using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders;
 using WebJob.Office365ActivityImporter.Engine.Graph;
 using WebJob.Office365ActivityImporter.Engine.Graph.Calls;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter
 {
@@ -17,55 +19,89 @@ namespace WebJob.Office365ActivityImporter
     /// </summary>
     public class ProgramTasks
     {
-        internal static async Task ProcessCallQueueAndWebhook(AppConfig configuredSettings, Uri webHookUrl, ILogger telemetry)
+        private bool _isInitialized = false;
+        private GraphServiceClient _graphClient = null;
+        private readonly GraphAppIndentityOAuthContext _graphAppIndentityOAuthContext;
+        private readonly AnalyticsLogger _telemetry;
+        private readonly AppConfig _settings;
+        private ManualGraphCallClient _manualGraphCallClient = null;
+        private GraphUserGroupsCache _graphUserGroupsCache = null;  
+
+        public ProgramTasks(AnalyticsLogger telemetry, AppConfig settings)
         {
-            var callQueueProcessor = await CallQueueProcessor.GetCallQueueProcessor(configuredSettings, configuredSettings.TenantGUID.ToString(), null);
+            _graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(telemetry, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
+            _telemetry = telemetry;
+            _settings = settings;
+        }
+
+        internal async Task ProcessCallQueueAndWebhook(Uri webHookUrl)
+        {
+            var callQueueProcessor = await CallQueueProcessor.GetCallQueueProcessor(_settings, _settings.TenantGUID.ToString(), null);
 
             // Fire and forget calls SB receiver
             _ = callQueueProcessor.BeginProcessCallsQueue();
 
-            telemetry.LogInformation("Verifying call webhook subscription.");
-            var callWebhook = new CallWebhook(configuredSettings, telemetry);
-            await callWebhook.CreateOrUpdateWebhook(webHookUrl, configuredSettings.ClientSecret);
+            _telemetry.LogInformation("Verifying call webhook subscription.");
+            var callWebhook = new CallWebhook(_settings, _telemetry);
+            await callWebhook.CreateOrUpdateWebhook(webHookUrl, _settings.ClientSecret);
 
         }
 
         /// <summary>
         /// Graph data
         /// </summary>
-        internal async static Task GetGraphTeamsAndUserData(AnalyticsLogger telemetry, AppConfig configuredSettings)
+        internal async Task GetGraphTeamsAndUserData()
         {
-            telemetry.LogInformation("Starting Teams & Graph import.");
-            var graphReader = new GraphImporter(telemetry, configuredSettings);
+            _telemetry.LogInformation("Starting Teams & Graph import.");
+
+            await InitAuth();
+
+            var graphReader = new GraphImporter(_telemetry, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings);
 
             try
             {
-                await graphReader.GetAndSaveAllGraphData(configuredSettings);
+                await graphReader.GetAndSaveAllGraphData(_settings);
             }
             catch (Microsoft.Graph.ServiceException ex)
             {
-
                 // Don't make a drama if Graph permissions aren't assigned yet.
                 if (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
                 {
-                    telemetry.LogWarning("ERROR: Can't access Teams user data - are application permissions configured correctly?");
+                    _telemetry.LogWarning("ERROR: Can't access Teams user data - are application permissions configured correctly?");
                     return;
                 }
                 else
                 {
-                    telemetry.LogError(ex, ex.Message);
+                    _telemetry.LogError(ex, ex.Message);
                     throw;
                 }
             }
 
-            telemetry.LogInformation("Finished Graph API import tasks.");
+            _telemetry.LogInformation("Finished Graph API import tasks.");
+        }
+
+        async Task InitAuth()
+        {
+            if (_isInitialized)
+            {
+                return;
+            }
+            await _graphAppIndentityOAuthContext.InitClientCredential();
+            _graphClient = new GraphServiceClient(_graphAppIndentityOAuthContext.Creds);
+            _graphClient.HttpProvider.OverallTimeout = TimeSpan.FromHours(1);
+            _manualGraphCallClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _telemetry);
+            _graphUserGroupsCache = new GraphUserGroupsCache(_manualGraphCallClient, _telemetry);
+            _isInitialized = true;
+
         }
 
         /// <summary>
         /// Activity API
         /// </summary>
-        internal async static Task DownloadActivityData(AppConfig configuredSettings, AnalyticsLogger telemetry)
+        internal async Task DownloadActivityData()
         {
+            await InitAuth();
+
             // Remember start time
             DateTime startTime = DateTime.Now;
 
@@ -75,36 +111,36 @@ namespace WebJob.Office365ActivityImporter
 
                 if (spFilterList.OrgUrlConfigs.Count == 0)
                 {
-                    telemetry.LogCritical("FATAL ERROR: No org URLs found in database! " +
+                    _telemetry.LogCritical("FATAL ERROR: No org URLs found in database! " +
                         "This means everything would be ignored for SharePoint audit data. Add at least one URL to the org_urls table for this to work.");
 
                     return;
 
                 }
 
-                telemetry.LogInformation("\nBeginning import. Filtering for SharePoint events below these URLs:");
+                _telemetry.LogInformation("\nBeginning import. Filtering for SharePoint events below these URLs:");
 
                 // Print URLs
-                spFilterList.Print(telemetry);
+                spFilterList.Print(_telemetry);
                 Console.WriteLine();
 
-                telemetry.LogInformation($"Starting activity import for {spFilterList.OrgUrlConfigs.Count} url filters");
+                _telemetry.LogInformation($"Starting activity import for {spFilterList.OrgUrlConfigs.Count} url filters");
 
                 // Start new O365 activity download session
                 const int MAX_IMPORTS_PER_BATCH = 20000;
-                var importer = new ActivityWebImporter(configuredSettings, telemetry, MAX_IMPORTS_PER_BATCH);
+                var importer = new ActivityWebImporter(_settings, _telemetry, MAX_IMPORTS_PER_BATCH);
 
-                var sqlAdaptor = new ActivityReportSqlPersistenceManager(spFilterList, telemetry, configuredSettings);
+                var sqlAdaptor = new ActivityReportSqlPersistenceManager(spFilterList, _graphUserGroupsCache, _telemetry, _settings);
                 try
                 {
                     var stats = await importer.LoadReportsAndSave(sqlAdaptor);
 
                     // Output stats
-                    telemetry.LogInformation($"Finished activity import. Time taken in = {DateTime.Now.Subtract(startTime).TotalMinutes.ToString("N2")} minutes. Stats: {stats}");
+                    _telemetry.LogInformation($"Finished activity import. Time taken in = {DateTime.Now.Subtract(startTime).TotalMinutes.ToString("N2")} minutes. Stats: {stats}");
                 }
                 catch (System.Net.Http.HttpRequestException ex)
                 {
-                    telemetry.LogError(ex, $"Got unexpected exception importing activity: {ex.Message}");
+                    _telemetry.LogError(ex, $"Got unexpected exception importing activity: {ex.Message}");
                 }
             }
         }


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Now for O365 imports (usage reports; audit logs), it's possible to filter data saved to SQL Server by Entra ID group names. There's an optional configuration value "UserGroupsFilter" that can be set to only save data for users within the groups configured here.

This value can be 1 or more group-names, separated by semicolons ";" to give a whitelist for group names with users to include data imports for. User data for users in groups not in these filters will be ignored. If no value is configured, all users be imported as before. 

Filter names are case insensitive, and supports wildcards via the "*" character. 

Example value:
``Design;*marketing``

This will import users in departments:
- Design (exact match)
- Contoso marketing (wildcard)
- Sales and Marketing (wildcard)


## Check list

- [ ] Related issue / work item is attached
- [x] Changes are tested
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)


#### PR Classification
New feature to implement user group filtering functionality.

#### PR Summary
This pull request introduces a user group filtering mechanism to enhance data processing based on Entra ID group memberships. Key changes include:
- **UserGroupsFilterModel.cs**: Added a new class to represent and match user group names from a filter string.
- **UserGroupsCache.cs**: Introduced an abstract class and its implementations for managing user group memberships.
- **ActivityReportSqlPersistenceManager.cs**: Modified to incorporate user group filtering when saving activity reports.
- **GraphImporter.cs**: Enhanced to support user group filtering during data import operations.
- **Unit Tests**: Updated to validate the new user groups filtering logic across various scenarios.
