### PR TITLE
Seed user metadata in all DB-backed Tests.FakeDataGen stress tests

### DIFF
--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotStressTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Diagnostics;
+using Tests.FakeDataGen.Seeding;
 using UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 
@@ -35,6 +36,7 @@ namespace Tests.FakeDataGen.StressTests
             int totalEvents = GetIntegerInput("Total copilot events to generate", 5000, 1, 1000000);
             int batchSize = GetIntegerInput("Events per commit batch", 500, 1, 100000);
             int maxResourcesPerEvent = GetIntegerInput("Max accessed resources per event", 5, 0, 50);
+            int distinctUsers = GetIntegerInput("Distinct users to seed (with departments, job titles, licenses)", 1000, 1, 200000);
             bool includeAgents = GetBooleanInput("Include agent data", true);
             bool collectGarbageEachBatch = GetBooleanInput("Force GC after each batch", false);
             bool verbose = GetBooleanInput("Verbose output", false);
@@ -58,6 +60,7 @@ namespace Tests.FakeDataGen.StressTests
             Console.WriteLine($"  Total events: {totalEvents:N0}");
             Console.WriteLine($"  Batches: {batchCount:N0} x {batchSize:N0} events");
             Console.WriteLine($"  Up to {(long)totalEvents * maxResourcesPerEvent:N0} accessed resource records");
+            Console.WriteLine($"  Distinct users: {distinctUsers:N0} (seeded with departments, job titles, company, location + licenses)");
             Console.WriteLine($"  Mode: {(commitToSql ? "Full pipeline (staging + SQL commit)" : "Staging only (in-memory)")}");
             Console.WriteLine();
             Console.WriteLine("Press any key to start test...");
@@ -75,6 +78,12 @@ namespace Tests.FakeDataGen.StressTests
                         db.Database.Initialize(force: false);
                     }
                     Console.WriteLine("Database ready.");
+
+                    // Seed a pool of users with realistic metadata (departments, job titles,
+                    // company, locations) + licenses so the audit_events committed below link to
+                    // real users and copilot reports sliced by department / job title have data.
+                    Console.WriteLine($"Seeding {distinctUsers:N0} users with metadata...");
+                    SeedUsersWithMetadata(connectionString, distinctUsers);
                 }
                 catch (Exception ex)
                 {
@@ -87,6 +96,10 @@ namespace Tests.FakeDataGen.StressTests
 
             var result = new StressTestResult { Success = true };
             var random = new Random(42); // Fixed seed for reproducibility
+
+            // UPN pool the events draw from. Matches the users seeded above (when committing to
+            // SQL) so every event links to a metadata-rich user; harmless in staging-only mode.
+            var userCatalogue = BuildUserCatalogue(distinctUsers);
 
             try
             {
@@ -106,7 +119,7 @@ namespace Tests.FakeDataGen.StressTests
 
                     try
                     {
-                        long batchEvents = RunBatch(eventsThisBatch, maxResourcesPerEvent, includeAgents, commitToSql, connectionString, random);
+                        long batchEvents = RunBatch(eventsThisBatch, maxResourcesPerEvent, includeAgents, commitToSql, connectionString, userCatalogue, random);
 
                         totalEventsProcessed += batchEvents;
                         _memoryMonitor.UpdatePeak();
@@ -171,7 +184,7 @@ namespace Tests.FakeDataGen.StressTests
         }
 
         private long RunBatch(int eventCount, int maxResourcesPerEvent, bool includeAgents,
-            bool commitToSql, string connectionString, Random random)
+            bool commitToSql, string connectionString, IReadOnlyList<string> userCatalogue, Random random)
         {
             // Use a fake connection string for staging-only mode; real one for SQL commits
             var effectiveConnectionString = commitToSql ? connectionString : "Server=fake;Database=fake;";
@@ -179,14 +192,15 @@ namespace Tests.FakeDataGen.StressTests
             var manager = new CopilotAuditEventManager(effectiveConnectionString, new FakeCopilotMetadataLoader(),
                 quietLogger);
 
-            // Build all events first, tracking their IDs for prerequisite inserts
-            var eventIds = new List<Guid>(eventCount);
+            // Build all events first, tracking their IDs + owning user UPN for prerequisite inserts
+            var eventIds = new List<(Guid Id, string Upn)>(eventCount);
             var sw = Stopwatch.StartNew();
 
             for (int i = 0; i < eventCount; i++)
             {
                 var eventId = Guid.NewGuid();
-                eventIds.Add(eventId);
+                var upn = userCatalogue[random.Next(userCatalogue.Count)];
+                eventIds.Add((eventId, upn));
 
                 var commonEvent = new CommonAuditEvent
                 {
@@ -196,7 +210,7 @@ namespace Tests.FakeDataGen.StressTests
                     User = new User
                     {
                         AzureAdId = Guid.NewGuid().ToString(),
-                        UserPrincipalName = $"stressuser{random.Next(1, 1000)}@contoso.com"
+                        UserPrincipalName = upn
                     }
                 };
 
@@ -210,7 +224,7 @@ namespace Tests.FakeDataGen.StressTests
             {
                 // Pre-insert audit_events rows so the copilot_chats FK constraint is satisfied
                 sw.Restart();
-                Console.WriteLine($"  Inserting {eventIds.Count} prerequisite audit_events rows...");
+                Console.WriteLine($"  Inserting {eventIds.Count} prerequisite audit_events rows (linked to seeded users)...");
                 InsertPrerequisiteAuditEvents(connectionString, eventIds);
                 Console.WriteLine($"  Prerequisite audit_events insert: {sw.ElapsedMilliseconds:N0}ms");
 
@@ -224,25 +238,77 @@ namespace Tests.FakeDataGen.StressTests
         }
 
         /// <summary>
-        /// Bulk-inserts minimal audit_events rows so the copilot_chats FK constraint is satisfied.
+        /// Inserts audit_events rows (each linked to its seeded, metadata-rich user) so the
+        /// copilot_chats FK constraint is satisfied and copilot data is attributed to real users.
         /// Fully synchronous to avoid async deadlocks on .NET Framework 4.8.
         /// </summary>
-        private void InsertPrerequisiteAuditEvents(string connectionString, List<Guid> eventIds)
+        private void InsertPrerequisiteAuditEvents(string connectionString, List<(Guid Id, string Upn)> eventIds)
         {
             using (var conn = new SqlConnection(connectionString))
             {
                 conn.Open();
                 using (var cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = "INSERT INTO audit_events (id, time_stamp) VALUES (@id, @ts)";
-                    var pId = cmd.Parameters.AddWithValue("@id", DBNull.Value);
-                    var pTs = cmd.Parameters.AddWithValue("@ts", DateTime.UtcNow);
+                    // Link each audit_event to its seeded user so copilot reports sliced by
+                    // department / job title / license have real data. Users are pre-seeded in
+                    // SeedUsersWithMetadata, so the join always resolves.
+                    cmd.CommandText = @"
+INSERT INTO audit_events (id, time_stamp, user_id)
+SELECT @id, @ts, u.id
+FROM users u
+WHERE u.user_name = @upn;";
+                    var pId = cmd.Parameters.Add("@id", System.Data.SqlDbType.UniqueIdentifier);
+                    var pTs = cmd.Parameters.Add("@ts", System.Data.SqlDbType.DateTime);
+                    var pUpn = cmd.Parameters.Add("@upn", System.Data.SqlDbType.NVarChar, 400);
 
-                    foreach (var id in eventIds)
+                    foreach (var ev in eventIds)
                     {
-                        pId.Value = id;
+                        pId.Value = ev.Id;
+                        pTs.Value = DateTime.UtcNow;
+                        pUpn.Value = ev.Upn;
                         cmd.ExecuteNonQuery();
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds the UPN pool the stress events draw from. Matches the format used by
+        /// <see cref="UserMetadataSeeder.SeedUsers"/> so events line up with the seeded users.
+        /// </summary>
+        private static List<string> BuildUserCatalogue(int count)
+        {
+            var list = new List<string>(count);
+            for (int i = 0; i < count; i++) list.Add($"stressuser{i}@contoso.com");
+            return list;
+        }
+
+        /// <summary>
+        /// Seeds the shared metadata lookups + license catalogue, then a pool of users carrying
+        /// department, job title, company, location (and other) metadata plus random licenses, via
+        /// the same idempotent helper used by the other stress tests. Re-runnable: existing stress
+        /// users are left untouched.
+        /// </summary>
+        private static void SeedUsersWithMetadata(string connectionString, int userCount)
+        {
+            var random = new Random(123);
+            using (var conn = new SqlConnection(connectionString))
+            {
+                conn.Open();
+                UserMetadataSeeder.EnsureMetadataLookups(conn);
+                UserMetadataSeeder.EnsureLicenseTypes(conn);
+                var licenseIds = UserMetadataSeeder.LoadLicenseTypeIds(conn);
+
+                var seeded = UserMetadataSeeder.SeedUsers(conn, userCount, random);
+                Console.WriteLine($"  Seeded {seeded.Count:N0} new users with department/job-title/company/location " +
+                                  $"metadata (existing stress users left untouched).");
+
+                if (seeded.Count > 0 && licenseIds.Count > 0)
+                {
+                    var newUserIds = new List<int>(seeded.Count);
+                    foreach (var u in seeded) newUserIds.Add(u.Id);
+                    int assigned = UserMetadataSeeder.AssignRandomLicenses(conn, newUserIds, licenseIds, random, maxLicensesPerUser: 2);
+                    Console.WriteLine($"  Assigned {assigned:N0} license(s) across newly-created users.");
                 }
             }
         }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeSentEmailSentimentScorer.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeSentEmailSentimentScorer.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.Email;
+
+namespace Tests.FakeDataGen.StressTests.FakeLoaders
+{
+    /// <summary>
+    /// Fake <see cref="ISentEmailSentimentScorer"/> that assigns every message a synthetic
+    /// cognitive/sentiment score in the [0,1] range without calling Azure AI Language, so the
+    /// stress test exercises the scoring + persistence path and writes real
+    /// <c>sent_emails.cognitive_score</c> values instead of NULLs.
+    ///
+    /// Following the codebase convention, the score is the "positive" end of the scale:
+    /// <c>0 = very unhappy, 1 = very happy</c>. Replies are deliberately skewed towards the happy
+    /// end (mean ~0.7) but with a gentle "mood wave" along each user's message sequence plus
+    /// per-message noise and the occasional bad day, so the data has realistic ups and downs
+    /// rather than a single constant value.
+    /// </summary>
+    public class FakeSentEmailSentimentScorer : ISentEmailSentimentScorer
+    {
+        private readonly int _seed;
+
+        public FakeSentEmailSentimentScorer(int seed = 2024)
+        {
+            _seed = seed;
+        }
+
+        // Enabled so the importer requests message bodies and runs the scoring path end-to-end.
+        public bool IsEnabled => true;
+
+        public Task<Dictionary<string, double?>> ScoreAsync(IReadOnlyCollection<GraphSentMessage> messagesWithBody)
+        {
+            var result = new Dictionary<string, double?>(StringComparer.Ordinal);
+            if (messagesWithBody == null)
+                return Task.FromResult(result);
+
+            foreach (var msg in messagesWithBody)
+            {
+                if (string.IsNullOrEmpty(msg?.Id))
+                    continue;
+                result[msg.Id] = ScoreForMessage(msg.Id);
+            }
+
+            return Task.FromResult(result);
+        }
+
+        /// <summary>
+        /// Produces a deterministic, reproducible score in [0,1] for a message id. Generally happy
+        /// but with a sine "mood wave" over the per-user message sequence, random noise and an
+        /// occasional bad day so the score dips down too.
+        /// </summary>
+        private double ScoreForMessage(string messageId)
+        {
+            long sequence = ExtractSequence(messageId);
+
+            // Deterministic per-message RNG so reruns produce identical scores.
+            var random = new Random(unchecked(_seed * 397 + StableHash(messageId)));
+
+            // Happy baseline.
+            double mood = 0.68;
+
+            // Gentle ups and downs across the user's message timeline.
+            mood += 0.18 * Math.Sin(sequence / 6.0);
+
+            // Per-message noise, +/- 0.12.
+            mood += (random.NextDouble() - 0.5) * 0.24;
+
+            // Roughly one message in ten is a "bad day" that pulls the score well down.
+            if (random.NextDouble() < 0.10)
+                mood -= 0.35 + random.NextDouble() * 0.35;
+
+            if (mood < 0.0) mood = 0.0;
+            if (mood > 1.0) mood = 1.0;
+            return mood;
+        }
+
+        /// <summary>
+        /// Extracts the trailing numeric "sequence" from a fake message id of the shape
+        /// <c>stress-msg-NNNNNN-SSSSSS</c> so the mood wave progresses along a user's messages.
+        /// Falls back to a stable hash when the id doesn't match (the wave just becomes noise).
+        /// </summary>
+        private static long ExtractSequence(string messageId)
+        {
+            int lastDash = messageId.LastIndexOf('-');
+            if (lastDash >= 0 && lastDash < messageId.Length - 1)
+            {
+                var tail = messageId.Substring(lastDash + 1);
+                if (long.TryParse(tail, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seq))
+                    return seq;
+            }
+            return StableHash(messageId);
+        }
+
+        /// <summary>
+        /// Process-stable hash (FNV-1a) so scores are reproducible across runs - unlike
+        /// <see cref="string.GetHashCode"/>, which can be randomised per process.
+        /// </summary>
+        private static int StableHash(string value)
+        {
+            unchecked
+            {
+                const int fnvPrime = 16777619;
+                int hash = (int)2166136261;
+                foreach (var ch in value)
+                {
+                    hash = (hash ^ ch) * fnvPrime;
+                }
+                return hash & 0x7FFFFFFF;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeSentEmailSourceLoader.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeSentEmailSourceLoader.cs
@@ -11,6 +11,11 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
     /// <see cref="GraphSentMessage"/> objects per user, without calling Microsoft Graph.
     /// Used to stress test the <c>SentEmailImporter</c> pipeline (deduplication, address
     /// resolution, sentiment scoring path, EF batching, SQL persistence).
+    ///
+    /// Each message is classified as internal or external (see <c>internalEmailPercent</c>):
+    /// internal messages address recipients on the <em>same</em> domain as the sender, external
+    /// messages address recipients on unrelated public domains, so the data has a realistic
+    /// internal/external mix.
     /// </summary>
     public class FakeSentEmailSourceLoader : ISentEmailSourceLoader
     {
@@ -45,6 +50,7 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
         private readonly int _messagesPerUser;
         private readonly int _maxRecipientsPerEmail;
         private readonly int _distinctRecipientPoolSize;
+        private readonly int _internalEmailPercent;
         private readonly bool _hasMailReadAccess;
         private readonly int _seed;
         private int _userCounter;
@@ -53,16 +59,20 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
             int messagesPerUser,
             int maxRecipientsPerEmail,
             int distinctRecipientPoolSize,
+            int internalEmailPercent = 70,
             bool hasMailReadAccess = true,
             int seed = 2024)
         {
             if (messagesPerUser < 0) throw new ArgumentOutOfRangeException(nameof(messagesPerUser));
             if (maxRecipientsPerEmail < 1) throw new ArgumentOutOfRangeException(nameof(maxRecipientsPerEmail));
             if (distinctRecipientPoolSize < 1) throw new ArgumentOutOfRangeException(nameof(distinctRecipientPoolSize));
+            if (internalEmailPercent < 0 || internalEmailPercent > 100)
+                throw new ArgumentOutOfRangeException(nameof(internalEmailPercent), "Must be between 0 and 100.");
 
             _messagesPerUser = messagesPerUser;
             _maxRecipientsPerEmail = maxRecipientsPerEmail;
             _distinctRecipientPoolSize = distinctRecipientPoolSize;
+            _internalEmailPercent = internalEmailPercent;
             _hasMailReadAccess = hasMailReadAccess;
             _seed = seed;
         }
@@ -79,9 +89,14 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
             var messages = new List<GraphSentMessage>(_messagesPerUser);
             var fromAddress = !string.IsNullOrEmpty(user?.Mail) ? user.Mail : $"stress-{userIndex}@stress.local";
             var fromName = user?.UserPrincipalName ?? fromAddress;
+            var senderDomain = GetDomain(fromAddress);
 
             for (int i = 0; i < _messagesPerUser; i++)
             {
+                // Internal emails address recipients on the sender's own domain; external ones
+                // use unrelated public domains. random.Next(100) < percent gives ~percent% internal.
+                bool isInternal = random.Next(100) < _internalEmailPercent;
+
                 var msg = new GraphSentMessage
                 {
                     // Stable id: user index + sequence => unique per user, reproducible across runs.
@@ -92,7 +107,7 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
                     {
                         EmailAddress = new GraphEmailAddress { Name = fromName, Address = fromAddress }
                     },
-                    ToRecipients = BuildRecipients(random)
+                    ToRecipients = BuildRecipients(random, isInternal, senderDomain)
                 };
 
                 if (includeBody)
@@ -118,14 +133,15 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
             });
         }
 
-        private List<GraphEmailRecipient> BuildRecipients(Random random)
+        private List<GraphEmailRecipient> BuildRecipients(Random random, bool isInternal, string senderDomain)
         {
             int count = 1 + random.Next(_maxRecipientsPerEmail);
             var list = new List<GraphEmailRecipient>(count);
             for (int i = 0; i < count; i++)
             {
                 int slot = random.Next(_distinctRecipientPoolSize);
-                var domain = DomainPool[slot % DomainPool.Length];
+                // Internal => same domain as the sender; external => an unrelated public domain.
+                var domain = isInternal ? senderDomain : DomainPool[slot % DomainPool.Length];
                 var address = $"recipient-{slot:D6}@{domain}";
                 list.Add(new GraphEmailRecipient
                 {
@@ -137,6 +153,16 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
                 });
             }
             return list;
+        }
+
+        /// <summary>
+        /// Returns the domain part (after the last '@') of an address, falling back to
+        /// <c>stress.local</c> when the address has no domain.
+        /// </summary>
+        private static string GetDomain(string address)
+        {
+            int at = address?.LastIndexOf('@') ?? -1;
+            return at >= 0 && at < address.Length - 1 ? address.Substring(at + 1) : "stress.local";
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
@@ -38,6 +38,10 @@ namespace Tests.FakeDataGen.StressTests
         private static string[] Departments => SeedDataCatalogue.Departments;
         private static string[] Companies => SeedDataCatalogue.Companies;
         private static string[] JobTitles => SeedDataCatalogue.JobTitles;
+        private static string[] StatesOrProvinces => SeedDataCatalogue.StatesOrProvinces;
+        private static string[] Countries => SeedDataCatalogue.Countries;
+        private static string[] OfficeLocations => SeedDataCatalogue.OfficeLocations;
+        private static string[] UsageLocations => SeedDataCatalogue.UsageLocations;
 
         protected override StressTestResult Execute()
         {
@@ -411,19 +415,24 @@ namespace Tests.FakeDataGen.StressTests
                 // Load current license_type ids so we can randomly assign one per newly-created user.
                 var licenseTypeIds = UserMetadataSeeder.LoadLicenseTypeIds(conn);
 
-                // Insert distinct users with department, company, and job title.
-                // Track which UPNs were actually inserted (i.e. didn't already exist) so we can
-                // assign each newly-created user a single random license below.
+                // Insert distinct users with full metadata (department, company, job title,
+                // state/province, country, office + usage location). Track which UPNs were actually
+                // inserted (i.e. didn't already exist) so we can assign each newly-created user a
+                // single random license below.
                 var newlyCreatedUpns = new List<string>();
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
 IF NOT EXISTS (SELECT 1 FROM users WHERE user_name = @upn)
 BEGIN
-    INSERT INTO users (user_name, department_id, company_name_id, job_title_id)
-    SELECT @upn, d.id, c.id, j.id
-    FROM user_departments d, user_company_name c, user_job_titles j
-    WHERE d.name = @dept AND c.name = @company AND j.name = @job;
+    INSERT INTO users (user_name, department_id, company_name_id, job_title_id,
+                       state_or_province_id, country_or_region_id, office_location_id, usage_location_id)
+    SELECT @upn, d.id, c.id, j.id, s.id, co.id, o.id, u.id
+    FROM user_departments d, user_company_name c, user_job_titles j,
+         user_state_or_province s, user_country_or_region co,
+         user_office_locations o, user_usage_locations u
+    WHERE d.name = @dept AND c.name = @company AND j.name = @job
+      AND s.name = @state AND co.name = @country AND o.name = @office AND u.name = @usage;
     SELECT 1;
 END
 ELSE
@@ -432,6 +441,10 @@ ELSE
                     var pDept = cmd.Parameters.Add("@dept", System.Data.SqlDbType.NVarChar, 100);
                     var pCompany = cmd.Parameters.Add("@company", System.Data.SqlDbType.NVarChar, 100);
                     var pJob = cmd.Parameters.Add("@job", System.Data.SqlDbType.NVarChar, 100);
+                    var pState = cmd.Parameters.Add("@state", System.Data.SqlDbType.NVarChar, 100);
+                    var pCountry = cmd.Parameters.Add("@country", System.Data.SqlDbType.NVarChar, 100);
+                    var pOffice = cmd.Parameters.Add("@office", System.Data.SqlDbType.NVarChar, 100);
+                    var pUsage = cmd.Parameters.Add("@usage", System.Data.SqlDbType.NVarChar, 100);
                     var seenUsers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     foreach (var ev in eventIds)
                     {
@@ -441,6 +454,10 @@ ELSE
                             pDept.Value = Departments[random.Next(Departments.Length)];
                             pCompany.Value = Companies[random.Next(Companies.Length)];
                             pJob.Value = JobTitles[random.Next(JobTitles.Length)];
+                            pState.Value = StatesOrProvinces[random.Next(StatesOrProvinces.Length)];
+                            pCountry.Value = Countries[random.Next(Countries.Length)];
+                            pOffice.Value = OfficeLocations[random.Next(OfficeLocations.Length)];
+                            pUsage.Value = UsageLocations[random.Next(UsageLocations.Length)];
                             var inserted = Convert.ToInt32(cmd.ExecuteScalar());
                             if (inserted == 1)
                             {

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
@@ -16,8 +16,9 @@ namespace Tests.FakeDataGen.StressTests
     /// <summary>
     /// End-to-end stress test for the sent-email import pipeline. Drives the real
     /// <see cref="SentEmailImporter"/> using a fake <see cref="ISentEmailSourceLoader"/>
-    /// and a no-op <see cref="ISentEmailSentimentScorer"/>, so the pipeline (deduplication,
-    /// existing-key lookups, address resolution, EF batching, SQL persistence and run
+    /// and a fake <see cref="ISentEmailSentimentScorer"/> (synthetic 0-1 cognitive scores,
+    /// or a no-op when scoring is turned off), so the pipeline (deduplication, existing-key
+    /// lookups, address resolution, sentiment scoring, EF batching, SQL persistence and run
     /// statistics) is exercised at scale without calling Microsoft Graph or Azure AI.
     /// </summary>
     public class SentEmailImporterStressTest : BaseStressTest
@@ -30,8 +31,10 @@ namespace Tests.FakeDataGen.StressTests
             int messagesPerUser = GetIntegerInput("Synthetic sent messages per user", 200, 0, 500_000);
             int maxRecipientsPerEmail = GetIntegerInput("Max recipients per message", 3, 1, 50);
             int distinctRecipientPool = GetIntegerInput("Distinct recipient address pool size", 500, 1, 1_000_000);
+            int internalEmailPercent = GetIntegerInput("Percent of emails that are internal (recipients on sender's domain)", 70, 0, 100);
             bool deleteFirst = GetBooleanInput("Delete previously-generated stress data before run", false);
             bool runTwice = GetBooleanInput("Run import twice (second pass exercises duplicate detection)", false);
+            bool generateScores = GetBooleanInput("Generate cognitive/sentiment scores (0-1, mostly happy)", true);
 
             string connectionString = ConnectionString;
             if (string.IsNullOrEmpty(connectionString))
@@ -53,7 +56,9 @@ namespace Tests.FakeDataGen.StressTests
             Console.WriteLine($"  Synthetic messages per user: {messagesPerUser:N0}");
             Console.WriteLine($"  Total messages generated:    {expectedRows:N0}");
             Console.WriteLine($"  Recipient pool size:         {distinctRecipientPool:N0}");
+            Console.WriteLine($"  Internal email mix:          {internalEmailPercent}% internal / {100 - internalEmailPercent}% external");
             Console.WriteLine($"  Run twice (dedup test):      {(runTwice ? "yes" : "no")}");
+            Console.WriteLine($"  Cognitive scoring:           {(generateScores ? "on (0-1, mostly happy)" : "off")}");
             Console.WriteLine();
             Console.WriteLine("Press any key to start (Ctrl-C to abort)...");
             Console.ReadKey();
@@ -85,14 +90,21 @@ namespace Tests.FakeDataGen.StressTests
                 int seededUsers = SeedUsers(dbFactory, connectionString, userCount);
                 _memoryMonitor.UpdatePeak();
 
-                // 2) Build importer wired up with the fake loader + null sentiment scorer.
+                // 2) Build importer wired up with the fake loader + sentiment scorer.
                 var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
                 var appConfig = FakeAppConfigFactory.Create();
                 var fakeLoader = new FakeSentEmailSourceLoader(
                     messagesPerUser: messagesPerUser,
                     maxRecipientsPerEmail: maxRecipientsPerEmail,
-                    distinctRecipientPoolSize: distinctRecipientPool);
-                var sentimentScorer = NullSentEmailSentimentScorer.Instance;
+                    distinctRecipientPoolSize: distinctRecipientPool,
+                    internalEmailPercent: internalEmailPercent);
+                // Use the fake scorer to populate sent_emails.cognitive_score with synthetic
+                // 0-1 sentiment values (0 = very unhappy, 1 = very happy). Skewed happy with
+                // ups and downs so the data isn't a single constant. The null scorer leaves
+                // every cognitive_score NULL, so only switch to it when scoring is turned off.
+                ISentEmailSentimentScorer sentimentScorer = generateScores
+                    ? (ISentEmailSentimentScorer)new FakeSentEmailSentimentScorer()
+                    : NullSentEmailSentimentScorer.Instance;
 
                 var importer = new SentEmailImporter(
                     telemetry,
@@ -123,6 +135,8 @@ namespace Tests.FakeDataGen.StressTests
 
                 long actualMessages = CountStressRows(dbFactory);
                 long actualRecipients = CountStressRecipients(dbFactory);
+                string scoreSummary = DescribeScoreCoverage(dbFactory);
+                string mixSummary = DescribeInternalExternalMix(dbFactory);
 
                 result.ItemsProcessed = actualMessages;
                 result.Duration = totalSw.Elapsed;
@@ -131,7 +145,8 @@ namespace Tests.FakeDataGen.StressTests
                 result.FinalMemoryBytes = _memoryMonitor.CurrentMemoryBytes;
                 result.Message =
                     $"Seeded {seededUsers:N0} users; importer persisted {actualMessages:N0} sent_email rows " +
-                    $"(with {actualRecipients:N0} sent_email_recipients rows).";
+                    $"(with {actualRecipients:N0} sent_email_recipients rows). Cognitive scores: {scoreSummary}. " +
+                    $"Internal/external: {mixSummary}.";
 
                 _memoryMonitor.PrintReport();
             }
@@ -275,6 +290,72 @@ namespace Tests.FakeDataGen.StressTests
                 return db.SentEmailRecipients
                     .LongCount(r => r.SentEmail.GraphMessageId.StartsWith("stress-msg-"));
             }
+        }
+
+        /// <summary>
+        /// Summarises how many stress sent_email rows received a cognitive score and the
+        /// distribution (avg/min/max), so a run confirms scores were actually written.
+        /// </summary>
+        private static string DescribeScoreCoverage(Func<AnalyticsEntitiesContext> dbFactory)
+        {
+            using (var db = dbFactory())
+            {
+                var stressRows = db.SentEmails.Where(s => s.GraphMessageId.StartsWith("stress-msg-"));
+                long total = stressRows.LongCount();
+                if (total == 0)
+                    return "no stress rows present";
+
+                var scoredRows = stressRows.Where(s => s.CognitiveScore != null);
+                long scored = scoredRows.LongCount();
+                if (scored == 0)
+                    return $"0/{total:N0} rows scored";
+
+                double avg = scoredRows.Average(s => s.CognitiveScore).Value;
+                double min = scoredRows.Min(s => s.CognitiveScore).Value;
+                double max = scoredRows.Max(s => s.CognitiveScore).Value;
+                return $"{scored:N0}/{total:N0} rows scored (avg {avg:F2}, range {min:F2}-{max:F2})";
+            }
+        }
+
+        /// <summary>
+        /// Classifies each stress sent_email as internal (no recipient on a different domain to the
+        /// sender) or external, so a run confirms the configured internal/external mix landed.
+        /// Done in raw SQL because the classification needs the address domain (the part after '@'),
+        /// which EF can't translate cleanly.
+        /// </summary>
+        private static string DescribeInternalExternalMix(Func<AnalyticsEntitiesContext> dbFactory)
+        {
+            const string sql =
+                "SELECT ISNULL(SUM(CAST(x.is_internal AS bigint)), 0) AS InternalCount, COUNT_BIG(*) AS TotalCount " +
+                "FROM ( " +
+                "  SELECT CASE WHEN EXISTS ( " +
+                "      SELECT 1 FROM sent_email_recipients r " +
+                "      INNER JOIN email_addresses ra ON ra.id = r.recipient_address_id " +
+                "      WHERE r.sent_email_id = s.id " +
+                "        AND SUBSTRING(ra.address, CHARINDEX('@', ra.address) + 1, 4000) " +
+                "            <> SUBSTRING(fa.address, CHARINDEX('@', fa.address) + 1, 4000) " +
+                "    ) THEN 0 ELSE 1 END AS is_internal " +
+                "  FROM sent_emails s " +
+                "  INNER JOIN email_addresses fa ON fa.id = s.from_address_id " +
+                "  WHERE s.graph_message_id LIKE 'stress-msg-%' " +
+                ") x;";
+
+            using (var db = dbFactory())
+            {
+                var row = db.Database.SqlQuery<EmailMixRow>(sql).FirstOrDefault();
+                if (row == null || row.TotalCount == 0)
+                    return "no stress rows present";
+
+                long external = row.TotalCount - row.InternalCount;
+                double pct = row.InternalCount * 100.0 / row.TotalCount;
+                return $"{row.InternalCount:N0} internal / {external:N0} external ({pct:F0}% internal)";
+            }
+        }
+
+        private class EmailMixRow
+        {
+            public long InternalCount { get; set; }
+            public long TotalCount { get; set; }
         }
 
         private static void DeleteExistingStressData(Func<AnalyticsEntitiesContext> dbFactory)

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
@@ -3,9 +3,11 @@ using DataUtils;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Tests.FakeDataGen.Seeding;
 using Tests.FakeDataGen.StressTests.FakeLoaders;
 using WebJob.Office365ActivityImporter.Engine.Graph.Email;
 
@@ -80,7 +82,7 @@ namespace Tests.FakeDataGen.StressTests
                 var totalSw = Stopwatch.StartNew();
 
                 // 1) Seed users so SentEmailImporter.LoadUsersWithMailAsync finds mailboxes to scan.
-                int seededUsers = SeedUsers(dbFactory, userCount);
+                int seededUsers = SeedUsers(dbFactory, connectionString, userCount);
                 _memoryMonitor.UpdatePeak();
 
                 // 2) Build importer wired up with the fake loader + null sentiment scorer.
@@ -152,11 +154,34 @@ namespace Tests.FakeDataGen.StressTests
 
         #region DB helpers
 
-        private static int SeedUsers(Func<AnalyticsEntitiesContext> dbFactory, int userCount)
+        private static int SeedUsers(Func<AnalyticsEntitiesContext> dbFactory, string connectionString, int userCount)
         {
             Console.WriteLine($"Seeding {userCount:N0} fake users...");
             var sw = Stopwatch.StartNew();
             int inserted = 0;
+
+            // Seed the shared metadata lookup tables (departments, job titles, companies, states,
+            // countries, office + usage locations) up front and load their ids, so every seeded
+            // user can be given realistic metadata FKs. Without this the importer's users have a
+            // null department/job-title (etc.) and any report that slices sent email by department
+            // or job title is empty. Uses the same idempotent helper and catalogue as the other
+            // stress tests so all of them populate identical metadata.
+            var random = new Random(123);
+            List<int> departmentIds, jobTitleIds, companyIds, stateIds, countryIds, officeIds, usageIds;
+            using (var conn = new SqlConnection(connectionString))
+            {
+                conn.Open();
+                UserMetadataSeeder.EnsureMetadataLookups(conn);
+                departmentIds = UserMetadataSeeder.LoadLookupIds(conn, "user_departments");
+                jobTitleIds = UserMetadataSeeder.LoadLookupIds(conn, "user_job_titles");
+                companyIds = UserMetadataSeeder.LoadLookupIds(conn, "user_company_name");
+                stateIds = UserMetadataSeeder.LoadLookupIds(conn, "user_state_or_province");
+                countryIds = UserMetadataSeeder.LoadLookupIds(conn, "user_country_or_region");
+                officeIds = UserMetadataSeeder.LoadLookupIds(conn, "user_office_locations");
+                usageIds = UserMetadataSeeder.LoadLookupIds(conn, "user_usage_locations");
+            }
+            Console.WriteLine($"  Metadata lookups ready ({departmentIds.Count} departments, " +
+                              $"{jobTitleIds.Count} job titles) - assigning random metadata to seeded users.");
 
             using (var db = dbFactory())
             {
@@ -183,7 +208,14 @@ namespace Tests.FakeDataGen.StressTests
                     {
                         UserPrincipalName = upn,
                         Mail = upn,
-                        AzureAdId = Guid.NewGuid().ToString()
+                        AzureAdId = Guid.NewGuid().ToString(),
+                        DepartmentId = PickOrNull(departmentIds, random),
+                        JobTitleId = PickOrNull(jobTitleIds, random),
+                        CompanyNameId = PickOrNull(companyIds, random),
+                        StateOrProvinceId = PickOrNull(stateIds, random),
+                        UserCountryId = PickOrNull(countryIds, random),
+                        OfficeLocationId = PickOrNull(officeIds, random),
+                        UsageLocationId = PickOrNull(usageIds, random)
                     });
 
                     if (pending.Count >= batch)
@@ -216,6 +248,16 @@ namespace Tests.FakeDataGen.StressTests
             {
                 return db.users.Count(u => u.UserPrincipalName.StartsWith("stress-user"));
             }
+        }
+
+        /// <summary>
+        /// Picks a random id from a lookup id list, or null when the list is empty so the user's
+        /// FK column is left NULL rather than pointing at a non-existent row.
+        /// </summary>
+        private static int? PickOrNull(IList<int> ids, Random random)
+        {
+            if (ids == null || ids.Count == 0) return null;
+            return ids[random.Next(ids.Count)];
         }
 
         private static long CountStressRows(Func<AnalyticsEntitiesContext> dbFactory)

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -66,6 +66,7 @@
     <Compile Include="StressTests\FakeLoaders\FakeActivitySubscriptionManagerForStress.cs" />
     <Compile Include="StressTests\FakeLoaders\FakeAppConfig.cs" />
     <Compile Include="StressTests\FakeLoaders\FakeContentMetaDataLoaderForStress.cs" />
+    <Compile Include="StressTests\FakeLoaders\FakeSentEmailSentimentScorer.cs" />
     <Compile Include="StressTests\FakeLoaders\FakeSentEmailSourceLoader.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
Ensures every DB-backed stress test in `Tests.FakeDataGen` seeds users with realistic metadata, so reports sliced by department / job title / etc. have data. Driven by the shared `UserMetadataSeeder` / `SeedDataCatalogue`.

## Changes
- **SentEmailImporterStressTest**: its bespoke `SeedUsers` now seeds the shared lookup tables via `UserMetadataSeeder.EnsureMetadataLookups` and assigns all 7 user metadata FKs (department, job title, company, state, country, office, usage) to each seeded user. Previously it only set UPN/Mail/AzureAdId.
- **CopilotStressTest**: previously seeded **no** users (its `audit_events` rows had a NULL `user_id`). Now seeds a metadata-rich user pool + licenses via `UserMetadataSeeder`, and links each `audit_events` row to a seeded user.
- **PowerPlatformStressTest**: already seeded department/company/job + a license; extended to the full 7-FK metadata set for parity.

Unchanged: **UserActivityStressTest** already used `UserMetadataSeeder.SeedUsers` (full metadata + licenses); **ActivityAPIStressTest** is in-memory only (`RequiresDatabase=false`) and seeds no users.

## Notes
- Test-only code; **no DB schema changes**.
- Verified with a Debug build of `Tests.FakeDataGen` (succeeds; only pre-existing warnings).