### PR TITLE
Release: Installer defaults to RBAC for new Azure Managed Redis + clearer install error chain

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -181,7 +181,21 @@ namespace App.ControlPanel.Engine
             // Build the Redis connection string from the install-task result, which abstracts over
             // both Azure Managed Redis (port 10000) and pre-existing legacy classic Azure Cache for
             // Redis (port 6380) that the installer chose to reuse.
-            var redisConnectionString = $"{redis.HostName}:{redis.Port},password={redis.PrimaryKey},ssl=True,abortConnect=False";
+            //
+            // When the cache is RBAC-only (no access keys), we deliberately omit the password
+            // segment so that CacheConnectionManager skips its key-based attempt and authenticates
+            // via Entra ID using the runtime service principal credentials.
+            string redisConnectionString;
+            if (redis.UseRbacAuth)
+            {
+                redisConnectionString = $"{redis.HostName}:{redis.Port},ssl=True,abortConnect=False";
+                _logger.LogInformation("Redis connection string built for RBAC/Entra ID auth (no access key).");
+            }
+            else
+            {
+                redisConnectionString = $"{redis.HostName}:{redis.Port},password={redis.PrimaryKey},ssl=True,abortConnect=False";
+                _logger.LogInformation("Redis connection string built for key-based auth.");
+            }
 
             var storageInfo = new AzStorageConnectionInfo(storage);
             var connectionStrings = new ConnectionStringDictionary();

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/InstallAppServiceContentsTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/InstallAppServiceContentsTask.cs
@@ -89,20 +89,35 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 {
                     await client.Connect();
                 }
-                catch (SocketException)
+                catch (SocketException ex)
                 {
-                    _logger.LogError($"Couldn't connect to {appServiceFtp.RootUrl} - check installer proxy settings (proxy enabled = {ftpConfig.UseFtpProxy})");
+                    _logger.LogError($"Couldn't connect to {appServiceFtp.RootUrl} - check installer proxy settings (proxy enabled = {ftpConfig.UseFtpProxy}). " +
+                        $"Details: {CloudInstallEngine.ExceptionMessages.Format(ex)}");
                     LogPrivateNetworkGuidanceIfApplicable();
                     throw;
                 }
-                catch (IOException)
+                catch (IOException ex)
                 {
-                    _logger.LogError($"Couldn't connect to {appServiceFtp.RootUrl} - check installer proxy settings (proxy enabled = {ftpConfig.UseFtpProxy}) and ensure app-service has 'FTP state' configured to 'FTPS only'");
+                    _logger.LogError($"Couldn't connect to {appServiceFtp.RootUrl} - check installer proxy settings (proxy enabled = {ftpConfig.UseFtpProxy}) and ensure app-service has 'FTP state' configured to 'FTPS only'. " +
+                        $"Details: {CloudInstallEngine.ExceptionMessages.Format(ex)}");
                     LogPrivateNetworkGuidanceIfApplicable();
                     throw;
                 }
 
-                await Upload(client, zipContentsDir, relativeThisJobSubDir);
+                try
+                {
+                    await Upload(client, zipContentsDir, relativeThisJobSubDir);
+                }
+                catch (Exception ex)
+                {
+                    // FluentFTP wraps the real cause in InnerException and its top-level message
+                    // is the unhelpful "An error occurred uploading file(s). See inner exception
+                    // for more info." Surface the full chain so the operator can act on it.
+                    _logger.LogError($"FTP upload to '{relativeThisJobSubDir}' on {appServiceFtp.RootUrl} failed: " +
+                        CloudInstallEngine.ExceptionMessages.Format(ex));
+                    LogPrivateNetworkGuidanceIfApplicable();
+                    throw;
+                }
 
                 await client.Disconnect();
             }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
@@ -139,10 +139,12 @@ namespace App.ControlPanel.Engine
             }
             catch (Exception ex)            // Anything else
             {
-                // Anything else. Log error as fatal
-                log.LogError($"FATAL: Unexpected error of type '{ex.GetType().Name}': " + ex.Message);
+                // Anything else. Log error as fatal — include the full InnerException chain
+                // (the installer ILogger drops the Exception arg, so without this the inner
+                // cause of e.g. FluentFTP "see inner exception for more info" is lost).
+                log.LogError($"FATAL: Unexpected error of type '{ex.GetType().Name}': " + CloudInstallEngine.ExceptionMessages.Format(ex));
                 Console.WriteLine(ex);
-                InstallerLogs.AddToWindowsEventLog($"FATAL: Unexpected error of type '{ex.GetType().Name}': " + ex.Message, true);
+                InstallerLogs.AddToWindowsEventLog($"FATAL: Unexpected error of type '{ex.GetType().Name}': " + CloudInstallEngine.ExceptionMessages.Format(ex), true);
                 InstallerLogs.AddToWindowsEventLog(ex.ToString(), true);
                 PrintFinalStatus(summary);
                 return;

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisAccessPolicyAssignmentTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisAccessPolicyAssignmentTask.cs
@@ -1,20 +1,38 @@
+using Azure;
 using Azure.Core;
+using Azure.ResourceManager.RedisEnterprise;
 using CloudInstallEngine.Models;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace CloudInstallEngine.Azure.InstallTasks
 {
     /// <summary>
-    /// Access policy assignment task for Azure Managed Redis.
-    /// Azure Managed Redis uses access key authentication by default, which does not require an
-    /// explicit RBAC access policy assignment. This task is therefore a passthrough that returns
-    /// the Redis install result unchanged.
-    /// If Entra ID (AAD) authentication is required in the future, configure
-    /// <c>AccessKeysAuthentication = Disabled</c> on the database and assign the appropriate
-    /// built-in RBAC role (e.g. "Redis Cache Contributor") to the service principal instead.
+    /// Grants the runtime service principal data-plane access on the Azure Managed Redis
+    /// database when the database is configured for RBAC / Entra ID authentication
+    /// (<see cref="RedisInstallResult.UseRbacAuth"/> == true).
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Azure Managed Redis (Redis Enterprise) RBAC works via per-database
+    /// <c>accessPolicyAssignments</c>. Today only the built-in <c>"default"</c> access policy
+    /// is supported (full data-plane access — read, write, eviction, etc., equivalent to what
+    /// an access-key-holder used to have).
+    /// </para>
+    /// <para>
+    /// We upsert a single assignment named <c>runtime</c> per database, targeting the runtime
+    /// service principal's Entra ID object ID. Re-runs are idempotent
+    /// (<c>CreateOrUpdateAsync</c>); if the runtime SP is rotated, the assignment is updated to
+    /// the new OID and the old principal loses data-plane access.
+    /// </para>
+    /// <para>
+    /// For a pre-existing classic Azure Cache for Redis (legacy reuse path) or a Managed Redis
+    /// database whose access keys are still enabled (existing pre-RBAC install we don't want to
+    /// break), this task no-ops and logs why.
+    /// </para>
+    /// </remarks>
     public class RedisAccessPolicyAssignmentTask : InstallTaskInAzResourceGroup<RedisInstallResult>
     {
         public const string CONFIG_KEY_CLIENT_ID = "clientId";
@@ -25,6 +43,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
         public const string CONFIG_KEY_INSTALLER_TENANT_ID = "installerTenantId";
         public const string CONFIG_KEY_ACCESS_POLICY_NAME = "accessPolicyName";
 
+        /// <summary>Built-in data-plane access policy name. Only "default" is supported by Managed Redis today.</summary>
+        private const string ACCESS_POLICY_NAME = "default";
+
+        /// <summary>Fixed assignment name so re-runs are idempotent (and re-targetable to a rotated runtime SP).</summary>
+        private const string ASSIGNMENT_NAME = "runtime";
+
         public RedisAccessPolicyAssignmentTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags)
             : base(config, logger, azureLocation, tags)
         {
@@ -32,7 +56,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
         public override string TaskName => "assign Redis access policy";
 
-        public override Task<RedisInstallResult> ExecuteTaskReturnResult(object contextArg)
+        public override async Task<RedisInstallResult> ExecuteTaskReturnResult(object contextArg)
         {
             var redis = contextArg as RedisInstallResult;
             if (redis == null)
@@ -43,12 +67,82 @@ namespace CloudInstallEngine.Azure.InstallTasks
             if (redis.IsLegacyClassicCache)
             {
                 _logger.LogInformation($"Skipping Redis access policy assignment: reusing legacy classic Azure Cache for Redis '{redis.ResourceName}' which already has its own access configuration from the previous install.");
-                return Task.FromResult(redis);
+                return redis;
             }
 
-            _logger.LogInformation("Azure Managed Redis uses access key authentication — no additional RBAC access policy assignment is required.");
+            if (!redis.UseRbacAuth)
+            {
+                _logger.LogInformation(
+                    $"Skipping Redis access policy assignment: existing Azure Managed Redis database '{redis.ResourceName}' has access keys enabled and the runtime is configured to use key auth. " +
+                    "To switch this cache to RBAC/Entra ID auth, delete the resource in the portal and re-run the installer — the new database will default to RBAC-only.");
+                return redis;
+            }
 
-            return Task.FromResult(redis);
+            // RBAC path: look up the runtime SP's OID and upsert the access policy assignment
+            // on the cluster's "default" database. ResourceId is the cluster resource ID
+            // (private endpoint tasks rely on that); the database resource is obtained from it.
+            var runtimeTenantId = _config[CONFIG_KEY_TENANT_ID];
+            var runtimeClientId = _config[CONFIG_KEY_CLIENT_ID];
+            var runtimeClientSecret = _config[CONFIG_KEY_CLIENT_SECRET];
+
+            string runtimeOid;
+            try
+            {
+                runtimeOid = await ServicePrincipalResolver.GetObjectIdFromClientCredentials(runtimeTenantId, runtimeClientId, runtimeClientSecret);
+            }
+            catch (Exception ex)
+            {
+                throw new InstallException(
+                    $"Couldn't resolve the runtime service principal's Entra ID object ID (clientId '{runtimeClientId}') needed for Redis RBAC assignment: " +
+                    ExceptionMessages.Format(ex));
+            }
+
+            var clusterResp = await base.Container.GetRedisEnterpriseClusterAsync(redis.ResourceName);
+            var cluster = clusterResp.Value;
+            var databaseResp = await cluster.GetRedisEnterpriseDatabaseAsync("default");
+            var database = databaseResp.Value;
+            var assignments = database.GetAccessPolicyAssignments();
+
+            // If an assignment already exists, log whether the OID matches so re-targets are visible.
+            try
+            {
+                var existing = await assignments.GetAsync(ASSIGNMENT_NAME);
+                var existingOid = existing.Value.Data.UserObjectId?.ToString();
+                if (!string.Equals(existingOid, runtimeOid, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogInformation(
+                        $"Updating Redis access policy assignment '{ASSIGNMENT_NAME}' on '{redis.ResourceName}/default' — previously assigned to object ID '{existingOid}', re-assigning to runtime object ID '{runtimeOid}'.");
+                }
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                // No existing assignment — first run, no-op.
+            }
+
+            var assignmentData = new AccessPolicyAssignmentData
+            {
+                AccessPolicyName = ACCESS_POLICY_NAME,
+                UserObjectId = Guid.Parse(runtimeOid),
+            };
+
+            try
+            {
+                await assignments.CreateOrUpdateAsync(WaitUntil.Completed, ASSIGNMENT_NAME, assignmentData);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 403 || ex.Status == 401)
+            {
+                throw new InstallException(
+                    $"Installer is not authorised to create the Redis access policy assignment on '{redis.ResourceName}/default'. " +
+                    "The installer service principal needs an Azure RBAC role on the Managed Redis cluster that includes the action " +
+                    "'Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments/write' — e.g. 'Redis Cache Contributor' or a custom role. " +
+                    $"Details: {ExceptionMessages.Format(ex)}");
+            }
+
+            _logger.LogInformation(
+                $"Assigned Redis '{ACCESS_POLICY_NAME}' access policy to runtime service principal (object ID '{runtimeOid}') on '{redis.ResourceName}/default'. " +
+                "Note: data-plane access policy assignments can take up to a minute to propagate after creation.");
+
+            return redis;
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisFirewallConfigTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisFirewallConfigTask.cs
@@ -36,7 +36,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 return Task.FromResult(redis);
             }
 
-            _logger.LogInformation("Azure Managed Redis uses access key authentication — IP-based firewall configuration is not required.");
+            _logger.LogInformation("Azure Managed Redis does not require IP-based firewall configuration here; access is controlled by Redis auth (key-based or RBAC/Entra ID) and, optionally, private endpoints.");
 
             return Task.FromResult(redis);
         }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
@@ -145,9 +145,21 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 await base.EnsureTagsOnExisting(cluster.Data.Tags, cluster.GetTagResource());
             }
 
-            // Get or create the default database
+            // Get or create the default database.
+            //
+            // For NEW databases we default to RBAC-only (AccessKeysAuthentication = Disabled)
+            // — the runtime authenticates via Entra ID / managed identity / service principal
+            // (see RedisAccessPolicyAssignmentTask and CacheConnectionManager). Key auth on a
+            // fresh deployment is left off by design so that the cache can never be reached by
+            // a leaked connection string alone.
+            //
+            // For EXISTING databases we preserve whatever access-key mode is already set:
+            // disabling keys on a running cache mid-install would instantly break any in-flight
+            // connection that still has the old keyed connection string, and existing
+            // deployments may legitimately rely on key auth.
             var databases = cluster.GetRedisEnterpriseDatabases();
             RedisEnterpriseDatabaseResource database;
+            bool isNewDatabase = false;
             try
             {
                 database = await cluster.GetRedisEnterpriseDatabaseAsync("default");
@@ -155,25 +167,52 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             catch (RequestFailedException ex) when (ex.Status == 404)
             {
-                _logger.LogInformation($"Creating default database for Azure Managed Redis cluster '{name}'...");
+                _logger.LogInformation($"Creating default database for Azure Managed Redis cluster '{name}' with access keys disabled (RBAC/Entra ID auth)...");
                 var dbData = new RedisEnterpriseDatabaseData
                 {
                     ClusteringPolicy = RedisEnterpriseClusteringPolicy.OssCluster,
                     EvictionPolicy = RedisEnterpriseEvictionPolicy.AllKeysLru,
-                    AccessKeysAuthentication = AccessKeysAuthentication.Enabled
+                    AccessKeysAuthentication = AccessKeysAuthentication.Disabled
                 };
                 var dbOp = await databases.CreateOrUpdateAsync(WaitUntil.Completed, "default", dbData);
                 database = dbOp.Value;
-                _logger.LogInformation($"Created Azure Managed Redis database on port {database.Data.Port}.");
+                isNewDatabase = true;
+                _logger.LogInformation($"Created Azure Managed Redis database on port {database.Data.Port} (RBAC-only — no access keys).");
             }
 
-            var keys = await database.GetKeysAsync();
+            // Decide auth mode for downstream tasks. Null = treat as Enabled (preserve current
+            // behaviour and never silently break an install whose runtime is already authed
+            // with keys).
+            var keysAuth = database.Data.AccessKeysAuthentication;
+            var rbacOnly = isNewDatabase
+                || (keysAuth.HasValue && keysAuth.Value == AccessKeysAuthentication.Disabled);
+
+            if (!isNewDatabase)
+            {
+                if (rbacOnly)
+                {
+                    _logger.LogInformation($"Azure Managed Redis database '{database.Data.Name}' has access keys disabled — using RBAC/Entra ID auth.");
+                }
+                else
+                {
+                    _logger.LogInformation($"Azure Managed Redis database '{database.Data.Name}' has access keys enabled — using key-based auth (existing configuration preserved).");
+                }
+            }
+
+            string primaryKey = null;
+            if (!rbacOnly)
+            {
+                var keys = await database.GetKeysAsync();
+                primaryKey = keys.Value.PrimaryKey;
+            }
+
             return new RedisInstallResult
             {
                 IsLegacyClassicCache = false,
+                UseRbacAuth = rbacOnly,
                 HostName = cluster.Data.HostName,
                 Port = database.Data.Port ?? DEFAULT_TLS_PORT,
-                PrimaryKey = keys.Value.PrimaryKey,
+                PrimaryKey = primaryKey,
                 ResourceId = cluster.Id.ToString(),
                 ResourceName = cluster.Data.Name,
             };

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/ExceptionMessages.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/ExceptionMessages.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+
+namespace CloudInstallEngine
+{
+    /// <summary>
+    /// Formats exceptions for installer logs so the inner-exception chain isn't lost when
+    /// only <see cref="Exception.Message"/> is written to the log (which is what the custom
+    /// installer <see cref="Microsoft.Extensions.Logging.ILogger"/> implementation does).
+    /// </summary>
+    public static class ExceptionMessages
+    {
+        /// <summary>
+        /// Returns the exception message followed by every inner-exception message in the chain,
+        /// one per line, indented. <see cref="AggregateException.InnerExceptions"/> are unrolled.
+        /// </summary>
+        public static string Format(Exception ex)
+        {
+            if (ex == null) return string.Empty;
+
+            var sb = new StringBuilder();
+            AppendChain(sb, ex, depth: 0);
+            return sb.ToString().TrimEnd();
+        }
+
+        private static void AppendChain(StringBuilder sb, Exception ex, int depth)
+        {
+            if (ex == null) return;
+
+            var indent = depth == 0 ? string.Empty : new string(' ', depth * 2) + "↳ ";
+            sb.Append(indent).Append('[').Append(ex.GetType().Name).Append("] ").AppendLine(ex.Message);
+
+            if (ex is AggregateException agg && agg.InnerExceptions != null)
+            {
+                foreach (var inner in agg.InnerExceptions)
+                {
+                    AppendChain(sb, inner, depth + 1);
+                }
+                return;
+            }
+
+            if (ex.InnerException != null)
+            {
+                AppendChain(sb, ex.InnerException, depth + 1);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/InstallJobInContainer.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/InstallJobInContainer.cs
@@ -54,7 +54,10 @@ namespace CloudInstallEngine
                     catch (Exception ex)
                     {
                         Logger.LogError($"Unexpected error on stage {thisTask.TaskName}:");
-                        Logger.LogError(ex, ex.Message);
+                        // Walk the InnerException chain — the custom installer ILogger
+                        // implementations drop the Exception arg, so feeding just ex.Message
+                        // here loses FluentFTP-style "see inner exception for more info" causes.
+                        Logger.LogError(ExceptionMessages.Format(ex));
                         throw;      // Error will be logged by parent
                     }
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Models/RedisInstallResult.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Models/RedisInstallResult.cs
@@ -24,8 +24,22 @@ namespace CloudInstallEngine.Models
         /// <summary>TLS port (6380 for classic Azure Cache for Redis, 10000 for Azure Managed Redis).</summary>
         public int Port { get; set; }
 
-        /// <summary>Primary access key (used in the App Service connection string).</summary>
+        /// <summary>
+        /// Primary access key. <c>null</c> when <see cref="UseRbacAuth"/> is true (the database
+        /// was created with access keys disabled) — in that case clients must connect via
+        /// Entra ID / RBAC instead. Always populated for legacy classic caches and for existing
+        /// Managed Redis databases that still have key auth enabled.
+        /// </summary>
         public string PrimaryKey { get; set; }
+
+        /// <summary>
+        /// True when this Managed Redis database has access keys disabled and clients must use
+        /// Entra ID / RBAC to connect. Set for newly-created Managed Redis databases (which now
+        /// default to RBAC-only) and for any existing database where the installer reads
+        /// <c>AccessKeysAuthentication = Disabled</c>. Always <c>false</c> for legacy classic
+        /// Azure Cache for Redis (those use key auth via the .NET SDK).
+        /// </summary>
+        public bool UseRbacAuth { get; set; }
 
         /// <summary>ARM resource ID of the underlying cache (the cluster for Managed Redis, the cache for classic).</summary>
         public string ResourceId { get; set; }

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -518,6 +518,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>10.0.8</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Azure.StackExchangeRedis">
+      <Version>3.3.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Abstractions">
       <Version>8.18.0</Version>
     </PackageReference>
@@ -544,9 +547,6 @@
     </PackageReference>
     <PackageReference Include="StackExchange.Redis">
       <Version>2.13.17</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Azure.StackExchangeRedis">
-      <Version>3.3.1</Version>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.PerformanceCounter">
       <Version>10.0.8</Version>

--- a/src/AnalyticsEngine/Common/Entities/Redis/CacheConnectionManager.cs
+++ b/src/AnalyticsEngine/Common/Entities/Redis/CacheConnectionManager.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Azure.StackExchangeRedis;
+﻿﻿using Microsoft.Azure.StackExchangeRedis;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using StackExchange.Redis;
@@ -8,13 +8,24 @@ using System.Threading.Tasks;
 namespace Common.Entities.Redis
 {
     /// <summary>
-    /// Wrapper class for redis connection. Tries key-based auth first, falls back to RBAC (Entra ID) if keys are disabled.
-    /// On the RBAC path the connection uses <see cref="Microsoft.Azure.StackExchangeRedis"/> which proactively refreshes
-    /// the Entra access token before it expires and re-authenticates the multiplexer on reconnect — without this the
-    /// multiplexer would silently start failing all commands ~60–90 min after process start with
-    /// <c>MicrosoftEntraAuthenticationFailure</c> on the server and <c>SocketClosed</c> / <c>RedisTimeoutException</c>
-    /// on the client.
+    /// Wrapper class for redis connection. Tries key-based auth first when the connection string
+    /// includes a password; otherwise (or on failure) authenticates via Entra ID / RBAC using the
+    /// runtime service principal.
     /// </summary>
+    /// <remarks>
+    /// New Azure Managed Redis databases provisioned by this installer ship with access keys
+    /// disabled (RBAC-only) and the App Service connection string is built without a
+    /// <c>password=</c> segment, so the RBAC path becomes the primary path on fresh deployments.
+    /// Existing installs with keyed caches keep working unchanged.
+    /// <para>
+    /// The RBAC path uses <see cref="AzureCacheForRedis.ConfigureForAzureWithServicePrincipalAsync"/>
+    /// from <c>Microsoft.Azure.StackExchangeRedis</c>, which proactively refreshes the Entra
+    /// bearer token before it expires and re-authenticates the multiplexer on reconnect — without
+    /// this the multiplexer would silently start failing all commands ~60–90 min after process
+    /// start with <c>MicrosoftEntraAuthenticationFailure</c> on the server and <c>SocketClosed</c>
+    /// / <c>RedisTimeoutException</c> on the client.
+    /// </para>
+    /// </remarks>
     public class CacheConnectionManager
     {
         #region Singleton
@@ -31,8 +42,9 @@ namespace Common.Entities.Redis
         private static readonly object _lock = new object();
 
         /// <summary>
-        /// Gets or creates a singleton connection manager. Tries key-based connection string first;
-        /// if that fails (e.g. keys disabled by policy), falls back to RBAC/Entra ID token auth using the runtime account.
+        /// Gets or creates a singleton connection manager. When the connection string contains a
+        /// <c>password=</c> the key-based path is attempted first; otherwise the RBAC path is
+        /// taken straight away. RBAC requires the runtime account credentials.
         /// </summary>
         public static CacheConnectionManager GetConnectionManager(string connectionString, ILogger logger = null, string tenantId = null, string clientId = null, string clientSecret = null)
         {
@@ -52,48 +64,57 @@ namespace Common.Entities.Redis
 
         private static CacheConnectionManager CreateConnectionManager(string connectionString, ILogger logger, string tenantId, string clientId, string clientSecret)
         {
-            // Try key-based auth first
-            try
+            // Parse the caller's connection string just to inspect whether a password was provided.
+            // The connect attempts below re-parse it so they each get a clean ConfigurationOptions.
+            var parsedOptions = ConfigurationOptions.Parse(connectionString);
+            var hasPassword = !string.IsNullOrEmpty(parsedOptions.Password);
+
+            if (hasPassword)
             {
-                var keyOptions = ConfigurationOptions.Parse(connectionString);
-                keyOptions.ConnectTimeout = 15000;
-                keyOptions.SyncTimeout = 15000;
-                keyOptions.AsyncTimeout = 15000;
-                var muxer = ConnectionMultiplexer.Connect(keyOptions);
-                // Test the connection with a ping
-                var db = muxer.GetDatabase();
-                db.Ping();
-                logger?.LogInformation("Redis connected using key-based authentication.");
-                return new CacheConnectionManager(muxer);
+                try
+                {
+                    var keyOptions = ConfigurationOptions.Parse(connectionString);
+                    keyOptions.ConnectTimeout = 15000;
+                    keyOptions.SyncTimeout = 15000;
+                    keyOptions.AsyncTimeout = 15000;
+                    var muxer = ConnectionMultiplexer.Connect(keyOptions);
+                    muxer.GetDatabase().Ping();
+                    logger?.LogInformation("Redis connected using key-based authentication.");
+                    return new CacheConnectionManager(muxer);
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning($"Redis key-based auth failed ({ex.Message}). Attempting RBAC/Entra ID auth...");
+                }
             }
-            catch (Exception ex)
+            else
             {
-                logger?.LogWarning($"Redis key-based auth failed ({ex.Message}). Attempting RBAC/Entra ID auth...");
+                logger?.LogInformation("Redis connection string has no password — using RBAC/Entra ID auth with runtime service principal.");
             }
 
-            // Fall back to RBAC (Entra ID) token auth using the runtime account
             if (string.IsNullOrWhiteSpace(tenantId) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
             {
                 throw new InvalidOperationException(
-                    "Redis key-based auth failed and RBAC fallback cannot proceed: runtime account credentials (tenantId, clientId, clientSecret) are not configured.");
+                    "Redis RBAC/Entra ID auth cannot proceed: runtime account credentials (tenantId, clientId, clientSecret) are not configured." +
+                    (hasPassword ? " Key-based auth also failed (see warning above)." : string.Empty));
             }
 
             try
             {
-                // Microsoft.Azure.StackExchangeRedis ConfigureForAzure* methods are async (they acquire the
-                // initial bearer token and register handlers to refresh it before expiry). We're inside a sync
-                // singleton-init path that runs once per process under _lock — wrap in Task.Run to detach from
-                // any ASP.NET / OWIN sync context and avoid the classic sync-over-async deadlock.
-                var muxer = Task.Run(() => ConnectWithRbacAsync(connectionString, tenantId, clientId, clientSecret)).GetAwaiter().GetResult();
-                var db = muxer.GetDatabase();
-                db.Ping();
-                logger?.LogInformation("Redis connected using RBAC/Entra ID authentication with runtime account (auto token refresh enabled).");
-                return new CacheConnectionManager(muxer);
+                // ConfigureForAzure* methods are async (they acquire the initial bearer token and register
+                // handlers to refresh it before expiry). We're inside a sync singleton-init path that runs
+                // once per process under _lock — wrap in Task.Run to detach from any ASP.NET / OWIN sync
+                // context and avoid the classic sync-over-async deadlock.
+                var rbacMuxer = Task.Run(() => ConnectWithRbacAsync(connectionString, tenantId, clientId, clientSecret)).GetAwaiter().GetResult();
+                PingWithRetryForPolicyPropagation(rbacMuxer, logger);
+                logger?.LogInformation("Redis connected using RBAC/Entra ID authentication with runtime service principal (auto token refresh enabled).");
+                return new CacheConnectionManager(rbacMuxer);
             }
             catch (Exception ex)
             {
                 throw new InvalidOperationException(
-                    $"Failed to connect to Redis with both key-based and RBAC auth. RBAC error: {ex.Message}", ex);
+                    $"Failed to connect to Redis via RBAC. RBAC error: {ex.Message}" +
+                    (hasPassword ? " (key-based auth was also attempted and failed earlier.)" : string.Empty), ex);
             }
         }
 
@@ -125,6 +146,31 @@ namespace Common.Entities.Redis
             await options.ConfigureForAzureWithServicePrincipalAsync(clientId, tenantId, clientSecret).ConfigureAwait(false);
 
             return await ConnectionMultiplexer.ConnectAsync(options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Pings Redis after RBAC connection with a small retry budget to absorb the typical
+        /// data-plane propagation delay after a fresh <c>accessPolicyAssignment</c> create
+        /// (the installer might have created the assignment seconds before this call).
+        /// </summary>
+        private static void PingWithRetryForPolicyPropagation(ConnectionMultiplexer muxer, ILogger logger)
+        {
+            const int maxAttempts = 4;
+            var db = muxer.GetDatabase();
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    db.Ping();
+                    return;
+                }
+                catch (Exception ex) when (attempt < maxAttempts)
+                {
+                    var waitMs = 5000 * attempt;
+                    logger?.LogWarning($"Redis RBAC ping failed (attempt {attempt} of {maxAttempts}): {ex.Message}. Waiting {waitMs / 1000}s for access policy propagation and retrying...");
+                    Task.Delay(waitMs).GetAwaiter().GetResult();
+                }
+            }
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Web/Web.Template.config
+++ b/src/AnalyticsEngine/Web/Web.Template.config
@@ -186,6 +186,11 @@
 			</dependentAssembly>
 		
 			<dependentAssembly>
+				<assemblyIdentity name="Azure.Identity" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
+			</dependentAssembly>
+		
+			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
 				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
 			</dependentAssembly>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
@@ -89,6 +89,11 @@
 			</dependentAssembly>
 
 			<dependentAssembly>
+				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159e12e44c8" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0"/>
+			</dependentAssembly>
+
+			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>


### PR DESCRIPTION
Post-1622 follow-up. Two installer-side improvements landed on dev since the 1622 release was tagged:

* **81dd785** — New Azure Managed Redis databases provisioned by the installer now default to `AccessKeysAuthentication = Disabled` (RBAC/Entra ID only). The runtime `CacheConnectionManager` skips the key-auth attempt entirely when the connection string has no `password=`, and the `RedisAccessPolicyAssignmentTask` now actually upserts the runtime SP's data-plane access policy assignment (instead of being a no-op). Existing keyed caches are left untouched.
* **6fadda0** — `InstallAppServiceContentsTask` and the SequentialTaskListInstallJob / SolutionInstaller pipeline funnels now walk the inner-exception chain (including `AggregateException`) into the install log, so FluentFTP upload failures and similar surface their actual root cause instead of the generic `See inner exception for more info`.

No DB schema changes.