### PR TITLE
Release: importer reliability (stop silent stalls/data-loss) + locale/paging/duration fixes + Key Vault firewall for public installs (publishable stable since 1648)

### DIFF
--- a/.github/agents/wiki-curator.agent.md
+++ b/.github/agents/wiki-curator.agent.md
@@ -1,0 +1,83 @@
+---
+name: wiki-curator
+description: Audits and improves this project's GitHub wiki for accuracy, structure, clarity, completeness and consistency. Produces a prioritized, citation-backed critique, applies clear-win fixes, verifies links/anchors/images, and (only with explicit permission) commits and pushes to the wiki. Use for "critique the wiki", "wiki day", wiki reorg, fixing stale docs, or refreshing screenshots.
+---
+
+# Wiki Curator
+
+You are the maintainer of this project's GitHub **wiki** — a separate Git repo from the code. Your job is to make the wiki **easy to read, accurate, complete and well structured**. You both *critique* and *fix*.
+
+## Where the wiki lives
+
+GitHub wikis are a sibling repo named `<repo>.wiki`. For this project that is normally cloned next to the code repo as `Microsoft365-Analytics-Insights.wiki` (e.g. `V:\Repos\Microsoft365-Analytics-Insights.wiki`). Confirm the real path before editing:
+
+- If the sibling `*.wiki` directory exists, work there.
+- If it does not, clone it (`git clone https://github.com/pnp/Microsoft365-Analytics-Insights.wiki.git` next to the code repo) **or** ask the user for the path. Never invent content from memory.
+
+The CLI discovers this agent from `.github/agents/` in the **code** repo, but all edits happen in the **wiki** repo.
+
+## Hard rules (never break these)
+
+1. **No real customer data, ever** — in any page, comment, code block, example or screenshot. Always use anonymized placeholders: `contoso.sharepoint.com`, fictional site/list names, fake tokens/IDs. If handed real customer data to work from, scrub it before anything lands in the wiki.
+2. **Never commit or push without explicit permission.** Make file changes only. The user grants push authorization per session ("push whenever you like to the wiki for this session"); if you don't have it for the current session, stop after editing and ask. This includes the wiki repo.
+3. **Always include the trailer** on any wiki commit you are authorized to make:
+   `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
+4. **Confirm before structural or branding changes** — splitting/merging/renaming pages, mass find-and-replace, reworking the sidebar IA, or changing the product name. Apply *clear wins* (typos, stale links, missing cross-links, broken anchors) directly; *gate* judgement calls behind a single focused question.
+5. **Verify every lead before you "fix" it.** Do not trust line numbers from sub-agents or from memory — open the file. Confirm "stale" facts against the **code** repo first. (Real examples that looked wrong but weren't: the SharePoint CSP Learn URL `content-securty-policy-trusted-script-sources` is Microsoft's genuine typo'd canonical slug; `Build: TBD` in the Release Notes "next release" section is an intentional placeholder; the App Insights *instrumentation key* references in manual setup are legitimate — the AITracker client script and legacy web-job logging use the key, while the importer uses the connection string.)
+
+## GitHub wiki mechanics
+
+- **Pages auto-title from the filename.** GitHub renders the page name as a heading above the body. Do **not** add an H1 that duplicates or contradicts the filename (it shows two titles). A page with no H1 is fine and common here — don't mass-add H1s.
+- **Filenames** map to URLs: spaces → `%20`, en-dash `–` → `%E2%80%93`. One page filename here contains an en-dash: `Installation-–-Manual-Setup.md`.
+- **Links** are `[Label](Page%20Name)` (no `.md`). Anchors are `#lower-kebab-case` derived from heading *text* and are position-independent — moving a section between pages keeps its anchor, but every inbound link must be repointed to the new page.
+- **Images** live in `media/` (and `media/screenshots/`); reference them relatively (`media/foo.png`). Prefer local assets over external `user-attachments` URLs, which can rot.
+- **Encoding:** read pages as UTF-8 and write them back as **UTF-8 without BOM**, preserving en-dashes and curly quotes. In PowerShell, read with `Get-Content -Raw -Encoding UTF8` (or `[IO.File]::ReadAllText`) and write with `[IO.File]::WriteAllText($path,$text,(New-Object Text.UTF8Encoding($false)))`. Do not let editors inject a BOM or mojibake en-dashes.
+
+## Project facts (so you don't re-derive them)
+
+- **Canonical product name: "Microsoft 365 Advanced Analytics"** (full solution: "Microsoft 365 Advanced Analytics Engine"). Standardize prose to this. **Protect** code/identifier strings — never rewrite `Office365ActivityImporter`, `operation_Name == "Office365ActivityImporter"`, the `Office 365 Management API`/Activity API name, or app-setting/connection-string keys. Generic platform references ("the Office 365 / Microsoft 365 admin center") are not the product name — only rename the `… Advanced Analytics [Engine]` phrases unless told otherwise.
+- **Use `learn.microsoft.com`**, not the legacy `docs.microsoft.com`, for Microsoft Learn links.
+- **Sidebar IA** is grouped into 8 sections (Overview, Getting started, Installation, Operations, Upgrade notes, Solutions, Reference, Project). `_Sidebar.md` is the source of truth for orphan checks; keep sidebar labels consistent with each page's title.
+- The wiki documents an Azure-hosted M365 analytics importer: two Entra app registrations (Installer + Runtime), RBAC-first auth (Service Bus / Storage / Redis / Cognitive / Key Vault), a SQL analytics DB, and Power BI reporting solutions built on top.
+
+## Method
+
+1. **Map it.** Read `_Sidebar.md`, then inventory every `*.md` with line counts. Note thin pages (<~15 lines) and very long pages (>~200 lines).
+2. **Mechanical checks** (scripts below): broken intra-wiki links, orphan pages, missing media, `[TBD]`/`[TODO]`/`FIXME`, sidebar-label vs page-title mismatches, and product-name variants.
+3. **Editorial review, page by page**, looking for: stale/inaccurate facts (verify against code first), duplicate/overlapping content across pages, cross-link gaps and dead-ends, readability red flags (unbroken paragraphs >6 lines, walls of consecutive screenshots, sections that need sub-headings, missing/stale manual TOCs), stubs, and vague/passive/informal tone or missing pass/fail checklists.
+4. **Prioritize by reader impact.** Present a "Top N highest-impact fixes" list, each citing `FileName.md:Lnn`. Filter out style nitpicks that don't affect a reader. Call out anything structural/branding for a decision.
+5. **Apply clear wins, gate the rest.** Edit directly for unambiguous fixes; ask one focused question for judgement calls.
+6. **Re-verify and finish.** Re-run the mechanical checks; if authorized, commit and push with a descriptive message + the Co-authored-by trailer.
+
+## Verification scripts
+
+Run from the wiki repo root. Report results; fix anything that fails.
+
+```powershell
+# Broken intra-wiki page links (ignores http(s), media/, and anchors)
+$pages = (Get-ChildItem -Filter *.md | ForEach-Object { [IO.Path]::GetFileNameWithoutExtension($_.Name) })
+$broken=@()
+foreach ($f in (Get-ChildItem -Filter *.md)) {
+  foreach ($m in ([regex]::Matches((Get-Content $f.FullName -Raw -Encoding UTF8), '\]\(([A-Za-z0-9%][A-Za-z0-9%\-]+)(#[^)]*)?\)'))) {
+    $t=[Uri]::UnescapeDataString($m.Groups[1].Value) -replace '%E2%80%93','–'
+    if ($t -notmatch '^https?:' -and $t -notmatch '^media' -and ($pages -notcontains $t)) { $broken += "BROKEN '$t' in $($f.Name)" } } }
+"Broken page links: " + ($(if($broken){$broken -join '; '}else{'none'}))
+
+# Orphan pages (exist but not linked from the sidebar)
+$side = Get-Content "_Sidebar.md" -Raw
+Get-ChildItem -Filter *.md | Where-Object { $_.Name -ne '_Sidebar.md' } | ForEach-Object {
+  $b=[IO.Path]::GetFileNameWithoutExtension($_.Name); $e=$b -replace ' ','%20' -replace '–','%E2%80%93'
+  if ($side -notmatch [regex]::Escape($b) -and $side -notmatch [regex]::Escape($e)) { "ORPHAN: $($_.Name)" } }
+
+# Missing referenced images
+foreach ($f in (Get-ChildItem -Filter *.md)) {
+  foreach ($m in ([regex]::Matches((Get-Content $f.FullName -Raw -Encoding UTF8), '\]\((media/[^)\s]+)\)'))) {
+    if (-not (Test-Path $m.Groups[1].Value)) { "MISSING IMAGE $($m.Groups[1].Value) in $($f.Name)" } } }
+
+# Placeholders left behind
+Select-String -Path *.md -Pattern '\[TBD\]|\[TODO\]|\bFIXME\b' | ForEach-Object { "$($_.Filename):$($_.LineNumber)" }
+```
+
+## Output
+
+Lead with what's already good (briefly), then the prioritized findings with `FileName.md:Lnn` citations, then a short list of structural/branding items needing a decision. Be concrete and high-signal. When you finish a fix pass, end with the verification results (links/orphans/images/placeholders all clean) and the commit you pushed.

--- a/src/AnalyticsEngine/.github/copilot-instructions.md
+++ b/src/AnalyticsEngine/.github/copilot-instructions.md
@@ -51,3 +51,34 @@ When writing or reviewing such code, call this out in the PR description / revie
 4. **For a one-off schema cleanup** (e.g. dropping orphan tables that were created by an older dev-only migration that we no longer want to ship), add a defensive follow-up migration that uses `IF OBJECT_ID(...) IS NOT NULL DROP TABLE [...]` so it is safe on fresh installs *and* on databases that already have the orphan tables.
 5. **Tests fail at `AnalyticsEntitiesContext..ctor` with `AutomaticDataLossException`?** Don't enable `AutomaticMigrationDataLossAllowed = true` to make them pass — that masks the real problem and silently drops customer data. Instead, fix the snapshot so the current model matches the latest migration's Target, or add an explicit cleanup migration.
 6. **Reproducing snapshot mismatches locally**: drop `(localdb)\MSSQLLocalDB::UnitTestingAnalytics` (the default test DB per `Tests.UnitTests/App.Debug.config`) to force a fresh migration replay; that's the fastest way to surface a snapshot/model mismatch before pushing.
+
+## Installer (App.ControlPanel) UI automation & screenshots
+
+Hard-won lessons for driving / screenshotting the built installer (`AnalyticsInstaller.exe` — the `App.ControlPanel` WinForms app) with PowerShell + UI Automation. The app's UIA tree is **sparse** and many standard controls surface as pattern-less `Pane`s with no Invoke/Toggle/Value patterns, so prefer Win32 window messages over UIA patterns.
+
+### Before launching
+- **Clear Mark-of-the-Web first.** A freshly built/copied output folder carries MOTW on the exe + DLLs, so Defender SmartScreen ("Windows protected your PC") blocks the launch and *hangs* `Start-Process` on the modal warning. Run `Get-ChildItem <outputDir> -Recurse -File | Unblock-File` before launching.
+- **The workstation must be UNLOCKED.** When the session is locked, `CopyFromScreen` (screenshots) and synthetic input (`mouse_event`/`keybd_event`/`SetForegroundWindow`) silently fail — only window messages (`SendMessage`/`BM_CLICK`/`WM_SETTEXT`) get through. `LogonUI.exe` can linger after unlock, so confirm with `CopyFromScreen`/`GetForegroundWindow`, not the LogonUI process.
+
+### Navigating the UI
+- **Welcome → wizard:** tick "I accept … at my own risk" then click "Install Solution" (`btnStartInstall`) to reveal the config tabs. This is *navigation, not an install*. The tab control's HWND already exists (hidden) on the Welcome screen, so detect wizard state with `IsWindowVisible`, not mere presence.
+- **Menus need the keyboard, not synthetic mouse clicks.** `Alt`+mnemonic opens them: File = `Alt+F` then `O` ("&Open Configuration File"). "Window" / "Solution Tests Configuration" have no mnemonic — use `Alt`, arrow keys, `Enter`. Requires the window to be foreground (hence unlocked).
+- **UIA `Invoke` on a menu item that opens a modal dialog BLOCKS / times out** until that dialog closes. Drive menus by keyboard, or run the Invoke in a background job while the main script handles the dialog.
+- **Tabs are a native `SysTabControl32`.** Read the selected index with `TCM_GETCURSEL`; to switch reliably, click the first header to focus the strip then `Ctrl+Tab` (auto-scrolls and fires `SelectedIndexChanged`). There are 8 tabs by default; loading a config (or enabling Web/Audit import on Targets) reveals the 9th, **SharePoint**.
+
+### Dialogs, fields, buttons
+- **Owned windows are UIA *Descendants*, not RootElement children.** The open-config dialog (custom title **"Load Configuration Details"**, not "Open"), the **"Enter Password"** form, and every MessageBox live under the main window — find them with `TreeScope::Descendants` filtered by process id.
+- **File-name field:** put the path on the clipboard and `Ctrl+V` into the focused field, then `Enter` (its inner edit isn't reliably reachable via UIA `SetValue`).
+- **Password fields:** UIA `ValuePattern.SetValue` throws on them; use `WM_SETTEXT` to the textbox HWND, then submit via the AcceptButton (`Enter`) or `BM_CLICK`.
+- **Buttons / checkboxes:** `BM_CLICK` via `SendMessage` to the control HWND (located by window text + class "BUTTON") is the most reliable click and ignores z-order/focus.
+- **Modal-stack deadlock:** `SendMessage`/`BM_CLICK` to a control whose UI thread is in a *nested* modal loop HANGS. Only message the innermost **enabled** window. Unwind a modal stack with the keyboard (`Enter` = OK, `Esc` = Cancel) against the window whose `IsEnabled = true`.
+- Sending one key sequence then a short retry loop can open the same modal **twice** — send once and poll patiently instead.
+
+### Solution Tests Configuration
+- Window menu → "Solution Tests Configuration" → "Autodetect from installer configuration" pulls SQL/FTP details from the deployed resources, then pops an **"Autodetect Complete"** MessageBox that must be dismissed *before* "Save" will register. SQL/FTP passwords are masked (`PasswordChar`), so the window is safe to screenshot.
+
+### Capturing
+- Capture the window region via `DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)` (tighter than `GetWindowRect`) + `Graphics.CopyFromScreen`. Raise the window first with `SetWindowPos(HWND_TOPMOST)` — more reliable than `SetForegroundWindow` alone.
+
+### Safety
+- **"Install/Upgrade" starts a real, irreversible Azure deployment immediately** — no confirmation prompt, and it re-saves the loaded config file first. **"Test Configuration" is read-only.** When a real (non-sanitized) config is loaded, do NOT screenshot the Credentials / Azure Config tabs (real secrets) — only the tests-config window (passwords masked), the test results, and the deploy-progress log are safe to capture.

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -194,11 +194,33 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 .AddSetting(KeyVaultSecretAddTask.CONFIG_KEY_CRED_TENANT_ID, config.InstallerAccount.DirectoryId)
                 .AddSetting(KeyVaultSecretAddTask.CONFIG_KEY_CRED_CLIENT_ID, config.InstallerAccount.ClientId)
                 .AddSetting(KeyVaultSecretAddTask.CONFIG_KEY_CRED_SECRET, config.InstallerAccount.Secret);
-            this.AddTask(_keyVaultTask,
-                new KeyVaultAddSecretAllPermissionsForAppRegistrationTask(kvAddInstallerAccountSecretAllPolicyConfig, logger, config.AzureLocation, tagDic),
-                new KeyVaultAddSecretReadPolicyForAppRegistrationTask(kvAddRuntimeAccountSecretReadPolicyConfig, logger, config.AzureLocation, tagDic),
-                new KeyVaultAddWebAppPermissionsTask(kvAddInstallerWebAppPermissionsConfig, logger, config.AzureLocation, tagDic),
-                new KeyVaultSecretAddTask(kvSecretAddConfig, logger));
+            var kvPolicyAllTask = new KeyVaultAddSecretAllPermissionsForAppRegistrationTask(kvAddInstallerAccountSecretAllPolicyConfig, logger, config.AzureLocation, tagDic);
+            var kvPolicyReadTask = new KeyVaultAddSecretReadPolicyForAppRegistrationTask(kvAddRuntimeAccountSecretReadPolicyConfig, logger, config.AzureLocation, tagDic);
+            var kvWebAppPermissionsTask = new KeyVaultAddWebAppPermissionsTask(kvAddInstallerWebAppPermissionsConfig, logger, config.AzureLocation, tagDic);
+            var kvSecretAddTask = new KeyVaultSecretAddTask(kvSecretAddConfig, logger);
+
+            // Enable the Key Vault firewall and allow-list the installer + App Service IPs (public
+            // deployments only). It runs right after the vault is created/updated and before the secret
+            // upload so the upload's data-plane call is allowed through. Private deployments keep public
+            // access disabled and reach the vault via a private endpoint, so no IP rules are needed.
+            // See issue #136.
+            if (allowPublicAccess)
+            {
+                var kvFirewallConfig = TaskConfig.GetConfigForName(config.KeyVaultName)
+                    .AddSetting(KeyVaultFirewallConfigTask.CONFIG_KEY_APP_SERVICE_NAME, config.AppServiceWebAppName);
+                if (vnetEnabled && !string.IsNullOrWhiteSpace(config.NetworkConfig.AppServiceIntegrationSubnetName))
+                {
+                    var integrationSubnetId = $"/subscriptions/{config.Subscription.SubId}/resourceGroups/{config.ResourceGroupName}/providers/Microsoft.Network/virtualNetworks/{config.NetworkConfig.VNetName}/subnets/{config.NetworkConfig.AppServiceIntegrationSubnetName}";
+                    kvFirewallConfig.AddSetting(KeyVaultFirewallConfigTask.CONFIG_KEY_VNET_SUBNET_ID, integrationSubnetId);
+                }
+                this.AddTask(_keyVaultTask,
+                    new KeyVaultFirewallConfigTask(kvFirewallConfig, logger, Location),
+                    kvPolicyAllTask, kvPolicyReadTask, kvWebAppPermissionsTask, kvSecretAddTask);
+            }
+            else
+            {
+                this.AddTask(_keyVaultTask, kvPolicyAllTask, kvPolicyReadTask, kvWebAppPermissionsTask, kvSecretAddTask);
+            }
 
             // ServiceBus - enforce Premium for VNet (private endpoints require Premium SKU)
             // Service Bus is only required by the Teams calls import; skip provisioning when disabled.

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultFirewallConfigTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultFirewallConfigTask.cs
@@ -1,0 +1,220 @@
+using Azure.ResourceManager.KeyVault;
+using Azure.ResourceManager.KeyVault.Models;
+using Azure.ResourceManager.AppService;
+using Azure.Core;
+using CloudInstallEngine.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure.InstallTasks
+{
+    /// <summary>
+    /// Enables the Key Vault firewall (network ACLs) and allow-lists the addresses the solution
+    /// actually uses, so the install both complies with Azure policies that require a firewall
+    /// (e.g. "Azure Key Vault should have firewall enabled or public network access disabled") and
+    /// keeps the vault reachable.
+    /// <para>
+    /// Runs only for public-access deployments (private deployments keep <c>publicNetworkAccess =
+    /// Disabled</c> and reach the vault through a private endpoint, so no IP rules are needed). It
+    /// allow-lists, depending on config:
+    /// <list type="bullet">
+    /// <item>the installer machine's public IP (so the runtime secret upload succeeds),</item>
+    /// <item>the App Service outbound IPs (so the web app / WebJobs can read secrets),</item>
+    /// <item>for VNet-integrated deployments, a virtual-network rule for the App Service integration subnet.</item>
+    /// </list>
+    /// The actual <c>defaultAction = Deny</c> / <c>bypass = AzureServices</c> is already set by
+    /// <see cref="KeyVaultTask"/> at create/update time; this task adds the allow rules via a PATCH so
+    /// existing access policies are preserved. Best-effort (non-critical): a networking hiccup logs
+    /// actionable guidance and does not abort an otherwise-successful install. See issue #136.
+    /// </summary>
+    public class KeyVaultFirewallConfigTask : InstallTaskInAzResourceGroup<KeyVaultResource>
+    {
+        public const string CONFIG_KEY_APP_SERVICE_NAME = "appServiceName";
+
+        /// <summary>Optional: App Service VNet-integration subnet resource ID (added as a virtual-network rule).</summary>
+        public const string CONFIG_KEY_VNET_SUBNET_ID = "vnetSubnetId";
+
+        const string IP_CHECK_URL = "http://icanhazip.com";
+        static readonly Regex IPv4Regex = new Regex(@"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", RegexOptions.Compiled);
+
+        public KeyVaultFirewallConfigTask(TaskConfig config, ILogger logger, AzureLocation azureLocation)
+            : base(config, logger, azureLocation, new Dictionary<string, string>())
+        {
+        }
+
+        public override string TaskName => "configure Key Vault firewall (allow installer + App Service IPs)";
+
+        // Best-effort networking config: a transient failure here must not abort an otherwise-successful install.
+        public override bool IsCritical => false;
+
+        public override async Task<KeyVaultResource> ExecuteTaskReturnResult(object contextArg)
+        {
+            var vault = EnsureContextArgType<KeyVaultResource>(contextArg);
+            var appServiceName = _config.GetConfigValue(CONFIG_KEY_APP_SERVICE_NAME);
+            var vnetSubnetId = _config.ContainsKey(CONFIG_KEY_VNET_SUBNET_ID) ? _config[CONFIG_KEY_VNET_SUBNET_ID] : null;
+
+            var allowIps = new List<string>();
+
+            // 1. Installer machine public IP - needed for the runtime secret upload (data-plane).
+            var installerIp = TryGetInstallerPublicIp();
+            if (!string.IsNullOrEmpty(installerIp))
+            {
+                allowIps.Add(installerIp);
+                _logger.LogInformation($"Allowing installer public IP '{installerIp}' through the Key Vault firewall.");
+            }
+            else
+            {
+                _logger.LogWarning("Could not determine the installer's public IP; the runtime secret upload may fail until the IP is added to the Key Vault firewall manually (vault Networking blade).");
+            }
+
+            // 2. App Service outbound IPs - needed so the web app / WebJobs can read secrets.
+            var appIps = GetAppServiceOutboundIps(appServiceName);
+            if (appIps.Count > 0)
+            {
+                allowIps.AddRange(appIps);
+                _logger.LogInformation($"Allowing {appIps.Count} App Service outbound IP(s) for '{appServiceName}' through the Key Vault firewall.");
+            }
+            else
+            {
+                _logger.LogWarning($"No outbound IPs resolved for App Service '{appServiceName}'; the web app may be unable to read secrets until its IPs are added to the Key Vault firewall manually.");
+            }
+
+            // 3. VNet-integrated deployments: allow the App Service integration subnet.
+            if (!string.IsNullOrWhiteSpace(vnetSubnetId))
+            {
+                _logger.LogInformation("Allowing the App Service VNet-integration subnet through the Key Vault firewall (virtual-network rule).");
+            }
+
+            var ruleSet = BuildFirewallRuleSet(vault.Data.Properties?.NetworkRuleSet, allowIps, vnetSubnetId);
+
+            _logger.LogInformation($"Enabling Key Vault '{vault.Data.Name}' firewall: default action 'Deny', bypass 'AzureServices', {ruleSet.IPRules.Count} IP rule(s), {ruleSet.VirtualNetworkRules.Count} virtual-network rule(s).");
+
+            var patch = new KeyVaultPatch { Properties = new KeyVaultPatchProperties { NetworkRuleSet = ruleSet } };
+            var updated = await vault.UpdateAsync(patch);
+            return updated.Value;
+        }
+
+        List<string> GetAppServiceOutboundIps(string appServiceName)
+        {
+            var site = Container.GetWebSites().Where(s => s.Data.Name == appServiceName).SingleOrDefault();
+            if (site == null)
+            {
+                _logger.LogWarning($"App Service '{appServiceName}' not found in the resource group; cannot allow its outbound IPs on the Key Vault firewall.");
+                return new List<string>();
+            }
+            return ParseOutboundIPv4Addresses(site.Data.PossibleOutboundIPAddresses);
+        }
+
+        string TryGetInstallerPublicIp()
+        {
+            try
+            {
+                var ip = new WebClient().DownloadString(IP_CHECK_URL)?.Trim();
+                if (!string.IsNullOrEmpty(ip) && IPv4Regex.IsMatch(ip))
+                {
+                    return ip;
+                }
+                _logger.LogWarning($"Public IP lookup from '{IP_CHECK_URL}' returned an unexpected value ('{ip}').");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not determine the installer's public IP from '{IP_CHECK_URL}': {ex.Message}");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Builds a firewall-enabled <see cref="KeyVaultNetworkRuleSet"/> (default action <c>Deny</c>,
+        /// bypass <c>AzureServices</c>) that preserves any existing IP / virtual-network rules and adds
+        /// the supplied allow IPs and (optional) VNet integration subnet. De-duplicates rules. Pure and
+        /// side-effect free so it can be unit tested without Azure.
+        /// </summary>
+        public static KeyVaultNetworkRuleSet BuildFirewallRuleSet(KeyVaultNetworkRuleSet existing, IEnumerable<string> allowIpAddresses, string vnetSubnetId)
+        {
+            var ruleSet = new KeyVaultNetworkRuleSet
+            {
+                DefaultAction = KeyVaultNetworkRuleAction.Deny,
+                Bypass = KeyVaultNetworkRuleBypassOption.AzureServices,
+            };
+
+            var seenIps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var seenSubnets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (existing != null)
+            {
+                foreach (var rule in existing.IPRules)
+                {
+                    if (!string.IsNullOrWhiteSpace(rule?.AddressRange) && seenIps.Add(rule.AddressRange))
+                    {
+                        ruleSet.IPRules.Add(new KeyVaultIPRule(rule.AddressRange));
+                    }
+                }
+                foreach (var rule in existing.VirtualNetworkRules)
+                {
+                    var existingSubnetId = rule?.Id?.ToString();
+                    if (!string.IsNullOrWhiteSpace(existingSubnetId) && seenSubnets.Add(existingSubnetId))
+                    {
+                        ruleSet.VirtualNetworkRules.Add(new KeyVaultVirtualNetworkRule(existingSubnetId)
+                        {
+                            IgnoreMissingVnetServiceEndpoint = rule.IgnoreMissingVnetServiceEndpoint
+                        });
+                    }
+                }
+            }
+
+            if (allowIpAddresses != null)
+            {
+                foreach (var ip in allowIpAddresses)
+                {
+                    var trimmed = ip?.Trim();
+                    if (!string.IsNullOrEmpty(trimmed) && seenIps.Add(trimmed))
+                    {
+                        ruleSet.IPRules.Add(new KeyVaultIPRule(trimmed));
+                    }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(vnetSubnetId) && seenSubnets.Add(vnetSubnetId))
+            {
+                // IgnoreMissingVnetServiceEndpoint = true so the rule is accepted even if the subnet's
+                // Microsoft.KeyVault service endpoint isn't (yet) enabled - the rule simply won't enforce
+                // until it is, which is harmless when a private endpoint already covers VNet access.
+                ruleSet.VirtualNetworkRules.Add(new KeyVaultVirtualNetworkRule(vnetSubnetId)
+                {
+                    IgnoreMissingVnetServiceEndpoint = true
+                });
+            }
+
+            return ruleSet;
+        }
+
+        /// <summary>
+        /// Parses a comma-separated list of IPv4 addresses (e.g. App Service
+        /// <c>PossibleOutboundIPAddresses</c>), trimming, validating and de-duplicating. Non-IPv4
+        /// entries (e.g. IPv6, which Key Vault IP rules don't support) and blanks are ignored.
+        /// </summary>
+        public static List<string> ParseOutboundIPv4Addresses(string commaSeparated)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrWhiteSpace(commaSeparated))
+            {
+                return result;
+            }
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var part in commaSeparated.Split(','))
+            {
+                var ip = part.Trim();
+                if (ip.Length > 0 && IPv4Regex.IsMatch(ip) && seen.Add(ip))
+                {
+                    result.Add(ip);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -52,7 +52,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
                 var props = new KeyVaultProperties(tenantId, new KeyVaultSku(KeyVaultSkuFamily.A, KeyVaultSkuName.Standard))
                 {
-                    PublicNetworkAccess = _allowPublicAccess ? "Enabled" : "Disabled"
+                    PublicNetworkAccess = _allowPublicAccess ? "Enabled" : "Disabled",
+                    // Enable the vault firewall up-front so the create itself complies with Azure
+                    // policies that require it (e.g. "Azure Key Vault should have firewall enabled or
+                    // public network access disabled"). KeyVaultFirewallConfigTask then allow-lists the
+                    // installer + App Service IPs so the vault stays reachable. See issue #136.
+                    NetworkRuleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(null, null, null)
                 };
                 var newKeyVaultInfo = new KeyVaultCreateOrUpdateContent(AzureLocation, props);
                 EnsureTagsOnNew(newKeyVaultInfo.Tags);
@@ -65,16 +70,25 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 _logger.LogInformation($"Found existing key vault '{r.Data.Name}'.");
 
                 var desiredAccess = _allowPublicAccess ? "Enabled" : "Disabled";
-                if (!string.Equals(r.Data.Properties.PublicNetworkAccess, desiredAccess, StringComparison.OrdinalIgnoreCase))
+                var publicAccessChanged = !string.Equals(r.Data.Properties.PublicNetworkAccess, desiredAccess, StringComparison.OrdinalIgnoreCase);
+                var firewallEnabled = r.Data.Properties.NetworkRuleSet?.DefaultAction == KeyVaultNetworkRuleAction.Deny;
+                if (publicAccessChanged || !firewallEnabled)
                 {
-                    _logger.LogInformation($"Updating key vault '{r.Data.Name}' public network access to '{desiredAccess}'...");
-                    var props = new KeyVaultProperties(r.Data.Properties.TenantId, r.Data.Properties.Sku)
+                    _logger.LogInformation($"Updating key vault '{r.Data.Name}': public network access '{desiredAccess}', firewall default action 'Deny'...");
+
+                    // PATCH (not a full CreateOrUpdate) so existing access policies and other vault
+                    // settings are preserved while we set public access and enable the firewall. The
+                    // firewall must be enabled here (not just by KeyVaultFirewallConfigTask) so this
+                    // update itself satisfies Azure Key Vault firewall policies. See issue #136.
+                    var patch = new KeyVaultPatch
                     {
-                        PublicNetworkAccess = desiredAccess
+                        Properties = new KeyVaultPatchProperties
+                        {
+                            PublicNetworkAccess = desiredAccess,
+                            NetworkRuleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(r.Data.Properties.NetworkRuleSet, null, null)
+                        }
                     };
-                    var update = new KeyVaultCreateOrUpdateContent(AzureLocation, props);
-                    EnsureTagsOnNew(update.Tags);
-                    var updateResult = await Container.GetKeyVaults().CreateOrUpdateAsync(WaitUntil.Completed, name, update);
+                    var updateResult = await r.UpdateAsync(patch);
                     r = updateResult.Value;
                 }
 

--- a/src/AnalyticsEngine/Common/DataUtils/ParallelListProcessor.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/ParallelListProcessor.cs
@@ -96,15 +96,36 @@ namespace DataUtils
                 // Throttle threads to max
                 await _sem.WaitAsync();
 
-                // Load chunk via delegate and release semaphore when done
-                var newTask = processListChunkDelegate(threadListChunk, threadIndex)
-                    .ContinueWith(_ => _sem.Release());
-
-                _tasks.Add(newTask);
+                // Track the actual WORK task (not a fire-and-forget release continuation) so any
+                // exception a chunk throws is surfaced by the Task.WhenAll below. The previous
+                // ContinueWith(_ => _sem.Release()) added the always-succeeding continuation to
+                // _tasks instead of the work, so every chunk exception was silently swallowed and
+                // callers (and operators) never found out a chunk had broken.
+                _tasks.Add(RunChunkAsync(processListChunkDelegate, threadListChunk, threadIndex));
             }
 
-            // Block for all threads
+            // Block for all threads. A faulted chunk re-throws here (unwrapped, so callers' typed
+            // catches still work) instead of being lost.
             await Task.WhenAll(_tasks);
+        }
+
+        /// <summary>
+        /// Runs a single chunk and always releases its throttle slot afterwards (success or failure).
+        /// Exceptions are deliberately allowed to propagate so the chunk's task faults and the awaiting
+        /// <see cref="Task.WhenAll(Task[])"/> re-throws them - the previous implementation released the
+        /// semaphore in a fire-and-forget ContinueWith and tracked that (always-successful) continuation
+        /// rather than the work, which silently swallowed every chunk exception.
+        /// </summary>
+        private async Task RunChunkAsync(Func<List<T>, int, Task> processListChunkDelegate, List<T> chunk, int threadIndex)
+        {
+            try
+            {
+                await processListChunkDelegate(chunk, threadIndex);
+            }
+            finally
+            {
+                _sem.Release();
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
@@ -284,19 +284,39 @@ namespace DataUtils
         }
 
         /// <summary>
-        /// Finds 'SPOInsightsDev' in 'Initial Catalog=SPOInsightsDev;' when propName='initial catalog'
+        /// Finds 'SPOInsightsDev' in 'Initial Catalog=SPOInsightsDev;' when propName='initial catalog'.
+        /// The value runs to the next ';' or, when the property is the last one with no trailing ';',
+        /// to the end of the string. Returns an empty string when the property is not present (or the
+        /// input is null/empty) rather than throwing.
         /// </summary>
         /// <param name="fullString"></param>
         /// <param name="propName"></param>
         public static string FindValueForProp(string fullString, string propName)
         {
-            int propStart = fullString.IndexOf(propName + "=", StringComparison.CurrentCultureIgnoreCase);
-            int propNameLength = propName.Length + "=".Length;
-            int propValStart = propStart + propNameLength;
-            int propValEnd = fullString.IndexOf(";", propValStart);
-            string returnVal = fullString.Substring(propValStart, propValEnd - propValStart);
+            if (string.IsNullOrEmpty(fullString) || string.IsNullOrEmpty(propName))
+            {
+                return string.Empty;
+            }
 
-            return returnVal;
+            int propStart = fullString.IndexOf(propName + "=", StringComparison.CurrentCultureIgnoreCase);
+            if (propStart == -1)
+            {
+                // Property not present in the string.
+                return string.Empty;
+            }
+
+            int propValStart = propStart + propName.Length + "=".Length;
+
+            // Value ends at the next ';', or - when this is the last property with no trailing ';' -
+            // at the end of the string. The old code fed the -1 from a missing ';' straight into
+            // Substring's length argument and threw ArgumentOutOfRangeException.
+            int propValEnd = fullString.IndexOf(";", propValStart, StringComparison.Ordinal);
+            if (propValEnd == -1)
+            {
+                propValEnd = fullString.Length;
+            }
+
+            return fullString.Substring(propValStart, propValEnd - propValStart);
         }
 
         static char SINGLE_QUOTE = char.Parse("\"");

--- a/src/AnalyticsEngine/Common/Entities/Installer/TargetSolutionConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Installer/TargetSolutionConfig.cs
@@ -56,7 +56,7 @@ namespace Common.Entities.Installer
         public override List<string> ValidatInputAndGetErrors()
         {
             var errors = new List<string>();
-            if (SolutionTargeted == SolutionImportType.Adoptify && (SolutionLanguageCode != LANG_ENGLISH || SolutionLanguageCode != LANG_ESPAÑOL))
+            if (SolutionTargeted == SolutionImportType.Adoptify && (SolutionLanguageCode != LANG_ENGLISH && SolutionLanguageCode != LANG_ESPAÑOL))
             {
                 errors.Add("Select a valid target language");
             }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotStressTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Diagnostics;
+using Tests.FakeDataGen.Seeding;
 using UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 
@@ -35,6 +36,7 @@ namespace Tests.FakeDataGen.StressTests
             int totalEvents = GetIntegerInput("Total copilot events to generate", 5000, 1, 1000000);
             int batchSize = GetIntegerInput("Events per commit batch", 500, 1, 100000);
             int maxResourcesPerEvent = GetIntegerInput("Max accessed resources per event", 5, 0, 50);
+            int distinctUsers = GetIntegerInput("Distinct users to seed (with departments, job titles, licenses)", 1000, 1, 200000);
             bool includeAgents = GetBooleanInput("Include agent data", true);
             bool collectGarbageEachBatch = GetBooleanInput("Force GC after each batch", false);
             bool verbose = GetBooleanInput("Verbose output", false);
@@ -58,6 +60,7 @@ namespace Tests.FakeDataGen.StressTests
             Console.WriteLine($"  Total events: {totalEvents:N0}");
             Console.WriteLine($"  Batches: {batchCount:N0} x {batchSize:N0} events");
             Console.WriteLine($"  Up to {(long)totalEvents * maxResourcesPerEvent:N0} accessed resource records");
+            Console.WriteLine($"  Distinct users: {distinctUsers:N0} (seeded with departments, job titles, company, location + licenses)");
             Console.WriteLine($"  Mode: {(commitToSql ? "Full pipeline (staging + SQL commit)" : "Staging only (in-memory)")}");
             Console.WriteLine();
             Console.WriteLine("Press any key to start test...");
@@ -75,6 +78,12 @@ namespace Tests.FakeDataGen.StressTests
                         db.Database.Initialize(force: false);
                     }
                     Console.WriteLine("Database ready.");
+
+                    // Seed a pool of users with realistic metadata (departments, job titles,
+                    // company, locations) + licenses so the audit_events committed below link to
+                    // real users and copilot reports sliced by department / job title have data.
+                    Console.WriteLine($"Seeding {distinctUsers:N0} users with metadata...");
+                    SeedUsersWithMetadata(connectionString, distinctUsers);
                 }
                 catch (Exception ex)
                 {
@@ -87,6 +96,10 @@ namespace Tests.FakeDataGen.StressTests
 
             var result = new StressTestResult { Success = true };
             var random = new Random(42); // Fixed seed for reproducibility
+
+            // UPN pool the events draw from. Matches the users seeded above (when committing to
+            // SQL) so every event links to a metadata-rich user; harmless in staging-only mode.
+            var userCatalogue = BuildUserCatalogue(distinctUsers);
 
             try
             {
@@ -106,7 +119,7 @@ namespace Tests.FakeDataGen.StressTests
 
                     try
                     {
-                        long batchEvents = RunBatch(eventsThisBatch, maxResourcesPerEvent, includeAgents, commitToSql, connectionString, random);
+                        long batchEvents = RunBatch(eventsThisBatch, maxResourcesPerEvent, includeAgents, commitToSql, connectionString, userCatalogue, random);
 
                         totalEventsProcessed += batchEvents;
                         _memoryMonitor.UpdatePeak();
@@ -171,7 +184,7 @@ namespace Tests.FakeDataGen.StressTests
         }
 
         private long RunBatch(int eventCount, int maxResourcesPerEvent, bool includeAgents,
-            bool commitToSql, string connectionString, Random random)
+            bool commitToSql, string connectionString, IReadOnlyList<string> userCatalogue, Random random)
         {
             // Use a fake connection string for staging-only mode; real one for SQL commits
             var effectiveConnectionString = commitToSql ? connectionString : "Server=fake;Database=fake;";
@@ -179,14 +192,15 @@ namespace Tests.FakeDataGen.StressTests
             var manager = new CopilotAuditEventManager(effectiveConnectionString, new FakeCopilotMetadataLoader(),
                 quietLogger);
 
-            // Build all events first, tracking their IDs for prerequisite inserts
-            var eventIds = new List<Guid>(eventCount);
+            // Build all events first, tracking their IDs + owning user UPN for prerequisite inserts
+            var eventIds = new List<(Guid Id, string Upn)>(eventCount);
             var sw = Stopwatch.StartNew();
 
             for (int i = 0; i < eventCount; i++)
             {
                 var eventId = Guid.NewGuid();
-                eventIds.Add(eventId);
+                var upn = userCatalogue[random.Next(userCatalogue.Count)];
+                eventIds.Add((eventId, upn));
 
                 var commonEvent = new CommonAuditEvent
                 {
@@ -196,7 +210,7 @@ namespace Tests.FakeDataGen.StressTests
                     User = new User
                     {
                         AzureAdId = Guid.NewGuid().ToString(),
-                        UserPrincipalName = $"stressuser{random.Next(1, 1000)}@contoso.com"
+                        UserPrincipalName = upn
                     }
                 };
 
@@ -210,7 +224,7 @@ namespace Tests.FakeDataGen.StressTests
             {
                 // Pre-insert audit_events rows so the copilot_chats FK constraint is satisfied
                 sw.Restart();
-                Console.WriteLine($"  Inserting {eventIds.Count} prerequisite audit_events rows...");
+                Console.WriteLine($"  Inserting {eventIds.Count} prerequisite audit_events rows (linked to seeded users)...");
                 InsertPrerequisiteAuditEvents(connectionString, eventIds);
                 Console.WriteLine($"  Prerequisite audit_events insert: {sw.ElapsedMilliseconds:N0}ms");
 
@@ -224,25 +238,77 @@ namespace Tests.FakeDataGen.StressTests
         }
 
         /// <summary>
-        /// Bulk-inserts minimal audit_events rows so the copilot_chats FK constraint is satisfied.
+        /// Inserts audit_events rows (each linked to its seeded, metadata-rich user) so the
+        /// copilot_chats FK constraint is satisfied and copilot data is attributed to real users.
         /// Fully synchronous to avoid async deadlocks on .NET Framework 4.8.
         /// </summary>
-        private void InsertPrerequisiteAuditEvents(string connectionString, List<Guid> eventIds)
+        private void InsertPrerequisiteAuditEvents(string connectionString, List<(Guid Id, string Upn)> eventIds)
         {
             using (var conn = new SqlConnection(connectionString))
             {
                 conn.Open();
                 using (var cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = "INSERT INTO audit_events (id, time_stamp) VALUES (@id, @ts)";
-                    var pId = cmd.Parameters.AddWithValue("@id", DBNull.Value);
-                    var pTs = cmd.Parameters.AddWithValue("@ts", DateTime.UtcNow);
+                    // Link each audit_event to its seeded user so copilot reports sliced by
+                    // department / job title / license have real data. Users are pre-seeded in
+                    // SeedUsersWithMetadata, so the join always resolves.
+                    cmd.CommandText = @"
+INSERT INTO audit_events (id, time_stamp, user_id)
+SELECT @id, @ts, u.id
+FROM users u
+WHERE u.user_name = @upn;";
+                    var pId = cmd.Parameters.Add("@id", System.Data.SqlDbType.UniqueIdentifier);
+                    var pTs = cmd.Parameters.Add("@ts", System.Data.SqlDbType.DateTime);
+                    var pUpn = cmd.Parameters.Add("@upn", System.Data.SqlDbType.NVarChar, 400);
 
-                    foreach (var id in eventIds)
+                    foreach (var ev in eventIds)
                     {
-                        pId.Value = id;
+                        pId.Value = ev.Id;
+                        pTs.Value = DateTime.UtcNow;
+                        pUpn.Value = ev.Upn;
                         cmd.ExecuteNonQuery();
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds the UPN pool the stress events draw from. Matches the format used by
+        /// <see cref="UserMetadataSeeder.SeedUsers"/> so events line up with the seeded users.
+        /// </summary>
+        private static List<string> BuildUserCatalogue(int count)
+        {
+            var list = new List<string>(count);
+            for (int i = 0; i < count; i++) list.Add($"stressuser{i}@contoso.com");
+            return list;
+        }
+
+        /// <summary>
+        /// Seeds the shared metadata lookups + license catalogue, then a pool of users carrying
+        /// department, job title, company, location (and other) metadata plus random licenses, via
+        /// the same idempotent helper used by the other stress tests. Re-runnable: existing stress
+        /// users are left untouched.
+        /// </summary>
+        private static void SeedUsersWithMetadata(string connectionString, int userCount)
+        {
+            var random = new Random(123);
+            using (var conn = new SqlConnection(connectionString))
+            {
+                conn.Open();
+                UserMetadataSeeder.EnsureMetadataLookups(conn);
+                UserMetadataSeeder.EnsureLicenseTypes(conn);
+                var licenseIds = UserMetadataSeeder.LoadLicenseTypeIds(conn);
+
+                var seeded = UserMetadataSeeder.SeedUsers(conn, userCount, random);
+                Console.WriteLine($"  Seeded {seeded.Count:N0} new users with department/job-title/company/location " +
+                                  $"metadata (existing stress users left untouched).");
+
+                if (seeded.Count > 0 && licenseIds.Count > 0)
+                {
+                    var newUserIds = new List<int>(seeded.Count);
+                    foreach (var u in seeded) newUserIds.Add(u.Id);
+                    int assigned = UserMetadataSeeder.AssignRandomLicenses(conn, newUserIds, licenseIds, random, maxLicensesPerUser: 2);
+                    Console.WriteLine($"  Assigned {assigned:N0} license(s) across newly-created users.");
                 }
             }
         }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeSentEmailSentimentScorer.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeSentEmailSentimentScorer.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.Email;
+
+namespace Tests.FakeDataGen.StressTests.FakeLoaders
+{
+    /// <summary>
+    /// Fake <see cref="ISentEmailSentimentScorer"/> that assigns every message a synthetic
+    /// cognitive/sentiment score in the [0,1] range without calling Azure AI Language, so the
+    /// stress test exercises the scoring + persistence path and writes real
+    /// <c>sent_emails.cognitive_score</c> values instead of NULLs.
+    ///
+    /// Following the codebase convention, the score is the "positive" end of the scale:
+    /// <c>0 = very unhappy, 1 = very happy</c>. Replies are deliberately skewed towards the happy
+    /// end (mean ~0.7) but with a gentle "mood wave" along each user's message sequence plus
+    /// per-message noise and the occasional bad day, so the data has realistic ups and downs
+    /// rather than a single constant value.
+    /// </summary>
+    public class FakeSentEmailSentimentScorer : ISentEmailSentimentScorer
+    {
+        private readonly int _seed;
+
+        public FakeSentEmailSentimentScorer(int seed = 2024)
+        {
+            _seed = seed;
+        }
+
+        // Enabled so the importer requests message bodies and runs the scoring path end-to-end.
+        public bool IsEnabled => true;
+
+        public Task<Dictionary<string, double?>> ScoreAsync(IReadOnlyCollection<GraphSentMessage> messagesWithBody)
+        {
+            var result = new Dictionary<string, double?>(StringComparer.Ordinal);
+            if (messagesWithBody == null)
+                return Task.FromResult(result);
+
+            foreach (var msg in messagesWithBody)
+            {
+                if (string.IsNullOrEmpty(msg?.Id))
+                    continue;
+                result[msg.Id] = ScoreForMessage(msg.Id);
+            }
+
+            return Task.FromResult(result);
+        }
+
+        /// <summary>
+        /// Produces a deterministic, reproducible score in [0,1] for a message id. Generally happy
+        /// but with a sine "mood wave" over the per-user message sequence, random noise and an
+        /// occasional bad day so the score dips down too.
+        /// </summary>
+        private double ScoreForMessage(string messageId)
+        {
+            long sequence = ExtractSequence(messageId);
+
+            // Deterministic per-message RNG so reruns produce identical scores.
+            var random = new Random(unchecked(_seed * 397 + StableHash(messageId)));
+
+            // Happy baseline.
+            double mood = 0.68;
+
+            // Gentle ups and downs across the user's message timeline.
+            mood += 0.18 * Math.Sin(sequence / 6.0);
+
+            // Per-message noise, +/- 0.12.
+            mood += (random.NextDouble() - 0.5) * 0.24;
+
+            // Roughly one message in ten is a "bad day" that pulls the score well down.
+            if (random.NextDouble() < 0.10)
+                mood -= 0.35 + random.NextDouble() * 0.35;
+
+            if (mood < 0.0) mood = 0.0;
+            if (mood > 1.0) mood = 1.0;
+            return mood;
+        }
+
+        /// <summary>
+        /// Extracts the trailing numeric "sequence" from a fake message id of the shape
+        /// <c>stress-msg-NNNNNN-SSSSSS</c> so the mood wave progresses along a user's messages.
+        /// Falls back to a stable hash when the id doesn't match (the wave just becomes noise).
+        /// </summary>
+        private static long ExtractSequence(string messageId)
+        {
+            int lastDash = messageId.LastIndexOf('-');
+            if (lastDash >= 0 && lastDash < messageId.Length - 1)
+            {
+                var tail = messageId.Substring(lastDash + 1);
+                if (long.TryParse(tail, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seq))
+                    return seq;
+            }
+            return StableHash(messageId);
+        }
+
+        /// <summary>
+        /// Process-stable hash (FNV-1a) so scores are reproducible across runs - unlike
+        /// <see cref="string.GetHashCode"/>, which can be randomised per process.
+        /// </summary>
+        private static int StableHash(string value)
+        {
+            unchecked
+            {
+                const int fnvPrime = 16777619;
+                int hash = (int)2166136261;
+                foreach (var ch in value)
+                {
+                    hash = (hash ^ ch) * fnvPrime;
+                }
+                return hash & 0x7FFFFFFF;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeSentEmailSourceLoader.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeSentEmailSourceLoader.cs
@@ -11,6 +11,11 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
     /// <see cref="GraphSentMessage"/> objects per user, without calling Microsoft Graph.
     /// Used to stress test the <c>SentEmailImporter</c> pipeline (deduplication, address
     /// resolution, sentiment scoring path, EF batching, SQL persistence).
+    ///
+    /// Each message is classified as internal or external (see <c>internalEmailPercent</c>):
+    /// internal messages address recipients on the <em>same</em> domain as the sender, external
+    /// messages address recipients on unrelated public domains, so the data has a realistic
+    /// internal/external mix.
     /// </summary>
     public class FakeSentEmailSourceLoader : ISentEmailSourceLoader
     {
@@ -45,6 +50,7 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
         private readonly int _messagesPerUser;
         private readonly int _maxRecipientsPerEmail;
         private readonly int _distinctRecipientPoolSize;
+        private readonly int _internalEmailPercent;
         private readonly bool _hasMailReadAccess;
         private readonly int _seed;
         private int _userCounter;
@@ -53,16 +59,20 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
             int messagesPerUser,
             int maxRecipientsPerEmail,
             int distinctRecipientPoolSize,
+            int internalEmailPercent = 70,
             bool hasMailReadAccess = true,
             int seed = 2024)
         {
             if (messagesPerUser < 0) throw new ArgumentOutOfRangeException(nameof(messagesPerUser));
             if (maxRecipientsPerEmail < 1) throw new ArgumentOutOfRangeException(nameof(maxRecipientsPerEmail));
             if (distinctRecipientPoolSize < 1) throw new ArgumentOutOfRangeException(nameof(distinctRecipientPoolSize));
+            if (internalEmailPercent < 0 || internalEmailPercent > 100)
+                throw new ArgumentOutOfRangeException(nameof(internalEmailPercent), "Must be between 0 and 100.");
 
             _messagesPerUser = messagesPerUser;
             _maxRecipientsPerEmail = maxRecipientsPerEmail;
             _distinctRecipientPoolSize = distinctRecipientPoolSize;
+            _internalEmailPercent = internalEmailPercent;
             _hasMailReadAccess = hasMailReadAccess;
             _seed = seed;
         }
@@ -79,9 +89,14 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
             var messages = new List<GraphSentMessage>(_messagesPerUser);
             var fromAddress = !string.IsNullOrEmpty(user?.Mail) ? user.Mail : $"stress-{userIndex}@stress.local";
             var fromName = user?.UserPrincipalName ?? fromAddress;
+            var senderDomain = GetDomain(fromAddress);
 
             for (int i = 0; i < _messagesPerUser; i++)
             {
+                // Internal emails address recipients on the sender's own domain; external ones
+                // use unrelated public domains. random.Next(100) < percent gives ~percent% internal.
+                bool isInternal = random.Next(100) < _internalEmailPercent;
+
                 var msg = new GraphSentMessage
                 {
                     // Stable id: user index + sequence => unique per user, reproducible across runs.
@@ -92,7 +107,7 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
                     {
                         EmailAddress = new GraphEmailAddress { Name = fromName, Address = fromAddress }
                     },
-                    ToRecipients = BuildRecipients(random)
+                    ToRecipients = BuildRecipients(random, isInternal, senderDomain)
                 };
 
                 if (includeBody)
@@ -118,14 +133,15 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
             });
         }
 
-        private List<GraphEmailRecipient> BuildRecipients(Random random)
+        private List<GraphEmailRecipient> BuildRecipients(Random random, bool isInternal, string senderDomain)
         {
             int count = 1 + random.Next(_maxRecipientsPerEmail);
             var list = new List<GraphEmailRecipient>(count);
             for (int i = 0; i < count; i++)
             {
                 int slot = random.Next(_distinctRecipientPoolSize);
-                var domain = DomainPool[slot % DomainPool.Length];
+                // Internal => same domain as the sender; external => an unrelated public domain.
+                var domain = isInternal ? senderDomain : DomainPool[slot % DomainPool.Length];
                 var address = $"recipient-{slot:D6}@{domain}";
                 list.Add(new GraphEmailRecipient
                 {
@@ -137,6 +153,16 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
                 });
             }
             return list;
+        }
+
+        /// <summary>
+        /// Returns the domain part (after the last '@') of an address, falling back to
+        /// <c>stress.local</c> when the address has no domain.
+        /// </summary>
+        private static string GetDomain(string address)
+        {
+            int at = address?.LastIndexOf('@') ?? -1;
+            return at >= 0 && at < address.Length - 1 ? address.Substring(at + 1) : "stress.local";
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
@@ -38,6 +38,10 @@ namespace Tests.FakeDataGen.StressTests
         private static string[] Departments => SeedDataCatalogue.Departments;
         private static string[] Companies => SeedDataCatalogue.Companies;
         private static string[] JobTitles => SeedDataCatalogue.JobTitles;
+        private static string[] StatesOrProvinces => SeedDataCatalogue.StatesOrProvinces;
+        private static string[] Countries => SeedDataCatalogue.Countries;
+        private static string[] OfficeLocations => SeedDataCatalogue.OfficeLocations;
+        private static string[] UsageLocations => SeedDataCatalogue.UsageLocations;
 
         protected override StressTestResult Execute()
         {
@@ -411,19 +415,24 @@ namespace Tests.FakeDataGen.StressTests
                 // Load current license_type ids so we can randomly assign one per newly-created user.
                 var licenseTypeIds = UserMetadataSeeder.LoadLicenseTypeIds(conn);
 
-                // Insert distinct users with department, company, and job title.
-                // Track which UPNs were actually inserted (i.e. didn't already exist) so we can
-                // assign each newly-created user a single random license below.
+                // Insert distinct users with full metadata (department, company, job title,
+                // state/province, country, office + usage location). Track which UPNs were actually
+                // inserted (i.e. didn't already exist) so we can assign each newly-created user a
+                // single random license below.
                 var newlyCreatedUpns = new List<string>();
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
 IF NOT EXISTS (SELECT 1 FROM users WHERE user_name = @upn)
 BEGIN
-    INSERT INTO users (user_name, department_id, company_name_id, job_title_id)
-    SELECT @upn, d.id, c.id, j.id
-    FROM user_departments d, user_company_name c, user_job_titles j
-    WHERE d.name = @dept AND c.name = @company AND j.name = @job;
+    INSERT INTO users (user_name, department_id, company_name_id, job_title_id,
+                       state_or_province_id, country_or_region_id, office_location_id, usage_location_id)
+    SELECT @upn, d.id, c.id, j.id, s.id, co.id, o.id, u.id
+    FROM user_departments d, user_company_name c, user_job_titles j,
+         user_state_or_province s, user_country_or_region co,
+         user_office_locations o, user_usage_locations u
+    WHERE d.name = @dept AND c.name = @company AND j.name = @job
+      AND s.name = @state AND co.name = @country AND o.name = @office AND u.name = @usage;
     SELECT 1;
 END
 ELSE
@@ -432,6 +441,10 @@ ELSE
                     var pDept = cmd.Parameters.Add("@dept", System.Data.SqlDbType.NVarChar, 100);
                     var pCompany = cmd.Parameters.Add("@company", System.Data.SqlDbType.NVarChar, 100);
                     var pJob = cmd.Parameters.Add("@job", System.Data.SqlDbType.NVarChar, 100);
+                    var pState = cmd.Parameters.Add("@state", System.Data.SqlDbType.NVarChar, 100);
+                    var pCountry = cmd.Parameters.Add("@country", System.Data.SqlDbType.NVarChar, 100);
+                    var pOffice = cmd.Parameters.Add("@office", System.Data.SqlDbType.NVarChar, 100);
+                    var pUsage = cmd.Parameters.Add("@usage", System.Data.SqlDbType.NVarChar, 100);
                     var seenUsers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     foreach (var ev in eventIds)
                     {
@@ -441,6 +454,10 @@ ELSE
                             pDept.Value = Departments[random.Next(Departments.Length)];
                             pCompany.Value = Companies[random.Next(Companies.Length)];
                             pJob.Value = JobTitles[random.Next(JobTitles.Length)];
+                            pState.Value = StatesOrProvinces[random.Next(StatesOrProvinces.Length)];
+                            pCountry.Value = Countries[random.Next(Countries.Length)];
+                            pOffice.Value = OfficeLocations[random.Next(OfficeLocations.Length)];
+                            pUsage.Value = UsageLocations[random.Next(UsageLocations.Length)];
                             var inserted = Convert.ToInt32(cmd.ExecuteScalar());
                             if (inserted == 1)
                             {

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
@@ -16,8 +16,9 @@ namespace Tests.FakeDataGen.StressTests
     /// <summary>
     /// End-to-end stress test for the sent-email import pipeline. Drives the real
     /// <see cref="SentEmailImporter"/> using a fake <see cref="ISentEmailSourceLoader"/>
-    /// and a no-op <see cref="ISentEmailSentimentScorer"/>, so the pipeline (deduplication,
-    /// existing-key lookups, address resolution, EF batching, SQL persistence and run
+    /// and a fake <see cref="ISentEmailSentimentScorer"/> (synthetic 0-1 cognitive scores,
+    /// or a no-op when scoring is turned off), so the pipeline (deduplication, existing-key
+    /// lookups, address resolution, sentiment scoring, EF batching, SQL persistence and run
     /// statistics) is exercised at scale without calling Microsoft Graph or Azure AI.
     /// </summary>
     public class SentEmailImporterStressTest : BaseStressTest
@@ -30,8 +31,10 @@ namespace Tests.FakeDataGen.StressTests
             int messagesPerUser = GetIntegerInput("Synthetic sent messages per user", 200, 0, 500_000);
             int maxRecipientsPerEmail = GetIntegerInput("Max recipients per message", 3, 1, 50);
             int distinctRecipientPool = GetIntegerInput("Distinct recipient address pool size", 500, 1, 1_000_000);
+            int internalEmailPercent = GetIntegerInput("Percent of emails that are internal (recipients on sender's domain)", 70, 0, 100);
             bool deleteFirst = GetBooleanInput("Delete previously-generated stress data before run", false);
             bool runTwice = GetBooleanInput("Run import twice (second pass exercises duplicate detection)", false);
+            bool generateScores = GetBooleanInput("Generate cognitive/sentiment scores (0-1, mostly happy)", true);
 
             string connectionString = ConnectionString;
             if (string.IsNullOrEmpty(connectionString))
@@ -53,7 +56,9 @@ namespace Tests.FakeDataGen.StressTests
             Console.WriteLine($"  Synthetic messages per user: {messagesPerUser:N0}");
             Console.WriteLine($"  Total messages generated:    {expectedRows:N0}");
             Console.WriteLine($"  Recipient pool size:         {distinctRecipientPool:N0}");
+            Console.WriteLine($"  Internal email mix:          {internalEmailPercent}% internal / {100 - internalEmailPercent}% external");
             Console.WriteLine($"  Run twice (dedup test):      {(runTwice ? "yes" : "no")}");
+            Console.WriteLine($"  Cognitive scoring:           {(generateScores ? "on (0-1, mostly happy)" : "off")}");
             Console.WriteLine();
             Console.WriteLine("Press any key to start (Ctrl-C to abort)...");
             Console.ReadKey();
@@ -85,14 +90,21 @@ namespace Tests.FakeDataGen.StressTests
                 int seededUsers = SeedUsers(dbFactory, connectionString, userCount);
                 _memoryMonitor.UpdatePeak();
 
-                // 2) Build importer wired up with the fake loader + null sentiment scorer.
+                // 2) Build importer wired up with the fake loader + sentiment scorer.
                 var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
                 var appConfig = FakeAppConfigFactory.Create();
                 var fakeLoader = new FakeSentEmailSourceLoader(
                     messagesPerUser: messagesPerUser,
                     maxRecipientsPerEmail: maxRecipientsPerEmail,
-                    distinctRecipientPoolSize: distinctRecipientPool);
-                var sentimentScorer = NullSentEmailSentimentScorer.Instance;
+                    distinctRecipientPoolSize: distinctRecipientPool,
+                    internalEmailPercent: internalEmailPercent);
+                // Use the fake scorer to populate sent_emails.cognitive_score with synthetic
+                // 0-1 sentiment values (0 = very unhappy, 1 = very happy). Skewed happy with
+                // ups and downs so the data isn't a single constant. The null scorer leaves
+                // every cognitive_score NULL, so only switch to it when scoring is turned off.
+                ISentEmailSentimentScorer sentimentScorer = generateScores
+                    ? (ISentEmailSentimentScorer)new FakeSentEmailSentimentScorer()
+                    : NullSentEmailSentimentScorer.Instance;
 
                 var importer = new SentEmailImporter(
                     telemetry,
@@ -123,6 +135,8 @@ namespace Tests.FakeDataGen.StressTests
 
                 long actualMessages = CountStressRows(dbFactory);
                 long actualRecipients = CountStressRecipients(dbFactory);
+                string scoreSummary = DescribeScoreCoverage(dbFactory);
+                string mixSummary = DescribeInternalExternalMix(dbFactory);
 
                 result.ItemsProcessed = actualMessages;
                 result.Duration = totalSw.Elapsed;
@@ -131,7 +145,8 @@ namespace Tests.FakeDataGen.StressTests
                 result.FinalMemoryBytes = _memoryMonitor.CurrentMemoryBytes;
                 result.Message =
                     $"Seeded {seededUsers:N0} users; importer persisted {actualMessages:N0} sent_email rows " +
-                    $"(with {actualRecipients:N0} sent_email_recipients rows).";
+                    $"(with {actualRecipients:N0} sent_email_recipients rows). Cognitive scores: {scoreSummary}. " +
+                    $"Internal/external: {mixSummary}.";
 
                 _memoryMonitor.PrintReport();
             }
@@ -275,6 +290,72 @@ namespace Tests.FakeDataGen.StressTests
                 return db.SentEmailRecipients
                     .LongCount(r => r.SentEmail.GraphMessageId.StartsWith("stress-msg-"));
             }
+        }
+
+        /// <summary>
+        /// Summarises how many stress sent_email rows received a cognitive score and the
+        /// distribution (avg/min/max), so a run confirms scores were actually written.
+        /// </summary>
+        private static string DescribeScoreCoverage(Func<AnalyticsEntitiesContext> dbFactory)
+        {
+            using (var db = dbFactory())
+            {
+                var stressRows = db.SentEmails.Where(s => s.GraphMessageId.StartsWith("stress-msg-"));
+                long total = stressRows.LongCount();
+                if (total == 0)
+                    return "no stress rows present";
+
+                var scoredRows = stressRows.Where(s => s.CognitiveScore != null);
+                long scored = scoredRows.LongCount();
+                if (scored == 0)
+                    return $"0/{total:N0} rows scored";
+
+                double avg = scoredRows.Average(s => s.CognitiveScore).Value;
+                double min = scoredRows.Min(s => s.CognitiveScore).Value;
+                double max = scoredRows.Max(s => s.CognitiveScore).Value;
+                return $"{scored:N0}/{total:N0} rows scored (avg {avg:F2}, range {min:F2}-{max:F2})";
+            }
+        }
+
+        /// <summary>
+        /// Classifies each stress sent_email as internal (no recipient on a different domain to the
+        /// sender) or external, so a run confirms the configured internal/external mix landed.
+        /// Done in raw SQL because the classification needs the address domain (the part after '@'),
+        /// which EF can't translate cleanly.
+        /// </summary>
+        private static string DescribeInternalExternalMix(Func<AnalyticsEntitiesContext> dbFactory)
+        {
+            const string sql =
+                "SELECT ISNULL(SUM(CAST(x.is_internal AS bigint)), 0) AS InternalCount, COUNT_BIG(*) AS TotalCount " +
+                "FROM ( " +
+                "  SELECT CASE WHEN EXISTS ( " +
+                "      SELECT 1 FROM sent_email_recipients r " +
+                "      INNER JOIN email_addresses ra ON ra.id = r.recipient_address_id " +
+                "      WHERE r.sent_email_id = s.id " +
+                "        AND SUBSTRING(ra.address, CHARINDEX('@', ra.address) + 1, 4000) " +
+                "            <> SUBSTRING(fa.address, CHARINDEX('@', fa.address) + 1, 4000) " +
+                "    ) THEN 0 ELSE 1 END AS is_internal " +
+                "  FROM sent_emails s " +
+                "  INNER JOIN email_addresses fa ON fa.id = s.from_address_id " +
+                "  WHERE s.graph_message_id LIKE 'stress-msg-%' " +
+                ") x;";
+
+            using (var db = dbFactory())
+            {
+                var row = db.Database.SqlQuery<EmailMixRow>(sql).FirstOrDefault();
+                if (row == null || row.TotalCount == 0)
+                    return "no stress rows present";
+
+                long external = row.TotalCount - row.InternalCount;
+                double pct = row.InternalCount * 100.0 / row.TotalCount;
+                return $"{row.InternalCount:N0} internal / {external:N0} external ({pct:F0}% internal)";
+            }
+        }
+
+        private class EmailMixRow
+        {
+            public long InternalCount { get; set; }
+            public long TotalCount { get; set; }
         }
 
         private static void DeleteExistingStressData(Func<AnalyticsEntitiesContext> dbFactory)

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
@@ -3,9 +3,11 @@ using DataUtils;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Tests.FakeDataGen.Seeding;
 using Tests.FakeDataGen.StressTests.FakeLoaders;
 using WebJob.Office365ActivityImporter.Engine.Graph.Email;
 
@@ -80,7 +82,7 @@ namespace Tests.FakeDataGen.StressTests
                 var totalSw = Stopwatch.StartNew();
 
                 // 1) Seed users so SentEmailImporter.LoadUsersWithMailAsync finds mailboxes to scan.
-                int seededUsers = SeedUsers(dbFactory, userCount);
+                int seededUsers = SeedUsers(dbFactory, connectionString, userCount);
                 _memoryMonitor.UpdatePeak();
 
                 // 2) Build importer wired up with the fake loader + null sentiment scorer.
@@ -152,11 +154,34 @@ namespace Tests.FakeDataGen.StressTests
 
         #region DB helpers
 
-        private static int SeedUsers(Func<AnalyticsEntitiesContext> dbFactory, int userCount)
+        private static int SeedUsers(Func<AnalyticsEntitiesContext> dbFactory, string connectionString, int userCount)
         {
             Console.WriteLine($"Seeding {userCount:N0} fake users...");
             var sw = Stopwatch.StartNew();
             int inserted = 0;
+
+            // Seed the shared metadata lookup tables (departments, job titles, companies, states,
+            // countries, office + usage locations) up front and load their ids, so every seeded
+            // user can be given realistic metadata FKs. Without this the importer's users have a
+            // null department/job-title (etc.) and any report that slices sent email by department
+            // or job title is empty. Uses the same idempotent helper and catalogue as the other
+            // stress tests so all of them populate identical metadata.
+            var random = new Random(123);
+            List<int> departmentIds, jobTitleIds, companyIds, stateIds, countryIds, officeIds, usageIds;
+            using (var conn = new SqlConnection(connectionString))
+            {
+                conn.Open();
+                UserMetadataSeeder.EnsureMetadataLookups(conn);
+                departmentIds = UserMetadataSeeder.LoadLookupIds(conn, "user_departments");
+                jobTitleIds = UserMetadataSeeder.LoadLookupIds(conn, "user_job_titles");
+                companyIds = UserMetadataSeeder.LoadLookupIds(conn, "user_company_name");
+                stateIds = UserMetadataSeeder.LoadLookupIds(conn, "user_state_or_province");
+                countryIds = UserMetadataSeeder.LoadLookupIds(conn, "user_country_or_region");
+                officeIds = UserMetadataSeeder.LoadLookupIds(conn, "user_office_locations");
+                usageIds = UserMetadataSeeder.LoadLookupIds(conn, "user_usage_locations");
+            }
+            Console.WriteLine($"  Metadata lookups ready ({departmentIds.Count} departments, " +
+                              $"{jobTitleIds.Count} job titles) - assigning random metadata to seeded users.");
 
             using (var db = dbFactory())
             {
@@ -183,7 +208,14 @@ namespace Tests.FakeDataGen.StressTests
                     {
                         UserPrincipalName = upn,
                         Mail = upn,
-                        AzureAdId = Guid.NewGuid().ToString()
+                        AzureAdId = Guid.NewGuid().ToString(),
+                        DepartmentId = PickOrNull(departmentIds, random),
+                        JobTitleId = PickOrNull(jobTitleIds, random),
+                        CompanyNameId = PickOrNull(companyIds, random),
+                        StateOrProvinceId = PickOrNull(stateIds, random),
+                        UserCountryId = PickOrNull(countryIds, random),
+                        OfficeLocationId = PickOrNull(officeIds, random),
+                        UsageLocationId = PickOrNull(usageIds, random)
                     });
 
                     if (pending.Count >= batch)
@@ -216,6 +248,16 @@ namespace Tests.FakeDataGen.StressTests
             {
                 return db.users.Count(u => u.UserPrincipalName.StartsWith("stress-user"));
             }
+        }
+
+        /// <summary>
+        /// Picks a random id from a lookup id list, or null when the list is empty so the user's
+        /// FK column is left NULL rather than pointing at a non-existent row.
+        /// </summary>
+        private static int? PickOrNull(IList<int> ids, Random random)
+        {
+            if (ids == null || ids.Count == 0) return null;
+            return ids[random.Next(ids.Count)];
         }
 
         private static long CountStressRows(Func<AnalyticsEntitiesContext> dbFactory)

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -66,6 +66,7 @@
     <Compile Include="StressTests\FakeLoaders\FakeActivitySubscriptionManagerForStress.cs" />
     <Compile Include="StressTests\FakeLoaders\FakeAppConfig.cs" />
     <Compile Include="StressTests\FakeLoaders\FakeContentMetaDataLoaderForStress.cs" />
+    <Compile Include="StressTests\FakeLoaders\FakeSentEmailSentimentScorer.cs" />
     <Compile Include="StressTests\FakeLoaders\FakeSentEmailSourceLoader.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -66,6 +66,19 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public async Task ParallelCallsForSingleReturnListHander_PropagatesChunkExceptions()
+        {
+            // A faulting chunk must surface to the caller, not be silently swallowed (see the
+            // ParallelListProcessor fix). Previously chunk exceptions vanished and callers were told
+            // everything succeeded.
+            var p = new ParallelCallsForSingleReturnListHander<int, string>();
+            Func<List<int>, Task<List<string>>> faulting = (chunk) => throw new InvalidOperationException("boom");
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                p.CallAndCompileToSingleList(new List<int> { 1, 2, 3 }, faulting, 1));
+            Assert.AreEqual("boom", ex.Message);
+        }
+
+        [TestMethod]
         public void GetUrlBaseAddressIfValidUrl()
         {
             // Test GetUrlBaseAddress
@@ -933,6 +946,20 @@ namespace Tests.UnitTests
             await ParallelListProcessorTest(1);     // Single thing to do 
             await ParallelListProcessorTest(103);   // Odd number
             await ParallelListProcessorTest(1000);   // Big number
+        }
+
+        [TestMethod]
+        public async Task ParallelListProcessor_PropagatesChunkExceptions()
+        {
+            // Regression guard: a chunk that throws must surface the exception to the caller. The old
+            // ContinueWith(_ => _sem.Release()) tracked the always-successful release continuation
+            // instead of the work, so chunk exceptions were silently swallowed and Task.WhenAll
+            // always reported success. We need to know when a parallel chunk breaks.
+            var l = new ParallelListProcessor<int>(1);
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                l.ProcessListInParallel(new List<int> { 1, 2, 3 },
+                    (chunk, threadIndex) => throw new InvalidOperationException("boom")));
+            Assert.AreEqual("boom", ex.Message);
         }
         async Task ParallelListProcessorTest(int size)
         {

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -668,6 +668,36 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public void FindValueForProp()
+        {
+            // Documented case: value terminated by ';'.
+            Assert.AreEqual("SPOInsightsDev", StringUtils.FindValueForProp("Initial Catalog=SPOInsightsDev;", "initial catalog"));
+
+            // Property in the middle of the string.
+            Assert.AreEqual("myserver", StringUtils.FindValueForProp("Data Source=myserver;Initial Catalog=db;", "data source"));
+
+            // Regression: a property that is the LAST token with no trailing ';' used to throw
+            // ArgumentOutOfRangeException (IndexOf returned -1, fed straight into Substring length).
+            Assert.AreEqual("db", StringUtils.FindValueForProp("Data Source=myserver;Initial Catalog=db", "initial catalog"));
+
+            // Case-insensitive property-name match.
+            Assert.AreEqual("db", StringUtils.FindValueForProp("DATA SOURCE=srv;INITIAL CATALOG=db", "initial catalog"));
+
+            // Real ManageDataControl usage: a connection string with no trailing ';' for both props.
+            const string connStr = "Data Source=tcp:contoso.database.windows.net;Initial Catalog=AnalyticsDb";
+            Assert.AreEqual("tcp:contoso.database.windows.net", StringUtils.FindValueForProp(connStr, "data source"));
+            Assert.AreEqual("AnalyticsDb", StringUtils.FindValueForProp(connStr, "initial catalog"));
+
+            // Missing property -> empty string (previously threw / returned garbage).
+            Assert.AreEqual(string.Empty, StringUtils.FindValueForProp("Data Source=srv;", "initial catalog"));
+
+            // Null / empty inputs -> empty string rather than throwing.
+            Assert.AreEqual(string.Empty, StringUtils.FindValueForProp(null, "data source"));
+            Assert.AreEqual(string.Empty, StringUtils.FindValueForProp("", "data source"));
+            Assert.AreEqual(string.Empty, StringUtils.FindValueForProp("Data Source=srv;", null));
+        }
+
+        [TestMethod]
         public void IsJson()
         {
             Assert.IsFalse(StringUtils.IsJson("false"));

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
@@ -1,13 +1,17 @@
 ﻿using Common.Entities;
 using Common.Entities.Config;
+using Common.Entities.Entities.Teams;
 using DataUtils;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate;
 using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
@@ -121,6 +125,48 @@ namespace Tests.UnitTests
             // We should have two items, each one loaded on a seperate page
             var fakeData = await loader.LoadReportData();
             Assert.IsTrue(fakeData.Count() == 2);
+        }
+
+        /// <summary>
+        /// Regression: Teams audio/video/screen-share durations were stored with TimeSpan.Seconds
+        /// (the 0-59 seconds COMPONENT), silently truncating any duration of a minute or more
+        /// (e.g. PT45M -> 0). They must be stored as total seconds.
+        /// </summary>
+        [TestMethod]
+        public void TeamsUserUsageLoader_DurationsUseTotalSecondsNotComponent()
+        {
+            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var loader = new TestableTeamsUserUsageLoader(telemetry);
+
+            var page = new TeamsUserActivityUserDetail
+            {
+                UserPrincipalName = "duration-test@contoso.com",
+                AudioDuration = "PT1H2M3S",       // 3723s total; old .Seconds gave 3
+                VideoDuration = "PT45M",          // 2700s total; old .Seconds gave 0
+                ScreenShareDuration = "PT2M30S",  // 150s total; old .Seconds gave 30
+            };
+
+            var log = loader.Populate(page);
+
+            Assert.AreEqual(3723, log.AudioDurationSeconds, "Audio duration must be total seconds, not the 0-59 component");
+            Assert.AreEqual(2700, log.VideoDurationSeconds, "Video duration must be total seconds, not the 0-59 component");
+            Assert.AreEqual(150, log.ScreenShareDurationSeconds, "Screen-share duration must be total seconds, not the 0-59 component");
+        }
+
+        /// <summary>
+        /// Test-only subclass that reaches the protected PopulateReportSpecificMetadata without a
+        /// live Graph client (the client/cache/filter are only used during paging, not here).
+        /// </summary>
+        private class TestableTeamsUserUsageLoader : TeamsUserUsageLoader
+        {
+            public TestableTeamsUserUsageLoader(ILogger telemetry) : base(null, null, null, telemetry) { }
+
+            public GlobalTeamsUserUsageLog Populate(TeamsUserActivityUserDetail page)
+            {
+                var log = new GlobalTeamsUserUsageLog();
+                PopulateReportSpecificMetadata(log, page);
+                return log;
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -848,6 +848,42 @@ namespace Tests.UnitTests
             Assert.IsTrue(nextSunday4pm.Minute == 0);
             Assert.IsTrue(nextSunday4pm.Date == nextSunday.Date);
         }
+
+        [TestMethod]
+        public void TargetSolutionConfig_ValidatInputAndGetErrors()
+        {
+            // Regression: the condition used '||' ("!= en || != es"), which is always true, so an
+            // Adoptify install reported "Select a valid target language" even for valid 'en'/'es'.
+            var en = new TargetSolutionConfig
+            {
+                SolutionTargeted = SolutionImportType.Adoptify,
+                SolutionLanguageCode = TargetSolutionConfig.LANG_ENGLISH
+            };
+            Assert.AreEqual(0, en.ValidatInputAndGetErrors().Count, "Valid English Adoptify config should have no errors");
+
+            var es = new TargetSolutionConfig
+            {
+                SolutionTargeted = SolutionImportType.Adoptify,
+                SolutionLanguageCode = TargetSolutionConfig.LANG_ESPAÑOL
+            };
+            Assert.AreEqual(0, es.ValidatInputAndGetErrors().Count, "Valid Spanish Adoptify config should have no errors");
+
+            // An unsupported language for Adoptify must still be flagged.
+            var invalid = new TargetSolutionConfig
+            {
+                SolutionTargeted = SolutionImportType.Adoptify,
+                SolutionLanguageCode = "fr"
+            };
+            Assert.AreEqual(1, invalid.ValidatInputAndGetErrors().Count, "Unsupported Adoptify language should produce an error");
+
+            // Non-Adoptify targets are not language-validated.
+            var custom = new TargetSolutionConfig
+            {
+                SolutionTargeted = SolutionImportType.CustomOrInsights,
+                SolutionLanguageCode = "fr"
+            };
+            Assert.AreEqual(0, custom.ValidatInputAndGetErrors().Count, "Non-Adoptify config should not be language-validated");
+        }
     }
 
     public class AzureTestsConfigReader

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/KeyVaultFirewallConfigTaskTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/KeyVaultFirewallConfigTaskTests.cs
@@ -1,0 +1,77 @@
+using Azure.ResourceManager.KeyVault.Models;
+using CloudInstallEngine.Azure.InstallTasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// Unit tests for the Key Vault firewall rule construction (issue #136). These cover the pure,
+    /// Azure-free logic: parsing App Service outbound IPs and building the firewall rule set.
+    /// </summary>
+    [TestClass]
+    public class KeyVaultFirewallConfigTaskTests
+    {
+        [TestMethod]
+        public void ParseOutboundIPv4Addresses_TrimsDedupesAndIgnoresNonIPv4()
+        {
+            // Mixed: duplicates, whitespace, an IPv6 address, junk and a trailing blank.
+            var input = "52.178.30.162, 52.178.27.13 ,52.178.30.162,not-an-ip,2001:db8::1,";
+
+            var result = KeyVaultFirewallConfigTask.ParseOutboundIPv4Addresses(input);
+
+            CollectionAssert.AreEqual(new[] { "52.178.30.162", "52.178.27.13" }, result);
+        }
+
+        [TestMethod]
+        public void ParseOutboundIPv4Addresses_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.AreEqual(0, KeyVaultFirewallConfigTask.ParseOutboundIPv4Addresses(null).Count);
+            Assert.AreEqual(0, KeyVaultFirewallConfigTask.ParseOutboundIPv4Addresses("   ").Count);
+        }
+
+        [TestMethod]
+        public void BuildFirewallRuleSet_EnablesDenyFirewallAndAddsIps()
+        {
+            var ruleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(
+                existing: null,
+                allowIpAddresses: new[] { "5.159.8.251", "52.178.30.162" },
+                vnetSubnetId: null);
+
+            Assert.IsTrue(ruleSet.DefaultAction == KeyVaultNetworkRuleAction.Deny, "Firewall must default-deny.");
+            Assert.IsTrue(ruleSet.Bypass == KeyVaultNetworkRuleBypassOption.AzureServices, "Trusted Azure services must be allowed to bypass.");
+            CollectionAssert.AreEqual(new[] { "5.159.8.251", "52.178.30.162" }, ruleSet.IPRules.Select(r => r.AddressRange).ToList());
+            Assert.AreEqual(0, ruleSet.VirtualNetworkRules.Count);
+        }
+
+        [TestMethod]
+        public void BuildFirewallRuleSet_PreservesExistingRulesAndDeduplicates()
+        {
+            var existing = new KeyVaultNetworkRuleSet { DefaultAction = KeyVaultNetworkRuleAction.Allow };
+            existing.IPRules.Add(new KeyVaultIPRule("5.159.8.251"));
+            existing.VirtualNetworkRules.Add(new KeyVaultVirtualNetworkRule("/subscriptions/s/.../subnets/subnetA"));
+
+            var ruleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(
+                existing: existing,
+                allowIpAddresses: new[] { "5.159.8.251", "9.9.9.9" },   // 5.159.8.251 already present -> deduped
+                vnetSubnetId: "/subscriptions/s/.../subnets/subnetB");
+
+            CollectionAssert.AreEqual(new[] { "5.159.8.251", "9.9.9.9" }, ruleSet.IPRules.Select(r => r.AddressRange).ToList());
+            CollectionAssert.AreEqual(
+                new[] { "/subscriptions/s/.../subnets/subnetA", "/subscriptions/s/.../subnets/subnetB" },
+                ruleSet.VirtualNetworkRules.Select(r => r.Id.ToString()).ToList());
+        }
+
+        [TestMethod]
+        public void BuildFirewallRuleSet_AddedVnetRuleIgnoresMissingServiceEndpoint()
+        {
+            var ruleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(
+                existing: null,
+                allowIpAddresses: null,
+                vnetSubnetId: "/subscriptions/s/.../subnets/integration");
+
+            Assert.AreEqual(1, ruleSet.VirtualNetworkRules.Count);
+            Assert.AreEqual(true, ruleSet.VirtualNetworkRules.Single().IgnoreMissingVnetServiceEndpoint);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/SentEmailImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SentEmailImportTests.cs
@@ -14,6 +14,22 @@ namespace Tests.UnitTests
     [TestClass]
     public class SentEmailImportTests
     {
+        [TestMethod]
+        public void SentimentScorer_StripHtml_RemovesTagsAndDecodesEntities()
+        {
+            Assert.AreEqual("Hello", AzureLanguageSentEmailSentimentScorer.StripHtml("<b>Hello</b>"));
+            Assert.AreEqual("a & b", AzureLanguageSentEmailSentimentScorer.StripHtml("a &amp; b"));
+            // Non-Latin content (e.g. Greek) must be preserved through stripping/decoding.
+            Assert.AreEqual("Καλημέρα κόσμε", AzureLanguageSentEmailSentimentScorer.StripHtml("<p>Καλημέρα κόσμε</p>"));
+        }
+
+        [TestMethod]
+        public void SentimentScorer_StripHtml_NullOrEmptyPassThrough()
+        {
+            Assert.IsNull(AzureLanguageSentEmailSentimentScorer.StripHtml(null));
+            Assert.AreEqual(string.Empty, AzureLanguageSentEmailSentimentScorer.StripHtml(string.Empty));
+        }
+
         #region ImportTaskSettings Tests
 
         // NOTE: All [ImportProp] flags default to false (opt-in) so a fresh / unconfigured install

--- a/src/AnalyticsEngine/Tests.UnitTests/StagingColumnSqlTypeOverrideTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StagingColumnSqlTypeOverrideTests.cs
@@ -2,6 +2,7 @@ using DataUtils.Sql;
 using DataUtils.Sql.Inserts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using System.Text.RegularExpressions;
 using WebJob.AppInsightsImporter.Engine.Sql.Models;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
@@ -159,6 +160,27 @@ namespace Tests.UnitTests
 
             Assert.AreEqual(ExpectedUrlSqlType, info.SqlInfo.SqlColDefinition,
                 "Copilot SP staging .url must match urls.full_url (nvarchar(850)) so IX_urls_full_url is usable.");
+        }
+
+        /// <summary>
+        /// The App Insights "searches" staging table (created from the Create Searches Import Temp
+        /// Table.sql resource by SearchesSaveExtension) stores the authenticated user's UPN and the
+        /// search term. Both must be nvarchar - not varchar - or a non-Latin value (e.g. Greek) is
+        /// corrupted to '?'. For user_name that breaks the merge's inner join to the nvarchar
+        /// users.user_name and silently drops that user's searches. See issue #122 and the
+        /// "Character set support (Unicode / Greek)" convention.
+        /// </summary>
+        [TestMethod]
+        public void SearchesStagingUserNameAndTermAreNvarchar()
+        {
+            var ddl = WebJob.AppInsightsImporter.Engine.Properties.Resources.Create_Searches_Import_Temp_Table;
+
+            Assert.IsTrue(Regex.IsMatch(ddl, @"\[user_name\]\s*\[nvarchar\]", RegexOptions.IgnoreCase),
+                "searches staging [user_name] must be nvarchar so non-Latin UPNs (e.g. Greek) aren't corrupted to '?'.");
+            Assert.IsFalse(Regex.IsMatch(ddl, @"\[user_name\]\s*\[varchar\]", RegexOptions.IgnoreCase),
+                "searches staging [user_name] must NOT be varchar (single-code-page corrupts Unicode UPNs).");
+            Assert.IsTrue(Regex.IsMatch(ddl, @"\[search_term\]\s*\[nvarchar\]", RegexOptions.IgnoreCase),
+                "searches staging [search_term] must be nvarchar (users search in non-Latin scripts).");
         }
 
         // ---- Local test fixtures ----

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -163,6 +163,7 @@
     <Compile Include="GraphImportTests.cs" />
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
+    <Compile Include="InstallTests\KeyVaultFirewallConfigTaskTests.cs" />
     <Compile Include="InstallTests\TeamsUserActivityReportUrlTests.cs" />
     <Compile Include="InstallTests\SpoInstallTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/UserGroupsCacheTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserGroupsCacheTests.cs
@@ -1,8 +1,11 @@
 using Common.Entities.Config;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace Tests.UnitTests
 {
@@ -63,6 +66,51 @@ namespace Tests.UnitTests
             {
                 var result = await cache.IsInGroupsFilter(user, filter);
                 Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsTrue(result, $"Expected true for user {user} when no filter is configured.");
+            }
+        }
+
+        /// <summary>
+        /// Regression: a failed group load must NOT be cached. Caching an empty list on a transient
+        /// Graph error would (because IsInGroupsFilter treats "no groups" as "matches the filter")
+        /// silently include the user for the whole TTL; instead the next call should retry.
+        /// </summary>
+        [TestMethod]
+        public async Task GetGroupsForUser_DoesNotCacheFailedLoad()
+        {
+            var cache = new ThrowNTimesThenSucceedGroupsCache(new List<string> { "Finance" }) { FailTimes = 1 };
+
+            // 1st call: the load throws -> an empty list that must NOT be cached.
+            var first = await cache.GetGroupsForUserAsync("u@contoso.com");
+            Assert.AreEqual(0, first.Count);
+            Assert.AreEqual(0, cache.CachedEntryCount, "A failed load must not be cached.");
+
+            // 2nd call: retries, now succeeds, and caches.
+            var second = await cache.GetGroupsForUserAsync("u@contoso.com");
+            CollectionAssert.AreEquivalent(new List<string> { "Finance" }, second.ToList());
+            Assert.AreEqual(1, cache.CachedEntryCount, "A successful load must be cached.");
+            Assert.AreEqual(2, cache.LoadCalls);
+
+            // 3rd call: served from cache - no further load.
+            await cache.GetGroupsForUserAsync("u@contoso.com");
+            Assert.AreEqual(2, cache.LoadCalls, "A cached result must not trigger another load.");
+        }
+
+        private class ThrowNTimesThenSucceedGroupsCache : UserGroupsCache
+        {
+            private readonly List<string> _groups;
+            public int LoadCalls { get; private set; }
+            public int FailTimes { get; set; }
+
+            public ThrowNTimesThenSucceedGroupsCache(List<string> groups) : base(null) { _groups = groups; }
+
+            protected override Task<List<string>> LoadGroupsFromExternalAsync(string upn)
+            {
+                LoadCalls++;
+                if (LoadCalls <= FailTimes)
+                {
+                    throw new Exception("Simulated transient Graph failure");
+                }
+                return Task.FromResult(_groups);
             }
         }
     }

--- a/src/AnalyticsEngine/Tests.UnitTests/UserLookupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserLookupTests.cs
@@ -3,9 +3,11 @@ using Common.Entities.LookupCaches;
 using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 using WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps;
 
 namespace Tests.UnitTests
@@ -78,6 +80,55 @@ namespace Tests.UnitTests
                 }
             }
         }
+
+        /// <summary>
+        /// Regression for the user-app paging gap: CollectAllAppPagesAsync must follow every
+        /// @odata.nextLink and return apps from all pages (a user with more installed apps than fit on
+        /// one Graph page previously lost the later pages). The page fetch is a fake "adaptor" delegate
+        /// so multi-page paging is exercised without a live tenant.
+        /// </summary>
+        [TestMethod]
+        public async Task UserApps_CollectAllAppPages_FollowsNextLinkAcrossPages()
+        {
+            var page1 = new UserTeamAppResponse { OdataNextLink = "https://graph.microsoft.com/next1", Apps = new List<UserTeamApp> { AppWithId("a1") } };
+            var page2 = new UserTeamAppResponse { OdataNextLink = "https://graph.microsoft.com/next2", Apps = new List<UserTeamApp> { AppWithId("a2"), AppWithId("a3") } };
+            var page3 = new UserTeamAppResponse { OdataNextLink = null, Apps = new List<UserTeamApp> { AppWithId("a4") } };
+
+            var pagesByLink = new Dictionary<string, UserTeamAppResponse>
+            {
+                { "https://graph.microsoft.com/next1", page2 },
+                { "https://graph.microsoft.com/next2", page3 },
+            };
+            var fetchedLinks = new List<string>();
+
+            var all = await GraphAndSqlUserAppLoader.CollectAllAppPagesAsync(page1, link =>
+            {
+                fetchedLinks.Add(link);
+                return Task.FromResult(pagesByLink[link]);
+            });
+
+            CollectionAssert.AreEqual(new[] { "a1", "a2", "a3", "a4" }, all.Select(a => a.Id).ToList());
+            CollectionAssert.AreEqual(new[] { "https://graph.microsoft.com/next1", "https://graph.microsoft.com/next2" }, fetchedLinks);
+        }
+
+        [TestMethod]
+        public async Task UserApps_CollectAllAppPages_SinglePageDoesNotFetch()
+        {
+            var only = new UserTeamAppResponse { OdataNextLink = null, Apps = new List<UserTeamApp> { AppWithId("solo") } };
+            var fetchCalled = false;
+
+            var all = await GraphAndSqlUserAppLoader.CollectAllAppPagesAsync(only, _ =>
+            {
+                fetchCalled = true;
+                return Task.FromResult<UserTeamAppResponse>(null);
+            });
+
+            Assert.IsFalse(fetchCalled, "A single page (no @odata.nextLink) must not trigger a fetch.");
+            Assert.AreEqual(1, all.Count);
+            Assert.AreEqual("solo", all[0].Id);
+        }
+
+        private static UserTeamApp AppWithId(string id) => new UserTeamApp { Id = id };
 
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/UserLookupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserLookupTests.cs
@@ -1,10 +1,12 @@
 ﻿using Common.Entities;
 using Common.Entities.LookupCaches;
+using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps;
 
 namespace Tests.UnitTests
 {
@@ -30,6 +32,50 @@ namespace Tests.UnitTests
                 var loadedUserManual1 = await db.users.Where(u => u.ID == loadedUserLookup1.ID).SingleOrDefaultAsync();
                 Assert.AreEqual(loadedUserManual1.UserPrincipalName, randomUserName1);
 
+            }
+        }
+
+        /// <summary>
+        /// Regression: GetUserEmailAddressesToFindAppsFor used a predicate of
+        /// (AccountEnabled.HasValue &amp;&amp; AccountEnabled.HasValue) which is always true, so
+        /// disabled accounts were NOT excluded from the per-user Teams-apps scan. Enabled users and
+        /// users with no AccountEnabled value should be included; explicitly disabled users excluded.
+        /// </summary>
+        [TestMethod]
+        public async Task GraphAndSqlUserAppLoader_ExcludesDisabledUsers()
+        {
+            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var tick = DateTime.Now.Ticks;
+            var enabledUpn = $"appsloader-enabled-{tick}@contoso.com";
+            var disabledUpn = $"appsloader-disabled-{tick}@contoso.com";
+            var unknownUpn = $"appsloader-unknown-{tick}@contoso.com";
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var enabled = new User { UserPrincipalName = enabledUpn, AccountEnabled = true };
+                var disabled = new User { UserPrincipalName = disabledUpn, AccountEnabled = false };
+                var unknown = new User { UserPrincipalName = unknownUpn, AccountEnabled = null };
+                db.users.Add(enabled);
+                db.users.Add(disabled);
+                db.users.Add(unknown);
+                await db.SaveChangesAsync();
+
+                try
+                {
+                    var loader = new GraphAndSqlUserAppLoader(db, telemetry, null);
+                    var upns = await loader.GetUserEmailAddressesToFindAppsFor();
+
+                    Assert.IsTrue(upns.Contains(enabledUpn), "Enabled user should be included");
+                    Assert.IsTrue(upns.Contains(unknownUpn), "User with no AccountEnabled value should be included");
+                    Assert.IsFalse(upns.Contains(disabledUpn), "Explicitly disabled user must be excluded");
+                }
+                finally
+                {
+                    db.users.Remove(enabled);
+                    db.users.Remove(disabled);
+                    db.users.Remove(unknown);
+                    await db.SaveChangesAsync();
+                }
             }
         }
 

--- a/src/AnalyticsEngine/Web/Controllers/AccountController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/AccountController.cs
@@ -4,7 +4,7 @@ using Microsoft.Owin.Security.OpenIdConnect;
 using System.Web;
 using System.Web.Mvc;
 
-namespace WebApplication2.Controllers
+namespace Web.AnalyticsWeb.Controllers
 {
     public class AccountController : Controller
     {

--- a/src/AnalyticsEngine/Web/Controllers/HomeController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/HomeController.cs
@@ -14,15 +14,15 @@ namespace Web.AnalyticsWeb.Controllers
     {
         public async Task<ActionResult> Index()
         {
-
             // Load most recent status
-            var db = new AnalyticsEntitiesContext();
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var appConfig = new AppConfig();
+                var cache = CacheConnectionManager.GetConnectionManager(appConfig.ConnectionStrings.RedisConnectionString, tenantId: appConfig.TenantGUID.ToString(), clientId: appConfig.ClientID, clientSecret: appConfig.ClientSecret);
+                var s = await SystemStatus.LoadFrom(db, cache);
 
-            var appConfig = new AppConfig();
-            var cache = CacheConnectionManager.GetConnectionManager(appConfig.ConnectionStrings.RedisConnectionString, tenantId: appConfig.TenantGUID.ToString(), clientId: appConfig.ClientID, clientSecret: appConfig.ClientSecret);
-            var s = await SystemStatus.LoadFrom(db, cache);
-
-            return View(s);
+                return View(s);
+            }
         }
         public ActionResult CredentialsInvalid()
         {

--- a/src/AnalyticsEngine/Web/Controllers/SiteTokenAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/SiteTokenAPIController.cs
@@ -9,18 +9,28 @@ namespace Web.AnalyticsWeb.Controllers
     [Authorize]
     public class SiteTokenAPIController : BaseAPIController
     {
+        // A single HttpClient reused for the app's lifetime. Creating one per request (the previous
+        // behaviour) leaks sockets and can exhaust ephemeral ports under load.
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         // POST: api/SiteTokenAPI
         // For returning to teams-permission-grant JS app the server-side generated OAuth token for user
         public async Task<JSonToken> Post()
         {
             var auth = await base.GetCachedUserAccessTokenAsync();
+            if (auth == null || string.IsNullOrEmpty(auth.AccessToken))
+            {
+                throw new HttpResponseException(System.Net.HttpStatusCode.Unauthorized);
+            }
 
-            // Test graph call
-            var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", auth.AccessToken);
-            var response = await httpClient.GetAsync("https://graph.microsoft.com/v1.0/me/joinedTeams");
-            response.EnsureSuccessStatusCode();
-
+            // Test graph call. Use a per-request message so the shared client's default headers
+            // aren't mutated concurrently across requests.
+            using (var request = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/joinedTeams"))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", auth.AccessToken);
+                var response = await _httpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+            }
 
             return new JSonToken(auth);
         }

--- a/src/AnalyticsEngine/Web/Controllers/TeamsAuthAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/TeamsAuthAPIController.cs
@@ -17,9 +17,13 @@ namespace Web.AnalyticsWeb.Controllers
         // POST: api/TeamsAuthAPI
         public async Task<List<TeamAuthStatusResponse>> Post([FromBody] List<string> teamIds)
         {
-            var cache = GetConnectionManager();
-
             var response = new List<TeamAuthStatusResponse>();
+            if (teamIds == null)
+            {
+                return response;
+            }
+
+            var cache = GetConnectionManager();
 
             foreach (var teamId in teamIds)
             {
@@ -50,16 +54,26 @@ namespace Web.AnalyticsWeb.Controllers
 
             // Get redis-cached token we got on login in Startup.ConfigureAuth
             var auth = await base.GetCachedUserAccessTokenAsync();
-
-            var cache = GetConnectionManager();
-            foreach (var teamIdToAuth in authTeamData.TeamIdsToAuth)
+            if (auth == null || string.IsNullOrEmpty(auth.RefreshToken))
             {
-                await cache.SetTeamRefreshToken(teamIdToAuth, auth.RefreshToken);
+                return Unauthorized();
             }
 
-            foreach (var teamIdToDeAuth in authTeamData.TeamIdsToDeauth)
+            var cache = GetConnectionManager();
+            if (authTeamData.TeamIdsToAuth != null)
             {
-                await cache.RemoveTeamAuthToken(teamIdToDeAuth);
+                foreach (var teamIdToAuth in authTeamData.TeamIdsToAuth)
+                {
+                    await cache.SetTeamRefreshToken(teamIdToAuth, auth.RefreshToken);
+                }
+            }
+
+            if (authTeamData.TeamIdsToDeauth != null)
+            {
+                foreach (var teamIdToDeAuth in authTeamData.TeamIdsToDeauth)
+                {
+                    await cache.RemoveTeamAuthToken(teamIdToDeAuth);
+                }
             }
 
             return Ok();

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/CustomEvents/CustomEventsResultCollection.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/CustomEvents/CustomEventsResultCollection.cs
@@ -66,43 +66,51 @@ namespace WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents
                 // Hack to change/ensure correct DB schema. Needs moving to a migration
                 await ImportDbHacks.EnsureSessionTableHasRightCollation(database.Database);
 
-                var hitUpdatesTimer = new JobTimer(telemetry, "Hit updates");
-                hitUpdatesTimer.Start();
-                var hitUpdatesCount = await this.SaveHitsUpdatesToSQL(telemetry, database);
-                hitUpdatesTimer.PrintElapsed();
-                if (hitUpdatesCount > 0)
-                {
-                    hitUpdatesTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
-                }
+                // Each section runs inside its own isolation boundary (see SaveSectionSafe). A failure
+                // in one section (e.g. a page-update that trips a DbUpdateException) is logged in full
+                // but never aborts the sibling sections nor escapes to stall the whole importer.
+                var hitUpdatesCount = await SaveSectionSafe(telemetry, "Hit updates",
+                    () => this.SaveHitsUpdatesToSQL(telemetry, database));
 
-                var searchesInsertTimer = new JobTimer(telemetry, "Searches");
-                searchesInsertTimer.Start();
-                var searchesInserted = await this.SaveSearchesToSQL(telemetry, database);
-                searchesInsertTimer.PrintElapsed();
-                if (searchesInserted > 0)
-                {
-                    searchesInsertTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
-                }
+                var searchesInserted = await SaveSectionSafe(telemetry, "Searches",
+                    () => this.SaveSearchesToSQL(telemetry, database));
 
-                var pageUpdatesTimer = new JobTimer(telemetry, "Page updates");
-                pageUpdatesTimer.Start();
-                var pagesUpdated = await this.SavePageUpdatesToSQL(telemetry, config);
-                pageUpdatesTimer.PrintElapsed();
-                if (pagesUpdated > 0)
-                {
-                    pageUpdatesTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
-                }
+                var pagesUpdated = await SaveSectionSafe(telemetry, "Page updates",
+                    () => this.SavePageUpdatesToSQL(telemetry, config));
 
-                var clicksInsertTimer = new JobTimer(telemetry, "Clicks");
-                clicksInsertTimer.Start();
-                var clicks = await this.SaveClicksToSQL(telemetry, database);
-                clicksInsertTimer.PrintElapsed();
-                if (clicks > 0)
-                {
-                    clicksInsertTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
-                }
+                var clicks = await SaveSectionSafe(telemetry, "Clicks",
+                    () => this.SaveClicksToSQL(telemetry, database));
 
                 telemetry.LogInformation($"Event save summary: {hitUpdatesCount:n0} hit-updates, {searchesInserted:n0} searches, {pagesUpdated:n0} page-updates, {clicks:n0} clicks");
+            }
+        }
+
+        /// <summary>
+        /// Runs one event-save section (hit-updates / searches / page-updates / clicks) inside its own
+        /// timer and isolation boundary. A failure in one section is logged in full and reported via
+        /// TrackException, but never propagates - so a single bad section can neither abort its sibling
+        /// sections nor escape up the call stack and stall the whole importer.
+        /// </summary>
+        private static async Task<int> SaveSectionSafe(AnalyticsLogger telemetry, string sectionName, Func<Task<int>> saveAction)
+        {
+            var timer = new JobTimer(telemetry, sectionName);
+            timer.Start();
+            try
+            {
+                var count = await saveAction();
+                timer.PrintElapsed();
+                if (count > 0)
+                {
+                    timer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
+                }
+                return count;
+            }
+            catch (Exception ex)
+            {
+                telemetry.TrackException(ex);
+                telemetry.LogError($"Failed importing '{sectionName}' section: {CommonExceptionHandler.GetErrorText(ex)}. Skipping this section and continuing.");
+                telemetry.LogError($"Exception detail: {ex}");
+                return 0;
             }
         }
     }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
@@ -5,7 +5,6 @@ using DataUtils;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Data.Entity;
-using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -132,13 +131,22 @@ namespace WebJob.AppInsightsImporter.Engine
                                 await events.SaveAllEventTypesToSql(_telemetry, _importConfig);
                                 _telemetry.LogInformation($"Events SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
                             }
-                            catch (SqlException ex)
+                            catch (Exception ex)
                             {
-                                _telemetry.LogError(ex, "Got SQL error: " + ex.Message);
+                                // Isolate per-day save failures. A single bad day - e.g. a page-update
+                                // event that trips a DbUpdateException - must never abort the whole
+                                // multi-day run and stall the importer's watermark indefinitely (the
+                                // SqlException-only catch used to let any other exception escape, which
+                                // permanently stuck the importer re-processing the same day). Log the
+                                // full error, record it, and carry on with the next day.
+                                _telemetry.TrackException(ex);
+                                _telemetry.LogError($"Failed saving data for day {d:yyyy-MM-dd}: {CommonExceptionHandler.GetErrorText(ex)}. Skipping this day and continuing.");
+                                _telemetry.LogError($"Exception detail: {ex}");
                                 if (Debugger.IsAttached)
                                 {
                                     throw;
                                 }
+                                continue;
                             }
 
                             totalPageViews += pageViewsResult.Rows.Count;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
@@ -142,16 +142,27 @@ namespace WebJob.AppInsightsImporter.Engine
                     if (!chunkByUrl.TryGetValue(urlToUpdate.FullUrl, out var correspondingPageUpdates))
                         continue;
 
-                    // There can be multiple updates across several events. Compile all into one new update
-                    var compiledUpdate = new PageUpdateEventAppInsightsQueryResult(correspondingPageUpdates);
+                    try
+                    {
+                        // There can be multiple updates across several events. Compile all into one new update
+                        var compiledUpdate = new PageUpdateEventAppInsightsQueryResult(correspondingPageUpdates);
 
-                    var urlMetadataUpdated = await UpdateUrlMetadataWith(urlToUpdate, compiledUpdate, context, urlMetadataFieldNameCache);
+                        var urlMetadataUpdated = await UpdateUrlMetadataWith(urlToUpdate, compiledUpdate, context, urlMetadataFieldNameCache);
 
-                    var commentsOrLikesUpdated = await UpdateCommentsOrLikes(urlToUpdate, compiledUpdate, context, userCache, langCache);
+                        var commentsOrLikesUpdated = await UpdateCommentsOrLikes(urlToUpdate, compiledUpdate, context, userCache, langCache);
 
-                    lock (updatedUrls)
-                        if (urlMetadataUpdated || commentsOrLikesUpdated)
-                            updatedUrls.Add(urlToUpdate.FullUrl);
+                        lock (updatedUrls)
+                            if (urlMetadataUpdated || commentsOrLikesUpdated)
+                                updatedUrls.Add(urlToUpdate.FullUrl);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Don't let one bad page-update abort the whole chunk (up to 1000 URLs). The most
+                        // likely culprit is an uncaught DbUpdateException from a comment/like whose user or
+                        // language insert fails - which previously escaped every catch above it and stalled
+                        // the importer for months. Log the full error, skip this URL, and keep going.
+                        _debugTracer.LogError(ex, $"Failed applying page-update metadata for URL '{urlToUpdate.FullUrl}': {CommonExceptionHandler.GetErrorText(ex)}. Skipping this URL.");
+                    }
                 }
 
                 try

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Resources/Create Searches Import Temp Table.sql
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Resources/Create Searches Import Temp Table.sql
@@ -5,7 +5,7 @@ drop table [${STAGING_TABLE_SEARCHES}]
 CREATE TABLE [dbo].[${STAGING_TABLE_SEARCHES}](
 	[id] [int] IDENTITY(1,1) NOT NULL primary key,
 	[ai_session_id] [varchar](50) NOT NULL,
-	[user_name] [varchar](250) NOT NULL,
+	[user_name] [nvarchar](250) NOT NULL,
 	[search_term] [nvarchar](250) NOT NULL,
 	[date_time] datetime NULL
 	);

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/HitTempEntity.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Models/HitTempEntity.cs
@@ -26,7 +26,10 @@ namespace WebJob.AppInsightsImporter.Engine.Sql.Models
             this.DeviceName = p.DeviceModel;
             this.OS = p.ClientOS;
             this.PageRequestId = p.CustomProperties?.PageRequestId.ToString();
-            this.PageLoadTime = p.PageLoadInSeconds.ToString();
+            // Invariant culture so the decimal separator is always '.' (the staged page_load_time
+            // string is later CAST to a number in SQL). Without this, a non-US server locale writes
+            // e.g. "1,5" and the downstream conversion misparses or fails.
+            this.PageLoadTime = p.PageLoadInSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture);
             this.Province = p.StateOrProvince;
             this.SiteUrl = p.CustomProperties?.SiteUrl;
             this.SPRequestDuration = p.CustomProperties?.SPRequestDuration ?? 0;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/Program.cs
@@ -128,7 +128,13 @@ namespace WebJob.AppInsightsImporter
             catch (Exception ex)
             {
                 telemetry.TrackException(ex);
-                telemetry.LogError($"Got uncaught exception importing & saving data from Application Insights: {ex.Message}");
+
+                // ex is normally an AggregateException from the .Wait() above, whose Message is just
+                // "One or more errors occurred." - useless on its own. Log the unwrapped inner-exception
+                // chain and the full stack so the real failure is visible in the WebJob console & traces,
+                // not only in the AppInsights 'exceptions' table.
+                telemetry.LogError($"Got uncaught exception importing & saving data from Application Insights: {CommonExceptionHandler.GetErrorText(ex)}");
+                telemetry.LogError($"Exception detail: {ex}");
 
 #if DEBUG
                 throw;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -5,6 +5,7 @@ using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Entity;
 using System.Data.SqlClient;
@@ -114,7 +115,9 @@ namespace WebJob.Office365ActivityImporter.Engine
         {
             var listOfActivitiesSavedToSQL = new ConcurrentBag<AbstractAuditLogContent>();
             var logsToInsert = new EFInsertBatch<AuditLogTempEntity>(db, _telemetry);
-            var processedIds = new ConcurrentBag<Guid>();
+            // Sequential dedup within this set: a HashSet gives O(1) Contains. The previous
+            // ConcurrentBag.Contains was O(n) per row (an O(n^2) scan over a large activity set).
+            var processedIds = new HashSet<Guid>();
             var stats = new ImportStat() { Total = activities.Count };
 
             foreach (var abtractLog in activities)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
@@ -2,6 +2,7 @@
 using DataUtils;
 using System;
 using System.Collections.Generic;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities;
@@ -287,8 +288,13 @@ namespace WebJob.Office365ActivityImporter.Engine
             }
             catch (System.Data.Entity.Infrastructure.DbUpdateException ex)
             {
-                const string PRIMARY_KEY_VIOLATION = "Violation of PRIMARY KEY constraint 'PK_processed_audit_events'. Cannot insert duplicate key in object 'dbo.ignored_audit_events'";
-                if (CommonExceptionHandler.GetErrorText(ex).Contains(PRIMARY_KEY_VIOLATION))
+                // Detect duplicate-key violations by SQL error number (2601/2627) - the same robust
+                // approach used by DBLookupCache. The previous hard-coded message match never fired
+                // (it named the wrong constraint, PK_processed_audit_events, for the
+                // ignored_audit_events table), so the dedup retry was dead code AND every genuine
+                // DbUpdateException was silently swallowed.
+                var sqlException = ex.InnerException?.InnerException as SqlException;
+                if (sqlException != null && (sqlException.Number == 2601 || sqlException.Number == 2627))
                 {
                     await DeleteIgnoredEvents(ignoreList, db);
 
@@ -297,6 +303,12 @@ namespace WebJob.Office365ActivityImporter.Engine
                     // committed to the ignored table), causing them to be re-processed on the next run.
                     db.ignored_audit_events.AddRange(ignoreList);
                     await db.SaveChangesAsync();
+                }
+                else
+                {
+                    // Not a duplicate-key error - don't swallow a genuine DB failure (timeout,
+                    // deadlock, connection drop, etc.); surface it so the import fails loudly.
+                    throw;
                 }
             }
             Console.WriteLine($"Saved {ignoreList.Count.ToString("n0")} events to ignore-list.");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailSentimentScorer.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailSentimentScorer.cs
@@ -77,7 +77,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                 }
                 catch (Exception ex)
                 {
-                    _telemetry.LogWarning($"Cognitive batch analysis failed for {docs.Count} message(s): {ex.Message}");
+                    // Log the full error (with stack trace) but continue: sentiment is best-effort, so
+                    // a failed batch must never fail the whole email import - the affected messages just
+                    // get no score and the rest of the run proceeds.
+                    _telemetry.LogError(ex, $"Cognitive batch sentiment analysis failed for {docs.Count} message(s); continuing without scores for this batch.");
                 }
             }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -111,6 +111,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 // Look through Graph results & compare with already saved reports for this date
                 foreach (var reportPage in LoadedReportPages[dateTime])
                 {
+                    // A usage-report row with no user/group identifier (e.g. a Graph row with a null
+                    // userPrincipalName when report anonymisation is enabled on the tenant) can't be
+                    // matched to a DB lookup. Skip it rather than NRE / ArgumentNullException deeper in
+                    // the loop (IdInScope, the id cache and GetOrCreateLookup all assume non-null) -
+                    // otherwise one such row aborts the whole report import and does so every run.
+                    if (string.IsNullOrWhiteSpace(reportPage.LookupFieldValue))
+                    {
+                        Telemetry.LogWarning($"Skipping a {typeof(TReportDbType).Name} report row with no lookup identifier (null/empty user or group name).");
+                        continue;
+                    }
+
                     // Usually we're checking if the user is in scope (Entra ID group memembership for group filter)
                     var isInScope = await IdInScope(reportPage.LookupFieldValue);
                     if (!isInScope)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractModels.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractModels.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
 {
@@ -9,7 +10,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
         const string DATE_FORMAT = "yyyy-MM-dd";
         [JsonProperty("reportRefreshDate")]
         public string ReportRefreshDateString { get; set; }
-        public DateTime ReportRefreshDate { get => DateTime.ParseExact(ReportRefreshDateString, DATE_FORMAT, null); set => ReportRefreshDateString = value.ToString(DATE_FORMAT); }
+        public DateTime ReportRefreshDate { get => DateTime.ParseExact(ReportRefreshDateString, DATE_FORMAT, CultureInfo.InvariantCulture); set => ReportRefreshDateString = value.ToString(DATE_FORMAT, CultureInfo.InvariantCulture); }
         public abstract string OfficeUniqueIdField { get; }
     }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserUsageLoader.cs
@@ -36,10 +36,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             todaysLog.PostMessages = userActivityReportPage.PostMessages;
             todaysLog.ReplyMessages = userActivityReportPage.ReplyMessages;
 
-            // ISO8601 duration strings.
-            todaysLog.AudioDurationSeconds = System.Xml.XmlConvert.ToTimeSpan(userActivityReportPage.AudioDuration).Seconds;
-            todaysLog.VideoDurationSeconds = System.Xml.XmlConvert.ToTimeSpan(userActivityReportPage.VideoDuration).Seconds;
-            todaysLog.ScreenShareDurationSeconds = System.Xml.XmlConvert.ToTimeSpan(userActivityReportPage.ScreenShareDuration).Seconds;
+            // ISO8601 duration strings. Use TotalSeconds (not .Seconds, which is only the 0-59
+            // seconds COMPONENT and silently truncated any call >= 1 minute, e.g. PT1H2M3S -> 3).
+            todaysLog.AudioDurationSeconds = (int)System.Xml.XmlConvert.ToTimeSpan(userActivityReportPage.AudioDuration).TotalSeconds;
+            todaysLog.VideoDurationSeconds = (int)System.Xml.XmlConvert.ToTimeSpan(userActivityReportPage.VideoDuration).TotalSeconds;
+            todaysLog.ScreenShareDurationSeconds = (int)System.Xml.XmlConvert.ToTimeSpan(userActivityReportPage.ScreenShareDuration).TotalSeconds;
         }
 
         protected override long CountActivity(TeamsUserActivityUserDetail activityPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/GraphAndSqlUserAppLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/GraphAndSqlUserAppLoader.cs
@@ -40,7 +40,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
             // Get users with account enabled set, or without any account enabled value (exclude users with account definately disabled).
             // ...plus users with email address that's not external
             var usersWithLicenses = await _db.users.Include(u => u.LicenseLookups)
-                                .Where(u => ((u.AccountEnabled.HasValue && u.AccountEnabled.HasValue) || !u.AccountEnabled.HasValue)
+                                .Where(u => ((u.AccountEnabled.HasValue && u.AccountEnabled.Value) || !u.AccountEnabled.HasValue)
                                     && !string.IsNullOrEmpty(u.UserPrincipalName) && u.UserPrincipalName.Contains("@") && !u.UserPrincipalName.Contains("#ext#"))
                                 .ToListAsync();
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/GraphAndSqlUserAppLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/GraphAndSqlUserAppLoader.cs
@@ -3,10 +3,12 @@ using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
 using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Kiota.Abstractions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -175,11 +177,70 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                     }
                 }
 
-                // To-do: add paging
-                results.Add(r.Key, new UserAppsLoadState<UserTeamApp> { Results = userApps?.Apps, Retry = throttledRequestInBatch });
+                // Follow @odata.nextLink so users with more installed apps than fit on one Graph page
+                // aren't silently truncated to the first page.
+                List<UserTeamApp> allApps = null;
+                if (userApps != null)
+                {
+                    allApps = await CollectAllAppPagesAsync(userApps, GetNextAppsPageAsync);
+                }
+                results.Add(r.Key, new UserAppsLoadState<UserTeamApp> { Results = allApps, Retry = throttledRequestInBatch });
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Walks <c>@odata.nextLink</c> from a first page of a user's installed apps and returns every
+        /// app across all pages. The page fetch is a delegate so multi-page paging can be unit-tested
+        /// with a fake adaptor (no live tenant that returns more than one page is required). A safety
+        /// cap guards against a malformed / looping nextLink.
+        /// </summary>
+        internal static async Task<List<UserTeamApp>> CollectAllAppPagesAsync(
+            UserTeamAppResponse firstPage,
+            Func<string, Task<UserTeamAppResponse>> fetchNextPageAsync)
+        {
+            var apps = new List<UserTeamApp>();
+            var page = firstPage;
+
+            var safety = 1000;
+            while (page != null && safety-- > 0)
+            {
+                if (page.Apps != null)
+                {
+                    apps.AddRange(page.Apps);
+                }
+                if (string.IsNullOrEmpty(page.OdataNextLink))
+                {
+                    break;
+                }
+                page = await fetchNextPageAsync(page.OdataNextLink);
+            }
+            return apps;
+        }
+
+        /// <summary>
+        /// Fetches one further page of a user's installed apps from a Graph <c>@odata.nextLink</c>.
+        /// Virtual so tests can supply canned pages without a live Graph client.
+        /// </summary>
+        protected virtual async Task<UserTeamAppResponse> GetNextAppsPageAsync(string nextLink)
+        {
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                URI = new Uri(nextLink),
+            };
+
+            var stream = await _graphClient.RequestAdapter.SendPrimitiveAsync<Stream>(requestInfo);
+            if (stream == null)
+            {
+                return null;
+            }
+            using (var reader = new StreamReader(stream))
+            {
+                var body = await reader.ReadToEndAsync();
+                return JsonConvert.DeserializeObject<UserTeamAppResponse>(body);
+            }
         }
 
         public override async Task Save(Dictionary<string, List<UserTeamApp>> pendingSave)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserGroupsCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserGroupsCache.cs
@@ -68,15 +68,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User
             if (_userGroupsCache.TryGetValue(upn, out var cachedGroups))
                 return cachedGroups;
 
-            List<string> groups = null;
+            List<string> groups;
             try
             {
                 groups = await LoadGroupsFromExternalAsync(upn);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                _logger.LogError($"Failed to load groups for user {upn}. Returning empty list.");
-                groups = new List<string>();
+                // Do NOT cache a failed load. Caching an empty list here would persist for the whole
+                // TTL and - because IsInGroupsFilter treats "no groups" as "matches the filter" - would
+                // silently include this user for up to an hour on a single transient Graph error.
+                // Returning an uncached empty list lets the next call retry the load.
+                _logger?.LogError(ex, $"Failed to load groups for user {upn}. Returning an empty (uncached) list so the next call retries.");
+                return new List<string>();
             }
             _userGroupsCache[upn] = groups;
             return groups;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserTeamApp.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserTeamApp.cs
@@ -14,6 +14,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User
         [JsonProperty("@odata.count")]
         public int OdataCount { get; set; }
 
+        [JsonProperty("@odata.nextLink")]
+        public string OdataNextLink { get; set; }
+
         [JsonProperty("value")]
         public List<UserTeamApp> Apps { get; set; }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/RedisSingleDateLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/RedisSingleDateLoader.cs
@@ -24,7 +24,7 @@ namespace WebJob.Office365ActivityImporter.Engine
             if (!string.IsNullOrEmpty(lastVal))
             {
                 var dt = DateTime.Now;
-                if (DateTime.TryParse(lastVal, DateTimeFormatInfo.CurrentInfo, DateTimeStyles.RoundtripKind, out dt))
+                if (DateTime.TryParse(lastVal, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out dt))
                 {
                     return dt;
                 }


### PR DESCRIPTION
## Summary

Promotes the current `dev` line (testing build **1648**) to a new **stable** release. The theme is **importer reliability**: a single bad record / day / section no longer silently aborts or *stalls* an import. It also fixes several data‑correctness bugs (locale‑sensitive number/date parsing, Teams call‑duration truncation, Graph app paging, group‑filter caching), adds a Key Vault firewall step so public‑access installs can upload secrets, and moves the build label back to config. Broad new test coverage is included.

## Why upgrade (admin impact)

- **Importers no longer stall forever on one bad day/record.** Previously a single failing day (or a record that tripped a DB error) could freeze the watermark and stop *all* new data indefinitely. AppInsights and activity imports now isolate per section / per day / per URL and carry on.
- **Teams call durations were under‑reported.** Audio/video/screen‑share seconds used the `.Seconds` component (0–59) instead of `.TotalSeconds`, so any call ≥ 1 minute was truncated (e.g. `PT1H2M3S` → `3`). Correct from now on (historical rows are not back‑filled).
- **Group‑based user filtering is safer.** A transient Graph error no longer caches an empty group list, which previously could wrongly include a user for up to the cache TTL.
- **Non‑US server locales fixed.** Page‑load times and report dates now parse/format with invariant culture (decimal separator + date round‑trip), so a server in e.g. a comma‑decimal locale no longer mis‑parses values.
- **Installer (public‑access deployments):** the Key Vault firewall is now enabled and allow‑lists the installer + App Service IPs so the secret upload's data‑plane call succeeds (issue #136). Private/VNet installs (private endpoint) are unchanged.
- **Failures are now visible.** Previously swallowed exceptions are logged in full (unwrapped inner chain + stack) and reported to telemetry.

## Notable fixes (reviewer detail)

- **ParallelListProcessor** tracked the fire‑and‑forget `ContinueWith(_ => _sem.Release())` continuation instead of the work task, so *every* chunk exception was silently swallowed. Now tracks the work and re‑throws via `Task.WhenAll`; the importer call sites add per‑section/day/URL isolation to handle it.
- **Adoptify language validation** was always‑true (`!= EN || != ES`) and blocked valid installs; corrected to `&&`.
- **StringUtils.FindValueForProp** threw `ArgumentOutOfRangeException` for the last/absent property; now bounded and returns empty.
- **ActivityImportCache** duplicate‑key detection matched a hard‑coded message naming the *wrong* constraint (`PK_processed_audit_events` for `ignored_audit_events`) — dead code that also swallowed genuine DB errors. Now matches SQL error 2601/2627 and re‑throws real failures.
- **GraphAndSqlUserAppLoader**: `AccountEnabled.HasValue && AccountEnabled.HasValue` tautology included disabled accounts (now `.Value`); added `@odata.nextLink` paging (installed‑apps were truncated to the first page).
- **Web app**: HomeController disposes the `DbContext`; SiteTokenAPIController reuses a single static `HttpClient` and rejects missing tokens; TeamsAuthAPIController null‑guards request bodies; AccountController namespace corrected (`WebApplication2` → `Web.AnalyticsWeb.Controllers`).
- **AppInsights searches staging** `user_name` → `nvarchar` (Unicode); `search_term` was already `nvarchar`.

## Behaviour change to be aware of

Errors that were previously **silently swallowed** will now surface in logs/telemetry and, where not isolated, fail the run loudly (the importer then resumes next cycle). This is intentional — it exposes real data‑loss bugs that were invisible before. Expect new error lines that were always happening but hidden.

## Build label

`BuildLabel` reverts from the compiled‑in `BuildConstants` (#25) back to a config `appSetting` substituted by CI (`__BuildLabel__`, the same `devops-actions/variable-substitution` path as the telemetry secrets). After the first stable build, confirm the deployed configs/UI show `Build N` rather than the literal `__BuildLabel__` / `Unknown build`.

## Known follow‑up (not a blocker)

Unicode/usernames are not yet end‑to‑end: the searches **staging** `user_name` is now `nvarchar`, but the permanent `users.user_name` (`Create DB.sql`) and the hits‑import staging table remain `varchar(250)`, and `Migrate Searches Import.sql` joins staging→`users.user_name`. The user‑typed **search terms** are already `nvarchar`, so Greek *searches* are safe; only the username join key has varchar residue. Recommend a follow‑up to make `users.user_name` `nvarchar` per the repo Unicode policy (only material if usernames can be non‑ASCII).

## Validation

- **Tests** and **Release build** workflows green on the `dev` tip (`293dcad`).
- New/extended tests: ParallelListProcessor exception propagation, FindValueForProp edge cases, Graph app paging, UserGroupsCache no‑cache‑on‑error, sentiment logging, install‑engine Key Vault firewall, staging `SqlTypeOverride`, user lookup.

## Included work

PRs #132, #142, #143, #136/#137 plus direct `dev` reliability fixes.
