### PR TITLE
Release: Fix Redis private DNS zone for Azure Managed Redis (#98)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -311,15 +311,16 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 // If RedisInstallTask detected and reused a pre-existing legacy classic
                 // Azure Cache for Redis, RedisPrivateEndpointInstallTask / RedisPrivateDnsZoneInstallTask
                 // will log a warning and skip — the legacy resource retains its own networking.
+                // The Private Link group ID, target resource ID, and DNS zone name are NOT hardcoded
+                // here: the Redis-aware wrappers derive them from RedisInstallTask.LastResult at
+                // execution time, so the values always match the Redis kind we actually got.
                 var redisPeName = peNames.GetNameOrDefault(peNames.Redis, $"pe-{config.RedisName}-redis");
                 var redisPeConfig = TaskConfig.GetConfigForName(redisPeName)
-                    .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_TARGET_RESOURCE_ID, $"/subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.Cache/redisEnterprise/{config.RedisName}")
-                    .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_GROUP_ID, "redisEnterprise")
                     .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_SUBNET_ID, subnetId);
                 this.AddTask(new RedisPrivateEndpointInstallTask(redisPeConfig, logger, Location, tagDic, _redisTask));
                 if (deployDns)
                 {
-                    var redisDnsConfig = TaskConfig.GetConfigForName("privatelink.redisenterprise.cache.azure.net")
+                    var redisDnsConfig = TaskConfig.NoConfig
                         .AddSetting(PrivateDnsZoneInstallTask.CONFIG_KEY_VNET_ID, vnetId)
                         .AddSetting(PrivateDnsZoneInstallTask.CONFIG_KEY_PE_NAME, redisPeName);
                     this.AddTask(new RedisPrivateDnsZoneInstallTask(redisDnsConfig, logger, Location, tagDic, _redisTask));

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/PrivateDnsZoneInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/PrivateDnsZoneInstallTask.cs
@@ -6,6 +6,7 @@ using Azure.ResourceManager.PrivateDns;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace CloudInstallEngine.Azure.InstallTasks
@@ -132,7 +133,47 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             else
             {
-                _logger.LogInformation($"Found existing DNS zone group '{zoneGroup.Data.Name}' on private endpoint '{peName}'.");
+                // Reconcile: if the existing zone group references a different (wrong) private DNS zone
+                // (e.g. an older installer pointed the PE at 'privatelink.redisenterprise.cache.azure.net'
+                // instead of 'privatelink.redis.azure.net'), recreate it. Without this, the bad config is
+                // sticky: A records never auto-register into the right zone and VNet-integrated clients
+                // keep resolving the public IP.
+                var configuredZoneIds = zoneGroup.Data.PrivateDnsZoneConfigs == null
+                    ? new List<string>()
+                    : zoneGroup.Data.PrivateDnsZoneConfigs
+                        .Where(c => c?.PrivateDnsZoneId != null)
+                        .Select(c => c.PrivateDnsZoneId.ToString())
+                        .ToList();
+                var pointsAtIntendedZone = configuredZoneIds
+                    .Any(id => string.Equals(id, dnsZone.Id.ToString(), System.StringComparison.OrdinalIgnoreCase));
+
+                if (!pointsAtIntendedZone)
+                {
+                    var existingSummary = configuredZoneIds.Count == 0
+                        ? "<none>"
+                        : string.Join(", ", configuredZoneIds);
+                    _logger.LogWarning(
+                        $"DNS zone group '{zoneGroupName}' on private endpoint '{peName}' references the wrong zone(s) [{existingSummary}] — expected '{dnsZone.Id}'. " +
+                        "Recreating so A records auto-register into the correct zone.");
+                    await zoneGroup.DeleteAsync(WaitUntil.Completed);
+
+                    var zoneGroupData = new PrivateDnsZoneGroupData()
+                    {
+                        Name = zoneGroupName,
+                    };
+                    zoneGroupData.PrivateDnsZoneConfigs.Add(new PrivateDnsZoneConfig()
+                    {
+                        Name = zoneName.Replace(".", "-"),
+                        PrivateDnsZoneId = dnsZone.Id,
+                    });
+                    var operation = await peResource.GetPrivateDnsZoneGroups().CreateOrUpdateAsync(WaitUntil.Completed, zoneGroupName, zoneGroupData);
+                    zoneGroup = operation.Value;
+                    _logger.LogInformation($"Recreated DNS zone group '{zoneGroup.Data.Name}' pointing at '{dnsZone.Data.Name}'.");
+                }
+                else
+                {
+                    _logger.LogInformation($"Found existing DNS zone group '{zoneGroup.Data.Name}' on private endpoint '{peName}'.");
+                }
             }
 
             return dnsZone;

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
@@ -20,6 +20,25 @@ namespace CloudInstallEngine.Azure.InstallTasks
         /// <summary>Classic Azure Cache for Redis uses port 6380 for TLS connections.</summary>
         public const int LEGACY_TLS_PORT = 6380;
 
+        /// <summary>Private Link sub-resource ("group") ID used when targeting Azure Managed Redis.</summary>
+        public const string MANAGED_REDIS_PE_GROUP_ID = "redisEnterprise";
+
+        /// <summary>
+        /// Private DNS zone that matches the CNAME chain produced by an Azure Managed Redis FQDN
+        /// (<c>&lt;name&gt;.&lt;region&gt;.redis.azure.net</c> → <c>...privatelink.redis.azure.net</c>).
+        /// Note: this is NOT <c>privatelink.redisenterprise.cache.azure.net</c> — that zone exists
+        /// historically but does not match the actual hostnames Azure Managed Redis uses today, so
+        /// a private endpoint pointed at it never auto-registers A records and VNet-integrated
+        /// clients fall through to public DNS (which the PE-only firewall then blocks).
+        /// </summary>
+        public const string MANAGED_REDIS_PRIVATE_DNS_ZONE = "privatelink.redis.azure.net";
+
+        /// <summary>Private Link sub-resource ("group") ID used when targeting classic Azure Cache for Redis.</summary>
+        public const string LEGACY_CLASSIC_PE_GROUP_ID = "redisCache";
+
+        /// <summary>Private DNS zone for classic Azure Cache for Redis (<c>&lt;name&gt;.redis.cache.windows.net</c>).</summary>
+        public const string LEGACY_CLASSIC_PRIVATE_DNS_ZONE = "privatelink.redis.cache.windows.net";
+
         private readonly bool _requireStandardSku;
         private readonly bool _allowPublicAccess;
 
@@ -116,6 +135,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 PrimaryKey = keys.Value.PrimaryKey,
                 ResourceId = legacy.Id.ToString(),
                 ResourceName = legacy.Data.Name,
+                PrivateLinkGroupId = LEGACY_CLASSIC_PE_GROUP_ID,
+                PrivateDnsZoneName = LEGACY_CLASSIC_PRIVATE_DNS_ZONE,
             };
         }
 
@@ -215,6 +236,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 PrimaryKey = primaryKey,
                 ResourceId = cluster.Id.ToString(),
                 ResourceName = cluster.Data.Name,
+                PrivateLinkGroupId = MANAGED_REDIS_PE_GROUP_ID,
+                PrivateDnsZoneName = MANAGED_REDIS_PRIVATE_DNS_ZONE,
             };
         }
     }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisPrivateDnsZoneInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisPrivateDnsZoneInstallTask.cs
@@ -13,18 +13,19 @@ namespace CloudInstallEngine.Azure.InstallTasks
     /// <see cref="RedisInstallTask"/> reused a pre-existing classic Azure Cache for
     /// Redis — that resource already has its own DNS configuration from the previous install,
     /// and creating a Managed-Redis DNS zone alongside it would not point to anything useful.
-    /// Otherwise delegates to a standard <see cref="PrivateDnsZoneInstallTask"/>.
+    /// Otherwise derives the private DNS zone name from <see cref="RedisInstallResult"/> at
+    /// execution time (so the zone always matches the Redis kind we actually got — e.g.
+    /// <c>privatelink.redis.azure.net</c> for Azure Managed Redis) and delegates to a
+    /// standard <see cref="PrivateDnsZoneInstallTask"/>.
     /// </summary>
     public class RedisPrivateDnsZoneInstallTask : InstallTaskInAzResourceGroup<PrivateDnsZoneResource>
     {
         private readonly RedisInstallTask _redisTask;
-        private readonly PrivateDnsZoneInstallTask _innerTask;
 
         public RedisPrivateDnsZoneInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, RedisInstallTask redisTask)
             : base(config, logger, azureLocation, tags)
         {
             _redisTask = redisTask;
-            _innerTask = new PrivateDnsZoneInstallTask(config, logger, azureLocation, tags);
         }
 
         public override string TaskName => "get/create Redis private DNS zone";
@@ -44,8 +45,25 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 return null;
             }
 
-            _innerTask.Container = base.Container;
-            return await _innerTask.ExecuteTaskReturnResult(contextArg);
+            if (string.IsNullOrEmpty(_redisTask.LastResult.PrivateDnsZoneName))
+            {
+                throw new InstallException(
+                    "RedisPrivateDnsZoneInstallTask cannot deploy a DNS zone: the Redis install task did not populate " +
+                    $"{nameof(RedisInstallResult.PrivateDnsZoneName)} on its result.");
+            }
+
+            var vnetId = _config.GetConfigValue(PrivateDnsZoneInstallTask.CONFIG_KEY_VNET_ID);
+            var peName = _config.GetConfigValue(PrivateDnsZoneInstallTask.CONFIG_KEY_PE_NAME);
+
+            var innerConfig = TaskConfig.GetConfigForName(_redisTask.LastResult.PrivateDnsZoneName)
+                .AddSetting(PrivateDnsZoneInstallTask.CONFIG_KEY_VNET_ID, vnetId)
+                .AddSetting(PrivateDnsZoneInstallTask.CONFIG_KEY_PE_NAME, peName);
+
+            var innerTask = new PrivateDnsZoneInstallTask(innerConfig, _logger, AzureLocation, Tags)
+            {
+                Container = base.Container,
+            };
+            return await innerTask.ExecuteTaskReturnResult(contextArg);
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisPrivateEndpointInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisPrivateEndpointInstallTask.cs
@@ -12,18 +12,19 @@ namespace CloudInstallEngine.Azure.InstallTasks
     /// Skips private endpoint creation (with a warning) when the associated
     /// <see cref="RedisInstallTask"/> reused a pre-existing classic Azure Cache for
     /// Redis — that resource already has its own networking from the previous install.
-    /// Otherwise delegates to a standard <see cref="PrivateEndpointInstallTask"/>.
+    /// Otherwise derives the Private Link sub-resource ("group") ID and target ARM
+    /// resource ID from <see cref="RedisInstallResult"/> at execution time (so the
+    /// values always match the Redis kind we actually got) and delegates to a
+    /// standard <see cref="PrivateEndpointInstallTask"/>.
     /// </summary>
     public class RedisPrivateEndpointInstallTask : InstallTaskInAzResourceGroup<PrivateEndpointResource>
     {
         private readonly RedisInstallTask _redisTask;
-        private readonly PrivateEndpointInstallTask _innerTask;
 
         public RedisPrivateEndpointInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, RedisInstallTask redisTask)
             : base(config, logger, azureLocation, tags)
         {
             _redisTask = redisTask;
-            _innerTask = new PrivateEndpointInstallTask(config, logger, azureLocation, tags);
         }
 
         public override string TaskName => "get/create Redis private endpoint";
@@ -44,8 +45,27 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 return null;
             }
 
-            _innerTask.Container = base.Container;
-            return await _innerTask.ExecuteTaskReturnResult(contextArg);
+            if (string.IsNullOrEmpty(_redisTask.LastResult.PrivateLinkGroupId)
+                || string.IsNullOrEmpty(_redisTask.LastResult.ResourceId))
+            {
+                throw new InstallException(
+                    "RedisPrivateEndpointInstallTask cannot build a private endpoint: the Redis install task did not populate " +
+                    $"{nameof(RedisInstallResult.PrivateLinkGroupId)} / {nameof(RedisInstallResult.ResourceId)} on its result.");
+            }
+
+            var peName = _config.GetNameConfigValue();
+            var subnetId = _config.GetConfigValue(PrivateEndpointInstallTask.CONFIG_KEY_SUBNET_ID);
+
+            var innerConfig = TaskConfig.GetConfigForName(peName)
+                .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_TARGET_RESOURCE_ID, _redisTask.LastResult.ResourceId)
+                .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_GROUP_ID, _redisTask.LastResult.PrivateLinkGroupId)
+                .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_SUBNET_ID, subnetId);
+
+            var innerTask = new PrivateEndpointInstallTask(innerConfig, _logger, AzureLocation, Tags)
+            {
+                Container = base.Container,
+            };
+            return await innerTask.ExecuteTaskReturnResult(contextArg);
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Models/RedisInstallResult.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Models/RedisInstallResult.cs
@@ -46,5 +46,27 @@ namespace CloudInstallEngine.Models
 
         /// <summary>Short resource name (as displayed in the portal).</summary>
         public string ResourceName { get; set; }
+
+        /// <summary>
+        /// Private Link sub-resource ("group") ID for a private endpoint targeting this cache:
+        /// <c>redisEnterprise</c> for Azure Managed Redis, <c>redisCache</c> for legacy classic.
+        /// Populated for both kinds so the value is correct for the cache we actually have, but
+        /// the Redis-aware private endpoint wrapper still respects <see cref="IsLegacyClassicCache"/>
+        /// and skips itself for reused legacy caches — these values are descriptive, not a licence
+        /// for downstream tasks to provision networking for a legacy cache that was deliberately
+        /// left alone.
+        /// </summary>
+        public string PrivateLinkGroupId { get; set; }
+
+        /// <summary>
+        /// Private DNS zone name that matches the CNAME chain produced by the cache's public
+        /// FQDN: <c>privatelink.redis.azure.net</c> for Azure Managed Redis
+        /// (<c>&lt;name&gt;.&lt;region&gt;.redis.azure.net</c>) and
+        /// <c>privatelink.redis.cache.windows.net</c> for legacy classic
+        /// (<c>&lt;name&gt;.redis.cache.windows.net</c>). Populated for both kinds for the same
+        /// reason as <see cref="PrivateLinkGroupId"/>; the DNS wrapper still honours
+        /// <see cref="IsLegacyClassicCache"/> and does not deploy a zone for reused legacy caches.
+        /// </summary>
+        public string PrivateDnsZoneName { get; set; }
     }
 }


### PR DESCRIPTION
Ships the fix for issue #98 (Redis cannot be deployed). The installer was creating private DNS zone `privatelink.redisenterprise.cache.azure.net`, which does not match the actual CNAME chain of Azure Managed Redis hostnames (`<name>.<region>.redis.azure.net` -> `privatelink.redis.azure.net`). VNet-integrated clients consequently resolved the public IP and were blocked by the PE-only firewall, causing 15s ConnectTimeout on every WebJob start.

This PR:
- Fixes the zone name and makes the choice live with `RedisInstallTask` instead of the orchestration job, so the right values (group ID, target ARM ID, DNS zone name) are always picked from `RedisInstallResult` at execution time for both Azure Managed Redis and reused legacy classic caches.
- Adds self-heal logic to `PrivateDnsZoneInstallTask`: if an existing PE zone group points at the wrong private DNS zone (e.g. left behind by a previous dev build), it is deleted and recreated against the correct one so A records auto-register.
- Verified end-to-end against the OfficeAnalytics RG: the installer recreated the PE zone group and the A record auto-registered as `sfbofficeanalytics.norwayeast -> 10.0.0.7`.

No DB schema changes.