### PR TITLE
Fix installer abort when runbook kind differs (different runbook kind is not allowed)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/RunbookCreateOrUpdateTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/RunbookCreateOrUpdateTasks.cs
@@ -87,12 +87,20 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
         public const string CONFIG_PARAM_FILE_LOCATION = "FileName";
         public const string CONFIG_PARAM_AUTOMATION_ACCOUNT_NAME = "AutomationAccount";
 
+        // Runbook runtime kind we standardise on. Azure Automation forbids changing a runbook's kind in
+        // place, so an existing runbook of a different kind is deleted and recreated as this type below.
+        const string RUNBOOK_TYPE = "PowerShell72";
+
         const int MAX_ATTEMPTS = 3;
         static readonly TimeSpan RETRY_DELAY = TimeSpan.FromSeconds(5);
 
         public RunbookUploadTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
         {
         }
+
+        // Deploying the profiling runbooks is a secondary feature: a failure here must never abort the
+        // rest of the install. The job loop logs the failure and continues (SequentialTaskListInstallJob).
+        public override bool IsCritical => false;
 
         public override async Task<RunbookFileLocalLocations> ExecuteTaskReturnResult(object contextArg)
         {
@@ -112,14 +120,21 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
 
             _logger.LogInformation($"Uploading runbook '{_config.ResourceName}' from '{localPath}' via Automation draft-content API.");
 
+            var runbooks = automationAccount.GetAutomationRunbooks();
+
             for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)
             {
                 try
                 {
+                    // Azure Automation forbids changing a runbook's kind in place ("Update runbook with
+                    // definition of different runbook kind is not allowed"). If an older install left this
+                    // runbook as a different kind, delete it first so it can be recreated as RUNBOOK_TYPE.
+                    await DeleteIfDifferentKindAsync(runbooks);
+
                     // 1. Create/update the runbook metadata with an empty draft (no PublishContentLink).
                     //    Setting Draft = new AutomationRunbookDraft() tells the API to allocate a fresh empty draft
                     //    that we'll then PUT bytes into via the next call.
-                    var newRunbookInfo = new AutomationRunbookCreateOrUpdateContent(new AutomationRunbookType("PowerShell72"))
+                    var newRunbookInfo = new AutomationRunbookCreateOrUpdateContent(new AutomationRunbookType(RUNBOOK_TYPE))
                     {
                         Location = base.AzureLocation,
                         Name = _config.ResourceName,
@@ -128,7 +143,7 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
                     };
                     base.EnsureTagsOnNew(newRunbookInfo.Tags);
 
-                    var createReq = await automationAccount.GetAutomationRunbooks().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newRunbookInfo);
+                    var createReq = await runbooks.CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newRunbookInfo);
                     var runbook = createReq.Value;
 
                     // 2. Upload the script body into the draft.
@@ -144,6 +159,14 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
                     await base.EnsureTagsOnExisting(runbook.Data.Tags, runbook.GetTagResource());
                     return context;
                 }
+                catch (RequestFailedException ex) when (IsDifferentKindError(ex) && attempt < MAX_ATTEMPTS)
+                {
+                    // Safety net for a race the proactive check above missed: the existing runbook is a
+                    // different kind. Delete it and let the loop retry with a clean create.
+                    _logger.LogWarning($"Attempt {attempt}/{MAX_ATTEMPTS}: runbook '{_config.ResourceName}' exists with a different kind; deleting so it can be recreated as {RUNBOOK_TYPE}.");
+                    await TryDeleteRunbookAsync(runbooks);
+                    await Task.Delay(RETRY_DELAY);
+                }
                 catch (RequestFailedException ex) when (attempt < MAX_ATTEMPTS)
                 {
                     _logger.LogWarning($"Attempt {attempt}/{MAX_ATTEMPTS}: Failed to create/update runbook '{_config.ResourceName}' - {ex.Message}. Retrying in {RETRY_DELAY.TotalSeconds:0}s...");
@@ -151,8 +174,52 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
                 }
             }
 
-            // All attempts exhausted - fail loudly so the install doesn't silently leave the Automation account in a broken state.
+            // All attempts exhausted. This task is non-critical (see IsCritical), so the job loop logs this
+            // and continues the install rather than aborting.
             throw new UnexpectedInstallException($"Failed to create/update runbook '{_config.ResourceName}' after {MAX_ATTEMPTS} attempts.");
+        }
+
+        static bool IsDifferentKindError(RequestFailedException ex)
+            => ex.Status == 400 && ex.Message.IndexOf("different runbook kind", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        /// <summary>
+        /// Azure Automation forbids changing a runbook's kind in place. If a runbook with this name already
+        /// exists with a kind other than <c>RUNBOOK_TYPE</c>, delete it so it can be recreated. Deleting a
+        /// runbook also removes its job history and any manually-created schedule-to-runbook links, so the
+        /// operator must re-link the recreated runbook to its schedule afterwards.
+        /// </summary>
+        async Task DeleteIfDifferentKindAsync(AutomationRunbookCollection runbooks)
+        {
+            var existing = await runbooks.GetIfExistsAsync(_config.ResourceName);
+            if (!existing.HasValue)
+            {
+                return;
+            }
+
+            var existingKind = existing.Value.Data.RunbookType?.ToString();
+            if (string.Equals(existingKind, RUNBOOK_TYPE, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            _logger.LogWarning($"Runbook '{_config.ResourceName}' already exists as kind '{existingKind}', which can't be updated in place to {RUNBOOK_TYPE}. Deleting and recreating it. NOTE: its job history and any manually-created schedule-to-runbook links will be lost - re-link the runbook to its schedule after the install completes.");
+            await existing.Value.DeleteAsync(WaitUntil.Completed);
+        }
+
+        async Task TryDeleteRunbookAsync(AutomationRunbookCollection runbooks)
+        {
+            try
+            {
+                var existing = await runbooks.GetIfExistsAsync(_config.ResourceName);
+                if (existing.HasValue)
+                {
+                    await existing.Value.DeleteAsync(WaitUntil.Completed);
+                }
+            }
+            catch (RequestFailedException delEx)
+            {
+                _logger.LogWarning($"Could not delete existing runbook '{_config.ResourceName}' before retry: {delEx.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
## What & why

Re-running the installer where the profiling Automation runbooks already exist as a different runbook kind aborted the whole install with HTTP 400 *"Update runbook with definition of different runbook kind is not allowed"*. Azure Automation does not allow changing a runbook's kind in place, and the retry loop blindly retried the identical request while the task was critical — so the install stopped.

Fixes #148.

## Changes

All in `RunbookUploadTask` (`App.ControlPanel.Engine/InstallerTasks/JobTasks/RunbookCreateOrUpdateTasks.cs`, shared base → `Aggregation_Status`, `Database_Maintenance`, `Weekly_Update`):

- **Delete + recreate on kind mismatch** — before create, `GetIfExistsAsync` + compare `Data.RunbookType`; if a different kind exists, log a warning and `DeleteAsync`, then recreate as `PowerShell72`. A reactive safety-net catch on the specific 400 also deletes + retries (handles races).
- **Non-critical** (`IsCritical => false`) — a runbook failure now logs `"Non-critical stage … failed; continuing installation"` and the install continues instead of aborting (matches the existing `KeyVaultSecretAddTask` precedent). Sibling runbooks still run because the loop carries the prior `RunbookFileLocalLocations` context forward.
- Extracted the `"PowerShell72"` magic string into a `const`.

## Behaviour matrix
- Fresh install (no runbook): normal create.
- Re-run, same kind (`PowerShell72`): in-place update, as before.
- Upgrade, different kind: warn → delete → recreate as `PowerShell72`.
- Any residual failure: logged, install continues (non-critical).

## Operator note
Delete + recreate is the only Azure-supported way to change a runbook's kind. It drops the runbook's job history and any **manually-created** schedule→runbook links (the installer creates the schedules but not the links). Admins must re-link the recreated runbooks to their schedules after upgrade. This is surfaced in the install warning log.

## Testing
- `App.ControlPanel.Engine` restores + builds clean (MSBuild VS18, exit 0); only pre-existing unrelated warnings.
- SDK API surface (`GetIfExistsAsync`/`NullableResponse`, `Data.RunbookType`, `DeleteAsync`) verified against `Azure.ResourceManager.Automation` 1.1.0.
- No existing unit tests cover these tasks; no package or binding-redirect changes.
