### PR TITLE
Docs: PRs target dev by default in repo Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,11 @@ That file is the source of truth for:
 
 Always read it before making changes under `src/AnalyticsEngine/`.
 
+## Pull requests
+- Always open PRs against the `dev` branch unless the user explicitly says to target `main` (or another branch).
+- This applies to both human-driven and Copilot-driven PRs, including coding-agent tasks that auto-create branches.
+- If a PR has already been opened against the wrong base, retarget it with `gh pr edit <num> --base dev` rather than closing and reopening.
+
 ## Documentation
 - The wiki repo for Microsoft365-Analytics-Insights is normally cloned as a sibling directory named `Microsoft365-Analytics-Insights.wiki` (e.g., `V:\Repos\Microsoft365-Analytics-Insights.wiki`).
 - When a docs update is requested, make the changes in the wiki repo.


### PR DESCRIPTION
## Title

Docs: Codify "PRs target `dev` by default" in repo Copilot instructions

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Adds a new **Pull requests** section to `.github/copilot-instructions.md` so that every PR opened against this repo — human-driven or Copilot coding-agent driven — defaults to `dev` as the base branch. `main` (or any other branch) requires an explicit instruction.

Also documents the `gh pr edit <num> --base dev` retargeting command so an already-opened PR can be fixed in place without churn from close-and-reopen.

### Why

Surfaced by PR #108 being auto-opened against `main` by the coding agent. Codifying this convention so future Copilot sessions (and any new contributors reading the instructions file) pick the right base from the start.

### No schema changes
Docs-only.

## Related issue(s)

n/a

## Check list

- [x] Related issue / work item is attached
- [x] Changes are tested (n/a, docs only)
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
