### PR TITLE
Installer Enhancement: Download latest stable release on GitHub

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AppServiceContentInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AppServiceContentInstallJob.cs
@@ -47,12 +47,11 @@ namespace App.ControlPanel.Engine.InstallerTasks
             // If we have no local source or stable release info, we can't do much
             if (localOverrideSources == null && softwareReleaseConfig == null) throw new ArgumentNullException(nameof(softwareReleaseConfig));
 
-            // Get local or from releases storage account?
+            // Get local or from GitHub releases?
             if (localOverrideSources == null)
             {
-                var downloadLatestStableCfg = TaskConfig.GetConfigForPropAndVal(LatestStableSoftwarePackageDownloadTask.CFG_KEY_ContainerName, softwareReleaseConfig.ContainerName)
-                            .AddSetting(LatestStableSoftwarePackageDownloadTask.CFG_KEY_AccountBaseUrl, softwareReleaseConfig.AccountBaseUrl)
-                            .AddSetting(LatestStableSoftwarePackageDownloadTask.CFG_KEY_SAS, softwareReleaseConfig.SAS);
+                var downloadLatestStableCfg = TaskConfig.GetConfigForPropAndVal(LatestStableSoftwarePackageDownloadTask.CFG_KEY_RepoOwner, SoftwareReleaseConfig.GITHUB_REPO_OWNER)
+                            .AddSetting(LatestStableSoftwarePackageDownloadTask.CFG_KEY_RepoName, SoftwareReleaseConfig.GITHUB_REPO_NAME);
 
                 _sourceGetTask = new LatestStableSoftwarePackageDownloadTask(downloadLatestStableCfg, logger);
             }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/SoftwarePackageDownloadTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/SoftwarePackageDownloadTasks.cs
@@ -46,11 +46,14 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
             var json = await response.Content.ReadAsStringAsync();
             var release = JObject.Parse(json);
+            var tagName = release["tag_name"]?.ToString();
             var assets = release["assets"] as JArray;
             if (assets == null || !assets.Any())
             {
                 throw new UnexpectedInstallException("Latest GitHub release has no assets");
             }
+
+            _logger.LogInformation($"Found latest stable release version '{tagName}' from GitHub repo {repoOwner}/{repoName}");
 
             // Map expected file names to software components
             var componentFiles = new Dictionary<SoftwareComponent, string>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/SoftwarePackageDownloadTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/SoftwarePackageDownloadTasks.cs
@@ -1,12 +1,13 @@
 ﻿using App.ControlPanel.Engine.Entities;
-using Azure;
-using Azure.Storage.Blobs;
-using Azure.Storage.Blobs.Models;
 using CloudInstallEngine;
 using DataUtils;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace App.ControlPanel.Engine.InstallerTasks
@@ -14,86 +15,119 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
     public class LatestStableSoftwarePackageDownloadTask : ResourceInstallTask<LocalStorageInstallSourceInfo>
     {
-        public const string CFG_KEY_AccountBaseUrl = "AccountBaseUrl", CFG_KEY_SAS = "SAS", CFG_KEY_ContainerName = "ContainerName";
+        public const string CFG_KEY_RepoOwner = "RepoOwner", CFG_KEY_RepoName = "RepoName";
+        private static readonly HttpClient _httpClient = CreateHttpClient();
+
         public LatestStableSoftwarePackageDownloadTask(TaskConfig config, ILogger logger) : base(config, logger)
         {
         }
 
+        private static HttpClient CreateHttpClient()
+        {
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.Add("User-Agent", "AnalyticsEngine-Installer");
+            client.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+            return client;
+        }
+
         public override async Task<LocalStorageInstallSourceInfo> ExecuteTaskReturnResult(object contextArg)
         {
-            // Get sources
-            var serviceClient = new BlobServiceClient(new Uri(_config[CFG_KEY_AccountBaseUrl]), new AzureSasCredential(_config[CFG_KEY_SAS]));
-            var containerClient = serviceClient.GetBlobContainerClient(_config[CFG_KEY_ContainerName]);
+            var repoOwner = _config[CFG_KEY_RepoOwner];
+            var repoName = _config[CFG_KEY_RepoName];
+            var apiUrl = $"https://api.github.com/repos/{repoOwner}/{repoName}/releases/latest";
 
-            var sourceInfo = AzStorageInstallerTasks.GetSoftwareInfoFromContainer(containerClient);
-
-            if (!sourceInfo.IsValid)
+            // Fetch latest release metadata from GitHub
+            _logger.LogInformation($"Fetching latest stable release from GitHub repo {repoOwner}/{repoName}...");
+            var response = await _httpClient.GetAsync(apiUrl);
+            if (!response.IsSuccessStatusCode)
             {
-                throw new UnexpectedInstallException("Couldn't locate source packages correctly");
+                throw new UnexpectedInstallException($"Failed to fetch latest release from GitHub ({response.StatusCode}). URL: {apiUrl}");
             }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var release = JObject.Parse(json);
+            var assets = release["assets"] as JArray;
+            if (assets == null || !assets.Any())
+            {
+                throw new UnexpectedInstallException("Latest GitHub release has no assets");
+            }
+
+            // Map expected file names to software components
+            var componentFiles = new Dictionary<SoftwareComponent, string>
+            {
+                { SoftwareComponent.WebJobActivity, InstallerConstants.FILENAME_ZIP_WEBJOB_ACTIVITY },
+                { SoftwareComponent.WebJobAppInsights, InstallerConstants.FILENAME_ZIP_WEBJOB_APPINSIGHTS },
+                { SoftwareComponent.AITracker, InstallerConstants.FILENAME_ZIP_AITRACKER },
+                { SoftwareComponent.ControlPanel, InstallerConstants.FILENAME_ZIP_CONTROL_PANEL },
+                { SoftwareComponent.WebSite, InstallerConstants.FILENAME_ZIP_WEBSITE }
+            };
+
+            // Build a lookup of asset name -> download URL
+            var assetUrls = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var asset in assets)
+            {
+                var name = asset["name"]?.ToString();
+                var downloadUrl = asset["browser_download_url"]?.ToString();
+                if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(downloadUrl))
+                {
+                    assetUrls[name] = downloadUrl;
+                }
+            }
+
+            // Verify all expected assets exist
+            foreach (var kvp in componentFiles)
+            {
+                if (!assetUrls.ContainsKey(kvp.Value))
+                {
+                    throw new UnexpectedInstallException($"Latest GitHub release is missing expected asset '{kvp.Value}'");
+                }
+            }
+
             _logger.LogInformation("Downloading latest stable release...");
 
             var locallyDownloadedRelease = new LocalStorageInstallSourceInfo();
             var tempDir = StringUtils.TempDirPath;
             Directory.CreateDirectory(tempDir);
 
-            // Get each local file in parrallel
-            var localWebJobActivityTask = Task.Run(() => DownloadAzureBlobToDir(containerClient, sourceInfo.GetSolutionComponentLocation(SoftwareComponent.WebJobActivity).Blob, tempDir));
-            var localWebJobAppInsightsTask = Task.Run(() => DownloadAzureBlobToDir(containerClient, sourceInfo.GetSolutionComponentLocation(SoftwareComponent.WebJobAppInsights).Blob, tempDir));
-            var localAITrackerTask = Task.Run(() => DownloadAzureBlobToDir(containerClient, sourceInfo.GetSolutionComponentLocation(SoftwareComponent.AITracker).Blob, tempDir));
-            var localControlPanelTask = Task.Run(() => DownloadAzureBlobToDir(containerClient, sourceInfo.GetSolutionComponentLocation(SoftwareComponent.ControlPanel).Blob, tempDir));
-            var localWebsiteTask = Task.Run(() => DownloadAzureBlobToDir(containerClient, sourceInfo.GetSolutionComponentLocation(SoftwareComponent.WebSite).Blob, tempDir));
+            // Download each asset in parallel
+            var downloadTasks = new Dictionary<SoftwareComponent, Task<string>>();
+            foreach (var kvp in componentFiles)
+            {
+                var url = assetUrls[kvp.Value];
+                var fileName = kvp.Value;
+                downloadTasks[kvp.Key] = Task.Run(() => DownloadFileToDir(url, fileName, tempDir));
+            }
 
-            // Wait for all jobs
-            await Task.WhenAll(localWebJobActivityTask, localWebJobActivityTask, localWebJobAppInsightsTask, localWebsiteTask);
-
-            var localWebJobActivity = localWebJobActivityTask.Result;
-            var localWebJobAppInsights = localWebJobAppInsightsTask.Result;
-            var localAITracker = localAITrackerTask.Result;
-            var localControlPanel = localControlPanelTask.Result;
-            var localWebsite = localWebsiteTask.Result;
+            await Task.WhenAll(downloadTasks.Values);
 
             // Build return structure
-            locallyDownloadedRelease.GetSolutionComponentLocation(SoftwareComponent.WebJobActivity).FileLocation = localWebJobActivity;
-            locallyDownloadedRelease.GetSolutionComponentLocation(SoftwareComponent.WebJobAppInsights).FileLocation = localWebJobAppInsights;
-            locallyDownloadedRelease.GetSolutionComponentLocation(SoftwareComponent.AITracker).FileLocation = localAITracker;
-            locallyDownloadedRelease.GetSolutionComponentLocation(SoftwareComponent.ControlPanel).FileLocation = localControlPanel;
-            locallyDownloadedRelease.GetSolutionComponentLocation(SoftwareComponent.WebSite).FileLocation = localWebsite;
+            foreach (var kvp in downloadTasks)
+            {
+                locallyDownloadedRelease.GetSolutionComponentLocation(kvp.Key).FileLocation = kvp.Value.Result;
+            }
 
             return locallyDownloadedRelease;
         }
 
-
-        async Task<string> DownloadAzureBlobToDir(BlobContainerClient containerClient, BlobItem blob, string baseDir)
+        async Task<string> DownloadFileToDir(string downloadUrl, string fileName, string baseDir)
         {
-            if (blob == null)
+            if (string.IsNullOrEmpty(downloadUrl))
             {
-                throw new ArgumentNullException("blob");
+                throw new ArgumentNullException(nameof(downloadUrl));
             }
 
-            // Read file data from Azure Storage
-            byte[] fileBytes = null;
-            using (var blobMemoryStream = new MemoryStream())
-            {
-                var b = containerClient.GetBlobClient(blob.Name);
-                await b.DownloadToAsync(blobMemoryStream);
-                fileBytes = blobMemoryStream.ToArray();
-            }
+            var fileBytes = await _httpClient.GetByteArrayAsync(downloadUrl);
 
-            // Generate file name in temp dir
-            var fileName = baseDir + @"\" + blob.Name.Replace(@"/".ToCharArray()[0], @"\".ToCharArray()[0]);
+            var filePath = Path.Combine(baseDir, fileName);
 
-            // Check parent dir exists
-            var fileDir = new FileInfo(fileName).Directory;
+            var fileDir = new FileInfo(filePath).Directory;
             if (!fileDir.Exists)
             {
                 fileDir.Create();
             }
 
-            // Save zip-file
-            File.WriteAllBytes(fileName, fileBytes);
-
-            return fileName;
+            File.WriteAllBytes(filePath, fileBytes);
+            return filePath;
         }
     }
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SoftwareReleaseConfig.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SoftwareReleaseConfig.cs
@@ -1,71 +1,14 @@
 ﻿namespace App.ControlPanel.Engine.Models
 {
     /// <summary>
-    /// Where solution engine binaries are located
+    /// Where solution engine binaries are located. Downloads from the GitHub repo releases.
     /// </summary>
     public class SoftwareReleaseConfig
     {
+        public const string GITHUB_REPO_OWNER = "pnp";
+        public const string GITHUB_REPO_NAME = "Microsoft365-Analytics-Insights";
 
-        /// <summary>
-        /// Storage account URL + SAS where to get software releases.
-        /// </summary>
-        public string SoftwareDownloadURL { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Calculated prop from full URL
-        /// </summary>
-        public string ContainerName
-        {
-            get
-            {
-                // URL: https://spoinsights.blob.core.windows.net/v2downloads?sv=2020-04-08&amp;ss=b&amp;srt=sco&amp;st=2021-06-06T11%3A27%3A00Z&amp;se=2029-02-08T12%3A27%3A00Z&amp;sp=rl&amp;sig=xxxx
-                const string DOMAIN = "blob.core.windows.net/";
-                var domainStart = SoftwareDownloadURL.IndexOf(DOMAIN);
-                if (domainStart > 0)
-                {
-                    var qsStart = SoftwareDownloadURL.IndexOf("?");
-                    if (qsStart > -1)
-                    {
-                        var start = domainStart + DOMAIN.Length;
-                        return SoftwareDownloadURL.Substring(start, qsStart - start);
-                    }
-                }
-                return "";
-            }
-        }
-
-        public string AccountBaseUrl
-        {
-            get
-            {
-                // URL: https://spoinsights.blob.core.windows.net/v2downloads?sv=2020-04-08&amp;ss=b&amp;srt=sco&amp;st=2021-06-06T11%3A27%3A00Z&amp;se=2029-02-08T12%3A27%3A00Z&amp;sp=rl&amp;sig=WLbftVXTlTzsGMdgge2Ey46XBJ07uTYcHurDIujernc%3D
-                const string DOMAIN = "blob.core.windows.net";
-                var domainStart = SoftwareDownloadURL.IndexOf(DOMAIN);
-                if (domainStart > 0)
-                {
-                    return SoftwareDownloadURL.Substring(0, domainStart + DOMAIN.Length);
-
-                }
-                return "";
-            }
-        }
-
-        public string SAS
-        {
-            get
-            {
-                // URL: https://spoinsights.blob.core.windows.net/v2downloads?sv=2020-04-08&amp;ss=b&amp;srt=sco&amp;st=2021-06-06T11%3A27%3A00Z&amp;se=2029-02-08T12%3A27%3A00Z&amp;sp=rl&amp;sig=WLbftVXTlTzsGMdgge2Ey46XBJ07uTYcHurDIujernc%3D
-
-                var qsStart = SoftwareDownloadURL.IndexOf("?");
-                if (qsStart > -1)
-                {
-                    return SoftwareDownloadURL.Substring(qsStart, SoftwareDownloadURL.Length - qsStart);
-                }
-
-                return "";
-            }
-        }
-
-        public bool IsValid => !string.IsNullOrEmpty(SoftwareDownloadURL) && !string.IsNullOrEmpty(ContainerName);
+        public string RepoOwner => GITHUB_REPO_OWNER;
+        public string RepoName => GITHUB_REPO_NAME;
     }
 }

--- a/src/AnalyticsEngine/App.ControlPanel/App.Release.config
+++ b/src/AnalyticsEngine/App.ControlPanel/App.Release.config
@@ -5,7 +5,6 @@
 	<appSettings xdt:Transform="Replace">
 
 		<!-- DevOps variables -->
-		<add key="SoftwareDownloadURL" value="__SoftwareDownloadURL__" />
 		<add key="BuildLabel" value="__BuildLabel__" />
 	</appSettings>
 

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.Designer.cs
@@ -370,7 +370,7 @@
             this.rdbLatest.Size = new System.Drawing.Size(241, 17);
             this.rdbLatest.TabIndex = 0;
             this.rdbLatest.TabStop = true;
-            this.rdbLatest.Text = "Latest stable release (download automatically)";
+            this.rdbLatest.Text = "Latest stable release on GitHub (download automatically)";
             this.rdbLatest.UseVisualStyleBackColor = true;
             this.rdbLatest.CheckedChanged += new System.EventHandler(this.rdbLatest_CheckedChanged);
             // 

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
@@ -3,7 +3,6 @@ using App.ControlPanel.Engine.Entities;
 using App.ControlPanel.Engine.Models;
 using DataUtils;
 using System;
-using System.Configuration;
 using System.Windows.Forms;
 using static App.ControlPanel.Frames.InstallWizard.InstallSolutionControl;
 
@@ -303,11 +302,7 @@ namespace App.ControlPanel.Frames
             var config = GetConfigFromGUI();
 
 
-            var urlConfig = ConfigurationManager.AppSettings.Get("SoftwareDownloadURL");
-            var softwareConfig = new SoftwareReleaseConfig
-            {
-                SoftwareDownloadURL = urlConfig
-            };
+            var softwareConfig = new SoftwareReleaseConfig();
 
             if (task == InstallTask.Install)
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -231,21 +231,46 @@ namespace Tests.UnitTests
             Assert.IsTrue(fExtension2.ToString() == "whatever/file.doc");
 
 
-            var valid = new SoftwareReleaseConfig() { SoftwareDownloadURL = "https://spoinsights.blob.core.windows.net/v2downloads?sv=blah" };
-            Assert.IsTrue(valid.ContainerName == "v2downloads");
-            Assert.IsTrue(valid.AccountBaseUrl == "https://spoinsights.blob.core.windows.net");
-            Assert.IsTrue(valid.SAS == "?sv=blah");
-
-
-            var invalid1 = new SoftwareReleaseConfig() { SoftwareDownloadURL = "https://spoinsights.blob.core.windows.net/v2downloads" };
-            Assert.IsTrue(invalid1.ContainerName == string.Empty);
-            Assert.IsTrue(invalid1.SAS == string.Empty);
-            Assert.IsFalse(invalid1.IsValid);
-            var invalid2 = new SoftwareReleaseConfig() { SoftwareDownloadURL = "https://spoinsights" };
-            Assert.IsTrue(invalid2.ContainerName == string.Empty);
-            Assert.IsFalse(invalid2.IsValid);
+            var config = new SoftwareReleaseConfig();
+            Assert.IsTrue(config.RepoOwner == SoftwareReleaseConfig.GITHUB_REPO_OWNER);
+            Assert.IsTrue(config.RepoName == SoftwareReleaseConfig.GITHUB_REPO_NAME);
+            Assert.IsTrue(config.RepoOwner == "pnp");
+            Assert.IsTrue(config.RepoName == "Microsoft365-Analytics-Insights");
         }
 
+
+        [TestMethod]
+        public async Task DownloadLatestReleaseZipsHaveContent()
+        {
+            var cfg = TaskConfig.GetConfigForPropAndVal(
+                    LatestStableSoftwarePackageDownloadTask.CFG_KEY_RepoOwner, SoftwareReleaseConfig.GITHUB_REPO_OWNER)
+                .AddSetting(LatestStableSoftwarePackageDownloadTask.CFG_KEY_RepoName, SoftwareReleaseConfig.GITHUB_REPO_NAME);
+
+            var task = new LatestStableSoftwarePackageDownloadTask(cfg, _logger);
+            var result = await task.ExecuteTaskReturnResult(null);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.IsValid, "Downloaded release should be valid (5 non-empty .zip files)");
+
+            // Verify each component zip exists and has content
+            var components = new[]
+            {
+                SoftwareComponent.WebJobActivity,
+                SoftwareComponent.WebJobAppInsights,
+                SoftwareComponent.AITracker,
+                SoftwareComponent.ControlPanel,
+                SoftwareComponent.WebSite
+            };
+            foreach (var component in components)
+            {
+                var fileLocation = result.GetSolutionComponentLocation(component).FileLocation;
+                Assert.IsTrue(System.IO.File.Exists(fileLocation), $"{component} zip should exist at {fileLocation}");
+
+                var fileInfo = new System.IO.FileInfo(fileLocation);
+                Assert.IsTrue(fileInfo.Length > 0, $"{component} zip should not be empty");
+                Assert.IsTrue(fileLocation.EndsWith(".zip"), $"{component} should be a .zip file");
+            }
+        }
         /// <summary>
         /// Tests we can chain one lookup to result of another
         /// </summary>


### PR DESCRIPTION
This pull request migrates the installer’s mechanism for downloading software packages from Azure Blob Storage to GitHub Releases, streamlining the release process and simplifying configuration. It removes all Azure Storage dependencies and related configuration, updates the UI and documentation to reflect the new source, and refactors the download logic to work with GitHub’s API and assets. Additionally, it introduces a new shared test base for Copilot-related unit tests.

**Migration from Azure Blob Storage to GitHub Releases:**

- The installer now fetches the latest stable release directly from a specified GitHub repository (`pnp/Microsoft365-Analytics-Insights`), replacing the previous Azure Blob Storage mechanism. All related Azure configuration and code have been removed or replaced. [[1]](diffhunk://#diff-f87e295a90a6b6007a8a5e37f68203391c6b218f9cba7ff3f021f503d03fe04eL2-R133) [[2]](diffhunk://#diff-48c05b85ce4f56757ad8e7a6536b6076813087b86d35f158d2b06798d863a3e2L50-R54) [[3]](diffhunk://#diff-f5c049960db15c26d9deb5056ba73a7e6929d33f028162dbc79887a96904e601L4-R12) [[4]](diffhunk://#diff-c922668ff78eb8962b3d6c734f2e276698dbeb3a528fae374a3602b227b180adL306-R305) [[5]](diffhunk://#diff-a76589e869bd1511798dc84719bcfb346330f5038e985e398bddc9795b0a3030L8)

- The `SoftwareReleaseConfig` class has been refactored to store and expose only the GitHub repository owner and name, removing all Azure-related properties and validation.

**Installer and UI updates:**

- The UI label for the latest release option now explicitly states that it downloads from GitHub.

- The installer initialization and configuration logic have been simplified to remove all Azure Storage dependencies and references to `SoftwareDownloadURL`. [[1]](diffhunk://#diff-c922668ff78eb8962b3d6c734f2e276698dbeb3a528fae374a3602b227b180adL306-R305) [[2]](diffhunk://#diff-a76589e869bd1511798dc84719bcfb346330f5038e985e398bddc9795b0a3030L8)

**Download logic improvements:**

- The download task (`LatestStableSoftwarePackageDownloadTask`) now uses the GitHub REST API to fetch the latest release metadata and downloads the required assets in parallel. It validates that all expected assets are present and handles errors if any are missing.

**Testing infrastructure:**

- A new `CopilotTestBase` abstract class is introduced, providing shared helpers for Copilot-related database setup and test flows, to facilitate more consistent and maintainable unit tests.