### PR TITLE
Make Azure Service Bus optional in installer

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -188,7 +188,14 @@ namespace App.ControlPanel.Engine
             connectionStrings.Properties.Add("AzureWebJobsDashboard", new ConnStringValueTypePair(storageInfo.StorageConnectionString, ConnectionStringType.Custom));
             connectionStrings.Properties.Add("AzureWebJobsStorage", new ConnStringValueTypePair(storageInfo.StorageConnectionString, ConnectionStringType.Custom));
             connectionStrings.Properties.Add("Storage", new ConnStringValueTypePair(storageInfo.StorageConnectionString, ConnectionStringType.Custom));
-            connectionStrings.Properties.Add("ServiceBus", new ConnStringValueTypePair(serviceBusConnectionString, ConnectionStringType.Custom));
+            if (!string.IsNullOrWhiteSpace(serviceBusConnectionString))
+            {
+                connectionStrings.Properties.Add("ServiceBus", new ConnStringValueTypePair(serviceBusConnectionString, ConnectionStringType.Custom));
+            }
+            else
+            {
+                _logger.LogInformation("Service Bus is disabled; skipping 'ServiceBus' connection-string on the App Service.");
+            }
             connectionStrings.Properties.Add("Redis", new ConnStringValueTypePair(redisConnectionString, ConnectionStringType.Custom));
 
             await webApp.UpdateAsync(new SitePatchInfo { SiteConfig = new SiteConfigProperties { Use32BitWorkerProcess = false, IsAlwaysOn = true } });

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -202,13 +202,21 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 new KeyVaultSecretAddTask(kvSecretAddConfig, logger));
 
             // ServiceBus - enforce Premium for VNet (private endpoints require Premium SKU)
-            const string QUEUE_NAME = "graphcalls";
-            const string RULE_NAME = "ListenAndSendPolicy";
-            _serviceBusNamespaceInstallTask = new ServiceBusNamespaceInstallTask(TaskConfig.GetConfigForName(config.ServiceBusName), logger, Location, tagDic, requirePremiumSku: vnetEnabled, allowPublicAccess: allowPublicAccess);
+            // Service Bus is only required by the Teams calls import; skip provisioning when disabled.
+            if (config.ServiceBusEnabled)
+            {
+                const string QUEUE_NAME = "graphcalls";
+                const string RULE_NAME = "ListenAndSendPolicy";
+                _serviceBusNamespaceInstallTask = new ServiceBusNamespaceInstallTask(TaskConfig.GetConfigForName(config.ServiceBusName), logger, Location, tagDic, requirePremiumSku: vnetEnabled, allowPublicAccess: allowPublicAccess);
 
-            var queueConfig = TaskConfig.GetConfigForName(QUEUE_NAME).AddSetting(ServiceBusQueueWithPolicyInstallTask.CONFIG_KEY_RULE_NAME, RULE_NAME);
-            _serviceBusQueueWithPolicyInstallTask = new ServiceBusQueueWithPolicyInstallTask(queueConfig, logger, Location);
-            this.AddTask(_serviceBusNamespaceInstallTask, _serviceBusQueueWithPolicyInstallTask);
+                var queueConfig = TaskConfig.GetConfigForName(QUEUE_NAME).AddSetting(ServiceBusQueueWithPolicyInstallTask.CONFIG_KEY_RULE_NAME, RULE_NAME);
+                _serviceBusQueueWithPolicyInstallTask = new ServiceBusQueueWithPolicyInstallTask(queueConfig, logger, Location);
+                this.AddTask(_serviceBusNamespaceInstallTask, _serviceBusQueueWithPolicyInstallTask);
+            }
+            else
+            {
+                logger.LogInformation("Service Bus is disabled in the installer configuration; skipping Service Bus namespace and queue provisioning. Teams call imports will not be available.");
+            }
 
             // Storage
             _storageAccountInstallTask = new StorageAccountInstallTask(TaskConfig.GetConfigForName(config.StorageAccountName), logger, Location, tagDic, allowPublicAccess);
@@ -319,10 +327,13 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 if (deployDns) AddPrivateDnsZoneTask("privatelink.vaultcore.azure.net", vnetId, kvPeName, logger, tagDic);
 
                 // Service Bus
-                var sbPeName = peNames.GetNameOrDefault(peNames.ServiceBus, $"pe-{config.ServiceBusName}-sb");
-                AddPrivateEndpointTask(sbPeName, $"/subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.ServiceBus/namespaces/{config.ServiceBusName}",
-                    "namespace", subnetId, logger, tagDic);
-                if (deployDns) AddPrivateDnsZoneTask("privatelink.servicebus.windows.net", vnetId, sbPeName, logger, tagDic);
+                if (config.ServiceBusEnabled)
+                {
+                    var sbPeName = peNames.GetNameOrDefault(peNames.ServiceBus, $"pe-{config.ServiceBusName}-sb");
+                    AddPrivateEndpointTask(sbPeName, $"/subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.ServiceBus/namespaces/{config.ServiceBusName}",
+                        "namespace", subnetId, logger, tagDic);
+                    if (deployDns) AddPrivateDnsZoneTask("privatelink.servicebus.windows.net", vnetId, sbPeName, logger, tagDic);
+                }
 
                 // Cognitive Services (Language/Text Analytics)
                 if (config.CognitiveServicesEnabled)
@@ -372,7 +383,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
         public StorageAccountResource Storage => GetTaskResult<StorageAccountResource>(_storageAccountInstallTask);
         public AppInsightsInfo AppInsights => GetTaskResult<AppInsightsInfo>(_appInsightsInstallTask);
         public CognitiveServicesInfo CognitiveServicesInfo => _cognitiveServicesInstallTask != null ? GetTaskResult<CognitiveServicesInfo>(_cognitiveServicesInstallTask) : new CognitiveServicesInfo();
-        public ServiceBusQueueResourceWithConnectionString SBQueueWithConnectionString => GetTaskResult<ServiceBusQueueResourceWithConnectionString>(_serviceBusQueueWithPolicyInstallTask);
+        public ServiceBusQueueResourceWithConnectionString SBQueueWithConnectionString => _serviceBusQueueWithPolicyInstallTask != null ? GetTaskResult<ServiceBusQueueResourceWithConnectionString>(_serviceBusQueueWithPolicyInstallTask) : null;
         public KeyVaultResource KeyVault => GetTaskResult<KeyVaultResource>(_keyVaultTask);
         public VirtualNetworkResource VNet => _vnetInstallTask != null ? GetTaskResult<VirtualNetworkResource>(_vnetInstallTask) : null;
         public string HybridWorkerGroupName => _hybridWorkerGroupName;

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/Config/SolutionInstallConfig.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/Config/SolutionInstallConfig.cs
@@ -106,6 +106,7 @@ namespace App.ControlPanel.Engine
             c.CognitiveServiceName = string.Empty;
             c.RedisName = string.Empty;
             c.CognitiveServicesEnabled = true;
+            c.ServiceBusEnabled = true;
             c.ServiceBusName = string.Empty;
             c.TasksConfig.InstallLatestSolutionContent = true;
             c.TasksConfig.UpgradeSchema = true;
@@ -358,22 +359,29 @@ namespace App.ControlPanel.Engine
             }
 
             // ServiceBus
-            if (string.IsNullOrWhiteSpace(this.ServiceBusName))
+            if (this.ServiceBusEnabled)
             {
-                errs.Add("Provide a service-bus name.");
-            }
-            else
-            {
-                bool isValidName = IsRegexExComplaint(this.ServiceBusName, @"^[-\w\._\(\)]+$", false);
-                if (!isValidName)
+                if (string.IsNullOrWhiteSpace(this.ServiceBusName))
                 {
-                    errs.Add("Enter valid service-bus name.");
+                    errs.Add("Provide a service-bus name.");
                 }
+                else
+                {
+                    bool isValidName = IsRegexExComplaint(this.ServiceBusName, @"^[-\w\._\(\)]+$", false);
+                    if (!isValidName)
+                    {
+                        errs.Add("Enter valid service-bus name.");
+                    }
 
-                if (this.ServiceBusName.Length > 50 || this.ServiceBusName.Length < 6)
-                {
-                    errs.Add("The service-bus name must be between 6 and 50 characters long.");
+                    if (this.ServiceBusName.Length > 50 || this.ServiceBusName.Length < 6)
+                    {
+                        errs.Add("The service-bus name must be between 6 and 50 characters long.");
+                    }
                 }
+            }
+            else if (SolutionConfig != null && SolutionConfig.ImportTaskSettings != null && SolutionConfig.ImportTaskSettings.Calls)
+            {
+                errs.Add("Teams calls import is enabled, but Service Bus is disabled. Either enable Service Bus or disable the calls import.");
             }
 
             // SQL

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
@@ -70,7 +70,7 @@ namespace App.ControlPanel.Engine
                     azureBackeEndCreationJob.Redis,
                     azureBackeEndCreationJob.CognitiveServicesInfo,
                     azureBackeEndCreationJob.KeyVault,
-                    azureBackeEndCreationJob.SBQueueWithConnectionString.ConnectionString, azureBackeEndCreationJob.Subscription
+                    azureBackeEndCreationJob.SBQueueWithConnectionString?.ConnectionString, azureBackeEndCreationJob.Subscription
                 );
 
                 // Warm-up app-service

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.Designer.cs
@@ -207,6 +207,7 @@
             this.azureStorageConfigControl1.Name = "azureStorageConfigControl1";
             this.azureStorageConfigControl1.RedisName = "";
             this.azureStorageConfigControl1.ServiceBusName = "";
+            this.azureStorageConfigControl1.ServiceBusEnabled = true;
             this.azureStorageConfigControl1.Size = new System.Drawing.Size(632, 537);
             this.azureStorageConfigControl1.SQLDb = "";
             this.azureStorageConfigControl1.SQLServerName = "";

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
@@ -94,6 +94,7 @@ namespace App.ControlPanel.Frames
                 SQLServerAdminUsername = azureStorageConfigControl1.SQLServerUsername,
                 SQLServerAdminPassword = azureStorageConfigControl1.SQLServerPassword,
                 ServiceBusName = azureStorageConfigControl1.ServiceBusName,
+                ServiceBusEnabled = azureStorageConfigControl1.ServiceBusEnabled,
                 RedisName = azureStorageConfigControl1.RedisName,
                 AllowTelemetry = installSolutionControl1.AllowTelemetry,
                 SolutionConfig = importJobSettingsSelection.Config,
@@ -181,6 +182,7 @@ namespace App.ControlPanel.Frames
             azureStorageConfigControl1.StorageAccount = config.StorageAccountName;
             azureStorageConfigControl1.RedisName = config.RedisName;
             azureStorageConfigControl1.ServiceBusName = config.ServiceBusName;
+            azureStorageConfigControl1.ServiceBusEnabled = config.ServiceBusEnabled;
 
             azurePaaSConfigControl1.AppInsightsName = config.AppInsightsName;
             azurePaaSConfigControl1.AppServicePlanName = config.AppServicePlanName;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
@@ -38,6 +38,7 @@
             this.lblGUIAzureHeaderServiceBus = new System.Windows.Forms.Label();
             this.txtServiceBusName = new System.Windows.Forms.TextBox();
             this.lblGUIAzureServiceBusName = new System.Windows.Forms.Label();
+            this.chkServiceBusEnabled = new System.Windows.Forms.CheckBox();
             this.lblGUIAzureHeaderSQL = new System.Windows.Forms.Label();
             this.txtSQLServerPassword = new System.Windows.Forms.TextBox();
             this.lblGUIAzureSQLPassword = new System.Windows.Forms.Label();
@@ -147,6 +148,19 @@
             this.lblGUIAzureServiceBusName.Size = new System.Drawing.Size(38, 13);
             this.lblGUIAzureServiceBusName.TabIndex = 168;
             this.lblGUIAzureServiceBusName.Text = "Name:";
+            // 
+            // chkServiceBusEnabled
+            // 
+            this.chkServiceBusEnabled.AutoSize = true;
+            this.chkServiceBusEnabled.Checked = true;
+            this.chkServiceBusEnabled.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkServiceBusEnabled.Location = new System.Drawing.Point(156, 219);
+            this.chkServiceBusEnabled.Name = "chkServiceBusEnabled";
+            this.chkServiceBusEnabled.Size = new System.Drawing.Size(186, 17);
+            this.chkServiceBusEnabled.TabIndex = 177;
+            this.chkServiceBusEnabled.Text = "Enable (required for Teams calls)";
+            this.chkServiceBusEnabled.UseVisualStyleBackColor = true;
+            this.chkServiceBusEnabled.CheckedChanged += new System.EventHandler(this.chkServiceBusEnabled_CheckedChanged);
             // 
             // lblGUIAzureHeaderSQL
             // 
@@ -334,6 +348,7 @@
             this.Controls.Add(this.lblGUIAzureStorageHeaderDesc);
             this.Controls.Add(this.lblGUIAzureStorageHeader);
             this.Controls.Add(this.lblGUIAzureHeaderServiceBus);
+            this.Controls.Add(this.chkServiceBusEnabled);
             this.Controls.Add(this.txtServiceBusName);
             this.Controls.Add(this.lblGUIAzureServiceBusName);
             this.Controls.Add(this.lblGUIAzureHeaderSQL);
@@ -377,6 +392,7 @@
         private System.Windows.Forms.Label lblGUIAzureHeaderServiceBus;
         private System.Windows.Forms.TextBox txtServiceBusName;
         private System.Windows.Forms.Label lblGUIAzureServiceBusName;
+        private System.Windows.Forms.CheckBox chkServiceBusEnabled;
         private System.Windows.Forms.Label lblGUIAzureHeaderSQL;
         private System.Windows.Forms.TextBox txtSQLServerPassword;
         private System.Windows.Forms.Label lblGUIAzureSQLPassword;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
@@ -154,7 +154,7 @@
             this.chkServiceBusEnabled.AutoSize = true;
             this.chkServiceBusEnabled.Checked = true;
             this.chkServiceBusEnabled.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkServiceBusEnabled.Location = new System.Drawing.Point(156, 219);
+            this.chkServiceBusEnabled.Location = new System.Drawing.Point(355, 240);
             this.chkServiceBusEnabled.Name = "chkServiceBusEnabled";
             this.chkServiceBusEnabled.Size = new System.Drawing.Size(186, 17);
             this.chkServiceBusEnabled.TabIndex = 177;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs
@@ -18,12 +18,26 @@ namespace App.ControlPanel.Frames.InstallWizard
         public string RedisName { get { return txtRedisName.Text; } set { txtRedisName.Text = value; } }
         public string ServiceBusName { get { return txtServiceBusName.Text; } set { txtServiceBusName.Text = value; } }
 
+        public bool ServiceBusEnabled
+        {
+            get { return chkServiceBusEnabled.Checked; }
+            set
+            {
+                chkServiceBusEnabled.Checked = value;
+                UpdateResponsiveUIControls();
+            }
+        }
+
         private void UpdateResponsiveUIControls()
         {
             lblStorageAccountURL.Text = $"https://{txtStorageAccount.Text}.blob.core.windows.net/";
             lblRedisName.Text = $"{txtRedisName.Text}.redis.cache.windows.net";
             lblServiceBusName.Text = $"{txtServiceBusName.Text}.servicebus.windows.net";
             lblSQLServerName.Text = $"{txtSQLServerName.Text}.database.windows.net";
+
+            // Disable SB name fields when Service Bus is disabled
+            txtServiceBusName.Enabled = chkServiceBusEnabled.Checked;
+            lblServiceBusName.Enabled = chkServiceBusEnabled.Checked;
         }
 
         private void txtStorageAccount_TextChanged(object sender, EventArgs e)
@@ -42,6 +56,11 @@ namespace App.ControlPanel.Frames.InstallWizard
         }
 
         private void txtSQLServerName_TextChanged(object sender, EventArgs e)
+        {
+            UpdateResponsiveUIControls();
+        }
+
+        private void chkServiceBusEnabled_CheckedChanged(object sender, EventArgs e)
         {
             UpdateResponsiveUIControls();
         }

--- a/src/AnalyticsEngine/Common/Entities/Config/AppConnectionStrings.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConnectionStrings.cs
@@ -59,14 +59,8 @@ namespace Common.Entities.Config
             this.RedisConnectionString = redisConnectionString?.ConnectionString;
 
             var sb = ConfigurationManager.ConnectionStrings["ServiceBus"];
-            if (sb == null)
-            {
-                throw new ConfigurationErrorsException("Missing ServiceBus connection string");
-            }
-            else
-            {
-                this.ServiceBusConnectionString = sb.ConnectionString;
-            }
+            // Service Bus is optional: only the Teams calls import needs it.
+            this.ServiceBusConnectionString = sb?.ConnectionString;
 
             var storageConfig = ConfigurationManager.ConnectionStrings["Storage"];
             if (storageConfig == null)

--- a/src/AnalyticsEngine/Common/Entities/Installer/BaseSolutionInstallConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Installer/BaseSolutionInstallConfig.cs
@@ -19,6 +19,7 @@ namespace Common.Entities.Installer
             this.SQLServerName = string.Empty;
             this.CognitiveServiceName = string.Empty;
             this.CognitiveServicesEnabled = true;
+            this.ServiceBusEnabled = true;
             this.AllowTelemetry = true;
 
             this.ConfigSchemaVersion = new Version(CONFIG_VERSION);
@@ -36,6 +37,12 @@ namespace Common.Entities.Installer
         public string AzureLocationName { get; set; } = null;
 
         public string ServiceBusName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whether to provision Azure Service Bus and configure related runtime connection strings.
+        /// Service Bus is only required by the Teams calls/call-records import.
+        /// </summary>
+        public bool ServiceBusEnabled { get; set; } = true;
 
         public string StorageAccountName { get; set; } = string.Empty;
 

--- a/src/AnalyticsEngine/Web/Controllers/CallRecordWebhookController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/CallRecordWebhookController.cs
@@ -47,6 +47,16 @@ namespace Web.AnalyticsWeb.Controllers
                 }
                 telemetry.LogInformation($"{nameof(CallRecordWebhookController)} invoked. {changes.Count} valid changes; {invalidChangeMsgs} invalid changes.");
 
+                // Service Bus is required to dispatch call notifications. If it's not configured, the calls feature is disabled.
+                if (string.IsNullOrWhiteSpace(config.ConnectionStrings.ServiceBusConnectionString))
+                {
+                    telemetry.LogError($"{nameof(CallRecordWebhookController)}: Service Bus is not configured. Teams call notifications cannot be processed. Enable Service Bus in the installer to use the Teams calls import.");
+                    return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    {
+                        Content = new StringContent("Service Bus is not configured on this deployment; Teams call notifications are disabled.", System.Text.Encoding.UTF8, "text/plain")
+                    };
+                }
+
                 // Create new SB client
                 var sbClient = new ServiceBusClient(config.ConnectionStrings.ServiceBusConnectionString);
                 var sbConnectionProps = ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString);

--- a/src/AnalyticsEngine/Web/Models/SystemStatus.cs
+++ b/src/AnalyticsEngine/Web/Models/SystemStatus.cs
@@ -99,7 +99,9 @@ namespace Web.AnalyticsWeb.Models
             status.WebAppConfigCognitive = config.CognitiveEndpoint;
             status.WebAppConfigRedis = StackExchange.Redis.ConfigurationOptions.Parse(config.ConnectionStrings.RedisConnectionString).SslHost;
             status.WebAppConfigSQL = new System.Data.SqlClient.SqlConnectionStringBuilder(config.ConnectionStrings.DatabaseConnectionString).DataSource;
-            status.WebAppConfigServiceBus = ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString).Endpoint.ToString();
+            status.WebAppConfigServiceBus = string.IsNullOrWhiteSpace(config.ConnectionStrings.ServiceBusConnectionString)
+                ? "(disabled)"
+                : ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString).Endpoint.ToString();
             status.CognitiveServiceEnabled = config.IsValidCognitiveConfig;
             status.WebAppBaseURL = config.WebAppURL;
             return status;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -178,14 +178,21 @@ namespace WebJob.Office365ActivityImporter
                 // Start listening for SB messages & register notifications web-hook with Graph 
                 if (webHookUrl != null && configuredSettings.ImportJobSettings.Calls)
                 {
-                    try
+                    if (string.IsNullOrWhiteSpace(configuredSettings.ConnectionStrings.ServiceBusConnectionString))
                     {
-                        await tasks.ProcessCallQueueAndWebhook(webHookUrl);
+                        telemetry.LogCritical("Teams calls import is enabled but Service Bus is not configured. Skipping Call Queue import & webhook validation. Re-run the installer with Service Bus enabled, or disable the Calls import.");
                     }
-                    catch (Exception ex)
+                    else
                     {
-                        telemetry.TrackException(ex);
-                        telemetry.LogCritical($"Got exception on {nameof(ProgramTasks.ProcessCallQueueAndWebhook)}: {ex.Message}");
+                        try
+                        {
+                            await tasks.ProcessCallQueueAndWebhook(webHookUrl);
+                        }
+                        catch (Exception ex)
+                        {
+                            telemetry.TrackException(ex);
+                            telemetry.LogCritical($"Got exception on {nameof(ProgramTasks.ProcessCallQueueAndWebhook)}: {ex.Message}");
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
## Summary

Makes **Azure Service Bus optional** in the installer, mirroring the existing pattern used for Cognitive Services.

Service Bus is only used by the **Teams calls** import (`CallQueueProcessor` + `CallRecordWebhookController`). All other imports (activity log, Graph users/usage/teams/apps, web traffic, Adoptify) are independent of Service Bus, so the installer can now skip it.

Without these changes, deleting Service Bus or removing the `ServiceBus` connection string would crash the entire webjob and website at startup (`AppConnectionStrings` threw a `ConfigurationErrorsException` if the connection string was missing) — not just the calls feature.

## Installer

- New `BaseSolutionInstallConfig.ServiceBusEnabled` flag (defaults to `true` for back-compat with existing saved configs).
- New **Enable (required for Teams calls)** checkbox on the Azure Storage wizard page, placed to the right of the Service Bus name field to match the Cognitive Services checkbox layout.
- Wired through `InstallSPOSitesControl.GetConfigFromGUI` / `ConfigureUI`.
- `SolutionInstallConfig.ValidatInputAndGetErrors` skips Service Bus name validation when disabled and **blocks the user from enabling the Calls import when Service Bus is off**.
- `AzurePaaSInstallJob` no longer registers the Service Bus namespace, queue, or private endpoint when disabled; `SBQueueWithConnectionString` returns `null`.
- `SolutionInstaller` and `ConfigureAzureComponentsTasks` no longer write the `ServiceBus` App Service connection string when disabled.

## Runtime hardening (so deleting Service Bus no longer kills everything)

- `AppConnectionStrings` no longer throws when the `ServiceBus` connection string is missing.
- `CallRecordWebhookController` returns `503 Service Unavailable` with a clear message when Service Bus isn't configured (instead of crashing on `ServiceBusConnectionStringProperties.Parse`).
- `WebJob.Program.cs` logs a critical message and skips the call queue/webhook when Service Bus is missing but `Calls` import is enabled.
- `SystemStatus` displays `(disabled)` instead of parsing a missing connection string.

## Files changed

- `Common/Entities/Installer/BaseSolutionInstallConfig.cs`
- `Common/Entities/Config/AppConnectionStrings.cs`
- `App.ControlPanel.Engine/Models/Config/SolutionInstallConfig.cs`
- `App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs`
- `App.ControlPanel.Engine/SolutionInstaller.cs`
- `App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs`
- `App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs` (+ Designer)
- `App.ControlPanel/Frames/InstallSPOSitesControl.cs` (+ Designer)
- `Web/Controllers/CallRecordWebhookController.cs`
- `Web/Models/SystemStatus.cs`
- `WebJob.Office365ActivityImporter/Program.cs`

## Test notes

- Solution builds clean.
- Existing saved install configs continue to work because `ServiceBusEnabled` defaults to `true`.
- New behavior verified by reasoning through the install paths and runtime startup paths; manual install testing recommended before release.
