### PR TITLE
Feature/enforce tls12

### DIFF
--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -80,6 +80,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 }
 
                 await base.EnsureTagsOnExisting(webApp.Data.Tags, webApp.GetTagResource());     // Add configured tags
+
+                _logger.LogInformation($"Using existing App Service '{webApp.Data.DefaultHostName}'.");
             }
 
             // Enable basic publishing credentials for SCM and FTP

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -36,7 +36,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     SiteConfig = new SiteConfigProperties
                     {
                         IsAlwaysOn = true,
-                        FtpsState = AppServiceFtpsState.FtpsOnly
+                        FtpsState = AppServiceFtpsState.FtpsOnly,
+                        MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2
                     },
                     Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.SystemAssigned)
                 };

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -61,9 +61,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 }
 
                 // Ensure minimum TLS version is 1.2
-                var webAppData = (await webApp.GetAsync()).Value.Data;
-                var currentTlsVersion = webAppData.SiteConfig?.MinTlsVersion;
-                if (currentTlsVersion == null || !currentTlsVersion.Value.ToString().Equals(AppServiceSupportedTlsVersion.Tls1_2.ToString()))
+                var siteConfig = (await webApp.GetWebSiteConfig().GetAsync()).Value.Data;
+                if (siteConfig.MinTlsVersion == null || !siteConfig.MinTlsVersion.Value.ToString().Equals(AppServiceSupportedTlsVersion.Tls1_2.ToString()))
                 {
                     webAppUpdateInfo.SiteConfig = new SiteConfigProperties
                     {

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -49,23 +49,37 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             else
             {
+                var needsUpdate = false;
+                var webAppUpdateInfo = new WebSiteData(base.AzureLocation);
+
                 // Ensure app has system assigned identity
                 if (webApp.HasData && webApp.Data.Identity == null)
                 {
-                    webApp.Data.Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.SystemAssigned);
+                    webAppUpdateInfo.Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.SystemAssigned);
                     _logger.LogInformation($"Updating App Service '{_config.ResourceName}' to use System Assigned identity...");
+                    needsUpdate = true;
+                }
 
-                    var webAppUpdateInfo = new WebSiteData(base.AzureLocation)
+                // Ensure minimum TLS version is 1.2
+                var webAppData = (await webApp.GetAsync()).Value.Data;
+                var currentTlsVersion = webAppData.SiteConfig?.MinTlsVersion;
+                if (currentTlsVersion == null || !currentTlsVersion.Value.ToString().Equals(AppServiceSupportedTlsVersion.Tls1_2.ToString()))
+                {
+                    webAppUpdateInfo.SiteConfig = new SiteConfigProperties
                     {
-                        Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.SystemAssigned)
+                        MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2
                     };
-                    base.EnsureTagsOnNew(webAppUpdateInfo.Tags);     // Add configured tags
-                    var newWebAppReq = await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, webAppUpdateInfo);
+                    _logger.LogInformation($"Updating App Service '{_config.ResourceName}' to enforce TLS 1.2...");
+                    needsUpdate = true;
+                }
+
+                if (needsUpdate)
+                {
+                    base.EnsureTagsOnNew(webAppUpdateInfo.Tags);
+                    await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, webAppUpdateInfo);
                 }
 
                 await base.EnsureTagsOnExisting(webApp.Data.Tags, webApp.GetTagResource());     // Add configured tags
-
-                _logger.LogInformation($"Using existing App Service '{webApp.Data.DefaultHostName}'.");
             }
 
             // Enable basic publishing credentials for SCM and FTP

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -84,17 +84,27 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 _logger.LogInformation($"Using existing App Service '{webApp.Data.DefaultHostName}'.");
             }
 
-            // Enable basic publishing credentials for SCM and FTP
+            // Enable basic publishing credentials for SCM and FTP if not already enabled
+            var scmPolicy = await webApp.GetScmSiteBasicPublishingCredentialsPolicy().GetAsync();
+            var ftpPolicy = await webApp.GetWebSiteFtpPublishingCredentialsPolicy().GetAsync();
+
             var publishingCredentialsPolicyData = new CsmPublishingCredentialsPoliciesEntityData()
             {
                 Allow = true,
             };
 
-            _logger.LogInformation($"Enabling basic publishing credentials (SCM & FTP) for '{_config.ResourceName}'...");
-            await webApp.GetScmSiteBasicPublishingCredentialsPolicy().CreateOrUpdateAsync(
-                WaitUntil.Completed, publishingCredentialsPolicyData);
-            await webApp.GetWebSiteFtpPublishingCredentialsPolicy().CreateOrUpdateAsync(
-                WaitUntil.Completed, publishingCredentialsPolicyData);
+            if (scmPolicy.Value.Data.Allow != true)
+            {
+                _logger.LogInformation($"Enabling basic publishing credentials (SCM) for '{_config.ResourceName}'...");
+                await webApp.GetScmSiteBasicPublishingCredentialsPolicy().CreateOrUpdateAsync(
+                    WaitUntil.Completed, publishingCredentialsPolicyData);
+            }
+            if (ftpPolicy.Value.Data.Allow != true)
+            {
+                _logger.LogInformation($"Enabling basic publishing credentials (FTP) for '{_config.ResourceName}'...");
+                await webApp.GetWebSiteFtpPublishingCredentialsPolicy().CreateOrUpdateAsync(
+                    WaitUntil.Completed, publishingCredentialsPolicyData);
+            }
 
             return webApp;
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
@@ -28,7 +28,10 @@ namespace CloudInstallEngine.Azure.InstallTasks
             {
                 _logger.LogInformation($"Creating new redis cache '{name}' at basic SKU. This may take several minutes...");
 
-                var newResourceData = new RedisCreateOrUpdateContent(AzureLocation, new RedisSku(RedisSkuName.Basic, RedisSkuFamily.BasicOrStandard, 0));
+                var newResourceData = new RedisCreateOrUpdateContent(AzureLocation, new RedisSku(RedisSkuName.Basic, RedisSkuFamily.BasicOrStandard, 0))
+                {
+                    MinimumTlsVersion = RedisTlsVersion.Tls1_2
+                };
                 base.EnsureTagsOnNew(newResourceData.Tags);
                 var operation = await allRedis.CreateOrUpdateAsync(WaitUntil.Completed, name, newResourceData);
                 _logger.LogInformation($"Created redis cache '{operation.Value.Data.Name}'.");

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
@@ -51,6 +51,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     await allRedis.CreateOrUpdateAsync(WaitUntil.Completed, name, updateData);
                 }
 
+                _logger.LogInformation($"Found existing Redis cache '{redisCache.Data.HostName}'.");
                 await base.EnsureTagsOnExisting(redisCache.Data.Tags, redisCache.GetTagResource());
             }
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
@@ -40,7 +40,17 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             else
             {
-                _logger.LogInformation($"Found existing Redis cache '{redisCache.Data.HostName}'.");
+                // Ensure minimum TLS version is 1.2
+                if (redisCache.Data.MinimumTlsVersion == null || !redisCache.Data.MinimumTlsVersion.Value.ToString().Equals(RedisTlsVersion.Tls1_2.ToString()))
+                {
+                    _logger.LogInformation($"Updating Redis cache '{name}' to enforce TLS 1.2...");
+                    var updateData = new RedisCreateOrUpdateContent(AzureLocation, new RedisSku(RedisSkuName.Basic, RedisSkuFamily.BasicOrStandard, 0))
+                    {
+                        MinimumTlsVersion = RedisTlsVersion.Tls1_2
+                    };
+                    await allRedis.CreateOrUpdateAsync(WaitUntil.Completed, name, updateData);
+                }
+
                 await base.EnsureTagsOnExisting(redisCache.Data.Tags, redisCache.GetTagResource());
             }
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
@@ -49,7 +49,17 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             else
             {
-                _logger.LogInformation($"Found existing SQL Server '{sqlServer.Data.FullyQualifiedDomainName}'.");
+                // Ensure minimum TLS version is 1.2
+                if (sqlServer.Data.MinimalTlsVersion == null || string.Compare(sqlServer.Data.MinimalTlsVersion, "1.2") < 0)
+                {
+                    _logger.LogInformation($"Updating SQL Server '{serverName}' to enforce TLS 1.2...");
+                    var updateData = new SqlServerData(AzureLocation)
+                    {
+                        MinimalTlsVersion = "1.2"
+                    };
+                    await Container.GetSqlServers().CreateOrUpdateAsync(WaitUntil.Completed, serverName, updateData);
+                }
+
                 await base.EnsureTagsOnExisting(sqlServer.Data.Tags, sqlServer.GetTagResource());
             }
             return sqlServer;

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
@@ -39,7 +39,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 var sqlServerData = new SqlServerData(AzureLocation)
                 {
                     AdministratorLogin = adminUsername,
-                    AdministratorLoginPassword = adminPassword
+                    AdministratorLoginPassword = adminPassword,
+                    MinimalTlsVersion = "1.2"
                 };
 
                 base.EnsureTagsOnNew(sqlServerData.Tags);

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
@@ -60,6 +60,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     await Container.GetSqlServers().CreateOrUpdateAsync(WaitUntil.Completed, serverName, updateData);
                 }
 
+                _logger.LogInformation($"Found existing SQL Server '{sqlServer.Data.FullyQualifiedDomainName}'.");
                 await base.EnsureTagsOnExisting(sqlServer.Data.Tags, sqlServer.GetTagResource());
             }
             return sqlServer;

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/StorageAccountInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/StorageAccountInstallTask.cs
@@ -56,6 +56,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     await storageAccount.UpdateAsync(patch);
                 }
 
+                _logger.LogInformation($"Found existing storage-account '{storageAccount.Data.Name}'.");
                 await EnsureTagsOnExisting(storageAccount.Data.Tags, storageAccount.GetTagResource());
             }
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/StorageAccountInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/StorageAccountInstallTask.cs
@@ -45,7 +45,17 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             else
             {
-                _logger.LogInformation($"Found existing storage-account '{storageAccount.Data.Name}'.");
+                // Ensure minimum TLS version is 1.2
+                if (storageAccount.Data.MinimumTlsVersion == null || !storageAccount.Data.MinimumTlsVersion.Value.ToString().Equals(StorageMinimumTlsVersion.Tls1_2.ToString()))
+                {
+                    _logger.LogInformation($"Updating storage account '{name}' to enforce TLS 1.2...");
+                    var patch = new StorageAccountPatch
+                    {
+                        MinimumTlsVersion = StorageMinimumTlsVersion.Tls1_2
+                    };
+                    await storageAccount.UpdateAsync(patch);
+                }
+
                 await EnsureTagsOnExisting(storageAccount.Data.Tags, storageAccount.GetTagResource());
             }
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/StorageAccountInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/StorageAccountInstallTask.cs
@@ -33,7 +33,10 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
             if (storageAccount == null)
             {
-                var newAccountInfo = new StorageAccountCreateOrUpdateContent(new StorageSku("Standard_LRS"), StorageKind.StorageV2, AzureLocation);
+                var newAccountInfo = new StorageAccountCreateOrUpdateContent(new StorageSku("Standard_LRS"), StorageKind.StorageV2, AzureLocation)
+                {
+                    MinimumTlsVersion = StorageMinimumTlsVersion.Tls1_2
+                };
                 EnsureTagsOnNew(newAccountInfo.Tags);
                 var storageAccountReq = await Container.GetStorageAccounts().CreateOrUpdateAsync(WaitUntil.Completed, name, newAccountInfo);
                 storageAccount = storageAccountReq.Value;


### PR DESCRIPTION
This pull request enhances the security of Azure resource provisioning by enforcing a minimum TLS version of 1.2 across App Service, Redis, SQL Server, and Storage Account resources. It ensures that both newly created and existing resources comply with this security standard, and updates existing resources if necessary. Additionally, the logic for enabling publishing credentials for App Services is improved to avoid redundant updates.

**Security Improvements: Enforce Minimum TLS 1.2**

* App Service (`AppServiceWebsiteTask.cs`): Ensures both new and existing App Services have `MinTlsVersion` set to TLS 1.2. Updates are made only if the setting is missing or incorrect. [[1]](diffhunk://#diff-1d11da7c35810a9daf460d68e36db4504e1387376ba9ca6a6b5e3a76461ac526L39-R40) [[2]](diffhunk://#diff-1d11da7c35810a9daf460d68e36db4504e1387376ba9ca6a6b5e3a76461ac526R52-R106)
* Redis (`RedisInstallTask.cs`): Sets `MinimumTlsVersion` to TLS 1.2 for new Redis caches and updates existing caches if needed. [[1]](diffhunk://#diff-760dce59ae1fc931551b0ced00aaba08c6be3d91796936527b9cd56aa70f7d49L31-R34) [[2]](diffhunk://#diff-760dce59ae1fc931551b0ced00aaba08c6be3d91796936527b9cd56aa70f7d49R43-R53)
* SQL Server (`SqlServerTask.cs`): Sets `MinimalTlsVersion` to "1.2" for new SQL Servers and updates existing servers if they do not meet the requirement. [[1]](diffhunk://#diff-5006bed49e85ab3082e054fc2d9509ce6e1d7fd2ed352f93a207db462101370eL42-R43) [[2]](diffhunk://#diff-5006bed49e85ab3082e054fc2d9509ce6e1d7fd2ed352f93a207db462101370eR52-R62)
* Storage Account (`StorageAccountInstallTask.cs`): Sets `MinimumTlsVersion` to TLS 1.2 for new storage accounts and patches existing accounts if the setting is missing or incorrect. [[1]](diffhunk://#diff-cc31f7388393ab7500537e1427866e695068481579e53863d63570c0ef62549bL36-R39) [[2]](diffhunk://#diff-cc31f7388393ab7500537e1427866e695068481579e53863d63570c0ef62549bR48-R58)

**Operational Improvements**

* App Service (`AppServiceWebsiteTask.cs`): Improves logic for enabling basic publishing credentials (SCM & FTP) by updating them only if not already enabled, reducing unnecessary operations.