### PR TITLE
Installer Test Configuration: warn when the installer account can't create RBAC role assignments

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -81,6 +81,13 @@ namespace App.ControlPanel.Engine
                 }
             }
 
+            // Verify the installer account can create RBAC role assignments
+            // (Microsoft.Authorization/roleAssignments/write). Lacking this permission is the cause of
+            // "...does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/write'
+            // over scope '/subscriptions/.../resourceGroups/...'" failures that abort an install part-way
+            // through (e.g. when the installer account only has Contributor). Logs only; never throws.
+            await VerifyInstallerCanAssignRoles(testRg, azCredsValid);
+
             // DNS resolution checks for the configured Azure resource hostnames. Catches the
             // "The remote name could not be resolved" class of failure (broken/limited DNS on the
             // installer host) up-front instead of letting it abort an install part-way through.
@@ -377,6 +384,89 @@ namespace App.ControlPanel.Engine
 
                 default:
                     _logger.LogError($"Unexpected error checking Key Vault '{Config.KeyVaultName}' data-plane access: {result.Message}");
+                    break;
+            }
+        }
+
+        #endregion
+
+        #region Azure RBAC permission checks
+
+        /// <summary>
+        /// Check the installer service principal is actually allowed to create Azure RBAC role assignments
+        /// (<c>Microsoft.Authorization/roleAssignments/write</c>) at the deployment scope - the permission whose
+        /// absence aborts an install with "...does not have authorization to perform action
+        /// 'Microsoft.Authorization/roleAssignments/write' over scope '/subscriptions/.../resourceGroups/...'".
+        /// Checks at the resource-group scope when it exists (the exact scope the install writes to), otherwise at
+        /// the subscription scope. Permissions are inherited, so a subscription-level grant is detected at the RG
+        /// scope too. Logs only; never throws.
+        /// </summary>
+        async Task VerifyInstallerCanAssignRoles(ResourceGroupResource testRg, bool azCredsValid)
+        {
+            if (!azCredsValid)
+            {
+                // No usable subscription / credentials - already reported above; nothing to check against.
+                return;
+            }
+
+            var installerErrs = Config.InstallerAccount?.GetValidationErrors();
+            if (installerErrs == null || installerErrs.Count > 0)
+            {
+                _logger.LogInformation("Skipping installer role-assignment permission check - installer account details are incomplete.");
+                return;
+            }
+
+            if (Config.Subscription == null || !Config.Subscription.IsValidSubscription)
+            {
+                _logger.LogInformation("Skipping installer role-assignment permission check - no valid subscription is configured.");
+                return;
+            }
+
+            string scopeId;
+            string scopeDescription;
+            if (testRg != null)
+            {
+                scopeId = testRg.Id.ToString();
+                scopeDescription = $"resource group '{Config.ResourceGroupName}'";
+            }
+            else
+            {
+                scopeId = $"/subscriptions/{Config.Subscription.SubId}";
+                scopeDescription = $"subscription '{Config.Subscription.DisplayName}'";
+            }
+
+            _logger.LogInformation($"Checking the installer account can create Azure role assignments on {scopeDescription}...");
+
+            var creds = new ClientSecretCredential(Config.InstallerAccount.DirectoryId, Config.InstallerAccount.ClientId, Config.InstallerAccount.Secret);
+            var result = await RbacPermissionProbe.CanAssignRolesAsync(scopeId, creds);
+
+            switch (result.Status)
+            {
+                case RbacAssignmentProbeStatus.CanAssignRoles:
+                    _logger.LogInformation($"Installer account can create role assignments on {scopeDescription} - the RBAC assignment step should succeed.");
+                    break;
+
+                case RbacAssignmentProbeStatus.CannotAssignRoles:
+                    _logger.LogError(
+                        $"The installer account ('{Config.InstallerAccount.ClientId}') does NOT have permission to create Azure role assignments " +
+                        $"(action '{RbacPermissionProbe.RoleAssignmentWriteAction}') on {scopeDescription}. " +
+                        $"The install will fail part-way through with an error like \"...does not have authorization to perform action " +
+                        $"'Microsoft.Authorization/roleAssignments/write' over scope '/subscriptions/.../resourceGroups/...'\". " +
+                        $"Grant the installer app registration the 'Owner' or 'User Access Administrator' (or 'Role Based Access Control Administrator') role " +
+                        $"on {scopeDescription} (or the subscription) and re-run. Note: 'Contributor' is NOT sufficient - it explicitly excludes role-assignment writes.");
+                    break;
+
+                case RbacAssignmentProbeStatus.TransportFailure:
+                    var guidance = PrivateNetworkGuidance.IsPrivateNetworkOnly(Config)
+                        ? PrivateNetworkGuidance.BuildVmOnVNetGuidance("checking installer role-assignment permissions", Config.NetworkConfig?.VNetName)
+                        : "Check DNS / network / firewall connectivity from this host to 'management.azure.com'.";
+                    _logger.LogError($"Could not check installer role-assignment permissions - Azure Resource Manager was unreachable ({result.Message}). " + guidance);
+                    break;
+
+                default:
+                    _logger.LogWarning(
+                        $"Could not determine whether the installer account can create role assignments on {scopeDescription}: {result.Message} " +
+                        $"Ensure the installer account has 'Owner' or 'User Access Administrator' before installing.");
                     break;
             }
         }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/RbacPermissionProbe.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/RbacPermissionProbe.cs
@@ -1,0 +1,196 @@
+using Azure.Core;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure
+{
+    /// <summary>Outcome of an installer-account RBAC role-assignment permission probe.</summary>
+    public enum RbacAssignmentProbeStatus
+    {
+        /// <summary>The account is allowed to create role assignments (Owner / User Access Administrator / RBAC Administrator / equivalent).</summary>
+        CanAssignRoles,
+
+        /// <summary>The account is NOT allowed to create role assignments - the install will fail at the RBAC step.</summary>
+        CannotAssignRoles,
+
+        /// <summary>Azure Resource Manager could not be reached at all (DNS / network / firewall transport failure).</summary>
+        TransportFailure,
+
+        /// <summary>Some other, unexpected error occurred and the permission could not be determined.</summary>
+        OtherError
+    }
+
+    /// <summary>Result of <see cref="RbacPermissionProbe.CanAssignRolesAsync"/>.</summary>
+    public class RbacAssignmentProbeResult
+    {
+        public RbacAssignmentProbeResult(RbacAssignmentProbeStatus status, string message)
+        {
+            Status = status;
+            Message = message;
+        }
+
+        public RbacAssignmentProbeStatus Status { get; }
+        public string Message { get; }
+    }
+
+    /// <summary>
+    /// A single <c>Microsoft.Authorization/permissions</c> entry: the control-plane actions a role grants
+    /// (<see cref="Actions"/>) or explicitly excludes (<see cref="NotActions"/>) for the caller at a scope.
+    /// </summary>
+    public class RbacPermissionEntry
+    {
+        [JsonProperty("actions")]
+        public List<string> Actions { get; set; } = new List<string>();
+
+        [JsonProperty("notActions")]
+        public List<string> NotActions { get; set; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Pre-flight check that the installer service principal is actually allowed to create Azure RBAC role
+    /// assignments (<c>Microsoft.Authorization/roleAssignments/write</c>) at the deployment scope. This pre-empts
+    /// the mid-install failure where <see cref="InstallTasks.RoleAssignmentTask"/> aborts with
+    /// "...does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/write' over
+    /// scope '/subscriptions/.../resourceGroups/...'", which happens when the installer account only has e.g.
+    /// Contributor instead of Owner / User Access Administrator.
+    /// <para>
+    /// It asks Azure Resource Manager for the caller's effective permissions at the scope
+    /// (<c>GET .../{scope}/providers/Microsoft.Authorization/permissions</c>) and evaluates them with Azure RBAC
+    /// wildcard semantics, so an Owner ("*"), User Access Administrator ("Microsoft.Authorization/*") or custom
+    /// role all pass, while Contributor (which excludes role-assignment writes via <c>notActions</c>) and Reader fail.
+    /// </para>
+    /// </summary>
+    public static class RbacPermissionProbe
+    {
+        /// <summary>The control-plane action the installer needs in order to create RBAC role assignments.</summary>
+        public const string RoleAssignmentWriteAction = "Microsoft.Authorization/roleAssignments/write";
+
+        /// <summary>GA api-version for the Microsoft.Authorization "List permissions" operation.</summary>
+        private const string PermissionsApiVersion = "2022-04-01";
+
+        private static readonly string[] ArmScopes = new[] { "https://management.azure.com/.default" };
+
+        /// <summary>
+        /// Determine whether the supplied credential can create role assignments at <paramref name="scopeId"/>.
+        /// <paramref name="scopeId"/> is an ARM scope path beginning with '/', e.g.
+        /// <c>/subscriptions/{subId}/resourceGroups/{rg}</c> or <c>/subscriptions/{subId}</c>. Never throws.
+        /// </summary>
+        public static async Task<RbacAssignmentProbeResult> CanAssignRolesAsync(string scopeId, TokenCredential credential, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(scopeId)) throw new ArgumentException($"'{nameof(scopeId)}' cannot be null or empty.", nameof(scopeId));
+            if (credential == null) throw new ArgumentNullException(nameof(credential));
+
+            try
+            {
+                var permissions = await GetEffectivePermissionsAsync(scopeId.Trim(), credential, cancellationToken);
+                if (ActionIsAllowed(RoleAssignmentWriteAction, permissions))
+                {
+                    return new RbacAssignmentProbeResult(RbacAssignmentProbeStatus.CanAssignRoles,
+                        "Installer account can create role assignments at the deployment scope.");
+                }
+
+                return new RbacAssignmentProbeResult(RbacAssignmentProbeStatus.CannotAssignRoles,
+                    $"Installer account is not granted '{RoleAssignmentWriteAction}' at the deployment scope.");
+            }
+            catch (Exception ex) when (TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leaf))
+            {
+                return new RbacAssignmentProbeResult(RbacAssignmentProbeStatus.TransportFailure, leaf);
+            }
+            catch (Exception ex)
+            {
+                return new RbacAssignmentProbeResult(RbacAssignmentProbeStatus.OtherError, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Call the ARM "List permissions" endpoint for the caller at the given scope, following paging.
+        /// Uses the same ARM-REST + bearer-token pattern as the rest of the install engine.
+        /// </summary>
+        private static async Task<List<RbacPermissionEntry>> GetEffectivePermissionsAsync(string scopeId, TokenCredential credential, CancellationToken cancellationToken)
+        {
+            var token = await credential.GetTokenAsync(new TokenRequestContext(ArmScopes), cancellationToken);
+
+            var all = new List<RbacPermissionEntry>();
+            var url = $"https://management.azure.com{scopeId}/providers/Microsoft.Authorization/permissions?api-version={PermissionsApiVersion}";
+
+            using (var http = new HttpClient())
+            {
+                http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+
+                while (!string.IsNullOrEmpty(url))
+                {
+                    using (var response = await http.GetAsync(url, cancellationToken))
+                    {
+                        var body = await response.Content.ReadAsStringAsync();
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            throw new InvalidOperationException(
+                                $"Azure Resource Manager returned {(int)response.StatusCode} ({response.ReasonPhrase}) listing permissions for scope '{scopeId}': {body}");
+                        }
+
+                        var page = JsonConvert.DeserializeObject<PermissionsListResponse>(body);
+                        if (page?.Value != null)
+                        {
+                            all.AddRange(page.Value);
+                        }
+                        url = page?.NextLink;
+                    }
+                }
+            }
+
+            return all;
+        }
+
+        /// <summary>
+        /// True when <paramref name="action"/> is permitted by any of the supplied permission entries, applying
+        /// Azure RBAC semantics: an entry grants the action when one of its <see cref="RbacPermissionEntry.Actions"/>
+        /// matches AND none of its <see cref="RbacPermissionEntry.NotActions"/> matches.
+        /// </summary>
+        public static bool ActionIsAllowed(string action, IEnumerable<RbacPermissionEntry> permissions)
+        {
+            if (string.IsNullOrEmpty(action) || permissions == null) return false;
+
+            foreach (var permission in permissions)
+            {
+                if (permission == null) continue;
+
+                var granted = permission.Actions != null && permission.Actions.Any(pattern => WildcardMatches(action, pattern));
+                if (!granted) continue;
+
+                var excluded = permission.NotActions != null && permission.NotActions.Any(pattern => WildcardMatches(action, pattern));
+                if (!excluded) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Azure RBAC wildcard match (case-insensitive). A '*' in <paramref name="pattern"/> matches any sequence
+        /// of characters, including '/', so e.g. "*", "Microsoft.Authorization/*" and "Microsoft.Authorization/*/Write"
+        /// all match "Microsoft.Authorization/roleAssignments/write".
+        /// </summary>
+        public static bool WildcardMatches(string action, string pattern)
+        {
+            if (string.IsNullOrEmpty(action) || string.IsNullOrEmpty(pattern)) return false;
+
+            var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+            return Regex.IsMatch(action, regex, RegexOptions.IgnoreCase);
+        }
+
+        private class PermissionsListResponse
+        {
+            [JsonProperty("value")]
+            public List<RbacPermissionEntry> Value { get; set; }
+
+            [JsonProperty("nextLink")]
+            public string NextLink { get; set; }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/RbacPermissionProbeTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/RbacPermissionProbeTests.cs
@@ -1,0 +1,151 @@
+using CloudInstallEngine.Azure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// Pure-logic tests for <see cref="RbacPermissionProbe"/>'s evaluation of whether an account can create
+    /// role assignments (the installer "Test Configuration" pre-flight check). No network is required - the live
+    /// ARM call is exercised separately; these cover the Azure RBAC wildcard / notActions matching that decides
+    /// the pass/fail, using the real built-in role permission sets (Owner, User Access Administrator, RBAC
+    /// Administrator, Contributor, Reader).
+    /// </summary>
+    [TestClass]
+    public class RbacPermissionProbeTests
+    {
+        private const string WriteAction = RbacPermissionProbe.RoleAssignmentWriteAction; // Microsoft.Authorization/roleAssignments/write
+
+        private static RbacPermissionEntry Entry(string[] actions, string[] notActions = null) =>
+            new RbacPermissionEntry
+            {
+                Actions = new List<string>(actions),
+                NotActions = new List<string>(notActions ?? new string[0])
+            };
+
+        #region WildcardMatches
+
+        [TestMethod]
+        public void WildcardMatches_StarMatchesEverything()
+        {
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "*"));
+        }
+
+        [TestMethod]
+        public void WildcardMatches_ProviderWildcardsMatch()
+        {
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/*"));
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/roleAssignments/*"));
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/*/Write"));
+        }
+
+        [TestMethod]
+        public void WildcardMatches_ExactMatchIsCaseInsensitive()
+        {
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/roleAssignments/WRITE"));
+        }
+
+        [TestMethod]
+        public void WildcardMatches_NonMatchingPatterns()
+        {
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, "*/read"));
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Storage/*"));
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/roleDefinitions/write"));
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, ""));
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, null));
+        }
+
+        #endregion
+
+        #region ActionIsAllowed - built-in roles
+
+        [TestMethod]
+        public void Owner_CanAssignRoles()
+        {
+            // Owner: actions ["*"], no notActions.
+            var perms = new[] { Entry(new[] { "*" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void UserAccessAdministrator_CanAssignRoles()
+        {
+            var perms = new[] { Entry(new[] { "*/read", "Microsoft.Authorization/*", "Microsoft.Support/*" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void RbacAdministrator_CanAssignRoles()
+        {
+            // Role Based Access Control Administrator (abridged): grants roleAssignments writes explicitly.
+            var perms = new[] { Entry(new[] { "Microsoft.Authorization/roleAssignments/write", "Microsoft.Authorization/roleAssignments/delete", "*/read" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void Contributor_CannotAssignRoles()
+        {
+            // Contributor: actions ["*"] but notActions excludes Authorization writes/deletes - the canonical
+            // failure mode this whole feature is designed to catch.
+            var perms = new[] { Entry(
+                new[] { "*" },
+                new[] { "Microsoft.Authorization/*/Delete", "Microsoft.Authorization/*/Write", "Microsoft.Authorization/elevateAccess/Action" }) };
+            Assert.IsFalse(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void Reader_CannotAssignRoles()
+        {
+            var perms = new[] { Entry(new[] { "*/read" }) };
+            Assert.IsFalse(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void CustomRole_WithExactAction_CanAssignRoles()
+        {
+            var perms = new[] { Entry(new[] { "Microsoft.Authorization/roleAssignments/write", "Microsoft.Resources/deployments/*" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        #endregion
+
+        #region ActionIsAllowed - multiple roles & edge cases
+
+        [TestMethod]
+        public void MultipleRoles_AnyGrantingEntryWins()
+        {
+            // Reader + a custom role that grants the write -> allowed.
+            var perms = new[]
+            {
+                Entry(new[] { "*/read" }),
+                Entry(new[] { "Microsoft.Authorization/roleAssignments/*" })
+            };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void ContributorPlusUserAccessAdministrator_CanAssignRoles()
+        {
+            // Contributor excludes the write, but a separate User Access Administrator assignment grants it.
+            var contributor = Entry(new[] { "*" }, new[] { "Microsoft.Authorization/*/Write", "Microsoft.Authorization/*/Delete" });
+            var userAccessAdmin = Entry(new[] { "*/read", "Microsoft.Authorization/*" });
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, new[] { contributor, userAccessAdmin }));
+        }
+
+        [TestMethod]
+        public void EmptyOrNullPermissions_NotAllowed()
+        {
+            Assert.IsFalse(RbacPermissionProbe.ActionIsAllowed(WriteAction, new RbacPermissionEntry[0]));
+            Assert.IsFalse(RbacPermissionProbe.ActionIsAllowed(WriteAction, null));
+        }
+
+        [TestMethod]
+        public void NullEntriesAreSkipped()
+        {
+            var perms = new RbacPermissionEntry[] { null, Entry(new[] { "*" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -164,6 +164,7 @@
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
     <Compile Include="InstallTests\KeyVaultFirewallConfigTaskTests.cs" />
+    <Compile Include="InstallTests\RbacPermissionProbeTests.cs" />
     <Compile Include="InstallTests\TeamsUserActivityReportUrlTests.cs" />
     <Compile Include="InstallTests\SpoInstallTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
## Problem

The installer fails part-way through a deployment when the installer service principal lacks `Microsoft.Authorization/roleAssignments/write` (typically because it only has **Contributor** rather than **Owner** / **User Access Administrator**). It aborts at the RBAC step with errors like:

```
[RBAC] Failed to assign RBAC roles: The client '...' with object id '...' does not have authorization
to perform action 'Microsoft.Authorization/roleAssignments/write' over scope
'/subscriptions/.../resourceGroups/.../providers/Microsoft.Authorization/roleAssignments/...'
```

Customers hit this repeatedly, and "Test Configuration" gave them no advance warning.

## What this adds

A read-only pre-flight check in the installer **Test Configuration** (`SolutionInstallVerifier.RunTests`) that verifies the installer account can actually create role assignments **before** an install is attempted. On failure it logs a precise, admin-facing remediation:

> The installer account ('...') does NOT have permission to create Azure role assignments (action 'Microsoft.Authorization/roleAssignments/write') on resource group '...'. ... Grant the installer app registration the 'Owner' or 'User Access Administrator' (or 'Role Based Access Control Administrator') role ... Note: 'Contributor' is NOT sufficient — it explicitly excludes role-assignment writes.

## How it works

- New **`RbacPermissionProbe`** (`Common/CloudInstallEngine/Azure`), mirroring `KeyVaultDataPlaneProbe`:
  - Calls ARM `GET .../{scope}/providers/Microsoft.Authorization/permissions` with the installer `ClientSecretCredential` to get the caller's **own effective permissions** (works for service principals).
  - Evaluates `Microsoft.Authorization/roleAssignments/write` using Azure RBAC **wildcard + `notActions`** semantics, so Owner (`*`), User Access Administrator (`Microsoft.Authorization/*`), RBAC Administrator and custom roles **pass**, while Contributor (`notActions: Microsoft.Authorization/*/Write`) and Reader **fail**.
  - Returns a status enum; **never throws**.
- New **`VerifyInstallerCanAssignRoles`** wired into `RunTests` right after the resource-group check. Scope = the resource group when it exists (the exact scope the install writes to), else the subscription; inherited grants are detected either way. `TransportFailure` → network guidance; indeterminate → warning (no false alarm).
- Checks the actual **action**, not the "Owner" role name — so any role that grants it is accepted.

## Tests

14 new unit tests (`RbacPermissionProbeTests`) covering the matching logic with the real built-in role permission sets — Owner / User Access Administrator / RBAC Administrator / custom roles pass; **Contributor** and Reader fail; wildcard, case-insensitivity, multi-role and null/empty edge cases. All green.

`CloudInstallEngine` + `App.ControlPanel.Engine` + `Tests.UnitTests` build clean.

## Notes

- Read-only and non-throwing — consistent with the other Test Configuration checks; it can never block or break an install.
- The live ARM call is not unit-tested (matches the repo's pattern for live-Azure code, e.g. the mostly-disabled `InstallEngineTests`); the pass/fail evaluation is fully covered.
- No Azure SDK package version changes (avoids the netstandard2.0/net48 CS1705 risk); uses the existing direct-ARM-REST + token pattern.
