### PR TITLE
Fix licence-count drift when users/delta token is persisted (#103)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserMetadataLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserMetadataLoader.cs
@@ -11,9 +11,9 @@ namespace Tests.UnitTests.FakeLoaderClasses
     /// </summary>
     public class FakeUserMetadataLoader : IUserMetadataLoader
     {
-        private readonly List<GraphUser> _fakeUsers;
-        private readonly IGraphServiceSubscribedSkusCollectionPage _fakeSkus;
-        private readonly Dictionary<Guid, List<Microsoft.Graph.User>> _fakeUsersBySku;
+        private List<GraphUser> _fakeUsers;
+        private IGraphServiceSubscribedSkusCollectionPage _fakeSkus;
+        private Dictionary<Guid, List<Microsoft.Graph.User>> _fakeUsersBySku;
         private readonly Dictionary<string, IUserLicenseDetailsCollectionPage> _fakeLicenseDetails;
         private readonly FakeDeltaValueProvider _deltaProvider;
 
@@ -29,6 +29,17 @@ namespace Tests.UnitTests.FakeLoaderClasses
         /// </summary>
         public string SimulatedNewDeltaToken { get; set; } = "fake-new-delta";
 
+        /// <summary>
+        /// When non-null AND the delta provider already has a token (i.e. this is
+        /// NOT the first run), LoadAllActiveUsers returns this list instead of the
+        /// full fake-user list. Mirrors the real Graph behaviour where /users/delta
+        /// only returns users whose tracked properties changed since the previous
+        /// delta token was issued. Used by the licence-drift regression test to
+        /// simulate a run where most of the tenant does not flow through the delta
+        /// even though their licence assignments in Graph have changed.
+        /// </summary>
+        public List<GraphUser> DeltaUsersOverride { get; set; }
+
         public FakeUserMetadataLoader(
             List<GraphUser> fakeUsers = null,
             IGraphServiceSubscribedSkusCollectionPage fakeSkus = null,
@@ -43,6 +54,22 @@ namespace Tests.UnitTests.FakeLoaderClasses
         }
 
         /// <summary>
+        /// Replaces the fake Graph state for a subsequent import run while keeping
+        /// the same loader (and therefore the same delta provider) so tests can
+        /// simulate persistent-delta-token scenarios such as a customer running
+        /// against Redis.
+        /// </summary>
+        public void SetFakeState(
+            List<GraphUser> fakeUsers,
+            IGraphServiceSubscribedSkusCollectionPage fakeSkus,
+            Dictionary<Guid, List<Microsoft.Graph.User>> fakeUsersBySku)
+        {
+            _fakeUsers = fakeUsers ?? new List<GraphUser>();
+            _fakeSkus = fakeSkus;
+            _fakeUsersBySku = fakeUsersBySku ?? new Dictionary<Guid, List<Microsoft.Graph.User>>();
+        }
+
+        /// <summary>
         /// Optional hook invoked by LoadUsersBySku before returning. Tests can
         /// set this to throw an exception, simulating a Graph error mid-import.
         /// </summary>
@@ -50,16 +77,26 @@ namespace Tests.UnitTests.FakeLoaderClasses
 
         public IDeltaValueProvider DeltaValueProvider => _deltaProvider;
 
-        public Task<List<GraphUser>> LoadAllActiveUsers()
+        public async Task<List<GraphUser>> LoadAllActiveUsers()
         {
             // Simulate GraphUserLoader behavior: buffer the new delta token in
             // memory; only CommitDeltaTokenAsync persists it.
             _pendingDeltaToken = SimulatedNewDeltaToken;
             _hasPendingDeltaToken = true;
 
+            // Simulate Graph delta behaviour: when a delta token is already
+            // persisted and the test has supplied a delta-only subset, return
+            // just that subset (mirrors the real /users/delta which only
+            // returns users whose tracked properties have changed).
+            var existingDelta = await _deltaProvider.GetDeltaToken();
+            if (!string.IsNullOrEmpty(existingDelta) && DeltaUsersOverride != null)
+            {
+                return new List<GraphUser>(DeltaUsersOverride);
+            }
+
             // Return a defensive copy so callers that Clear() the result
             // do not wipe the original list (InsertAndUpdateDatabaseFromExternalUsers does this).
-            return Task.FromResult(new List<GraphUser>(_fakeUsers));
+            return new List<GraphUser>(_fakeUsers);
         }
 
         public Task<IGraphServiceSubscribedSkusCollectionPage> LoadTenantSkus()

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterLicenseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterLicenseTests.cs
@@ -685,5 +685,154 @@ namespace Tests.UnitTests
             Assert.AreEqual(newDelta, persistedDelta,
                 "Delta token should be persisted after a successful import.");
         }
+
+        [TestMethod]
+        public async Task UserMetadataUpdater_LicenceRefreshSpansEntireDb_NotJustDeltaUsers()
+        {
+            // Regression test for the licence-count drift bug seen against tenants
+            // that persist the Graph users/delta token (e.g. Redis-backed deployments).
+            //
+            // Scenario reproduced:
+            //   Run 1: two users (A and B) exist in Graph, neither has a licence.
+            //          Both are inserted into the DB, delta token gets persisted.
+            //   Run 2: in Graph both users have just been assigned a licence, but
+            //          only user A also has a non-licence metadata change. The
+            //          Graph /users/delta response therefore returns ONLY user A.
+            //          LoadUsersBySku for the new SKU returns BOTH users.
+            //
+            // Bug (pre-fix): UserLicenseProcessor.ProcessSKUsForAllUsers was called
+            // with the delta-matched subset, so only user A got a licence row. User B
+            // - despite having the licence in Graph - was never written, exactly the
+            // pattern that produced the customer's ~1/4 licence counts.
+            //
+            // Fix: the licence refresh now spans the entire DB user population (all
+            // existing DB users plus newly inserted ones), so both A and B end up
+            // with the correct licence row.
+
+            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var config = new AppConfig();
+
+            var tick = DateTime.Now.Ticks;
+            var userAId = Guid.NewGuid().ToString();
+            var userBId = Guid.NewGuid().ToString();
+            var userAUpn = $"licencedriftA{tick}@test.com";
+            var userBUpn = $"licencedriftB{tick}@test.com";
+
+            var skuId = Guid.NewGuid();
+            var skuPartNumber = "ENTERPRISEPACK";
+            var licenseName = "Office 365 E3";
+
+            using (var cleanupDb = new AnalyticsEntitiesContext())
+            {
+                var existing = await cleanupDb.users
+                    .Include(u => u.LicenseLookups)
+                    .Where(u => u.UserPrincipalName == userAUpn || u.UserPrincipalName == userBUpn)
+                    .ToListAsync();
+                foreach (var u in existing)
+                {
+                    cleanupDb.UserLicenseTypeLookups.RemoveRange(u.LicenseLookups);
+                }
+                cleanupDb.users.RemoveRange(existing);
+                await cleanupDb.SaveChangesAsync();
+
+                var staleLicenseTypes = await cleanupDb.LicenseTypes
+                    .Where(l => l.Name == licenseName)
+                    .ToListAsync();
+                if (staleLicenseTypes.Any())
+                {
+                    cleanupDb.LicenseTypes.RemoveRange(staleLicenseTypes);
+                    await cleanupDb.SaveChangesAsync();
+                }
+            }
+
+            // -------- Run 1: insert both users, no licence assigned to either --------
+
+            var userAGraph = new GraphUser { UserPrincipalName = userAUpn, Id = userAId, AccountEnabled = true, Mail = userAUpn, JobTitle = "Engineer" };
+            var userBGraph = new GraphUser { UserPrincipalName = userBUpn, Id = userBId, AccountEnabled = true, Mail = userBUpn, JobTitle = "Engineer" };
+
+            var emptySkuPage = new GraphServiceSubscribedSkusCollectionPage();
+            var emptyUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>>();
+
+            // IMPORTANT: re-use the SAME loader instance across both runs so the
+            // FakeDeltaValueProvider keeps the token persisted by run 1 - this
+            // mirrors a Redis-backed deployment.
+            var fakeLoader = new FakeUserMetadataLoader(
+                new List<GraphUser> { userAGraph, userBGraph },
+                emptySkuPage,
+                emptyUsersBySku);
+            fakeLoader.SimulatedNewDeltaToken = $"delta-after-run-1-{tick}";
+
+            await new UserMetadataUpdater(telemetry, config, fakeLoader)
+                .InsertAndUpdateDatabaseFromExternalUsers();
+
+            using (var verifyDb = new AnalyticsEntitiesContext())
+            {
+                var a = await verifyDb.users.Include(u => u.LicenseLookups)
+                    .FirstOrDefaultAsync(u => u.UserPrincipalName == userAUpn);
+                var b = await verifyDb.users.Include(u => u.LicenseLookups)
+                    .FirstOrDefaultAsync(u => u.UserPrincipalName == userBUpn);
+                Assert.IsNotNull(a, "User A should be inserted in run 1.");
+                Assert.IsNotNull(b, "User B should be inserted in run 1.");
+                Assert.AreEqual(0, a.LicenseLookups.Count, "User A should have no licences after run 1.");
+                Assert.AreEqual(0, b.LicenseLookups.Count, "User B should have no licences after run 1.");
+            }
+
+            var persistedDeltaAfterRun1 = await fakeLoader.DeltaValueProvider.GetDeltaToken();
+            Assert.IsFalse(string.IsNullOrEmpty(persistedDeltaAfterRun1),
+                "Delta token must be persisted after run 1 so run 2 simulates the bugged scenario.");
+
+            // -------- Run 2: both users now have the SKU in Graph, but only user A
+            //                 surfaces in the delta response. --------
+
+            var sku = new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber };
+            var skuPage = new GraphServiceSubscribedSkusCollectionPage { sku };
+            var usersWithSku = new List<Microsoft.Graph.User>
+            {
+                new Microsoft.Graph.User { UserPrincipalName = userAUpn, Id = userAId },
+                new Microsoft.Graph.User { UserPrincipalName = userBUpn, Id = userBId }
+            };
+            var usersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>> { { skuId, usersWithSku } };
+
+            // Mutate fake state in place so the same loader/delta provider is reused.
+            fakeLoader.SetFakeState(
+                new List<GraphUser> { userAGraph, userBGraph },
+                skuPage,
+                usersBySku);
+
+            // Only user A has a non-licence metadata change, so the simulated
+            // /users/delta response returns ONLY user A.
+            userAGraph.JobTitle = "Senior Engineer";
+            fakeLoader.DeltaUsersOverride = new List<GraphUser> { userAGraph };
+            fakeLoader.SimulatedNewDeltaToken = $"delta-after-run-2-{tick}";
+
+            await new UserMetadataUpdater(telemetry, config, fakeLoader)
+                .InsertAndUpdateDatabaseFromExternalUsers();
+
+            // -------- Assert: BOTH users have the licence row, not just user A. --------
+
+            using (var verifyDb = new AnalyticsEntitiesContext())
+            {
+                var a = await verifyDb.users
+                    .Include(u => u.LicenseLookups.Select(l => l.License))
+                    .FirstOrDefaultAsync(u => u.UserPrincipalName == userAUpn);
+                var b = await verifyDb.users
+                    .Include(u => u.LicenseLookups.Select(l => l.License))
+                    .FirstOrDefaultAsync(u => u.UserPrincipalName == userBUpn);
+
+                Assert.IsNotNull(a, "User A should still exist after run 2.");
+                Assert.IsNotNull(b, "User B should still exist after run 2.");
+
+                Assert.AreEqual(1, a.LicenseLookups.Count,
+                    "User A (in delta) should have the new licence row.");
+                Assert.AreEqual(licenseName, a.LicenseLookups[0].License.Name);
+
+                Assert.AreEqual(1, b.LicenseLookups.Count,
+                    "REGRESSION: User B is not in the current Graph delta response but is reported by LoadUsersBySku. " +
+                    "Pre-fix, ProcessSKUsForAllUsers was scoped to delta users so user B never got a licence row even " +
+                    "though Graph said they had the SKU - this caused the customer's tenant-wide licence counts to " +
+                    "drift downward run after run. The fix scopes the licence refresh to the entire DB user population.");
+                Assert.AreEqual(licenseName, b.LicenseLookups[0].License.Name);
+            }
+        }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserLoader.cs
@@ -42,8 +42,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         {
             // Cache delta using tenant ID
             var usersQueryDelta = await _deltaValueProvider.GetDeltaToken();
+            // assignedLicenses / assignedPlans are added to $select as defence-in-depth
+            // so that a user whose ONLY change is a licence assignment will still be
+            // surfaced by /users/delta on subsequent runs. The primary correctness
+            // guarantee for licence counts now comes from UserMetadataUpdater /
+            // UserLicenseProcessor processing the full DB user population each run
+            // (not just delta users) - selecting these fields here is a belt-and-
+            // braces measure: without them, Graph would not flag a user as changed
+            // when only their licence assignments were updated, even though those
+            // are tracked properties on the underlying user object.
             var initialDeltaUrl = $"https://graph.microsoft.com:443/v1.0/users/delta" +
-                "?$select=id,accountEnabled,officeLocation,usageLocation,jobTitle,department,mail,userPrincipalName,manager,companyName,postalCode,country,state" +
+                "?$select=id,accountEnabled,officeLocation,usageLocation,jobTitle,department,mail,userPrincipalName,manager,companyName,postalCode,country,state,assignedLicenses,assignedPlans" +
                 "&$expand=manager";
             if (!string.IsNullOrEmpty(usersQueryDelta))
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -198,9 +198,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     }
                 }
 
-                // Clear the large list to free memory
-                allDbUsers.Clear();
-                allDbUsers = null;
+                // NOTE: we deliberately do NOT clear allDbUsers here yet when
+                // tenant-level SKUs are available. The licence refresh step below
+                // (ProcessSKUsForAllUsers) MUST iterate over the entire DB user
+                // population - not just the users returned by the current Graph
+                // delta - otherwise users whose only change in Graph is a licence
+                // assignment will never have their user_license_type_lookups
+                // rows refreshed. With a persisted delta token (e.g. Redis) this
+                // causes licence counts to drift downward run after run until
+                // they no longer match the tenant's actual licence assignments.
+                // When SKUs are not available the per-user path inside
+                // UpdateDbUserWithGraphData handles licences as part of the
+                // per-user Graph call, so we can free the list early in that
+                // branch to save memory.
+                if (skus == null)
+                {
+                    allDbUsers.Clear();
+                    allDbUsers = null;
+                }
 
                 // Update existing users.
                 // When tenant-level SKUs are available we can use the fast bulk-SQL
@@ -241,20 +256,50 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     throw;
                 }
 
-                // Combine inserted & modified db users for SKU processing
-                var allProcessedDbUsers = new List<Common.Entities.User>(insertedDbUsers.Count + notInsertedUpns.Count);
-                allProcessedDbUsers.AddRange(insertedDbUsers);
-
-                // Get existing (non-inserted) users that were updated
-                foreach (var graphUser in allActiveGraphUsers)
+                // Build the user list passed to ProcessSKUsForAllUsers.
+                //
+                // IMPORTANT: this MUST cover every user in the database, not just
+                // the users returned by the current Graph delta response. The
+                // licence refresh step deletes user_license_type_lookups rows
+                // for the supplied users and re-creates them from the per-SKU
+                // Graph queries; any user not in the supplied list keeps their
+                // stale rows forever and any new licence assignment for them is
+                // never written. When the delta token is persisted (Redis) the
+                // delta response shrinks to only users with metadata changes,
+                // so scoping the licence refresh to delta users causes the
+                // tenant-wide licence counts to drift downward over time.
+                //
+                // We build the list from allDbUsers (every existing DB user
+                // loaded at the start of this run) plus insertedDbUsers (users
+                // freshly created in this run), de-duplicated by primary key
+                // because AddSkuForUsers turns it into a UPN-keyed dictionary.
+                List<Common.Entities.User> allDbUsersForLicenseRefresh = null;
+                if (skus != null)
                 {
-                    var upn = graphUser.UserPrincipalName;
-                    if (!string.IsNullOrEmpty(upn) &&
-                        dbUsersByUpn.TryGetValue(upn, out var dbUser) &&
-                        !insertedUpnSet.Contains(upn.ToLower()))
+                    var combinedById = new Dictionary<int, Common.Entities.User>(
+                        (allDbUsers?.Count ?? 0) + insertedDbUsers.Count);
+
+                    if (allDbUsers != null)
                     {
-                        allProcessedDbUsers.Add(dbUser);
+                        foreach (var u in allDbUsers)
+                        {
+                            if (u.ID > 0)
+                            {
+                                combinedById[u.ID] = u;
+                            }
+                        }
                     }
+
+                    foreach (var u in insertedDbUsers)
+                    {
+                        if (u.ID > 0)
+                        {
+                            combinedById[u.ID] = u;
+                        }
+                    }
+
+                    allDbUsersForLicenseRefresh = new List<Common.Entities.User>(combinedById.Values);
+                    _telemetry.LogInformation($"User import - licence refresh will cover {allDbUsersForLicenseRefresh.Count.ToString("N0")} DB users (entire population, not just delta).");
                 }
 
                 // Can we update SKUs for users on batch (ie Organization.Read.All granted)?
@@ -263,7 +308,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     // No re-attach loop needed: AddSkuForUsers now uses FK IDs (UserId)
                     // instead of the User navigation property, so the entities do not
                     // need to be tracked by EF.
-                    await _licenseProcessor.ProcessSKUsForAllUsers(skus, allProcessedDbUsers, db);
+                    await _licenseProcessor.ProcessSKUsForAllUsers(skus, allDbUsersForLicenseRefresh, db);
                     _telemetry.LogInformation($"User import - updated user license information from {skus.Count.ToString("N0")} tenant SKUs");
 
                     db.ChangeTracker.DetectChanges();
@@ -285,7 +330,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 dbUsersByUpn.Clear();
                 dbUsersByAadId.Clear();
                 allActiveGraphUsers.Clear();
-                allProcessedDbUsers.Clear();
+                allDbUsersForLicenseRefresh?.Clear();
+                allDbUsers?.Clear();
             }
         }
 


### PR DESCRIPTION
Fixes #103.

## Root cause
`UserMetadataUpdater.InsertAndUpdateDatabaseFromExternalUsers` was passing the **delta-scoped** user list (`allProcessedDbUsers`) into `UserLicenseProcessor.ProcessSKUsForAllUsers`. That method DELETEs-then-re-INSERTs `user_license_type_lookups` rows scoped to the supplied list. On tenants that persist the Graph `users/delta` token (e.g. Redis-backed deployments), the supplied list shrinks to "users with metadata changes since the last run" — so users with a SKU but no other change in the current delta never had their licence row rewritten. Counts drift downward run after run.

Dev environments using the in-process delta provider didn't see this because every WebJob restart wiped the in-memory token and forced a full snapshot.

## Changes
- **`UserMetadataUpdater.cs`** — when SKUs are being processed, build `allDbUsersForLicenseRefresh` = `allDbUsers` ∪ `insertedDbUsers` (deduped by ID) and pass that to `ProcessSKUsForAllUsers`. The licence refresh now covers the whole tenant population, not just the delta slice.
- **`GraphUserLoader.cs`** — add `assignedLicenses,assignedPlans` to the users/delta `` as defence-in-depth so licence-only changes surface the user in the delta payload.
- **`FakeUserMetadataLoader.cs`** — add `SetFakeState(...)` and `DeltaUsersOverride` so tests can reuse the same loader (and therefore the same delta provider) across runs and simulate `users/delta` returning a subset on the follow-up run. This is the gap that hid the bug.
- **`UserMetadataUpdaterLicenseTests.cs`** — new regression test `UserMetadataUpdater_LicenceRefreshSpansEntireDb_NotJustDeltaUsers` reproduces the customer scenario (two users, only one in the simulated delta response on run 2, both reported by `LoadUsersBySku`) and asserts both get the licence row.

## Verification
- Solution builds clean.
- All 57 `UserMetadataUpdater` tests pass, including the new regression test and the existing perf tests on 1000 users.

## Customer mitigation until this ships
Clear the Redis key `UserDeltaCode-{tenantId}` once to force a full snapshot on the next import.
