### PR TITLE
Remove build_reports job from CI and PR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,32 +228,12 @@ jobs:
           if-no-files-found: error
 
 
-  build_reports:
-    runs-on: windows-latest
-    needs: setup_build
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v6
-      - name: Archive Reports
-        run: |
-          Get-ChildItem '.\reports\Usage Analytics\*' `
-          -Exclude "*_base.pbit" -Include "*.pbit","Readme.txt" | Compress-Archive `
-          -Force -DestinationPath "${{ runner.temp }}\Analytics_Reports.zip"
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          path: ${{ runner.temp }}/Analytics_Reports.zip
-          name: drop_Reports
-          if-no-files-found: error
-
-
   release:
     runs-on: ubuntu-latest
     needs:
       - setup_build
       - build_dotnet
       - build_aitracker
-      - build_reports
     permissions: 
       # Required to create tags in the repo
       contents: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -160,21 +160,3 @@ jobs:
           path: src/SPO/AITrackerInstaller.zip
           name: drop_aitracker
           if-no-files-found: error
-
-  build_reports:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v6
-      - name: Archive Reports
-        run: |
-          Get-ChildItem '.\reports\Usage Analytics\*' `
-          -Exclude "*_base.pbit" -Include "*.pbit","Readme.txt" | Compress-Archive `
-          -Force -DestinationPath "${{ runner.temp }}\Analytics_Reports.zip"
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          path: ${{ runner.temp }}/Analytics_Reports.zip
-          name: drop_Reports
-          if-no-files-found: error
-


### PR DESCRIPTION
Removes the `build_reports` job that archived Power BI reports (`*.pbit`) from both `.github/workflows/ci.yml` and `.github/workflows/pr.yml`, and drops it from the `release` job's `needs` list.

### Changes
- `ci.yml`: removed `build_reports` job and its entry under `release.needs`.
- `pr.yml`: removed `build_reports` job.