### PR TITLE
Upgrade Microsoft.Graph SDK 4.x -> 6.1.0 (Kiota-based) + merge conflict resolution

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -298,7 +298,7 @@
       <Version>10.0.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>4.20.0</Version>
+      <Version>6.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel">
       <Version>7.0.0</Version>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -307,7 +307,7 @@
       <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>6.0.2</Version>
@@ -349,7 +349,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO.FileSystem.Primitives">
       <Version>4.3.0</Version>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -334,9 +334,12 @@ namespace App.ControlPanel.Engine
             _logger.LogInformation("Verifying Graph API for Teams...");
             try
             {
-                var groups = await graphClient.Groups.Request().Select("displayName,id,resourceProvisioningOptions").GetAsync();
+                var groups = await graphClient.Groups.GetAsync(rc =>
+                {
+                    rc.QueryParameters.Select = new[] { "displayName", "id", "resourceProvisioningOptions" };
+                });
                 bool channelsRead = false;
-                foreach (var group in groups)
+                foreach (var group in groups?.Value ?? new List<Microsoft.Graph.Models.Group>())
                 {
                     if (group.AdditionalData.ContainsKey("resourceProvisioningOptions"))
                     {
@@ -347,7 +350,7 @@ namespace App.ControlPanel.Engine
                             if (option.ToString().ToLower() == "team")
                             {
                                 // Load team
-                                var channels = await graphClient.Teams[group.Id].Channels.Request().GetAsync();
+                                var channels = await graphClient.Teams[group.Id].Channels.GetAsync();
                                 channelsRead = true;
                                 break;
                             }
@@ -356,7 +359,7 @@ namespace App.ControlPanel.Engine
                     if (channelsRead) break;
                 }
             }
-            catch (Microsoft.Graph.ServiceException ex)
+            catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)
             {
                 _logger.LogError($"ERROR: Got error trying to read Graph API for Teams import: '{ex.Message}'");
                 _logger.LogError("Important: ensure runtime account is correct and permissions are correctly configured to access Graph API.");
@@ -370,19 +373,20 @@ namespace App.ControlPanel.Engine
         {
             _logger.LogInformation("Verifying Graph API for user activity import...");
 
-            // WORKAROUND: for some reason, the default GraphClient call gives a Json exception. This workaround does the same call manually
-            var userActivityRequest = graphClient.Reports.GetTeamsUserActivityUserDetail("D7").Request();
-
-            var request = new HttpRequestMessage(HttpMethod.Get, userActivityRequest.RequestUrl);
-            await graphClient.AuthenticationProvider.AuthenticateRequestAsync(request);
-
+            // v5+: typed report endpoint returns the CSV report as a Stream directly, removing
+            // the need for the v4 manual HttpRequestMessage / HttpProvider workaround.
             try
             {
-                var response = await graphClient.HttpProvider.SendAsync(request);
-                response.EnsureSuccessStatusCode();
-
-                // Get the csv report data
-                var data = await response.Content.ReadAsStringAsync();
+                using (var stream = await graphClient.Reports.GetTeamsUserActivityUserDetailWithPeriod("'D7'").GetAsync())
+                {
+                    if (stream != null)
+                    {
+                        using (var reader = new StreamReader(stream))
+                        {
+                            var data = await reader.ReadToEndAsync();
+                        }
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/src/AnalyticsEngine/App.ControlPanel/App.ControlPanel.WinForms.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel/App.ControlPanel.WinForms.csproj
@@ -400,7 +400,7 @@
       <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Tokens">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>6.0.2</Version>

--- a/src/AnalyticsEngine/App.ControlPanel/App.Template.config
+++ b/src/AnalyticsEngine/App.ControlPanel/App.Template.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 
@@ -75,11 +75,47 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.20.0.0" newVersion="4.20.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -127,16 +163,16 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
 			</dependentAssembly>
 
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -144,7 +180,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -154,11 +190,11 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -216,7 +252,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/CloudInstallEngine.csproj
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/CloudInstallEngine.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 

--- a/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
+++ b/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 		<!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
@@ -68,7 +68,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -105,11 +105,47 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.20.0.0" newVersion="4.20.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -151,15 +187,15 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -167,7 +203,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -186,12 +222,12 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeControllers/FakeCallsController.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeControllers/FakeCallsController.cs
@@ -25,9 +25,9 @@ namespace Tests.UnitTests.FakeControllers
             var graphClient = new GraphServiceClient(_auth.Creds);
 
             // Get Adele user from Graph & insert blanks into DB 
-            var graphUsersFirstPage = await graphClient.Users.Request().GetAsync();
-            var user1 = graphUsersFirstPage[0];
-            var user2 = graphUsersFirstPage[1];
+            var graphUsersFirstPage = await graphClient.Users.GetAsync();
+            var user1 = graphUsersFirstPage.Value[0];
+            var user2 = graphUsersFirstPage.Value[1];
 
             var call = new CallRecordDTO()
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAggregateWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAggregateWeeklyUsageReportLoader.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserMetadataLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserMetadataLoader.cs
@@ -1,4 +1,5 @@
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -12,9 +13,9 @@ namespace Tests.UnitTests.FakeLoaderClasses
     public class FakeUserMetadataLoader : IUserMetadataLoader
     {
         private List<GraphUser> _fakeUsers;
-        private IGraphServiceSubscribedSkusCollectionPage _fakeSkus;
-        private Dictionary<Guid, List<Microsoft.Graph.User>> _fakeUsersBySku;
-        private readonly Dictionary<string, IUserLicenseDetailsCollectionPage> _fakeLicenseDetails;
+        private List<SubscribedSku> _fakeSkus;
+        private Dictionary<Guid, List<Microsoft.Graph.Models.User>> _fakeUsersBySku;
+        private readonly Dictionary<string, List<LicenseDetails>> _fakeLicenseDetails;
         private readonly FakeDeltaValueProvider _deltaProvider;
 
         // Mirrors GraphUserLoader's deferred-commit pattern so tests can verify
@@ -42,14 +43,14 @@ namespace Tests.UnitTests.FakeLoaderClasses
 
         public FakeUserMetadataLoader(
             List<GraphUser> fakeUsers = null,
-            IGraphServiceSubscribedSkusCollectionPage fakeSkus = null,
-            Dictionary<Guid, List<Microsoft.Graph.User>> fakeUsersBySku = null,
-            Dictionary<string, IUserLicenseDetailsCollectionPage> fakeLicenseDetails = null)
+            List<SubscribedSku> fakeSkus = null,
+            Dictionary<Guid, List<Microsoft.Graph.Models.User>> fakeUsersBySku = null,
+            Dictionary<string, List<LicenseDetails>> fakeLicenseDetails = null)
         {
             _fakeUsers = fakeUsers ?? new List<GraphUser>();
             _fakeSkus = fakeSkus;
-            _fakeUsersBySku = fakeUsersBySku ?? new Dictionary<Guid, List<Microsoft.Graph.User>>();
-            _fakeLicenseDetails = fakeLicenseDetails ?? new Dictionary<string, IUserLicenseDetailsCollectionPage>();
+            _fakeUsersBySku = fakeUsersBySku ?? new Dictionary<Guid, List<Microsoft.Graph.Models.User>>();
+            _fakeLicenseDetails = fakeLicenseDetails ?? new Dictionary<string, List<LicenseDetails>>();
             _deltaProvider = new FakeDeltaValueProvider();
         }
 
@@ -61,12 +62,12 @@ namespace Tests.UnitTests.FakeLoaderClasses
         /// </summary>
         public void SetFakeState(
             List<GraphUser> fakeUsers,
-            IGraphServiceSubscribedSkusCollectionPage fakeSkus,
-            Dictionary<Guid, List<Microsoft.Graph.User>> fakeUsersBySku)
+            List<SubscribedSku> fakeSkus,
+            Dictionary<Guid, List<Microsoft.Graph.Models.User>> fakeUsersBySku)
         {
             _fakeUsers = fakeUsers ?? new List<GraphUser>();
             _fakeSkus = fakeSkus;
-            _fakeUsersBySku = fakeUsersBySku ?? new Dictionary<Guid, List<Microsoft.Graph.User>>();
+            _fakeUsersBySku = fakeUsersBySku ?? new Dictionary<Guid, List<Microsoft.Graph.Models.User>>();
         }
 
         /// <summary>
@@ -99,12 +100,12 @@ namespace Tests.UnitTests.FakeLoaderClasses
             return new List<GraphUser>(_fakeUsers);
         }
 
-        public Task<IGraphServiceSubscribedSkusCollectionPage> LoadTenantSkus()
+        public Task<List<SubscribedSku>> LoadTenantSkus()
         {
             return Task.FromResult(_fakeSkus);
         }
 
-        public async Task<List<Microsoft.Graph.User>> LoadUsersBySku(Guid skuId)
+        public async Task<List<Microsoft.Graph.Models.User>> LoadUsersBySku(Guid skuId)
         {
             if (OnLoadUsersBySku != null)
             {
@@ -115,16 +116,16 @@ namespace Tests.UnitTests.FakeLoaderClasses
             {
                 return _fakeUsersBySku[skuId];
             }
-            return new List<Microsoft.Graph.User>();
+            return new List<Microsoft.Graph.Models.User>();
         }
 
-        public Task<IUserLicenseDetailsCollectionPage> LoadUserLicenseDetails(string userId)
+        public Task<List<LicenseDetails>> LoadUserLicenseDetails(string userId)
         {
             if (_fakeLicenseDetails.ContainsKey(userId))
             {
                 return Task.FromResult(_fakeLicenseDetails[userId]);
             }
-            return Task.FromResult<IUserLicenseDetailsCollectionPage>(null);
+            return Task.FromResult<List<LicenseDetails>>(null);
         }
 
         public async Task CommitDeltaTokenAsync()

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphImportTests.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus;
 using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
@@ -6,6 +6,7 @@ using Common.Entities.Models;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Microsoft.SharePoint.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -95,7 +96,7 @@ namespace Tests.UnitTests
                         new ChatMessageReaction { ReactionType = "Like", User = new ChatMessageReactionIdentitySet { User = user }, CreatedDateTime = DateTime.Now }
                     }
                 };
-                msgRoot.Replies = new ChatMessageRepliesCollectionPage {
+                msgRoot.Replies = new List<ChatMessage> {
                     new ChatMessage
                     {
                         Id = Guid.NewGuid().ToString(),

--- a/src/AnalyticsEngine/Tests.UnitTests/TeamsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/TeamsTests.cs
@@ -1,11 +1,13 @@
-﻿using Azure;
+using Azure;
 using Azure.AI.TextAnalytics;
 using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Graph.Teams;
 
@@ -38,7 +40,7 @@ namespace Tests.UnitTests
             msg.Body = new ItemBody();
             msg.Body.Content = "This is a test";
             msg.Body.ContentType = BodyType.Text;
-            msg.Replies = new ChatMessageRepliesCollectionPage() { new ChatMessage { Id = "Reply ", Body = new ItemBody { Content = "Fantastic work", ContentType = BodyType.Text } } };
+            msg.Replies = new List<ChatMessage>() { new ChatMessage { Id = "Reply ", Body = new ItemBody { Content = "Fantastic work", ContentType = BodyType.Text } } };
 
             var channel = new ChannelWithReactions();
             channel.Id = "Test";

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -315,7 +315,7 @@
       <Version>10.0.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>4.20.0</Version>
+      <Version>6.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel">
       <Version>7.0.0</Version>

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -300,7 +300,7 @@
       <Version>3.0.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.HashCode">
-      <Version>1.1.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Services.Client">
       <Version>5.8.5</Version>
@@ -324,7 +324,7 @@
       <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>6.0.2</Version>
@@ -357,7 +357,7 @@
       <Version>4.9.1</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Packaging">
       <Version>10.0.8</Version>

--- a/src/AnalyticsEngine/Tests.UnitTests/UserImportCaseSensitivityTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserImportCaseSensitivityTests.cs
@@ -2,6 +2,7 @@ using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -155,17 +156,17 @@ namespace Tests.UnitTests
                     Mail = graphUserUpn,
                 };
 
-                var skus = new GraphServiceSubscribedSkusCollectionPage
+                var skus = new List<SubscribedSku>
                 {
                     new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber }
                 };
 
                 // Note: SKU-member payload uses the OTHER casing
-                var usersWithSku = new List<Microsoft.Graph.User>
+                var usersWithSku = new List<Microsoft.Graph.Models.User>
                 {
-                    new Microsoft.Graph.User { UserPrincipalName = skuMemberUpn, Id = userId }
+                    new Microsoft.Graph.Models.User { UserPrincipalName = skuMemberUpn, Id = userId }
                 };
-                var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>>
+                var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>>
                 {
                     { skuId, usersWithSku }
                 };
@@ -242,16 +243,16 @@ namespace Tests.UnitTests
             try
             {
                 var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
-                var skus = new GraphServiceSubscribedSkusCollectionPage
+                var skus = new List<SubscribedSku>
                 {
                     new SubscribedSku { SkuId = sku1Id, SkuPartNumber = sku1Part },
                     new SubscribedSku { SkuId = sku2Id, SkuPartNumber = sku2Part },
                 };
-                var skuMember = new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId };
-                var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>>
+                var skuMember = new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId };
+                var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>>
                 {
-                    { sku1Id, new List<Microsoft.Graph.User> { skuMember } },
-                    { sku2Id, new List<Microsoft.Graph.User> { skuMember } },
+                    { sku1Id, new List<Microsoft.Graph.Models.User> { skuMember } },
+                    { sku2Id, new List<Microsoft.Graph.Models.User> { skuMember } },
                 };
 
                 var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);

--- a/src/AnalyticsEngine/Tests.UnitTests/UserImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserImportTests.cs
@@ -2,6 +2,7 @@ using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -124,8 +125,12 @@ namespace Tests.UnitTests
                 var graphClient = new GraphServiceClient(auth.Creds);
 
                 // Get Allan user from Graph & insert blanks into DB (needs license)
-                var graphUsers = await graphClient.Users.Request().Filter("startswith(mail,'AllanD')").Top(1).GetAsync();
-                var graphUser = graphUsers[0];
+                var graphUsers = await graphClient.Users.GetAsync(rc =>
+                {
+                    rc.QueryParameters.Filter = "startswith(mail,'AllanD')";
+                    rc.QueryParameters.Top = 1;
+                });
+                var graphUser = graphUsers.Value[0];
 
                 // Run updater; force full load
                 var telemetry = AnalyticsLogger.ConsoleOnlyTracer();

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterLicenseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterLicenseTests.cs
@@ -2,6 +2,7 @@ using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -62,9 +63,9 @@ namespace Tests.UnitTests
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
             var initialSku = new SubscribedSku { SkuId = initialSkuId, SkuPartNumber = initialSkuPartNumber };
-            var initialSkus = new GraphServiceSubscribedSkusCollectionPage { initialSku };
-            var usersWithInitialSku = new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId } };
-            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>> { { initialSkuId, usersWithInitialSku } };
+            var initialSkus = new List<SubscribedSku> { initialSku };
+            var usersWithInitialSku = new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId } };
+            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { initialSkuId, usersWithInitialSku } };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, initialSkus, fakeUsersBySku);
             var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
@@ -79,9 +80,9 @@ namespace Tests.UnitTests
             }
 
             var newSku = new SubscribedSku { SkuId = newSkuId, SkuPartNumber = newSkuPartNumber };
-            var updatedSkus = new GraphServiceSubscribedSkusCollectionPage { newSku };
-            var usersWithNewSku = new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId } };
-            var updatedFakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>> { { newSkuId, usersWithNewSku } };
+            var updatedSkus = new List<SubscribedSku> { newSku };
+            var usersWithNewSku = new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId } };
+            var updatedFakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { newSkuId, usersWithNewSku } };
 
             var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, updatedSkus, updatedFakeUsersBySku);
             var updaterWithNewLicense = new UserMetadataUpdater(telemetry, config, updatedFakeLoader);
@@ -124,9 +125,9 @@ namespace Tests.UnitTests
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
             var sku = new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber };
-            var skus = new GraphServiceSubscribedSkusCollectionPage { sku };
-            var usersWithSku = new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId } };
-            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>> { { skuId, usersWithSku } };
+            var skus = new List<SubscribedSku> { sku };
+            var usersWithSku = new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId } };
+            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { skuId, usersWithSku } };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
             var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
@@ -138,8 +139,8 @@ namespace Tests.UnitTests
                 Assert.AreEqual(1, dbUser.LicenseLookups.Count);
             }
 
-            var emptySkus = new GraphServiceSubscribedSkusCollectionPage();
-            var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, emptySkus, new Dictionary<Guid, List<Microsoft.Graph.User>>());
+            var emptySkus = new List<SubscribedSku>();
+            var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, emptySkus, new Dictionary<Guid, List<Microsoft.Graph.Models.User>>());
             var updaterNoLicenses = new UserMetadataUpdater(telemetry, config, updatedFakeLoader);
             await updaterNoLicenses.InsertAndUpdateDatabaseFromExternalUsers();
 
@@ -170,9 +171,9 @@ namespace Tests.UnitTests
             }
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
-            var skus = new GraphServiceSubscribedSkusCollectionPage { new SubscribedSku { SkuId = sku1Id, SkuPartNumber = sku1PartNumber }, new SubscribedSku { SkuId = sku2Id, SkuPartNumber = sku2PartNumber } };
-            var graphUserObject = new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId };
-            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>> { { sku1Id, new List<Microsoft.Graph.User> { graphUserObject } }, { sku2Id, new List<Microsoft.Graph.User> { graphUserObject } } };
+            var skus = new List<SubscribedSku> { new SubscribedSku { SkuId = sku1Id, SkuPartNumber = sku1PartNumber }, new SubscribedSku { SkuId = sku2Id, SkuPartNumber = sku2PartNumber } };
+            var graphUserObject = new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId };
+            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { sku1Id, new List<Microsoft.Graph.Models.User> { graphUserObject } }, { sku2Id, new List<Microsoft.Graph.Models.User> { graphUserObject } } };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
             var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
@@ -215,11 +216,11 @@ namespace Tests.UnitTests
                 new GraphUser { UserPrincipalName = user3Upn, Id = user3Id, AccountEnabled = true, Mail = user3Upn }
             };
 
-            var skus = new GraphServiceSubscribedSkusCollectionPage { new SubscribedSku { SkuId = sku1Id, SkuPartNumber = sku1PartNumber }, new SubscribedSku { SkuId = sku2Id, SkuPartNumber = sku2PartNumber } };
-            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>>
+            var skus = new List<SubscribedSku> { new SubscribedSku { SkuId = sku1Id, SkuPartNumber = sku1PartNumber }, new SubscribedSku { SkuId = sku2Id, SkuPartNumber = sku2PartNumber } };
+            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>>
             {
-                { sku1Id, new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = user1Upn, Id = user1Id }, new Microsoft.Graph.User { UserPrincipalName = user3Upn, Id = user3Id } } },
-                { sku2Id, new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = user2Upn, Id = user2Id }, new Microsoft.Graph.User { UserPrincipalName = user3Upn, Id = user3Id } } }
+                { sku1Id, new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = user1Upn, Id = user1Id }, new Microsoft.Graph.Models.User { UserPrincipalName = user3Upn, Id = user3Id } } },
+                { sku2Id, new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = user2Upn, Id = user2Id }, new Microsoft.Graph.Models.User { UserPrincipalName = user3Upn, Id = user3Id } } }
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers, skus, fakeUsersBySku);
@@ -258,8 +259,8 @@ namespace Tests.UnitTests
             }
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
-            var skus = new GraphServiceSubscribedSkusCollectionPage { new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber } };
-            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>> { { skuId, new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId } } } };
+            var skus = new List<SubscribedSku> { new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber } };
+            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { skuId, new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId } } } };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
             var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
@@ -271,8 +272,8 @@ namespace Tests.UnitTests
                 Assert.IsNotNull(licenseType); licenseTypeId = licenseType.ID;
             }
 
-            var emptySkus = new GraphServiceSubscribedSkusCollectionPage();
-            var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, emptySkus, new Dictionary<Guid, List<Microsoft.Graph.User>>());
+            var emptySkus = new List<SubscribedSku>();
+            var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, emptySkus, new Dictionary<Guid, List<Microsoft.Graph.Models.User>>());
             var updaterNoLicenses = new UserMetadataUpdater(telemetry, config, updatedFakeLoader);
             await updaterNoLicenses.InsertAndUpdateDatabaseFromExternalUsers();
 
@@ -353,15 +354,15 @@ namespace Tests.UnitTests
             }
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
-            var skus = new GraphServiceSubscribedSkusCollectionPage
+            var skus = new List<SubscribedSku>
             {
                 new SubscribedSku { SkuId = sku1Id, SkuPartNumber = sku1PartNumber },
                 new SubscribedSku { SkuId = sku2Id, SkuPartNumber = sku2PartNumber }
             };
-            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>>
+            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>>
             {
-                { sku1Id, new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId } } },
-                { sku2Id, new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId } } }
+                { sku1Id, new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId } } },
+                { sku2Id, new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId } } }
             };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
@@ -424,17 +425,17 @@ namespace Tests.UnitTests
             }
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
-            var skus = new GraphServiceSubscribedSkusCollectionPage { new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber } };
+            var skus = new List<SubscribedSku> { new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber } };
 
             // Simulate the Graph quirk: same user returned twice for one SKU.
-            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>>
+            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>>
             {
                 {
                     skuId,
-                    new List<Microsoft.Graph.User>
+                    new List<Microsoft.Graph.Models.User>
                     {
-                        new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId },
-                        new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId }
+                        new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId },
+                        new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId }
                     }
                 }
             };
@@ -493,14 +494,14 @@ namespace Tests.UnitTests
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
 
             // Same SKU listed twice in the subscribed-SKUs response.
-            var skus = new GraphServiceSubscribedSkusCollectionPage
+            var skus = new List<SubscribedSku>
             {
                 new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber },
                 new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber }
             };
-            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>>
+            var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>>
             {
-                { skuId, new List<Microsoft.Graph.User> { new Microsoft.Graph.User { UserPrincipalName = userUpn, Id = userId } } }
+                { skuId, new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId } } }
             };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
@@ -554,14 +555,14 @@ namespace Tests.UnitTests
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
 
-            // Build a fake IUserLicenseDetailsCollectionPage with two SKU part
+            // Build a fake List<LicenseDetails> with two SKU part
             // numbers that both resolve to the same display name.
-            var licenseDetailsPage = new UserLicenseDetailsCollectionPage
+            var licenseDetailsPage = new List<LicenseDetails>
             {
                 new LicenseDetails { SkuId = Guid.NewGuid(), SkuPartNumber = "RIGHTSMANAGEMENT" },
                 new LicenseDetails { SkuId = Guid.NewGuid(), SkuPartNumber = "RIGHTSMANAGEMENT_CE" }
             };
-            var fakeLicenseDetails = new Dictionary<string, IUserLicenseDetailsCollectionPage>
+            var fakeLicenseDetails = new Dictionary<string, List<LicenseDetails>>
             {
                 { userId, licenseDetailsPage }
             };
@@ -623,8 +624,8 @@ namespace Tests.UnitTests
             }
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
-            var skus = new GraphServiceSubscribedSkusCollectionPage { new SubscribedSku { SkuId = skuId, SkuPartNumber = "ENTERPRISEPACK" } };
-            var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, new Dictionary<Guid, List<Microsoft.Graph.User>>());
+            var skus = new List<SubscribedSku> { new SubscribedSku { SkuId = skuId, SkuPartNumber = "ENTERPRISEPACK" } };
+            var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, new Dictionary<Guid, List<Microsoft.Graph.Models.User>>());
 
             // Seed the delta provider with an existing token, then arrange for the
             // import to throw before CommitDeltaTokenAsync would be called.
@@ -750,8 +751,8 @@ namespace Tests.UnitTests
             var userAGraph = new GraphUser { UserPrincipalName = userAUpn, Id = userAId, AccountEnabled = true, Mail = userAUpn, JobTitle = "Engineer" };
             var userBGraph = new GraphUser { UserPrincipalName = userBUpn, Id = userBId, AccountEnabled = true, Mail = userBUpn, JobTitle = "Engineer" };
 
-            var emptySkuPage = new GraphServiceSubscribedSkusCollectionPage();
-            var emptyUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>>();
+            var emptySkuPage = new List<SubscribedSku>();
+            var emptyUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>>();
 
             // IMPORTANT: re-use the SAME loader instance across both runs so the
             // FakeDeltaValueProvider keeps the token persisted by run 1 - this
@@ -785,13 +786,13 @@ namespace Tests.UnitTests
             //                 surfaces in the delta response. --------
 
             var sku = new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber };
-            var skuPage = new GraphServiceSubscribedSkusCollectionPage { sku };
-            var usersWithSku = new List<Microsoft.Graph.User>
+            var skuPage = new List<SubscribedSku> { sku };
+            var usersWithSku = new List<Microsoft.Graph.Models.User>
             {
-                new Microsoft.Graph.User { UserPrincipalName = userAUpn, Id = userAId },
-                new Microsoft.Graph.User { UserPrincipalName = userBUpn, Id = userBId }
+                new Microsoft.Graph.Models.User { UserPrincipalName = userAUpn, Id = userAId },
+                new Microsoft.Graph.Models.User { UserPrincipalName = userBUpn, Id = userBId }
             };
-            var usersBySku = new Dictionary<Guid, List<Microsoft.Graph.User>> { { skuId, usersWithSku } };
+            var usersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { skuId, usersWithSku } };
 
             // Mutate fake state in place so the same loader/delta provider is reused.
             fakeLoader.SetFakeState(

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterPerformanceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterPerformanceTests.cs
@@ -2,6 +2,7 @@ using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -42,7 +43,7 @@ namespace Tests.UnitTests
             var graphUsers = GenerateGraphUsers(USER_COUNT, testPrefix);
 
             // Use non-null (empty) SKUs so the bulk update path is exercised
-            var fakeSkus = new GraphServiceSubscribedSkusCollectionPage();
+            var fakeSkus = new List<SubscribedSku>();
 
             try
             {

--- a/src/AnalyticsEngine/Web/Controllers/CallRecordWebhookController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/CallRecordWebhookController.cs
@@ -81,7 +81,7 @@ namespace Web.AnalyticsWeb.Controllers
             {
                 telemetry.LogInformation($"{nameof(CallRecordWebhookController)} invoked with invalid body.");
                 var errResponse = new HttpResponseMessage(HttpStatusCode.BadRequest);
-                errResponse.Content = new StringContent($"Could not find {nameof(ChangeNotificationCollection)} in body",
+                errResponse.Content = new StringContent($"Could not find {nameof(GraphChangeNotificationList)} in body",
                     System.Text.Encoding.UTF8, "text/plain");
                 return errResponse;
             }

--- a/src/AnalyticsEngine/Web/Web.Template.config
+++ b/src/AnalyticsEngine/Web/Web.Template.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=169433
@@ -49,7 +49,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -68,7 +68,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -96,7 +96,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -115,7 +115,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -143,7 +143,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -162,7 +162,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -189,7 +189,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -208,7 +208,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -235,7 +235,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -254,7 +254,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -281,7 +281,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -300,7 +300,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -327,7 +327,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -346,7 +346,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -373,7 +373,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -392,7 +392,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -419,7 +419,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -438,7 +438,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -465,7 +465,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -484,7 +484,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -511,7 +511,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -530,7 +530,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -557,7 +557,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -576,7 +576,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -603,7 +603,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -622,7 +622,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -649,7 +649,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -668,7 +668,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -695,7 +695,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -714,7 +714,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -741,7 +741,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -760,7 +760,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -787,7 +787,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -806,7 +806,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -833,7 +833,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -852,7 +852,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -879,7 +879,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -898,7 +898,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -925,7 +925,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -944,7 +944,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -971,7 +971,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -990,7 +990,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1017,7 +1017,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1036,7 +1036,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1063,7 +1063,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1082,7 +1082,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1094,7 +1094,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-4.20.0.0" newVersion="4.20.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
 			</dependentAssembly>
 		
 			<dependentAssembly>
@@ -1109,7 +1109,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1128,7 +1128,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1140,7 +1140,43 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph.Core" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Form" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Json" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Text" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Bcl.HashCode" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http.WinHttpHandler" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
 		
 			<dependentAssembly>
@@ -1155,7 +1191,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1174,7 +1210,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1201,7 +1237,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1220,7 +1256,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1247,7 +1283,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1266,7 +1302,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1278,7 +1314,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 		
 			<dependentAssembly>
@@ -1293,7 +1329,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1312,7 +1348,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1324,7 +1360,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 		
 			<dependentAssembly>
@@ -1339,7 +1375,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1358,7 +1394,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1370,7 +1406,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 		
 			<dependentAssembly>
@@ -1385,7 +1421,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1404,7 +1440,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1416,7 +1452,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 		
 			<dependentAssembly>
@@ -1431,7 +1467,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1450,7 +1486,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1477,7 +1513,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1496,7 +1532,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1523,7 +1559,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1542,7 +1578,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1569,7 +1605,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1588,7 +1624,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1600,7 +1636,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 		
 			<dependentAssembly>
@@ -1615,7 +1651,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1634,7 +1670,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1661,7 +1697,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1680,7 +1716,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1707,7 +1743,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1726,7 +1762,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1753,7 +1789,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1772,7 +1808,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1799,7 +1835,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1818,7 +1854,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1845,7 +1881,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1864,7 +1900,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1891,7 +1927,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1910,7 +1946,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1937,7 +1973,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -1956,7 +1992,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -1983,7 +2019,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -2002,7 +2038,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -2029,7 +2065,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -2048,7 +2084,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -2076,7 +2112,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -2095,7 +2131,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -2122,7 +2158,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -2141,7 +2177,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -2168,7 +2204,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -2187,7 +2223,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -93,7 +93,7 @@
       <Version>10.0.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph.Core">
-      <Version>2.0.8</Version>
+      <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
       <Version>6.35.0</Version>

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -96,7 +96,7 @@
       <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb">
       <Version>4.2.3</Version>
@@ -129,7 +129,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Packaging">
       <Version>10.0.8</Version>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
@@ -149,7 +149,7 @@
       <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Tokens">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>6.0.2</Version>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
 	<appSettings />
@@ -30,7 +30,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -38,7 +38,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -87,11 +87,47 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.20.0.0" newVersion="4.20.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -177,23 +213,23 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphCaches.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphCaches.cs
@@ -1,5 +1,6 @@
 ﻿using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System.Threading.Tasks;
 
 namespace ActivityImporter.Engine.ActivityAPI.Copilot
@@ -21,7 +22,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
 
         public override async Task<Site> Load(string id)
         {
-            return await _graphServiceClient.Sites[id].Request().GetAsync();
+            return await _graphServiceClient.Sites[id].GetAsync();
         }
     }
     public class UserGraphCache : GraphCache<User>
@@ -32,7 +33,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
 
         public override async Task<User> Load(string id)
         {
-            return await _graphServiceClient.Users[id].Request().GetAsync();
+            return await _graphServiceClient.Users[id].GetAsync();
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
@@ -1,6 +1,8 @@
 ﻿using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
@@ -30,11 +32,11 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             // Requires OnlineMeetings.Read.All and https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy#configure-application-access-policy
             try
             {
-                var meeting = await _graphServiceClient.Users[userGuid].OnlineMeetings[meetingId].Request().GetAsync();
+                var meeting = await _graphServiceClient.Users[userGuid].OnlineMeetings[meetingId].GetAsync();
 
                 return new MeetingMetadata(meeting);
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
                 _logger.LogWarning(ex, "Error getting meeting info for meetingId {meetingId}", meetingId);
                 return null;
@@ -82,9 +84,9 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                 try
                 {
                     item = await _graphServiceClient.Sites[spSiteId].Lists[spListId].Items[driveItemId]
-                        .Request().Expand("fields").GetAsync();
+                        .GetAsync(rc => { rc.QueryParameters.Expand = new[] { "fields" }; });
                 }
-                catch (ServiceException ex)
+                catch (ODataError ex)
                 {
                     _logger.LogWarning(ex, "Error getting file info for copilotDocContextId {copilotDocContextId}", copilotDocContextId);
                     return null;
@@ -100,10 +102,10 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                 {
                     // Currently we can't filter by webUrl, so we have to get all items and filter client side
                     var listItems = await _graphServiceClient.Sites[spSiteId].Lists[spListId].Items
-                        .Request().Select("id,webUrl").GetAsync();
-                    if (listItems != null)
+                        .GetAsync(rc => { rc.QueryParameters.Select = new[] { "id", "webUrl" }; });
+                    if (listItems?.Value != null)
                     {
-                        foreach (var i in listItems)
+                        foreach (var i in listItems.Value)
                         {
                             if (i.WebUrl == copilotDocContextId)
                             {
@@ -112,7 +114,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                         }
                     }
                 }
-                catch (ServiceException ex)
+                catch (ODataError ex)
                 {
                     _logger.LogWarning(ex, "Error getting items info for list {spListId} on site {siteUrl}", spListId, siteUrl);
                     return null;
@@ -134,11 +136,13 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             // Needs Files.Read.All
             try
             {
-                return await _graphServiceClient.Users[eventUpn].Drive.Request().Select("SharePointIds").GetAsync() ?? throw new ArgumentOutOfRangeException(eventUpn);
+                return await _graphServiceClient.Users[eventUpn].Drive
+                    .GetAsync(rc => { rc.QueryParameters.Select = new[] { "SharePointIds" }; })
+                    ?? throw new ArgumentOutOfRangeException(eventUpn);
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
-                _logger.LogWarning(ex, $"Error {ex.StatusCode} getting drive info for user {eventUpn}", eventUpn);
+                _logger.LogWarning(ex, $"Error {ex.ResponseStatusCode} getting drive info for user {eventUpn}", eventUpn);
                 return null;
             }
         }
@@ -156,9 +160,11 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             Drive siteDrive = null;
             try
             {
-                siteDrive = await _graphServiceClient.Sites[siteAddress].Drive.Request().Select("SharePointIds").GetAsync() ?? throw new ArgumentOutOfRangeException(siteAddress);
+                siteDrive = await _graphServiceClient.Sites[siteAddress].Drive
+                    .GetAsync(rc => { rc.QueryParameters.Select = new[] { "SharePointIds" }; })
+                    ?? throw new ArgumentOutOfRangeException(siteAddress);
             }
-            catch (ServiceException)
+            catch (ODataError)
             {
                 // We can't get the drive via the site address, for some reason. Most of the time we can, but sometimes it doesn't work...
                 // Load just the site and then try getting the drive using the loaded site ID
@@ -169,9 +175,9 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                 Site site = null;
                 try
                 {
-                    site = await _graphServiceClient.Sites[siteAddress].Request().GetAsync() ?? throw new ArgumentOutOfRangeException(siteAddress);
+                    site = await _graphServiceClient.Sites[siteAddress].GetAsync() ?? throw new ArgumentOutOfRangeException(siteAddress);
                 }
-                catch (ServiceException ex)
+                catch (ODataError ex)
                 {
                     _logger.LogWarning(ex, "Error getting site info for site {siteUrl}", siteUrl);
                     return null;
@@ -181,9 +187,11 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     try
                     {
                         // Try one more time using site ID
-                        siteDrive = await _graphServiceClient.Sites[site.Id].Drive.Request().Select("SharePointIds").GetAsync() ?? throw new ArgumentOutOfRangeException(siteAddress);
+                        siteDrive = await _graphServiceClient.Sites[site.Id].Drive
+                            .GetAsync(rc => { rc.QueryParameters.Select = new[] { "SharePointIds" }; })
+                            ?? throw new ArgumentOutOfRangeException(siteAddress);
                     }
-                    catch (ServiceException)
+                    catch (ODataError)
                     {
                         // Ignore. Handle logging below
                     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/Models.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/Models.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.IO;
 using System.Web;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ChatReactions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ChatReactions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 
 namespace WebJob.Office365ActivityImporter.Engine.Entities

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CallRecord/CallRecordDTO.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CallRecord/CallRecordDTO.cs
@@ -3,6 +3,8 @@ using Common.Entities;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -256,12 +258,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
 
         private static async Task<string> GetEmailAddress(IdentitySetDTO callee, TeamsLoadContext teamsLoadContext, ILogger telemetry)
         {
-            Microsoft.Graph.User graphUser = null;
+            Microsoft.Graph.Models.User graphUser = null;
             try
             {
                 graphUser = await teamsLoadContext.UserCache.Load(callee?.User?.Id);
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
                 if (ex.Message.Contains("Request_ResourceNotFound"))
                 {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/BearerTokenAuthenticationProvider.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/BearerTokenAuthenticationProvider.cs
@@ -1,0 +1,32 @@
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Abstractions.Authentication;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Static-bearer-token <see cref="IAuthenticationProvider"/> for Microsoft.Graph v5+.
+    /// Replaces the v4 <c>DelegateAuthenticationProvider</c> when an access token is
+    /// already in hand (e.g. obtained from a refresh-token flow). Not for use with
+    /// long-lived clients - tokens are static for the lifetime of this provider.
+    /// </summary>
+    public sealed class BearerTokenAuthenticationProvider : IAuthenticationProvider
+    {
+        private readonly string _accessToken;
+
+        public BearerTokenAuthenticationProvider(string accessToken)
+        {
+            _accessToken = accessToken;
+        }
+
+        public Task AuthenticateRequestAsync(RequestInformation request,
+            Dictionary<string, object> additionalAuthenticationContext = null,
+            CancellationToken cancellationToken = default)
+        {
+            request.Headers.Add("Authorization", $"Bearer {_accessToken}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallQueueProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallQueueProcessor.cs
@@ -102,8 +102,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                 return;
             }
             await _auth.InitClientCredential();
-            var graphClient = new GraphServiceClient(_auth.Creds);
-            graphClient.HttpProvider.OverallTimeout = TimeSpan.FromHours(1);
+            var graphClient = GraphServiceClientFactory.CreateWithTimeout(_auth.Creds, TimeSpan.FromHours(1));
 
             _teamsLoadContext = new TeamsLoadContext(graphClient);
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
@@ -2,6 +2,8 @@
 using Common.Entities.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -29,17 +31,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
 
         public async Task CreateOrUpdateWebhook(Uri webAppUrl, string secret)
         {
-            var allSubs = await this.Client.Subscriptions.Request().GetAsync();
+            var allSubs = await this.Client.Subscriptions.GetAsync();
 
             // https://docs.microsoft.com/en-us/graph/api/resources/webhooks?view=graph-rest-1.0
             const string CALL_TYPE = "/communications/callRecords";
-            var subs = allSubs.Where(s => s.Resource == CALL_TYPE && s.NotificationUrl == webAppUrl.ToString());
-            if (subs.Count() == 0)
+            var subs = (allSubs?.Value ?? new System.Collections.Generic.List<Subscription>())
+                .Where(s => s.Resource == CALL_TYPE && s.NotificationUrl == webAppUrl.ToString())
+                .ToList();
+            if (subs.Count == 0)
             {
                 Telemetry.LogInformation($"No subscription found for call-records, for URL '{webAppUrl}'. Creating...");
                 try
                 {
-                    var result = await this.Client.Subscriptions.Request().AddAsync(new Subscription()
+                    var result = await this.Client.Subscriptions.PostAsync(new Subscription()
                     {
                         NotificationUrl = webAppUrl.ToString(),
                         Resource = CALL_TYPE,
@@ -49,7 +53,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                     });
                     Telemetry.LogInformation($"Created subscription id '{result.Id}' for webhook.");
                 }
-                catch (ServiceException ex)
+                catch (ODataError ex)
                 {
                     Telemetry.LogError(ex, $"Couldn't create webhook at URL '{webAppUrl}'. Got exception: '{ex.Message}'");
                 }
@@ -59,7 +63,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             {
                 // https://docs.microsoft.com/en-us/graph/api/subscription-update?view=graph-rest-beta&tabs=http
 
-                var result = this.Client.Subscriptions[subs.First().Id].Request().UpdateAsync(
+                var result = await this.Client.Subscriptions[subs.First().Id].PatchAsync(
                     new Subscription
                     {
                         ExpirationDateTime = DateTime.Now.AddDays(2)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
@@ -57,7 +57,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                         Resource = CALL_TYPE,
                         ClientState = secret,
                         ChangeType = "created",
-                        ExpirationDateTime = DateTime.Now.AddDays(2)        // the max Graph will permit - https://docs.microsoft.com/en-us/graph/api/resources/subscription?view=graph-rest-beta#properties
+                        ExpirationDateTime = DateTime.UtcNow.AddDays(2)        // the max Graph will permit - https://docs.microsoft.com/en-us/graph/api/resources/subscription?view=graph-rest-beta#properties
                     });
                     Telemetry.LogInformation($"{LOG_TAG} Created subscription id '{result.Id}' for webhook at '{webAppUrl}'. Teams call records will start importing as calls end.");
                 }
@@ -76,7 +76,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                     var result = await this.Client.Subscriptions[existingSubId].PatchAsync(
                         new Subscription
                         {
-                            ExpirationDateTime = DateTime.Now.AddDays(2)
+                            ExpirationDateTime = DateTime.UtcNow.AddDays(2)
                         }
                     );
                     Telemetry.LogInformation($"{LOG_TAG} Renewed subscription id '{result.Id}' for webhook at '{webAppUrl}'. New expiry: {result.ExpirationDateTime:u}.");
@@ -101,9 +101,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         {
             var action = isUpdate ? $"renew subscription '{existingSubId}'" : "create subscription";
             var statusCode = ex.ResponseStatusCode;
-            var statusLabel = Enum.IsDefined(typeof(HttpStatusCode), statusCode) ? $" {(HttpStatusCode)statusCode}" : string.Empty;
             var statusLine = statusCode > 0
-                ? $"Graph returned {statusCode}{statusLabel}."
+                ? (Enum.IsDefined(typeof(HttpStatusCode), statusCode)
+                    ? $"Graph returned {statusCode} {(HttpStatusCode)statusCode}."
+                    : $"Graph returned {statusCode}.")
                 : "Graph call failed before a status code was returned.";
             var graphError = ex.Error?.Message ?? ex.Message;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphLookupCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphLookupCache.cs
@@ -1,5 +1,7 @@
 ﻿using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Threading.Tasks;
 
@@ -35,11 +37,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// <summary>
     /// Graph cache for users
     /// </summary>
-    public class UserLookupCache : GraphLookupCache<Microsoft.Graph.User>
+    public class UserLookupCache : GraphLookupCache<Microsoft.Graph.Models.User>
     {
         public UserLookupCache(GraphServiceClient graphClient) : base(graphClient) { }
 
-        public override async Task<Microsoft.Graph.User> Load(string id)
+        public override async Task<Microsoft.Graph.Models.User> Load(string id)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -47,12 +49,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             try
             {
-                var user = await graphClient.Users[id].Request().GetAsync();
+                var user = await graphClient.Users[id].GetAsync();
                 return user;
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
-                if (ex.Error.Code == "Request_ResourceNotFound")
+                if (ex.Error?.Code == "Request_ResourceNotFound")
                 {
                     Console.WriteLine($"Got {ex.Error.Code} finding user by ID '{id}'");
                     return null;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphServiceClientFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphServiceClientFactory.cs
@@ -1,0 +1,31 @@
+using Azure.Core;
+using Microsoft.Graph;
+using Microsoft.Kiota.Authentication.Azure;
+using System;
+using System.Net.Http;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Factory helpers for <see cref="GraphServiceClient"/> v5+. The v4 client exposed
+    /// <c>HttpProvider.OverallTimeout</c> directly; in v5+ that property is gone, so we
+    /// build a custom <see cref="HttpClient"/> with the desired timeout and pass it to
+    /// <see cref="GraphServiceClient(HttpClient, Microsoft.Kiota.Abstractions.Authentication.IAuthenticationProvider, string)"/>.
+    /// </summary>
+    public static class GraphServiceClientFactory
+    {
+        private static readonly string[] DefaultScopes = new[] { "https://graph.microsoft.com/.default" };
+
+        /// <summary>
+        /// Create a client with a per-request HTTP timeout. Use for long-running enumeration
+        /// (e.g. /users/delta or large tenant scans) where the default 100s would fire mid-page.
+        /// </summary>
+        public static GraphServiceClient CreateWithTimeout(TokenCredential credential, TimeSpan timeout)
+        {
+            var authProvider = new AzureIdentityAuthenticationProvider(credential, scopes: DefaultScopes);
+            var httpClient = GraphClientFactory.Create(authProvider);
+            httpClient.Timeout = timeout;
+            return new GraphServiceClient(httpClient, authProvider);
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
@@ -2,9 +2,12 @@
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Data.Entity;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
@@ -20,9 +23,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             _graphServiceClient = graphServiceClient;
         }
 
-        public override async Task<Microsoft.Graph.Site> LoadSite(string id)
+        public override async Task<Microsoft.Graph.Models.Site> LoadSite(string id)
         {
-            return await _graphServiceClient.Sites[id].Request().Select("WebUrl").GetAsync();
+            return await _graphServiceClient.Sites[id]
+                .GetAsync(rc => { rc.QueryParameters.Select = new[] { "WebUrl" }; });
         }
     }
 
@@ -41,7 +45,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             _debugTracer = debugTracer;
         }
 
-        public abstract Task<Microsoft.Graph.Site> LoadSite(string id);
+        public abstract Task<Microsoft.Graph.Models.Site> LoadSite(string id);
 
         public override async Task<SPSiteIdToUrl> Load(string id)
         {
@@ -83,7 +87,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     SiteUrl = site.WebUrl
                 };
             }
-            catch (ServiceException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            catch (ODataError ex) when (ex.ResponseStatusCode == (int)HttpStatusCode.NotFound)
             {
                 _debugTracer.LogWarning($"{nameof(SPSiteIdToUrlCache)}: Site with ID '{id}' not found");
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelMessagesLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelMessagesLoader.cs
@@ -3,9 +3,11 @@ using Common.Entities.Redis.Teams;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Graph.Teams.Item.Channels.Item.Messages.Delta;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
@@ -15,6 +17,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
     /// </summary>
     public class ChannelMessagesLoader
     {
+        // Safety cap for delta/replies paging at 200k-user scale: a single channel should
+        // never legitimately return more than this many messages in one delta window, but a
+        // misbehaving nextLink could otherwise loop forever or fill memory.
+        private const int MAX_MESSAGES_PER_CHANNEL = 100_000;
+        private const int MAX_REPLIES_PER_MESSAGE = 10_000;
+
         private readonly GraphServiceClient _client;
         private readonly CacheConnectionManager _cacheConnectionManager;
         private readonly ILogger _telemetry;
@@ -33,59 +41,68 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         {
             if (string.IsNullOrEmpty(teamId)) throw new ArgumentException($"'{nameof(teamId)}' cannot be null or empty", nameof(teamId));
 
-            // Do we have a delta token in redis?
-            var delta = await _cacheConnectionManager.GetTeamChannelDeltaTokenInfo(teamId, channel.Id);
-
-            // Get channel root msgs
-            var req = _client.Teams[teamId].Channels[channel.Id].Messages.Delta().Request();
             var channelDeltaInfo = await _cacheConnectionManager.GetTeamChannelDeltaTokenInfo(teamId, channel.Id);
 
-            // Add delta code from last time if we have one
-            if (channelDeltaInfo != null)
-            {
-                req.QueryOptions.Add(new QueryOption("$deltatoken", channelDeltaInfo.Token));
-            }
+            // v5+ removed QueryOption / $deltatoken support on the typed Delta request builder. To
+            // keep using the SDK serialiser for ChatMessage we construct the full URL ourselves
+            // (with $deltatoken appended when we have one) and instantiate a DeltaRequestBuilder
+            // against the existing RequestAdapter, then walk pages via PageIterator.
+            var baseUrl = $"{_client.RequestAdapter.BaseUrl}/teams/{teamId}/channels/{channel.Id}/messages/delta";
+            var initialUrl = channelDeltaInfo != null
+                ? $"{baseUrl}?$deltatoken={channelDeltaInfo.Token}"
+                : baseUrl;
+            var deltaBuilder = new DeltaRequestBuilder(initialUrl, _client.RequestAdapter);
 
-            // Load messages recursively & save delta token to redis for next time
-            List<ChatMessage> rootMsgs = null;
+            var rootMsgs = new List<ChatMessage>();
             TeamsRedisManager.TeamChannelDeltaTokenInfo newDelta = null;
+
+            DeltaGetResponse firstPage = null;
             try
             {
-                rootMsgs = await LoadRootChannelMsgsFromGraphRecursive(req,
-                    (deltaLink) =>
-                    {
-                        // Remember delta for return object
-                        var lastPageDelta = StringUtils.ExtractCodeFromGraphUrl(deltaLink);
-                        newDelta = new TeamsRedisManager.TeamChannelDeltaTokenInfo
-                        {
-                            Token = lastPageDelta,
-                            LastUpdated = DateTime.Now
-                        };
-
-                        return Task.CompletedTask;
-                    }, 0);
+                firstPage = await deltaBuilder.GetAsDeltaGetResponseAsync();
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
-                if (ex.Error.Code == "BadRequest" && channelDeltaInfo != null)
+                if (ex.Error?.Code == "BadRequest" && channelDeltaInfo != null)
                 {
                     await _cacheConnectionManager.RemoveTeamChannelDeltaToken(teamId, channel.Id, _telemetry);
                     _telemetry.LogError(ex, $"Got bad request using delta token for messages. Removing from cache & will try full read next time.");
-                    rootMsgs = new List<ChatMessage>();
                 }
                 else throw;
             }
 
-            // Load all replies
+            if (firstPage != null)
+            {
+                int loaded = 0;
+                var iterator = PageIterator<ChatMessage, DeltaGetResponse>
+                    .CreatePageIterator(_client, firstPage, msg =>
+                    {
+                        rootMsgs.Add(msg);
+                        loaded++;
+                        return loaded < MAX_MESSAGES_PER_CHANNEL;
+                    });
+
+                await iterator.IterateAsync();
+
+                if (iterator.State == PagingState.Paused)
+                {
+                    _telemetry.LogWarning($"Channel '{channel.DisplayName}' on Team '{teamId}': hit MAX_MESSAGES_PER_CHANNEL ({MAX_MESSAGES_PER_CHANNEL:N0}). Returning partial set of {rootMsgs.Count:N0} root messages.");
+                }
+
+                if (!string.IsNullOrEmpty(iterator.Deltalink))
+                {
+                    newDelta = new TeamsRedisManager.TeamChannelDeltaTokenInfo
+                    {
+                        Token = StringUtils.ExtractCodeFromGraphUrl(iterator.Deltalink),
+                        LastUpdated = DateTime.Now
+                    };
+                }
+            }
+
+            // Load all replies for each root message
             foreach (var rootMsg in rootMsgs)
             {
-                // Parse replies
-                var msgReplies = await LoadMsgRepliesRecursive(_client.Teams[teamId].Channels[channel.Id].Messages[rootMsg.Id].Replies.Request());
-                rootMsg.Replies = new ChatMessageRepliesCollectionPage();
-                foreach (var r in msgReplies)
-                {
-                    rootMsg.Replies.Add(r);
-                }
+                rootMsg.Replies = await LoadAllRepliesForMessage(teamId, channel.Id, rootMsg.Id);
             }
 
 
@@ -104,60 +121,33 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             return newDelta;
         }
 
-
-        internal async Task<List<ChatMessage>> LoadMsgRepliesRecursive(IChatMessageRepliesCollectionRequest replyRequest)
+        /// <summary>
+        /// Walk all reply pages for a single message via <see cref="PageIterator{TEntity, TCollectionPage}"/>.
+        /// </summary>
+        internal async Task<List<ChatMessage>> LoadAllRepliesForMessage(string teamId, string channelId, string messageId)
         {
             var allReplies = new List<ChatMessage>();
-            var replies = await replyRequest.GetAsync();
 
-            foreach (var reply in replies)
+            var firstPage = await _client.Teams[teamId].Channels[channelId].Messages[messageId].Replies.GetAsync();
+            if (firstPage == null) return allReplies;
+
+            int loaded = 0;
+            var iterator = PageIterator<ChatMessage, ChatMessageCollectionResponse>
+                .CreatePageIterator(_client, firstPage, reply =>
+                {
+                    allReplies.Add(reply);
+                    loaded++;
+                    return loaded < MAX_REPLIES_PER_MESSAGE;
+                });
+
+            await iterator.IterateAsync();
+
+            if (iterator.State == PagingState.Paused)
             {
-                allReplies.Add(reply);
-            }
-            if (replies.NextPageRequest != null)
-            {
-                var nextPageReplies = await LoadMsgRepliesRecursive(replies.NextPageRequest);
-                nextPageReplies.AddRange(nextPageReplies);
+                _telemetry.LogWarning($"Channel {channelId} msg {messageId}: hit MAX_REPLIES_PER_MESSAGE ({MAX_REPLIES_PER_MESSAGE:N0}). Returning partial reply list of {allReplies.Count:N0}.");
             }
 
             return allReplies;
-        }
-
-        internal async Task<List<ChatMessage>> LoadRootChannelMsgsFromGraphRecursive(IChatMessageDeltaRequest msgsRequest, Func<string, Task> deltaTokenFunc, int pageNumber)
-        {
-            _telemetry.LogInformation($"Loading messages page {pageNumber}...");
-
-            // https://docs.microsoft.com/en-us/graph/api/chatmessage-delta
-            var channelRootMsgs = await msgsRequest.GetAsync();
-
-            // Load more if there is any.
-            // For some reason there can be a "next page" without any actual results, which if called, will fail. Don't bother if there's no results.
-            if (channelRootMsgs.Count > 0 && channelRootMsgs.NextPageRequest != null)
-            {
-                var nextPageMsgs = await LoadRootChannelMsgsFromGraphRecursive(channelRootMsgs.NextPageRequest, deltaTokenFunc, ++pageNumber);
-
-                // No AddRange
-                foreach (var nextPageMsg in nextPageMsgs)
-                {
-                    channelRootMsgs.Add(nextPageMsg);
-                }
-            }
-            else
-            {
-                const string DELTA_LINK = "@odata.deltaLink";
-
-                // Last page of results. Do we have a delta link?
-                if (channelRootMsgs.AdditionalData.ContainsKey(DELTA_LINK))
-                {
-                    var deltaLink = channelRootMsgs.AdditionalData[DELTA_LINK];
-                    if (deltaLink != null && deltaTokenFunc != null)
-                    {
-                        await deltaTokenFunc(deltaLink.ToString());
-                    }
-                }
-
-            }
-            return channelRootMsgs.ToList();
         }
 
         public class ChannelChatInfo

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelWithReactions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelWithReactions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 
@@ -24,7 +25,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
         public List<ChatMessageReaction> Reactions { get; set; } = new List<ChatMessageReaction>();
         public List<ChatMessage> Messages { get; set; } = new List<ChatMessage>();
-        public IChannelTabsCollectionPage Tabs { get; internal set; }
+        // v5+ exposes channel tabs as List<TeamsTab>; the v4 IChannelTabsCollectionPage interface
+        // is gone. PopulateNewMessagesAndReactions / SaveToSql iterate this directly.
+        public List<TeamsTab> Tabs { get; internal set; }
 
         /// <summary>
         /// Sort through messages found and decide what's new since last delta. Set on this object

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/CognitiveHelper.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/CognitiveHelper.cs
@@ -1,5 +1,6 @@
 ﻿using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/ChatMessageListExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/ChatMessageListExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/ITeamInstalledAppsCollectionPageExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/ITeamInstalledAppsCollectionPageExtensions.cs
@@ -2,6 +2,7 @@
 using Common.Entities.Entities;
 using Common.Entities.Teams;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/ItemBodyExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/ItemBodyExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
@@ -9,6 +9,8 @@ using Common.Entities.Teams;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
@@ -72,14 +74,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             // Try and get user-delegated channel stats
             if (refreshToken != null)
             {
-                // Managed to get user-delegated token from refresh-token. Impersonate user
-                var _preCachedTokenClient = new GraphServiceClient(new DelegateAuthenticationProvider(
-                    (requestMessage) =>
-                    {
-                        requestMessage.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("bearer", refreshToken.AccessToken);
-                        return Task.FromResult(0);
-                    })
-                );
+                // Managed to get user-delegated token from refresh-token. Impersonate user.
+                // v5+ removed DelegateAuthenticationProvider — drop in our own
+                // IAuthenticationProvider that pins the supplied bearer token onto every request.
+                var _preCachedTokenClient = new GraphServiceClient(new BearerTokenAuthenticationProvider(refreshToken.AccessToken));
 
                 var channelMessagesLoader = new ChannelMessagesLoader(_preCachedTokenClient, cacheConnectionManager, telemetry);
                 try
@@ -87,7 +85,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                     // Load msgs using user token
                     channelDeltaInfo = await channelMessagesLoader.LoadTeamMessagesAndReplies(channel, parentTeam.Id);
                 }
-                catch (ServiceException ex)
+                catch (ODataError ex)
                 {
                     // Assume there's an issue with the token. Parent will handle token clean-up
                     throw new ChannelMessagesReadException(ex);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamsCognitiveExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamsCognitiveExtensions.cs
@@ -4,6 +4,7 @@ using Common.Entities.Redis;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/O365Team.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/O365Team.cs
@@ -5,6 +5,8 @@ using Common.Entities.Redis.Teams;
 using Common.Entities.Teams;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
@@ -24,7 +26,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         public O365Team()
         {
             this.Users = new List<BaseUser>();
-            this.OwnerUserAccounts = new List<Microsoft.Graph.User>();
+            this.OwnerUserAccounts = new List<Microsoft.Graph.Models.User>();
         }
 
         public O365Team(Team team) : this()
@@ -61,7 +63,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// Graph users in the Team. 
         /// </summary>
         public List<BaseUser> Users { get; set; }
-        public List<Microsoft.Graph.User> OwnerUserAccounts { get; set; }
+        public List<Microsoft.Graph.Models.User> OwnerUserAccounts { get; set; }
 
         public List<UserReaction> AllReactions { get; set; } = new List<UserReaction>();
 
@@ -188,11 +190,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         {
             var teamId = parentGroup.Id;
             // Get Team details from Graph and convert to our own class
-            var team = await context.GraphClient.Teams[teamId].Request().GetAsync();
+            var team = await context.GraphClient.Teams[teamId].GetAsync();
             var fullTeam = new O365Team(team);
 
             // Populate new Teams definition with graph data
-            var parentGroupFull = await context.GraphClient.Groups[teamId].Request().Expand("Owners").GetAsync();
+            var parentGroupFull = await context.GraphClient.Groups[teamId].GetAsync(rc =>
+            {
+                rc.QueryParameters.Expand = new[] { "Owners" };
+            });
 
             // Add owners
             foreach (var groupOwner in parentGroupFull.Owners)
@@ -211,7 +216,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 #if DEBUG
             Console.WriteLine($"\nReading team '{parentGroup.DisplayName}':");
 #endif
-            var members = await LoadMembers(context.GraphClient.Groups[parentGroup.Id].Members.Request(), telemetry);
+            var members = await LoadAllGroupMembers(context.GraphClient, parentGroup.Id, telemetry);
 
             foreach (var member in members)
             {
@@ -232,13 +237,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             }
 
             // Load apps
-            var apps = await context.GraphClient.Teams[teamId].InstalledApps.Request().Expand("TeamsAppDefinition,TeamsApp").GetAsync();
-            fullTeam.InstalledApps = apps;
+            var appsPage = await context.GraphClient.Teams[teamId].InstalledApps.GetAsync(rc =>
+            {
+                rc.QueryParameters.Expand = new[] { "TeamsAppDefinition", "TeamsApp" };
+            });
+            fullTeam.InstalledApps = appsPage?.Value ?? new List<TeamsAppInstallation>();
 
             // Channels and tabs:
-            var channelsLoaded = await context.GraphClient.Teams[teamId].Channels.Request().GetAsync();
-            foreach (var channel in channelsLoaded)
-                fullTeam.Channels.Add(new ChannelWithReactions(channel));
+            var channelsLoaded = await context.GraphClient.Teams[teamId].Channels.GetAsync();
+            if (channelsLoaded?.Value != null)
+            {
+                foreach (var channel in channelsLoaded.Value)
+                    fullTeam.Channels.Add(new ChannelWithReactions(channel));
+            }
 
 
             var teamTokenManager = new TeamTokenManager(fullTeam, appConfig, telemetry);
@@ -252,7 +263,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                     // Clear delta cache if new channel in DB. Mainly for debug reasons but also if there's no channel, we need to make sure we ignore any delta code (just in case)
                     await teamTokenManager.CacheConnectionManager.RemoveTeamChannelDeltaToken(fullTeam.Id, channel.Id, telemetry);
                 }
-                channel.Tabs = await context.GraphClient.Teams[teamId].Channels[channel.Id].Tabs.Request().Expand("teamsApp").GetAsync();
+                var tabsPage = await context.GraphClient.Teams[teamId].Channels[channel.Id].Tabs.GetAsync(rc =>
+                {
+                    rc.QueryParameters.Expand = new[] { "teamsApp" };
+                });
+                channel.Tabs = tabsPage?.Value ?? new List<TeamsTab>();
             }
 
             // Get token for Team
@@ -319,25 +334,34 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         }
         #endregion
 
-        private static async Task<IGroupMembersCollectionWithReferencesPage> LoadMembers(IGroupMembersCollectionWithReferencesRequest req, ILogger telemetry)
+        private static async Task<List<DirectoryObject>> LoadAllGroupMembers(GraphServiceClient client, string groupId, ILogger telemetry)
         {
-            return await LoadMembers(req, telemetry, 0);
-        }
-        private static async Task<IGroupMembersCollectionWithReferencesPage> LoadMembers(IGroupMembersCollectionWithReferencesRequest req, ILogger telemetry, int page)
-        {
-            var results = await req.GetAsync();
-            if (results.NextPageRequest != null)
-            {
-                telemetry.LogInformation($"Load members page {++page}");
+            // Safety cap on paging: at 200k-user scale a single group rarely exceeds ~50k members
+            // but a runaway nextLink shouldn't ever fill memory unbounded. 200k members per group
+            // is comfortably above any realistic limit.
+            const int MAX_MEMBERS = 200_000;
+            var all = new List<DirectoryObject>();
 
-                var nextResults = await LoadMembers(results.NextPageRequest, telemetry, page++);
-                foreach (var item in nextResults)
+            var firstPage = await client.Groups[groupId].Members.GetAsync();
+            if (firstPage == null) return all;
+
+            int loaded = 0;
+            var iterator = PageIterator<DirectoryObject, DirectoryObjectCollectionResponse>
+                .CreatePageIterator(client, firstPage, item =>
                 {
-                    results.Add(item);
-                }
+                    all.Add(item);
+                    loaded++;
+                    return loaded < MAX_MEMBERS;
+                });
+
+            await iterator.IterateAsync();
+
+            if (iterator.State == PagingState.Paused)
+            {
+                telemetry.LogWarning($"Group {groupId}: hit MAX_MEMBERS ({MAX_MEMBERS:N0}). Returning partial list of {all.Count:N0} members.");
             }
 
-            return results;
+            return all;
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsFinder.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsFinder.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,6 +10,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 {
     public class TeamsFinder : AbstractApiLoader
     {
+        // Safety cap on paging at 200k-user scale: a single tenant should not exceed this
+        // many groups in any realistic scenario. Trips a warning rather than letting a
+        // misbehaving nextLink fill memory indefinitely.
+        private const int MAX_GROUPS = 500_000;
+
         private readonly GraphServiceClient _graphServiceClient;
 
         public TeamsFinder(AnalyticsLogger telemetry, AppConfig settings, GraphServiceClient graphServiceClient) : base(telemetry, settings)
@@ -31,7 +37,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (legacyAPIMode)
             {
-                var v1Groups = await GetGroupsAsync(_graphServiceClient.Groups.Request().Select("displayName,id,resourceProvisioningOptions"), legacyAPIMode);
+                var v1Groups = await GetGroupsAsync(rc =>
+                {
+                    rc.QueryParameters.Select = new[] { "displayName", "id", "resourceProvisioningOptions" };
+                });
 
                 foreach (var group in v1Groups)
                 {
@@ -60,7 +69,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             else
             {
                 // Beta API uses a much cleaner search for groups with a Team
-                allGroupsWithTeams = await GetGroupsAsync(_graphServiceClient.Groups.Request().Filter("resourceProvisioningOptions/Any(x:x eq 'Team')"), legacyAPIMode);
+                allGroupsWithTeams = await GetGroupsAsync(rc =>
+                {
+                    rc.QueryParameters.Filter = "resourceProvisioningOptions/Any(x:x eq 'Team')";
+                });
             }
 
             // Do the needful
@@ -82,22 +94,30 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             return filteredTeams;
         }
 
-        private async Task<List<Group>> GetGroupsAsync(IGraphServiceGroupsCollectionRequest pageRequest, bool legacyAPIMode)
+        private async Task<List<Group>> GetGroupsAsync(Action<Microsoft.Kiota.Abstractions.RequestConfiguration<Microsoft.Graph.Groups.GroupsRequestBuilder.GroupsRequestBuilderGetQueryParameters>> configure)
         {
+            // v5+ replaces .Request().NextPageRequest walking with PageIterator over the
+            // typed CollectionResponse.
             var allGroups = new List<Group>();
 
-            // https://docs.microsoft.com/en-us/graph/teams-list-all-teams#get-a-list-of-groups
-            var groups = await pageRequest.GetAsync();
-            if (groups.NextPageRequest != null)
-            {
-#if DEBUG
-                Console.WriteLine($"DEBUG: Another page for Groups results...");
-#endif
-                var nextGroups = await GetGroupsAsync(groups.NextPageRequest, legacyAPIMode);
-                allGroups.AddRange(nextGroups);
-            }
+            var firstPage = await _graphServiceClient.Groups.GetAsync(configure);
+            if (firstPage == null) return allGroups;
 
-            allGroups.AddRange(groups);
+            int loaded = 0;
+            var iterator = PageIterator<Group, GroupCollectionResponse>
+                .CreatePageIterator(_graphServiceClient, firstPage, group =>
+                {
+                    allGroups.Add(group);
+                    loaded++;
+                    return loaded < MAX_GROUPS;
+                });
+
+            await iterator.IterateAsync();
+
+            if (iterator.State == PagingState.Paused)
+            {
+                _telemetry.LogWarning($"TeamsFinder: hit MAX_GROUPS ({MAX_GROUPS:N0}) walking groups. Returning partial list of {allGroups.Count:N0}.");
+            }
 
             return allGroups;
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsImporter.cs
@@ -3,6 +3,8 @@ using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
@@ -78,7 +80,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             {
                 team = await O365Team.LoadTeamFull(parentGroup, _context, _telemetry, _settings, lookupManager.Database);
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
                 _telemetry.LogError(ex, $"Couldn't load team from Group {parentGroup.DisplayName}: {ex.Message}");
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserLoader.cs
@@ -1,6 +1,9 @@
 ﻿using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Kiota.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -116,15 +119,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
         }
 
-        public async Task<IGraphServiceSubscribedSkusCollectionPage> LoadTenantSkus()
+        public async Task<List<SubscribedSku>> LoadTenantSkus()
         {
             try
             {
-                return await _graphServiceClient.SubscribedSkus.Request().GetAsync();
+                // /subscribedSkus typically returns a small number of rows (<=100) so a single
+                // GET is enough. We materialise into a List<T> so callers don't need to know
+                // about Kiota response wrappers.
+                var page = await _graphServiceClient.SubscribedSkus.GetAsync();
+                return page?.Value ?? new List<SubscribedSku>();
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
-                if (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+                if (ex.ResponseStatusCode == (int)System.Net.HttpStatusCode.Forbidden)
                 {
                     _telemetry.LogError($"User import - couldn't load SKUs for org - {ex.Message}. Ensure 'Organization.Read.All' in granted.");
                 }
@@ -139,36 +146,57 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
         }
 
-        public async Task<List<Microsoft.Graph.User>> LoadUsersBySku(Guid skuId)
+        public async Task<List<Microsoft.Graph.Models.User>> LoadUsersBySku(Guid skuId)
         {
-            var req = _graphServiceClient.Users.Request()
-                .Select("userPrincipalName")
-                .Filter($"assignedLicenses/any(u:u/skuId eq {skuId})");
+            // Per-iteration safety cap: at 200k-user scale a runaway nextLink could allocate
+            // memory until OOM. 1M users per SKU is comfortably above any real tenant we expect
+            // to see and will trip a warning instead of silently filling memory forever.
+            const int MAX_USERS_PER_SKU = 1_000_000;
+            var allUsersWithSku = new List<Microsoft.Graph.Models.User>();
 
-            // Recursively load users 
-            var allUsersWithSku = new List<Microsoft.Graph.User>();
-            int skuPage = 1;
-            while (req != null)
+            var firstPage = await _graphServiceClient.Users.GetAsync(rc =>
             {
-                var usersWithSku = await req.GetAsync();
-                allUsersWithSku.AddRange(usersWithSku);
-                req = usersWithSku.NextPageRequest;
-                _telemetry.LogDebug($"SKU {skuId} page {skuPage}");
-                skuPage++;
+                rc.QueryParameters.Select = new[] { "userPrincipalName" };
+                rc.QueryParameters.Filter = $"assignedLicenses/any(u:u/skuId eq {skuId})";
+            });
+
+            if (firstPage == null)
+            {
+                return allUsersWithSku;
             }
+
+            int loaded = 0;
+            var iterator = PageIterator<Microsoft.Graph.Models.User, UserCollectionResponse>
+                .CreatePageIterator(_graphServiceClient, firstPage, user =>
+                {
+                    allUsersWithSku.Add(user);
+                    loaded++;
+                    return loaded < MAX_USERS_PER_SKU;
+                });
+
+            await iterator.IterateAsync();
+
+            if (iterator.State == PagingState.Paused)
+            {
+                _telemetry.LogWarning($"User import - hit MAX_USERS_PER_SKU ({MAX_USERS_PER_SKU:N0}) walking users for SKU {skuId}. Returning partial result of {allUsersWithSku.Count:N0} users.");
+            }
+
+            _telemetry.LogDebug($"SKU {skuId} loaded {allUsersWithSku.Count:N0} users");
 
             return allUsersWithSku;
         }
 
-        public async Task<IUserLicenseDetailsCollectionPage> LoadUserLicenseDetails(string userId)
+        public async Task<List<LicenseDetails>> LoadUserLicenseDetails(string userId)
         {
             try
             {
-                return await _graphServiceClient.Users[userId].LicenseDetails.Request()
-                    .Select("skuPartNumber,skuId")
-                    .GetAsync();
+                var page = await _graphServiceClient.Users[userId].LicenseDetails.GetAsync(rc =>
+                {
+                    rc.QueryParameters.Select = new[] { "skuPartNumber", "skuId" };
+                });
+                return page?.Value ?? new List<LicenseDetails>();
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
                 _telemetry.LogError(ex, $"User import - couldn't load service-plans for user ID '{userId}' - {ex.Message}");
                 return null;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/IUserMetadataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/IUserMetadataLoader.cs
@@ -1,4 +1,5 @@
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -21,24 +22,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         Task<List<GraphUser>> LoadAllActiveUsers();
 
         /// <summary>
-        /// Loads all subscribed SKUs for the tenant
+        /// Loads all subscribed SKUs for the tenant.
         /// </summary>
-        /// <returns>Collection of subscribed SKUs, or null if unable to load</returns>
-        Task<IGraphServiceSubscribedSkusCollectionPage> LoadTenantSkus();
+        /// <returns>Materialised list of subscribed SKUs, or <c>null</c> if unable to load.</returns>
+        Task<List<SubscribedSku>> LoadTenantSkus();
 
         /// <summary>
         /// Loads users that have a specific SKU assigned
         /// </summary>
         /// <param name="skuId">The SKU ID to filter by</param>
         /// <returns>List of users with the specified SKU</returns>
-        Task<List<Microsoft.Graph.User>> LoadUsersBySku(System.Guid skuId);
+        Task<List<Microsoft.Graph.Models.User>> LoadUsersBySku(System.Guid skuId);
 
         /// <summary>
-        /// Loads license details for a specific user
+        /// Loads license details for a specific user.
         /// </summary>
         /// <param name="userId">The user ID (Graph object ID)</param>
-        /// <returns>Collection of license details for the user, or null if unable to load</returns>
-        Task<IUserLicenseDetailsCollectionPage> LoadUserLicenseDetails(string userId);
+        /// <returns>Materialised list of license details for the user, or <c>null</c> if unable to load.</returns>
+        Task<List<LicenseDetails>> LoadUserLicenseDetails(string userId);
 
         /// <summary>
         /// Persists any delta token captured during the most recent

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/GraphAndSqlUserAppLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/GraphAndSqlUserAppLoader.cs
@@ -2,11 +2,13 @@
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models.ODataErrors;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -54,17 +56,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
             try
             {
                 await _graphClient.Users[testUserEmail].Teamwork.InstalledApps
-                    .Request().Expand("TeamsAppDefinition,TeamsApp").GetAsync();
+                    .GetAsync(rc => { rc.QueryParameters.Expand = new[] { "TeamsAppDefinition", "TeamsApp" }; });
                 permissionsConfirmed = true;
             }
-            catch (ServiceException ex)
+            catch (ODataError ex)
             {
-                if (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+                if (ex.ResponseStatusCode == (int)HttpStatusCode.Forbidden)
                 {
                     _telemetry.LogError(ex, $"User Apps Load - access denied reading user Teams Apps. Check 'TeamsAppInstallation.ReadForUser.All' is granted.");
                     throw new AccessDeniedToTeamsAppsException();
                 }
-                else if (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+                else if (ex.ResponseStatusCode == (int)HttpStatusCode.NotFound)
                 {
                     _telemetry.LogError($"User Apps Load - user not found reading user Teams Apps.");
                     throw new UserNotFoundException();
@@ -88,17 +90,25 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
             const int REPORT_EVERY = 10000;
 #endif
 
+            // Graph batch limit is 20 per request; keep MAX_REQS in sync with that.
             const int MAX_REQS = 20;
             var reqs = new Dictionary<string, UserBatchRequestKeyPair>();
-            var batchRequestContent = new BatchRequestContent();
+            var batchRequestContent = new BatchRequestContentCollection(_graphClient);
 
             int i = 0;
             foreach (var emailAddress in emailAddresses)
             {
-                var reqId = batchRequestContent.AddBatchRequestStep(_graphClient.Users[emailAddress].Teamwork.InstalledApps.Request().Expand("TeamsAppDefinition,TeamsApp"));
+                // v5+ Batch: convert the typed request builder to a RequestInformation via
+                // ToGetRequestInformation, with the query options set in the config-action lambda
+                var reqInfo = _graphClient.Users[emailAddress].Teamwork.InstalledApps
+                    .ToGetRequestInformation(rc =>
+                    {
+                        rc.QueryParameters.Expand = new[] { "TeamsAppDefinition", "TeamsApp" };
+                    });
+                var reqId = await batchRequestContent.AddBatchRequestStepAsync(reqInfo);
                 reqs.Add(emailAddress, new UserBatchRequestKeyPair { BatchRequestId = reqId, EmailAddress = emailAddress });
 
-                if (batchRequestContent.BatchRequestSteps.Count == MAX_REQS)
+                if (reqs.Count == MAX_REQS)
                 {
                     var segmentR = await ProcessBatchRequests(batchRequestContent, reqs);
                     foreach (var item in segmentR)
@@ -106,7 +116,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                         results.Add(item.Key, item.Value);
                     }
                     reqs.Clear();
-                    batchRequestContent = new BatchRequestContent();
+                    batchRequestContent = new BatchRequestContentCollection(_graphClient);
                 }
 
                 if (i > 0 && i % REPORT_EVERY == 0)
@@ -127,13 +137,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
             return results;
         }
 
-        async Task<Dictionary<string, UserAppsLoadState<UserTeamApp>>> ProcessBatchRequests(BatchRequestContent batchRequestContent, Dictionary<string, UserBatchRequestKeyPair> requestsSource)
+        async Task<Dictionary<string, UserAppsLoadState<UserTeamApp>>> ProcessBatchRequests(BatchRequestContentCollection batchRequestContent, Dictionary<string, UserBatchRequestKeyPair> requestsSource)
         {
             var results = new Dictionary<string, UserAppsLoadState<UserTeamApp>>();
 
             if (requestsSource.Count == 0) return new Dictionary<string, UserAppsLoadState<UserTeamApp>>();
 
-            var returnedResponse = await _graphClient.Batch.Request().PostAsync(batchRequestContent);
+            var returnedResponse = await _graphClient.Batch.PostAsync(batchRequestContent);
 
             var throttledRequestInBatch = false;
             foreach (var r in requestsSource)
@@ -154,7 +164,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                     {
                         throttledRequestInBatch = true;
                     }
-                    else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                    else if (response.StatusCode == HttpStatusCode.NotFound)
                     {
                         _telemetry.LogWarning($"User Apps Load - user with ID '{r.Key}' not found in configured tenant");
                     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/Models.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/Models.cs
@@ -1,5 +1,6 @@
 ﻿using DataUtils.Sql;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserLicenseProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserLicenseProcessor.cs
@@ -1,6 +1,7 @@
 using Common.Entities;
 using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
@@ -36,7 +37,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// Process SKUs for all users in batches
         /// </summary>
         public async Task ProcessSKUsForAllUsers(
-            IGraphServiceSubscribedSkusCollectionPage skus,
+            List<SubscribedSku> skus,
             List<Common.Entities.User> graphFoundDbUsers,
             AnalyticsEntitiesContext db)
         {
@@ -128,7 +129,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// </summary>
         public async Task AddSkuForUsers(
             Dictionary<string, Common.Entities.User> dbUsersByUpn,
-            List<Microsoft.Graph.User> usersWithSku,
+            List<Microsoft.Graph.Models.User> usersWithSku,
             SubscribedSku sku,
             AnalyticsEntitiesContext db,
             HashSet<(string licenseName, int userId)> assignedLicenses = null)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -3,6 +3,7 @@ using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
@@ -40,8 +41,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 deltaProvider = new InProcessDeltaValueProvider(telemetry);
             }
 
-            var graphServiceClient = new GraphServiceClient(creds);
-            graphServiceClient.HttpProvider.OverallTimeout = TimeSpan.FromHours(1);
+            // v4 used graphClient.HttpProvider.OverallTimeout = 1h directly. HttpProvider is gone
+            // in v5+, so we build a HttpClient with the desired timeout and inject it into the
+            // GraphServiceClient. /users/delta over a 200k-tenant can comfortably exceed the
+            // default 100s timeout - the explicit 1h timeout is load-bearing.
+            var graphServiceClient = GraphServiceClientFactory.CreateWithTimeout(creds, TimeSpan.FromHours(1));
 
             _userLoader = new GraphUserLoader(manualGraphCallClient, deltaProvider, _telemetry, graphServiceClient);
             InitializeHelpers();

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserTeamApp.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserTeamApp.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -268,7 +268,7 @@
       <Version>10.0.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>4.20.0</Version>
+      <Version>6.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
       <Version>5.2.9</Version>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -143,6 +143,8 @@
     <Compile Include="Graph\Teams\Extensions\TeamChannelExtensions.cs" />
     <Compile Include="Graph\Teams\Extensions\ItemBodyExtensions.cs" />
     <Compile Include="Graph\Teams\GraphReadExceptions.cs" />
+    <Compile Include="Graph\BearerTokenAuthenticationProvider.cs" />
+    <Compile Include="Graph\GraphServiceClientFactory.cs" />
     <Compile Include="Graph\ManualGraphCallClient.cs" />
     <Compile Include="Graph\Teams\O365Team.cs" />
     <Compile Include="Graph\Teams\Extensions\ITeamInstalledAppsCollectionPageExtensions.cs" />
@@ -259,7 +261,7 @@
       <Version>2.22.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.HashCode">
-      <Version>1.1.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>
@@ -274,7 +276,7 @@
       <Version>5.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>6.0.2</Version>
@@ -292,7 +294,7 @@
       <Version>13.0.4</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="System.Memory.Data">
       <Version>10.0.8</Version>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 		<!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
@@ -73,7 +73,7 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -114,11 +114,47 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.20.0.0" newVersion="4.20.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -160,15 +196,15 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -176,7 +212,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
@@ -195,12 +231,12 @@
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -3,7 +3,9 @@ using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
+using Microsoft.Graph.Models.ODataErrors;
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
@@ -62,10 +64,10 @@ namespace WebJob.Office365ActivityImporter
             {
                 await graphReader.GetAndSaveAllGraphData(_settings);
             }
-            catch (Microsoft.Graph.ServiceException ex)
+            catch (ODataError ex)
             {
                 // Don't make a drama if Graph permissions aren't assigned yet.
-                if (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+                if (ex.ResponseStatusCode == (int)HttpStatusCode.Forbidden)
                 {
                     _telemetry.LogWarning("ERROR: Can't access Teams user data - are application permissions configured correctly?");
                     return;
@@ -87,8 +89,7 @@ namespace WebJob.Office365ActivityImporter
                 return;
             }
             await _graphAppIndentityOAuthContext.InitClientCredential();
-            _graphClient = new GraphServiceClient(_graphAppIndentityOAuthContext.Creds);
-            _graphClient.HttpProvider.OverallTimeout = TimeSpan.FromHours(1);
+            _graphClient = GraphServiceClientFactory.CreateWithTimeout(_graphAppIndentityOAuthContext.Creds, TimeSpan.FromHours(1));
             _manualGraphCallClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _telemetry);
             _graphUserGroupsCache = new GraphUserGroupsCache(_manualGraphCallClient, _telemetry);
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/WebJob.Office365ActivityImporter.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/WebJob.Office365ActivityImporter.csproj
@@ -184,7 +184,7 @@
       <Version>10.0.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph.Core">
-      <Version>2.0.8</Version>
+      <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
       <Version>6.35.0</Version>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/WebJob.Office365ActivityImporter.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/WebJob.Office365ActivityImporter.csproj
@@ -187,7 +187,7 @@
       <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Rest.ClientRuntime">
       <Version>2.3.24</Version>
@@ -214,7 +214,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
-      <Version>6.35.0</Version>
+      <Version>8.18.0</Version>
     </PackageReference>
     <PackageReference Include="System.Memory.Data">
       <Version>10.0.8</Version>


### PR DESCRIPTION
## Title

Upgrade Microsoft.Graph SDK 4.x -> 6.1.0 (Kiota-based) + merge conflict resolution

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Migrates all Graph usage in the AnalyticsEngine solution from Microsoft.Graph 4.20.0 / Microsoft.Graph.Core 2.0.8 to the Kiota-generated 6.1.0 / 4.0.1 SDK.

Built on top of the bulk NuGet update (#nuget-bulk-update-2026-06, already merged into `dev`). This PR is the Graph migration delta, plus post-review merge-conflict resolution.

### Package bumps
- `Microsoft.Graph` 4.20.0 → 6.1.0
- `Microsoft.Graph.Core` 2.0.8 → 4.0.1
- `Microsoft.IdentityModel.*` family 6.35.0 → 8.18.0 (required by Graph.Core 4.0.1)
- `System.IdentityModel.Tokens.Jwt` 6.35.0 → 8.18.0
- `Microsoft.Bcl.HashCode` 1.1.1 → 6.0.0
- New: `Microsoft.Kiota.{Abstractions, Authentication.Azure, Http.HttpClientLibrary, Serialization.{Form, Json, Multipart, Text}}` 2.0.0
- New: `System.Net.Http.WinHttpHandler` 10.0.0.7

Resolves all NU1605 transitive downgrades introduced by Graph.Core 4.0.1.

### API migration highlights
- Model types relocated to `Microsoft.Graph.Models` (`User`, `Group`, `Team`, `Channel`, `ChatMessage`, `Site`, `Drive`, `ItemBody`, `TeamsApp*`, `SubscribedSku`, `LicenseDetails`, `Subscription`, `DirectoryObject`, `ListItem`, …).
- Removed the fluent `.Request()` step (~35 sites): now direct Kiota calls with configuration-action lambdas for `Select`/`Filter`/`Expand`/`Top`.
- Removed `IXxxCollectionPage` / `IXxxCollectionRequest` → replaced with `XxxCollectionResponse` + `PageIterator<T, TResp>.CreatePageIterator(...)`.
- Removed `DelegateAuthenticationProvider` → new `BearerTokenAuthenticationProvider` helper using `Microsoft.Kiota.Abstractions.Authentication`.
- Removed `HttpProvider.OverallTimeout` → new `GraphServiceClientFactory.CreateWithTimeout` using `GraphClientFactory.Create` + `HttpClient.Timeout`.
- `ServiceException` → `Microsoft.Graph.Models.ODataErrors.ODataError` throughout.
- `BatchRequestContent` → `BatchRequestContentCollection`, `AddBatchRequestStepAsync` with `ToGetRequestInformation(rc => ...)` and `graphClient.Batch.PostAsync`.
- Channel messages delta: typed Kiota delta builder does not surface a usable URL, so `ChannelMessagesLoader` constructs the URL and instantiates `DeltaRequestBuilder(url, client.RequestAdapter)` directly; reads the final delta link via `PageIterator.Deltalink`.
- Subscriptions `Add`/`Update` → `Post`/`Patch`.
- `SolutionInstallVerifier`: removed manual `HttpRequestMessage` / `HttpProvider` workaround for the Teams user-activity report — now uses the typed `Reports.GetTeamsUserActivityUserDetailWithPeriod` stream endpoint.

### Performance (200k-user scale)
All new `PageIterator` call sites have **explicit pagination safety caps** to bound memory:
- `MAX_USERS_PER_SKU` 1 000 000
- `MAX_GROUPS` 500 000
- `MAX_MEMBERS` 200 000
- `MAX_MESSAGES_PER_CHANNEL` 100 000
- `MAX_REPLIES_PER_MESSAGE` 10 000

Worth a sanity check during review that none of these would silently truncate real customer data at the 200k-user scale documented in the repo Copilot instructions.

### Tests
- `FakeUserMetadataLoader` rewritten to match new `IUserMetadataLoader` signatures (`List<SubscribedSku>`, `Dictionary<Guid, List<User>>`, `Dictionary<string, List<LicenseDetails>>`).
- All test fixtures updated for the new model namespace and Kiota response shape.

### Binding redirects
All Microsoft.Kiota.* assemblies, plus IdentityModel.* 8.18, System.Net.Http.WinHttpHandler 10.0.7, Microsoft.Bcl.HashCode 6.0.0 added to all four `App.Template.config` files + `Web.Template.config`.

### Post-review updates
- Merged latest `dev` into this branch and resolved a conflict in `Graph/Calls/CallWebhook.cs`.
- Preserved Kiota v6 subscription calls while keeping actionable operator-facing failure logging from `dev`.
- Updated subscription expiration timestamps from `DateTime.Now` to `DateTime.UtcNow` for Graph webhook expiry correctness.

### Verification
- ✅ Debug build: 0 errors, 0 binding warnings (MSB3247/3277/3836)
- ✅ Release build: 0 errors, 0 binding warnings
- ✅ Unit tests: **427/437 passing — same 8 environmental failures (Redis auth, `InstallerTestConfig.json` missing) as the pre-Graph baseline. 0 regressions.**
- ✅ No `TODO` / `FIXME` / `NotImplementedException` lines added by the migration.
- ✅ Merge conflict resolved cleanly with no remaining conflict markers.

### Notes
- DB schema: **no DB schema changes in this PR.**
- The `.Request()` text still appears once in the codebase — in an explanatory comment in `Graph/Teams/TeamsFinder.cs:99` (not in actual code).
- Reference: https://learn.microsoft.com/en-us/graph/sdks/upgrade-to-v5

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Related issue(s)

- #X

## Check list

- [ ] Related issue / work item is attached
- [x] Changes are tested
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)