### PR TITLE
Service Bus: authenticate with RBAC, not SAS keys (#138)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/ResourceSecurityInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/ResourceSecurityInstallJob.cs
@@ -16,6 +16,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
         private readonly RoleAssignmentTask _storageBlobDataContributorRoleTask;
         private readonly RoleAssignmentTask _redisCacheContributorRoleTask;
         private readonly RoleAssignmentTask _cognitiveServicesUserRoleTask;
+        private readonly RoleAssignmentTask _serviceBusDataOwnerRoleTask;
 
         public ResourceSecurityInstallJob(ILogger logger, SolutionInstallConfig config, SubscriptionResource subscription) : base(logger, config, subscription)
         {
@@ -68,6 +69,22 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 _cognitiveServicesUserRoleTask = new RoleAssignmentTask(cognitiveServicesUserConfig, logger, Location, tagDic);
                 this.AddTask(_cognitiveServicesUserRoleTask);
             }
+
+            // Assign "Azure Service Bus Data Owner" to the runtime account for data-plane access
+            // (send from the calls webhook + receive in the importer) now that Service Bus authenticates
+            // with RBAC instead of a SAS key. Without it the runtime SP gets 401, and with namespace local
+            // auth disabled SAS would fail anyway. Only when Service Bus is part of the install. See issue #138.
+            if (config.ServiceBusEnabled)
+            {
+                var serviceBusDataOwnerConfig = TaskConfig.GetConfigForPropAndVal(RoleAssignmentTask.CONFIG_KEY_ROLE_NAME, "Azure Service Bus Data Owner")
+                    .AddSetting(RoleAssignmentTask.CONFIG_KEY_CLIENT_ID, config.RuntimeAccountOffice365.ClientId)
+                    .AddSetting(RoleAssignmentTask.CONFIG_KEY_CLIENT_SECRET, config.RuntimeAccountOffice365.Secret)
+                    .AddSetting(RoleAssignmentTask.CONFIG_KEY_TENANT_ID, config.RuntimeAccountOffice365.DirectoryId)
+                    .AddSetting(RoleAssignmentTask.CONFIG_KEY_PRINCIPAL_TYPE, "ServicePrincipal");
+
+                _serviceBusDataOwnerRoleTask = new RoleAssignmentTask(serviceBusDataOwnerConfig, logger, Location, tagDic);
+                this.AddTask(_serviceBusDataOwnerRoleTask);
+            }
         }
 
         public RoleAssignmentResource AppInsightsReaderRole => GetTaskResult<RoleAssignmentResource>(_appInsightsReaderRoleTask);
@@ -75,5 +92,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
         public RoleAssignmentResource RedisCacheContributorRole => GetTaskResult<RoleAssignmentResource>(_redisCacheContributorRoleTask);
         public RoleAssignmentResource CognitiveServicesUserRole =>
             _cognitiveServicesUserRoleTask == null ? null : GetTaskResult<RoleAssignmentResource>(_cognitiveServicesUserRoleTask);
+        public RoleAssignmentResource ServiceBusDataOwnerRole =>
+            _serviceBusDataOwnerRoleTask == null ? null : GetTaskResult<RoleAssignmentResource>(_serviceBusDataOwnerRoleTask);
     }
 }

--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -90,16 +90,6 @@ namespace Common.Entities.Config
                 this.MetadataRefreshMinutes = metadataRefreshMinutesInt;
             }
 
-            // New optional flag: UseRBACForServiceBus (default false)
-            var useRbacForSb = ConfigurationManager.AppSettings.Get("UseRBACForServiceBus");
-            if (!string.IsNullOrEmpty(useRbacForSb))
-            {
-                if (bool.TryParse(useRbacForSb, out var parsed))
-                {
-                    this.UseRBACForServiceBus = parsed;
-                }
-            }
-
             // Optional flag to bypass the "recently imported" gate for usage reports (default false).
             // Replaces a #if DEBUG override so it can be toggled in any build.
             var forceUsageReportsImport = ConfigurationManager.AppSettings.Get("ForceUsageReportsImport");
@@ -227,12 +217,6 @@ namespace Common.Entities.Config
         /// Optional filter for user groups
         /// </summary>
         public string UserGroupsFilter { get; set; }
-
-        /// <summary>
-        /// When true, use RBAC (AAD) auth to connect to Service Bus instead of SAS connection string.
-        /// Default false.
-        /// </summary>
-        public bool UseRBACForServiceBus { get; set; } = false;
 
         /// <summary>
         /// When true, bypasses the "recently imported" gate for Graph usage reports and runs every invocation.

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeAppConfig.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeAppConfig.cs
@@ -33,7 +33,6 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
             config.WebAppURL = "https://fake-webapp.azurewebsites.net";
             config.BuildLabel = "stress-test";
             config.MetadataRefreshMinutes = 24 * 60; // 24 hours
-            config.UseRBACForServiceBus = false;
 
             // Create minimal connection strings using same technique
             var connStrings = (AppConnectionStrings)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(AppConnectionStrings));

--- a/src/AnalyticsEngine/Web/Controllers/CallRecordWebhookController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/CallRecordWebhookController.cs
@@ -59,7 +59,8 @@ namespace Web.AnalyticsWeb.Controllers
 
                 // Create new SB client. Wrap in try/finally so client + sender are disposed
                 // even if AddChangeMsgToQueue throws - otherwise sockets leak per webhook call.
-                var sbClient = new ServiceBusClient(config.ConnectionStrings.ServiceBusConnectionString);
+                // Authenticate with Entra ID RBAC (runtime service principal), never a SAS key. See issue #138.
+                var sbClient = CallQueueProcessor.CreateRbacServiceBusClient(config);
                 var sbConnectionProps = ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString);
                 var sbSender = sbClient.CreateSender(sbConnectionProps.EntityPath);
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallQueueProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallQueueProcessor.cs
@@ -70,41 +70,39 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             _auth = new GraphAppIndentityOAuthContext(_telemetry, config.ClientID, config.TenantGUID.ToString(), config.ClientSecret, config.KeyVaultUrl, config.UseClientCertificate);
             this._thisTenantId = thisTenantId;
 
-            // If RBAC is enabled, build ServiceBusClient using AAD credential
-            if (config.UseRBACForServiceBus)
+            // Always authenticate to Service Bus with Entra ID RBAC (the runtime service principal) -
+            // never a SAS key. The namespace + queue are still read from the existing ServiceBus
+            // connection string's Endpoint, so existing installs keep their current config; the shared
+            // access key in it is ignored. The runtime SP needs the "Azure Service Bus Data Owner" role
+            // on the namespace (assigned by the installer). See issue #138.
+            _telemetry.LogInformation("Initializing ServiceBusClient using Entra ID RBAC (no SAS keys).");
+            var sbProps = ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString);
+            _sbClient = CreateRbacServiceBusClient(config);
+            _processor = _sbClient.CreateProcessor(sbProps.EntityPath, new ServiceBusProcessorOptions
             {
-                _telemetry.LogInformation("Initializing ServiceBusClient using RBAC (ClientSecretCredential).");
-                var credential = new ClientSecretCredential(config.TenantGUID.ToString(), config.ClientID, config.ClientSecret);
-                // Extract fully qualified namespace from connection string (Endpoint=sb://namespace.servicebus.windows.net/;...)
-                var sbProps = ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString);
-                var fullyQualifiedNamespace = sbProps.FullyQualifiedNamespace; // e.g. namespace.servicebus.windows.net
-                _sbClient = new ServiceBusClient(fullyQualifiedNamespace, credential);
-                _processor = _sbClient.CreateProcessor(sbProps.EntityPath, new ServiceBusProcessorOptions
-                {
-                    MaxConcurrentCalls = 10,
-                    PrefetchCount = 0,
-                    ReceiveMode = ServiceBusReceiveMode.PeekLock,
-                    MaxAutoLockRenewalDuration = TimeSpan.FromHours(24),        // Queue should be configured for 5 minute lock timeout
-                    AutoCompleteMessages = false                                // Messages are completed only when the migrator has succeeded to migrate the file
-                });
-            }
-            else
-            {
-                // Legacy SAS connection string approach
-                _sbClient = new ServiceBusClient(config.ConnectionStrings.ServiceBusConnectionString);
-                var sbConnectionInfo = ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString);
-                _processor = _sbClient.CreateProcessor(sbConnectionInfo.EntityPath, new ServiceBusProcessorOptions
-                {
-                    MaxConcurrentCalls = 10,
-                    PrefetchCount = 0,
-                    ReceiveMode = ServiceBusReceiveMode.PeekLock,
-                    MaxAutoLockRenewalDuration = TimeSpan.FromHours(24),        // Queue should be configured for 5 minute lock timeout
-                    AutoCompleteMessages = false                                // Messages are completed only when the migrator has succeeded to migrate the file
-                });
-            }
+                MaxConcurrentCalls = 10,
+                PrefetchCount = 0,
+                ReceiveMode = ServiceBusReceiveMode.PeekLock,
+                MaxAutoLockRenewalDuration = TimeSpan.FromHours(24),        // Queue should be configured for 5 minute lock timeout
+                AutoCompleteMessages = false                                // Messages are completed only when the migrator has succeeded to migrate the file
+            });
         }
 
         #endregion
+
+        /// <summary>
+        /// Builds a <see cref="ServiceBusClient"/> that authenticates with Entra ID RBAC (the runtime
+        /// service principal via <see cref="ClientSecretCredential"/>) - never a SAS key. The fully
+        /// qualified namespace is read from the configured Service Bus connection string's Endpoint; the
+        /// shared access key in that string is ignored. The runtime service principal needs the
+        /// "Azure Service Bus Data Owner" role on the namespace (assigned by the installer). See issue #138.
+        /// </summary>
+        public static ServiceBusClient CreateRbacServiceBusClient(AppConfig config)
+        {
+            var sbProps = ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString);
+            var credential = new ClientSecretCredential(config.TenantGUID.ToString(), config.ClientID, config.ClientSecret);
+            return new ServiceBusClient(sbProps.FullyQualifiedNamespace, credential);
+        }
 
         public async Task Init()
         {
@@ -296,7 +294,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         Task ExceptionReceivedHandler(ProcessErrorEventArgs args)
         {
             _telemetry.LogError(args.Exception, args.Exception.Message);
-            _telemetry.LogError($"ServiceBus processor encountered an exception '{args.Exception.Message}'.");
+            // Log the full exception (type + message + stack) as text too: the AppInsights ILogger
+            // adapter formats only the message and drops the Exception argument above, so otherwise the
+            // stack never reaches the trace logs (why a bare 401 showed up with "no exception logged").
+            _telemetry.LogError($"ServiceBus processor encountered an exception: {args.Exception}");
 
             _telemetry.LogError("Exception context for troubleshooting:");
             _telemetry.LogError($"- Namespace: {args.FullyQualifiedNamespace}");


### PR DESCRIPTION
Fixes #138.

## Problem

After deploying to a tenant whose Service Bus namespace has **local/SAS auth disabled**, the importer's Service Bus processor fails with `401 LocalAuthDisabled`. `CallQueueProcessor` picked the **SAS** path because `AppConfig.UseRBACForServiceBus` defaults `false` and isn't set in the WebJob's production config.

## Fix — minimal, no config-hive rebuild

- **`CallQueueProcessor`** (importer) and **`CallRecordWebhookController`** (Web sender) always authenticate with **Entra ID RBAC** (runtime service principal) via a shared `CreateRbacServiceBusClient` helper. The namespace + queue are still read from the **existing `ServiceBus` connection string's `Endpoint`** — the shared access key is ignored — so **existing installs keep their current config** (no connection-string/app-setting rebuild).
- Removed the `UseRBACForServiceBus` flag — RBAC is the only path.
- **Installer** now assigns the runtime SP **"Azure Service Bus Data Owner"** (gated on `ServiceBusEnabled`), alongside the existing Storage/Redis/Cognitive role assignments — so RBAC is authorized on the next installer run.
- Processor error handler now logs the **full exception text** (the AppInsights `ILogger` adapter formats only the message and drops the `Exception` arg — why a bare 401 showed up with "no exception logged").

## Out of scope

The broader config refactor (moving endpoints to app settings, dropping keys for Redis/Cognitive/Storage, wiki docs) is **deferred to a separate PR/release** — customers shouldn't have to rebuild their config hive for this fix.

## Verification

- Built clean with MSBuild 18: `Tests.UnitTests`, `Web`, `Tests.FakeDataGen` (covers all 5 changed projects).
- No remaining code references to `UseRBACForServiceBus`.

## Operator note

RBAC requires the runtime SP to hold **"Azure Service Bus Data Owner"** on the namespace. The installer assigns it on re-run; for a binaries-only redeploy, assign it once manually.

**No DB schema change.**
