### PR TITLE
Feature/installer allow public access

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -54,6 +54,10 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
             var tagDic = config.Tags.ToDictionary();
             var vnetEnabled = config.NetworkConfig != null && config.NetworkConfig.Enabled;
+            // When VNet is disabled we always allow public access (legacy/default behaviour).
+            // When VNet is enabled, honour the AllowPublicAccess flag (some customer Azure policies
+            // disallow public access on PaaS resources).
+            var allowPublicAccess = !vnetEnabled || (config.NetworkConfig != null && config.NetworkConfig.AllowPublicAccess);
 
             _rgCreateTask = new GetOrCreateResourceGroupTask(TaskConfig.GetConfigForName(config.ResourceGroupName), logger, Location, tagDic, subscription);
             this.AddTask(_rgCreateTask);
@@ -104,7 +108,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 var integrationSubnetId = $"/subscriptions/{config.Subscription.SubId}/resourceGroups/{config.ResourceGroupName}/providers/Microsoft.Network/virtualNetworks/{config.NetworkConfig.VNetName}/subnets/{config.NetworkConfig.AppServiceIntegrationSubnetName}";
                 appServiceConfig.AddSetting(AppServiceWebsiteTask.CONFIG_KEY_VNET_INTEGRATION_SUBNET_ID, integrationSubnetId);
             }
-            _appServiceWebsiteTask = new AppServiceWebsiteTask(appServiceConfig, logger, Location, tagDic);
+            _appServiceWebsiteTask = new AppServiceWebsiteTask(appServiceConfig, logger, Location, tagDic, allowPublicAccess);
             this.AddTask(_appServicePlanTask, _appServiceWebsiteTask);
 
             // SQL 
@@ -181,7 +185,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
             // ServiceBus - enforce Premium for VNet (private endpoints require Premium SKU)
             const string QUEUE_NAME = "graphcalls";
             const string RULE_NAME = "ListenAndSendPolicy";
-            _serviceBusNamespaceInstallTask = new ServiceBusNamespaceInstallTask(TaskConfig.GetConfigForName(config.ServiceBusName), logger, Location, tagDic, requirePremiumSku: vnetEnabled);
+            _serviceBusNamespaceInstallTask = new ServiceBusNamespaceInstallTask(TaskConfig.GetConfigForName(config.ServiceBusName), logger, Location, tagDic, requirePremiumSku: vnetEnabled, allowPublicAccess: allowPublicAccess);
 
             var queueConfig = TaskConfig.GetConfigForName(QUEUE_NAME).AddSetting(ServiceBusQueueWithPolicyInstallTask.CONFIG_KEY_RULE_NAME, RULE_NAME);
             _serviceBusQueueWithPolicyInstallTask = new ServiceBusQueueWithPolicyInstallTask(queueConfig, logger, Location);

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -59,6 +59,14 @@ namespace App.ControlPanel.Engine.InstallerTasks
             // disallow public access on PaaS resources).
             var allowPublicAccess = !vnetEnabled || (config.NetworkConfig != null && config.NetworkConfig.AllowPublicAccess);
 
+            if (!allowPublicAccess)
+            {
+                logger.LogWarning("Public network access will be disabled on Azure PaaS resources (SQL, Storage, Key Vault, Redis, Service Bus, App Service, Automation, Cognitive Services). " +
+                    "If this installer is NOT running on a machine connected to the private network (VNet, peered network, VPN/ExpressRoute, or Azure Bastion-attached host), the following steps will fail: " +
+                    "Key Vault secret upload (appsecret), SQL connectivity test and database initialization, and the App Service warm-up request. " +
+                    "These failures are non-fatal — the resources are still created and configured — but you must re-run the installer from inside the private network (or temporarily re-enable public access on Key Vault and SQL) to complete those steps.");
+            }
+
             _rgCreateTask = new GetOrCreateResourceGroupTask(TaskConfig.GetConfigForName(config.ResourceGroupName), logger, Location, tagDic, subscription);
             this.AddTask(_rgCreateTask);
 
@@ -117,7 +125,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 .AddSetting(SqlServerTask.CONFIG_KEY_PASSWORD, config.SQLServerAdminPassword);
             const string FIREWALL_RULE_NAME = "O365 Adv Analytics Setup Rule";
 
-            _sqlServerTask = new SqlServerTask(sqlServerConfig, logger, Location, tagDic);
+            _sqlServerTask = new SqlServerTask(sqlServerConfig, logger, Location, tagDic, allowPublicAccess);
             _sqlServerFirewallConfigTask = new SqlServerFirewallConfigTask(TaskConfig.GetConfigForName(FIREWALL_RULE_NAME), logger, Location);
 
             var sqlDbConfig = TaskConfig.GetConfigForName(config.SQLServerDatabaseName).AddSetting(SqlDatabaseTask.CONFIG_KEY_PERF_TIER, sqlPerfTier);
@@ -127,7 +135,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
 
             // Redis - enforce Standard SKU for VNet
-            _redisTask = new RedisInstallTask(TaskConfig.GetConfigForName(config.RedisName), logger, Location, tagDic, vnetEnabled);
+            _redisTask = new RedisInstallTask(TaskConfig.GetConfigForName(config.RedisName), logger, Location, tagDic, vnetEnabled, allowPublicAccess);
 
             // Redis access policy assignment for data-plane RBAC access (required when key-based auth is disabled)
             var redisAccessPolicyConfig = TaskConfig.GetConfigForName(config.RedisName)
@@ -154,7 +162,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
             // Key vault
             var kvConfig = TaskConfig.GetConfigForName(config.KeyVaultName).AddSetting(KeyVaultTask.CONFIG_KEY_TENANT_ID, config.InstallerAccount.DirectoryId);
-            _keyVaultTask = new KeyVaultTask(kvConfig, logger, Location, tagDic);
+            _keyVaultTask = new KeyVaultTask(kvConfig, logger, Location, tagDic, allowPublicAccess);
 
             // Allow installer account all permissions
             var kvAddRuntimeAccountSecretReadPolicyConfig = TaskConfig.GetConfigForPropAndVal(BaseKeyVaultAddPolicyTask.CONFIG_KEY_CLIENT_ID, config.RuntimeAccountOffice365.ClientId)
@@ -192,10 +200,22 @@ namespace App.ControlPanel.Engine.InstallerTasks
             this.AddTask(_serviceBusNamespaceInstallTask, _serviceBusQueueWithPolicyInstallTask);
 
             // Storage
-            _storageAccountInstallTask = new StorageAccountInstallTask(TaskConfig.GetConfigForName(config.StorageAccountName), logger, Location, tagDic);
+            _storageAccountInstallTask = new StorageAccountInstallTask(TaskConfig.GetConfigForName(config.StorageAccountName), logger, Location, tagDic, allowPublicAccess);
             this.AddTask(_storageAccountInstallTask);
 
             // AppInsights
+            // Note: Log Analytics and Application Insights are intentionally always created with public
+            // network access enabled, even when the user has selected "no public access". Making these
+            // private requires an Azure Monitor Private Link Scope (AMPLS) plus the Azure Monitor private
+            // DNS zones, which can affect Azure Monitor connectivity for every VNet that resolves those
+            // zones (potentially across unrelated workloads/subscriptions). Customers that need these
+            // resources to be private must configure AMPLS manually after install.
+            if (!allowPublicAccess)
+            {
+                logger.LogWarning("Log Analytics and Application Insights will be created with public network access enabled. " +
+                    "To make them private, configure an Azure Monitor Private Link Scope (AMPLS) manually after install. " +
+                    "See https://learn.microsoft.com/azure/azure-monitor/logs/private-link-security for details.");
+            }
             _logAnalyticsInstallTask = new LogAnalyticsInstallTask(TaskConfig.GetConfigForName(config.AppInsightsWorkspaceName), logger, Location, tagDic);
 
             var creds = new ClientSecretCredential(config.InstallerAccount.DirectoryId, config.InstallerAccount.ClientId, config.InstallerAccount.Secret);
@@ -206,7 +226,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
             // Cognitive
             if (config.CognitiveServicesEnabled)
             {
-                _cognitiveServicesInstallTask = new TextAnalyticsInstallTask(TaskConfig.GetConfigForName(config.CognitiveServiceName), logger, Location, tagDic);
+                _cognitiveServicesInstallTask = new TextAnalyticsInstallTask(TaskConfig.GetConfigForName(config.CognitiveServiceName), logger, Location, tagDic, allowPublicAccess);
                 this.AddTask(_cognitiveServicesInstallTask);
             }
 
@@ -220,7 +240,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
                     .AddSetting(AutomationAccountTask.CONFIG_PARAM_NAME_SQL_PASSWORD, config.SQLServerAdminPassword)
                     ;
 
-                _automationAccountTask = new AutomationAccountTask(automationAccountConfig, logger, Location, tagDic);
+                _automationAccountTask = new AutomationAccountTask(automationAccountConfig, logger, Location, tagDic, allowPublicAccess);
                 this.AddTask(_automationAccountTask);
 
                 // Hybrid Worker Group - when VNet is enabled and a VM resource ID is configured,

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
@@ -67,16 +67,13 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
                 if (automationAccount.Data.IsPublicNetworkAccessAllowed != _allowPublicAccess)
                 {
                     _logger.LogInformation($"Updating Automation account '{automationAccount.Data.Name}' public network access to '{(_allowPublicAccess ? "enabled" : "disabled")}'...");
-                    var update = new AutomationAccountCreateOrUpdateContent()
+                    var patch = new AutomationAccountPatch
                     {
-                        Location = base.AzureLocation,
-                        Sku = automationAccount.Data.Sku,
-                        Name = _config.ResourceName,
                         IsPublicNetworkAccessAllowed = _allowPublicAccess
                     };
                     try
                     {
-                        var updateReq = await Container.GetAutomationAccounts().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, update);
+                        var updateReq = await automationAccount.UpdateAsync(patch);
                         automationAccount = updateReq.Value;
                     }
                     catch (RequestFailedException ex)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
@@ -24,8 +24,11 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
         public const string CONFIG_PARAM_NAME_SQL_USERNAME = "sqlusername";
         public const string CONFIG_PARAM_NAME_SQL_PASSWORD = "sqlpassword";
 
-        public AutomationAccountTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
+        private readonly bool _allowPublicAccess;
+
+        public AutomationAccountTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override async Task<AutomationAccountResource> ExecuteTaskReturnResult(object contextArg)
@@ -38,11 +41,12 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
                 {
                     Location = base.AzureLocation,
                     Sku = new AutomationSku(AutomationSkuName.Free),
-                    Name = _config.ResourceName
+                    Name = _config.ResourceName,
+                    IsPublicNetworkAccessAllowed = _allowPublicAccess
                 };
                 base.EnsureTagsOnNew(newAutomationAccountInfo.Tags);     // Add configured tags
 
-                _logger.LogInformation($"Creating Automation account '{_config.ResourceName}' ...");
+                _logger.LogInformation($"Creating Automation account '{_config.ResourceName}' (public access: {(_allowPublicAccess ? "enabled" : "disabled")}) ...");
                 try
                 {
                     var newAccountReq = await Container.GetAutomationAccounts().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newAutomationAccountInfo);
@@ -59,6 +63,27 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
             {
                 _logger.LogInformation($"Using existing Automation account'{automationAccount.Data.Name}'.");
                 await base.EnsureTagsOnExisting(automationAccount.Data.Tags, automationAccount.GetTagResource());
+
+                if (automationAccount.Data.IsPublicNetworkAccessAllowed != _allowPublicAccess)
+                {
+                    _logger.LogInformation($"Updating Automation account '{automationAccount.Data.Name}' public network access to '{(_allowPublicAccess ? "enabled" : "disabled")}'...");
+                    var update = new AutomationAccountCreateOrUpdateContent()
+                    {
+                        Location = base.AzureLocation,
+                        Sku = automationAccount.Data.Sku,
+                        Name = _config.ResourceName,
+                        IsPublicNetworkAccessAllowed = _allowPublicAccess
+                    };
+                    try
+                    {
+                        var updateReq = await Container.GetAutomationAccounts().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, update);
+                        automationAccount = updateReq.Value;
+                    }
+                    catch (RequestFailedException ex)
+                    {
+                        _logger.LogWarning($"Could not update Automation account '{_config.ResourceName}' public access setting: {ex.Message}");
+                    }
+                }
             }
 
             // Vars

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
@@ -122,6 +122,7 @@ namespace App.ControlPanel.Frames
                     AppServiceIntegrationSubnetName = networkingConfigControl1.AppServiceSubnetName,
                     AppServiceIntegrationSubnetAddressPrefix = networkingConfigControl1.AppServiceSubnetAddressPrefix,
                     DeployDnsZones = networkingConfigControl1.DeployDnsZones,
+                    AllowPublicAccess = networkingConfigControl1.AllowPublicAccess,
                     CustomEndpointNames = networkingConfigControl1.GetEndpointNames(),
                     HybridWorkerVmResourceId = networkingConfigControl1.HybridWorkerVmResourceId
                 }
@@ -201,6 +202,7 @@ namespace App.ControlPanel.Frames
                 networkingConfigControl1.AppServiceSubnetName = config.NetworkConfig.AppServiceIntegrationSubnetName;
                 networkingConfigControl1.AppServiceSubnetAddressPrefix = config.NetworkConfig.AppServiceIntegrationSubnetAddressPrefix;
                 networkingConfigControl1.DeployDnsZones = config.NetworkConfig.DeployDnsZones;
+                networkingConfigControl1.AllowPublicAccess = config.NetworkConfig.AllowPublicAccess;
                 networkingConfigControl1.SetEndpointNames(config.NetworkConfig.CustomEndpointNames);
                 networkingConfigControl1.HybridWorkerVmResourceId = config.NetworkConfig.HybridWorkerVmResourceId;
             }

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.Designer.cs
@@ -277,9 +277,9 @@ namespace App.ControlPanel.Frames.InstallWizard
             this.lblAllowPublicAccessHelp.ForeColor = System.Drawing.SystemColors.GrayText;
             this.lblAllowPublicAccessHelp.Location = new System.Drawing.Point(35, 162);
             this.lblAllowPublicAccessHelp.Name = "lblAllowPublicAccessHelp";
-            this.lblAllowPublicAccessHelp.Size = new System.Drawing.Size(550, 28);
+            this.lblAllowPublicAccessHelp.Size = new System.Drawing.Size(550, 42);
             this.lblAllowPublicAccessHelp.TabIndex = 36;
-            this.lblAllowPublicAccessHelp.Text = "Uncheck to disable public network access on supported PaaS resources (SQL, Storage, Key Vault, Redis, Service Bus, App Service, Automation, Cognitive Services). Log Analytics and Application Insights stay public; configure AMPLS manually if private access is required.";
+            this.lblAllowPublicAccessHelp.Text = "Uncheck to disable public access on SQL, Storage, Key Vault, Redis, Service Bus, App Service,\r\nAutomation, and Cognitive Services. Log Analytics and Application Insights always stay public —\r\nconfigure Azure Monitor Private Link Scope (AMPLS) manually if private access is required.";
             // 
             // grpEndpointNames
             // 
@@ -300,7 +300,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             this.grpEndpointNames.Controls.Add(this.txtPeCognitive);
             this.grpEndpointNames.Controls.Add(this.lblPeAutomation);
             this.grpEndpointNames.Controls.Add(this.txtPeAutomation);
-            this.grpEndpointNames.Location = new System.Drawing.Point(15, 195);
+            this.grpEndpointNames.Location = new System.Drawing.Point(15, 210);
             this.grpEndpointNames.Name = "grpEndpointNames";
             this.grpEndpointNames.Size = new System.Drawing.Size(570, 145);
             this.grpEndpointNames.TabIndex = 10;
@@ -447,7 +447,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             // lblHybridWorkerVm
             // 
             this.lblHybridWorkerVm.AutoSize = true;
-            this.lblHybridWorkerVm.Location = new System.Drawing.Point(15, 402);
+            this.lblHybridWorkerVm.Location = new System.Drawing.Point(15, 417);
             this.lblHybridWorkerVm.Name = "lblHybridWorkerVm";
             this.lblHybridWorkerVm.Size = new System.Drawing.Size(140, 13);
             this.lblHybridWorkerVm.TabIndex = 17;
@@ -455,14 +455,14 @@ namespace App.ControlPanel.Frames.InstallWizard
             // 
             // txtHybridWorkerVm
             // 
-            this.txtHybridWorkerVm.Location = new System.Drawing.Point(160, 349);
+            this.txtHybridWorkerVm.Location = new System.Drawing.Point(160, 364);
             this.txtHybridWorkerVm.Name = "txtHybridWorkerVm";
             this.txtHybridWorkerVm.Size = new System.Drawing.Size(340, 20);
             this.txtHybridWorkerVm.TabIndex = 18;
             // 
             // btnBrowseVm
             // 
-            this.btnBrowseVm.Location = new System.Drawing.Point(506, 347);
+            this.btnBrowseVm.Location = new System.Drawing.Point(506, 362);
             this.btnBrowseVm.Name = "btnBrowseVm";
             this.btnBrowseVm.Size = new System.Drawing.Size(75, 23);
             this.btnBrowseVm.TabIndex = 19;
@@ -473,7 +473,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             // lblHybridWorkerVmHelp
             // 
             this.lblHybridWorkerVmHelp.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.lblHybridWorkerVmHelp.Location = new System.Drawing.Point(157, 372);
+            this.lblHybridWorkerVmHelp.Location = new System.Drawing.Point(157, 387);
             this.lblHybridWorkerVmHelp.Name = "lblHybridWorkerVmHelp";
             this.lblHybridWorkerVmHelp.Size = new System.Drawing.Size(430, 42);
             this.lblHybridWorkerVmHelp.TabIndex = 20;
@@ -482,7 +482,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             // lblSkuWarning
             // 
             this.lblSkuWarning.ForeColor = System.Drawing.Color.DarkOrange;
-            this.lblSkuWarning.Location = new System.Drawing.Point(15, 422);
+            this.lblSkuWarning.Location = new System.Drawing.Point(15, 437);
             this.lblSkuWarning.Name = "lblSkuWarning";
             this.lblSkuWarning.Size = new System.Drawing.Size(570, 90);
             this.lblSkuWarning.TabIndex = 21;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.Designer.cs
@@ -120,6 +120,8 @@ namespace App.ControlPanel.Frames.InstallWizard
             this.grpVNetSettings.Controls.Add(this.txtAppSubnetAddressPrefix);
             this.grpVNetSettings.Controls.Add(this.chkDeployDnsZones);
             this.grpVNetSettings.Controls.Add(this.lblDnsZonesHelp);
+            this.grpVNetSettings.Controls.Add(this.chkAllowPublicAccess);
+            this.grpVNetSettings.Controls.Add(this.lblAllowPublicAccessHelp);
             this.grpVNetSettings.Controls.Add(this.grpEndpointNames);
             this.grpVNetSettings.Controls.Add(this.lblHybridWorkerVm);
             this.grpVNetSettings.Controls.Add(this.txtHybridWorkerVm);
@@ -422,7 +424,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             // lblHybridWorkerVm
             // 
             this.lblHybridWorkerVm.AutoSize = true;
-            this.lblHybridWorkerVm.Location = new System.Drawing.Point(15, 302);
+            this.lblHybridWorkerVm.Location = new System.Drawing.Point(15, 352);
             this.lblHybridWorkerVm.Name = "lblHybridWorkerVm";
             this.lblHybridWorkerVm.Size = new System.Drawing.Size(140, 13);
             this.lblHybridWorkerVm.TabIndex = 17;
@@ -502,6 +504,8 @@ namespace App.ControlPanel.Frames.InstallWizard
         private System.Windows.Forms.TextBox txtSubnetAddressPrefix;
         private System.Windows.Forms.CheckBox chkDeployDnsZones;
         private System.Windows.Forms.Label lblDnsZonesHelp;
+        private System.Windows.Forms.CheckBox chkAllowPublicAccess;
+        private System.Windows.Forms.Label lblAllowPublicAccessHelp;
         private System.Windows.Forms.GroupBox grpEndpointNames;
         private System.Windows.Forms.Label lblPeHelp;
         private System.Windows.Forms.Label lblPeSql;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.Designer.cs
@@ -46,6 +46,8 @@ namespace App.ControlPanel.Frames.InstallWizard
             this.txtAppSubnetAddressPrefix = new System.Windows.Forms.TextBox();
             this.chkDeployDnsZones = new System.Windows.Forms.CheckBox();
             this.lblDnsZonesHelp = new System.Windows.Forms.Label();
+            this.chkAllowPublicAccess = new System.Windows.Forms.CheckBox();
+            this.lblAllowPublicAccessHelp = new System.Windows.Forms.Label();
             this.grpEndpointNames = new System.Windows.Forms.GroupBox();
             this.lblPeSql = new System.Windows.Forms.Label();
             this.txtPeSql = new System.Windows.Forms.TextBox();
@@ -258,6 +260,27 @@ namespace App.ControlPanel.Frames.InstallWizard
             this.lblDnsZonesHelp.TabIndex = 9;
             this.lblDnsZonesHelp.Text = "Uncheck if you manage DNS externally (e.g. on-premises DNS, Azure DNS Private Resolver, or custom forwarding).";
             // 
+            // chkAllowPublicAccess
+            // 
+            this.chkAllowPublicAccess.AutoSize = true;
+            this.chkAllowPublicAccess.Checked = true;
+            this.chkAllowPublicAccess.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkAllowPublicAccess.Location = new System.Drawing.Point(18, 144);
+            this.chkAllowPublicAccess.Name = "chkAllowPublicAccess";
+            this.chkAllowPublicAccess.Size = new System.Drawing.Size(280, 17);
+            this.chkAllowPublicAccess.TabIndex = 35;
+            this.chkAllowPublicAccess.Text = "Allow public network access on Azure PaaS resources";
+            this.chkAllowPublicAccess.UseVisualStyleBackColor = true;
+            // 
+            // lblAllowPublicAccessHelp
+            // 
+            this.lblAllowPublicAccessHelp.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.lblAllowPublicAccessHelp.Location = new System.Drawing.Point(35, 162);
+            this.lblAllowPublicAccessHelp.Name = "lblAllowPublicAccessHelp";
+            this.lblAllowPublicAccessHelp.Size = new System.Drawing.Size(550, 28);
+            this.lblAllowPublicAccessHelp.TabIndex = 36;
+            this.lblAllowPublicAccessHelp.Text = "Uncheck to disable public network access on supported PaaS resources (SQL, Storage, Key Vault, Redis, Service Bus, App Service, Automation, Cognitive Services). Log Analytics and Application Insights stay public; configure AMPLS manually if private access is required.";
+            // 
             // grpEndpointNames
             // 
             this.grpEndpointNames.Controls.Add(this.lblPeHelp);
@@ -277,7 +300,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             this.grpEndpointNames.Controls.Add(this.txtPeCognitive);
             this.grpEndpointNames.Controls.Add(this.lblPeAutomation);
             this.grpEndpointNames.Controls.Add(this.txtPeAutomation);
-            this.grpEndpointNames.Location = new System.Drawing.Point(15, 145);
+            this.grpEndpointNames.Location = new System.Drawing.Point(15, 195);
             this.grpEndpointNames.Name = "grpEndpointNames";
             this.grpEndpointNames.Size = new System.Drawing.Size(570, 145);
             this.grpEndpointNames.TabIndex = 10;
@@ -424,7 +447,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             // lblHybridWorkerVm
             // 
             this.lblHybridWorkerVm.AutoSize = true;
-            this.lblHybridWorkerVm.Location = new System.Drawing.Point(15, 352);
+            this.lblHybridWorkerVm.Location = new System.Drawing.Point(15, 402);
             this.lblHybridWorkerVm.Name = "lblHybridWorkerVm";
             this.lblHybridWorkerVm.Size = new System.Drawing.Size(140, 13);
             this.lblHybridWorkerVm.TabIndex = 17;
@@ -432,14 +455,14 @@ namespace App.ControlPanel.Frames.InstallWizard
             // 
             // txtHybridWorkerVm
             // 
-            this.txtHybridWorkerVm.Location = new System.Drawing.Point(160, 299);
+            this.txtHybridWorkerVm.Location = new System.Drawing.Point(160, 349);
             this.txtHybridWorkerVm.Name = "txtHybridWorkerVm";
             this.txtHybridWorkerVm.Size = new System.Drawing.Size(340, 20);
             this.txtHybridWorkerVm.TabIndex = 18;
             // 
             // btnBrowseVm
             // 
-            this.btnBrowseVm.Location = new System.Drawing.Point(506, 297);
+            this.btnBrowseVm.Location = new System.Drawing.Point(506, 347);
             this.btnBrowseVm.Name = "btnBrowseVm";
             this.btnBrowseVm.Size = new System.Drawing.Size(75, 23);
             this.btnBrowseVm.TabIndex = 19;
@@ -450,7 +473,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             // lblHybridWorkerVmHelp
             // 
             this.lblHybridWorkerVmHelp.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.lblHybridWorkerVmHelp.Location = new System.Drawing.Point(157, 322);
+            this.lblHybridWorkerVmHelp.Location = new System.Drawing.Point(157, 372);
             this.lblHybridWorkerVmHelp.Name = "lblHybridWorkerVmHelp";
             this.lblHybridWorkerVmHelp.Size = new System.Drawing.Size(430, 42);
             this.lblHybridWorkerVmHelp.TabIndex = 20;
@@ -459,7 +482,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             // lblSkuWarning
             // 
             this.lblSkuWarning.ForeColor = System.Drawing.Color.DarkOrange;
-            this.lblSkuWarning.Location = new System.Drawing.Point(15, 372);
+            this.lblSkuWarning.Location = new System.Drawing.Point(15, 422);
             this.lblSkuWarning.Name = "lblSkuWarning";
             this.lblSkuWarning.Size = new System.Drawing.Size(570, 90);
             this.lblSkuWarning.TabIndex = 21;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.cs
@@ -34,6 +34,7 @@ namespace App.ControlPanel.Frames.InstallWizard
         public string AppServiceSubnetName { get { return txtAppSubnetName.Text; } set { txtAppSubnetName.Text = value; } }
         public string AppServiceSubnetAddressPrefix { get { return txtAppSubnetAddressPrefix.Text; } set { txtAppSubnetAddressPrefix.Text = value; } }
         public bool DeployDnsZones { get { return chkDeployDnsZones.Checked; } set { chkDeployDnsZones.Checked = value; } }
+        public bool AllowPublicAccess { get { return chkAllowPublicAccess.Checked; } set { chkAllowPublicAccess.Checked = value; } }
         public string HybridWorkerVmResourceId { get { return txtHybridWorkerVm.Text; } set { txtHybridWorkerVm.Text = value; } }
 
         public PrivateEndpointNames GetEndpointNames()

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppInsightsInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppInsightsInstallTask.cs
@@ -10,12 +10,14 @@ namespace CloudInstallEngine.Azure.InstallTasks
     {
         const string APP_INSIGHTS_RESOURCE_TYPE = "microsoft.insights/components";
 
-        private readonly bool _allowPublicAccess;
-
-        public AppInsightsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, string resourceGroupName, string subscriptionId, TokenCredential credential, bool allowPublicAccess = true)
+        // Note: Application Insights public network access is intentionally not toggled by the installer.
+        // Disabling public access on an App Insights component requires an Azure Monitor Private Link
+        // Scope (AMPLS) plus the corresponding private DNS zones, which can affect Azure Monitor
+        // connectivity for every VNet that resolves those zones. Customers that need a private
+        // App Insights component must configure AMPLS manually after install.
+        public AppInsightsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, string resourceGroupName, string subscriptionId, TokenCredential credential)
                     : base(config, logger, azureLocation, tags, resourceGroupName, subscriptionId, credential)
         {
-            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create Application Insights";
@@ -26,7 +28,6 @@ namespace CloudInstallEngine.Azure.InstallTasks
             base.EnsureContextArgType<LogWorkspaceInfo>(contextArg);
             var name = _config.GetNameConfigValue();
             var workspaceInfo = (LogWorkspaceInfo)contextArg;
-            var accessFlag = _allowPublicAccess ? "Enabled" : "Disabled";
 
             // Get or create from ARM template
             var createOrUpdateAppInsightsInfo = new
@@ -39,9 +40,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 {
                     value = workspaceInfo.AzureID
                 },
-                tagsArray = new { value = Tags },
-                publicNetworkAccessForIngestion = new { value = accessFlag },
-                publicNetworkAccessForQuery = new { value = accessFlag }
+                tagsArray = new { value = Tags }
             };
             var resourceCreateInfo = await base.GetOrCreateGenericAzResource(name, APP_INSIGHTS_RESOURCE_TYPE,
                 createOrUpdateAppInsightsInfo, Properties.Resources.AppInsightsArmTemplate);

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppInsightsInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppInsightsInstallTask.cs
@@ -10,10 +10,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
     {
         const string APP_INSIGHTS_RESOURCE_TYPE = "microsoft.insights/components";
 
+        private readonly bool _allowPublicAccess;
 
-        public AppInsightsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, string resourceGroupName, string subscriptionId, TokenCredential credential)
+        public AppInsightsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, string resourceGroupName, string subscriptionId, TokenCredential credential, bool allowPublicAccess = true)
                     : base(config, logger, azureLocation, tags, resourceGroupName, subscriptionId, credential)
         {
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create Application Insights";
@@ -24,6 +26,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             base.EnsureContextArgType<LogWorkspaceInfo>(contextArg);
             var name = _config.GetNameConfigValue();
             var workspaceInfo = (LogWorkspaceInfo)contextArg;
+            var accessFlag = _allowPublicAccess ? "Enabled" : "Disabled";
 
             // Get or create from ARM template
             var createOrUpdateAppInsightsInfo = new
@@ -36,7 +39,9 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 {
                     value = workspaceInfo.AzureID
                 },
-                tagsArray = new { value = Tags }
+                tagsArray = new { value = Tags },
+                publicNetworkAccessForIngestion = new { value = accessFlag },
+                publicNetworkAccessForQuery = new { value = accessFlag }
             };
             var resourceCreateInfo = await base.GetOrCreateGenericAzResource(name, APP_INSIGHTS_RESOURCE_TYPE,
                 createOrUpdateAppInsightsInfo, Properties.Resources.AppInsightsArmTemplate);

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -13,9 +13,11 @@ namespace CloudInstallEngine.Azure.InstallTasks
     public class AppServiceWebsiteTask : InstallTaskInAzResourceGroup<WebSiteResource>
     {
         public const string CONFIG_KEY_VNET_INTEGRATION_SUBNET_ID = "vnetIntegrationSubnetId";
+        private readonly bool _allowPublicAccess;
 
-        public AppServiceWebsiteTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
+        public AppServiceWebsiteTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create App Service website";
@@ -26,6 +28,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             base.EnsureContextArgType<AppServicePlanResource>(contextArg);
 
             var appServicePlan = (AppServicePlanResource)contextArg;
+            var desiredAccess = _allowPublicAccess ? "Enabled" : "Disabled";
 
             // Get/create app-service with plan
             var webApp = Container.GetWebSites().Where(s => s.Data.Name == _config.ResourceName).SingleOrDefault();
@@ -40,13 +43,13 @@ namespace CloudInstallEngine.Azure.InstallTasks
                         IsAlwaysOn = true,
                         FtpsState = AppServiceFtpsState.FtpsOnly,
                         MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2,
-                        PublicNetworkAccess = "Enabled"  // Explicit: adding a PE later auto-disables this otherwise
+                        PublicNetworkAccess = desiredAccess
                     },
                     Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.SystemAssigned)
                 };
 
                 base.EnsureTagsOnNew(newWebAppInfo.Tags);     // Add configured tags
-                _logger.LogInformation($"Creating App Service '{_config.ResourceName}' on plan '{appServicePlan.Data.Name}'...");
+                _logger.LogInformation($"Creating App Service '{_config.ResourceName}' on plan '{appServicePlan.Data.Name}' (public access: {(_allowPublicAccess ? "enabled" : "disabled")})...");
                 var newWebAppReq = await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newWebAppInfo);
                 webApp = newWebAppReq.Value;
             }
@@ -67,17 +70,21 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 var siteConfig = (await webApp.GetWebSiteConfig().GetAsync()).Value.Data;
                 var needsTlsUpdate = siteConfig.MinTlsVersion == null || !siteConfig.MinTlsVersion.Value.ToString().Equals(AppServiceSupportedTlsVersion.Tls1_2.ToString());
                 var needsAlwaysOnUpdate = siteConfig.IsAlwaysOn != true;
-                if (needsTlsUpdate || needsAlwaysOnUpdate)
+                var needsPublicAccessUpdate = !string.Equals(siteConfig.PublicNetworkAccess, desiredAccess, System.StringComparison.OrdinalIgnoreCase);
+                if (needsTlsUpdate || needsAlwaysOnUpdate || needsPublicAccessUpdate)
                 {
                     webAppUpdateInfo.SiteConfig = new SiteConfigProperties
                     {
                         MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2,
-                        IsAlwaysOn = true
+                        IsAlwaysOn = true,
+                        PublicNetworkAccess = desiredAccess
                     };
                     if (needsTlsUpdate)
                         _logger.LogInformation($"Updating App Service '{_config.ResourceName}' to enforce TLS 1.2...");
                     if (needsAlwaysOnUpdate)
                         _logger.LogInformation($"Updating App Service '{_config.ResourceName}' to enable Always On...");
+                    if (needsPublicAccessUpdate)
+                        _logger.LogInformation($"Updating App Service '{_config.ResourceName}' public network access to '{desiredAccess}'...");
                     needsUpdate = true;
                 }
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -20,8 +20,11 @@ namespace CloudInstallEngine.Azure.InstallTasks
     public class KeyVaultTask : InstallTaskInAzResourceGroup<KeyVaultResource>
     {
         public const string CONFIG_KEY_TENANT_ID = "tenantId";
-        public KeyVaultTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
+        private readonly bool _allowPublicAccess;
+
+        public KeyVaultTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create key vault";
@@ -45,9 +48,13 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             if (r == null)
             {
-                _logger.LogInformation($"Creating new key vault '{name}'...");
+                _logger.LogInformation($"Creating new key vault '{name}' (public access: {(_allowPublicAccess ? "enabled" : "disabled")})...");
 
-                var newKeyVaultInfo = new KeyVaultCreateOrUpdateContent(AzureLocation, new KeyVaultProperties(tenantId, new KeyVaultSku(KeyVaultSkuFamily.A, KeyVaultSkuName.Standard)));
+                var props = new KeyVaultProperties(tenantId, new KeyVaultSku(KeyVaultSkuFamily.A, KeyVaultSkuName.Standard))
+                {
+                    PublicNetworkAccess = _allowPublicAccess ? "Enabled" : "Disabled"
+                };
+                var newKeyVaultInfo = new KeyVaultCreateOrUpdateContent(AzureLocation, props);
                 EnsureTagsOnNew(newKeyVaultInfo.Tags);
 
                 var serverCreateResult = await Container.GetKeyVaults().CreateOrUpdateAsync(WaitUntil.Completed, name, newKeyVaultInfo);
@@ -56,6 +63,21 @@ namespace CloudInstallEngine.Azure.InstallTasks
             else
             {
                 _logger.LogInformation($"Found existing key vault '{r.Data.Name}'.");
+
+                var desiredAccess = _allowPublicAccess ? "Enabled" : "Disabled";
+                if (!string.Equals(r.Data.Properties.PublicNetworkAccess, desiredAccess, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogInformation($"Updating key vault '{r.Data.Name}' public network access to '{desiredAccess}'...");
+                    var props = new KeyVaultProperties(r.Data.Properties.TenantId, r.Data.Properties.Sku)
+                    {
+                        PublicNetworkAccess = desiredAccess
+                    };
+                    var update = new KeyVaultCreateOrUpdateContent(AzureLocation, props);
+                    EnsureTagsOnNew(update.Tags);
+                    var updateResult = await Container.GetKeyVaults().CreateOrUpdateAsync(WaitUntil.Completed, name, update);
+                    r = updateResult.Value;
+                }
+
                 await EnsureTagsOnExisting(r.Data.Tags, r.GetTagResource());
             }
             return r;

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/LogAnalyticsInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/LogAnalyticsInstallTask.cs
@@ -1,7 +1,6 @@
 ﻿using Azure;
 using Azure.Core;
 using Azure.ResourceManager.OperationalInsights;
-using Azure.ResourceManager.OperationalInsights.Models;
 using CloudInstallEngine.Models;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
@@ -12,11 +11,13 @@ namespace CloudInstallEngine.Azure.InstallTasks
 {
     public class LogAnalyticsInstallTask : InstallTaskInAzResourceGroup<LogWorkspaceInfo>
     {
-        private readonly bool _allowPublicAccess;
-
-        public LogAnalyticsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
+        // Note: Log Analytics public network access is intentionally not toggled by the installer.
+        // Disabling public access on a workspace requires an Azure Monitor Private Link Scope (AMPLS)
+        // plus the corresponding private DNS zones, which can affect Azure Monitor connectivity for
+        // every VNet that resolves those zones (potentially across unrelated workloads/subscriptions).
+        // Customers that need a private workspace must configure AMPLS manually after install.
+        public LogAnalyticsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
         {
-            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create Log Analytics workspace";
@@ -24,19 +25,14 @@ namespace CloudInstallEngine.Azure.InstallTasks
         public async override Task<LogWorkspaceInfo> ExecuteTaskReturnResult(object contextArg)
         {
             var name = base._config.GetNameConfigValue();
-            var desiredAccess = _allowPublicAccess ? OperationalInsightsPublicNetworkAccessType.Enabled : OperationalInsightsPublicNetworkAccessType.Disabled;
             var insightsLogs = Container.GetOperationalInsightsWorkspaces()
                             .Where(r => r.Data.Name == name).SingleOrDefault();
 
             if (insightsLogs == null)
             {
-                _logger.LogInformation($"Creating log-analytics {name} (public access: {(_allowPublicAccess ? "enabled" : "disabled")})...");
+                _logger.LogInformation($"Creating log-analytics {name}...");
 
-                var newWsInfo = new OperationalInsightsWorkspaceData(AzureLocation)
-                {
-                    PublicNetworkAccessForIngestion = desiredAccess,
-                    PublicNetworkAccessForQuery = desiredAccess
-                };
+                var newWsInfo = new OperationalInsightsWorkspaceData(AzureLocation);
 
                 base.EnsureTagsOnNew(newWsInfo.Tags);     // Add configured tags
                 var result = await Container.GetOperationalInsightsWorkspaces().CreateOrUpdateAsync(WaitUntil.Completed, name, newWsInfo);
@@ -47,31 +43,6 @@ namespace CloudInstallEngine.Azure.InstallTasks
             {
                 _logger.LogInformation($"Found existing log-analytics {name}");
                 await base.EnsureTagsOnExisting(insightsLogs.Data.Tags, insightsLogs.GetTagResource());
-
-                var needsUpdate = false;
-                var updateData = new OperationalInsightsWorkspaceData(AzureLocation)
-                {
-                    PublicNetworkAccessForIngestion = insightsLogs.Data.PublicNetworkAccessForIngestion,
-                    PublicNetworkAccessForQuery = insightsLogs.Data.PublicNetworkAccessForQuery
-                };
-
-                if (insightsLogs.Data.PublicNetworkAccessForIngestion == null || insightsLogs.Data.PublicNetworkAccessForIngestion.Value != desiredAccess)
-                {
-                    updateData.PublicNetworkAccessForIngestion = desiredAccess;
-                    needsUpdate = true;
-                }
-                if (insightsLogs.Data.PublicNetworkAccessForQuery == null || insightsLogs.Data.PublicNetworkAccessForQuery.Value != desiredAccess)
-                {
-                    updateData.PublicNetworkAccessForQuery = desiredAccess;
-                    needsUpdate = true;
-                }
-
-                if (needsUpdate)
-                {
-                    _logger.LogInformation($"Updating log-analytics {name} public network access to '{desiredAccess}'...");
-                    var result = await Container.GetOperationalInsightsWorkspaces().CreateOrUpdateAsync(WaitUntil.Completed, name, updateData);
-                    insightsLogs = result.Value;
-                }
             }
 
             return new LogWorkspaceInfo() { AzureID = insightsLogs.Id, WorkspaceID = insightsLogs.Data.CustomerId.ToString() };

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/LogAnalyticsInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/LogAnalyticsInstallTask.cs
@@ -1,6 +1,7 @@
 ﻿using Azure;
 using Azure.Core;
 using Azure.ResourceManager.OperationalInsights;
+using Azure.ResourceManager.OperationalInsights.Models;
 using CloudInstallEngine.Models;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
@@ -11,8 +12,11 @@ namespace CloudInstallEngine.Azure.InstallTasks
 {
     public class LogAnalyticsInstallTask : InstallTaskInAzResourceGroup<LogWorkspaceInfo>
     {
-        public LogAnalyticsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
+        private readonly bool _allowPublicAccess;
+
+        public LogAnalyticsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create Log Analytics workspace";
@@ -20,14 +24,19 @@ namespace CloudInstallEngine.Azure.InstallTasks
         public async override Task<LogWorkspaceInfo> ExecuteTaskReturnResult(object contextArg)
         {
             var name = base._config.GetNameConfigValue();
+            var desiredAccess = _allowPublicAccess ? OperationalInsightsPublicNetworkAccessType.Enabled : OperationalInsightsPublicNetworkAccessType.Disabled;
             var insightsLogs = Container.GetOperationalInsightsWorkspaces()
                             .Where(r => r.Data.Name == name).SingleOrDefault();
 
             if (insightsLogs == null)
             {
-                _logger.LogInformation($"Creating log-analytics {name}...");
+                _logger.LogInformation($"Creating log-analytics {name} (public access: {(_allowPublicAccess ? "enabled" : "disabled")})...");
 
-                var newWsInfo = new OperationalInsightsWorkspaceData(AzureLocation);
+                var newWsInfo = new OperationalInsightsWorkspaceData(AzureLocation)
+                {
+                    PublicNetworkAccessForIngestion = desiredAccess,
+                    PublicNetworkAccessForQuery = desiredAccess
+                };
 
                 base.EnsureTagsOnNew(newWsInfo.Tags);     // Add configured tags
                 var result = await Container.GetOperationalInsightsWorkspaces().CreateOrUpdateAsync(WaitUntil.Completed, name, newWsInfo);
@@ -38,6 +47,31 @@ namespace CloudInstallEngine.Azure.InstallTasks
             {
                 _logger.LogInformation($"Found existing log-analytics {name}");
                 await base.EnsureTagsOnExisting(insightsLogs.Data.Tags, insightsLogs.GetTagResource());
+
+                var needsUpdate = false;
+                var updateData = new OperationalInsightsWorkspaceData(AzureLocation)
+                {
+                    PublicNetworkAccessForIngestion = insightsLogs.Data.PublicNetworkAccessForIngestion,
+                    PublicNetworkAccessForQuery = insightsLogs.Data.PublicNetworkAccessForQuery
+                };
+
+                if (insightsLogs.Data.PublicNetworkAccessForIngestion == null || insightsLogs.Data.PublicNetworkAccessForIngestion.Value != desiredAccess)
+                {
+                    updateData.PublicNetworkAccessForIngestion = desiredAccess;
+                    needsUpdate = true;
+                }
+                if (insightsLogs.Data.PublicNetworkAccessForQuery == null || insightsLogs.Data.PublicNetworkAccessForQuery.Value != desiredAccess)
+                {
+                    updateData.PublicNetworkAccessForQuery = desiredAccess;
+                    needsUpdate = true;
+                }
+
+                if (needsUpdate)
+                {
+                    _logger.LogInformation($"Updating log-analytics {name} public network access to '{desiredAccess}'...");
+                    var result = await Container.GetOperationalInsightsWorkspaces().CreateOrUpdateAsync(WaitUntil.Completed, name, updateData);
+                    insightsLogs = result.Value;
+                }
             }
 
             return new LogWorkspaceInfo() { AzureID = insightsLogs.Id, WorkspaceID = insightsLogs.Data.CustomerId.ToString() };

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
@@ -12,10 +12,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
     public class RedisInstallTask : InstallTaskInAzResourceGroup<RedisResource>
     {
         private readonly bool _requireStandardSku;
+        private readonly bool _allowPublicAccess;
 
-        public RedisInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool requireStandardSku = false) : base(config, logger, azureLocation, tags)
+        public RedisInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool requireStandardSku = false, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
             _requireStandardSku = requireStandardSku;
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create redis cache";
@@ -25,6 +27,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             var name = base._config.GetNameConfigValue();
             var skuName = _requireStandardSku ? RedisSkuName.Standard : RedisSkuName.Basic;
             var skuFamily = RedisSkuFamily.BasicOrStandard;
+            var desiredAccess = _allowPublicAccess ? RedisPublicNetworkAccess.Enabled : RedisPublicNetworkAccess.Disabled;
 
             var allRedis = base.Container.GetAllRedis();
             RedisResource redisCache = allRedis.Where(c => c.Data.Name.ToLower() == name.ToLower()).SingleOrDefault();
@@ -32,11 +35,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
             if (redisCache == null)
             {
                 var skuLabel = _requireStandardSku ? "standard" : "basic";
-                _logger.LogInformation($"Creating new redis cache '{name}' at {skuLabel} SKU. This may take several minutes...");
+                _logger.LogInformation($"Creating new redis cache '{name}' at {skuLabel} SKU (public access: {(_allowPublicAccess ? "enabled" : "disabled")}). This may take several minutes...");
 
                 var newResourceData = new RedisCreateOrUpdateContent(AzureLocation, new RedisSku(skuName, skuFamily, 0))
                 {
-                    MinimumTlsVersion = RedisTlsVersion.Tls1_2
+                    MinimumTlsVersion = RedisTlsVersion.Tls1_2,
+                    PublicNetworkAccess = desiredAccess
                 };
                 base.EnsureTagsOnNew(newResourceData.Tags);
                 var operation = await allRedis.CreateOrUpdateAsync(WaitUntil.Completed, name, newResourceData);
@@ -61,15 +65,11 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     needsUpdate = true;
                 }
 
-                // Only enable public network access when not using VNet/private endpoints
-                if (!_requireStandardSku)
+                if (redisCache.Data.PublicNetworkAccess == null || redisCache.Data.PublicNetworkAccess.Value != desiredAccess)
                 {
-                    if (redisCache.Data.PublicNetworkAccess == null || redisCache.Data.PublicNetworkAccess.Value != RedisPublicNetworkAccess.Enabled)
-                    {
-                        _logger.LogInformation($"Enabling public network access on Redis cache '{name}' so firewall rules apply...");
-                        updateData.PublicNetworkAccess = RedisPublicNetworkAccess.Enabled;
-                        needsUpdate = true;
-                    }
+                    _logger.LogInformation($"Updating Redis cache '{name}' public network access to '{desiredAccess}'...");
+                    updateData.PublicNetworkAccess = desiredAccess;
+                    needsUpdate = true;
                 }
 
                 if (needsUpdate)

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
@@ -12,10 +12,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
     public class ServiceBusNamespaceInstallTask : InstallTaskInAzResourceGroup<ServiceBusNamespaceResource>
     {
         private readonly bool _requirePremiumSku;
+        private readonly bool _allowPublicAccess;
 
-        public ServiceBusNamespaceInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool requirePremiumSku = false) : base(config, logger, azureLocation, tags)
+        public ServiceBusNamespaceInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool requirePremiumSku = false, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
             _requirePremiumSku = requirePremiumSku;
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create Service-bus namespace";
@@ -24,16 +26,18 @@ namespace CloudInstallEngine.Azure.InstallTasks
         {
             var allNSs = Container.GetServiceBusNamespaces();
             var name = base._config.GetNameConfigValue();
+            var desiredAccess = _allowPublicAccess ? ServiceBusPublicNetworkAccess.Enabled : ServiceBusPublicNetworkAccess.Disabled;
 
             var sbNS = allNSs.Where(ns => ns.Data.Name.ToLower() == name.ToLower()).SingleOrDefault();
 
             if (sbNS == null)
             {
                 var skuLabel = _requirePremiumSku ? "premium" : "basic";
-                _logger.LogInformation($"Creating new service-bus namespace '{name}' at {skuLabel} SKU. This may take several minutes...");
+                _logger.LogInformation($"Creating new service-bus namespace '{name}' at {skuLabel} SKU (public access: {(_allowPublicAccess ? "enabled" : "disabled")}). This may take several minutes...");
 
                 var newResourceData = new ServiceBusNamespaceData(AzureLocation);
                 newResourceData.MinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls1_2;
+                newResourceData.PublicNetworkAccess = desiredAccess;
                 if (_requirePremiumSku)
                 {
                     newResourceData.Sku = new ServiceBusSku(ServiceBusSkuName.Premium);
@@ -51,17 +55,32 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 _logger.LogInformation($"Found existing service-bus namespace '{sbNS.Data.Name}'.");
                 await base.EnsureTagsOnExisting(sbNS.Data.Tags, sbNS.GetTagResource());
 
+                bool needsUpdate = false;
+                var updateData = new ServiceBusNamespaceData(sbNS.Data.Location);
+                if (sbNS.Data.Sku != null)
+                    updateData.Sku = sbNS.Data.Sku;
+                updateData.MinimumTlsVersion = sbNS.Data.MinimumTlsVersion;
+                updateData.PublicNetworkAccess = sbNS.Data.PublicNetworkAccess;
+
                 // Enforce TLS 1.2 minimum
                 if (sbNS.Data.MinimumTlsVersion == null || sbNS.Data.MinimumTlsVersion != ServiceBusMinimumTlsVersion.Tls1_2)
                 {
                     _logger.LogInformation($"Updating service-bus namespace '{sbNS.Data.Name}' to enforce TLS 1.2 minimum...");
-                    var updateData = new ServiceBusNamespaceData(sbNS.Data.Location);
                     updateData.MinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls1_2;
-                    if (sbNS.Data.Sku != null)
-                        updateData.Sku = sbNS.Data.Sku;
+                    needsUpdate = true;
+                }
+
+                if (sbNS.Data.PublicNetworkAccess == null || sbNS.Data.PublicNetworkAccess != desiredAccess)
+                {
+                    _logger.LogInformation($"Updating service-bus namespace '{sbNS.Data.Name}' public network access to '{desiredAccess}'...");
+                    updateData.PublicNetworkAccess = desiredAccess;
+                    needsUpdate = true;
+                }
+
+                if (needsUpdate)
+                {
                     var operation = await allNSs.CreateOrUpdateAsync(WaitUntil.Completed, name, updateData);
                     sbNS = operation.Value;
-                    _logger.LogInformation($"Updated service-bus namespace '{sbNS.Data.Name}' to TLS 1.2.");
                 }
 
                 // Upgrade to Premium if required for private endpoints and not already Premium

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
@@ -1,6 +1,7 @@
 ﻿using Azure;
 using Azure.Core;
 using Azure.ResourceManager.Sql;
+using Azure.ResourceManager.Sql.Models;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -11,8 +12,11 @@ namespace CloudInstallEngine.Azure.InstallTasks
     {
         public const string CONFIG_KEY_USERNAME = "username";
         public const string CONFIG_KEY_PASSWORD = "password";
-        public SqlServerTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
+        private readonly bool _allowPublicAccess;
+
+        public SqlServerTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create SQL Server";
@@ -22,6 +26,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             var serverName = base._config.GetNameConfigValue();
             var adminUsername = base._config.GetConfigValue(CONFIG_KEY_USERNAME);
             var adminPassword = base._config.GetConfigValue(CONFIG_KEY_PASSWORD);
+            var desiredAccess = _allowPublicAccess ? ServerNetworkAccessFlag.Enabled : ServerNetworkAccessFlag.Disabled;
 
             SqlServerResource sqlServer = null;
             foreach (var server in Container.GetSqlServers())
@@ -34,13 +39,14 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             if (sqlServer == null)
             {
-                _logger.LogInformation($"Creating new SQL Server '{serverName}'...");
+                _logger.LogInformation($"Creating new SQL Server '{serverName}' (public access: {(_allowPublicAccess ? "enabled" : "disabled")})...");
 
                 var sqlServerData = new SqlServerData(AzureLocation)
                 {
                     AdministratorLogin = adminUsername,
                     AdministratorLoginPassword = adminPassword,
-                    MinimalTlsVersion = "1.2"
+                    MinimalTlsVersion = "1.2",
+                    PublicNetworkAccess = desiredAccess
                 };
 
                 base.EnsureTagsOnNew(sqlServerData.Tags);
@@ -49,14 +55,26 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             else
             {
+                var needsUpdate = false;
+                var updateData = new SqlServerData(AzureLocation);
+
                 // Ensure minimum TLS version is 1.2
                 if (sqlServer.Data.MinimalTlsVersion == null || string.Compare(sqlServer.Data.MinimalTlsVersion, "1.2") < 0)
                 {
                     _logger.LogInformation($"Updating SQL Server '{serverName}' to enforce TLS 1.2...");
-                    var updateData = new SqlServerData(AzureLocation)
-                    {
-                        MinimalTlsVersion = "1.2"
-                    };
+                    updateData.MinimalTlsVersion = "1.2";
+                    needsUpdate = true;
+                }
+
+                if (sqlServer.Data.PublicNetworkAccess == null || sqlServer.Data.PublicNetworkAccess.Value != desiredAccess)
+                {
+                    _logger.LogInformation($"Updating SQL Server '{serverName}' public network access to '{desiredAccess}'...");
+                    updateData.PublicNetworkAccess = desiredAccess;
+                    needsUpdate = true;
+                }
+
+                if (needsUpdate)
+                {
                     await Container.GetSqlServers().CreateOrUpdateAsync(WaitUntil.Completed, serverName, updateData);
                 }
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/StorageAccountInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/StorageAccountInstallTask.cs
@@ -10,8 +10,11 @@ namespace CloudInstallEngine.Azure.InstallTasks
 {
     public class StorageAccountInstallTask : InstallTaskInAzResourceGroup<StorageAccountResource>
     {
-        public StorageAccountInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
+        private readonly bool _allowPublicAccess;
+
+        public StorageAccountInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create storage account";
@@ -35,24 +38,38 @@ namespace CloudInstallEngine.Azure.InstallTasks
             {
                 var newAccountInfo = new StorageAccountCreateOrUpdateContent(new StorageSku("Standard_LRS"), StorageKind.StorageV2, AzureLocation)
                 {
-                    MinimumTlsVersion = StorageMinimumTlsVersion.Tls1_2
+                    MinimumTlsVersion = StorageMinimumTlsVersion.Tls1_2,
+                    PublicNetworkAccess = _allowPublicAccess ? StoragePublicNetworkAccess.Enabled : StoragePublicNetworkAccess.Disabled
                 };
                 EnsureTagsOnNew(newAccountInfo.Tags);
                 var storageAccountReq = await Container.GetStorageAccounts().CreateOrUpdateAsync(WaitUntil.Completed, name, newAccountInfo);
                 storageAccount = storageAccountReq.Value;
 
-                _logger.LogInformation($"Created storage-account '{storageAccount.Data.Name}'");
+                _logger.LogInformation($"Created storage-account '{storageAccount.Data.Name}' (public access: {(_allowPublicAccess ? "enabled" : "disabled")}).");
             }
             else
             {
+                var patch = new StorageAccountPatch();
+                var needsPatch = false;
+
                 // Ensure minimum TLS version is 1.2
                 if (storageAccount.Data.MinimumTlsVersion == null || !storageAccount.Data.MinimumTlsVersion.Value.ToString().Equals(StorageMinimumTlsVersion.Tls1_2.ToString()))
                 {
                     _logger.LogInformation($"Updating storage account '{name}' to enforce TLS 1.2...");
-                    var patch = new StorageAccountPatch
-                    {
-                        MinimumTlsVersion = StorageMinimumTlsVersion.Tls1_2
-                    };
+                    patch.MinimumTlsVersion = StorageMinimumTlsVersion.Tls1_2;
+                    needsPatch = true;
+                }
+
+                var desiredAccess = _allowPublicAccess ? StoragePublicNetworkAccess.Enabled : StoragePublicNetworkAccess.Disabled;
+                if (storageAccount.Data.PublicNetworkAccess == null || storageAccount.Data.PublicNetworkAccess.Value != desiredAccess)
+                {
+                    _logger.LogInformation($"Updating storage account '{name}' public network access to '{desiredAccess}'...");
+                    patch.PublicNetworkAccess = desiredAccess;
+                    needsPatch = true;
+                }
+
+                if (needsPatch)
+                {
                     await storageAccount.UpdateAsync(patch);
                 }
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/TextAnalyticsInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/TextAnalyticsInstallTask.cs
@@ -12,8 +12,11 @@ namespace CloudInstallEngine.Azure.InstallTasks
 {
     public class TextAnalyticsInstallTask : InstallTaskInAzResourceGroup<CognitiveServicesInfo>
     {
-        public TextAnalyticsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
+        private readonly bool _allowPublicAccess;
+
+        public TextAnalyticsInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
+            _allowPublicAccess = allowPublicAccess;
         }
 
         public override string TaskName => "get/create Cognitive Services (text analytics)";
@@ -21,6 +24,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
         public async override Task<CognitiveServicesInfo> ExecuteTaskReturnResult(object contextArg)
         {
             var name = _config.GetNameConfigValue();
+            var desiredAccess = _allowPublicAccess ? ServiceAccountPublicNetworkAccess.Enabled : ServiceAccountPublicNetworkAccess.Disabled;
 
             var analytics = Container.GetCognitiveServicesAccounts().Where(s => s.Data.Name == name).SingleOrDefault();
 
@@ -33,7 +37,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     Kind = "TextAnalytics",
                     Properties = new CognitiveServicesAccountProperties
                     {
-                        CustomSubDomainName = name
+                        CustomSubDomainName = name,
+                        PublicNetworkAccess = desiredAccess
                     }
                 };
                 base.EnsureTagsOnNew(creationParams.Tags);
@@ -48,25 +53,41 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     throw new InstallException(ex.Message);
                 }
 
-                logMsg = $"Created new Cognitive Service application '{analytics.Data.Name}' at 'Standard' SKU.";
+                logMsg = $"Created new Cognitive Service application '{analytics.Data.Name}' at 'Standard' SKU (public access: {(_allowPublicAccess ? "enabled" : "disabled")}).";
             }
             else
             {
+                var needsUpdate = false;
+                var updateProps = new CognitiveServicesAccountProperties
+                {
+                    CustomSubDomainName = analytics.Data.Properties?.CustomSubDomainName ?? name,
+                    PublicNetworkAccess = analytics.Data.Properties?.PublicNetworkAccess
+                };
+
                 // Ensure custom subdomain is set (required for private endpoints)
                 if (string.IsNullOrEmpty(analytics.Data.Properties?.CustomSubDomainName))
+                {
+                    updateProps.CustomSubDomainName = name;
+                    needsUpdate = true;
+                }
+
+                if (analytics.Data.Properties?.PublicNetworkAccess == null || analytics.Data.Properties.PublicNetworkAccess.Value != desiredAccess)
+                {
+                    _logger.LogInformation($"Updating Cognitive Service '{name}' public network access to '{desiredAccess}'...");
+                    updateProps.PublicNetworkAccess = desiredAccess;
+                    needsUpdate = true;
+                }
+
+                if (needsUpdate)
                 {
                     var updateParams = new CognitiveServicesAccountData(AzureLocation)
                     {
                         Sku = analytics.Data.Sku,
                         Kind = analytics.Data.Kind,
-                        Properties = new CognitiveServicesAccountProperties
-                        {
-                            CustomSubDomainName = name
-                        }
+                        Properties = updateProps
                     };
                     var result = await Container.GetCognitiveServicesAccounts().CreateOrUpdateAsync(WaitUntil.Completed, name, updateParams);
                     analytics = result.Value;
-                    _logger.LogInformation($"Set custom subdomain '{name}' on existing Cognitive Service '{name}'.");
                 }
 
                 logMsg = $"Found existing Cognitive Service '{name}'";

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Resources/AppInsightsArmTemplate.json
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Resources/AppInsightsArmTemplate.json
@@ -19,14 +19,6 @@
     },
     "workspaceResourceId": {
       "type": "string"
-    },
-    "publicNetworkAccessForIngestion": {
-      "type": "string",
-      "defaultValue": "Enabled"
-    },
-    "publicNetworkAccessForQuery": {
-      "type": "string",
-      "defaultValue": "Enabled"
     }
   },
   "resources": [

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Resources/AppInsightsArmTemplate.json
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Resources/AppInsightsArmTemplate.json
@@ -19,6 +19,14 @@
     },
     "workspaceResourceId": {
       "type": "string"
+    },
+    "publicNetworkAccessForIngestion": {
+      "type": "string",
+      "defaultValue": "Enabled"
+    },
+    "publicNetworkAccessForQuery": {
+      "type": "string",
+      "defaultValue": "Enabled"
     }
   },
   "resources": [
@@ -34,7 +42,9 @@
         "Application_Type": "[parameters('type')]",
         "Flow_Type": "Redfield",
         "Request_Source": "[parameters('requestSource')]",
-        "WorkspaceResourceId": "[parameters('workspaceResourceId')]"
+        "WorkspaceResourceId": "[parameters('workspaceResourceId')]",
+        "publicNetworkAccessForIngestion": "[parameters('publicNetworkAccessForIngestion')]",
+        "publicNetworkAccessForQuery": "[parameters('publicNetworkAccessForQuery')]"
       }
     }
   ]

--- a/src/AnalyticsEngine/Common/Entities/Installer/BaseSolutionInstallConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Installer/BaseSolutionInstallConfig.cs
@@ -130,6 +130,15 @@ namespace Common.Entities.Installer
         public bool DeployDnsZones { get; set; } = true;
 
         /// <summary>
+        /// Whether to allow public network access on Azure PaaS resources created/updated by the installer.
+        /// Only honoured when <see cref="Enabled"/> is true (VNet integration enabled). When VNet is disabled,
+        /// resources are always created with public access enabled (legacy/default behaviour).
+        /// Some customers' Azure policies disallow creation of PaaS resources with public access, so this can
+        /// be turned off to require all data-plane access to flow over private endpoints.
+        /// </summary>
+        public bool AllowPublicAccess { get; set; } = true;
+
+        /// <summary>
         /// Custom private endpoint names. Leave empty/null to use auto-generated defaults (pe-{resourceName}-{suffix}).
         /// </summary>
         public PrivateEndpointNames CustomEndpointNames { get; set; } = new PrivateEndpointNames();


### PR DESCRIPTION
This pull request introduces a new installer option to control public network access on Azure PaaS resources when deploying with a Virtual Network (VNet). It adds a "Allow public network access" checkbox to the installer UI, threads this setting through the configuration and install tasks, and updates the provisioning logic to honor the user's selection for SQL, Storage, Key Vault, Redis, Service Bus, App Service, Automation, and Cognitive Services. Additional warnings are logged to inform users of the impact of disabling public access, and the UI is updated to help explain this option.

Key changes:

**Public Access Control for Azure PaaS Resources**

* Added a new `AllowPublicAccess` option to the installer UI (`NetworkingConfigControl`) and threaded this setting through the configuration and install pipeline, allowing users to disable public network access for supported Azure PaaS resources when VNet integration is enabled. [[1]](diffhunk://#diff-6126072fa558bc265eb5f9d1ddb3d3b23b2d34e31905fd41f4a8a6771415ffdcR49-R50) [[2]](diffhunk://#diff-6126072fa558bc265eb5f9d1ddb3d3b23b2d34e31905fd41f4a8a6771415ffdcR125-R126) [[3]](diffhunk://#diff-6126072fa558bc265eb5f9d1ddb3d3b23b2d34e31905fd41f4a8a6771415ffdcR263-R283) [[4]](diffhunk://#diff-6126072fa558bc265eb5f9d1ddb3d3b23b2d34e31905fd41f4a8a6771415ffdcL278-R303) [[5]](diffhunk://#diff-6126072fa558bc265eb5f9d1ddb3d3b23b2d34e31905fd41f4a8a6771415ffdcL425-R465) [[6]](diffhunk://#diff-c922668ff78eb8962b3d6c734f2e276698dbeb3a528fae374a3602b227b180adR125) [[7]](diffhunk://#diff-c922668ff78eb8962b3d6c734f2e276698dbeb3a528fae374a3602b227b180adR205) [[8]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12R57-R68)

* Updated the constructors for install tasks (`AppServiceWebsiteTask`, `SqlServerTask`, `RedisInstallTask`, `KeyVaultTask`, `ServiceBusNamespaceInstallTask`, `StorageAccountInstallTask`, `TextAnalyticsInstallTask`, `AutomationAccountTask`) to accept the `allowPublicAccess` parameter and apply it to resource creation. [[1]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12L107-R119) [[2]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12L116-R128) [[3]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12L126-R138) [[4]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12L153-R165) [[5]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12L184-R218) [[6]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12L205-R229) [[7]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12L219-R243) [[8]](diffhunk://#diff-24e8dfa199f7edd14d4dde0dfa90f049a2bf0119e165486c77c2eb34b201d256L27-R31)

**Automation Account Task Enhancements**

* Modified `AutomationAccountTask` to support updating the public network access setting on both new and existing Automation Accounts, with improved logging and error handling if the update fails. [[1]](diffhunk://#diff-24e8dfa199f7edd14d4dde0dfa90f049a2bf0119e165486c77c2eb34b201d256L41-R49) [[2]](diffhunk://#diff-24e8dfa199f7edd14d4dde0dfa90f049a2bf0119e165486c77c2eb34b201d256R66-R83)

**User Warnings and Documentation**

* Added installer warnings when public network access is disabled, explaining which steps may fail and how to resolve them, and clarifying that Log Analytics and Application Insights always remain public unless manually configured post-install. [[1]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12R57-R68) [[2]](diffhunk://#diff-3ef147d5585f10c799039716a307caee9e534c7015375356faecd2a15a15db12L184-R218)

These changes provide customers with greater control over their network security posture in Azure, while improving transparency and usability during installation.