### PR TITLE
Make Key Vault secret upload non-critical; add DNS pre-flight checks to Test Configuration

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -4,6 +4,7 @@ using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.AppService;
 using Azure.ResourceManager.AppService.Models;
+using Azure.ResourceManager.KeyVault;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Sql;
 using CloudInstallEngine.Azure;
@@ -49,6 +50,21 @@ namespace App.ControlPanel.Engine
             WindowsVersionCheck();
             _logger.LogInformation($"Starting installation/update tests...");
 
+            // Validate the configuration itself first (names, accounts, region, etc.) so fundamental
+            // mistakes are reported before we make any Azure calls.
+            ReportConfigValidationIssues();
+
+            // When public access is disabled the data-plane checks below (DNS, Key Vault) only succeed
+            // from a host with private-network line-of-sight to the resources - tell the operator up-front.
+            if (PrivateNetworkGuidance.IsPrivateNetworkOnly(Config))
+            {
+                _logger.LogInformation(
+                    $"Public network access is disabled for this deployment. Run 'Test Configuration' (and the install itself) " +
+                    $"from a host with private-network line-of-sight to the resources - a VM on VNet '{Config.NetworkConfig?.VNetName}' " +
+                    $"(or a peered VNet, VPN/ExpressRoute, or Azure Bastion-attached host) - otherwise public DNS may not resolve to " +
+                    $"the private endpoint IPs and the DNS / Key Vault data-plane checks below will fail.");
+            }
+
             // Check sub & az group if possible
             var (testRg, azCredsValid) = await GetResourceGroupIfValid();
             if (!azCredsValid)
@@ -69,6 +85,10 @@ namespace App.ControlPanel.Engine
             // "The remote name could not be resolved" class of failure (broken/limited DNS on the
             // installer host) up-front instead of letting it abort an install part-way through.
             await VerifyResourceDnsResolution();
+
+            // Key Vault data-plane reachability with the installer account (the exact call that failed
+            // mid-install). Only runs when the vault already exists and installer credentials are present.
+            await VerifyKeyVaultDataPlaneAccess(testRg);
 
             // Firewall tests
             if (_testConfig.IsValid)
@@ -257,8 +277,113 @@ namespace App.ControlPanel.Engine
             }
         }
 
-        #region DNS resolution checks
+        #region Configuration & Key Vault checks
 
+        /// <summary>
+        /// Run the same configuration validation the installer uses and log any issues up-front, so
+        /// fundamental mistakes (missing names, accounts, region, etc.) are reported before any Azure calls.
+        /// Logs only; never throws.
+        /// </summary>
+        void ReportConfigValidationIssues()
+        {
+            try
+            {
+                var errors = Config?.ValidatInputAndGetErrors();
+                if (errors != null && errors.Count > 0)
+                {
+                    _logger.LogError($"Configuration validation found {errors.Count} issue(s) that may block installation:");
+                    foreach (var e in errors)
+                    {
+                        _logger.LogError($"  - {e}");
+                    }
+                }
+                else
+                {
+                    _logger.LogInformation("Configuration validation passed - no issues found.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not run configuration validation: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Probe the Key Vault data-plane endpoint with the installer account - the exact call
+        /// (<c>KeyVaultSecretAddTask</c>) that aborts an install when DNS/network to
+        /// <c>&lt;vault&gt;.vault.azure.net</c> is broken. Only runs when the vault already exists and the
+        /// installer credentials are present, so it never false-alarms on a fresh install. Logs only; never throws.
+        /// </summary>
+        async Task VerifyKeyVaultDataPlaneAccess(ResourceGroupResource testRg)
+        {
+            if (Config == null || string.IsNullOrWhiteSpace(Config.KeyVaultName)) return;
+
+            var installerErrs = Config.InstallerAccount?.GetValidationErrors();
+            if (installerErrs == null || installerErrs.Count > 0)
+            {
+                _logger.LogInformation("Skipping Key Vault data-plane reachability check - installer account details are incomplete.");
+                return;
+            }
+
+            if (testRg == null)
+            {
+                _logger.LogInformation("Skipping Key Vault data-plane reachability check - resource group is not available.");
+                return;
+            }
+
+            KeyVaultResource vault;
+            try
+            {
+                vault = testRg.GetKeyVaults().Where(v => v.Data.Name == Config.KeyVaultName).SingleOrDefault();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not enumerate key vaults to check '{Config.KeyVaultName}': {ex.Message}");
+                return;
+            }
+
+            if (vault == null)
+            {
+                _logger.LogInformation($"Key Vault '{Config.KeyVaultName}' not found yet; skipping data-plane reachability check (it will be created during install).");
+                return;
+            }
+
+            _logger.LogInformation($"Checking Key Vault data-plane access to '{Config.KeyVaultName}' with the installer account...");
+
+            var creds = new ClientSecretCredential(Config.InstallerAccount.DirectoryId, Config.InstallerAccount.ClientId, Config.InstallerAccount.Secret);
+            var result = await KeyVaultDataPlaneProbe.TryReadAsync(Config.KeyVaultName, creds);
+
+            switch (result.Status)
+            {
+                case KeyVaultProbeStatus.Reachable:
+                    _logger.LogInformation($"Key Vault '{Config.KeyVaultName}' data-plane is reachable and the installer account can read secrets.");
+                    break;
+
+                case KeyVaultProbeStatus.TransportFailure:
+                    var transportGuidance = PrivateNetworkGuidance.IsPrivateNetworkOnly(Config)
+                        ? PrivateNetworkGuidance.BuildVmOnVNetGuidance("reaching the Key Vault", Config.NetworkConfig?.VNetName)
+                        : $"Check DNS / network / firewall connectivity from this host to '{Config.KeyVaultName}.vault.azure.net'.";
+                    _logger.LogError(
+                        $"Could not reach Key Vault '{Config.KeyVaultName}' data-plane ({result.Message}). " +
+                        $"This is the DNS/network failure that aborts secret upload during install. " + transportGuidance);
+                    break;
+
+                case KeyVaultProbeStatus.Unauthorized:
+                    _logger.LogError(
+                        $"Key Vault '{Config.KeyVaultName}' is reachable but the installer account was denied data-plane access (403): {result.Message} " +
+                        $"Ensure the installer app registration has a Key Vault access policy granting secret Get/List/Set, " +
+                        $"and that any vault firewall allows this host's IP.");
+                    break;
+
+                default:
+                    _logger.LogError($"Unexpected error checking Key Vault '{Config.KeyVaultName}' data-plane access: {result.Message}");
+                    break;
+            }
+        }
+
+        #endregion
+
+        #region DNS resolution checks
         /// <summary>Public DNS suffix for each Azure PaaS resource the installer / runtime must resolve.</summary>
         private const string DNS_SUFFIX_KEY_VAULT = ".vault.azure.net";
         private const string DNS_SUFFIX_SQL = ".database.windows.net";

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -63,6 +64,11 @@ namespace App.ControlPanel.Engine
                     _logger.LogInformation($"Resource-group found with name {Config.ResourceGroupName}.");
                 }
             }
+
+            // DNS resolution checks for the configured Azure resource hostnames. Catches the
+            // "The remote name could not be resolved" class of failure (broken/limited DNS on the
+            // installer host) up-front instead of letting it abort an install part-way through.
+            await VerifyResourceDnsResolution();
 
             // Firewall tests
             if (_testConfig.IsValid)
@@ -251,6 +257,154 @@ namespace App.ControlPanel.Engine
             }
         }
 
+        #region DNS resolution checks
+
+        /// <summary>Public DNS suffix for each Azure PaaS resource the installer / runtime must resolve.</summary>
+        private const string DNS_SUFFIX_KEY_VAULT = ".vault.azure.net";
+        private const string DNS_SUFFIX_SQL = ".database.windows.net";
+        private const string DNS_SUFFIX_STORAGE_BLOB = ".blob.core.windows.net";
+        private const string DNS_SUFFIX_APP_SERVICE = ".azurewebsites.net";
+        private const string DNS_SUFFIX_REDIS = ".redis.cache.windows.net";
+        private const string DNS_SUFFIX_SERVICE_BUS = ".servicebus.windows.net";
+        private const string DNS_SUFFIX_COGNITIVE = ".cognitiveservices.azure.com";
+
+        /// <summary>
+        /// Control host the installer always needs to resolve (ARM management plane). If even this fails,
+        /// the installer host has no working DNS for Azure at all (broken DNS / no internet / proxy issue).
+        /// </summary>
+        private const string DNS_CONTROL_HOST = "management.azure.com";
+
+        /// <summary>Max time to wait for a single DNS lookup before treating it as a failure.</summary>
+        private static readonly TimeSpan _dnsLookupTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Resolve the public hostnames of the configured Azure resources so DNS / network problems on the
+        /// installer host - the cause of "The remote name could not be resolved: '&lt;x&gt;.vault.azure.net'"
+        /// install failures - are caught up-front rather than mid-install. Logs only; never throws.
+        /// </summary>
+        async Task VerifyResourceDnsResolution()
+        {
+            _logger.LogInformation("Checking DNS resolution for configured Azure resource hostnames...");
+
+            // First confirm the host can resolve Azure DNS at all. management.azure.com always exists, so a
+            // failure here means broken DNS / no connectivity / proxy issue - every data-plane call will fail.
+            var (controlOk, controlError) = await TryResolveHost(DNS_CONTROL_HOST);
+            if (!controlOk)
+            {
+                _logger.LogError(
+                    $"The installer host cannot resolve Azure DNS names (failed to resolve '{DNS_CONTROL_HOST}': {controlError}). " +
+                    $"Installation will fail until DNS / network / proxy connectivity is fixed on this machine.");
+            }
+
+            var targets = BuildResourceDnsTargets(Config);
+            if (targets.Count == 0)
+            {
+                _logger.LogInformation("No named Azure resources configured to DNS-check.");
+                return;
+            }
+
+            var privateOnly = PrivateNetworkGuidance.IsPrivateNetworkOnly(Config);
+
+            foreach (var target in targets)
+            {
+                var (ok, error) = await TryResolveHost(target.Fqdn);
+                if (ok)
+                {
+                    _logger.LogInformation($"DNS OK: {target.Label} '{target.Fqdn}' resolved.");
+                    continue;
+                }
+
+                if (!controlOk)
+                {
+                    // Root cause already reported above; don't repeat the per-resource guidance.
+                    _logger.LogError($"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}).");
+                }
+                else if (privateOnly)
+                {
+                    // Public access disabled: the host must be on the VNet to resolve the private endpoint IP.
+                    _logger.LogError(
+                        $"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}). " +
+                        PrivateNetworkGuidance.BuildVmOnVNetGuidance($"reaching the {target.Label}", Config.NetworkConfig?.VNetName));
+                }
+                else
+                {
+                    // Public access path: if the resource already exists this is a real DNS / network problem
+                    // that will break the install; if it has not been created yet, it is expected.
+                    _logger.LogError(
+                        $"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}). " +
+                        $"If this resource has not been created yet this is expected and can be ignored; " +
+                        $"if it already exists, the installer host cannot reach it and data-plane steps " +
+                        $"(e.g. Key Vault secret upload) will fail.");
+                }
+            }
+
+            _logger.LogInformation("DNS resolution checks complete.");
+        }
+
+        /// <summary>
+        /// Build the list of (resource, public-FQDN) DNS targets for every resource that is both enabled
+        /// and has a name configured. Pure string logic so it is unit-testable without any network access.
+        /// </summary>
+        public static List<ResourceDnsTarget> BuildResourceDnsTargets(SolutionInstallConfig config)
+        {
+            var targets = new List<ResourceDnsTarget>();
+            if (config == null) return targets;
+
+            void Add(string label, string name, string suffix)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    targets.Add(new ResourceDnsTarget(label, name.Trim() + suffix));
+                }
+            }
+
+            Add("Key Vault", config.KeyVaultName, DNS_SUFFIX_KEY_VAULT);
+            Add("SQL Server", config.SQLServerName, DNS_SUFFIX_SQL);
+            Add("Storage account", config.StorageAccountName, DNS_SUFFIX_STORAGE_BLOB);
+            Add("App Service", config.AppServiceWebAppName, DNS_SUFFIX_APP_SERVICE);
+            Add("Redis cache", config.RedisName, DNS_SUFFIX_REDIS);
+            if (config.ServiceBusEnabled)
+            {
+                Add("Service Bus", config.ServiceBusName, DNS_SUFFIX_SERVICE_BUS);
+            }
+            if (config.CognitiveServicesEnabled)
+            {
+                Add("Cognitive Services", config.CognitiveServiceName, DNS_SUFFIX_COGNITIVE);
+            }
+
+            return targets;
+        }
+
+        /// <summary>
+        /// Resolve a host name with a timeout. Returns (true, null) on success and (false, message) on
+        /// failure or timeout. Never throws.
+        /// </summary>
+        static async Task<(bool ok, string error)> TryResolveHost(string host)
+        {
+            try
+            {
+                var lookup = Dns.GetHostAddressesAsync(host);
+                var completed = await Task.WhenAny(lookup, Task.Delay(_dnsLookupTimeout));
+                if (completed != lookup)
+                {
+                    return (false, $"DNS lookup timed out after {_dnsLookupTimeout.TotalSeconds:0}s");
+                }
+
+                var addresses = await lookup;   // also re-throws any lookup exception
+                if (addresses != null && addresses.Length > 0)
+                {
+                    return (true, null);
+                }
+                return (false, "no IP addresses returned");
+            }
+            catch (Exception ex)
+            {
+                return (false, ex.Message);
+            }
+        }
+
+        #endregion
+
         void WindowsVersionCheck()
         {
             var os = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
@@ -434,5 +588,24 @@ namespace App.ControlPanel.Engine
 
             _logger.LogInformation("Successfully verified user activity settings.");
         }
+    }
+
+    /// <summary>
+    /// A configured Azure resource and the public hostname that must resolve for the installer / runtime
+    /// to reach it. Built by <see cref="SolutionInstallVerifier.BuildResourceDnsTargets"/>.
+    /// </summary>
+    public class ResourceDnsTarget
+    {
+        public ResourceDnsTarget(string label, string fqdn)
+        {
+            Label = label;
+            Fqdn = fqdn;
+        }
+
+        /// <summary>Human-readable resource description, e.g. "Key Vault".</summary>
+        public string Label { get; }
+
+        /// <summary>Public fully-qualified hostname, e.g. "myvault.vault.azure.net".</summary>
+        public string Fqdn { get; }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -231,12 +231,41 @@ namespace CloudInstallEngine.Azure.InstallTasks
         {
         }
 
+        /// <summary>
+        /// Writing the runtime app-registration secret to Key Vault is best-effort: a transient
+        /// network/DNS/permission failure here must not abort an otherwise-successful install. The
+        /// existing vault value (if any) remains valid and the secret can be re-written on a later run.
+        /// </summary>
+        public override bool IsCritical => false;
+
         public override async Task<object> ExecuteTask(object contextArg)
         {
             base.EnsureContextArgType<KeyVaultResource>(contextArg);
             var vault = (KeyVaultResource)contextArg;
 
             var name = _config.GetNameConfigValue();
+            try
+            {
+                return await AddRuntimeSecretAsync(vault, name);
+            }
+            catch (Exception ex) when (IsTransportOrDnsFailure(ex, out var leafMessage))
+            {
+                // DNS/network transport failure reaching the Key Vault data-plane endpoint
+                // (e.g. "The remote name could not be resolved: '<vault>.vault.azure.net'"), as opposed
+                // to an HTTP error response. Writing the secret is best-effort (see IsCritical), so log
+                // an actionable warning and let the install continue instead of aborting everything.
+                _logger.LogWarning(
+                    $"Could not reach key vault '{vault.Data.Name}' over the network to update secret '{name}': {leafMessage} " +
+                    $"This is usually a DNS / network / firewall issue resolving '{vault.Data.Name}.vault.azure.net' from the installer host " +
+                    $"(for example when public network access is disabled and the host is not on the VNet). " +
+                    $"The secret was not written; any existing value in the vault remains valid. " +
+                    $"Re-run the installer once connectivity is restored if the secret needs updating.");
+                return vault;
+            }
+        }
+
+        private async Task<object> AddRuntimeSecretAsync(KeyVaultResource vault, string name)
+        {
             var val = _config.GetConfigValue(CONFIG_KEY_SECRET_VAL);
 
 
@@ -339,6 +368,50 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 $"Likely causes: access policy / RBAC propagation lag (longer than the {(_retryDelaysSeconds.Length + 1)}-attempt retry window) or a vault firewall rule rejecting the runner IP — check the vault's Networking blade. " +
                 $"App-registration secrets in the vault may now be out of date — re-run the installer once the underlying cause is resolved.");
             return vault;
+        }
+
+        /// <summary>
+        /// True when <paramref name="ex"/> (or any exception nested within it, including
+        /// <see cref="AggregateException.InnerExceptions"/>) is a network transport / DNS resolution
+        /// failure rather than an HTTP error response from Key Vault. Azure.Core surfaces these as a
+        /// <see cref="RequestFailedException"/> with <c>Status == 0</c> wrapping a
+        /// <see cref="System.Net.WebException"/> / <see cref="System.Net.Http.HttpRequestException"/> /
+        /// <see cref="System.Net.Sockets.SocketException"/>, and the retry policy rethrows them inside an
+        /// <see cref="AggregateException"/>.
+        /// </summary>
+        private static bool IsTransportOrDnsFailure(Exception ex, out string leafMessage)
+        {
+            leafMessage = null;
+            foreach (var node in Flatten(ex))
+            {
+                if (node is System.Net.Sockets.SocketException
+                    || node is System.Net.WebException
+                    || node is System.Net.Http.HttpRequestException
+                    || (node is RequestFailedException rfe && rfe.Status == 0))
+                {
+                    // Keep walking so the innermost (most specific) message wins.
+                    leafMessage = node.Message;
+                }
+            }
+            return leafMessage != null;
+        }
+
+        private static IEnumerable<Exception> Flatten(Exception ex)
+        {
+            if (ex == null) yield break;
+            yield return ex;
+
+            if (ex is AggregateException agg)
+            {
+                foreach (var inner in agg.InnerExceptions)
+                {
+                    foreach (var n in Flatten(inner)) yield return n;
+                }
+            }
+            else if (ex.InnerException != null)
+            {
+                foreach (var n in Flatten(ex.InnerException)) yield return n;
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -248,7 +248,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             {
                 return await AddRuntimeSecretAsync(vault, name);
             }
-            catch (Exception ex) when (IsTransportOrDnsFailure(ex, out var leafMessage))
+            catch (Exception ex) when (TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leafMessage))
             {
                 // DNS/network transport failure reaching the Key Vault data-plane endpoint
                 // (e.g. "The remote name could not be resolved: '<vault>.vault.azure.net'"), as opposed
@@ -368,50 +368,6 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 $"Likely causes: access policy / RBAC propagation lag (longer than the {(_retryDelaysSeconds.Length + 1)}-attempt retry window) or a vault firewall rule rejecting the runner IP — check the vault's Networking blade. " +
                 $"App-registration secrets in the vault may now be out of date — re-run the installer once the underlying cause is resolved.");
             return vault;
-        }
-
-        /// <summary>
-        /// True when <paramref name="ex"/> (or any exception nested within it, including
-        /// <see cref="AggregateException.InnerExceptions"/>) is a network transport / DNS resolution
-        /// failure rather than an HTTP error response from Key Vault. Azure.Core surfaces these as a
-        /// <see cref="RequestFailedException"/> with <c>Status == 0</c> wrapping a
-        /// <see cref="System.Net.WebException"/> / <see cref="System.Net.Http.HttpRequestException"/> /
-        /// <see cref="System.Net.Sockets.SocketException"/>, and the retry policy rethrows them inside an
-        /// <see cref="AggregateException"/>.
-        /// </summary>
-        private static bool IsTransportOrDnsFailure(Exception ex, out string leafMessage)
-        {
-            leafMessage = null;
-            foreach (var node in Flatten(ex))
-            {
-                if (node is System.Net.Sockets.SocketException
-                    || node is System.Net.WebException
-                    || node is System.Net.Http.HttpRequestException
-                    || (node is RequestFailedException rfe && rfe.Status == 0))
-                {
-                    // Keep walking so the innermost (most specific) message wins.
-                    leafMessage = node.Message;
-                }
-            }
-            return leafMessage != null;
-        }
-
-        private static IEnumerable<Exception> Flatten(Exception ex)
-        {
-            if (ex == null) yield break;
-            yield return ex;
-
-            if (ex is AggregateException agg)
-            {
-                foreach (var inner in agg.InnerExceptions)
-                {
-                    foreach (var n in Flatten(inner)) yield return n;
-                }
-            }
-            else if (ex.InnerException != null)
-            {
-                foreach (var n in Flatten(ex.InnerException)) yield return n;
-            }
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/KeyVaultDataPlaneProbe.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/KeyVaultDataPlaneProbe.cs
@@ -1,0 +1,86 @@
+using Azure;
+using Azure.Core;
+using Azure.Security.KeyVault.Secrets;
+using System;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure
+{
+    /// <summary>Outcome of a Key Vault data-plane reachability probe.</summary>
+    public enum KeyVaultProbeStatus
+    {
+        /// <summary>The vault data-plane endpoint was reached and the credential is authorized to read.</summary>
+        Reachable,
+
+        /// <summary>The vault was reached but the credential was denied (HTTP 403) - missing access policy or a firewall rule.</summary>
+        Unauthorized,
+
+        /// <summary>The vault data-plane endpoint could not be reached at all (DNS / network / firewall transport failure).</summary>
+        TransportFailure,
+
+        /// <summary>Some other, unexpected error occurred.</summary>
+        OtherError
+    }
+
+    /// <summary>Result of <see cref="KeyVaultDataPlaneProbe.TryReadAsync"/>.</summary>
+    public class KeyVaultProbeResult
+    {
+        public KeyVaultProbeResult(KeyVaultProbeStatus status, string message)
+        {
+            Status = status;
+            Message = message;
+        }
+
+        public KeyVaultProbeStatus Status { get; }
+        public string Message { get; }
+    }
+
+    /// <summary>
+    /// Lightweight pre-flight check that the Key Vault data-plane endpoint
+    /// (<c>&lt;name&gt;.vault.azure.net</c>) is actually reachable and readable with a given credential.
+    /// This pre-empts the install-time failure where <c>KeyVaultSecretAddTask</c> cannot resolve / reach the
+    /// vault, distinguishing a DNS/network problem from an authorization (access policy / firewall) problem.
+    /// </summary>
+    public static class KeyVaultDataPlaneProbe
+    {
+        /// <summary>
+        /// Sentinel secret name used only to prove reachability + read authorization. It is expected NOT to
+        /// exist, so a 404 is the success signal (the call got through and we were authorized to read).
+        /// </summary>
+        private const string ProbeSecretName = "aitracker-testconfig-connectivity-probe";
+
+        /// <summary>
+        /// Attempt a single, read-only data-plane call against the vault and classify the outcome. Never throws.
+        /// </summary>
+        public static async Task<KeyVaultProbeResult> TryReadAsync(string vaultName, TokenCredential credential)
+        {
+            if (string.IsNullOrWhiteSpace(vaultName)) throw new ArgumentException($"'{nameof(vaultName)}' cannot be null or empty.", nameof(vaultName));
+            if (credential == null) throw new ArgumentNullException(nameof(credential));
+
+            var client = new SecretClient(new Uri($"https://{vaultName.Trim()}.vault.azure.net"), credential);
+            try
+            {
+                await client.GetSecretAsync(ProbeSecretName);
+                // The probe secret unexpectedly exists, but the call still proves reachability + Get permission.
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.Reachable, "Key Vault data-plane reachable.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                // Reached the vault and were authorized to read; the probe secret simply doesn't exist (expected).
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.Reachable, "Key Vault data-plane reachable.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == 403)
+            {
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.Unauthorized, ex.Message);
+            }
+            catch (Exception ex) when (TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leaf))
+            {
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.TransportFailure, leaf);
+            }
+            catch (Exception ex)
+            {
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.OtherError, ex.Message);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/InstallJobInContainer.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/InstallJobInContainer.cs
@@ -53,12 +53,23 @@ namespace CloudInstallEngine
                     }
                     catch (Exception ex)
                     {
-                        Logger.LogError($"Unexpected error on stage {thisTask.TaskName}:");
-                        // Walk the InnerException chain — the custom installer ILogger
-                        // implementations drop the Exception arg, so feeding just ex.Message
-                        // here loses FluentFTP-style "see inner exception for more info" causes.
-                        Logger.LogError(ExceptionMessages.Format(ex));
-                        throw;      // Error will be logged by parent
+                        if (!thisTask.IsCritical)
+                        {
+                            // Best-effort task: log the failure but let the install continue. The
+                            // assignment above threw, so previousRunResult still holds the prior task's
+                            // result and is carried forward to downstream tasks that chain on it.
+                            Logger.LogError($"Non-critical stage {thisTask.TaskName} failed; continuing installation. Error:");
+                            Logger.LogError(ExceptionMessages.Format(ex));
+                        }
+                        else
+                        {
+                            Logger.LogError($"Unexpected error on stage {thisTask.TaskName}:");
+                            // Walk the InnerException chain — the custom installer ILogger
+                            // implementations drop the Exception arg, so feeding just ex.Message
+                            // here loses FluentFTP-style "see inner exception for more info" causes.
+                            Logger.LogError(ExceptionMessages.Format(ex));
+                            throw;      // Error will be logged by parent
+                        }
                     }
 
                     // Remember result

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/InstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/InstallTask.cs
@@ -20,6 +20,20 @@ namespace CloudInstallEngine
         public virtual async Task<object> ExecuteTask() { return await ExecuteTask(null); }
         public virtual string TaskName => this.GetType().Name;
 
+        /// <summary>
+        /// Whether a failure of this task should abort the whole install.
+        /// <para>
+        /// Defaults to <c>true</c> (the historic behaviour): if the task throws, the running
+        /// <see cref="SequentialTaskListInstallJob"/> logs the error and rethrows, stopping the install.
+        /// </para>
+        /// <para>
+        /// Tasks that are "best-effort" (e.g. writing a runtime secret to Key Vault, where a transient
+        /// network/DNS/permission failure should not abort an otherwise-successful install) can override
+        /// this to <c>false</c>. The job then logs the failure and continues with the next task.
+        /// </para>
+        /// </summary>
+        public virtual bool IsCritical => true;
+
         protected readonly TaskConfig _config;
         protected readonly ILogger _logger;
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/TransportFailureDetector.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/TransportFailureDetector.cs
@@ -1,0 +1,65 @@
+using Azure;
+using System;
+using System.Collections.Generic;
+
+namespace CloudInstallEngine
+{
+    /// <summary>
+    /// Classifies whether an exception is a network transport / DNS resolution failure (the cause of
+    /// "The remote name could not be resolved: '&lt;x&gt;.vault.azure.net'" install failures) as opposed to
+    /// an HTTP error response from the service.
+    /// <para>
+    /// Azure.Core surfaces transport failures as a <see cref="RequestFailedException"/> with
+    /// <c>Status == 0</c> wrapping a <see cref="System.Net.WebException"/> /
+    /// <see cref="System.Net.Http.HttpRequestException"/> / <see cref="System.Net.Sockets.SocketException"/>,
+    /// and the retry policy rethrows them inside an <see cref="AggregateException"/>.
+    /// </para>
+    /// </summary>
+    public static class TransportFailureDetector
+    {
+        /// <summary>
+        /// True when <paramref name="ex"/> (or any exception nested within it, including
+        /// <see cref="AggregateException.InnerExceptions"/>) is a network transport / DNS resolution failure.
+        /// <paramref name="leafMessage"/> receives the innermost (most specific) matching message.
+        /// </summary>
+        public static bool IsTransportOrDnsFailure(Exception ex, out string leafMessage)
+        {
+            leafMessage = null;
+            foreach (var node in Flatten(ex))
+            {
+                if (node is System.Net.Sockets.SocketException
+                    || node is System.Net.WebException
+                    || node is System.Net.Http.HttpRequestException
+                    || (node is RequestFailedException rfe && rfe.Status == 0))
+                {
+                    // Keep walking so the innermost (most specific) message wins.
+                    leafMessage = node.Message;
+                }
+            }
+            return leafMessage != null;
+        }
+
+        /// <summary>
+        /// Depth-first walk of an exception and everything nested within it (the
+        /// <see cref="Exception.InnerException"/> chain and <see cref="AggregateException.InnerExceptions"/>),
+        /// outermost first.
+        /// </summary>
+        public static IEnumerable<Exception> Flatten(Exception ex)
+        {
+            if (ex == null) yield break;
+            yield return ex;
+
+            if (ex is AggregateException agg)
+            {
+                foreach (var inner in agg.InnerExceptions)
+                {
+                    foreach (var n in Flatten(inner)) yield return n;
+                }
+            }
+            else if (ex.InnerException != null)
+            {
+                foreach (var n in Flatten(ex.InnerException)) yield return n;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
@@ -113,4 +113,44 @@ namespace Tests.UnitTests.InstallTests
         // Read a prop to check we have a not-null container in tasks
         public Guid RandomId { get; set; }
     }
+
+    /// <summary>Concrete <see cref="SequentialTaskListInstallJob"/> so the task-loop can be unit-tested directly.</summary>
+    public class FakeSequentialJob : SequentialTaskListInstallJob
+    {
+        public FakeSequentialJob(ILogger logger) : base(logger) { }
+    }
+
+    /// <summary>Task that always throws. <see cref="IsCritical"/> is configurable to test abort-vs-continue behaviour.</summary>
+    public class FakeThrowingTask : BaseInstallTask
+    {
+        private readonly bool _isCritical;
+        public bool WasRun { get; private set; }
+
+        public FakeThrowingTask(TaskConfig config, ILogger logger, bool isCritical) : base(config, logger)
+        {
+            _isCritical = isCritical;
+        }
+
+        public override bool IsCritical => _isCritical;
+
+        public override Task<object> ExecuteTask(object contextArg)
+        {
+            WasRun = true;
+            throw new InvalidOperationException("Simulated task failure for testing");
+        }
+    }
+
+    /// <summary>Task that records whether it ran, used to assert downstream tasks still execute (or not).</summary>
+    public class FakeMarkerTask : BaseInstallTask
+    {
+        public bool WasRun { get; private set; }
+
+        public FakeMarkerTask(TaskConfig config, ILogger logger) : base(config, logger) { }
+
+        public override Task<object> ExecuteTask(object contextArg)
+        {
+            WasRun = true;
+            return Task.FromResult<object>(new object());
+        }
+    }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
@@ -153,4 +153,36 @@ namespace Tests.UnitTests.InstallTests
             return Task.FromResult<object>(new object());
         }
     }
+
+    /// <summary>Task that returns a caller-supplied result object, used to test result carry-forward.</summary>
+    public class FakeResultTask : BaseInstallTask
+    {
+        private readonly object _result;
+
+        public FakeResultTask(TaskConfig config, ILogger logger, object result) : base(config, logger)
+        {
+            _result = result;
+        }
+
+        public override Task<object> ExecuteTask(object contextArg)
+        {
+            return Task.FromResult(_result);
+        }
+    }
+
+    /// <summary>Task that records the context argument it received, used to assert what was carried forward.</summary>
+    public class FakeContextCapturingTask : BaseInstallTask
+    {
+        public bool WasRun { get; private set; }
+        public object ReceivedContext { get; private set; }
+
+        public FakeContextCapturingTask(TaskConfig config, ILogger logger) : base(config, logger) { }
+
+        public override Task<object> ExecuteTask(object contextArg)
+        {
+            WasRun = true;
+            ReceivedContext = contextArg;
+            return Task.FromResult<object>(new object());
+        }
+    }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -7,6 +7,7 @@ using App.ControlPanel.Engine.InstallerTasks.Tasks;
 using App.ControlPanel.Engine.Models;
 using App.ControlPanel.Engine.SharePointModelBuilder;
 using App.ControlPanel.Engine.SharePointModelBuilder.ValueLookups;
+using Azure;
 using Azure.Core;
 using Azure.Identity;
 using CloudInstallEngine;
@@ -253,6 +254,147 @@ namespace Tests.UnitTests
             CollectionAssert.DoesNotContain(labels, "SQL Server");
             CollectionAssert.DoesNotContain(labels, "Service Bus");
             CollectionAssert.DoesNotContain(labels, "Cognitive Services");
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsNullConfigReturnsEmpty()
+        {
+            Assert.AreEqual(0, SolutionInstallVerifier.BuildResourceDnsTargets(null).Count);
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsDefaultConfigReturnsEmpty()
+        {
+            // A brand-new config has no resource names set yet.
+            Assert.AreEqual(0, SolutionInstallVerifier.BuildResourceDnsTargets(new SolutionInstallConfig()).Count);
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsTrimsAndIgnoresWhitespaceNames()
+        {
+            var config = new SolutionInstallConfig
+            {
+                KeyVaultName = "  myvault  ",   // padded -> trimmed
+                SQLServerName = "   ",           // whitespace only -> excluded
+            };
+
+            var targets = SolutionInstallVerifier.BuildResourceDnsTargets(config);
+
+            Assert.AreEqual(1, targets.Count);
+            Assert.AreEqual("myvault.vault.azure.net", targets.Single().Fqdn);
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsServiceBusEnabledButEmptyIsExcluded()
+        {
+            var config = new SolutionInstallConfig
+            {
+                ServiceBusEnabled = true,
+                ServiceBusName = "",   // enabled but no name -> nothing to resolve
+            };
+
+            CollectionAssert.DoesNotContain(
+                SolutionInstallVerifier.BuildResourceDnsTargets(config).Select(t => t.Label).ToList(),
+                "Service Bus");
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsSingleResourceHasCorrectLabelAndFqdn()
+        {
+            var config = new SolutionInstallConfig { RedisName = "mycache" };
+
+            var targets = SolutionInstallVerifier.BuildResourceDnsTargets(config);
+
+            Assert.AreEqual(1, targets.Count);
+            Assert.AreEqual("Redis cache", targets.Single().Label);
+            Assert.AreEqual("mycache.redis.cache.windows.net", targets.Single().Fqdn);
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorDetectsDnsAggregateException()
+        {
+            // Mirrors the field failure: AggregateException -> RequestFailedException(Status 0) -> WebException.
+            var dns = new System.Net.WebException("The remote name could not be resolved: 'x.vault.azure.net'");
+            var ex = new AggregateException(new RequestFailedException(0, "Retry failed after 4 tries", dns));
+
+            Assert.IsTrue(TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leaf));
+            StringAssert.Contains(leaf, "could not be resolved");
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorIgnoresHttpErrorResponses()
+        {
+            Assert.IsFalse(TransportFailureDetector.IsTransportOrDnsFailure(new RequestFailedException(403, "Forbidden"), out _));
+            Assert.IsFalse(TransportFailureDetector.IsTransportOrDnsFailure(new RequestFailedException(404, "Not Found"), out _));
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorDetectsSocketAndHttpExceptions()
+        {
+            Assert.IsTrue(TransportFailureDetector.IsTransportOrDnsFailure(new System.Net.Sockets.SocketException(11001), out _));
+            Assert.IsTrue(TransportFailureDetector.IsTransportOrDnsFailure(
+                new InvalidOperationException("wrap", new System.Net.Http.HttpRequestException("transport down")), out _));
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorNullAndGenericAreNotTransport()
+        {
+            Assert.IsFalse(TransportFailureDetector.IsTransportOrDnsFailure(null, out _));
+            Assert.IsFalse(TransportFailureDetector.IsTransportOrDnsFailure(new InvalidOperationException("boom"), out _));
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorInnermostMessageWins()
+        {
+            var sock = new System.Net.Sockets.SocketException(11001);
+            var ex = new AggregateException(new RequestFailedException(0, "outer status-0 wrapper", sock));
+
+            Assert.IsTrue(TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leaf));
+            Assert.AreEqual(sock.Message, leaf, "The innermost (most specific) transport message should win.");
+        }
+
+        [TestMethod]
+        public async Task NonCriticalTaskFailureCarriesPreviousResultForward()
+        {
+            var job = new FakeSequentialJob(_logger);
+            var sentinel = new object();
+            var produce = new FakeResultTask(TaskConfig.NoConfig, _logger, sentinel);
+            var failing = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: false);
+            var capture = new FakeContextCapturingTask(TaskConfig.NoConfig, _logger);
+            job.AddTask(produce);
+            job.AddTask(failing);
+            job.AddTask(capture);
+
+            await job.Install();
+
+            Assert.IsTrue(capture.WasRun, "Task after a non-critical failure should still run.");
+            Assert.AreSame(sentinel, capture.ReceivedContext,
+                "After a non-critical failure, the previous task's result must carry forward to the next task.");
+        }
+
+        [TestMethod]
+        public async Task NonCriticalThenCriticalFailureStillAborts()
+        {
+            var job = new FakeSequentialJob(_logger);
+            var nonCrit = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: false);
+            var crit = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: true);
+            var after = new FakeMarkerTask(TaskConfig.NoConfig, _logger);
+            job.AddTask(nonCrit);
+            job.AddTask(crit);
+            job.AddTask(after);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => job.Install());
+
+            Assert.IsTrue(nonCrit.WasRun);
+            Assert.IsTrue(crit.WasRun);
+            Assert.IsFalse(after.WasRun, "A task after a critical failure must not run.");
+        }
+
+        [TestMethod]
+        public void TaskIsCriticalDefaultsToTrue()
+        {
+            Assert.IsTrue(new FakeMarkerTask(TaskConfig.NoConfig, _logger).IsCritical,
+                "Install tasks should be critical by default.");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Tests.UnitTests.InstallTests;
@@ -168,6 +169,90 @@ namespace Tests.UnitTests
             Assert.IsNotNull(fakeJob.TaskResult.FakeCloudResourceType1);
             Assert.IsNotNull(fakeJob.TaskResult.FakeCloudResourceType2);
             Assert.IsNotNull(fakeJob.ResultingContainer);
+        }
+
+        /// <summary>
+        /// A non-critical task that fails must be logged but NOT abort the install - the next task still runs.
+        /// This is the KeyVaultSecretAddTask DNS-failure scenario from the field.
+        /// </summary>
+        [TestMethod]
+        public async Task NonCriticalTaskFailureDoesNotAbortInstall()
+        {
+            var job = new FakeSequentialJob(_logger);
+            var failing = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: false);
+            var after = new FakeMarkerTask(TaskConfig.NoConfig, _logger);
+            job.AddTask(failing);
+            job.AddTask(after);
+
+            // Should complete without throwing despite the failing task.
+            await job.Install();
+
+            Assert.IsTrue(failing.WasRun, "The non-critical failing task should have run.");
+            Assert.IsTrue(after.WasRun, "A task after a non-critical failure should still run.");
+        }
+
+        /// <summary>A critical task that fails must abort the install - the next task does not run.</summary>
+        [TestMethod]
+        public async Task CriticalTaskFailureAbortsInstall()
+        {
+            var job = new FakeSequentialJob(_logger);
+            var failing = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: true);
+            var after = new FakeMarkerTask(TaskConfig.NoConfig, _logger);
+            job.AddTask(failing);
+            job.AddTask(after);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => job.Install());
+
+            Assert.IsTrue(failing.WasRun, "The critical failing task should have run.");
+            Assert.IsFalse(after.WasRun, "A task after a critical failure should NOT run.");
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsIncludesEnabledResources()
+        {
+            var config = new SolutionInstallConfig
+            {
+                KeyVaultName = "myvault",
+                SQLServerName = "mysqlsvr",
+                StorageAccountName = "mystorage",
+                AppServiceWebAppName = "myapp",
+                RedisName = "mycache",
+                ServiceBusName = "mysb",
+                ServiceBusEnabled = true,
+                CognitiveServiceName = "mycog",
+                CognitiveServicesEnabled = true,
+            };
+
+            var fqdns = SolutionInstallVerifier.BuildResourceDnsTargets(config).Select(t => t.Fqdn).ToList();
+
+            CollectionAssert.Contains(fqdns, "myvault.vault.azure.net");
+            CollectionAssert.Contains(fqdns, "mysqlsvr.database.windows.net");
+            CollectionAssert.Contains(fqdns, "mystorage.blob.core.windows.net");
+            CollectionAssert.Contains(fqdns, "myapp.azurewebsites.net");
+            CollectionAssert.Contains(fqdns, "mycache.redis.cache.windows.net");
+            CollectionAssert.Contains(fqdns, "mysb.servicebus.windows.net");
+            CollectionAssert.Contains(fqdns, "mycog.cognitiveservices.azure.com");
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsExcludesDisabledAndEmptyResources()
+        {
+            var config = new SolutionInstallConfig
+            {
+                KeyVaultName = "myvault",
+                SQLServerName = "",                 // empty -> excluded
+                ServiceBusName = "mysb",
+                ServiceBusEnabled = false,          // disabled -> excluded even though named
+                CognitiveServiceName = "mycog",
+                CognitiveServicesEnabled = false,   // disabled -> excluded even though named
+            };
+
+            var labels = SolutionInstallVerifier.BuildResourceDnsTargets(config).Select(t => t.Label).ToList();
+
+            CollectionAssert.Contains(labels, "Key Vault");
+            CollectionAssert.DoesNotContain(labels, "SQL Server");
+            CollectionAssert.DoesNotContain(labels, "Service Bus");
+            CollectionAssert.DoesNotContain(labels, "Cognitive Services");
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem
An install/upgrade aborted **FATAL** when `KeyVaultSecretAddTask` hit a DNS resolution failure:

`
ERROR  Unexpected error on stage KeyVaultSecretAddTask:
[AggregateException] Retry failed after 4 tries...
  -> [RequestFailedException] The remote name could not be resolved: '<vault>.vault.azure.net'
`

The Azure SDK retry threw an `AggregateException` (transport-level, `Status == 0`) that escaped the task's 403/404-only handling, hit `SequentialTaskListInstallJob.Install`'s catch (which rethrows), and stopped the whole install. Writing the runtime secret is best-effort and should never abort an otherwise-successful install.

## Changes
### Make the step non-critical (CloudInstallEngine)
- `BaseInstallTask.IsCritical` (virtual, default `true`).
- `SequentialTaskListInstallJob.Install` logs and continues (carrying the previous task result forward) when a **non-critical** task throws; critical behaviour unchanged.
- `KeyVaultSecretAddTask` overrides `IsCritical => false` and now catches transport/DNS failures with an actionable warning, returning the vault (existing value stays valid). Helper `IsTransportOrDnsFailure` walks the `AggregateException`/inner-exception tree.

### DNS validation in the "Test Configuration" button (App.ControlPanel.Engine)
- `SolutionInstallVerifier.VerifyResourceDnsResolution()` (called from `RunTests()`): probes `management.azure.com` as a control, then resolves each configured + enabled resource hostname (Key Vault, SQL, Storage, App Service, Redis, Service Bus, Cognitive Services) with a 10s timeout, surfacing private-network guidance where relevant. Logs only - never aborts the test run.
- Testable `BuildResourceDnsTargets()` + `ResourceDnsTarget`.

### Tests
- New: non-critical failure continues / critical aborts; `BuildResourceDnsTargets` include/exclude correctness. All pass; existing task-loop tests still pass.

## Database schema changes
None.

## Verification
- `Tests.UnitTests` and the installer UI (`AnalyticsInstaller.exe`) build clean (only pre-existing warnings).
- 4 new unit tests pass; existing `InstallTestsFake` / `TaskConfigTests` pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
