### PR TITLE
Fix user import perf: replace per-user license lookup load + EF Remov…

### DIFF
--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserLicenseProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserLicenseProcessor.cs
@@ -40,22 +40,37 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             List<Common.Entities.User> graphFoundDbUsers,
             AnalyticsEntitiesContext db)
         {
-            // Process license removals in batches to reduce memory pressure
+            // Remove all existing license lookups for these users via direct SQL for performance.
+            // EF RemoveRange generates individual DELETE statements per entity which is extremely
+            // slow for large user counts (10+ hours for ~187K users). A single SQL DELETE is instant.
             _telemetry.LogInformation($"User import - removing old license lookups for {graphFoundDbUsers.Count.ToString("N0")} users");
 
-            for (int i = 0; i < graphFoundDbUsers.Count; i += DEFAULT_BATCH_SIZE)
+            // Detach all tracked license lookups from EF before the SQL delete so the
+            // change-tracker doesn't try to re-process rows that no longer exist.
+            foreach (var entry in db.ChangeTracker.Entries<UserLicenseTypeLookup>().ToList())
             {
-                var batchCount = Math.Min(DEFAULT_BATCH_SIZE, graphFoundDbUsers.Count - i);
-                var batch = graphFoundDbUsers.GetRange(i, batchCount);
-                var licenseLookupsToRemove = batch.SelectMany(u => u.LicenseLookups.Where(l => l.IsSavedToDB)).ToList();
+                entry.State = EntityState.Detached;
+            }
 
-                if (licenseLookupsToRemove.Any())
+            var userIds = graphFoundDbUsers.Where(u => u.IsSavedToDB).Select(u => u.ID).ToList();
+
+            if (userIds.Count > 0)
+            {
+                const int SQL_BATCH_SIZE = 10000;
+                for (int i = 0; i < userIds.Count; i += SQL_BATCH_SIZE)
                 {
-                    db.UserLicenseTypeLookups.RemoveRange(licenseLookupsToRemove);
+                    var batchIds = userIds.Skip(i).Take(SQL_BATCH_SIZE).ToList();
+                    var idList = string.Join(",", batchIds);
+                    await db.Database.ExecuteSqlCommandAsync(
+                        $"DELETE FROM dbo.user_license_type_lookups WHERE user_id IN ({idList})");
                 }
             }
 
-            await db.SaveChangesAsync();
+            // Clear in-memory license collections so new lookups are added cleanly
+            foreach (var user in graphFoundDbUsers)
+            {
+                user.LicenseLookups.Clear();
+            }
 
             foreach (var sku in skus)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -223,15 +223,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 // Can we update SKUs for users on batch (ie Organization.Read.All granted)?
                 if (skus != null)
                 {
-                    // Re-attach users to the context to ensure they're tracked properly
+                    // Re-attach users to the context to ensure they're tracked properly.
+                    // License lookups are NOT loaded here because ProcessSKUsForAllUsers
+                    // deletes them via direct SQL (no EF tracking needed for removal).
                     foreach (var user in allProcessedDbUsers)
                     {
                         if (db.Entry(user).State == EntityState.Detached)
                         {
                             db.users.Attach(user);
                         }
-                        // Reload license lookups from database to get current state
-                        db.Entry(user).Collection(u => u.LicenseLookups).Load();
                     }
                     
                     await _licenseProcessor.ProcessSKUsForAllUsers(skus, allProcessedDbUsers, db);


### PR DESCRIPTION
This pull request significantly improves the performance and reliability of the license lookup removal process for users during SKU processing. The main change is replacing the slow Entity Framework (EF) `RemoveRange` approach with a direct SQL `DELETE`, which greatly speeds up large-scale deletions. Related logic is updated to ensure EF's change tracker and in-memory collections remain consistent.

**Performance improvements for license lookup removal:**

* In `UserLicenseProcessor.cs`, replaced the EF `RemoveRange` batch deletion with a direct SQL `DELETE` for all relevant user license lookups, addressing severe performance issues when removing large numbers of records.
* Detached all tracked `UserLicenseTypeLookup` entities from EF before executing the SQL delete, preventing the change tracker from processing entities that no longer exist in the database.
* Cleared each user's in-memory `LicenseLookups` collection after deletion to ensure subsequent operations start with a clean state.

**Entity Framework tracking adjustments:**

* In `UserMetadataUpdater.cs`, removed the explicit loading of `LicenseLookups` for each user before processing SKUs, as this is now unnecessary due to the direct SQL deletion approach. Users are still re-attached to the context to maintain correct tracking.