### PR TITLE
Ensure Always On is enabled on existing App Services

### DIFF
--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -63,15 +63,21 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     needsUpdate = true;
                 }
 
-                // Ensure minimum TLS version is 1.2
+                // Ensure minimum TLS version is 1.2 and Always On is enabled
                 var siteConfig = (await webApp.GetWebSiteConfig().GetAsync()).Value.Data;
-                if (siteConfig.MinTlsVersion == null || !siteConfig.MinTlsVersion.Value.ToString().Equals(AppServiceSupportedTlsVersion.Tls1_2.ToString()))
+                var needsTlsUpdate = siteConfig.MinTlsVersion == null || !siteConfig.MinTlsVersion.Value.ToString().Equals(AppServiceSupportedTlsVersion.Tls1_2.ToString());
+                var needsAlwaysOnUpdate = siteConfig.IsAlwaysOn != true;
+                if (needsTlsUpdate || needsAlwaysOnUpdate)
                 {
                     webAppUpdateInfo.SiteConfig = new SiteConfigProperties
                     {
-                        MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2
+                        MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2,
+                        IsAlwaysOn = true
                     };
-                    _logger.LogInformation($"Updating App Service '{_config.ResourceName}' to enforce TLS 1.2...");
+                    if (needsTlsUpdate)
+                        _logger.LogInformation($"Updating App Service '{_config.ResourceName}' to enforce TLS 1.2...");
+                    if (needsAlwaysOnUpdate)
+                        _logger.LogInformation($"Updating App Service '{_config.ResourceName}' to enable Always On...");
                     needsUpdate = true;
                 }
 


### PR DESCRIPTION
This pull request updates the Azure App Service installation logic to strengthen security and reliability settings. In addition to enforcing a minimum TLS version of 1.2, it now also ensures that the "Always On" feature is enabled for the deployed web app. Logging has been improved to clearly indicate which settings are being updated.

**App Service configuration improvements:**

* The `AppServiceWebsiteTask.cs` logic now checks and enforces that both the minimum TLS version is set to 1.2 and the "Always On" feature is enabled for App Service web apps.
* Logging has been enhanced to provide clear messages when updating either the TLS version or the "Always On" setting, making it easier to track configuration changes during deployment.