### PR TITLE
Skip over-width staging rows instead of failing the whole batch, with diagnostics

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DataUtils.Sql.Inserts
@@ -20,6 +22,10 @@ namespace DataUtils.Sql.Inserts
         private readonly string _connectionString;
         private readonly ILogger _telemetry;
         private InsertBatchTypeFieldCache<T> _batchTypeFieldCache = null;
+
+        // Count of rows dropped during the current save because a value was wider than its staging
+        // column. Written from parallel insert threads via Interlocked, reset per SaveToStagingTable.
+        private int _rowsSkippedTooWide = 0;
         public InsertBatch(string connectionString, ILogger telemetry)
         {
             _connectionString = connectionString;
@@ -40,6 +46,10 @@ namespace DataUtils.Sql.Inserts
         public async Task<int> SaveToStagingTable(int insertsPerThread, string mergeSql)
         {
             if (Rows.Count == 0) return 0;
+
+            // This instance can be reused for several saves (e.g. the Copilot manager keeps one
+            // InsertBatch per staging table and commits repeatedly), so reset the skip counter.
+            _rowsSkippedTooWide = 0;
 
             // Extract/validate schema
             var typeParameterType = typeof(T);
@@ -72,6 +82,12 @@ namespace DataUtils.Sql.Inserts
                 await loader.ProcessListInParallel(Rows,
                     async (threadListChunk, threadIndex) => await ProcessChunkAsync(tempTableName, _telemetry, threadListChunk, threadIndex),
                     threads => _telemetry.LogInformation($"Inserting {Rows.Count.ToString("n0")} records into {tempTableName}, across {threads} thread(s)..."));
+
+                // Tell operators if we dropped any rows because a value was too wide for its column.
+                if (_rowsSkippedTooWide > 0)
+                {
+                    _telemetry.LogWarning($"{_rowsSkippedTooWide.ToString("n0")} of {Rows.Count.ToString("n0")} record(s) were NOT staged into {tempTableName} because a column value was longer than that staging column allows; data for those rows is missing from this import (everything else was saved). See the 'Skipping over-width record' messages above for the offending column(s). For SharePoint URLs longer than urls.full_url (nvarchar(850)) see issue #122 / #127.");
+                }
 
                 // Merge with supplied SQL
                 if (!string.IsNullOrEmpty(mergeSql))
@@ -139,9 +155,21 @@ namespace DataUtils.Sql.Inserts
                     {
                         await cmd.ExecuteNonQueryAsync();
                     }
+                    catch (SqlException ex) when (IsColumnTruncationError(ex))
+                    {
+                        // A value is longer than its staging column allows (e.g. a SharePoint URL
+                        // longer than the urls.full_url-width nvarchar(850) columns - see issue
+                        // #122 / #127). This row can never be inserted, so log exactly which column
+                        // overflowed and skip just this row, rather than aborting the whole batch -
+                        // which would discard every other row's data too and fail again on every
+                        // retry as a "poison batch".
+                        Interlocked.Increment(ref _rowsSkippedTooWide);
+                        _telemetry.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. SQL error {ex.Number}: {ex.Message}. Continuing with the rest of the batch.");
+                        continue;
+                    }
                     catch (SqlException ex)
                     {
-                        _telemetry.LogCritical($"Failed to insert record into {tempTableName} - {sqlInsert}: {ex.Message}");
+                        _telemetry.LogCritical($"Failed to insert record into {tempTableName} - {sqlInsert} | row: {BuildRowDiagnostic(insertObj, false)} | SQL error {ex.Number}: {ex.Message}");
                         throw;
                     }
                 }
@@ -149,6 +177,56 @@ namespace DataUtils.Sql.Inserts
                 Console.Write($"Done:#{chunkIdx}...");
 #endif
             }
+        }
+
+        // SQL Server raises 8152 ("String or binary data would be truncated.") on all versions, and
+        // 2628 (the verbose variant that also names the table/column/value) on SQL Server 2019+ and
+        // Azure SQL, when an inserted value is wider than its target column. Both mean the same here.
+        private static bool IsColumnTruncationError(SqlException ex) => ex.Number == 8152 || ex.Number == 2628;
+
+        // Parses the declared length from a staging column definition such as "nvarchar(850)".
+        // Returns null for unbounded definitions ("nvarchar(max)") or anything without an explicit length.
+        private static int? GetDeclaredColumnLength(string sqlColDefinition)
+        {
+            if (string.IsNullOrEmpty(sqlColDefinition)) return null;
+            if (sqlColDefinition.IndexOf("max", StringComparison.OrdinalIgnoreCase) >= 0) return null;
+            var match = Regex.Match(sqlColDefinition, @"\((\d+)\)");
+            return match.Success && int.TryParse(match.Groups[1].Value, out var len) ? (int?)len : null;
+        }
+
+        // Builds a privacy-conscious, single-line description of a row to help operators locate the
+        // source record and the offending column when an insert fails. String VALUES are never logged
+        // (they may hold customer data such as URLs, file/user names) - only the over-width column's
+        // name, declared width and actual length, plus a short prefix sample when requested so the
+        // value can be recognised. Guid/DateTime/number/bool fields (e.g. log_id, time_stamp) are
+        // logged in full as they are non-sensitive keys for finding the record.
+        private string BuildRowDiagnostic(T insertObj, bool includeOverWidthSample)
+        {
+            const int SAMPLE_CHARS = 64;
+            var parts = new List<string>();
+            foreach (var fieldMapping in _batchTypeFieldCache.PropertyMappingInfo)
+            {
+                var fieldName = fieldMapping.SqlInfo.FieldName;
+                var val = fieldMapping.Property.GetValue(insertObj);
+                if (val is string s)
+                {
+                    var declaredLen = GetDeclaredColumnLength(fieldMapping.SqlInfo.SqlColDefinition);
+                    if (declaredLen.HasValue && s.Length > declaredLen.Value)
+                    {
+                        var part = $"column '{fieldName}' ({fieldMapping.SqlInfo.SqlColDefinition}) holds {s.Length} chars but the limit is {declaredLen.Value}";
+                        if (includeOverWidthSample)
+                        {
+                            part += $" (starts with \"{s.Substring(0, Math.Min(SAMPLE_CHARS, s.Length))}…\")";
+                        }
+                        parts.Add(part);
+                    }
+                }
+                else if (val != null)
+                {
+                    parts.Add($"{fieldName}={val}");
+                }
+            }
+            return parts.Count > 0 ? string.Join(", ", parts) : "(no over-width column detected; see SQL error detail)";
         }
 
         private async Task DropAndCreateStagingTable(SqlConnection opConnection, string tableName, List<ColumnSqlInfo> fields)

--- a/src/AnalyticsEngine/Tests.UnitTests/InsertBatchOverWidthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InsertBatchOverWidthTests.cs
@@ -1,0 +1,120 @@
+using Common.Entities;
+using DataUtils.Sql;
+using DataUtils.Sql.Inserts;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Verifies that <see cref="InsertBatch{T}"/> skips an individual row whose value is wider than
+    /// its staging column (SQL Server error 8152/2628) and still saves the rest of the batch, rather
+    /// than throwing and discarding the whole batch (the pre-#127 "poison batch" behaviour). This is
+    /// the resilience behind issue #122 / #127, where over-width SharePoint URLs broke imports into
+    /// the nvarchar(850) urls.full_url-sized staging columns.
+    /// </summary>
+    [TestClass]
+    public class InsertBatchOverWidthTests
+    {
+        [TempTableName("##overwidth_test_staging")]
+        private class OverWidthTestEntity
+        {
+            [Column("row_id")]
+            public Guid RowId { get; set; }
+
+            // nvarchar(10): anything longer than 10 chars must be skipped, not inserted.
+            [Column("v", SqlTypeOverride = "nvarchar(10)")]
+            public string Value { get; set; }
+        }
+
+        [TestMethod]
+        public async Task OverWidthRowIsSkippedAndRestOfBatchIsSaved()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var connectionString = db.Database.Connection.ConnectionString;
+                var logger = new CapturingLogger();
+
+                using (var keepAlive = new SqlConnection(connectionString))
+                {
+                    await keepAlive.OpenAsync();
+
+                    // A global (##) temp results table is visible to InsertBatch's own connections,
+                    // and is kept alive by this connection so we can assert on it after
+                    // SaveToStagingTable returns (which disposes its own connections + staging table).
+                    using (var create = keepAlive.CreateCommand())
+                    {
+                        create.CommandText =
+                            "IF OBJECT_ID('tempdb..##overwidth_test_results') IS NOT NULL DROP TABLE ##overwidth_test_results; " +
+                            "CREATE TABLE ##overwidth_test_results (row_id uniqueidentifier, v nvarchar(850));";
+                        await create.ExecuteNonQueryAsync();
+                    }
+
+                    var okId1 = Guid.NewGuid();
+                    var okId2 = Guid.NewGuid();
+                    var tooWideId = Guid.NewGuid();
+
+                    var batch = new InsertBatch<OverWidthTestEntity>(connectionString, logger);
+                    batch.Rows.Add(new OverWidthTestEntity { RowId = okId1, Value = "short" });
+                    batch.Rows.Add(new OverWidthTestEntity { RowId = tooWideId, Value = new string('x', 50) });
+                    batch.Rows.Add(new OverWidthTestEntity { RowId = okId2, Value = "alsoshort" });
+
+                    const string mergeSql =
+                        "INSERT INTO ##overwidth_test_results (row_id, v) SELECT row_id, v FROM ##overwidth_test_staging;";
+
+                    // Must NOT throw, even though one row is over-width.
+                    var survivors = await batch.SaveToStagingTable(mergeSql);
+
+                    Assert.AreEqual(2, survivors, "Merge should have copied exactly the 2 in-width rows.");
+
+                    var savedIds = new List<Guid>();
+                    using (var read = keepAlive.CreateCommand())
+                    {
+                        read.CommandText = "SELECT row_id FROM ##overwidth_test_results;";
+                        using (var reader = await read.ExecuteReaderAsync())
+                        {
+                            while (await reader.ReadAsync()) savedIds.Add(reader.GetGuid(0));
+                        }
+                    }
+
+                    CollectionAssert.Contains(savedIds, okId1, "First in-width row should be saved.");
+                    CollectionAssert.Contains(savedIds, okId2, "Second in-width row should be saved.");
+                    CollectionAssert.DoesNotContain(savedIds, tooWideId, "Over-width row must be skipped, not saved.");
+
+                    Assert.IsTrue(
+                        logger.Messages.Any(m => m.Contains("Skipping over-width record") && m.Contains("'v'")),
+                        "The skip should be logged identifying the offending column. Captured: " + string.Join(" | ", logger.Messages));
+
+                    using (var drop = keepAlive.CreateCommand())
+                    {
+                        drop.CommandText = "IF OBJECT_ID('tempdb..##overwidth_test_results') IS NOT NULL DROP TABLE ##overwidth_test_results;";
+                        await drop.ExecuteNonQueryAsync();
+                    }
+                }
+            }
+        }
+
+        /// <summary>Minimal <see cref="ILogger"/> that records formatted messages for assertions.</summary>
+        private class CapturingLogger : ILogger
+        {
+            public readonly List<string> Messages = new List<string>();
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+
+            private class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="GraphStringUtilsTests.cs" />
     <Compile Include="DataCleanupTests.cs" />
     <Compile Include="DuplicateUrlTests.cs" />
+    <Compile Include="InsertBatchOverWidthTests.cs" />
     <Compile Include="AppInsightsImportTests.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="CopilotTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -208,8 +208,15 @@ namespace WebJob.Office365ActivityImporter.Engine
                         Console.Write($"{Math.Round(percentDone, 0)}%...");
                     }
 #endif
-                    // Add metadata
-                    eventsJustSavedById.TryGetValue(log.Id, out var savedEvent);
+                    // Add metadata. If the event isn't in eventsJustSavedById it wasn't persisted
+                    // (e.g. its staging row was skipped because a column value exceeded the staging
+                    // column width - see InsertBatch over-width handling), so there's no row to
+                    // attach metadata to. Skip it rather than risk a NullReferenceException.
+                    if (!eventsJustSavedById.TryGetValue(log.Id, out var savedEvent))
+                    {
+                        metaSaveIdx++;
+                        continue;
+                    }
                     var changesMade = await log.ProcessExtendedProperties(saveSession, savedEvent, _telemetry);
                     if (changesMade)
                         changesMadeCount++;


### PR DESCRIPTION
## What & why

Without the #127 mitigation, a URL longer than the `nvarchar(850)` staging columns (`object_id`, click `url`, Copilot `Url`) makes the per-row staging INSERT in `InsertBatch.ProcessChunkAsync` throw `SqlException` 8152/2628 ("String or binary data would be truncated"). It was rethrown, so the whole batch's merge never ran (every row in the batch lost), and re-runs hit the same data and failed identically — a **poison batch**. The only log was the parameterised INSERT text + SQL message: no column, no value, no row key.

## Changes

- **`InsertBatch.ProcessChunkAsync`** — detect a column-truncation error (SQL `8152`/`2628`) and:
  - log exactly which column overflowed (name, declared width, value length, a short prefix sample) plus non-PII key fields (Guid/DateTime), then
  - **skip just that row and continue**, so one over-wide value can no longer discard the whole batch.
  - A per-save `LogWarning` summarises how many rows were dropped.
  - Other `SqlException`s keep the existing `LogCritical` + rethrow (now also with a row diagnostic).
  - String **values** are never logged in full, to avoid leaking customer data into telemetry.
- **`ActivityReportSqlPersistenceManager`** — skip metadata for events whose staging row was not persisted (guards against a `NullReferenceException` when a row is skipped).
- **`InsertBatchOverWidthTests`** — new localdb integration test: an over-width row is skipped while the rest of the batch is saved, and the skip is logged with the offending column.

This is defence-in-depth on top of #127 (`EnsureUrlWithinLength` already trims URLs at the known insert points); it protects any staging column from a single over-wide value.

## Testing

Built `Tests.UnitTests` with MSBuild 18 (Debug). Locally green: the new over-width test, `StagingColumnSqlTypeOverrideTests`, `DuplicateUrlTests`, and the full `ActivityImporterTests` suite (23 tests).

## Schema

**No DB schema change.** The `nvarchar(850)` shrink shipped in stable build 1634.

## Docs

Plain-English wiki page added: **How URLs are shortened**.

Related: #127
