### PR TITLE
Release: installer Teams usage-report OData fix (#133) + URL import reliability (publishable stable since 1634)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Properties/AssemblyInfo.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © __year__")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("Tests.UnitTests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -648,6 +648,34 @@ namespace App.ControlPanel.Engine
             _logger.LogInformation("Successfully verified Graph API for Teams.");
         }
 
+        // Graph usage-report aggregation period for the Teams user-activity verification call.
+        // MUST be the bare OData value ("D7"): the typed Kiota builder
+        // Reports.GetTeamsUserActivityUserDetailWithPeriod(period) wraps the value in single quotes
+        // itself when composing getTeamsUserActivityUserDetail(period='...'). Passing a pre-quoted
+        // "'D7'" produces period=''D7'', which Graph's OData parser rejects ("Syntax error at
+        // position 13 in 'period=''D7'''"). See issue #133.
+        internal const string TeamsUserActivityReportPeriod = "D7";
+
+        /// <summary>
+        /// Reads the Teams user-activity usage report via the typed Graph SDK - the exact call the
+        /// installer "Test Configuration" verification exercises. Extracted so the OData period
+        /// quoting is covered by an integration test (issue #133).
+        /// </summary>
+        internal static async Task<string> ReadTeamsUserActivityReportAsync(Microsoft.Graph.GraphServiceClient graphClient)
+        {
+            using (var stream = await graphClient.Reports.GetTeamsUserActivityUserDetailWithPeriod(TeamsUserActivityReportPeriod).GetAsync())
+            {
+                if (stream == null)
+                {
+                    return null;
+                }
+                using (var reader = new StreamReader(stream))
+                {
+                    return await reader.ReadToEndAsync();
+                }
+            }
+        }
+
         async Task VerifyUserActivityImport(Microsoft.Graph.GraphServiceClient graphClient, TeamsUserUsageLoader teamsUserUsageLoader)
         {
             _logger.LogInformation("Verifying Graph API for user activity import...");
@@ -656,16 +684,7 @@ namespace App.ControlPanel.Engine
             // the need for the v4 manual HttpRequestMessage / HttpProvider workaround.
             try
             {
-                using (var stream = await graphClient.Reports.GetTeamsUserActivityUserDetailWithPeriod("'D7'").GetAsync())
-                {
-                    if (stream != null)
-                    {
-                        using (var reader = new StreamReader(stream))
-                        {
-                            var data = await reader.ReadToEndAsync();
-                        }
-                    }
-                }
+                await ReadTeamsUserActivityReportAsync(graphClient);
             }
             catch (Exception ex)
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/TeamsUserActivityReportUrlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/TeamsUserActivityReportUrlTests.cs
@@ -1,0 +1,73 @@
+using App.ControlPanel.Engine;
+using Microsoft.Graph;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// Regression test for issue #133. The installer "Test Configuration" Teams user-activity
+    /// report check must send a valid OData period (<c>period='D7'</c>), not the double-quoted
+    /// <c>period=''D7''</c> that the Graph v6 (Kiota) typed builder produces when handed a
+    /// pre-quoted value - which Graph rejects with "Syntax error at position 13 in 'period=''D7'''".
+    /// </summary>
+    [TestClass]
+    public class TeamsUserActivityReportUrlTests
+    {
+        [TestMethod]
+        public async Task ReadTeamsUserActivityReport_SendsSingleQuotedODataPeriod()
+        {
+            // Arrange: a Graph client whose transport captures the SDK-composed request URI and
+            // returns an empty CSV report (200). This exercises the real Kiota URL composition -
+            // where the bug lives - with no network call and no credentials.
+            var handler = new UriCapturingHandler("Report Refresh Date,User Principal Name\r\n");
+            var httpClient = new HttpClient(handler);
+            var graphClient = new GraphServiceClient(httpClient, new BearerTokenAuthenticationProvider("test-token"));
+
+            // Act: the exact production call used by SolutionInstallVerifier.VerifyUserActivityImport.
+            await SolutionInstallVerifier.ReadTeamsUserActivityReportAsync(graphClient);
+
+            // Assert: the typed builder wraps the period in single quotes itself, so the value must
+            // be the bare "D7". A pre-quoted "'D7'" yields period=''D7'' (the issue #133 bug).
+            Assert.IsNotNull(handler.CapturedUri, "Expected the Graph SDK to send a request.");
+            var url = Uri.UnescapeDataString(handler.CapturedUri.AbsoluteUri);
+            StringAssert.Contains(url, "getTeamsUserActivityUserDetail(period='D7')",
+                $"Period must be valid single-quoted OData. Actual URL: {url}");
+            Assert.IsFalse(url.Contains("period=''"),
+                $"Period must not be double-quoted (issue #133). Actual URL: {url}");
+        }
+
+        /// <summary>
+        /// Test transport that records the outgoing request URI and returns a stubbed 200 CSV
+        /// response, so the typed report call completes without hitting Microsoft Graph.
+        /// </summary>
+        private sealed class UriCapturingHandler : HttpMessageHandler
+        {
+            private readonly string _csvBody;
+
+            public UriCapturingHandler(string csvBody)
+            {
+                _csvBody = csvBody;
+            }
+
+            public Uri CapturedUri { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                CapturedUri = request.RequestUri;
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_csvBody, Encoding.UTF8, "application/octet-stream"),
+                    RequestMessage = request,
+                };
+                return Task.FromResult(response);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -163,6 +163,7 @@
     <Compile Include="GraphImportTests.cs" />
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
+    <Compile Include="InstallTests\TeamsUserActivityReportUrlTests.cs" />
     <Compile Include="InstallTests\SpoInstallTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">


### PR DESCRIPTION
Cuts the next **stable release** by bringing the installer **Teams usage-report OData fix (#133)** to `main`, on top of the URL-import-reliability + installer-hardening content that landed via #131.

The diff in this PR vs `main` is the #133 fix only — everything else below already merged to `main` in #131 but was **never published** as a stable release (it sits in the unpublished draft "Stable build 1640"). The stable build produced from this merge is the first **publishable** stable since **1634**, so its release notes cover the full set below and it **supersedes the unpublished 1640 draft**.

## In this PR

- **Installer "Test Configuration": Teams user-activity report OData period fix (#133).** The verifier passed a pre-quoted `'D7'` to the Graph v6 (Kiota) typed builder, which adds the OData quotes itself — producing `period=''D7''` and the error *"Syntax error at position 13 in 'period=''D7'''"*. Fixed to pass the bare `"D7"`. **Activity imports were never affected** (they use `ManualGraphCallClient` with a `(date=…)` URL); only the installer verification logged the misleading error. Covered by a new integration test that captures the SDK-composed request URI. (#134, fixes #133)

## Also included in the resulting stable build (already on `main` from #131, since 1634)

- **Reduce oversized Teams `xsdata` URLs to fit `nvarchar(850)` before staging** + upgrade-guide clean-up script. (#128, fixes #127)
- **Skip over-width staging rows** instead of poisoning the whole batch, with diagnostics. (#129)
- **…via an in-memory length check before the SQL round-trip** (perf; ~5 s → ~28 ms). (#130)
- **Installer:** Key Vault secret upload made non-critical + DNS pre-flight checks in "Test Configuration". (#126)
- **Build label compiled into assemblies.** (#125)

## Database schema changes

**None.** The `urls.full_url` → `nvarchar(850)` schema change shipped in **1634**; nothing new to run here. Operators upgrading from a pre-1634 build still get 1634's long-running migration — see the upgrade guidance linked in the release notes.

**Full changelog:** https://github.com/pnp/Microsoft365-Analytics-Insights/compare/main...dev
