### PR TITLE
Allow ReadHitsDaysBeforeToday to be configured via app settings / environment variable

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -52,6 +52,18 @@ namespace Common.Entities.Config
             int.TryParse(ConfigurationManager.AppSettings.Get("DaysBeforeNowToDownload"), out daysBeforeNowToDownload);
             this.DaysBeforeNowToDownload = daysBeforeNowToDownload;
 
+            // Optional: how many days before today to start reading hits from App Insights.
+            // Can be overridden via the -readHitsDaysBeforeToday command line argument.
+            var readHitsDaysBeforeTodayString = ConfigurationManager.AppSettings.Get("ReadHitsDaysBeforeToday");
+            if (!string.IsNullOrEmpty(readHitsDaysBeforeTodayString))
+            {
+                int readHitsDaysBeforeTodayInt;
+                if (int.TryParse(readHitsDaysBeforeTodayString, out readHitsDaysBeforeTodayInt) && readHitsDaysBeforeTodayInt > 0)
+                {
+                    this.ReadHitsDaysBeforeToday = readHitsDaysBeforeTodayInt;
+                }
+            }
+
             // Time chunk overlap in minutes to prevent missing events at boundaries
             int timeChunkOverlapMinutes = 5;
             int.TryParse(ConfigurationManager.AppSettings.Get("TimeChunkOverlapMinutes"), out timeChunkOverlapMinutes);
@@ -137,6 +149,13 @@ namespace Common.Entities.Config
         public string ContentTypesString { get; set; }
 
         public int DaysBeforeNowToDownload { get; set; }
+
+        /// <summary>
+        /// Optional: how many days before today to start reading hits from App Insights.
+        /// When set, overrides the default scan-from date logic in the App Insights importer.
+        /// The -readHitsDaysBeforeToday command line argument takes precedence over this value.
+        /// </summary>
+        public int? ReadHitsDaysBeforeToday { get; set; } = null;
 
         /// <summary>
         /// Number of minutes to overlap between time chunks to prevent missing events at boundaries.

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/Program.cs
@@ -63,6 +63,14 @@ namespace WebJob.AppInsightsImporter
 
             var telemetry = new AnalyticsLogger(config.AppInsightsConnectionString, "AppInsightsImporter");
 
+            // If no command line override was supplied, fall back to the config/app-setting value (if any).
+            // The command line argument takes precedence over the config value.
+            if (daysBeforeReadOverride == 0 && config.ReadHitsDaysBeforeToday.HasValue && config.ReadHitsDaysBeforeToday.Value > 0)
+            {
+                daysBeforeReadOverride = config.ReadHitsDaysBeforeToday.Value;
+                Console.WriteLine($"Using ReadHitsDaysBeforeToday='{daysBeforeReadOverride}' from app configuration.");
+            }
+
             bool validConfig = ValidateAndPrintConfig(config, telemetry);
             if (validConfig)
             {


### PR DESCRIPTION
The WebJob.AppInsightsImporter previously only accepted `-readHitsDaysBeforeToday <int>` as a command-line argument. This change adds a new optional `ReadHitsDaysBeforeToday` app setting (also surfaced from Azure App Service application settings / environment variables) so the value can be configured at the App Service environmental config level.

- Added `int? ReadHitsDaysBeforeToday` to `AppConfig`, populated from `ConfigurationManager.AppSettings[\"ReadHitsDaysBeforeToday\"]`.
- `Program.cs` falls back to the configured value only if the `-readHitsDaysBeforeToday` command-line arg was not supplied - the command-line argument continues to take precedence.
- The `debugSwitchDetected` flag remains tied only to the command-line switch, so configuring this via app settings will not change the looping/run-once behavior in release.