### PR TITLE
Installer: enable Key Vault firewall (allow installer + App Service IPs) (#136)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -194,11 +194,33 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 .AddSetting(KeyVaultSecretAddTask.CONFIG_KEY_CRED_TENANT_ID, config.InstallerAccount.DirectoryId)
                 .AddSetting(KeyVaultSecretAddTask.CONFIG_KEY_CRED_CLIENT_ID, config.InstallerAccount.ClientId)
                 .AddSetting(KeyVaultSecretAddTask.CONFIG_KEY_CRED_SECRET, config.InstallerAccount.Secret);
-            this.AddTask(_keyVaultTask,
-                new KeyVaultAddSecretAllPermissionsForAppRegistrationTask(kvAddInstallerAccountSecretAllPolicyConfig, logger, config.AzureLocation, tagDic),
-                new KeyVaultAddSecretReadPolicyForAppRegistrationTask(kvAddRuntimeAccountSecretReadPolicyConfig, logger, config.AzureLocation, tagDic),
-                new KeyVaultAddWebAppPermissionsTask(kvAddInstallerWebAppPermissionsConfig, logger, config.AzureLocation, tagDic),
-                new KeyVaultSecretAddTask(kvSecretAddConfig, logger));
+            var kvPolicyAllTask = new KeyVaultAddSecretAllPermissionsForAppRegistrationTask(kvAddInstallerAccountSecretAllPolicyConfig, logger, config.AzureLocation, tagDic);
+            var kvPolicyReadTask = new KeyVaultAddSecretReadPolicyForAppRegistrationTask(kvAddRuntimeAccountSecretReadPolicyConfig, logger, config.AzureLocation, tagDic);
+            var kvWebAppPermissionsTask = new KeyVaultAddWebAppPermissionsTask(kvAddInstallerWebAppPermissionsConfig, logger, config.AzureLocation, tagDic);
+            var kvSecretAddTask = new KeyVaultSecretAddTask(kvSecretAddConfig, logger);
+
+            // Enable the Key Vault firewall and allow-list the installer + App Service IPs (public
+            // deployments only). It runs right after the vault is created/updated and before the secret
+            // upload so the upload's data-plane call is allowed through. Private deployments keep public
+            // access disabled and reach the vault via a private endpoint, so no IP rules are needed.
+            // See issue #136.
+            if (allowPublicAccess)
+            {
+                var kvFirewallConfig = TaskConfig.GetConfigForName(config.KeyVaultName)
+                    .AddSetting(KeyVaultFirewallConfigTask.CONFIG_KEY_APP_SERVICE_NAME, config.AppServiceWebAppName);
+                if (vnetEnabled && !string.IsNullOrWhiteSpace(config.NetworkConfig.AppServiceIntegrationSubnetName))
+                {
+                    var integrationSubnetId = $"/subscriptions/{config.Subscription.SubId}/resourceGroups/{config.ResourceGroupName}/providers/Microsoft.Network/virtualNetworks/{config.NetworkConfig.VNetName}/subnets/{config.NetworkConfig.AppServiceIntegrationSubnetName}";
+                    kvFirewallConfig.AddSetting(KeyVaultFirewallConfigTask.CONFIG_KEY_VNET_SUBNET_ID, integrationSubnetId);
+                }
+                this.AddTask(_keyVaultTask,
+                    new KeyVaultFirewallConfigTask(kvFirewallConfig, logger, Location),
+                    kvPolicyAllTask, kvPolicyReadTask, kvWebAppPermissionsTask, kvSecretAddTask);
+            }
+            else
+            {
+                this.AddTask(_keyVaultTask, kvPolicyAllTask, kvPolicyReadTask, kvWebAppPermissionsTask, kvSecretAddTask);
+            }
 
             // ServiceBus - enforce Premium for VNet (private endpoints require Premium SKU)
             // Service Bus is only required by the Teams calls import; skip provisioning when disabled.

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultFirewallConfigTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultFirewallConfigTask.cs
@@ -1,0 +1,220 @@
+using Azure.ResourceManager.KeyVault;
+using Azure.ResourceManager.KeyVault.Models;
+using Azure.ResourceManager.AppService;
+using Azure.Core;
+using CloudInstallEngine.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure.InstallTasks
+{
+    /// <summary>
+    /// Enables the Key Vault firewall (network ACLs) and allow-lists the addresses the solution
+    /// actually uses, so the install both complies with Azure policies that require a firewall
+    /// (e.g. "Azure Key Vault should have firewall enabled or public network access disabled") and
+    /// keeps the vault reachable.
+    /// <para>
+    /// Runs only for public-access deployments (private deployments keep <c>publicNetworkAccess =
+    /// Disabled</c> and reach the vault through a private endpoint, so no IP rules are needed). It
+    /// allow-lists, depending on config:
+    /// <list type="bullet">
+    /// <item>the installer machine's public IP (so the runtime secret upload succeeds),</item>
+    /// <item>the App Service outbound IPs (so the web app / WebJobs can read secrets),</item>
+    /// <item>for VNet-integrated deployments, a virtual-network rule for the App Service integration subnet.</item>
+    /// </list>
+    /// The actual <c>defaultAction = Deny</c> / <c>bypass = AzureServices</c> is already set by
+    /// <see cref="KeyVaultTask"/> at create/update time; this task adds the allow rules via a PATCH so
+    /// existing access policies are preserved. Best-effort (non-critical): a networking hiccup logs
+    /// actionable guidance and does not abort an otherwise-successful install. See issue #136.
+    /// </summary>
+    public class KeyVaultFirewallConfigTask : InstallTaskInAzResourceGroup<KeyVaultResource>
+    {
+        public const string CONFIG_KEY_APP_SERVICE_NAME = "appServiceName";
+
+        /// <summary>Optional: App Service VNet-integration subnet resource ID (added as a virtual-network rule).</summary>
+        public const string CONFIG_KEY_VNET_SUBNET_ID = "vnetSubnetId";
+
+        const string IP_CHECK_URL = "http://icanhazip.com";
+        static readonly Regex IPv4Regex = new Regex(@"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", RegexOptions.Compiled);
+
+        public KeyVaultFirewallConfigTask(TaskConfig config, ILogger logger, AzureLocation azureLocation)
+            : base(config, logger, azureLocation, new Dictionary<string, string>())
+        {
+        }
+
+        public override string TaskName => "configure Key Vault firewall (allow installer + App Service IPs)";
+
+        // Best-effort networking config: a transient failure here must not abort an otherwise-successful install.
+        public override bool IsCritical => false;
+
+        public override async Task<KeyVaultResource> ExecuteTaskReturnResult(object contextArg)
+        {
+            var vault = EnsureContextArgType<KeyVaultResource>(contextArg);
+            var appServiceName = _config.GetConfigValue(CONFIG_KEY_APP_SERVICE_NAME);
+            var vnetSubnetId = _config.ContainsKey(CONFIG_KEY_VNET_SUBNET_ID) ? _config[CONFIG_KEY_VNET_SUBNET_ID] : null;
+
+            var allowIps = new List<string>();
+
+            // 1. Installer machine public IP - needed for the runtime secret upload (data-plane).
+            var installerIp = TryGetInstallerPublicIp();
+            if (!string.IsNullOrEmpty(installerIp))
+            {
+                allowIps.Add(installerIp);
+                _logger.LogInformation($"Allowing installer public IP '{installerIp}' through the Key Vault firewall.");
+            }
+            else
+            {
+                _logger.LogWarning("Could not determine the installer's public IP; the runtime secret upload may fail until the IP is added to the Key Vault firewall manually (vault Networking blade).");
+            }
+
+            // 2. App Service outbound IPs - needed so the web app / WebJobs can read secrets.
+            var appIps = GetAppServiceOutboundIps(appServiceName);
+            if (appIps.Count > 0)
+            {
+                allowIps.AddRange(appIps);
+                _logger.LogInformation($"Allowing {appIps.Count} App Service outbound IP(s) for '{appServiceName}' through the Key Vault firewall.");
+            }
+            else
+            {
+                _logger.LogWarning($"No outbound IPs resolved for App Service '{appServiceName}'; the web app may be unable to read secrets until its IPs are added to the Key Vault firewall manually.");
+            }
+
+            // 3. VNet-integrated deployments: allow the App Service integration subnet.
+            if (!string.IsNullOrWhiteSpace(vnetSubnetId))
+            {
+                _logger.LogInformation("Allowing the App Service VNet-integration subnet through the Key Vault firewall (virtual-network rule).");
+            }
+
+            var ruleSet = BuildFirewallRuleSet(vault.Data.Properties?.NetworkRuleSet, allowIps, vnetSubnetId);
+
+            _logger.LogInformation($"Enabling Key Vault '{vault.Data.Name}' firewall: default action 'Deny', bypass 'AzureServices', {ruleSet.IPRules.Count} IP rule(s), {ruleSet.VirtualNetworkRules.Count} virtual-network rule(s).");
+
+            var patch = new KeyVaultPatch { Properties = new KeyVaultPatchProperties { NetworkRuleSet = ruleSet } };
+            var updated = await vault.UpdateAsync(patch);
+            return updated.Value;
+        }
+
+        List<string> GetAppServiceOutboundIps(string appServiceName)
+        {
+            var site = Container.GetWebSites().Where(s => s.Data.Name == appServiceName).SingleOrDefault();
+            if (site == null)
+            {
+                _logger.LogWarning($"App Service '{appServiceName}' not found in the resource group; cannot allow its outbound IPs on the Key Vault firewall.");
+                return new List<string>();
+            }
+            return ParseOutboundIPv4Addresses(site.Data.PossibleOutboundIPAddresses);
+        }
+
+        string TryGetInstallerPublicIp()
+        {
+            try
+            {
+                var ip = new WebClient().DownloadString(IP_CHECK_URL)?.Trim();
+                if (!string.IsNullOrEmpty(ip) && IPv4Regex.IsMatch(ip))
+                {
+                    return ip;
+                }
+                _logger.LogWarning($"Public IP lookup from '{IP_CHECK_URL}' returned an unexpected value ('{ip}').");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not determine the installer's public IP from '{IP_CHECK_URL}': {ex.Message}");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Builds a firewall-enabled <see cref="KeyVaultNetworkRuleSet"/> (default action <c>Deny</c>,
+        /// bypass <c>AzureServices</c>) that preserves any existing IP / virtual-network rules and adds
+        /// the supplied allow IPs and (optional) VNet integration subnet. De-duplicates rules. Pure and
+        /// side-effect free so it can be unit tested without Azure.
+        /// </summary>
+        public static KeyVaultNetworkRuleSet BuildFirewallRuleSet(KeyVaultNetworkRuleSet existing, IEnumerable<string> allowIpAddresses, string vnetSubnetId)
+        {
+            var ruleSet = new KeyVaultNetworkRuleSet
+            {
+                DefaultAction = KeyVaultNetworkRuleAction.Deny,
+                Bypass = KeyVaultNetworkRuleBypassOption.AzureServices,
+            };
+
+            var seenIps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var seenSubnets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (existing != null)
+            {
+                foreach (var rule in existing.IPRules)
+                {
+                    if (!string.IsNullOrWhiteSpace(rule?.AddressRange) && seenIps.Add(rule.AddressRange))
+                    {
+                        ruleSet.IPRules.Add(new KeyVaultIPRule(rule.AddressRange));
+                    }
+                }
+                foreach (var rule in existing.VirtualNetworkRules)
+                {
+                    var existingSubnetId = rule?.Id?.ToString();
+                    if (!string.IsNullOrWhiteSpace(existingSubnetId) && seenSubnets.Add(existingSubnetId))
+                    {
+                        ruleSet.VirtualNetworkRules.Add(new KeyVaultVirtualNetworkRule(existingSubnetId)
+                        {
+                            IgnoreMissingVnetServiceEndpoint = rule.IgnoreMissingVnetServiceEndpoint
+                        });
+                    }
+                }
+            }
+
+            if (allowIpAddresses != null)
+            {
+                foreach (var ip in allowIpAddresses)
+                {
+                    var trimmed = ip?.Trim();
+                    if (!string.IsNullOrEmpty(trimmed) && seenIps.Add(trimmed))
+                    {
+                        ruleSet.IPRules.Add(new KeyVaultIPRule(trimmed));
+                    }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(vnetSubnetId) && seenSubnets.Add(vnetSubnetId))
+            {
+                // IgnoreMissingVnetServiceEndpoint = true so the rule is accepted even if the subnet's
+                // Microsoft.KeyVault service endpoint isn't (yet) enabled - the rule simply won't enforce
+                // until it is, which is harmless when a private endpoint already covers VNet access.
+                ruleSet.VirtualNetworkRules.Add(new KeyVaultVirtualNetworkRule(vnetSubnetId)
+                {
+                    IgnoreMissingVnetServiceEndpoint = true
+                });
+            }
+
+            return ruleSet;
+        }
+
+        /// <summary>
+        /// Parses a comma-separated list of IPv4 addresses (e.g. App Service
+        /// <c>PossibleOutboundIPAddresses</c>), trimming, validating and de-duplicating. Non-IPv4
+        /// entries (e.g. IPv6, which Key Vault IP rules don't support) and blanks are ignored.
+        /// </summary>
+        public static List<string> ParseOutboundIPv4Addresses(string commaSeparated)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrWhiteSpace(commaSeparated))
+            {
+                return result;
+            }
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var part in commaSeparated.Split(','))
+            {
+                var ip = part.Trim();
+                if (ip.Length > 0 && IPv4Regex.IsMatch(ip) && seen.Add(ip))
+                {
+                    result.Add(ip);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -52,7 +52,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
                 var props = new KeyVaultProperties(tenantId, new KeyVaultSku(KeyVaultSkuFamily.A, KeyVaultSkuName.Standard))
                 {
-                    PublicNetworkAccess = _allowPublicAccess ? "Enabled" : "Disabled"
+                    PublicNetworkAccess = _allowPublicAccess ? "Enabled" : "Disabled",
+                    // Enable the vault firewall up-front so the create itself complies with Azure
+                    // policies that require it (e.g. "Azure Key Vault should have firewall enabled or
+                    // public network access disabled"). KeyVaultFirewallConfigTask then allow-lists the
+                    // installer + App Service IPs so the vault stays reachable. See issue #136.
+                    NetworkRuleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(null, null, null)
                 };
                 var newKeyVaultInfo = new KeyVaultCreateOrUpdateContent(AzureLocation, props);
                 EnsureTagsOnNew(newKeyVaultInfo.Tags);
@@ -65,16 +70,25 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 _logger.LogInformation($"Found existing key vault '{r.Data.Name}'.");
 
                 var desiredAccess = _allowPublicAccess ? "Enabled" : "Disabled";
-                if (!string.Equals(r.Data.Properties.PublicNetworkAccess, desiredAccess, StringComparison.OrdinalIgnoreCase))
+                var publicAccessChanged = !string.Equals(r.Data.Properties.PublicNetworkAccess, desiredAccess, StringComparison.OrdinalIgnoreCase);
+                var firewallEnabled = r.Data.Properties.NetworkRuleSet?.DefaultAction == KeyVaultNetworkRuleAction.Deny;
+                if (publicAccessChanged || !firewallEnabled)
                 {
-                    _logger.LogInformation($"Updating key vault '{r.Data.Name}' public network access to '{desiredAccess}'...");
-                    var props = new KeyVaultProperties(r.Data.Properties.TenantId, r.Data.Properties.Sku)
+                    _logger.LogInformation($"Updating key vault '{r.Data.Name}': public network access '{desiredAccess}', firewall default action 'Deny'...");
+
+                    // PATCH (not a full CreateOrUpdate) so existing access policies and other vault
+                    // settings are preserved while we set public access and enable the firewall. The
+                    // firewall must be enabled here (not just by KeyVaultFirewallConfigTask) so this
+                    // update itself satisfies Azure Key Vault firewall policies. See issue #136.
+                    var patch = new KeyVaultPatch
                     {
-                        PublicNetworkAccess = desiredAccess
+                        Properties = new KeyVaultPatchProperties
+                        {
+                            PublicNetworkAccess = desiredAccess,
+                            NetworkRuleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(r.Data.Properties.NetworkRuleSet, null, null)
+                        }
                     };
-                    var update = new KeyVaultCreateOrUpdateContent(AzureLocation, props);
-                    EnsureTagsOnNew(update.Tags);
-                    var updateResult = await Container.GetKeyVaults().CreateOrUpdateAsync(WaitUntil.Completed, name, update);
+                    var updateResult = await r.UpdateAsync(patch);
                     r = updateResult.Value;
                 }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/KeyVaultFirewallConfigTaskTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/KeyVaultFirewallConfigTaskTests.cs
@@ -1,0 +1,77 @@
+using Azure.ResourceManager.KeyVault.Models;
+using CloudInstallEngine.Azure.InstallTasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// Unit tests for the Key Vault firewall rule construction (issue #136). These cover the pure,
+    /// Azure-free logic: parsing App Service outbound IPs and building the firewall rule set.
+    /// </summary>
+    [TestClass]
+    public class KeyVaultFirewallConfigTaskTests
+    {
+        [TestMethod]
+        public void ParseOutboundIPv4Addresses_TrimsDedupesAndIgnoresNonIPv4()
+        {
+            // Mixed: duplicates, whitespace, an IPv6 address, junk and a trailing blank.
+            var input = "52.178.30.162, 52.178.27.13 ,52.178.30.162,not-an-ip,2001:db8::1,";
+
+            var result = KeyVaultFirewallConfigTask.ParseOutboundIPv4Addresses(input);
+
+            CollectionAssert.AreEqual(new[] { "52.178.30.162", "52.178.27.13" }, result);
+        }
+
+        [TestMethod]
+        public void ParseOutboundIPv4Addresses_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.AreEqual(0, KeyVaultFirewallConfigTask.ParseOutboundIPv4Addresses(null).Count);
+            Assert.AreEqual(0, KeyVaultFirewallConfigTask.ParseOutboundIPv4Addresses("   ").Count);
+        }
+
+        [TestMethod]
+        public void BuildFirewallRuleSet_EnablesDenyFirewallAndAddsIps()
+        {
+            var ruleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(
+                existing: null,
+                allowIpAddresses: new[] { "5.159.8.251", "52.178.30.162" },
+                vnetSubnetId: null);
+
+            Assert.IsTrue(ruleSet.DefaultAction == KeyVaultNetworkRuleAction.Deny, "Firewall must default-deny.");
+            Assert.IsTrue(ruleSet.Bypass == KeyVaultNetworkRuleBypassOption.AzureServices, "Trusted Azure services must be allowed to bypass.");
+            CollectionAssert.AreEqual(new[] { "5.159.8.251", "52.178.30.162" }, ruleSet.IPRules.Select(r => r.AddressRange).ToList());
+            Assert.AreEqual(0, ruleSet.VirtualNetworkRules.Count);
+        }
+
+        [TestMethod]
+        public void BuildFirewallRuleSet_PreservesExistingRulesAndDeduplicates()
+        {
+            var existing = new KeyVaultNetworkRuleSet { DefaultAction = KeyVaultNetworkRuleAction.Allow };
+            existing.IPRules.Add(new KeyVaultIPRule("5.159.8.251"));
+            existing.VirtualNetworkRules.Add(new KeyVaultVirtualNetworkRule("/subscriptions/s/.../subnets/subnetA"));
+
+            var ruleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(
+                existing: existing,
+                allowIpAddresses: new[] { "5.159.8.251", "9.9.9.9" },   // 5.159.8.251 already present -> deduped
+                vnetSubnetId: "/subscriptions/s/.../subnets/subnetB");
+
+            CollectionAssert.AreEqual(new[] { "5.159.8.251", "9.9.9.9" }, ruleSet.IPRules.Select(r => r.AddressRange).ToList());
+            CollectionAssert.AreEqual(
+                new[] { "/subscriptions/s/.../subnets/subnetA", "/subscriptions/s/.../subnets/subnetB" },
+                ruleSet.VirtualNetworkRules.Select(r => r.Id.ToString()).ToList());
+        }
+
+        [TestMethod]
+        public void BuildFirewallRuleSet_AddedVnetRuleIgnoresMissingServiceEndpoint()
+        {
+            var ruleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(
+                existing: null,
+                allowIpAddresses: null,
+                vnetSubnetId: "/subscriptions/s/.../subnets/integration");
+
+            Assert.AreEqual(1, ruleSet.VirtualNetworkRules.Count);
+            Assert.AreEqual(true, ruleSet.VirtualNetworkRules.Single().IgnoreMissingVnetServiceEndpoint);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -163,6 +163,7 @@
     <Compile Include="GraphImportTests.cs" />
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
+    <Compile Include="InstallTests\KeyVaultFirewallConfigTaskTests.cs" />
     <Compile Include="InstallTests\TeamsUserActivityReportUrlTests.cs" />
     <Compile Include="InstallTests\SpoInstallTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fixes #136.

## Problem

An install aborted **FATAL** at the *get/create key vault* stage on a subscription that enforces the Azure policy **"Azure Key Vault should have firewall enabled or public network access disabled"** (`Deny` effect):

```
Updating key vault 'kv-...-01' public network access to 'Enabled'...
Error - Resource 'kv-...-01' was disallowed by policy. ... RequestDisallowedByPolicy
Status: 403 (Forbidden)
Error - FATAL: ... RequestFailedException ...
```

`KeyVaultTask` set `publicNetworkAccess = Enabled` but never configured `networkAcls`, so `defaultAction` stayed `Allow` — exactly what the policy denies. The `CreateOrUpdate` (PUT) was rejected and the install stopped.

## Change

Enable the Key Vault firewall and allow-list the addresses the solution actually uses, depending on the deployment config.

- **`KeyVaultTask`** now sets `networkAcls.defaultAction = Deny` + `bypass = AzureServices` on create and update, so the create/update **itself** complies with the policy. The update path switched from a full `CreateOrUpdate` to a **PATCH**, so existing access policies and other vault settings are preserved.
- **New `KeyVaultFirewallConfigTask`** (public-access deployments only; runs right after the vault and before the secret upload) allow-lists:
  - the **installer machine's public IP** (so the runtime secret upload — a data-plane call — succeeds), and
  - the **App Service outbound IPs** (`PossibleOutboundIPAddresses`, so the web app / WebJobs can read secrets),
  - plus a **virtual-network rule** for the App Service integration subnet on **VNet-integrated** deployments.
  - It applies the rules via **PATCH** and is **non-critical** — a transient networking failure logs actionable guidance (which IPs to add on the vault Networking blade) instead of aborting the install.
- **Private deployments** (`AllowPublicAccess = false`) already comply (`publicNetworkAccess = Disabled`) and reach the vault through the **private endpoint** that the installer already provisions, so no IP rules are added there (mirrors the existing SQL / Redis firewall gating).

## "Allow private/public IP addresses depending on config"

| Deployment config | What the firewall allows |
|---|---|
| Public, no VNet (the failing case) | installer public IP + App Service **public** outbound IPs |
| VNet-integrated, public access on | the above **+ a virtual-network rule** for the App Service integration subnet |
| Private (public access off) | nothing added — `publicNetworkAccess = Disabled` + access via **private endpoint** |

Trusted Microsoft services keep working via the `AzureServices` bypass.

## Tests

New `KeyVaultFirewallConfigTaskTests` (5 tests, all green) cover the pure logic with no Azure calls:
- `ParseOutboundIPv4Addresses` — trims, de-duplicates, ignores IPv6 / junk / blanks.
- `BuildFirewallRuleSet` — sets `Deny` + `AzureServices`, adds the allow IPs, preserves & de-duplicates existing rules, and adds the VNet rule with `IgnoreMissingVnetServiceEndpoint`.

Built with MSBuild 18; `Tests.UnitTests` compiles and the new tests pass.

## Schema

**No DB schema change.**
