### PR TITLE
Skip over-width staging rows in memory, before the SQL round-trip

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Classes.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Classes.cs
@@ -19,6 +19,15 @@ namespace DataUtils.Sql
         public DbType SqlType { get; internal set; }
 
         /// <summary>
+        /// Declared maximum length, in characters, parsed once from a bounded string column
+        /// definition such as <c>nvarchar(850)</c>. Null for unbounded (<c>nvarchar(max)</c>) or
+        /// non-length-bounded types (int, datetime2, ...). Lets <see cref="Inserts.InsertBatch{T}"/>
+        /// skip an over-width row in memory before the INSERT, instead of catching a per-row SQL
+        /// truncation error (8152/2628) on every doomed row.
+        /// </summary>
+        public int? MaxLength { get; set; }
+
+        /// <summary>
         /// Optional explicit SQL column type (e.g. "nvarchar(850)") that overrides the default
         /// <c>[nvarchar] (max)</c> emitted for <see cref="string"/> properties by
         /// <see cref="Inserts.InsertBatchTypeFieldCache{T}"/>. Set via <see cref="ColumnAttribute.SqlTypeOverride"/>

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -140,6 +139,7 @@ namespace DataUtils.Sql.Inserts
                 {
                     cmd.Parameters.Clear();
                     int fieldIdx = 0;
+                    var rowExceedsColumnWidth = false;
                     foreach (var fieldMapping in _batchTypeFieldCache.PropertyMappingInfo)
                     {
                         var objVal = fieldMapping.Property.GetValue(insertObj);
@@ -147,22 +147,44 @@ namespace DataUtils.Sql.Inserts
                         {
                             throw new BatchSaveException($"Couldn't insert null into batch insert field '{fieldMapping.SqlInfo.FieldName}' in table '{tempTableName}'");
                         }
+
+                        // Cheap in-memory width check, using the length parsed once when the field
+                        // cache was built, so the hot path stays a single integer comparison (no
+                        // per-row reflection or regex). A value wider than its bounded nvarchar
+                        // column can never be inserted, so flag the row and skip it below instead of
+                        // paying a doomed SQL round-trip + truncation error (8152/2628) per over-width
+                        // row. SQL Server nvarchar(n) counts UTF-16 units, exactly what string.Length
+                        // returns, so this predicts the server's truncation faithfully.
+                        if (objVal is string s && fieldMapping.SqlInfo.MaxLength.HasValue && s.Length > fieldMapping.SqlInfo.MaxLength.Value)
+                        {
+                            rowExceedsColumnWidth = true;
+                        }
+
                         cmd.ParamUp("@p" + fieldIdx, objVal, fieldMapping.SqlInfo.SqlType);
 
                         fieldIdx++;
                     }
+
+                    if (rowExceedsColumnWidth)
+                    {
+                        // Predicted over-width: skip just this row rather than aborting the whole
+                        // batch - which would discard every other row's data too and fail again on
+                        // every retry as a "poison batch". For SharePoint URLs longer than the
+                        // urls.full_url-width nvarchar(850) columns see issue #122 / #127.
+                        Interlocked.Increment(ref _rowsSkippedTooWide);
+                        _telemetry.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. Continuing with the rest of the batch.");
+                        continue;
+                    }
+
                     try
                     {
                         await cmd.ExecuteNonQueryAsync();
                     }
                     catch (SqlException ex) when (IsColumnTruncationError(ex))
                     {
-                        // A value is longer than its staging column allows (e.g. a SharePoint URL
-                        // longer than the urls.full_url-width nvarchar(850) columns - see issue
-                        // #122 / #127). This row can never be inserted, so log exactly which column
-                        // overflowed and skip just this row, rather than aborting the whole batch -
-                        // which would discard every other row's data too and fail again on every
-                        // retry as a "poison batch".
+                        // Backstop: a value was wider than its column but the in-memory check above
+                        // didn't predict it (e.g. a column whose declared width we couldn't parse).
+                        // Skip just this row so one bad value can't poison the whole batch.
                         Interlocked.Increment(ref _rowsSkippedTooWide);
                         _telemetry.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. SQL error {ex.Number}: {ex.Message}. Continuing with the rest of the batch.");
                         continue;
@@ -184,16 +206,6 @@ namespace DataUtils.Sql.Inserts
         // Azure SQL, when an inserted value is wider than its target column. Both mean the same here.
         private static bool IsColumnTruncationError(SqlException ex) => ex.Number == 8152 || ex.Number == 2628;
 
-        // Parses the declared length from a staging column definition such as "nvarchar(850)".
-        // Returns null for unbounded definitions ("nvarchar(max)") or anything without an explicit length.
-        private static int? GetDeclaredColumnLength(string sqlColDefinition)
-        {
-            if (string.IsNullOrEmpty(sqlColDefinition)) return null;
-            if (sqlColDefinition.IndexOf("max", StringComparison.OrdinalIgnoreCase) >= 0) return null;
-            var match = Regex.Match(sqlColDefinition, @"\((\d+)\)");
-            return match.Success && int.TryParse(match.Groups[1].Value, out var len) ? (int?)len : null;
-        }
-
         // Builds a privacy-conscious, single-line description of a row to help operators locate the
         // source record and the offending column when an insert fails. String VALUES are never logged
         // (they may hold customer data such as URLs, file/user names) - only the over-width column's
@@ -210,7 +222,7 @@ namespace DataUtils.Sql.Inserts
                 var val = fieldMapping.Property.GetValue(insertObj);
                 if (val is string s)
                 {
-                    var declaredLen = GetDeclaredColumnLength(fieldMapping.SqlInfo.SqlColDefinition);
+                    var declaredLen = fieldMapping.SqlInfo.MaxLength;
                     if (declaredLen.HasValue && s.Length > declaredLen.Value)
                     {
                         var part = $"column '{fieldName}' ({fieldMapping.SqlInfo.SqlColDefinition}) holds {s.Length} chars but the limit is {declaredLen.Value}";

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatchTypeFieldCache.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatchTypeFieldCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace DataUtils.Sql.Inserts
 {
@@ -65,6 +66,16 @@ namespace DataUtils.Sql.Inserts
                             }
                             fieldInfo.Nullable = attribute.Nullable ? true : propTypeIsNullable;
                             fieldInfo.SqlType = SqlHelper.GetDbType(property.PropertyType);
+
+                            // Parse the bounded length once here (not per row) so the hot insert
+                            // loop can skip an over-width value with a single integer comparison
+                            // instead of a per-row SQL truncation error. Only meaningful for string
+                            // columns; inferred numeric/date types have no character length to enforce.
+                            if (property.PropertyType == typeof(string))
+                            {
+                                fieldInfo.MaxLength = ParseDeclaredLength(fieldInfo.SqlColDefinition);
+                            }
+
                             _fieldInfoPropertyInfoCache.Add(new InsertBatchPropertyMapping { Property = property, SqlInfo = fieldInfo });
                         }
                     }
@@ -116,6 +127,16 @@ namespace DataUtils.Sql.Inserts
                 return ("uniqueidentifier", false);
             }
             return ("[nvarchar] (max)", false);
+        }
+
+        // Parses the declared length from a column definition such as "nvarchar(850)" -> 850.
+        // Returns null for unbounded ("nvarchar(max)") or definitions without an explicit length.
+        private static int? ParseDeclaredLength(string sqlColDefinition)
+        {
+            if (string.IsNullOrEmpty(sqlColDefinition)) return null;
+            if (sqlColDefinition.IndexOf("max", StringComparison.OrdinalIgnoreCase) >= 0) return null;
+            var match = Regex.Match(sqlColDefinition, @"\((\d+)\)");
+            return match.Success && int.TryParse(match.Groups[1].Value, out var len) ? (int?)len : null;
         }
     }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/StagingColumnSqlTypeOverrideTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StagingColumnSqlTypeOverrideTests.cs
@@ -53,6 +53,36 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
+        /// A bounded string override (e.g. <c>nvarchar(850)</c>) must expose its parsed character
+        /// limit on <see cref="ColumnSqlInfo.MaxLength"/>, so the batch insert can skip an over-width
+        /// value in memory (a single integer comparison) instead of catching a per-row SQL truncation
+        /// error. See InsertBatch over-width handling and issue #122 / #127.
+        /// </summary>
+        [TestMethod]
+        public void OverriddenStringColumnExposesParsedMaxLength()
+        {
+            var cache = new InsertBatchTypeFieldCache<OverriddenStringEntity>();
+            var info = cache.PropertyMappingInfo.Single(p => p.SqlInfo.FieldName == "overridden_string");
+
+            Assert.AreEqual(850, info.SqlInfo.MaxLength,
+                "nvarchar(850) override must parse to an 850-character limit for the in-memory width check.");
+        }
+
+        /// <summary>
+        /// An unbounded <c>nvarchar(max)</c> string column must have no parsed limit, so the
+        /// in-memory width check never trips on it (only bounded columns can truncate).
+        /// </summary>
+        [TestMethod]
+        public void DefaultMaxStringColumnHasNoParsedMaxLength()
+        {
+            var cache = new InsertBatchTypeFieldCache<DefaultStringEntity>();
+            var info = cache.PropertyMappingInfo.Single(p => p.SqlInfo.FieldName == "default_string");
+
+            Assert.IsNull(info.SqlInfo.MaxLength,
+                "nvarchar(max) default must have no length limit (no in-memory truncation).");
+        }
+
+        /// <summary>
         /// <see cref="ColumnAttribute.SqlTypeOverride"/> must be ignored for non-string CLR types -
         /// the inferred type (e.g. <c>int</c>) stays authoritative. This stops misuse from silently
         /// breaking schema generation for typed columns.


### PR DESCRIPTION
## What & why

Follow-up to #129. That PR made over-width staging rows **skip-and-continue** (so one bad value no longer poisons the whole batch), but it relied on **catching SQL Server's truncation error (8152/2628) per row** — each doomed row still cost a server round-trip + a thrown `SqlException`. With many over-width rows that becomes a hot failure path (the perf concern flagged in review).

## Change

- Parse each staging column's declared length **once** when the field cache is built (`InsertBatchTypeFieldCache` → `ColumnSqlInfo.MaxLength`).
- In the per-row insert loop, skip a value wider than its bounded `nvarchar` column with a **single integer comparison**, *before* the INSERT — no SQL round-trip, no exception.
- `nvarchar(n)` and `string.Length` both count UTF-16 units, so the in-memory check predicts the server's truncation exactly.
- The `8152`/`2628` catch is kept as a **backstop** for anything the in-memory check can't predict (e.g. a column whose declared width we couldn't parse).
- Removes the per-failure `Regex` from `InsertBatch` (the parse now happens once, in the field cache).

## Performance

- In-width hot path (the 200k-scale case): unchanged apart from one integer compare per string field. All reflection/diagnostic work stays on the failure path.
- The over-width path no longer pays a doomed SQL round-trip + thrown exception per row.
- Evidence: the over-width integration test drops from **~5 s → ~28 ms**.

## Tests

Built with MSBuild 18 (Debug). Green locally (11): the over-width integration test, new `MaxLength` parsing unit tests, the staging-type regression suite, and `DuplicateUrlTests`.

## Schema

**No DB schema change.**

Related: #129, #127
