### PR TITLE
Fix oversized Teams deep-link (xsdata) URLs blocking urls.full_url migration

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
@@ -207,13 +207,21 @@ namespace DataUtils
         }
 
         /// <summary>
-        /// Ensures <paramref name="url"/> fits the <c>dbo.urls.full_url</c> column. URLs already
-        /// within <paramref name="maxLength"/> are returned unchanged (so we avoid needless churn).
-        /// Otherwise the volatile <c>xsdata</c> parameter is removed (see <see cref="RemoveXsDataParam"/>);
-        /// if the result is STILL too long (e.g. a huge <c>FilterValues</c> list, or a URL with no
-        /// <c>xsdata</c> at all) it is hard-truncated to <paramref name="maxLength"/> as a last resort,
-        /// so the importer never fails staging an over-length value into the nvarchar(850) staging
-        /// column. Pass <c>Common.Entities.Url.FullUrlMaxLength</c> as <paramref name="maxLength"/>.
+        /// Ensures <paramref name="url"/> fits the <c>dbo.urls.full_url</c> column, mirroring the
+        /// staged clean-up in ShrinkUrlsFullUrlColumn-UpgradeGuide.md so the importer can never fail
+        /// staging an over-length value into the nvarchar(850) staging columns. URLs already within
+        /// <paramref name="maxLength"/> are returned unchanged (no needless churn). Otherwise, in order:
+        /// <list type="number">
+        /// <item>the volatile <c>xsdata</c> token is removed (see <see cref="RemoveXsDataParam"/>) -
+        /// on its own this brings the large majority of oversized SharePoint URLs back under the limit;</item>
+        /// <item>if it is STILL too long (e.g. a giant <c>SafelinksUrl</c>/<c>FilterValues</c> list or
+        /// comma-merged Teams parameters), the whole query string and <c>#fragment</c> are dropped,
+        /// keeping just the page path - the only part with analytic value (this matches the "reduce to
+        /// path" step of the upgrade guide);</item>
+        /// <item>only in the pathological case where even the bare path exceeds <paramref name="maxLength"/>
+        /// is it hard-truncated as an absolute last resort.</item>
+        /// </list>
+        /// Pass <c>Common.Entities.Url.FullUrlMaxLength</c> as <paramref name="maxLength"/>.
         /// </summary>
         public static string EnsureUrlWithinLength(string url, int maxLength)
         {
@@ -222,14 +230,41 @@ namespace DataUtils
                 return url;
             }
 
+            // 1. Remove the volatile xsdata token - usually enough on its own.
             var trimmed = RemoveXsDataParam(url);
-            if (trimmed.Length > maxLength)
+            if (trimmed.Length <= maxLength)
             {
-                // A degenerate URL (junk tracking params) that xsdata removal can't shrink enough:
-                // truncate so the staging insert never overflows the column.
-                trimmed = trimmed.Substring(0, maxLength);
+                return trimmed;
             }
-            return trimmed;
+
+            // 2. Still too long: drop the entire query string and #fragment, keeping just the page
+            //    path. Everything after '?' on these URLs is volatile Teams junk with no analytic value.
+            var path = GetUrlPath(trimmed);
+            if (path.Length <= maxLength)
+            {
+                return path;
+            }
+
+            // 3. Pathological (even the bare path is over the limit): hard-truncate as an absolute
+            //    last resort so the staging insert never overflows the column.
+            return path.Substring(0, maxLength);
+        }
+
+        static readonly char[] QueryOrFragmentStart = { '?', '#' };
+
+        /// <summary>
+        /// Returns everything in <paramref name="url"/> before the first <c>?</c> or <c>#</c> (the
+        /// page path), or the whole string if neither is present. String-based to match the T-SQL
+        /// <c>pathkey</c> logic in ShrinkUrlsFullUrlColumn-UpgradeGuide.md exactly.
+        /// </summary>
+        private static string GetUrlPath(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return url;
+            }
+            var cut = url.IndexOfAny(QueryOrFragmentStart);
+            return cut < 0 ? url : url.Substring(0, cut);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
@@ -149,6 +149,89 @@ namespace DataUtils
             }
         }
 
+        internal const string XsDataParam = "xsdata=";
+
+        /// <summary>
+        /// Removes the volatile <c>xsdata</c> query parameter from <paramref name="url"/>, preserving
+        /// the rest of the URL (path, all other query parameters, and any <c>#fragment</c>). The
+        /// <c>xsdata</c> value is a large, transient Teams / SharePoint deep-link token with no
+        /// analytic value that routinely pushes SharePoint URLs past the <c>dbo.urls.full_url</c>
+        /// limit (<c>nvarchar(850)</c>, see migration ShrinkUrlsFullUrlColumn / issue #122). Matching
+        /// is case-insensitive on the parameter name and boundary-aware (only a real <c>?xsdata=</c>
+        /// or <c>&amp;xsdata=</c> parameter is removed, never an <c>xsdata</c> substring inside
+        /// another value). Returns the input unchanged when it is null/empty or has no such parameter.
+        /// Mirrors the T-SQL clean-up in ShrinkUrlsFullUrlColumn-UpgradeGuide.md.
+        /// </summary>
+        public static string RemoveXsDataParam(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return url;
+            }
+
+            var lower = url.ToLowerInvariant();
+            var sep = lower.IndexOf("?" + XsDataParam, StringComparison.Ordinal);
+            if (sep == -1)
+            {
+                sep = lower.IndexOf("&" + XsDataParam, StringComparison.Ordinal);
+            }
+            if (sep == -1)
+            {
+                return url; // No xsdata parameter present.
+            }
+
+            var sepChar = url[sep];
+            var valStart = sep + 1 + XsDataParam.Length; // First char of the xsdata value.
+
+            // The value ends at the next '&' or '#' (whichever comes first), or end-of-string.
+            var amp = url.IndexOf('&', valStart);
+            var hash = url.IndexOf('#', valStart);
+            int term;
+            if (amp == -1) term = hash;
+            else if (hash == -1) term = amp;
+            else term = Math.Min(amp, hash);
+
+            if (term == -1)
+            {
+                // xsdata is the last parameter and there is no fragment: drop the separator + value.
+                return url.Substring(0, sep);
+            }
+            if (sepChar == '?' && url[term] == '&')
+            {
+                // xsdata is the first parameter: keep '?', drop 'xsdata=...&'.
+                return url.Substring(0, sep + 1) + url.Substring(term + 1);
+            }
+            // '&' separator, or '?' separator immediately followed by a fragment: drop the parameter
+            // and keep the remainder (the following '&param' or '#fragment').
+            return url.Substring(0, sep) + url.Substring(term);
+        }
+
+        /// <summary>
+        /// Ensures <paramref name="url"/> fits the <c>dbo.urls.full_url</c> column. URLs already
+        /// within <paramref name="maxLength"/> are returned unchanged (so we avoid needless churn).
+        /// Otherwise the volatile <c>xsdata</c> parameter is removed (see <see cref="RemoveXsDataParam"/>);
+        /// if the result is STILL too long (e.g. a huge <c>FilterValues</c> list, or a URL with no
+        /// <c>xsdata</c> at all) it is hard-truncated to <paramref name="maxLength"/> as a last resort,
+        /// so the importer never fails staging an over-length value into the nvarchar(850) staging
+        /// column. Pass <c>Common.Entities.Url.FullUrlMaxLength</c> as <paramref name="maxLength"/>.
+        /// </summary>
+        public static string EnsureUrlWithinLength(string url, int maxLength)
+        {
+            if (url == null || url.Length <= maxLength)
+            {
+                return url;
+            }
+
+            var trimmed = RemoveXsDataParam(url);
+            if (trimmed.Length > maxLength)
+            {
+                // A degenerate URL (junk tracking params) that xsdata removal can't shrink enough:
+                // truncate so the staging insert never overflows the column.
+                trimmed = trimmed.Substring(0, maxLength);
+            }
+            return trimmed;
+        }
+
         /// <summary>
         /// https://contoso.sharepoint.com/sites/site/Shared Documents/
         /// to 

--- a/src/AnalyticsEngine/Common/Entities/Entities/Url.cs
+++ b/src/AnalyticsEngine/Common/Entities/Entities/Url.cs
@@ -13,6 +13,14 @@ namespace Common.Entities
     [Table("urls")]
     public class Url : AbstractEFEntity, IUrlObject
     {
+        /// <summary>
+        /// Maximum length (characters) of <see cref="FullUrl"/> / <c>dbo.urls.full_url</c>. The
+        /// column is <c>nvarchar(850)</c> after migration ShrinkUrlsFullUrlColumn (850 nvarchar
+        /// chars = the 1700-byte non-clustered index-key limit). Used to gate insert-time URL
+        /// trimming (see <see cref="DataUtils.StringUtils.EnsureUrlWithinLength"/>) so the
+        /// importer never stages a URL longer than the target column. See issue #122 (#108/#109).
+        /// </summary>
+        public const int FullUrlMaxLength = 850;
 
         // nvarchar(850) NOT NULL is the on-disk schema after migration ShrinkUrlsFullUrlColumn
         // (the column is shrunk from a (max) LOB so it can be the IX_urls_full_url index key -
@@ -21,7 +29,7 @@ namespace Common.Entities
         // would corrupt to '?'. The matching EF mapping below keeps EF emitting nvarchar parameters
         // so EF-driven queries on urls can use IX_urls_full_url. See issue #122 (#108/#109).
         [Required]
-        [MaxLength(850)]
+        [MaxLength(FullUrlMaxLength)]
         [Column("full_url", TypeName = "nvarchar")]
         public string FullUrl { get; set; }
 

--- a/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md
@@ -140,7 +140,27 @@ no‑op.
 ## If the migration aborts
 
 If a customer DB has URLs longer than 850 characters, the migration **aborts before changing
-anything** and prints the offending rows. Find them with:
+anything** and prints the offending rows.
+
+### 1. How many URLs are there, and how many are oversized?
+
+First get the scale of the problem — the **total** row count and how many are actually over the
+limit (the abort only tells you about the oversized ones):
+
+```sql
+SELECT
+    COUNT(*)                                                              AS total_urls,
+    SUM(CASE WHEN LEN(full_url) > 850 THEN 1 ELSE 0 END)                  AS oversize_urls,
+    SUM(CASE WHEN LEN(full_url) > 850
+              AND (full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%')
+             THEN 1 ELSE 0 END)                                           AS oversize_with_xsdata,
+    SUM(CASE WHEN LEN(full_url) > 850
+              AND NOT (full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%')
+             THEN 1 ELSE 0 END)                                           AS oversize_other
+FROM dbo.urls;
+```
+
+Then list the offending rows themselves:
 
 ```sql
 SELECT id, LEN(full_url) AS length, full_url
@@ -149,9 +169,134 @@ WHERE LEN(full_url) > 850
 ORDER BY length DESC;
 ```
 
-Resolve each offending URL (and the `hits` / `event_meta_sharepoint` rows that reference it via
-`url_id`) — e.g. delete the obsolete records or shorten the stored URL — then re‑run the upgrade.
-The migration is idempotent, so re‑running after a fix simply continues.
+In practice most of the `oversize_with_xsdata` rows can be fixed automatically (next section). Any
+`oversize_other` rows (over 850 even without an `xsdata` parameter) must be resolved by hand —
+delete the obsolete records or shorten the stored URL (and the `hits` / `event_meta_sharepoint`
+rows that reference them via `url_id`) — then re‑run the upgrade. The migration is idempotent, so
+re‑running after a fix simply continues.
 
 > There is no longer a "not representable as varchar" abort: the target is `nvarchar`, which holds
 > every Unicode character, so Greek (and any other script) is preserved rather than rejected.
+
+---
+
+## Cleaning up oversized Teams deep‑link (`xsdata`) URLs
+
+A large share of real‑world oversized URLs are SharePoint links opened from Microsoft Teams. Teams
+appends a big, **transient** `xsdata=` token (plus `sdata`, `ovuser`, `clickparams`, …) to the URL.
+The `xsdata` value alone is typically **600–1100 characters** of opaque base64 and carries **no
+analytic value** — it just records *how* the link was opened. Example (line‑wrapped for clarity):
+
+```
+https://contoso.sharepoint.com/sites/Marketing/Lists/Announcements/AllItems.aspx
+    ?xsdata=<opaque base64 token, ~700 chars>&sdata=…&ovuser=…&clickparams=…&viewid=…
+```
+
+Removing just the `xsdata` parameter brings these URLs back under 850 characters in the vast
+majority of cases (observed: real samples of **1213–1515** chars drop to **601–935** chars). The
+remainder of the URL — path, all other query parameters and any `#fragment` — is preserved.
+
+> **Note** — going forward the importers no longer store these tokens: when a URL exceeds the
+> column limit (`Url.FullUrlMaxLength` = 850) the activity / click / Copilot import paths strip the
+> `xsdata` parameter **at insert time** — and, as a last resort, hard‑truncate to 850 if the URL is
+> *still* too long — via `StringUtils.EnsureUrlWithinLength`. This clean‑up script is for databases
+> that already accumulated oversized rows before that change.
+
+### 2. Clean up the oversized `xsdata` URLs (transaction defaults to ROLLBACK)
+
+The script below **defaults to `ROLLBACK`** so it is safe to run as a *preview*: it does all the
+work, prints how many rows it would clean and how many would still be oversized, then throws it all
+away. **Verify those numbers, then — and only then — change the final `ROLLBACK TRANSACTION;` to
+`COMMIT TRANSACTION;` and re‑run to apply the changes for real.** Back up / snapshot the database
+first, as with any data fix.
+
+It only touches rows that are **over 850 characters** and contain a real `xsdata` parameter, only
+applies the cleaned value when it **fits** (≤ 850) **and does not already exist** on another row
+(so it never creates a duplicate `full_url`), and collapses multiple oversized rows that clean to
+the same value down to one.
+
+```sql
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+BEGIN TRANSACTION;
+
+-- 1. Collect oversize URLs that carry a real xsdata parameter, with the parameter's position.
+--    Materialising into #fix first stops the query optimiser from evaluating the string-slicing
+--    below against rows that have no xsdata parameter (which would pass a negative length to
+--    LEFT/SUBSTRING). Every #fix row is guaranteed to have sep >= 1.
+IF OBJECT_ID('tempdb..#fix') IS NOT NULL DROP TABLE #fix;
+SELECT id, full_url,
+       sep = CASE WHEN CHARINDEX(N'?xsdata=', full_url) > 0 THEN CHARINDEX(N'?xsdata=', full_url)
+                  ELSE CHARINDEX(N'&xsdata=', full_url) END,
+       cleaned_url = CAST(NULL AS nvarchar(max))
+INTO #fix
+FROM dbo.urls
+WHERE LEN(full_url) > 850
+  AND (full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%');
+
+-- 2. Build the cleaned URL (xsdata parameter removed, everything else - including any #fragment -
+--    preserved). The value ends at the next '&' or '#', or end-of-string.
+UPDATE f
+SET cleaned_url = CASE
+        WHEN term = 0 THEN LEFT(full_url, sep - 1)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'&'
+             THEN LEFT(full_url, sep) + SUBSTRING(full_url, term + 1, 4000)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'#'
+             THEN LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+        ELSE LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+    END
+FROM #fix f
+CROSS APPLY (SELECT sepChar = SUBSTRING(full_url, sep, 1),
+                    endAmp  = CHARINDEX(N'&', full_url, sep + 8),
+                    endHash = CHARINDEX(N'#', full_url, sep + 8)) a
+CROSS APPLY (SELECT term = CASE WHEN a.endAmp = 0 AND a.endHash = 0 THEN 0
+                               WHEN a.endAmp = 0 THEN a.endHash
+                               WHEN a.endHash = 0 THEN a.endAmp
+                               WHEN a.endAmp < a.endHash THEN a.endAmp
+                               ELSE a.endHash END) b;
+
+-- 3. Apply: only rows that now fit (<= 850) AND whose cleaned value does not already exist on
+--    another row (so we never create a duplicate full_url). ROW_NUMBER collapses any oversize
+--    rows that clean to the same value, updating just one of them.
+;WITH ranked AS (
+    SELECT id, cleaned_url,
+           rn = ROW_NUMBER() OVER (PARTITION BY CAST(cleaned_url AS nvarchar(850)) ORDER BY id)
+    FROM #fix
+    WHERE LEN(cleaned_url) <= 850
+)
+UPDATE u
+   SET u.full_url = r.cleaned_url
+FROM dbo.urls u
+INNER JOIN ranked r ON r.id = u.id
+WHERE r.rn = 1
+  AND NOT EXISTS (SELECT 1 FROM dbo.urls e WHERE e.full_url = r.cleaned_url AND e.id <> r.id);
+
+DECLARE @cleaned int = @@ROWCOUNT;
+RAISERROR('Rows cleaned: %d', 0, 1, @cleaned) WITH NOWAIT;
+
+-- 4. What still exceeds 850 (xsdata couldn't shrink it enough, or its cleaned form already exists)?
+SELECT remaining_oversize    = COUNT(*),
+       of_which_still_xsdata = SUM(CASE WHEN full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%' THEN 1 ELSE 0 END)
+FROM dbo.urls WHERE LEN(full_url) > 850;
+
+DROP TABLE #fix;
+
+-- VERIFY the two result sets above, then change ROLLBACK to COMMIT and re-run to apply.
+ROLLBACK TRANSACTION;
+-- COMMIT TRANSACTION;
+```
+
+### 3. What's left after the clean‑up
+
+`remaining_oversize` counts the rows the script could **not** auto‑fix:
+
+- **Still > 850 after removing `xsdata`** — a few URLs are long because of *other* parameters (e.g.
+  a huge `FilterValues1=…` list), not `xsdata`. Removing `xsdata` isn't enough; shorten or delete
+  these by hand.
+- **Cleaned value already exists** — the de‑duplicated URL is already tracked by another `urls`
+  row, so the oversized duplicate was left untouched to avoid creating a duplicate key. Re‑point its
+  `hits` / `event_meta_sharepoint` / Copilot rows (via `url_id`) at the existing row and delete the
+  duplicate, or simply delete the oversized duplicate if its facts are redundant.
+
+Re‑run the count query from step 1 to confirm `oversize_urls` is `0`, then re‑run the upgrade. The
+migration is idempotent, so it simply continues once the data fits.

--- a/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md
@@ -286,17 +286,199 @@ ROLLBACK TRANSACTION;
 -- COMMIT TRANSACTION;
 ```
 
-### 3. What's left after the clean‑up
+### 3. What's left after the clean‑up — classify it
 
-`remaining_oversize` counts the rows the script could **not** auto‑fix:
+`remaining_oversize` counts the rows the `xsdata` strip could **not** auto‑fix. In practice the strip
+resolves the large majority of oversized URLs (the `xsdata` token is usually the bulk of the bloat);
+only a handful remain. Each remaining row falls into one of these buckets:
 
-- **Still > 850 after removing `xsdata`** — a few URLs are long because of *other* parameters (e.g.
-  a huge `FilterValues1=…` list), not `xsdata`. Removing `xsdata` isn't enough; shorten or delete
-  these by hand.
-- **Cleaned value already exists** — the de‑duplicated URL is already tracked by another `urls`
-  row, so the oversized duplicate was left untouched to avoid creating a duplicate key. Re‑point its
-  `hits` / `event_meta_sharepoint` / Copilot rows (via `url_id`) at the existing row and delete the
-  duplicate, or simply delete the oversized duplicate if its facts are redundant.
+- **Still > 850 after removing `xsdata`** — long because of *other* junk (e.g. a big `FilterValues1=…`
+  list, or a `SafelinksUrl=` that embeds a whole second copy of the URL, often with duplicated
+  comma‑merged Teams parameters). Removing `xsdata` isn't enough.
+- **Cleaned value already exists** — the de‑duplicated URL is already tracked by another `urls` row,
+  so the oversized duplicate was left untouched to avoid creating a duplicate `full_url`.
+- **No `xsdata` at all** — oversized for some unrelated reason.
+
+This read‑only query classifies every remaining oversized row so you know which bucket each is in
+(it materialises the `xsdata` rows into `#fix` first so the slicing never sees a row without the
+parameter):
+
+```sql
+SET NOCOUNT ON;
+IF OBJECT_ID('tempdb..#over') IS NOT NULL DROP TABLE #over;
+SELECT id, full_url INTO #over FROM dbo.urls WHERE LEN(full_url) > 850;
+
+IF OBJECT_ID('tempdb..#fix') IS NOT NULL DROP TABLE #fix;
+SELECT id, full_url,
+       sep = CASE WHEN CHARINDEX(N'?xsdata=', full_url) > 0 THEN CHARINDEX(N'?xsdata=', full_url)
+                  ELSE CHARINDEX(N'&xsdata=', full_url) END,
+       cleaned_url = CAST(NULL AS nvarchar(max))
+INTO #fix
+FROM #over
+WHERE full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%';
+
+UPDATE f
+SET cleaned_url = CASE
+        WHEN term = 0 THEN LEFT(full_url, sep - 1)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'&'
+             THEN LEFT(full_url, sep) + SUBSTRING(full_url, term + 1, 4000)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'#'
+             THEN LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+        ELSE LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+    END
+FROM #fix f
+CROSS APPLY (SELECT sepChar = SUBSTRING(full_url, sep, 1),
+                    endAmp  = CHARINDEX(N'&', full_url, sep + 8),
+                    endHash = CHARINDEX(N'#', full_url, sep + 8)) a
+CROSS APPLY (SELECT term = CASE WHEN a.endAmp = 0 AND a.endHash = 0 THEN 0
+                               WHEN a.endAmp = 0 THEN a.endHash
+                               WHEN a.endHash = 0 THEN a.endAmp
+                               WHEN a.endAmp < a.endHash THEN a.endAmp
+                               ELSE a.endHash END) b;
+
+SELECT
+    o.id,
+    original_length = LEN(o.full_url),
+    length_after_removing_xsdata = LEN(f.cleaned_url),
+    reason = CASE
+        WHEN f.id IS NULL THEN N'No xsdata parameter - long for other reasons'
+        WHEN LEN(f.cleaned_url) > 850 THEN N'Still > 850 after removing xsdata (other bloat)'
+        WHEN EXISTS (SELECT 1 FROM dbo.urls e WHERE e.full_url = f.cleaned_url AND e.id <> o.id)
+             THEN N'Cleaned value already exists on another row'
+        ELSE N'Would clean to <= 850 - re-run the clean-up script (with COMMIT)'
+    END,
+    o.full_url
+FROM #over o
+LEFT JOIN #fix f ON f.id = o.id
+ORDER BY original_length DESC;
+DROP TABLE #over; DROP TABLE #fix;
+```
+
+> If any row shows **"Would clean to <= 850 - re-run the clean-up script (with COMMIT)"**, you have
+> only run the section‑2 preview — the `xsdata` strip will fix it once you flip `ROLLBACK` → `COMMIT`.
+> Only rows in the other three buckets are genuinely stuck.
+
+### 4. Reduce the genuinely‑stuck rows to their path (dedup merge)
+
+For the stuck rows, the only meaningful part is the **page path** — everything after `?` is volatile
+Teams junk (`xsdata`, `sdata`, `ovuser`, `clickparams`, `SafelinksUrl`, filters, `viewid`). The
+script below reduces each genuinely‑stuck row (still > 850 after the `xsdata` strip, *or* with no
+`xsdata` at all) to its path. Because several stuck rows can share the same page — and a clean copy
+of that page may already exist — it does a proper **de‑duplicating merge**: it picks one canonical
+`urls` row per path, **repoints every foreign key that references `urls`** (discovered from the
+catalog, so no referencing table — `hits`, `event_meta_sharepoint`, comments, likes, Copilot files,
+file metadata, … — is missed) onto the canonical row, then deletes the duplicates. It therefore
+never creates a duplicate `full_url` and never loses the referenced facts.
+
+It leaves every row that the section‑2 `xsdata` strip can already fix **untouched** (it only acts on
+rows whose `xsdata`‑stripped length is still > 850), so run it **after** section 2 has been
+committed. Like the others it **defaults to `ROLLBACK`** — verify `remaining_oversize = 0` and
+`duplicate_full_urls = 0`, then flip to `COMMIT`. Back up / snapshot first.
+
+```sql
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+BEGIN TRANSACTION;
+
+-- 1. Oversize rows.
+IF OBJECT_ID('tempdb..#over') IS NOT NULL DROP TABLE #over;
+SELECT id, full_url INTO #over FROM dbo.urls WHERE LEN(full_url) > 850;
+
+-- 2. Of those, the ones carrying xsdata, with the length they'd have AFTER removing it.
+IF OBJECT_ID('tempdb..#fix') IS NOT NULL DROP TABLE #fix;
+SELECT id, full_url,
+       sep = CASE WHEN CHARINDEX(N'?xsdata=', full_url) > 0 THEN CHARINDEX(N'?xsdata=', full_url)
+                  ELSE CHARINDEX(N'&xsdata=', full_url) END,
+       cleaned_len = CAST(NULL AS int)
+INTO #fix
+FROM #over
+WHERE full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%';
+
+UPDATE f
+SET cleaned_len = LEN(CASE
+        WHEN term = 0 THEN LEFT(full_url, sep - 1)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'&' THEN LEFT(full_url, sep) + SUBSTRING(full_url, term + 1, 4000)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'#' THEN LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+        ELSE LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000) END)
+FROM #fix f
+CROSS APPLY (SELECT sepChar = SUBSTRING(full_url, sep, 1),
+                    endAmp  = CHARINDEX(N'&', full_url, sep + 8),
+                    endHash = CHARINDEX(N'#', full_url, sep + 8)) a
+CROSS APPLY (SELECT term = CASE WHEN a.endAmp = 0 AND a.endHash = 0 THEN 0
+                               WHEN a.endAmp = 0 THEN a.endHash
+                               WHEN a.endHash = 0 THEN a.endAmp
+                               WHEN a.endAmp < a.endHash THEN a.endAmp
+                               ELSE a.endHash END) b;
+
+-- 3. Stuck rows = oversize rows STILL > 850 after removing xsdata (or with no xsdata at all).
+--    Reduce them to their path (everything before the first '?' or '#'); paths are short, so they fit.
+IF OBJECT_ID('tempdb..#stuck') IS NOT NULL DROP TABLE #stuck;
+SELECT o.id, o.full_url,
+       pathkey = CAST(CASE WHEN cut = 0 THEN o.full_url ELSE LEFT(o.full_url, cut - 1) END AS nvarchar(850))
+INTO #stuck
+FROM #over o
+LEFT JOIN #fix f ON f.id = o.id
+CROSS APPLY (SELECT qpos = CHARINDEX(N'?', o.full_url), hpos = CHARINDEX(N'#', o.full_url)) q
+CROSS APPLY (SELECT cut = CASE WHEN qpos = 0 AND hpos = 0 THEN 0
+                               WHEN qpos = 0 THEN hpos
+                               WHEN hpos = 0 THEN qpos
+                               WHEN qpos < hpos THEN qpos ELSE hpos END) c
+WHERE f.id IS NULL OR f.cleaned_len > 850;
+
+-- 4. Pick a canonical url row per path: an existing clean row that already holds that exact path,
+--    otherwise the lowest-id stuck row.
+IF OBJECT_ID('tempdb..#path') IS NOT NULL DROP TABLE #path;
+SELECT DISTINCT pathkey INTO #path FROM #stuck;
+ALTER TABLE #path ADD existing_id int NULL, canonical_id int NULL;
+UPDATE p SET existing_id = (SELECT MIN(u.id) FROM dbo.urls u WHERE u.full_url = p.pathkey) FROM #path p;
+UPDATE p SET canonical_id = COALESCE(existing_id, (SELECT MIN(s.id) FROM #stuck s WHERE s.pathkey = p.pathkey)) FROM #path p;
+
+-- 5. Map every non-canonical stuck row -> its canonical row.
+IF OBJECT_ID('tempdb..#map') IS NOT NULL DROP TABLE #map;
+SELECT s.id AS dup_id, p.canonical_id
+INTO #map
+FROM #stuck s JOIN #path p ON p.pathkey = s.pathkey
+WHERE s.id <> p.canonical_id;
+
+-- 6. Repoint EVERY foreign key that references dbo.urls(id) from the duplicate rows to the canonical
+--    row (schema-driven, so no referencing table is missed). Temp tables are visible to the batch.
+DECLARE @sql nvarchar(max) = N'';
+SELECT @sql = @sql + N'UPDATE p SET p.' + QUOTENAME(pc.name) + N' = m.canonical_id FROM '
+    + QUOTENAME(SCHEMA_NAME(t.schema_id)) + N'.' + QUOTENAME(t.name) + N' p '
+    + N'JOIN #map m ON p.' + QUOTENAME(pc.name) + N' = m.dup_id;' + CHAR(13)
+FROM sys.foreign_keys fk
+JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id
+JOIN sys.tables t ON t.object_id = fk.parent_object_id
+JOIN sys.columns pc ON pc.object_id = fk.parent_object_id AND pc.column_id = fkc.parent_column_id
+WHERE fk.referenced_object_id = OBJECT_ID(N'dbo.urls');
+IF @sql <> N'' EXEC sys.sp_executesql @sql;
+
+-- 7. Delete the now-unreferenced duplicate rows.
+DELETE u FROM dbo.urls u JOIN #map m ON m.dup_id = u.id;
+DECLARE @deleted int = @@ROWCOUNT;
+
+-- 8. Set the canonical rows that are themselves stuck rows (no pre-existing clean row) to the path.
+UPDATE u SET u.full_url = p.pathkey
+FROM dbo.urls u JOIN #path p ON p.canonical_id = u.id
+WHERE p.existing_id IS NULL;
+DECLARE @reduced int = @@ROWCOUNT;
+
+RAISERROR('Stuck rows reduced to path: %d ; duplicate rows merged away: %d', 0, 1, @reduced, @deleted) WITH NOWAIT;
+SELECT remaining_oversize = COUNT(*) FROM dbo.urls WHERE LEN(full_url) > 850;
+SELECT duplicate_full_urls = ISNULL((SELECT COUNT(*) FROM (SELECT full_url FROM dbo.urls GROUP BY full_url HAVING COUNT(*) > 1) d), 0);
+
+DROP TABLE #over; DROP TABLE #fix; DROP TABLE #stuck; DROP TABLE #path; DROP TABLE #map;
+
+-- VERIFY remaining_oversize = 0 and duplicate_full_urls = 0, then change ROLLBACK to COMMIT and re-run.
+ROLLBACK TRANSACTION;
+-- COMMIT TRANSACTION;
+```
+
+> **Edge case:** if a child table has a `UNIQUE (url_id, …)` constraint and both a duplicate and the
+> canonical row already hold a matching child row, repointing would violate that unique key. Because
+> the script runs under `SET XACT_ABORT ON` inside the transaction, such a clash rolls the whole
+> thing back cleanly (nothing is lost) and reports the error — resolve those few child rows by hand
+> (delete the redundant duplicate child rows) and re‑run. This is rare for SharePoint page URLs.
 
 Re‑run the count query from step 1 to confirm `oversize_urls` is `0`, then re‑run the upgrade. The
 migration is idempotent, so it simply continues once the data fits.

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -149,30 +149,44 @@ namespace Tests.UnitTests
             Assert.IsTrue(shortWithXsData.Length <= max);
             Assert.AreEqual(shortWithXsData, StringUtils.EnsureUrlWithinLength(shortWithXsData, max));
 
-            // Over the limit and has xsdata -> stripped (and now fits).
+            // Over the limit and has xsdata -> stripping xsdata alone is enough; the rest is preserved.
             var longWithXsData = "https://x/a.aspx?xsdata=" + new string('Q', 100) + "&b=2";
             Assert.IsTrue(longWithXsData.Length > max);
             Assert.AreEqual("https://x/a.aspx?b=2", StringUtils.EnsureUrlWithinLength(longWithXsData, max));
 
-            // Over the limit, no xsdata -> nothing to strip, so hard-truncated to max as a last resort.
+            // Over the limit, no xsdata -> nothing to strip, so reduced to the page path (not truncated).
             var longNoXsData = "https://x/a.aspx?b=" + new string('Q', 100);
-            var truncated = StringUtils.EnsureUrlWithinLength(longNoXsData, max);
-            Assert.AreEqual(max, truncated.Length);
-            Assert.AreEqual(longNoXsData.Substring(0, max), truncated);
+            Assert.AreEqual("https://x/a.aspx", StringUtils.EnsureUrlWithinLength(longNoXsData, max));
 
-            // Over the limit AND still over after stripping xsdata -> truncated to exactly max.
+            // Over the limit AND still over after stripping xsdata -> reduced to the page path.
             var stillLong = "https://x/a.aspx?xsdata=" + new string('Q', 100) + "&" + new string('Z', 100);
-            var result2 = StringUtils.EnsureUrlWithinLength(stillLong, max);
-            Assert.AreEqual(max, result2.Length);
-            Assert.AreEqual(("https://x/a.aspx?" + new string('Z', 100)).Substring(0, max), result2);
+            Assert.AreEqual("https://x/a.aspx", StringUtils.EnsureUrlWithinLength(stillLong, max));
 
-            // Wired to the real column width: a 900-char token pushes a SharePoint URL over 850, but
-            // once removed the URL comfortably fits, so it is returned in full (not truncated).
+            // Reducing to path drops the query string AND any #fragment.
+            var withFragment = "https://x/a.aspx?notxs=" + new string('P', 100) + "#section";
+            Assert.AreEqual("https://x/a.aspx", StringUtils.EnsureUrlWithinLength(withFragment, max));
+
+            // Pathological: even the bare path exceeds the limit -> hard-truncated as an absolute last resort.
+            var longPath = "https://x/" + new string('a', 100); // no '?' or '#'
+            var truncated = StringUtils.EnsureUrlWithinLength(longPath, max);
+            Assert.AreEqual(max, truncated.Length);
+            Assert.AreEqual(longPath.Substring(0, max), truncated);
+
+            // Real column width: a 900-char xsdata token pushes a SharePoint URL over 850, but once
+            // removed it comfortably fits, so the rest (filters etc.) is kept in full - NOT reduced to path.
             var oversized = "https://contoso.sharepoint.com/sites/Marketing/a.aspx?xsdata=" + new string('Q', 900) + "&v=1";
             Assert.IsTrue(oversized.Length > Url.FullUrlMaxLength);
             var result = StringUtils.EnsureUrlWithinLength(oversized, Url.FullUrlMaxLength);
             Assert.AreEqual("https://contoso.sharepoint.com/sites/Marketing/a.aspx?v=1", result);
             Assert.IsTrue(result.Length <= Url.FullUrlMaxLength);
+
+            // Real column width: still over 850 even after xsdata (a huge SafelinksUrl) -> reduced to path.
+            var basePath = "https://contoso.sharepoint.com/sites/Marketing/Lists/Announcements/AllItems.aspx";
+            var stuck = basePath + "?xsdata=" + new string('Q', 900) + "&SafelinksUrl=" + new string('Z', 900);
+            Assert.IsTrue(stuck.Length > Url.FullUrlMaxLength);
+            var stuckResult = StringUtils.EnsureUrlWithinLength(stuck, Url.FullUrlMaxLength);
+            Assert.AreEqual(basePath, stuckResult);
+            Assert.IsTrue(stuckResult.Length <= Url.FullUrlMaxLength);
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -189,6 +189,57 @@ namespace Tests.UnitTests
             Assert.IsTrue(stuckResult.Length <= Url.FullUrlMaxLength);
         }
 
+        /// <summary>
+        /// Locks in the behaviour against the shape of the real customer URLs that aborted the
+        /// ShrinkUrlsFullUrlColumn migration: SharePoint list/page URLs opened from Microsoft Teams,
+        /// carrying a large transient xsdata token plus the usual sdata/ovuser/OR/CT/clickparams/
+        /// SafelinksUrl/Filter*/viewid tail (sometimes comma-merged). All values here are anonymised
+        /// (contoso tenant, fictional site/list, zeroed GUIDs, filler tokens) - no real tenant data.
+        /// </summary>
+        [TestMethod]
+        public void EnsureUrlWithinLength_RealWorldTeamsDeepLinkExamples()
+        {
+            const int max = 850; // Url.FullUrlMaxLength
+
+            var path = "https://contoso.sharepoint.com/sites/Marketing/Lists/Announcements/AllItems.aspx";
+            var xsdata = "xsdata=" + new string('A', 700);   // ~700-char opaque base64 deep-link token
+            var trailing =
+                "&sdata=" + new string('B', 40) +
+                "&ovuser=00000000%2D0000%2D0000%2D0000%2D000000000000%2Cuser%40contoso.com" +
+                "&OR=Teams%2DHL&CT=1677594627797" +
+                "&clickparams=" + new string('C', 80) +
+                "&FilterField1=field%5F1&FilterValue1=Manager%20Transport&FilterType1=Text" +
+                "&viewid=00000000%2D0000%2D0000%2D0000%2D000000000000";
+
+            // Case 1 (mirrors the ~99% auto-fixable rows): xsdata is the bulk of the bloat. Removing it
+            // alone brings the URL back under 850 and keeps the distinguishing params (filters, viewid).
+            var teamsUrl = path + "?" + xsdata + trailing;
+            Assert.IsTrue(teamsUrl.Length > max, "sample should exceed the column width");
+            var fixedUrl = StringUtils.EnsureUrlWithinLength(teamsUrl, max);
+            Assert.AreEqual(path + "?" + trailing.Substring(1), fixedUrl); // '?' kept, 'xsdata=...&' removed
+            Assert.IsTrue(fixedUrl.Length <= max);
+            Assert.IsFalse(fixedUrl.ToLowerInvariant().Contains("xsdata="));
+            StringAssert.Contains(fixedUrl, "viewid=");                    // distinguishing params preserved
+
+            // Case 2 (mirrors the handful of genuinely-stuck rows): still over 850 even after removing
+            // xsdata, because of a huge SafelinksUrl copy + duplicated comma-merged params. Reduced to path.
+            var safelinks = "&SafelinksUrl=" + new string('D', 700);
+            var doubled = "&OR=Teams%2DHL%2CTeams%2DHL&CT=1698908960461%2C1698908960461";
+            var stuckUrl = path + "?" + xsdata + trailing + safelinks + doubled;
+            Assert.IsTrue(StringUtils.RemoveXsDataParam(stuckUrl).Length > max, "should still exceed 850 after xsdata strip");
+            var reduced = StringUtils.EnsureUrlWithinLength(stuckUrl, max);
+            Assert.AreEqual(path, reduced);                                // whole query string dropped
+            Assert.IsTrue(reduced.Length <= max);
+
+            // Case 3: a URL ending with a bare '#' fragment marker (seen in the real data).
+            var withTrailingHash = path + "?xsdata=" + new string('A', 800) + "&viewid=00000000#";
+            Assert.IsTrue(withTrailingHash.Length > max);
+            var fixedHash = StringUtils.EnsureUrlWithinLength(withTrailingHash, max);
+            Assert.IsTrue(fixedHash.Length <= max);
+            Assert.IsFalse(fixedHash.ToLowerInvariant().Contains("xsdata="));
+            StringAssert.StartsWith(fixedHash, path);
+        }
+
         [TestMethod]
         public void ConvertSharePointUrl()
         {

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -95,6 +95,87 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public void RemoveXsDataParamTests()
+        {
+            // Null / empty / no xsdata parameter -> returned unchanged.
+            Assert.IsNull(StringUtils.RemoveXsDataParam(null));
+            Assert.AreEqual(string.Empty, StringUtils.RemoveXsDataParam(string.Empty));
+            Assert.AreEqual("https://x/a?foo=1&bar=2", StringUtils.RemoveXsDataParam("https://x/a?foo=1&bar=2"));
+
+            // xsdata as the first / middle / last / only parameter (everything else preserved).
+            Assert.AreEqual("https://x/a.aspx?sdata=z&v=1",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?xsdata=ABC&sdata=z&v=1"));
+            Assert.AreEqual("https://x/a.aspx?foo=1&bar=2",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?foo=1&xsdata=ABC&bar=2"));
+            Assert.AreEqual("https://x/a.aspx?foo=1",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?foo=1&xsdata=ABC"));
+            Assert.AreEqual("https://x/a.aspx",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?xsdata=ABC"));
+
+            // Any #fragment is preserved.
+            Assert.AreEqual("https://x/a.aspx#sec",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?xsdata=ABC#sec"));
+            Assert.AreEqual("https://x/a.aspx?b=2#sec",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?xsdata=ABC&b=2#sec"));
+            Assert.AreEqual("https://x/a?foo=1#sec",
+                StringUtils.RemoveXsDataParam("https://x/a?foo=1&xsdata=ABC#sec"));
+
+            // Case-insensitive on the parameter name.
+            Assert.AreEqual("https://x/a?b=2", StringUtils.RemoveXsDataParam("https://x/a?XSDATA=ABC&b=2"));
+
+            // Boundary-aware: 'xsdata' as a substring of another parameter name is NOT removed.
+            Assert.AreEqual("https://x/a?notxsdata=1&b=2", StringUtils.RemoveXsDataParam("https://x/a?notxsdata=1&b=2"));
+            Assert.AreEqual("https://x/a?b=1&myxsdata=2", StringUtils.RemoveXsDataParam("https://x/a?b=1&myxsdata=2"));
+
+            // Real-world shape: a long Teams deep-link token as the first parameter, followed by the
+            // usual trailing parameters. The cleaned URL keeps the rest and no longer contains xsdata.
+            var basePath = "https://contoso.sharepoint.com/sites/Marketing/Lists/Announcements/AllItems.aspx";
+            var rest = "&sdata=AAAA%3D%3D&ovuser=user%40contoso.com&viewid=00000000";
+            var oversized = basePath + "?xsdata=" + new string('Q', 900) + rest;
+            var cleaned = StringUtils.RemoveXsDataParam(oversized);
+            Assert.AreEqual(basePath + "?" + rest.TrimStart('&'), cleaned);
+            Assert.IsFalse(cleaned.ToLowerInvariant().Contains("xsdata="));
+            Assert.IsTrue(cleaned.Length < oversized.Length);
+        }
+
+        [TestMethod]
+        public void EnsureUrlWithinLengthTests()
+        {
+            const int max = 50;
+            Assert.IsNull(StringUtils.EnsureUrlWithinLength(null, max));
+
+            // Has xsdata but is within the limit -> left unchanged (no needless churn).
+            var shortWithXsData = "https://x/a?xsdata=AB&b=2"; // <= 50 chars
+            Assert.IsTrue(shortWithXsData.Length <= max);
+            Assert.AreEqual(shortWithXsData, StringUtils.EnsureUrlWithinLength(shortWithXsData, max));
+
+            // Over the limit and has xsdata -> stripped (and now fits).
+            var longWithXsData = "https://x/a.aspx?xsdata=" + new string('Q', 100) + "&b=2";
+            Assert.IsTrue(longWithXsData.Length > max);
+            Assert.AreEqual("https://x/a.aspx?b=2", StringUtils.EnsureUrlWithinLength(longWithXsData, max));
+
+            // Over the limit, no xsdata -> nothing to strip, so hard-truncated to max as a last resort.
+            var longNoXsData = "https://x/a.aspx?b=" + new string('Q', 100);
+            var truncated = StringUtils.EnsureUrlWithinLength(longNoXsData, max);
+            Assert.AreEqual(max, truncated.Length);
+            Assert.AreEqual(longNoXsData.Substring(0, max), truncated);
+
+            // Over the limit AND still over after stripping xsdata -> truncated to exactly max.
+            var stillLong = "https://x/a.aspx?xsdata=" + new string('Q', 100) + "&" + new string('Z', 100);
+            var result2 = StringUtils.EnsureUrlWithinLength(stillLong, max);
+            Assert.AreEqual(max, result2.Length);
+            Assert.AreEqual(("https://x/a.aspx?" + new string('Z', 100)).Substring(0, max), result2);
+
+            // Wired to the real column width: a 900-char token pushes a SharePoint URL over 850, but
+            // once removed the URL comfortably fits, so it is returned in full (not truncated).
+            var oversized = "https://contoso.sharepoint.com/sites/Marketing/a.aspx?xsdata=" + new string('Q', 900) + "&v=1";
+            Assert.IsTrue(oversized.Length > Url.FullUrlMaxLength);
+            var result = StringUtils.EnsureUrlWithinLength(oversized, Url.FullUrlMaxLength);
+            Assert.AreEqual("https://contoso.sharepoint.com/sites/Marketing/a.aspx?v=1", result);
+            Assert.IsTrue(result.Length <= Url.FullUrlMaxLength);
+        }
+
+        [TestMethod]
         public void ConvertSharePointUrl()
         {
             const string expectedResult = "https://contoso.sharepoint.com/sites/site/Shared%20Documents/";

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/ClickTempEntity.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/ClickTempEntity.cs
@@ -23,7 +23,9 @@ namespace WebJob.AppInsightsImporter.Engine.Sql.Models
             if (p.CustomProperties.PageRequestId.HasValue)
             {
                 this.Timestamp = p.Timestamp;
-                this.Url = p.CustomProperties.HRef;
+                // Strip the volatile xsdata deep-link token when the click href would otherwise
+                // exceed the urls.full_url column width (nvarchar(850)). See issue #122.
+                this.Url = StringUtils.EnsureUrlWithinLength(p.CustomProperties.HRef, Common.Entities.Url.FullUrlMaxLength);
                 this.Username = p.Username;
                 this.ClassNames = StringUtils.EnsureMaxLength(p.CustomProperties.ClassNames, 800);
                 this.PageRequestId = p.CustomProperties.PageRequestId.Value;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/ClickTempEntity.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/ClickTempEntity.cs
@@ -23,8 +23,8 @@ namespace WebJob.AppInsightsImporter.Engine.Sql.Models
             if (p.CustomProperties.PageRequestId.HasValue)
             {
                 this.Timestamp = p.Timestamp;
-                // Strip the volatile xsdata deep-link token when the click href would otherwise
-                // exceed the urls.full_url column width (nvarchar(850)). See issue #122.
+                // Keep the SharePoint URL within the urls.full_url column width (nvarchar(850)): strip
+                // the volatile xsdata token, else reduce to the page path. See issue #122.
                 this.Url = StringUtils.EnsureUrlWithinLength(p.CustomProperties.HRef, Common.Entities.Url.FullUrlMaxLength);
                 this.Username = p.Username;
                 this.ClassNames = StringUtils.EnsureMaxLength(p.CustomProperties.ClassNames, 800);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -244,8 +244,8 @@ namespace WebJob.Office365ActivityImporter.Engine
             this.OperationName = abtractLog.Operation;
             this.TimeStamp = abtractLog.CreationTime;
             this.TypeName = abtractLog.ItemType;
-            // Strip the volatile xsdata deep-link token when the object id (a SharePoint URL) would
-            // otherwise exceed the urls.full_url column width (nvarchar(850)). See issue #122.
+            // Keep the SharePoint URL within the urls.full_url column width (nvarchar(850)): strip the
+            // volatile xsdata token, else reduce to the page path. See issue #122.
             this.ObjectId = StringUtils.EnsureUrlWithinLength(abtractLog.ObjectId, Common.Entities.Url.FullUrlMaxLength);
             this.Workload = abtractLog.Workload;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Entities;
 using Common.Entities.Config;
+using DataUtils;
 using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
@@ -243,7 +244,9 @@ namespace WebJob.Office365ActivityImporter.Engine
             this.OperationName = abtractLog.Operation;
             this.TimeStamp = abtractLog.CreationTime;
             this.TypeName = abtractLog.ItemType;
-            this.ObjectId = abtractLog.ObjectId;
+            // Strip the volatile xsdata deep-link token when the object id (a SharePoint URL) would
+            // otherwise exceed the urls.full_url column width (nvarchar(850)). See issue #122.
+            this.ObjectId = StringUtils.EnsureUrlWithinLength(abtractLog.ObjectId, Common.Entities.Url.FullUrlMaxLength);
             this.Workload = abtractLog.Workload;
 
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -165,8 +165,8 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     AppHost = auditRecord.CopilotEventData.AppHost,
                     FileExtension = spFileInfo?.Extension,
                     FileName = spFileInfo?.Filename,
-                    // Strip the volatile xsdata deep-link token when the URL would otherwise exceed
-                    // the urls.full_url column width (nvarchar(850)). See issue #122.
+                    // Keep the SharePoint URL within the urls.full_url column width (nvarchar(850)):
+                    // strip the volatile xsdata token, else reduce to the page path. See issue #122.
                     Url = StringUtils.EnsureUrlWithinLength(spFileInfo?.Url, Common.Entities.Url.FullUrlMaxLength),
                     UrlBase = spFileInfo?.SiteUrl,
                     AgentId = auditRecord.AgentId,

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -165,7 +165,9 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     AppHost = auditRecord.CopilotEventData.AppHost,
                     FileExtension = spFileInfo?.Extension,
                     FileName = spFileInfo?.Filename,
-                    Url = spFileInfo?.Url,
+                    // Strip the volatile xsdata deep-link token when the URL would otherwise exceed
+                    // the urls.full_url column width (nvarchar(850)). See issue #122.
+                    Url = StringUtils.EnsureUrlWithinLength(spFileInfo?.Url, Common.Entities.Url.FullUrlMaxLength),
                     UrlBase = spFileInfo?.SiteUrl,
                     AgentId = auditRecord.AgentId,
                     AgentName = auditRecord.AgentName,


### PR DESCRIPTION
Fixes #127.

## What

Oversized SharePoint **Teams deep-link** URLs (carrying a large transient `xsdata=` token) were
blocking the `ShrinkUrlsFullUrlColumn` migration (`dbo.urls.full_url` → `nvarchar(850)`) and would
fail imports into the new `nvarchar(850)` staging columns. Removing just `xsdata` brings observed
real samples (1213–1515 chars) back under 850 (601–935).

## Changes

**Docs — `ShrinkUrlsFullUrlColumn-UpgradeGuide.md`**
- Count queries: `total_urls`, `oversize_urls`, `oversize_with_xsdata`, `oversize_other`.
- A clean-up script that strips `xsdata` from oversized rows. It only applies a cleaned value when
  it **fits** (≤ 850) **and does not already exist** (never creates a duplicate `full_url`), and
  collapses rows that clean to the same value. Wrapped in a transaction that **defaults to
  `ROLLBACK`** — runs as a preview, admin flips to `COMMIT` after verifying.
- A "what's left" section for rows still > 850 after stripping or that collide.

**Importers**
- New `StringUtils.RemoveXsDataParam` (boundary-aware, case-insensitive, preserves the rest of the
  URL incl. `#fragment`) and `StringUtils.EnsureUrlWithinLength(url, max)` — strips `xsdata` only
  when over `Url.FullUrlMaxLength` (new `850` const), then hard-truncates to 850 as a last resort so
  staging never overflows.
- Applied at audit `ObjectId`, click `HRef`, and Copilot `Url` insert points. (`HitTempEntity`
  already drops the whole query string.)

## Validation

- Cleaning logic 15/15 (5 real customer URLs + 10 edge cases) cross-checked Python ↔ T-SQL.
- Clean-up script verified end-to-end on localdb: rollback is a no-op; commit cleans the right rows
  with **0 duplicates**, skips collisions, leaves still-oversized rows, ignores short / non-xsdata
  URLs.
- Solution builds; 2 new unit tests pass.

## Notes

- All text stays Unicode-safe (`nvarchar`, never `varchar`).
- Hard-truncation can rarely make two distinct degenerate URLs share an 850-char prefix and merge
  into one `urls` row — acceptable for junk Teams tracking URLs, flagged for awareness.
