### PR TITLE
Release: URL import reliability under urls.full_url nvarchar(850) + installer DNS hardening

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -4,6 +4,7 @@ using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.AppService;
 using Azure.ResourceManager.AppService.Models;
+using Azure.ResourceManager.KeyVault;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Sql;
 using CloudInstallEngine.Azure;
@@ -49,6 +50,21 @@ namespace App.ControlPanel.Engine
             WindowsVersionCheck();
             _logger.LogInformation($"Starting installation/update tests...");
 
+            // Validate the configuration itself first (names, accounts, region, etc.) so fundamental
+            // mistakes are reported before we make any Azure calls.
+            ReportConfigValidationIssues();
+
+            // When public access is disabled the data-plane checks below (DNS, Key Vault) only succeed
+            // from a host with private-network line-of-sight to the resources - tell the operator up-front.
+            if (PrivateNetworkGuidance.IsPrivateNetworkOnly(Config))
+            {
+                _logger.LogInformation(
+                    $"Public network access is disabled for this deployment. Run 'Test Configuration' (and the install itself) " +
+                    $"from a host with private-network line-of-sight to the resources - a VM on VNet '{Config.NetworkConfig?.VNetName}' " +
+                    $"(or a peered VNet, VPN/ExpressRoute, or Azure Bastion-attached host) - otherwise public DNS may not resolve to " +
+                    $"the private endpoint IPs and the DNS / Key Vault data-plane checks below will fail.");
+            }
+
             // Check sub & az group if possible
             var (testRg, azCredsValid) = await GetResourceGroupIfValid();
             if (!azCredsValid)
@@ -69,6 +85,10 @@ namespace App.ControlPanel.Engine
             // "The remote name could not be resolved" class of failure (broken/limited DNS on the
             // installer host) up-front instead of letting it abort an install part-way through.
             await VerifyResourceDnsResolution();
+
+            // Key Vault data-plane reachability with the installer account (the exact call that failed
+            // mid-install). Only runs when the vault already exists and installer credentials are present.
+            await VerifyKeyVaultDataPlaneAccess(testRg);
 
             // Firewall tests
             if (_testConfig.IsValid)
@@ -257,8 +277,113 @@ namespace App.ControlPanel.Engine
             }
         }
 
-        #region DNS resolution checks
+        #region Configuration & Key Vault checks
 
+        /// <summary>
+        /// Run the same configuration validation the installer uses and log any issues up-front, so
+        /// fundamental mistakes (missing names, accounts, region, etc.) are reported before any Azure calls.
+        /// Logs only; never throws.
+        /// </summary>
+        void ReportConfigValidationIssues()
+        {
+            try
+            {
+                var errors = Config?.ValidatInputAndGetErrors();
+                if (errors != null && errors.Count > 0)
+                {
+                    _logger.LogError($"Configuration validation found {errors.Count} issue(s) that may block installation:");
+                    foreach (var e in errors)
+                    {
+                        _logger.LogError($"  - {e}");
+                    }
+                }
+                else
+                {
+                    _logger.LogInformation("Configuration validation passed - no issues found.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not run configuration validation: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Probe the Key Vault data-plane endpoint with the installer account - the exact call
+        /// (<c>KeyVaultSecretAddTask</c>) that aborts an install when DNS/network to
+        /// <c>&lt;vault&gt;.vault.azure.net</c> is broken. Only runs when the vault already exists and the
+        /// installer credentials are present, so it never false-alarms on a fresh install. Logs only; never throws.
+        /// </summary>
+        async Task VerifyKeyVaultDataPlaneAccess(ResourceGroupResource testRg)
+        {
+            if (Config == null || string.IsNullOrWhiteSpace(Config.KeyVaultName)) return;
+
+            var installerErrs = Config.InstallerAccount?.GetValidationErrors();
+            if (installerErrs == null || installerErrs.Count > 0)
+            {
+                _logger.LogInformation("Skipping Key Vault data-plane reachability check - installer account details are incomplete.");
+                return;
+            }
+
+            if (testRg == null)
+            {
+                _logger.LogInformation("Skipping Key Vault data-plane reachability check - resource group is not available.");
+                return;
+            }
+
+            KeyVaultResource vault;
+            try
+            {
+                vault = testRg.GetKeyVaults().Where(v => v.Data.Name == Config.KeyVaultName).SingleOrDefault();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not enumerate key vaults to check '{Config.KeyVaultName}': {ex.Message}");
+                return;
+            }
+
+            if (vault == null)
+            {
+                _logger.LogInformation($"Key Vault '{Config.KeyVaultName}' not found yet; skipping data-plane reachability check (it will be created during install).");
+                return;
+            }
+
+            _logger.LogInformation($"Checking Key Vault data-plane access to '{Config.KeyVaultName}' with the installer account...");
+
+            var creds = new ClientSecretCredential(Config.InstallerAccount.DirectoryId, Config.InstallerAccount.ClientId, Config.InstallerAccount.Secret);
+            var result = await KeyVaultDataPlaneProbe.TryReadAsync(Config.KeyVaultName, creds);
+
+            switch (result.Status)
+            {
+                case KeyVaultProbeStatus.Reachable:
+                    _logger.LogInformation($"Key Vault '{Config.KeyVaultName}' data-plane is reachable and the installer account can read secrets.");
+                    break;
+
+                case KeyVaultProbeStatus.TransportFailure:
+                    var transportGuidance = PrivateNetworkGuidance.IsPrivateNetworkOnly(Config)
+                        ? PrivateNetworkGuidance.BuildVmOnVNetGuidance("reaching the Key Vault", Config.NetworkConfig?.VNetName)
+                        : $"Check DNS / network / firewall connectivity from this host to '{Config.KeyVaultName}.vault.azure.net'.";
+                    _logger.LogError(
+                        $"Could not reach Key Vault '{Config.KeyVaultName}' data-plane ({result.Message}). " +
+                        $"This is the DNS/network failure that aborts secret upload during install. " + transportGuidance);
+                    break;
+
+                case KeyVaultProbeStatus.Unauthorized:
+                    _logger.LogError(
+                        $"Key Vault '{Config.KeyVaultName}' is reachable but the installer account was denied data-plane access (403): {result.Message} " +
+                        $"Ensure the installer app registration has a Key Vault access policy granting secret Get/List/Set, " +
+                        $"and that any vault firewall allows this host's IP.");
+                    break;
+
+                default:
+                    _logger.LogError($"Unexpected error checking Key Vault '{Config.KeyVaultName}' data-plane access: {result.Message}");
+                    break;
+            }
+        }
+
+        #endregion
+
+        #region DNS resolution checks
         /// <summary>Public DNS suffix for each Azure PaaS resource the installer / runtime must resolve.</summary>
         private const string DNS_SUFFIX_KEY_VAULT = ".vault.azure.net";
         private const string DNS_SUFFIX_SQL = ".database.windows.net";

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -63,6 +64,11 @@ namespace App.ControlPanel.Engine
                     _logger.LogInformation($"Resource-group found with name {Config.ResourceGroupName}.");
                 }
             }
+
+            // DNS resolution checks for the configured Azure resource hostnames. Catches the
+            // "The remote name could not be resolved" class of failure (broken/limited DNS on the
+            // installer host) up-front instead of letting it abort an install part-way through.
+            await VerifyResourceDnsResolution();
 
             // Firewall tests
             if (_testConfig.IsValid)
@@ -251,6 +257,154 @@ namespace App.ControlPanel.Engine
             }
         }
 
+        #region DNS resolution checks
+
+        /// <summary>Public DNS suffix for each Azure PaaS resource the installer / runtime must resolve.</summary>
+        private const string DNS_SUFFIX_KEY_VAULT = ".vault.azure.net";
+        private const string DNS_SUFFIX_SQL = ".database.windows.net";
+        private const string DNS_SUFFIX_STORAGE_BLOB = ".blob.core.windows.net";
+        private const string DNS_SUFFIX_APP_SERVICE = ".azurewebsites.net";
+        private const string DNS_SUFFIX_REDIS = ".redis.cache.windows.net";
+        private const string DNS_SUFFIX_SERVICE_BUS = ".servicebus.windows.net";
+        private const string DNS_SUFFIX_COGNITIVE = ".cognitiveservices.azure.com";
+
+        /// <summary>
+        /// Control host the installer always needs to resolve (ARM management plane). If even this fails,
+        /// the installer host has no working DNS for Azure at all (broken DNS / no internet / proxy issue).
+        /// </summary>
+        private const string DNS_CONTROL_HOST = "management.azure.com";
+
+        /// <summary>Max time to wait for a single DNS lookup before treating it as a failure.</summary>
+        private static readonly TimeSpan _dnsLookupTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Resolve the public hostnames of the configured Azure resources so DNS / network problems on the
+        /// installer host - the cause of "The remote name could not be resolved: '&lt;x&gt;.vault.azure.net'"
+        /// install failures - are caught up-front rather than mid-install. Logs only; never throws.
+        /// </summary>
+        async Task VerifyResourceDnsResolution()
+        {
+            _logger.LogInformation("Checking DNS resolution for configured Azure resource hostnames...");
+
+            // First confirm the host can resolve Azure DNS at all. management.azure.com always exists, so a
+            // failure here means broken DNS / no connectivity / proxy issue - every data-plane call will fail.
+            var (controlOk, controlError) = await TryResolveHost(DNS_CONTROL_HOST);
+            if (!controlOk)
+            {
+                _logger.LogError(
+                    $"The installer host cannot resolve Azure DNS names (failed to resolve '{DNS_CONTROL_HOST}': {controlError}). " +
+                    $"Installation will fail until DNS / network / proxy connectivity is fixed on this machine.");
+            }
+
+            var targets = BuildResourceDnsTargets(Config);
+            if (targets.Count == 0)
+            {
+                _logger.LogInformation("No named Azure resources configured to DNS-check.");
+                return;
+            }
+
+            var privateOnly = PrivateNetworkGuidance.IsPrivateNetworkOnly(Config);
+
+            foreach (var target in targets)
+            {
+                var (ok, error) = await TryResolveHost(target.Fqdn);
+                if (ok)
+                {
+                    _logger.LogInformation($"DNS OK: {target.Label} '{target.Fqdn}' resolved.");
+                    continue;
+                }
+
+                if (!controlOk)
+                {
+                    // Root cause already reported above; don't repeat the per-resource guidance.
+                    _logger.LogError($"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}).");
+                }
+                else if (privateOnly)
+                {
+                    // Public access disabled: the host must be on the VNet to resolve the private endpoint IP.
+                    _logger.LogError(
+                        $"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}). " +
+                        PrivateNetworkGuidance.BuildVmOnVNetGuidance($"reaching the {target.Label}", Config.NetworkConfig?.VNetName));
+                }
+                else
+                {
+                    // Public access path: if the resource already exists this is a real DNS / network problem
+                    // that will break the install; if it has not been created yet, it is expected.
+                    _logger.LogError(
+                        $"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}). " +
+                        $"If this resource has not been created yet this is expected and can be ignored; " +
+                        $"if it already exists, the installer host cannot reach it and data-plane steps " +
+                        $"(e.g. Key Vault secret upload) will fail.");
+                }
+            }
+
+            _logger.LogInformation("DNS resolution checks complete.");
+        }
+
+        /// <summary>
+        /// Build the list of (resource, public-FQDN) DNS targets for every resource that is both enabled
+        /// and has a name configured. Pure string logic so it is unit-testable without any network access.
+        /// </summary>
+        public static List<ResourceDnsTarget> BuildResourceDnsTargets(SolutionInstallConfig config)
+        {
+            var targets = new List<ResourceDnsTarget>();
+            if (config == null) return targets;
+
+            void Add(string label, string name, string suffix)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    targets.Add(new ResourceDnsTarget(label, name.Trim() + suffix));
+                }
+            }
+
+            Add("Key Vault", config.KeyVaultName, DNS_SUFFIX_KEY_VAULT);
+            Add("SQL Server", config.SQLServerName, DNS_SUFFIX_SQL);
+            Add("Storage account", config.StorageAccountName, DNS_SUFFIX_STORAGE_BLOB);
+            Add("App Service", config.AppServiceWebAppName, DNS_SUFFIX_APP_SERVICE);
+            Add("Redis cache", config.RedisName, DNS_SUFFIX_REDIS);
+            if (config.ServiceBusEnabled)
+            {
+                Add("Service Bus", config.ServiceBusName, DNS_SUFFIX_SERVICE_BUS);
+            }
+            if (config.CognitiveServicesEnabled)
+            {
+                Add("Cognitive Services", config.CognitiveServiceName, DNS_SUFFIX_COGNITIVE);
+            }
+
+            return targets;
+        }
+
+        /// <summary>
+        /// Resolve a host name with a timeout. Returns (true, null) on success and (false, message) on
+        /// failure or timeout. Never throws.
+        /// </summary>
+        static async Task<(bool ok, string error)> TryResolveHost(string host)
+        {
+            try
+            {
+                var lookup = Dns.GetHostAddressesAsync(host);
+                var completed = await Task.WhenAny(lookup, Task.Delay(_dnsLookupTimeout));
+                if (completed != lookup)
+                {
+                    return (false, $"DNS lookup timed out after {_dnsLookupTimeout.TotalSeconds:0}s");
+                }
+
+                var addresses = await lookup;   // also re-throws any lookup exception
+                if (addresses != null && addresses.Length > 0)
+                {
+                    return (true, null);
+                }
+                return (false, "no IP addresses returned");
+            }
+            catch (Exception ex)
+            {
+                return (false, ex.Message);
+            }
+        }
+
+        #endregion
+
         void WindowsVersionCheck()
         {
             var os = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
@@ -434,5 +588,24 @@ namespace App.ControlPanel.Engine
 
             _logger.LogInformation("Successfully verified user activity settings.");
         }
+    }
+
+    /// <summary>
+    /// A configured Azure resource and the public hostname that must resolve for the installer / runtime
+    /// to reach it. Built by <see cref="SolutionInstallVerifier.BuildResourceDnsTargets"/>.
+    /// </summary>
+    public class ResourceDnsTarget
+    {
+        public ResourceDnsTarget(string label, string fqdn)
+        {
+            Label = label;
+            Fqdn = fqdn;
+        }
+
+        /// <summary>Human-readable resource description, e.g. "Key Vault".</summary>
+        public string Label { get; }
+
+        /// <summary>Public fully-qualified hostname, e.g. "myvault.vault.azure.net".</summary>
+        public string Fqdn { get; }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -231,12 +231,41 @@ namespace CloudInstallEngine.Azure.InstallTasks
         {
         }
 
+        /// <summary>
+        /// Writing the runtime app-registration secret to Key Vault is best-effort: a transient
+        /// network/DNS/permission failure here must not abort an otherwise-successful install. The
+        /// existing vault value (if any) remains valid and the secret can be re-written on a later run.
+        /// </summary>
+        public override bool IsCritical => false;
+
         public override async Task<object> ExecuteTask(object contextArg)
         {
             base.EnsureContextArgType<KeyVaultResource>(contextArg);
             var vault = (KeyVaultResource)contextArg;
 
             var name = _config.GetNameConfigValue();
+            try
+            {
+                return await AddRuntimeSecretAsync(vault, name);
+            }
+            catch (Exception ex) when (IsTransportOrDnsFailure(ex, out var leafMessage))
+            {
+                // DNS/network transport failure reaching the Key Vault data-plane endpoint
+                // (e.g. "The remote name could not be resolved: '<vault>.vault.azure.net'"), as opposed
+                // to an HTTP error response. Writing the secret is best-effort (see IsCritical), so log
+                // an actionable warning and let the install continue instead of aborting everything.
+                _logger.LogWarning(
+                    $"Could not reach key vault '{vault.Data.Name}' over the network to update secret '{name}': {leafMessage} " +
+                    $"This is usually a DNS / network / firewall issue resolving '{vault.Data.Name}.vault.azure.net' from the installer host " +
+                    $"(for example when public network access is disabled and the host is not on the VNet). " +
+                    $"The secret was not written; any existing value in the vault remains valid. " +
+                    $"Re-run the installer once connectivity is restored if the secret needs updating.");
+                return vault;
+            }
+        }
+
+        private async Task<object> AddRuntimeSecretAsync(KeyVaultResource vault, string name)
+        {
             var val = _config.GetConfigValue(CONFIG_KEY_SECRET_VAL);
 
 
@@ -339,6 +368,50 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 $"Likely causes: access policy / RBAC propagation lag (longer than the {(_retryDelaysSeconds.Length + 1)}-attempt retry window) or a vault firewall rule rejecting the runner IP — check the vault's Networking blade. " +
                 $"App-registration secrets in the vault may now be out of date — re-run the installer once the underlying cause is resolved.");
             return vault;
+        }
+
+        /// <summary>
+        /// True when <paramref name="ex"/> (or any exception nested within it, including
+        /// <see cref="AggregateException.InnerExceptions"/>) is a network transport / DNS resolution
+        /// failure rather than an HTTP error response from Key Vault. Azure.Core surfaces these as a
+        /// <see cref="RequestFailedException"/> with <c>Status == 0</c> wrapping a
+        /// <see cref="System.Net.WebException"/> / <see cref="System.Net.Http.HttpRequestException"/> /
+        /// <see cref="System.Net.Sockets.SocketException"/>, and the retry policy rethrows them inside an
+        /// <see cref="AggregateException"/>.
+        /// </summary>
+        private static bool IsTransportOrDnsFailure(Exception ex, out string leafMessage)
+        {
+            leafMessage = null;
+            foreach (var node in Flatten(ex))
+            {
+                if (node is System.Net.Sockets.SocketException
+                    || node is System.Net.WebException
+                    || node is System.Net.Http.HttpRequestException
+                    || (node is RequestFailedException rfe && rfe.Status == 0))
+                {
+                    // Keep walking so the innermost (most specific) message wins.
+                    leafMessage = node.Message;
+                }
+            }
+            return leafMessage != null;
+        }
+
+        private static IEnumerable<Exception> Flatten(Exception ex)
+        {
+            if (ex == null) yield break;
+            yield return ex;
+
+            if (ex is AggregateException agg)
+            {
+                foreach (var inner in agg.InnerExceptions)
+                {
+                    foreach (var n in Flatten(inner)) yield return n;
+                }
+            }
+            else if (ex.InnerException != null)
+            {
+                foreach (var n in Flatten(ex.InnerException)) yield return n;
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -248,7 +248,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             {
                 return await AddRuntimeSecretAsync(vault, name);
             }
-            catch (Exception ex) when (IsTransportOrDnsFailure(ex, out var leafMessage))
+            catch (Exception ex) when (TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leafMessage))
             {
                 // DNS/network transport failure reaching the Key Vault data-plane endpoint
                 // (e.g. "The remote name could not be resolved: '<vault>.vault.azure.net'"), as opposed
@@ -368,50 +368,6 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 $"Likely causes: access policy / RBAC propagation lag (longer than the {(_retryDelaysSeconds.Length + 1)}-attempt retry window) or a vault firewall rule rejecting the runner IP — check the vault's Networking blade. " +
                 $"App-registration secrets in the vault may now be out of date — re-run the installer once the underlying cause is resolved.");
             return vault;
-        }
-
-        /// <summary>
-        /// True when <paramref name="ex"/> (or any exception nested within it, including
-        /// <see cref="AggregateException.InnerExceptions"/>) is a network transport / DNS resolution
-        /// failure rather than an HTTP error response from Key Vault. Azure.Core surfaces these as a
-        /// <see cref="RequestFailedException"/> with <c>Status == 0</c> wrapping a
-        /// <see cref="System.Net.WebException"/> / <see cref="System.Net.Http.HttpRequestException"/> /
-        /// <see cref="System.Net.Sockets.SocketException"/>, and the retry policy rethrows them inside an
-        /// <see cref="AggregateException"/>.
-        /// </summary>
-        private static bool IsTransportOrDnsFailure(Exception ex, out string leafMessage)
-        {
-            leafMessage = null;
-            foreach (var node in Flatten(ex))
-            {
-                if (node is System.Net.Sockets.SocketException
-                    || node is System.Net.WebException
-                    || node is System.Net.Http.HttpRequestException
-                    || (node is RequestFailedException rfe && rfe.Status == 0))
-                {
-                    // Keep walking so the innermost (most specific) message wins.
-                    leafMessage = node.Message;
-                }
-            }
-            return leafMessage != null;
-        }
-
-        private static IEnumerable<Exception> Flatten(Exception ex)
-        {
-            if (ex == null) yield break;
-            yield return ex;
-
-            if (ex is AggregateException agg)
-            {
-                foreach (var inner in agg.InnerExceptions)
-                {
-                    foreach (var n in Flatten(inner)) yield return n;
-                }
-            }
-            else if (ex.InnerException != null)
-            {
-                foreach (var n in Flatten(ex.InnerException)) yield return n;
-            }
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/KeyVaultDataPlaneProbe.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/KeyVaultDataPlaneProbe.cs
@@ -1,0 +1,86 @@
+using Azure;
+using Azure.Core;
+using Azure.Security.KeyVault.Secrets;
+using System;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure
+{
+    /// <summary>Outcome of a Key Vault data-plane reachability probe.</summary>
+    public enum KeyVaultProbeStatus
+    {
+        /// <summary>The vault data-plane endpoint was reached and the credential is authorized to read.</summary>
+        Reachable,
+
+        /// <summary>The vault was reached but the credential was denied (HTTP 403) - missing access policy or a firewall rule.</summary>
+        Unauthorized,
+
+        /// <summary>The vault data-plane endpoint could not be reached at all (DNS / network / firewall transport failure).</summary>
+        TransportFailure,
+
+        /// <summary>Some other, unexpected error occurred.</summary>
+        OtherError
+    }
+
+    /// <summary>Result of <see cref="KeyVaultDataPlaneProbe.TryReadAsync"/>.</summary>
+    public class KeyVaultProbeResult
+    {
+        public KeyVaultProbeResult(KeyVaultProbeStatus status, string message)
+        {
+            Status = status;
+            Message = message;
+        }
+
+        public KeyVaultProbeStatus Status { get; }
+        public string Message { get; }
+    }
+
+    /// <summary>
+    /// Lightweight pre-flight check that the Key Vault data-plane endpoint
+    /// (<c>&lt;name&gt;.vault.azure.net</c>) is actually reachable and readable with a given credential.
+    /// This pre-empts the install-time failure where <c>KeyVaultSecretAddTask</c> cannot resolve / reach the
+    /// vault, distinguishing a DNS/network problem from an authorization (access policy / firewall) problem.
+    /// </summary>
+    public static class KeyVaultDataPlaneProbe
+    {
+        /// <summary>
+        /// Sentinel secret name used only to prove reachability + read authorization. It is expected NOT to
+        /// exist, so a 404 is the success signal (the call got through and we were authorized to read).
+        /// </summary>
+        private const string ProbeSecretName = "aitracker-testconfig-connectivity-probe";
+
+        /// <summary>
+        /// Attempt a single, read-only data-plane call against the vault and classify the outcome. Never throws.
+        /// </summary>
+        public static async Task<KeyVaultProbeResult> TryReadAsync(string vaultName, TokenCredential credential)
+        {
+            if (string.IsNullOrWhiteSpace(vaultName)) throw new ArgumentException($"'{nameof(vaultName)}' cannot be null or empty.", nameof(vaultName));
+            if (credential == null) throw new ArgumentNullException(nameof(credential));
+
+            var client = new SecretClient(new Uri($"https://{vaultName.Trim()}.vault.azure.net"), credential);
+            try
+            {
+                await client.GetSecretAsync(ProbeSecretName);
+                // The probe secret unexpectedly exists, but the call still proves reachability + Get permission.
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.Reachable, "Key Vault data-plane reachable.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                // Reached the vault and were authorized to read; the probe secret simply doesn't exist (expected).
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.Reachable, "Key Vault data-plane reachable.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == 403)
+            {
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.Unauthorized, ex.Message);
+            }
+            catch (Exception ex) when (TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leaf))
+            {
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.TransportFailure, leaf);
+            }
+            catch (Exception ex)
+            {
+                return new KeyVaultProbeResult(KeyVaultProbeStatus.OtherError, ex.Message);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/InstallJobInContainer.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/InstallJobInContainer.cs
@@ -53,12 +53,23 @@ namespace CloudInstallEngine
                     }
                     catch (Exception ex)
                     {
-                        Logger.LogError($"Unexpected error on stage {thisTask.TaskName}:");
-                        // Walk the InnerException chain — the custom installer ILogger
-                        // implementations drop the Exception arg, so feeding just ex.Message
-                        // here loses FluentFTP-style "see inner exception for more info" causes.
-                        Logger.LogError(ExceptionMessages.Format(ex));
-                        throw;      // Error will be logged by parent
+                        if (!thisTask.IsCritical)
+                        {
+                            // Best-effort task: log the failure but let the install continue. The
+                            // assignment above threw, so previousRunResult still holds the prior task's
+                            // result and is carried forward to downstream tasks that chain on it.
+                            Logger.LogError($"Non-critical stage {thisTask.TaskName} failed; continuing installation. Error:");
+                            Logger.LogError(ExceptionMessages.Format(ex));
+                        }
+                        else
+                        {
+                            Logger.LogError($"Unexpected error on stage {thisTask.TaskName}:");
+                            // Walk the InnerException chain — the custom installer ILogger
+                            // implementations drop the Exception arg, so feeding just ex.Message
+                            // here loses FluentFTP-style "see inner exception for more info" causes.
+                            Logger.LogError(ExceptionMessages.Format(ex));
+                            throw;      // Error will be logged by parent
+                        }
                     }
 
                     // Remember result

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/InstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/InstallTask.cs
@@ -20,6 +20,20 @@ namespace CloudInstallEngine
         public virtual async Task<object> ExecuteTask() { return await ExecuteTask(null); }
         public virtual string TaskName => this.GetType().Name;
 
+        /// <summary>
+        /// Whether a failure of this task should abort the whole install.
+        /// <para>
+        /// Defaults to <c>true</c> (the historic behaviour): if the task throws, the running
+        /// <see cref="SequentialTaskListInstallJob"/> logs the error and rethrows, stopping the install.
+        /// </para>
+        /// <para>
+        /// Tasks that are "best-effort" (e.g. writing a runtime secret to Key Vault, where a transient
+        /// network/DNS/permission failure should not abort an otherwise-successful install) can override
+        /// this to <c>false</c>. The job then logs the failure and continues with the next task.
+        /// </para>
+        /// </summary>
+        public virtual bool IsCritical => true;
+
         protected readonly TaskConfig _config;
         protected readonly ILogger _logger;
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/TransportFailureDetector.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/TransportFailureDetector.cs
@@ -1,0 +1,65 @@
+using Azure;
+using System;
+using System.Collections.Generic;
+
+namespace CloudInstallEngine
+{
+    /// <summary>
+    /// Classifies whether an exception is a network transport / DNS resolution failure (the cause of
+    /// "The remote name could not be resolved: '&lt;x&gt;.vault.azure.net'" install failures) as opposed to
+    /// an HTTP error response from the service.
+    /// <para>
+    /// Azure.Core surfaces transport failures as a <see cref="RequestFailedException"/> with
+    /// <c>Status == 0</c> wrapping a <see cref="System.Net.WebException"/> /
+    /// <see cref="System.Net.Http.HttpRequestException"/> / <see cref="System.Net.Sockets.SocketException"/>,
+    /// and the retry policy rethrows them inside an <see cref="AggregateException"/>.
+    /// </para>
+    /// </summary>
+    public static class TransportFailureDetector
+    {
+        /// <summary>
+        /// True when <paramref name="ex"/> (or any exception nested within it, including
+        /// <see cref="AggregateException.InnerExceptions"/>) is a network transport / DNS resolution failure.
+        /// <paramref name="leafMessage"/> receives the innermost (most specific) matching message.
+        /// </summary>
+        public static bool IsTransportOrDnsFailure(Exception ex, out string leafMessage)
+        {
+            leafMessage = null;
+            foreach (var node in Flatten(ex))
+            {
+                if (node is System.Net.Sockets.SocketException
+                    || node is System.Net.WebException
+                    || node is System.Net.Http.HttpRequestException
+                    || (node is RequestFailedException rfe && rfe.Status == 0))
+                {
+                    // Keep walking so the innermost (most specific) message wins.
+                    leafMessage = node.Message;
+                }
+            }
+            return leafMessage != null;
+        }
+
+        /// <summary>
+        /// Depth-first walk of an exception and everything nested within it (the
+        /// <see cref="Exception.InnerException"/> chain and <see cref="AggregateException.InnerExceptions"/>),
+        /// outermost first.
+        /// </summary>
+        public static IEnumerable<Exception> Flatten(Exception ex)
+        {
+            if (ex == null) yield break;
+            yield return ex;
+
+            if (ex is AggregateException agg)
+            {
+                foreach (var inner in agg.InnerExceptions)
+                {
+                    foreach (var n in Flatten(inner)) yield return n;
+                }
+            }
+            else if (ex.InnerException != null)
+            {
+                foreach (var n in Flatten(ex.InnerException)) yield return n;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Classes.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Classes.cs
@@ -19,6 +19,15 @@ namespace DataUtils.Sql
         public DbType SqlType { get; internal set; }
 
         /// <summary>
+        /// Declared maximum length, in characters, parsed once from a bounded string column
+        /// definition such as <c>nvarchar(850)</c>. Null for unbounded (<c>nvarchar(max)</c>) or
+        /// non-length-bounded types (int, datetime2, ...). Lets <see cref="Inserts.InsertBatch{T}"/>
+        /// skip an over-width row in memory before the INSERT, instead of catching a per-row SQL
+        /// truncation error (8152/2628) on every doomed row.
+        /// </summary>
+        public int? MaxLength { get; set; }
+
+        /// <summary>
         /// Optional explicit SQL column type (e.g. "nvarchar(850)") that overrides the default
         /// <c>[nvarchar] (max)</c> emitted for <see cref="string"/> properties by
         /// <see cref="Inserts.InsertBatchTypeFieldCache{T}"/>. Set via <see cref="ColumnAttribute.SqlTypeOverride"/>

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -140,6 +139,7 @@ namespace DataUtils.Sql.Inserts
                 {
                     cmd.Parameters.Clear();
                     int fieldIdx = 0;
+                    var rowExceedsColumnWidth = false;
                     foreach (var fieldMapping in _batchTypeFieldCache.PropertyMappingInfo)
                     {
                         var objVal = fieldMapping.Property.GetValue(insertObj);
@@ -147,22 +147,44 @@ namespace DataUtils.Sql.Inserts
                         {
                             throw new BatchSaveException($"Couldn't insert null into batch insert field '{fieldMapping.SqlInfo.FieldName}' in table '{tempTableName}'");
                         }
+
+                        // Cheap in-memory width check, using the length parsed once when the field
+                        // cache was built, so the hot path stays a single integer comparison (no
+                        // per-row reflection or regex). A value wider than its bounded nvarchar
+                        // column can never be inserted, so flag the row and skip it below instead of
+                        // paying a doomed SQL round-trip + truncation error (8152/2628) per over-width
+                        // row. SQL Server nvarchar(n) counts UTF-16 units, exactly what string.Length
+                        // returns, so this predicts the server's truncation faithfully.
+                        if (objVal is string s && fieldMapping.SqlInfo.MaxLength.HasValue && s.Length > fieldMapping.SqlInfo.MaxLength.Value)
+                        {
+                            rowExceedsColumnWidth = true;
+                        }
+
                         cmd.ParamUp("@p" + fieldIdx, objVal, fieldMapping.SqlInfo.SqlType);
 
                         fieldIdx++;
                     }
+
+                    if (rowExceedsColumnWidth)
+                    {
+                        // Predicted over-width: skip just this row rather than aborting the whole
+                        // batch - which would discard every other row's data too and fail again on
+                        // every retry as a "poison batch". For SharePoint URLs longer than the
+                        // urls.full_url-width nvarchar(850) columns see issue #122 / #127.
+                        Interlocked.Increment(ref _rowsSkippedTooWide);
+                        _telemetry.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. Continuing with the rest of the batch.");
+                        continue;
+                    }
+
                     try
                     {
                         await cmd.ExecuteNonQueryAsync();
                     }
                     catch (SqlException ex) when (IsColumnTruncationError(ex))
                     {
-                        // A value is longer than its staging column allows (e.g. a SharePoint URL
-                        // longer than the urls.full_url-width nvarchar(850) columns - see issue
-                        // #122 / #127). This row can never be inserted, so log exactly which column
-                        // overflowed and skip just this row, rather than aborting the whole batch -
-                        // which would discard every other row's data too and fail again on every
-                        // retry as a "poison batch".
+                        // Backstop: a value was wider than its column but the in-memory check above
+                        // didn't predict it (e.g. a column whose declared width we couldn't parse).
+                        // Skip just this row so one bad value can't poison the whole batch.
                         Interlocked.Increment(ref _rowsSkippedTooWide);
                         _telemetry.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. SQL error {ex.Number}: {ex.Message}. Continuing with the rest of the batch.");
                         continue;
@@ -184,16 +206,6 @@ namespace DataUtils.Sql.Inserts
         // Azure SQL, when an inserted value is wider than its target column. Both mean the same here.
         private static bool IsColumnTruncationError(SqlException ex) => ex.Number == 8152 || ex.Number == 2628;
 
-        // Parses the declared length from a staging column definition such as "nvarchar(850)".
-        // Returns null for unbounded definitions ("nvarchar(max)") or anything without an explicit length.
-        private static int? GetDeclaredColumnLength(string sqlColDefinition)
-        {
-            if (string.IsNullOrEmpty(sqlColDefinition)) return null;
-            if (sqlColDefinition.IndexOf("max", StringComparison.OrdinalIgnoreCase) >= 0) return null;
-            var match = Regex.Match(sqlColDefinition, @"\((\d+)\)");
-            return match.Success && int.TryParse(match.Groups[1].Value, out var len) ? (int?)len : null;
-        }
-
         // Builds a privacy-conscious, single-line description of a row to help operators locate the
         // source record and the offending column when an insert fails. String VALUES are never logged
         // (they may hold customer data such as URLs, file/user names) - only the over-width column's
@@ -210,7 +222,7 @@ namespace DataUtils.Sql.Inserts
                 var val = fieldMapping.Property.GetValue(insertObj);
                 if (val is string s)
                 {
-                    var declaredLen = GetDeclaredColumnLength(fieldMapping.SqlInfo.SqlColDefinition);
+                    var declaredLen = fieldMapping.SqlInfo.MaxLength;
                     if (declaredLen.HasValue && s.Length > declaredLen.Value)
                     {
                         var part = $"column '{fieldName}' ({fieldMapping.SqlInfo.SqlColDefinition}) holds {s.Length} chars but the limit is {declaredLen.Value}";

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DataUtils.Sql.Inserts
@@ -20,6 +22,10 @@ namespace DataUtils.Sql.Inserts
         private readonly string _connectionString;
         private readonly ILogger _telemetry;
         private InsertBatchTypeFieldCache<T> _batchTypeFieldCache = null;
+
+        // Count of rows dropped during the current save because a value was wider than its staging
+        // column. Written from parallel insert threads via Interlocked, reset per SaveToStagingTable.
+        private int _rowsSkippedTooWide = 0;
         public InsertBatch(string connectionString, ILogger telemetry)
         {
             _connectionString = connectionString;
@@ -40,6 +46,10 @@ namespace DataUtils.Sql.Inserts
         public async Task<int> SaveToStagingTable(int insertsPerThread, string mergeSql)
         {
             if (Rows.Count == 0) return 0;
+
+            // This instance can be reused for several saves (e.g. the Copilot manager keeps one
+            // InsertBatch per staging table and commits repeatedly), so reset the skip counter.
+            _rowsSkippedTooWide = 0;
 
             // Extract/validate schema
             var typeParameterType = typeof(T);
@@ -72,6 +82,12 @@ namespace DataUtils.Sql.Inserts
                 await loader.ProcessListInParallel(Rows,
                     async (threadListChunk, threadIndex) => await ProcessChunkAsync(tempTableName, _telemetry, threadListChunk, threadIndex),
                     threads => _telemetry.LogInformation($"Inserting {Rows.Count.ToString("n0")} records into {tempTableName}, across {threads} thread(s)..."));
+
+                // Tell operators if we dropped any rows because a value was too wide for its column.
+                if (_rowsSkippedTooWide > 0)
+                {
+                    _telemetry.LogWarning($"{_rowsSkippedTooWide.ToString("n0")} of {Rows.Count.ToString("n0")} record(s) were NOT staged into {tempTableName} because a column value was longer than that staging column allows; data for those rows is missing from this import (everything else was saved). See the 'Skipping over-width record' messages above for the offending column(s). For SharePoint URLs longer than urls.full_url (nvarchar(850)) see issue #122 / #127.");
+                }
 
                 // Merge with supplied SQL
                 if (!string.IsNullOrEmpty(mergeSql))
@@ -139,9 +155,21 @@ namespace DataUtils.Sql.Inserts
                     {
                         await cmd.ExecuteNonQueryAsync();
                     }
+                    catch (SqlException ex) when (IsColumnTruncationError(ex))
+                    {
+                        // A value is longer than its staging column allows (e.g. a SharePoint URL
+                        // longer than the urls.full_url-width nvarchar(850) columns - see issue
+                        // #122 / #127). This row can never be inserted, so log exactly which column
+                        // overflowed and skip just this row, rather than aborting the whole batch -
+                        // which would discard every other row's data too and fail again on every
+                        // retry as a "poison batch".
+                        Interlocked.Increment(ref _rowsSkippedTooWide);
+                        _telemetry.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. SQL error {ex.Number}: {ex.Message}. Continuing with the rest of the batch.");
+                        continue;
+                    }
                     catch (SqlException ex)
                     {
-                        _telemetry.LogCritical($"Failed to insert record into {tempTableName} - {sqlInsert}: {ex.Message}");
+                        _telemetry.LogCritical($"Failed to insert record into {tempTableName} - {sqlInsert} | row: {BuildRowDiagnostic(insertObj, false)} | SQL error {ex.Number}: {ex.Message}");
                         throw;
                     }
                 }
@@ -149,6 +177,56 @@ namespace DataUtils.Sql.Inserts
                 Console.Write($"Done:#{chunkIdx}...");
 #endif
             }
+        }
+
+        // SQL Server raises 8152 ("String or binary data would be truncated.") on all versions, and
+        // 2628 (the verbose variant that also names the table/column/value) on SQL Server 2019+ and
+        // Azure SQL, when an inserted value is wider than its target column. Both mean the same here.
+        private static bool IsColumnTruncationError(SqlException ex) => ex.Number == 8152 || ex.Number == 2628;
+
+        // Parses the declared length from a staging column definition such as "nvarchar(850)".
+        // Returns null for unbounded definitions ("nvarchar(max)") or anything without an explicit length.
+        private static int? GetDeclaredColumnLength(string sqlColDefinition)
+        {
+            if (string.IsNullOrEmpty(sqlColDefinition)) return null;
+            if (sqlColDefinition.IndexOf("max", StringComparison.OrdinalIgnoreCase) >= 0) return null;
+            var match = Regex.Match(sqlColDefinition, @"\((\d+)\)");
+            return match.Success && int.TryParse(match.Groups[1].Value, out var len) ? (int?)len : null;
+        }
+
+        // Builds a privacy-conscious, single-line description of a row to help operators locate the
+        // source record and the offending column when an insert fails. String VALUES are never logged
+        // (they may hold customer data such as URLs, file/user names) - only the over-width column's
+        // name, declared width and actual length, plus a short prefix sample when requested so the
+        // value can be recognised. Guid/DateTime/number/bool fields (e.g. log_id, time_stamp) are
+        // logged in full as they are non-sensitive keys for finding the record.
+        private string BuildRowDiagnostic(T insertObj, bool includeOverWidthSample)
+        {
+            const int SAMPLE_CHARS = 64;
+            var parts = new List<string>();
+            foreach (var fieldMapping in _batchTypeFieldCache.PropertyMappingInfo)
+            {
+                var fieldName = fieldMapping.SqlInfo.FieldName;
+                var val = fieldMapping.Property.GetValue(insertObj);
+                if (val is string s)
+                {
+                    var declaredLen = GetDeclaredColumnLength(fieldMapping.SqlInfo.SqlColDefinition);
+                    if (declaredLen.HasValue && s.Length > declaredLen.Value)
+                    {
+                        var part = $"column '{fieldName}' ({fieldMapping.SqlInfo.SqlColDefinition}) holds {s.Length} chars but the limit is {declaredLen.Value}";
+                        if (includeOverWidthSample)
+                        {
+                            part += $" (starts with \"{s.Substring(0, Math.Min(SAMPLE_CHARS, s.Length))}…\")";
+                        }
+                        parts.Add(part);
+                    }
+                }
+                else if (val != null)
+                {
+                    parts.Add($"{fieldName}={val}");
+                }
+            }
+            return parts.Count > 0 ? string.Join(", ", parts) : "(no over-width column detected; see SQL error detail)";
         }
 
         private async Task DropAndCreateStagingTable(SqlConnection opConnection, string tableName, List<ColumnSqlInfo> fields)

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatchTypeFieldCache.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatchTypeFieldCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace DataUtils.Sql.Inserts
 {
@@ -65,6 +66,16 @@ namespace DataUtils.Sql.Inserts
                             }
                             fieldInfo.Nullable = attribute.Nullable ? true : propTypeIsNullable;
                             fieldInfo.SqlType = SqlHelper.GetDbType(property.PropertyType);
+
+                            // Parse the bounded length once here (not per row) so the hot insert
+                            // loop can skip an over-width value with a single integer comparison
+                            // instead of a per-row SQL truncation error. Only meaningful for string
+                            // columns; inferred numeric/date types have no character length to enforce.
+                            if (property.PropertyType == typeof(string))
+                            {
+                                fieldInfo.MaxLength = ParseDeclaredLength(fieldInfo.SqlColDefinition);
+                            }
+
                             _fieldInfoPropertyInfoCache.Add(new InsertBatchPropertyMapping { Property = property, SqlInfo = fieldInfo });
                         }
                     }
@@ -116,6 +127,16 @@ namespace DataUtils.Sql.Inserts
                 return ("uniqueidentifier", false);
             }
             return ("[nvarchar] (max)", false);
+        }
+
+        // Parses the declared length from a column definition such as "nvarchar(850)" -> 850.
+        // Returns null for unbounded ("nvarchar(max)") or definitions without an explicit length.
+        private static int? ParseDeclaredLength(string sqlColDefinition)
+        {
+            if (string.IsNullOrEmpty(sqlColDefinition)) return null;
+            if (sqlColDefinition.IndexOf("max", StringComparison.OrdinalIgnoreCase) >= 0) return null;
+            var match = Regex.Match(sqlColDefinition, @"\((\d+)\)");
+            return match.Success && int.TryParse(match.Groups[1].Value, out var len) ? (int?)len : null;
         }
     }
 

--- a/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
@@ -207,13 +207,21 @@ namespace DataUtils
         }
 
         /// <summary>
-        /// Ensures <paramref name="url"/> fits the <c>dbo.urls.full_url</c> column. URLs already
-        /// within <paramref name="maxLength"/> are returned unchanged (so we avoid needless churn).
-        /// Otherwise the volatile <c>xsdata</c> parameter is removed (see <see cref="RemoveXsDataParam"/>);
-        /// if the result is STILL too long (e.g. a huge <c>FilterValues</c> list, or a URL with no
-        /// <c>xsdata</c> at all) it is hard-truncated to <paramref name="maxLength"/> as a last resort,
-        /// so the importer never fails staging an over-length value into the nvarchar(850) staging
-        /// column. Pass <c>Common.Entities.Url.FullUrlMaxLength</c> as <paramref name="maxLength"/>.
+        /// Ensures <paramref name="url"/> fits the <c>dbo.urls.full_url</c> column, mirroring the
+        /// staged clean-up in ShrinkUrlsFullUrlColumn-UpgradeGuide.md so the importer can never fail
+        /// staging an over-length value into the nvarchar(850) staging columns. URLs already within
+        /// <paramref name="maxLength"/> are returned unchanged (no needless churn). Otherwise, in order:
+        /// <list type="number">
+        /// <item>the volatile <c>xsdata</c> token is removed (see <see cref="RemoveXsDataParam"/>) -
+        /// on its own this brings the large majority of oversized SharePoint URLs back under the limit;</item>
+        /// <item>if it is STILL too long (e.g. a giant <c>SafelinksUrl</c>/<c>FilterValues</c> list or
+        /// comma-merged Teams parameters), the whole query string and <c>#fragment</c> are dropped,
+        /// keeping just the page path - the only part with analytic value (this matches the "reduce to
+        /// path" step of the upgrade guide);</item>
+        /// <item>only in the pathological case where even the bare path exceeds <paramref name="maxLength"/>
+        /// is it hard-truncated as an absolute last resort.</item>
+        /// </list>
+        /// Pass <c>Common.Entities.Url.FullUrlMaxLength</c> as <paramref name="maxLength"/>.
         /// </summary>
         public static string EnsureUrlWithinLength(string url, int maxLength)
         {
@@ -222,14 +230,41 @@ namespace DataUtils
                 return url;
             }
 
+            // 1. Remove the volatile xsdata token - usually enough on its own.
             var trimmed = RemoveXsDataParam(url);
-            if (trimmed.Length > maxLength)
+            if (trimmed.Length <= maxLength)
             {
-                // A degenerate URL (junk tracking params) that xsdata removal can't shrink enough:
-                // truncate so the staging insert never overflows the column.
-                trimmed = trimmed.Substring(0, maxLength);
+                return trimmed;
             }
-            return trimmed;
+
+            // 2. Still too long: drop the entire query string and #fragment, keeping just the page
+            //    path. Everything after '?' on these URLs is volatile Teams junk with no analytic value.
+            var path = GetUrlPath(trimmed);
+            if (path.Length <= maxLength)
+            {
+                return path;
+            }
+
+            // 3. Pathological (even the bare path is over the limit): hard-truncate as an absolute
+            //    last resort so the staging insert never overflows the column.
+            return path.Substring(0, maxLength);
+        }
+
+        static readonly char[] QueryOrFragmentStart = { '?', '#' };
+
+        /// <summary>
+        /// Returns everything in <paramref name="url"/> before the first <c>?</c> or <c>#</c> (the
+        /// page path), or the whole string if neither is present. String-based to match the T-SQL
+        /// <c>pathkey</c> logic in ShrinkUrlsFullUrlColumn-UpgradeGuide.md exactly.
+        /// </summary>
+        private static string GetUrlPath(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return url;
+            }
+            var cut = url.IndexOfAny(QueryOrFragmentStart);
+            return cut < 0 ? url : url.Substring(0, cut);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
@@ -149,6 +149,89 @@ namespace DataUtils
             }
         }
 
+        internal const string XsDataParam = "xsdata=";
+
+        /// <summary>
+        /// Removes the volatile <c>xsdata</c> query parameter from <paramref name="url"/>, preserving
+        /// the rest of the URL (path, all other query parameters, and any <c>#fragment</c>). The
+        /// <c>xsdata</c> value is a large, transient Teams / SharePoint deep-link token with no
+        /// analytic value that routinely pushes SharePoint URLs past the <c>dbo.urls.full_url</c>
+        /// limit (<c>nvarchar(850)</c>, see migration ShrinkUrlsFullUrlColumn / issue #122). Matching
+        /// is case-insensitive on the parameter name and boundary-aware (only a real <c>?xsdata=</c>
+        /// or <c>&amp;xsdata=</c> parameter is removed, never an <c>xsdata</c> substring inside
+        /// another value). Returns the input unchanged when it is null/empty or has no such parameter.
+        /// Mirrors the T-SQL clean-up in ShrinkUrlsFullUrlColumn-UpgradeGuide.md.
+        /// </summary>
+        public static string RemoveXsDataParam(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return url;
+            }
+
+            var lower = url.ToLowerInvariant();
+            var sep = lower.IndexOf("?" + XsDataParam, StringComparison.Ordinal);
+            if (sep == -1)
+            {
+                sep = lower.IndexOf("&" + XsDataParam, StringComparison.Ordinal);
+            }
+            if (sep == -1)
+            {
+                return url; // No xsdata parameter present.
+            }
+
+            var sepChar = url[sep];
+            var valStart = sep + 1 + XsDataParam.Length; // First char of the xsdata value.
+
+            // The value ends at the next '&' or '#' (whichever comes first), or end-of-string.
+            var amp = url.IndexOf('&', valStart);
+            var hash = url.IndexOf('#', valStart);
+            int term;
+            if (amp == -1) term = hash;
+            else if (hash == -1) term = amp;
+            else term = Math.Min(amp, hash);
+
+            if (term == -1)
+            {
+                // xsdata is the last parameter and there is no fragment: drop the separator + value.
+                return url.Substring(0, sep);
+            }
+            if (sepChar == '?' && url[term] == '&')
+            {
+                // xsdata is the first parameter: keep '?', drop 'xsdata=...&'.
+                return url.Substring(0, sep + 1) + url.Substring(term + 1);
+            }
+            // '&' separator, or '?' separator immediately followed by a fragment: drop the parameter
+            // and keep the remainder (the following '&param' or '#fragment').
+            return url.Substring(0, sep) + url.Substring(term);
+        }
+
+        /// <summary>
+        /// Ensures <paramref name="url"/> fits the <c>dbo.urls.full_url</c> column. URLs already
+        /// within <paramref name="maxLength"/> are returned unchanged (so we avoid needless churn).
+        /// Otherwise the volatile <c>xsdata</c> parameter is removed (see <see cref="RemoveXsDataParam"/>);
+        /// if the result is STILL too long (e.g. a huge <c>FilterValues</c> list, or a URL with no
+        /// <c>xsdata</c> at all) it is hard-truncated to <paramref name="maxLength"/> as a last resort,
+        /// so the importer never fails staging an over-length value into the nvarchar(850) staging
+        /// column. Pass <c>Common.Entities.Url.FullUrlMaxLength</c> as <paramref name="maxLength"/>.
+        /// </summary>
+        public static string EnsureUrlWithinLength(string url, int maxLength)
+        {
+            if (url == null || url.Length <= maxLength)
+            {
+                return url;
+            }
+
+            var trimmed = RemoveXsDataParam(url);
+            if (trimmed.Length > maxLength)
+            {
+                // A degenerate URL (junk tracking params) that xsdata removal can't shrink enough:
+                // truncate so the staging insert never overflows the column.
+                trimmed = trimmed.Substring(0, maxLength);
+            }
+            return trimmed;
+        }
+
         /// <summary>
         /// https://contoso.sharepoint.com/sites/site/Shared Documents/
         /// to 

--- a/src/AnalyticsEngine/Common/Entities/Entities/Url.cs
+++ b/src/AnalyticsEngine/Common/Entities/Entities/Url.cs
@@ -13,6 +13,14 @@ namespace Common.Entities
     [Table("urls")]
     public class Url : AbstractEFEntity, IUrlObject
     {
+        /// <summary>
+        /// Maximum length (characters) of <see cref="FullUrl"/> / <c>dbo.urls.full_url</c>. The
+        /// column is <c>nvarchar(850)</c> after migration ShrinkUrlsFullUrlColumn (850 nvarchar
+        /// chars = the 1700-byte non-clustered index-key limit). Used to gate insert-time URL
+        /// trimming (see <see cref="DataUtils.StringUtils.EnsureUrlWithinLength"/>) so the
+        /// importer never stages a URL longer than the target column. See issue #122 (#108/#109).
+        /// </summary>
+        public const int FullUrlMaxLength = 850;
 
         // nvarchar(850) NOT NULL is the on-disk schema after migration ShrinkUrlsFullUrlColumn
         // (the column is shrunk from a (max) LOB so it can be the IX_urls_full_url index key -
@@ -21,7 +29,7 @@ namespace Common.Entities
         // would corrupt to '?'. The matching EF mapping below keeps EF emitting nvarchar parameters
         // so EF-driven queries on urls can use IX_urls_full_url. See issue #122 (#108/#109).
         [Required]
-        [MaxLength(850)]
+        [MaxLength(FullUrlMaxLength)]
         [Column("full_url", TypeName = "nvarchar")]
         public string FullUrl { get; set; }
 

--- a/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md
@@ -140,7 +140,27 @@ no‑op.
 ## If the migration aborts
 
 If a customer DB has URLs longer than 850 characters, the migration **aborts before changing
-anything** and prints the offending rows. Find them with:
+anything** and prints the offending rows.
+
+### 1. How many URLs are there, and how many are oversized?
+
+First get the scale of the problem — the **total** row count and how many are actually over the
+limit (the abort only tells you about the oversized ones):
+
+```sql
+SELECT
+    COUNT(*)                                                              AS total_urls,
+    SUM(CASE WHEN LEN(full_url) > 850 THEN 1 ELSE 0 END)                  AS oversize_urls,
+    SUM(CASE WHEN LEN(full_url) > 850
+              AND (full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%')
+             THEN 1 ELSE 0 END)                                           AS oversize_with_xsdata,
+    SUM(CASE WHEN LEN(full_url) > 850
+              AND NOT (full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%')
+             THEN 1 ELSE 0 END)                                           AS oversize_other
+FROM dbo.urls;
+```
+
+Then list the offending rows themselves:
 
 ```sql
 SELECT id, LEN(full_url) AS length, full_url
@@ -149,9 +169,134 @@ WHERE LEN(full_url) > 850
 ORDER BY length DESC;
 ```
 
-Resolve each offending URL (and the `hits` / `event_meta_sharepoint` rows that reference it via
-`url_id`) — e.g. delete the obsolete records or shorten the stored URL — then re‑run the upgrade.
-The migration is idempotent, so re‑running after a fix simply continues.
+In practice most of the `oversize_with_xsdata` rows can be fixed automatically (next section). Any
+`oversize_other` rows (over 850 even without an `xsdata` parameter) must be resolved by hand —
+delete the obsolete records or shorten the stored URL (and the `hits` / `event_meta_sharepoint`
+rows that reference them via `url_id`) — then re‑run the upgrade. The migration is idempotent, so
+re‑running after a fix simply continues.
 
 > There is no longer a "not representable as varchar" abort: the target is `nvarchar`, which holds
 > every Unicode character, so Greek (and any other script) is preserved rather than rejected.
+
+---
+
+## Cleaning up oversized Teams deep‑link (`xsdata`) URLs
+
+A large share of real‑world oversized URLs are SharePoint links opened from Microsoft Teams. Teams
+appends a big, **transient** `xsdata=` token (plus `sdata`, `ovuser`, `clickparams`, …) to the URL.
+The `xsdata` value alone is typically **600–1100 characters** of opaque base64 and carries **no
+analytic value** — it just records *how* the link was opened. Example (line‑wrapped for clarity):
+
+```
+https://contoso.sharepoint.com/sites/Marketing/Lists/Announcements/AllItems.aspx
+    ?xsdata=<opaque base64 token, ~700 chars>&sdata=…&ovuser=…&clickparams=…&viewid=…
+```
+
+Removing just the `xsdata` parameter brings these URLs back under 850 characters in the vast
+majority of cases (observed: real samples of **1213–1515** chars drop to **601–935** chars). The
+remainder of the URL — path, all other query parameters and any `#fragment` — is preserved.
+
+> **Note** — going forward the importers no longer store these tokens: when a URL exceeds the
+> column limit (`Url.FullUrlMaxLength` = 850) the activity / click / Copilot import paths strip the
+> `xsdata` parameter **at insert time** — and, as a last resort, hard‑truncate to 850 if the URL is
+> *still* too long — via `StringUtils.EnsureUrlWithinLength`. This clean‑up script is for databases
+> that already accumulated oversized rows before that change.
+
+### 2. Clean up the oversized `xsdata` URLs (transaction defaults to ROLLBACK)
+
+The script below **defaults to `ROLLBACK`** so it is safe to run as a *preview*: it does all the
+work, prints how many rows it would clean and how many would still be oversized, then throws it all
+away. **Verify those numbers, then — and only then — change the final `ROLLBACK TRANSACTION;` to
+`COMMIT TRANSACTION;` and re‑run to apply the changes for real.** Back up / snapshot the database
+first, as with any data fix.
+
+It only touches rows that are **over 850 characters** and contain a real `xsdata` parameter, only
+applies the cleaned value when it **fits** (≤ 850) **and does not already exist** on another row
+(so it never creates a duplicate `full_url`), and collapses multiple oversized rows that clean to
+the same value down to one.
+
+```sql
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+BEGIN TRANSACTION;
+
+-- 1. Collect oversize URLs that carry a real xsdata parameter, with the parameter's position.
+--    Materialising into #fix first stops the query optimiser from evaluating the string-slicing
+--    below against rows that have no xsdata parameter (which would pass a negative length to
+--    LEFT/SUBSTRING). Every #fix row is guaranteed to have sep >= 1.
+IF OBJECT_ID('tempdb..#fix') IS NOT NULL DROP TABLE #fix;
+SELECT id, full_url,
+       sep = CASE WHEN CHARINDEX(N'?xsdata=', full_url) > 0 THEN CHARINDEX(N'?xsdata=', full_url)
+                  ELSE CHARINDEX(N'&xsdata=', full_url) END,
+       cleaned_url = CAST(NULL AS nvarchar(max))
+INTO #fix
+FROM dbo.urls
+WHERE LEN(full_url) > 850
+  AND (full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%');
+
+-- 2. Build the cleaned URL (xsdata parameter removed, everything else - including any #fragment -
+--    preserved). The value ends at the next '&' or '#', or end-of-string.
+UPDATE f
+SET cleaned_url = CASE
+        WHEN term = 0 THEN LEFT(full_url, sep - 1)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'&'
+             THEN LEFT(full_url, sep) + SUBSTRING(full_url, term + 1, 4000)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'#'
+             THEN LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+        ELSE LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+    END
+FROM #fix f
+CROSS APPLY (SELECT sepChar = SUBSTRING(full_url, sep, 1),
+                    endAmp  = CHARINDEX(N'&', full_url, sep + 8),
+                    endHash = CHARINDEX(N'#', full_url, sep + 8)) a
+CROSS APPLY (SELECT term = CASE WHEN a.endAmp = 0 AND a.endHash = 0 THEN 0
+                               WHEN a.endAmp = 0 THEN a.endHash
+                               WHEN a.endHash = 0 THEN a.endAmp
+                               WHEN a.endAmp < a.endHash THEN a.endAmp
+                               ELSE a.endHash END) b;
+
+-- 3. Apply: only rows that now fit (<= 850) AND whose cleaned value does not already exist on
+--    another row (so we never create a duplicate full_url). ROW_NUMBER collapses any oversize
+--    rows that clean to the same value, updating just one of them.
+;WITH ranked AS (
+    SELECT id, cleaned_url,
+           rn = ROW_NUMBER() OVER (PARTITION BY CAST(cleaned_url AS nvarchar(850)) ORDER BY id)
+    FROM #fix
+    WHERE LEN(cleaned_url) <= 850
+)
+UPDATE u
+   SET u.full_url = r.cleaned_url
+FROM dbo.urls u
+INNER JOIN ranked r ON r.id = u.id
+WHERE r.rn = 1
+  AND NOT EXISTS (SELECT 1 FROM dbo.urls e WHERE e.full_url = r.cleaned_url AND e.id <> r.id);
+
+DECLARE @cleaned int = @@ROWCOUNT;
+RAISERROR('Rows cleaned: %d', 0, 1, @cleaned) WITH NOWAIT;
+
+-- 4. What still exceeds 850 (xsdata couldn't shrink it enough, or its cleaned form already exists)?
+SELECT remaining_oversize    = COUNT(*),
+       of_which_still_xsdata = SUM(CASE WHEN full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%' THEN 1 ELSE 0 END)
+FROM dbo.urls WHERE LEN(full_url) > 850;
+
+DROP TABLE #fix;
+
+-- VERIFY the two result sets above, then change ROLLBACK to COMMIT and re-run to apply.
+ROLLBACK TRANSACTION;
+-- COMMIT TRANSACTION;
+```
+
+### 3. What's left after the clean‑up
+
+`remaining_oversize` counts the rows the script could **not** auto‑fix:
+
+- **Still > 850 after removing `xsdata`** — a few URLs are long because of *other* parameters (e.g.
+  a huge `FilterValues1=…` list), not `xsdata`. Removing `xsdata` isn't enough; shorten or delete
+  these by hand.
+- **Cleaned value already exists** — the de‑duplicated URL is already tracked by another `urls`
+  row, so the oversized duplicate was left untouched to avoid creating a duplicate key. Re‑point its
+  `hits` / `event_meta_sharepoint` / Copilot rows (via `url_id`) at the existing row and delete the
+  duplicate, or simply delete the oversized duplicate if its facts are redundant.
+
+Re‑run the count query from step 1 to confirm `oversize_urls` is `0`, then re‑run the upgrade. The
+migration is idempotent, so it simply continues once the data fits.

--- a/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md
@@ -286,17 +286,199 @@ ROLLBACK TRANSACTION;
 -- COMMIT TRANSACTION;
 ```
 
-### 3. What's left after the clean‑up
+### 3. What's left after the clean‑up — classify it
 
-`remaining_oversize` counts the rows the script could **not** auto‑fix:
+`remaining_oversize` counts the rows the `xsdata` strip could **not** auto‑fix. In practice the strip
+resolves the large majority of oversized URLs (the `xsdata` token is usually the bulk of the bloat);
+only a handful remain. Each remaining row falls into one of these buckets:
 
-- **Still > 850 after removing `xsdata`** — a few URLs are long because of *other* parameters (e.g.
-  a huge `FilterValues1=…` list), not `xsdata`. Removing `xsdata` isn't enough; shorten or delete
-  these by hand.
-- **Cleaned value already exists** — the de‑duplicated URL is already tracked by another `urls`
-  row, so the oversized duplicate was left untouched to avoid creating a duplicate key. Re‑point its
-  `hits` / `event_meta_sharepoint` / Copilot rows (via `url_id`) at the existing row and delete the
-  duplicate, or simply delete the oversized duplicate if its facts are redundant.
+- **Still > 850 after removing `xsdata`** — long because of *other* junk (e.g. a big `FilterValues1=…`
+  list, or a `SafelinksUrl=` that embeds a whole second copy of the URL, often with duplicated
+  comma‑merged Teams parameters). Removing `xsdata` isn't enough.
+- **Cleaned value already exists** — the de‑duplicated URL is already tracked by another `urls` row,
+  so the oversized duplicate was left untouched to avoid creating a duplicate `full_url`.
+- **No `xsdata` at all** — oversized for some unrelated reason.
+
+This read‑only query classifies every remaining oversized row so you know which bucket each is in
+(it materialises the `xsdata` rows into `#fix` first so the slicing never sees a row without the
+parameter):
+
+```sql
+SET NOCOUNT ON;
+IF OBJECT_ID('tempdb..#over') IS NOT NULL DROP TABLE #over;
+SELECT id, full_url INTO #over FROM dbo.urls WHERE LEN(full_url) > 850;
+
+IF OBJECT_ID('tempdb..#fix') IS NOT NULL DROP TABLE #fix;
+SELECT id, full_url,
+       sep = CASE WHEN CHARINDEX(N'?xsdata=', full_url) > 0 THEN CHARINDEX(N'?xsdata=', full_url)
+                  ELSE CHARINDEX(N'&xsdata=', full_url) END,
+       cleaned_url = CAST(NULL AS nvarchar(max))
+INTO #fix
+FROM #over
+WHERE full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%';
+
+UPDATE f
+SET cleaned_url = CASE
+        WHEN term = 0 THEN LEFT(full_url, sep - 1)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'&'
+             THEN LEFT(full_url, sep) + SUBSTRING(full_url, term + 1, 4000)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'#'
+             THEN LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+        ELSE LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+    END
+FROM #fix f
+CROSS APPLY (SELECT sepChar = SUBSTRING(full_url, sep, 1),
+                    endAmp  = CHARINDEX(N'&', full_url, sep + 8),
+                    endHash = CHARINDEX(N'#', full_url, sep + 8)) a
+CROSS APPLY (SELECT term = CASE WHEN a.endAmp = 0 AND a.endHash = 0 THEN 0
+                               WHEN a.endAmp = 0 THEN a.endHash
+                               WHEN a.endHash = 0 THEN a.endAmp
+                               WHEN a.endAmp < a.endHash THEN a.endAmp
+                               ELSE a.endHash END) b;
+
+SELECT
+    o.id,
+    original_length = LEN(o.full_url),
+    length_after_removing_xsdata = LEN(f.cleaned_url),
+    reason = CASE
+        WHEN f.id IS NULL THEN N'No xsdata parameter - long for other reasons'
+        WHEN LEN(f.cleaned_url) > 850 THEN N'Still > 850 after removing xsdata (other bloat)'
+        WHEN EXISTS (SELECT 1 FROM dbo.urls e WHERE e.full_url = f.cleaned_url AND e.id <> o.id)
+             THEN N'Cleaned value already exists on another row'
+        ELSE N'Would clean to <= 850 - re-run the clean-up script (with COMMIT)'
+    END,
+    o.full_url
+FROM #over o
+LEFT JOIN #fix f ON f.id = o.id
+ORDER BY original_length DESC;
+DROP TABLE #over; DROP TABLE #fix;
+```
+
+> If any row shows **"Would clean to <= 850 - re-run the clean-up script (with COMMIT)"**, you have
+> only run the section‑2 preview — the `xsdata` strip will fix it once you flip `ROLLBACK` → `COMMIT`.
+> Only rows in the other three buckets are genuinely stuck.
+
+### 4. Reduce the genuinely‑stuck rows to their path (dedup merge)
+
+For the stuck rows, the only meaningful part is the **page path** — everything after `?` is volatile
+Teams junk (`xsdata`, `sdata`, `ovuser`, `clickparams`, `SafelinksUrl`, filters, `viewid`). The
+script below reduces each genuinely‑stuck row (still > 850 after the `xsdata` strip, *or* with no
+`xsdata` at all) to its path. Because several stuck rows can share the same page — and a clean copy
+of that page may already exist — it does a proper **de‑duplicating merge**: it picks one canonical
+`urls` row per path, **repoints every foreign key that references `urls`** (discovered from the
+catalog, so no referencing table — `hits`, `event_meta_sharepoint`, comments, likes, Copilot files,
+file metadata, … — is missed) onto the canonical row, then deletes the duplicates. It therefore
+never creates a duplicate `full_url` and never loses the referenced facts.
+
+It leaves every row that the section‑2 `xsdata` strip can already fix **untouched** (it only acts on
+rows whose `xsdata`‑stripped length is still > 850), so run it **after** section 2 has been
+committed. Like the others it **defaults to `ROLLBACK`** — verify `remaining_oversize = 0` and
+`duplicate_full_urls = 0`, then flip to `COMMIT`. Back up / snapshot first.
+
+```sql
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+BEGIN TRANSACTION;
+
+-- 1. Oversize rows.
+IF OBJECT_ID('tempdb..#over') IS NOT NULL DROP TABLE #over;
+SELECT id, full_url INTO #over FROM dbo.urls WHERE LEN(full_url) > 850;
+
+-- 2. Of those, the ones carrying xsdata, with the length they'd have AFTER removing it.
+IF OBJECT_ID('tempdb..#fix') IS NOT NULL DROP TABLE #fix;
+SELECT id, full_url,
+       sep = CASE WHEN CHARINDEX(N'?xsdata=', full_url) > 0 THEN CHARINDEX(N'?xsdata=', full_url)
+                  ELSE CHARINDEX(N'&xsdata=', full_url) END,
+       cleaned_len = CAST(NULL AS int)
+INTO #fix
+FROM #over
+WHERE full_url LIKE N'%?xsdata=%' OR full_url LIKE N'%&xsdata=%';
+
+UPDATE f
+SET cleaned_len = LEN(CASE
+        WHEN term = 0 THEN LEFT(full_url, sep - 1)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'&' THEN LEFT(full_url, sep) + SUBSTRING(full_url, term + 1, 4000)
+        WHEN sepChar = N'?' AND SUBSTRING(full_url, term, 1) = N'#' THEN LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000)
+        ELSE LEFT(full_url, sep - 1) + SUBSTRING(full_url, term, 4000) END)
+FROM #fix f
+CROSS APPLY (SELECT sepChar = SUBSTRING(full_url, sep, 1),
+                    endAmp  = CHARINDEX(N'&', full_url, sep + 8),
+                    endHash = CHARINDEX(N'#', full_url, sep + 8)) a
+CROSS APPLY (SELECT term = CASE WHEN a.endAmp = 0 AND a.endHash = 0 THEN 0
+                               WHEN a.endAmp = 0 THEN a.endHash
+                               WHEN a.endHash = 0 THEN a.endAmp
+                               WHEN a.endAmp < a.endHash THEN a.endAmp
+                               ELSE a.endHash END) b;
+
+-- 3. Stuck rows = oversize rows STILL > 850 after removing xsdata (or with no xsdata at all).
+--    Reduce them to their path (everything before the first '?' or '#'); paths are short, so they fit.
+IF OBJECT_ID('tempdb..#stuck') IS NOT NULL DROP TABLE #stuck;
+SELECT o.id, o.full_url,
+       pathkey = CAST(CASE WHEN cut = 0 THEN o.full_url ELSE LEFT(o.full_url, cut - 1) END AS nvarchar(850))
+INTO #stuck
+FROM #over o
+LEFT JOIN #fix f ON f.id = o.id
+CROSS APPLY (SELECT qpos = CHARINDEX(N'?', o.full_url), hpos = CHARINDEX(N'#', o.full_url)) q
+CROSS APPLY (SELECT cut = CASE WHEN qpos = 0 AND hpos = 0 THEN 0
+                               WHEN qpos = 0 THEN hpos
+                               WHEN hpos = 0 THEN qpos
+                               WHEN qpos < hpos THEN qpos ELSE hpos END) c
+WHERE f.id IS NULL OR f.cleaned_len > 850;
+
+-- 4. Pick a canonical url row per path: an existing clean row that already holds that exact path,
+--    otherwise the lowest-id stuck row.
+IF OBJECT_ID('tempdb..#path') IS NOT NULL DROP TABLE #path;
+SELECT DISTINCT pathkey INTO #path FROM #stuck;
+ALTER TABLE #path ADD existing_id int NULL, canonical_id int NULL;
+UPDATE p SET existing_id = (SELECT MIN(u.id) FROM dbo.urls u WHERE u.full_url = p.pathkey) FROM #path p;
+UPDATE p SET canonical_id = COALESCE(existing_id, (SELECT MIN(s.id) FROM #stuck s WHERE s.pathkey = p.pathkey)) FROM #path p;
+
+-- 5. Map every non-canonical stuck row -> its canonical row.
+IF OBJECT_ID('tempdb..#map') IS NOT NULL DROP TABLE #map;
+SELECT s.id AS dup_id, p.canonical_id
+INTO #map
+FROM #stuck s JOIN #path p ON p.pathkey = s.pathkey
+WHERE s.id <> p.canonical_id;
+
+-- 6. Repoint EVERY foreign key that references dbo.urls(id) from the duplicate rows to the canonical
+--    row (schema-driven, so no referencing table is missed). Temp tables are visible to the batch.
+DECLARE @sql nvarchar(max) = N'';
+SELECT @sql = @sql + N'UPDATE p SET p.' + QUOTENAME(pc.name) + N' = m.canonical_id FROM '
+    + QUOTENAME(SCHEMA_NAME(t.schema_id)) + N'.' + QUOTENAME(t.name) + N' p '
+    + N'JOIN #map m ON p.' + QUOTENAME(pc.name) + N' = m.dup_id;' + CHAR(13)
+FROM sys.foreign_keys fk
+JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id
+JOIN sys.tables t ON t.object_id = fk.parent_object_id
+JOIN sys.columns pc ON pc.object_id = fk.parent_object_id AND pc.column_id = fkc.parent_column_id
+WHERE fk.referenced_object_id = OBJECT_ID(N'dbo.urls');
+IF @sql <> N'' EXEC sys.sp_executesql @sql;
+
+-- 7. Delete the now-unreferenced duplicate rows.
+DELETE u FROM dbo.urls u JOIN #map m ON m.dup_id = u.id;
+DECLARE @deleted int = @@ROWCOUNT;
+
+-- 8. Set the canonical rows that are themselves stuck rows (no pre-existing clean row) to the path.
+UPDATE u SET u.full_url = p.pathkey
+FROM dbo.urls u JOIN #path p ON p.canonical_id = u.id
+WHERE p.existing_id IS NULL;
+DECLARE @reduced int = @@ROWCOUNT;
+
+RAISERROR('Stuck rows reduced to path: %d ; duplicate rows merged away: %d', 0, 1, @reduced, @deleted) WITH NOWAIT;
+SELECT remaining_oversize = COUNT(*) FROM dbo.urls WHERE LEN(full_url) > 850;
+SELECT duplicate_full_urls = ISNULL((SELECT COUNT(*) FROM (SELECT full_url FROM dbo.urls GROUP BY full_url HAVING COUNT(*) > 1) d), 0);
+
+DROP TABLE #over; DROP TABLE #fix; DROP TABLE #stuck; DROP TABLE #path; DROP TABLE #map;
+
+-- VERIFY remaining_oversize = 0 and duplicate_full_urls = 0, then change ROLLBACK to COMMIT and re-run.
+ROLLBACK TRANSACTION;
+-- COMMIT TRANSACTION;
+```
+
+> **Edge case:** if a child table has a `UNIQUE (url_id, …)` constraint and both a duplicate and the
+> canonical row already hold a matching child row, repointing would violate that unique key. Because
+> the script runs under `SET XACT_ABORT ON` inside the transaction, such a clash rolls the whole
+> thing back cleanly (nothing is lost) and reports the error — resolve those few child rows by hand
+> (delete the redundant duplicate child rows) and re‑run. This is rare for SharePoint page URLs.
 
 Re‑run the count query from step 1 to confirm `oversize_urls` is `0`, then re‑run the upgrade. The
 migration is idempotent, so it simply continues once the data fits.

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -149,30 +149,44 @@ namespace Tests.UnitTests
             Assert.IsTrue(shortWithXsData.Length <= max);
             Assert.AreEqual(shortWithXsData, StringUtils.EnsureUrlWithinLength(shortWithXsData, max));
 
-            // Over the limit and has xsdata -> stripped (and now fits).
+            // Over the limit and has xsdata -> stripping xsdata alone is enough; the rest is preserved.
             var longWithXsData = "https://x/a.aspx?xsdata=" + new string('Q', 100) + "&b=2";
             Assert.IsTrue(longWithXsData.Length > max);
             Assert.AreEqual("https://x/a.aspx?b=2", StringUtils.EnsureUrlWithinLength(longWithXsData, max));
 
-            // Over the limit, no xsdata -> nothing to strip, so hard-truncated to max as a last resort.
+            // Over the limit, no xsdata -> nothing to strip, so reduced to the page path (not truncated).
             var longNoXsData = "https://x/a.aspx?b=" + new string('Q', 100);
-            var truncated = StringUtils.EnsureUrlWithinLength(longNoXsData, max);
-            Assert.AreEqual(max, truncated.Length);
-            Assert.AreEqual(longNoXsData.Substring(0, max), truncated);
+            Assert.AreEqual("https://x/a.aspx", StringUtils.EnsureUrlWithinLength(longNoXsData, max));
 
-            // Over the limit AND still over after stripping xsdata -> truncated to exactly max.
+            // Over the limit AND still over after stripping xsdata -> reduced to the page path.
             var stillLong = "https://x/a.aspx?xsdata=" + new string('Q', 100) + "&" + new string('Z', 100);
-            var result2 = StringUtils.EnsureUrlWithinLength(stillLong, max);
-            Assert.AreEqual(max, result2.Length);
-            Assert.AreEqual(("https://x/a.aspx?" + new string('Z', 100)).Substring(0, max), result2);
+            Assert.AreEqual("https://x/a.aspx", StringUtils.EnsureUrlWithinLength(stillLong, max));
 
-            // Wired to the real column width: a 900-char token pushes a SharePoint URL over 850, but
-            // once removed the URL comfortably fits, so it is returned in full (not truncated).
+            // Reducing to path drops the query string AND any #fragment.
+            var withFragment = "https://x/a.aspx?notxs=" + new string('P', 100) + "#section";
+            Assert.AreEqual("https://x/a.aspx", StringUtils.EnsureUrlWithinLength(withFragment, max));
+
+            // Pathological: even the bare path exceeds the limit -> hard-truncated as an absolute last resort.
+            var longPath = "https://x/" + new string('a', 100); // no '?' or '#'
+            var truncated = StringUtils.EnsureUrlWithinLength(longPath, max);
+            Assert.AreEqual(max, truncated.Length);
+            Assert.AreEqual(longPath.Substring(0, max), truncated);
+
+            // Real column width: a 900-char xsdata token pushes a SharePoint URL over 850, but once
+            // removed it comfortably fits, so the rest (filters etc.) is kept in full - NOT reduced to path.
             var oversized = "https://contoso.sharepoint.com/sites/Marketing/a.aspx?xsdata=" + new string('Q', 900) + "&v=1";
             Assert.IsTrue(oversized.Length > Url.FullUrlMaxLength);
             var result = StringUtils.EnsureUrlWithinLength(oversized, Url.FullUrlMaxLength);
             Assert.AreEqual("https://contoso.sharepoint.com/sites/Marketing/a.aspx?v=1", result);
             Assert.IsTrue(result.Length <= Url.FullUrlMaxLength);
+
+            // Real column width: still over 850 even after xsdata (a huge SafelinksUrl) -> reduced to path.
+            var basePath = "https://contoso.sharepoint.com/sites/Marketing/Lists/Announcements/AllItems.aspx";
+            var stuck = basePath + "?xsdata=" + new string('Q', 900) + "&SafelinksUrl=" + new string('Z', 900);
+            Assert.IsTrue(stuck.Length > Url.FullUrlMaxLength);
+            var stuckResult = StringUtils.EnsureUrlWithinLength(stuck, Url.FullUrlMaxLength);
+            Assert.AreEqual(basePath, stuckResult);
+            Assert.IsTrue(stuckResult.Length <= Url.FullUrlMaxLength);
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -189,6 +189,57 @@ namespace Tests.UnitTests
             Assert.IsTrue(stuckResult.Length <= Url.FullUrlMaxLength);
         }
 
+        /// <summary>
+        /// Locks in the behaviour against the shape of the real customer URLs that aborted the
+        /// ShrinkUrlsFullUrlColumn migration: SharePoint list/page URLs opened from Microsoft Teams,
+        /// carrying a large transient xsdata token plus the usual sdata/ovuser/OR/CT/clickparams/
+        /// SafelinksUrl/Filter*/viewid tail (sometimes comma-merged). All values here are anonymised
+        /// (contoso tenant, fictional site/list, zeroed GUIDs, filler tokens) - no real tenant data.
+        /// </summary>
+        [TestMethod]
+        public void EnsureUrlWithinLength_RealWorldTeamsDeepLinkExamples()
+        {
+            const int max = 850; // Url.FullUrlMaxLength
+
+            var path = "https://contoso.sharepoint.com/sites/Marketing/Lists/Announcements/AllItems.aspx";
+            var xsdata = "xsdata=" + new string('A', 700);   // ~700-char opaque base64 deep-link token
+            var trailing =
+                "&sdata=" + new string('B', 40) +
+                "&ovuser=00000000%2D0000%2D0000%2D0000%2D000000000000%2Cuser%40contoso.com" +
+                "&OR=Teams%2DHL&CT=1677594627797" +
+                "&clickparams=" + new string('C', 80) +
+                "&FilterField1=field%5F1&FilterValue1=Manager%20Transport&FilterType1=Text" +
+                "&viewid=00000000%2D0000%2D0000%2D0000%2D000000000000";
+
+            // Case 1 (mirrors the ~99% auto-fixable rows): xsdata is the bulk of the bloat. Removing it
+            // alone brings the URL back under 850 and keeps the distinguishing params (filters, viewid).
+            var teamsUrl = path + "?" + xsdata + trailing;
+            Assert.IsTrue(teamsUrl.Length > max, "sample should exceed the column width");
+            var fixedUrl = StringUtils.EnsureUrlWithinLength(teamsUrl, max);
+            Assert.AreEqual(path + "?" + trailing.Substring(1), fixedUrl); // '?' kept, 'xsdata=...&' removed
+            Assert.IsTrue(fixedUrl.Length <= max);
+            Assert.IsFalse(fixedUrl.ToLowerInvariant().Contains("xsdata="));
+            StringAssert.Contains(fixedUrl, "viewid=");                    // distinguishing params preserved
+
+            // Case 2 (mirrors the handful of genuinely-stuck rows): still over 850 even after removing
+            // xsdata, because of a huge SafelinksUrl copy + duplicated comma-merged params. Reduced to path.
+            var safelinks = "&SafelinksUrl=" + new string('D', 700);
+            var doubled = "&OR=Teams%2DHL%2CTeams%2DHL&CT=1698908960461%2C1698908960461";
+            var stuckUrl = path + "?" + xsdata + trailing + safelinks + doubled;
+            Assert.IsTrue(StringUtils.RemoveXsDataParam(stuckUrl).Length > max, "should still exceed 850 after xsdata strip");
+            var reduced = StringUtils.EnsureUrlWithinLength(stuckUrl, max);
+            Assert.AreEqual(path, reduced);                                // whole query string dropped
+            Assert.IsTrue(reduced.Length <= max);
+
+            // Case 3: a URL ending with a bare '#' fragment marker (seen in the real data).
+            var withTrailingHash = path + "?xsdata=" + new string('A', 800) + "&viewid=00000000#";
+            Assert.IsTrue(withTrailingHash.Length > max);
+            var fixedHash = StringUtils.EnsureUrlWithinLength(withTrailingHash, max);
+            Assert.IsTrue(fixedHash.Length <= max);
+            Assert.IsFalse(fixedHash.ToLowerInvariant().Contains("xsdata="));
+            StringAssert.StartsWith(fixedHash, path);
+        }
+
         [TestMethod]
         public void ConvertSharePointUrl()
         {

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -95,6 +95,87 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public void RemoveXsDataParamTests()
+        {
+            // Null / empty / no xsdata parameter -> returned unchanged.
+            Assert.IsNull(StringUtils.RemoveXsDataParam(null));
+            Assert.AreEqual(string.Empty, StringUtils.RemoveXsDataParam(string.Empty));
+            Assert.AreEqual("https://x/a?foo=1&bar=2", StringUtils.RemoveXsDataParam("https://x/a?foo=1&bar=2"));
+
+            // xsdata as the first / middle / last / only parameter (everything else preserved).
+            Assert.AreEqual("https://x/a.aspx?sdata=z&v=1",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?xsdata=ABC&sdata=z&v=1"));
+            Assert.AreEqual("https://x/a.aspx?foo=1&bar=2",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?foo=1&xsdata=ABC&bar=2"));
+            Assert.AreEqual("https://x/a.aspx?foo=1",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?foo=1&xsdata=ABC"));
+            Assert.AreEqual("https://x/a.aspx",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?xsdata=ABC"));
+
+            // Any #fragment is preserved.
+            Assert.AreEqual("https://x/a.aspx#sec",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?xsdata=ABC#sec"));
+            Assert.AreEqual("https://x/a.aspx?b=2#sec",
+                StringUtils.RemoveXsDataParam("https://x/a.aspx?xsdata=ABC&b=2#sec"));
+            Assert.AreEqual("https://x/a?foo=1#sec",
+                StringUtils.RemoveXsDataParam("https://x/a?foo=1&xsdata=ABC#sec"));
+
+            // Case-insensitive on the parameter name.
+            Assert.AreEqual("https://x/a?b=2", StringUtils.RemoveXsDataParam("https://x/a?XSDATA=ABC&b=2"));
+
+            // Boundary-aware: 'xsdata' as a substring of another parameter name is NOT removed.
+            Assert.AreEqual("https://x/a?notxsdata=1&b=2", StringUtils.RemoveXsDataParam("https://x/a?notxsdata=1&b=2"));
+            Assert.AreEqual("https://x/a?b=1&myxsdata=2", StringUtils.RemoveXsDataParam("https://x/a?b=1&myxsdata=2"));
+
+            // Real-world shape: a long Teams deep-link token as the first parameter, followed by the
+            // usual trailing parameters. The cleaned URL keeps the rest and no longer contains xsdata.
+            var basePath = "https://contoso.sharepoint.com/sites/Marketing/Lists/Announcements/AllItems.aspx";
+            var rest = "&sdata=AAAA%3D%3D&ovuser=user%40contoso.com&viewid=00000000";
+            var oversized = basePath + "?xsdata=" + new string('Q', 900) + rest;
+            var cleaned = StringUtils.RemoveXsDataParam(oversized);
+            Assert.AreEqual(basePath + "?" + rest.TrimStart('&'), cleaned);
+            Assert.IsFalse(cleaned.ToLowerInvariant().Contains("xsdata="));
+            Assert.IsTrue(cleaned.Length < oversized.Length);
+        }
+
+        [TestMethod]
+        public void EnsureUrlWithinLengthTests()
+        {
+            const int max = 50;
+            Assert.IsNull(StringUtils.EnsureUrlWithinLength(null, max));
+
+            // Has xsdata but is within the limit -> left unchanged (no needless churn).
+            var shortWithXsData = "https://x/a?xsdata=AB&b=2"; // <= 50 chars
+            Assert.IsTrue(shortWithXsData.Length <= max);
+            Assert.AreEqual(shortWithXsData, StringUtils.EnsureUrlWithinLength(shortWithXsData, max));
+
+            // Over the limit and has xsdata -> stripped (and now fits).
+            var longWithXsData = "https://x/a.aspx?xsdata=" + new string('Q', 100) + "&b=2";
+            Assert.IsTrue(longWithXsData.Length > max);
+            Assert.AreEqual("https://x/a.aspx?b=2", StringUtils.EnsureUrlWithinLength(longWithXsData, max));
+
+            // Over the limit, no xsdata -> nothing to strip, so hard-truncated to max as a last resort.
+            var longNoXsData = "https://x/a.aspx?b=" + new string('Q', 100);
+            var truncated = StringUtils.EnsureUrlWithinLength(longNoXsData, max);
+            Assert.AreEqual(max, truncated.Length);
+            Assert.AreEqual(longNoXsData.Substring(0, max), truncated);
+
+            // Over the limit AND still over after stripping xsdata -> truncated to exactly max.
+            var stillLong = "https://x/a.aspx?xsdata=" + new string('Q', 100) + "&" + new string('Z', 100);
+            var result2 = StringUtils.EnsureUrlWithinLength(stillLong, max);
+            Assert.AreEqual(max, result2.Length);
+            Assert.AreEqual(("https://x/a.aspx?" + new string('Z', 100)).Substring(0, max), result2);
+
+            // Wired to the real column width: a 900-char token pushes a SharePoint URL over 850, but
+            // once removed the URL comfortably fits, so it is returned in full (not truncated).
+            var oversized = "https://contoso.sharepoint.com/sites/Marketing/a.aspx?xsdata=" + new string('Q', 900) + "&v=1";
+            Assert.IsTrue(oversized.Length > Url.FullUrlMaxLength);
+            var result = StringUtils.EnsureUrlWithinLength(oversized, Url.FullUrlMaxLength);
+            Assert.AreEqual("https://contoso.sharepoint.com/sites/Marketing/a.aspx?v=1", result);
+            Assert.IsTrue(result.Length <= Url.FullUrlMaxLength);
+        }
+
+        [TestMethod]
         public void ConvertSharePointUrl()
         {
             const string expectedResult = "https://contoso.sharepoint.com/sites/site/Shared%20Documents/";

--- a/src/AnalyticsEngine/Tests.UnitTests/InsertBatchOverWidthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InsertBatchOverWidthTests.cs
@@ -1,0 +1,120 @@
+using Common.Entities;
+using DataUtils.Sql;
+using DataUtils.Sql.Inserts;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Verifies that <see cref="InsertBatch{T}"/> skips an individual row whose value is wider than
+    /// its staging column (SQL Server error 8152/2628) and still saves the rest of the batch, rather
+    /// than throwing and discarding the whole batch (the pre-#127 "poison batch" behaviour). This is
+    /// the resilience behind issue #122 / #127, where over-width SharePoint URLs broke imports into
+    /// the nvarchar(850) urls.full_url-sized staging columns.
+    /// </summary>
+    [TestClass]
+    public class InsertBatchOverWidthTests
+    {
+        [TempTableName("##overwidth_test_staging")]
+        private class OverWidthTestEntity
+        {
+            [Column("row_id")]
+            public Guid RowId { get; set; }
+
+            // nvarchar(10): anything longer than 10 chars must be skipped, not inserted.
+            [Column("v", SqlTypeOverride = "nvarchar(10)")]
+            public string Value { get; set; }
+        }
+
+        [TestMethod]
+        public async Task OverWidthRowIsSkippedAndRestOfBatchIsSaved()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var connectionString = db.Database.Connection.ConnectionString;
+                var logger = new CapturingLogger();
+
+                using (var keepAlive = new SqlConnection(connectionString))
+                {
+                    await keepAlive.OpenAsync();
+
+                    // A global (##) temp results table is visible to InsertBatch's own connections,
+                    // and is kept alive by this connection so we can assert on it after
+                    // SaveToStagingTable returns (which disposes its own connections + staging table).
+                    using (var create = keepAlive.CreateCommand())
+                    {
+                        create.CommandText =
+                            "IF OBJECT_ID('tempdb..##overwidth_test_results') IS NOT NULL DROP TABLE ##overwidth_test_results; " +
+                            "CREATE TABLE ##overwidth_test_results (row_id uniqueidentifier, v nvarchar(850));";
+                        await create.ExecuteNonQueryAsync();
+                    }
+
+                    var okId1 = Guid.NewGuid();
+                    var okId2 = Guid.NewGuid();
+                    var tooWideId = Guid.NewGuid();
+
+                    var batch = new InsertBatch<OverWidthTestEntity>(connectionString, logger);
+                    batch.Rows.Add(new OverWidthTestEntity { RowId = okId1, Value = "short" });
+                    batch.Rows.Add(new OverWidthTestEntity { RowId = tooWideId, Value = new string('x', 50) });
+                    batch.Rows.Add(new OverWidthTestEntity { RowId = okId2, Value = "alsoshort" });
+
+                    const string mergeSql =
+                        "INSERT INTO ##overwidth_test_results (row_id, v) SELECT row_id, v FROM ##overwidth_test_staging;";
+
+                    // Must NOT throw, even though one row is over-width.
+                    var survivors = await batch.SaveToStagingTable(mergeSql);
+
+                    Assert.AreEqual(2, survivors, "Merge should have copied exactly the 2 in-width rows.");
+
+                    var savedIds = new List<Guid>();
+                    using (var read = keepAlive.CreateCommand())
+                    {
+                        read.CommandText = "SELECT row_id FROM ##overwidth_test_results;";
+                        using (var reader = await read.ExecuteReaderAsync())
+                        {
+                            while (await reader.ReadAsync()) savedIds.Add(reader.GetGuid(0));
+                        }
+                    }
+
+                    CollectionAssert.Contains(savedIds, okId1, "First in-width row should be saved.");
+                    CollectionAssert.Contains(savedIds, okId2, "Second in-width row should be saved.");
+                    CollectionAssert.DoesNotContain(savedIds, tooWideId, "Over-width row must be skipped, not saved.");
+
+                    Assert.IsTrue(
+                        logger.Messages.Any(m => m.Contains("Skipping over-width record") && m.Contains("'v'")),
+                        "The skip should be logged identifying the offending column. Captured: " + string.Join(" | ", logger.Messages));
+
+                    using (var drop = keepAlive.CreateCommand())
+                    {
+                        drop.CommandText = "IF OBJECT_ID('tempdb..##overwidth_test_results') IS NOT NULL DROP TABLE ##overwidth_test_results;";
+                        await drop.ExecuteNonQueryAsync();
+                    }
+                }
+            }
+        }
+
+        /// <summary>Minimal <see cref="ILogger"/> that records formatted messages for assertions.</summary>
+        private class CapturingLogger : ILogger
+        {
+            public readonly List<string> Messages = new List<string>();
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+
+            private class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
@@ -113,4 +113,44 @@ namespace Tests.UnitTests.InstallTests
         // Read a prop to check we have a not-null container in tasks
         public Guid RandomId { get; set; }
     }
+
+    /// <summary>Concrete <see cref="SequentialTaskListInstallJob"/> so the task-loop can be unit-tested directly.</summary>
+    public class FakeSequentialJob : SequentialTaskListInstallJob
+    {
+        public FakeSequentialJob(ILogger logger) : base(logger) { }
+    }
+
+    /// <summary>Task that always throws. <see cref="IsCritical"/> is configurable to test abort-vs-continue behaviour.</summary>
+    public class FakeThrowingTask : BaseInstallTask
+    {
+        private readonly bool _isCritical;
+        public bool WasRun { get; private set; }
+
+        public FakeThrowingTask(TaskConfig config, ILogger logger, bool isCritical) : base(config, logger)
+        {
+            _isCritical = isCritical;
+        }
+
+        public override bool IsCritical => _isCritical;
+
+        public override Task<object> ExecuteTask(object contextArg)
+        {
+            WasRun = true;
+            throw new InvalidOperationException("Simulated task failure for testing");
+        }
+    }
+
+    /// <summary>Task that records whether it ran, used to assert downstream tasks still execute (or not).</summary>
+    public class FakeMarkerTask : BaseInstallTask
+    {
+        public bool WasRun { get; private set; }
+
+        public FakeMarkerTask(TaskConfig config, ILogger logger) : base(config, logger) { }
+
+        public override Task<object> ExecuteTask(object contextArg)
+        {
+            WasRun = true;
+            return Task.FromResult<object>(new object());
+        }
+    }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
@@ -153,4 +153,36 @@ namespace Tests.UnitTests.InstallTests
             return Task.FromResult<object>(new object());
         }
     }
+
+    /// <summary>Task that returns a caller-supplied result object, used to test result carry-forward.</summary>
+    public class FakeResultTask : BaseInstallTask
+    {
+        private readonly object _result;
+
+        public FakeResultTask(TaskConfig config, ILogger logger, object result) : base(config, logger)
+        {
+            _result = result;
+        }
+
+        public override Task<object> ExecuteTask(object contextArg)
+        {
+            return Task.FromResult(_result);
+        }
+    }
+
+    /// <summary>Task that records the context argument it received, used to assert what was carried forward.</summary>
+    public class FakeContextCapturingTask : BaseInstallTask
+    {
+        public bool WasRun { get; private set; }
+        public object ReceivedContext { get; private set; }
+
+        public FakeContextCapturingTask(TaskConfig config, ILogger logger) : base(config, logger) { }
+
+        public override Task<object> ExecuteTask(object contextArg)
+        {
+            WasRun = true;
+            ReceivedContext = contextArg;
+            return Task.FromResult<object>(new object());
+        }
+    }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -7,6 +7,7 @@ using App.ControlPanel.Engine.InstallerTasks.Tasks;
 using App.ControlPanel.Engine.Models;
 using App.ControlPanel.Engine.SharePointModelBuilder;
 using App.ControlPanel.Engine.SharePointModelBuilder.ValueLookups;
+using Azure;
 using Azure.Core;
 using Azure.Identity;
 using CloudInstallEngine;
@@ -253,6 +254,147 @@ namespace Tests.UnitTests
             CollectionAssert.DoesNotContain(labels, "SQL Server");
             CollectionAssert.DoesNotContain(labels, "Service Bus");
             CollectionAssert.DoesNotContain(labels, "Cognitive Services");
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsNullConfigReturnsEmpty()
+        {
+            Assert.AreEqual(0, SolutionInstallVerifier.BuildResourceDnsTargets(null).Count);
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsDefaultConfigReturnsEmpty()
+        {
+            // A brand-new config has no resource names set yet.
+            Assert.AreEqual(0, SolutionInstallVerifier.BuildResourceDnsTargets(new SolutionInstallConfig()).Count);
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsTrimsAndIgnoresWhitespaceNames()
+        {
+            var config = new SolutionInstallConfig
+            {
+                KeyVaultName = "  myvault  ",   // padded -> trimmed
+                SQLServerName = "   ",           // whitespace only -> excluded
+            };
+
+            var targets = SolutionInstallVerifier.BuildResourceDnsTargets(config);
+
+            Assert.AreEqual(1, targets.Count);
+            Assert.AreEqual("myvault.vault.azure.net", targets.Single().Fqdn);
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsServiceBusEnabledButEmptyIsExcluded()
+        {
+            var config = new SolutionInstallConfig
+            {
+                ServiceBusEnabled = true,
+                ServiceBusName = "",   // enabled but no name -> nothing to resolve
+            };
+
+            CollectionAssert.DoesNotContain(
+                SolutionInstallVerifier.BuildResourceDnsTargets(config).Select(t => t.Label).ToList(),
+                "Service Bus");
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsSingleResourceHasCorrectLabelAndFqdn()
+        {
+            var config = new SolutionInstallConfig { RedisName = "mycache" };
+
+            var targets = SolutionInstallVerifier.BuildResourceDnsTargets(config);
+
+            Assert.AreEqual(1, targets.Count);
+            Assert.AreEqual("Redis cache", targets.Single().Label);
+            Assert.AreEqual("mycache.redis.cache.windows.net", targets.Single().Fqdn);
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorDetectsDnsAggregateException()
+        {
+            // Mirrors the field failure: AggregateException -> RequestFailedException(Status 0) -> WebException.
+            var dns = new System.Net.WebException("The remote name could not be resolved: 'x.vault.azure.net'");
+            var ex = new AggregateException(new RequestFailedException(0, "Retry failed after 4 tries", dns));
+
+            Assert.IsTrue(TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leaf));
+            StringAssert.Contains(leaf, "could not be resolved");
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorIgnoresHttpErrorResponses()
+        {
+            Assert.IsFalse(TransportFailureDetector.IsTransportOrDnsFailure(new RequestFailedException(403, "Forbidden"), out _));
+            Assert.IsFalse(TransportFailureDetector.IsTransportOrDnsFailure(new RequestFailedException(404, "Not Found"), out _));
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorDetectsSocketAndHttpExceptions()
+        {
+            Assert.IsTrue(TransportFailureDetector.IsTransportOrDnsFailure(new System.Net.Sockets.SocketException(11001), out _));
+            Assert.IsTrue(TransportFailureDetector.IsTransportOrDnsFailure(
+                new InvalidOperationException("wrap", new System.Net.Http.HttpRequestException("transport down")), out _));
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorNullAndGenericAreNotTransport()
+        {
+            Assert.IsFalse(TransportFailureDetector.IsTransportOrDnsFailure(null, out _));
+            Assert.IsFalse(TransportFailureDetector.IsTransportOrDnsFailure(new InvalidOperationException("boom"), out _));
+        }
+
+        [TestMethod]
+        public void TransportFailureDetectorInnermostMessageWins()
+        {
+            var sock = new System.Net.Sockets.SocketException(11001);
+            var ex = new AggregateException(new RequestFailedException(0, "outer status-0 wrapper", sock));
+
+            Assert.IsTrue(TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leaf));
+            Assert.AreEqual(sock.Message, leaf, "The innermost (most specific) transport message should win.");
+        }
+
+        [TestMethod]
+        public async Task NonCriticalTaskFailureCarriesPreviousResultForward()
+        {
+            var job = new FakeSequentialJob(_logger);
+            var sentinel = new object();
+            var produce = new FakeResultTask(TaskConfig.NoConfig, _logger, sentinel);
+            var failing = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: false);
+            var capture = new FakeContextCapturingTask(TaskConfig.NoConfig, _logger);
+            job.AddTask(produce);
+            job.AddTask(failing);
+            job.AddTask(capture);
+
+            await job.Install();
+
+            Assert.IsTrue(capture.WasRun, "Task after a non-critical failure should still run.");
+            Assert.AreSame(sentinel, capture.ReceivedContext,
+                "After a non-critical failure, the previous task's result must carry forward to the next task.");
+        }
+
+        [TestMethod]
+        public async Task NonCriticalThenCriticalFailureStillAborts()
+        {
+            var job = new FakeSequentialJob(_logger);
+            var nonCrit = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: false);
+            var crit = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: true);
+            var after = new FakeMarkerTask(TaskConfig.NoConfig, _logger);
+            job.AddTask(nonCrit);
+            job.AddTask(crit);
+            job.AddTask(after);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => job.Install());
+
+            Assert.IsTrue(nonCrit.WasRun);
+            Assert.IsTrue(crit.WasRun);
+            Assert.IsFalse(after.WasRun, "A task after a critical failure must not run.");
+        }
+
+        [TestMethod]
+        public void TaskIsCriticalDefaultsToTrue()
+        {
+            Assert.IsTrue(new FakeMarkerTask(TaskConfig.NoConfig, _logger).IsCritical,
+                "Install tasks should be critical by default.");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Tests.UnitTests.InstallTests;
@@ -168,6 +169,90 @@ namespace Tests.UnitTests
             Assert.IsNotNull(fakeJob.TaskResult.FakeCloudResourceType1);
             Assert.IsNotNull(fakeJob.TaskResult.FakeCloudResourceType2);
             Assert.IsNotNull(fakeJob.ResultingContainer);
+        }
+
+        /// <summary>
+        /// A non-critical task that fails must be logged but NOT abort the install - the next task still runs.
+        /// This is the KeyVaultSecretAddTask DNS-failure scenario from the field.
+        /// </summary>
+        [TestMethod]
+        public async Task NonCriticalTaskFailureDoesNotAbortInstall()
+        {
+            var job = new FakeSequentialJob(_logger);
+            var failing = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: false);
+            var after = new FakeMarkerTask(TaskConfig.NoConfig, _logger);
+            job.AddTask(failing);
+            job.AddTask(after);
+
+            // Should complete without throwing despite the failing task.
+            await job.Install();
+
+            Assert.IsTrue(failing.WasRun, "The non-critical failing task should have run.");
+            Assert.IsTrue(after.WasRun, "A task after a non-critical failure should still run.");
+        }
+
+        /// <summary>A critical task that fails must abort the install - the next task does not run.</summary>
+        [TestMethod]
+        public async Task CriticalTaskFailureAbortsInstall()
+        {
+            var job = new FakeSequentialJob(_logger);
+            var failing = new FakeThrowingTask(TaskConfig.NoConfig, _logger, isCritical: true);
+            var after = new FakeMarkerTask(TaskConfig.NoConfig, _logger);
+            job.AddTask(failing);
+            job.AddTask(after);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => job.Install());
+
+            Assert.IsTrue(failing.WasRun, "The critical failing task should have run.");
+            Assert.IsFalse(after.WasRun, "A task after a critical failure should NOT run.");
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsIncludesEnabledResources()
+        {
+            var config = new SolutionInstallConfig
+            {
+                KeyVaultName = "myvault",
+                SQLServerName = "mysqlsvr",
+                StorageAccountName = "mystorage",
+                AppServiceWebAppName = "myapp",
+                RedisName = "mycache",
+                ServiceBusName = "mysb",
+                ServiceBusEnabled = true,
+                CognitiveServiceName = "mycog",
+                CognitiveServicesEnabled = true,
+            };
+
+            var fqdns = SolutionInstallVerifier.BuildResourceDnsTargets(config).Select(t => t.Fqdn).ToList();
+
+            CollectionAssert.Contains(fqdns, "myvault.vault.azure.net");
+            CollectionAssert.Contains(fqdns, "mysqlsvr.database.windows.net");
+            CollectionAssert.Contains(fqdns, "mystorage.blob.core.windows.net");
+            CollectionAssert.Contains(fqdns, "myapp.azurewebsites.net");
+            CollectionAssert.Contains(fqdns, "mycache.redis.cache.windows.net");
+            CollectionAssert.Contains(fqdns, "mysb.servicebus.windows.net");
+            CollectionAssert.Contains(fqdns, "mycog.cognitiveservices.azure.com");
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsExcludesDisabledAndEmptyResources()
+        {
+            var config = new SolutionInstallConfig
+            {
+                KeyVaultName = "myvault",
+                SQLServerName = "",                 // empty -> excluded
+                ServiceBusName = "mysb",
+                ServiceBusEnabled = false,          // disabled -> excluded even though named
+                CognitiveServiceName = "mycog",
+                CognitiveServicesEnabled = false,   // disabled -> excluded even though named
+            };
+
+            var labels = SolutionInstallVerifier.BuildResourceDnsTargets(config).Select(t => t.Label).ToList();
+
+            CollectionAssert.Contains(labels, "Key Vault");
+            CollectionAssert.DoesNotContain(labels, "SQL Server");
+            CollectionAssert.DoesNotContain(labels, "Service Bus");
+            CollectionAssert.DoesNotContain(labels, "Cognitive Services");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/StagingColumnSqlTypeOverrideTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StagingColumnSqlTypeOverrideTests.cs
@@ -53,6 +53,36 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
+        /// A bounded string override (e.g. <c>nvarchar(850)</c>) must expose its parsed character
+        /// limit on <see cref="ColumnSqlInfo.MaxLength"/>, so the batch insert can skip an over-width
+        /// value in memory (a single integer comparison) instead of catching a per-row SQL truncation
+        /// error. See InsertBatch over-width handling and issue #122 / #127.
+        /// </summary>
+        [TestMethod]
+        public void OverriddenStringColumnExposesParsedMaxLength()
+        {
+            var cache = new InsertBatchTypeFieldCache<OverriddenStringEntity>();
+            var info = cache.PropertyMappingInfo.Single(p => p.SqlInfo.FieldName == "overridden_string");
+
+            Assert.AreEqual(850, info.SqlInfo.MaxLength,
+                "nvarchar(850) override must parse to an 850-character limit for the in-memory width check.");
+        }
+
+        /// <summary>
+        /// An unbounded <c>nvarchar(max)</c> string column must have no parsed limit, so the
+        /// in-memory width check never trips on it (only bounded columns can truncate).
+        /// </summary>
+        [TestMethod]
+        public void DefaultMaxStringColumnHasNoParsedMaxLength()
+        {
+            var cache = new InsertBatchTypeFieldCache<DefaultStringEntity>();
+            var info = cache.PropertyMappingInfo.Single(p => p.SqlInfo.FieldName == "default_string");
+
+            Assert.IsNull(info.SqlInfo.MaxLength,
+                "nvarchar(max) default must have no length limit (no in-memory truncation).");
+        }
+
+        /// <summary>
         /// <see cref="ColumnAttribute.SqlTypeOverride"/> must be ignored for non-string CLR types -
         /// the inferred type (e.g. <c>int</c>) stays authoritative. This stops misuse from silently
         /// breaking schema generation for typed columns.

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="GraphStringUtilsTests.cs" />
     <Compile Include="DataCleanupTests.cs" />
     <Compile Include="DuplicateUrlTests.cs" />
+    <Compile Include="InsertBatchOverWidthTests.cs" />
     <Compile Include="AppInsightsImportTests.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="CopilotTests.cs" />

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/ClickTempEntity.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/ClickTempEntity.cs
@@ -23,7 +23,9 @@ namespace WebJob.AppInsightsImporter.Engine.Sql.Models
             if (p.CustomProperties.PageRequestId.HasValue)
             {
                 this.Timestamp = p.Timestamp;
-                this.Url = p.CustomProperties.HRef;
+                // Strip the volatile xsdata deep-link token when the click href would otherwise
+                // exceed the urls.full_url column width (nvarchar(850)). See issue #122.
+                this.Url = StringUtils.EnsureUrlWithinLength(p.CustomProperties.HRef, Common.Entities.Url.FullUrlMaxLength);
                 this.Username = p.Username;
                 this.ClassNames = StringUtils.EnsureMaxLength(p.CustomProperties.ClassNames, 800);
                 this.PageRequestId = p.CustomProperties.PageRequestId.Value;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/ClickTempEntity.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/ClickTempEntity.cs
@@ -23,8 +23,8 @@ namespace WebJob.AppInsightsImporter.Engine.Sql.Models
             if (p.CustomProperties.PageRequestId.HasValue)
             {
                 this.Timestamp = p.Timestamp;
-                // Strip the volatile xsdata deep-link token when the click href would otherwise
-                // exceed the urls.full_url column width (nvarchar(850)). See issue #122.
+                // Keep the SharePoint URL within the urls.full_url column width (nvarchar(850)): strip
+                // the volatile xsdata token, else reduce to the page path. See issue #122.
                 this.Url = StringUtils.EnsureUrlWithinLength(p.CustomProperties.HRef, Common.Entities.Url.FullUrlMaxLength);
                 this.Username = p.Username;
                 this.ClassNames = StringUtils.EnsureMaxLength(p.CustomProperties.ClassNames, 800);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -208,8 +208,15 @@ namespace WebJob.Office365ActivityImporter.Engine
                         Console.Write($"{Math.Round(percentDone, 0)}%...");
                     }
 #endif
-                    // Add metadata
-                    eventsJustSavedById.TryGetValue(log.Id, out var savedEvent);
+                    // Add metadata. If the event isn't in eventsJustSavedById it wasn't persisted
+                    // (e.g. its staging row was skipped because a column value exceeded the staging
+                    // column width - see InsertBatch over-width handling), so there's no row to
+                    // attach metadata to. Skip it rather than risk a NullReferenceException.
+                    if (!eventsJustSavedById.TryGetValue(log.Id, out var savedEvent))
+                    {
+                        metaSaveIdx++;
+                        continue;
+                    }
                     var changesMade = await log.ProcessExtendedProperties(saveSession, savedEvent, _telemetry);
                     if (changesMade)
                         changesMadeCount++;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -244,8 +244,8 @@ namespace WebJob.Office365ActivityImporter.Engine
             this.OperationName = abtractLog.Operation;
             this.TimeStamp = abtractLog.CreationTime;
             this.TypeName = abtractLog.ItemType;
-            // Strip the volatile xsdata deep-link token when the object id (a SharePoint URL) would
-            // otherwise exceed the urls.full_url column width (nvarchar(850)). See issue #122.
+            // Keep the SharePoint URL within the urls.full_url column width (nvarchar(850)): strip the
+            // volatile xsdata token, else reduce to the page path. See issue #122.
             this.ObjectId = StringUtils.EnsureUrlWithinLength(abtractLog.ObjectId, Common.Entities.Url.FullUrlMaxLength);
             this.Workload = abtractLog.Workload;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Entities;
 using Common.Entities.Config;
+using DataUtils;
 using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
@@ -243,7 +244,9 @@ namespace WebJob.Office365ActivityImporter.Engine
             this.OperationName = abtractLog.Operation;
             this.TimeStamp = abtractLog.CreationTime;
             this.TypeName = abtractLog.ItemType;
-            this.ObjectId = abtractLog.ObjectId;
+            // Strip the volatile xsdata deep-link token when the object id (a SharePoint URL) would
+            // otherwise exceed the urls.full_url column width (nvarchar(850)). See issue #122.
+            this.ObjectId = StringUtils.EnsureUrlWithinLength(abtractLog.ObjectId, Common.Entities.Url.FullUrlMaxLength);
             this.Workload = abtractLog.Workload;
 
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -165,8 +165,8 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     AppHost = auditRecord.CopilotEventData.AppHost,
                     FileExtension = spFileInfo?.Extension,
                     FileName = spFileInfo?.Filename,
-                    // Strip the volatile xsdata deep-link token when the URL would otherwise exceed
-                    // the urls.full_url column width (nvarchar(850)). See issue #122.
+                    // Keep the SharePoint URL within the urls.full_url column width (nvarchar(850)):
+                    // strip the volatile xsdata token, else reduce to the page path. See issue #122.
                     Url = StringUtils.EnsureUrlWithinLength(spFileInfo?.Url, Common.Entities.Url.FullUrlMaxLength),
                     UrlBase = spFileInfo?.SiteUrl,
                     AgentId = auditRecord.AgentId,

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -165,7 +165,9 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     AppHost = auditRecord.CopilotEventData.AppHost,
                     FileExtension = spFileInfo?.Extension,
                     FileName = spFileInfo?.Filename,
-                    Url = spFileInfo?.Url,
+                    // Strip the volatile xsdata deep-link token when the URL would otherwise exceed
+                    // the urls.full_url column width (nvarchar(850)). See issue #122.
+                    Url = StringUtils.EnsureUrlWithinLength(spFileInfo?.Url, Common.Entities.Url.FullUrlMaxLength),
                     UrlBase = spFileInfo?.SiteUrl,
                     AgentId = auditRecord.AgentId,
                     AgentName = auditRecord.AgentName,


### PR DESCRIPTION
## Reliability release — make imports resilient to the `urls.full_url` `nvarchar(850)` limit shipped in stable **1634**

Stable build **1634** shrank `dbo.urls.full_url` to **`nvarchar(850)`** (Greek/Unicode fix + the `IX_urls_full_url` performance index). That tighter column is a **hard limit on every URL the importers stage**: any address longer than 850 characters — overwhelmingly Teams deep-links carrying a large transient `xsdata` token (real samples 1,200–1,500 chars) — would otherwise throw *"String or binary data would be truncated"* (SQL `8152`/`2628`) and **poison the whole staging batch**, so every row in that batch was lost and the next cycle hit the same data and failed identically.

This release makes the importers **clean and bound URLs before they are staged**, and makes a single over-width value **skip-and-continue** instead of failing the batch. It also hardens the installer against a transport/DNS failure aborting an otherwise-successful install.

> **There is no new database schema change in this release.** The `nvarchar(850)` schema change shipped in **1634** — operators upgrading from a pre-1634 build must still read the 1634 guidance (long-running `ALTER COLUMN` on large `urls` tables; performance implications). See **Operator notes** below.

---

## What's changed

### URL import reliability (the main theme)

**1. Reduce oversized URLs to fit `nvarchar(850)` before staging — #128 (fixes #127)**
- New `StringUtils.EnsureUrlWithinLength(url, max)` + `StringUtils.RemoveXsDataParam(url)` and `Url.FullUrlMaxLength` (`850`). A URL already within the limit is returned unchanged; otherwise, in order: (1) strip the volatile `xsdata` token — enough for the large majority of oversized SharePoint/Teams URLs; (2) if still too long, keep just the **page path** (drop query string + `#fragment` — the only part with analytic value); (3) only in the pathological case where even the bare path is over 850, hard-truncate as a last resort.
- Applied at every URL insert point: audit `ObjectId`, App Insights click `HRef`, and Copilot `Url`.
- Mirrors the T-SQL clean-up now in the upgrade guide. `RemoveXsDataParam` is boundary-aware + case-insensitive and preserves the rest of the URL (other params and `#fragment`). All text stays Unicode-safe (`nvarchar`, never `varchar`).
- **Docs:** `ShrinkUrlsFullUrlColumn-UpgradeGuide.md` gains count queries (`total_urls`, `oversize_urls`, `oversize_with_xsdata`, `oversize_other`), an `xsdata` clean-up script that only rewrites a row when the cleaned value **fits and does not already exist** (never creates a duplicate `full_url`), wrapped in a transaction that **defaults to `ROLLBACK`** (admin previews, then flips to `COMMIT`), plus a "what's left" residual-row section.

**2. Skip over-width staging rows instead of failing the whole batch, with diagnostics — #129**
- `InsertBatch.ProcessChunkAsync` detects a column-truncation error (`8152`/`2628`), logs exactly which column overflowed (name, declared width, value length, a short non-PII prefix) plus key fields (Guid/DateTime), then **skips just that row and continues** so one over-wide value can no longer discard the whole batch. A per-save warning summarises how many rows were dropped. String values are never logged in full (no customer data in telemetry).
- `ActivityReportSqlPersistenceManager` skips metadata for events whose staging row wasn't persisted (guards a `NullReferenceException`).
- Defence-in-depth on top of the #128 trimming: protects **any** staging column from a single over-wide value.

**3. Skip over-width rows in memory, before the SQL round-trip (performance) — #130**
- The #129 backstop relied on catching SQL Server's truncation error **per row** — each doomed row cost a server round-trip + a thrown `SqlException`, a hot failure path at scale. Now each staging column's declared length is parsed **once** when the field cache is built (`InsertBatchTypeFieldCache` → `ColumnSqlInfo.MaxLength`), and the per-row loop skips an over-width value with a **single integer compare**, before the INSERT. `nvarchar(n)` and `string.Length` both count UTF-16 units, so the in-memory check predicts truncation exactly; the `8152`/`2628` catch is kept as a backstop. The in-width hot path (the ~200k-user case) is unchanged apart from one integer compare per string field. Over-width integration test drops **~5 s → ~28 ms**.

### Installer hardening — #126

- **Key Vault secret upload is now non-critical.** A transport/DNS failure (e.g. `The remote name could not be resolved: '<vault>.vault.azure.net'`) surfaced as an `AggregateException` (`Status == 0`) that escaped the task's 403/404-only handling and aborted the whole install. `BaseInstallTask.IsCritical` (virtual, default `true`); `SequentialTaskListInstallJob.Install` logs and continues (carrying the previous result) for non-critical tasks; `KeyVaultSecretAddTask` overrides `IsCritical => false` and catches transport/DNS failures with an actionable warning (existing secret value stays valid).
- **DNS pre-flight checks in the "Test Configuration" button.** `SolutionInstallVerifier.VerifyResourceDnsResolution()` probes `management.azure.com` as a control, then resolves each configured+enabled resource hostname (Key Vault, SQL, Storage, App Service, Redis, Service Bus, Cognitive Services) with private-network guidance where relevant. Logs only — never aborts the test run.

## Operator notes

- **No schema change in this release.** Nothing new to run; the importers simply stop overflowing `urls.full_url` and degrade gracefully if they ever do.
- **Upgrading and skipped 1634?** You still get the long-running `nvarchar(850)` `ALTER COLUMN` and the `IX_urls_full_url` build from 1634 — read its schema/performance guidance and the upgrade guide first.
- **Plain-English explanation of the URL cleaning** (for admins/end-users): [How URLs are shortened (wiki)](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/How-URLs-Are-Shortened).
- **DB / upgrade side & performance** (why the field is 850, timings, the `>850` probe): [URLs Full URL Shrink Upgrade (wiki)](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/URLs-Full-URL-Shrink-Upgrade) and [`ShrinkUrlsFullUrlColumn-UpgradeGuide.md`](https://github.com/pnp/Microsoft365-Analytics-Insights/blob/main/src/AnalyticsEngine/Common/Entities/Migrations/ShrinkUrlsFullUrlColumn-UpgradeGuide.md).

## Tests

New/updated unit + localdb integration tests, all green locally:
- `DataUtilsTests` — `RemoveXsDataParam` / `EnsureUrlWithinLength` (real-world anonymised Teams URL shapes + edge cases).
- `InsertBatchOverWidthTests` — over-width row skipped while the rest of the batch is saved, with the offending column logged.
- `StagingColumnSqlTypeOverrideTests` + `ColumnSqlInfo.MaxLength` parsing.
- `InstallEngineTests` — non-critical task continues / critical aborts; `BuildResourceDnsTargets` include/exclude.

## PRs included (dev → main)

- #128 Fix oversized Teams deep-link (xsdata) URLs blocking `urls.full_url` migration (fixes #127)
- #129 Skip over-width staging rows instead of failing the whole batch, with diagnostics
- #130 Skip over-width staging rows in memory, before the SQL round-trip
- #126 Make Key Vault secret upload non-critical; add DNS pre-flight checks to Test Configuration

**Full changelog:** https://github.com/pnp/Microsoft365-Analytics-Insights/compare/main...dev
