### PR TITLE
Installer: only create automation schedules/variables if missing by name

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
@@ -84,7 +84,10 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
             }
 
             // Vars
-            _logger.LogInformation($"Creating/updating automation variables for '{_config.ResourceName}'...");
+            // Re-running the installer must NOT overwrite operator-customized variable values
+            // (e.g. an operator who increased WeeksToKeep from 52 to 104). Only create when
+            // a variable with this name doesn't already exist.
+            _logger.LogInformation($"Ensuring automation variables exist for '{_config.ResourceName}'...");
             var varSqlServer = new AutomationVariableCreateOrUpdateContent(CONFIG_PARAM_NAME_SQL_SERVER)
             {
                 Value = $"\"{_config[CONFIG_PARAM_NAME_SQL_SERVER]}\"",
@@ -104,11 +107,10 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
                 Description = "Number of weeks to keep data"
             };
 
-            // Update variables
             var variables = automationAccount.GetAutomationVariables();
-            await UpdateVarCatchArgumentNullException(variables, CONFIG_PARAM_NAME_SQL_SERVER, varSqlServer);
-            await UpdateVarCatchArgumentNullException(variables, CONFIG_PARAM_NAME_SQL_DB, varSqlDb);
-            await UpdateVarCatchArgumentNullException(variables, CONFIG_PARAM_NAME_WEEKS_TO_KEEP, varWeeksToKeep);
+            await CreateVariableIfMissingAsync(variables, CONFIG_PARAM_NAME_SQL_SERVER, varSqlServer);
+            await CreateVariableIfMissingAsync(variables, CONFIG_PARAM_NAME_SQL_DB, varSqlDb);
+            await CreateVariableIfMissingAsync(variables, CONFIG_PARAM_NAME_WEEKS_TO_KEEP, varWeeksToKeep);
 
             // Creds
             _logger.LogInformation($"Creating/updating automation credentials for '{_config.ResourceName}'...");
@@ -117,7 +119,11 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
             await automationAccount.GetAutomationCredentials().CreateOrUpdateAsync(WaitUntil.Completed, CRED_SQL_NAME, credSql);
 
             // Schedules
-            _logger.LogInformation($"Creating/updating automation schedules for '{_config.ResourceName}'...");
+            // Re-running the installer must NOT update existing schedules: doing so would reset
+            // the StartTime to a fresh "next Sunday" calculated at install time, which can disrupt
+            // schedule-runbook job bindings and confuse operators who have linked these schedules
+            // to runbooks manually. Only create when a schedule with this name doesn't already exist.
+            _logger.LogInformation($"Ensuring automation schedules exist for '{_config.ResourceName}'...");
 
             var nextSunday1pm = NextSundayAt(13, DateTimeKind.Utc);
             var nextSunday6pm = NextSundayAt(18, DateTimeKind.Utc);
@@ -127,23 +133,42 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
             var nextSunday11pmSchedule = new AutomationScheduleCreateOrUpdateContent("Weekly Sunday 11pm", nextSunday11pm, AutomationScheduleFrequency.Week) { Interval = BinaryData.FromString("1") };
 
             var schedules = automationAccount.GetAutomationSchedules();
-            await schedules.CreateOrUpdateAsync(WaitUntil.Completed, nextSunday1pmSchedule.Name, nextSunday1pmSchedule);
-            await schedules.CreateOrUpdateAsync(WaitUntil.Completed, nextSunday6pmSchedule.Name, nextSunday6pmSchedule);
-            await schedules.CreateOrUpdateAsync(WaitUntil.Completed, nextSunday11pmSchedule.Name, nextSunday11pmSchedule);
+            await CreateScheduleIfMissingAsync(schedules, nextSunday1pmSchedule);
+            await CreateScheduleIfMissingAsync(schedules, nextSunday6pmSchedule);
+            await CreateScheduleIfMissingAsync(schedules, nextSunday11pmSchedule);
 
             return automationAccount;
         }
 
-        async Task UpdateVarCatchArgumentNullException(AutomationVariableCollection variables, string varName, AutomationVariableCreateOrUpdateContent varContent)
+        async Task CreateVariableIfMissingAsync(AutomationVariableCollection variables, string varName, AutomationVariableCreateOrUpdateContent varContent)
         {
+            if ((await variables.ExistsAsync(varName)).Value)
+            {
+                _logger.LogInformation($"Automation variable '{varName}' already exists in '{_config.ResourceName}' — leaving existing value untouched.");
+                return;
+            }
+
             try
             {
                 await variables.CreateOrUpdateAsync(WaitUntil.Completed, varName, varContent);
+                _logger.LogInformation($"Created automation variable '{varName}'.");
             }
             catch (ArgumentNullException)
             {
                 // Ignore. https://github.com/Azure/azure-sdk-for-net/issues/34261
             }
+        }
+
+        async Task CreateScheduleIfMissingAsync(AutomationScheduleCollection schedules, AutomationScheduleCreateOrUpdateContent scheduleContent)
+        {
+            if ((await schedules.ExistsAsync(scheduleContent.Name)).Value)
+            {
+                _logger.LogInformation($"Automation schedule '{scheduleContent.Name}' already exists in '{_config.ResourceName}' — leaving existing start time and runbook bindings untouched.");
+                return;
+            }
+
+            await schedules.CreateOrUpdateAsync(WaitUntil.Completed, scheduleContent.Name, scheduleContent);
+            _logger.LogInformation($"Created automation schedule '{scheduleContent.Name}'.");
         }
 
         public static DateTime Next(DateTime from, DayOfWeek dayOfWeek)


### PR DESCRIPTION
## Problem

When the installer is re-run against an existing Azure Automation account, `AutomationAccountTask` calls `CreateOrUpdateAsync` unconditionally on every variable and every schedule. This means:

1. **Operator-customized variable values are silently overwritten.** For example, if an operator increased `WeeksToKeep` from 52 → 104 after the first install, every subsequent installer run silently resets it back to 52.
2. **Schedule `StartTime` is reset on every re-install** to a freshly calculated *"next Sunday"*. This can disrupt the schedule-runbook job bindings that operators wired up manually after the initial install, and produces confusing schedule drift between installs.

## Fix

- New `CreateVariableIfMissingAsync` helper checks `AutomationVariableCollection.ExistsAsync(name)` and only creates when the variable is missing. If it exists, logs that the existing value is being left untouched.
- New `CreateScheduleIfMissingAsync` helper does the same for `AutomationScheduleCollection`.
- `SQLCredential` is intentionally still updated unconditionally — SQL password rotation on re-install is a legitimate use case and the user did not ask for it to change.
- Removed the now-unused `UpdateVarCatchArgumentNullException` helper. The SDK bug workaround for [azure-sdk-for-net#34261](https://github.com/Azure/azure-sdk-for-net/issues/34261) is preserved inside the new variable helper so the swallow behavior is unchanged.

## Behavior

| Scenario                            | Before                                                                 | After                                                       |
| ----------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------- |
| First install                       | Creates variables + schedules                                          | Creates variables + schedules (unchanged)                   |
| Re-install, customized `WeeksToKeep` | Silently reset to 52                                                   | Left at operator value, info logged                         |
| Re-install, schedules already exist | `StartTime` reset, runbook job bindings may be disturbed             | Schedules left untouched, info logged                       |
| Re-install, `SQLCredential`       | Updated                                                                | Still updated (intentional — password rotation works)       |

## Scope / risk

Single file, one Azure SDK pattern (`ExistsAsync`). No schema changes, no infra changes, no migrations. Existing unit tests in `InstallEngineTests.cs` only cover the pure-date helpers (`Next` / `NextSundayAt`) which are not modified.

## Build

Full `O365 Advanced Analytics Engine.sln` Debug build clean locally.