### PR TITLE
Release: installer reliability - RBAC permission pre-flight check + runbook-kind install fix (publishable stable since 1653)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/RunbookCreateOrUpdateTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/RunbookCreateOrUpdateTasks.cs
@@ -87,12 +87,20 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
         public const string CONFIG_PARAM_FILE_LOCATION = "FileName";
         public const string CONFIG_PARAM_AUTOMATION_ACCOUNT_NAME = "AutomationAccount";
 
+        // Runbook runtime kind we standardise on. Azure Automation forbids changing a runbook's kind in
+        // place, so an existing runbook of a different kind is deleted and recreated as this type below.
+        const string RUNBOOK_TYPE = "PowerShell72";
+
         const int MAX_ATTEMPTS = 3;
         static readonly TimeSpan RETRY_DELAY = TimeSpan.FromSeconds(5);
 
         public RunbookUploadTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
         {
         }
+
+        // Deploying the profiling runbooks is a secondary feature: a failure here must never abort the
+        // rest of the install. The job loop logs the failure and continues (SequentialTaskListInstallJob).
+        public override bool IsCritical => false;
 
         public override async Task<RunbookFileLocalLocations> ExecuteTaskReturnResult(object contextArg)
         {
@@ -112,14 +120,21 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
 
             _logger.LogInformation($"Uploading runbook '{_config.ResourceName}' from '{localPath}' via Automation draft-content API.");
 
+            var runbooks = automationAccount.GetAutomationRunbooks();
+
             for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)
             {
                 try
                 {
+                    // Azure Automation forbids changing a runbook's kind in place ("Update runbook with
+                    // definition of different runbook kind is not allowed"). If an older install left this
+                    // runbook as a different kind, delete it first so it can be recreated as RUNBOOK_TYPE.
+                    await DeleteIfDifferentKindAsync(runbooks);
+
                     // 1. Create/update the runbook metadata with an empty draft (no PublishContentLink).
                     //    Setting Draft = new AutomationRunbookDraft() tells the API to allocate a fresh empty draft
                     //    that we'll then PUT bytes into via the next call.
-                    var newRunbookInfo = new AutomationRunbookCreateOrUpdateContent(new AutomationRunbookType("PowerShell72"))
+                    var newRunbookInfo = new AutomationRunbookCreateOrUpdateContent(new AutomationRunbookType(RUNBOOK_TYPE))
                     {
                         Location = base.AzureLocation,
                         Name = _config.ResourceName,
@@ -128,7 +143,7 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
                     };
                     base.EnsureTagsOnNew(newRunbookInfo.Tags);
 
-                    var createReq = await automationAccount.GetAutomationRunbooks().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newRunbookInfo);
+                    var createReq = await runbooks.CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newRunbookInfo);
                     var runbook = createReq.Value;
 
                     // 2. Upload the script body into the draft.
@@ -144,6 +159,14 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
                     await base.EnsureTagsOnExisting(runbook.Data.Tags, runbook.GetTagResource());
                     return context;
                 }
+                catch (RequestFailedException ex) when (IsDifferentKindError(ex) && attempt < MAX_ATTEMPTS)
+                {
+                    // Safety net for a race the proactive check above missed: the existing runbook is a
+                    // different kind. Delete it and let the loop retry with a clean create.
+                    _logger.LogWarning($"Attempt {attempt}/{MAX_ATTEMPTS}: runbook '{_config.ResourceName}' exists with a different kind; deleting so it can be recreated as {RUNBOOK_TYPE}.");
+                    await TryDeleteRunbookAsync(runbooks);
+                    await Task.Delay(RETRY_DELAY);
+                }
                 catch (RequestFailedException ex) when (attempt < MAX_ATTEMPTS)
                 {
                     _logger.LogWarning($"Attempt {attempt}/{MAX_ATTEMPTS}: Failed to create/update runbook '{_config.ResourceName}' - {ex.Message}. Retrying in {RETRY_DELAY.TotalSeconds:0}s...");
@@ -151,8 +174,52 @@ namespace App.ControlPanel.Engine.InstallerTasks.JobTasks
                 }
             }
 
-            // All attempts exhausted - fail loudly so the install doesn't silently leave the Automation account in a broken state.
+            // All attempts exhausted. This task is non-critical (see IsCritical), so the job loop logs this
+            // and continues the install rather than aborting.
             throw new UnexpectedInstallException($"Failed to create/update runbook '{_config.ResourceName}' after {MAX_ATTEMPTS} attempts.");
+        }
+
+        static bool IsDifferentKindError(RequestFailedException ex)
+            => ex.Status == 400 && ex.Message.IndexOf("different runbook kind", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        /// <summary>
+        /// Azure Automation forbids changing a runbook's kind in place. If a runbook with this name already
+        /// exists with a kind other than <c>RUNBOOK_TYPE</c>, delete it so it can be recreated. Deleting a
+        /// runbook also removes its job history and any manually-created schedule-to-runbook links, so the
+        /// operator must re-link the recreated runbook to its schedule afterwards.
+        /// </summary>
+        async Task DeleteIfDifferentKindAsync(AutomationRunbookCollection runbooks)
+        {
+            var existing = await runbooks.GetIfExistsAsync(_config.ResourceName);
+            if (!existing.HasValue)
+            {
+                return;
+            }
+
+            var existingKind = existing.Value.Data.RunbookType?.ToString();
+            if (string.Equals(existingKind, RUNBOOK_TYPE, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            _logger.LogWarning($"Runbook '{_config.ResourceName}' already exists as kind '{existingKind}', which can't be updated in place to {RUNBOOK_TYPE}. Deleting and recreating it. NOTE: its job history and any manually-created schedule-to-runbook links will be lost - re-link the runbook to its schedule after the install completes.");
+            await existing.Value.DeleteAsync(WaitUntil.Completed);
+        }
+
+        async Task TryDeleteRunbookAsync(AutomationRunbookCollection runbooks)
+        {
+            try
+            {
+                var existing = await runbooks.GetIfExistsAsync(_config.ResourceName);
+                if (existing.HasValue)
+                {
+                    await existing.Value.DeleteAsync(WaitUntil.Completed);
+                }
+            }
+            catch (RequestFailedException delEx)
+            {
+                _logger.LogWarning($"Could not delete existing runbook '{_config.ResourceName}' before retry: {delEx.Message}");
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -81,6 +81,13 @@ namespace App.ControlPanel.Engine
                 }
             }
 
+            // Verify the installer account can create RBAC role assignments
+            // (Microsoft.Authorization/roleAssignments/write). Lacking this permission is the cause of
+            // "...does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/write'
+            // over scope '/subscriptions/.../resourceGroups/...'" failures that abort an install part-way
+            // through (e.g. when the installer account only has Contributor). Logs only; never throws.
+            await VerifyInstallerCanAssignRoles(testRg, azCredsValid);
+
             // DNS resolution checks for the configured Azure resource hostnames. Catches the
             // "The remote name could not be resolved" class of failure (broken/limited DNS on the
             // installer host) up-front instead of letting it abort an install part-way through.
@@ -377,6 +384,89 @@ namespace App.ControlPanel.Engine
 
                 default:
                     _logger.LogError($"Unexpected error checking Key Vault '{Config.KeyVaultName}' data-plane access: {result.Message}");
+                    break;
+            }
+        }
+
+        #endregion
+
+        #region Azure RBAC permission checks
+
+        /// <summary>
+        /// Check the installer service principal is actually allowed to create Azure RBAC role assignments
+        /// (<c>Microsoft.Authorization/roleAssignments/write</c>) at the deployment scope - the permission whose
+        /// absence aborts an install with "...does not have authorization to perform action
+        /// 'Microsoft.Authorization/roleAssignments/write' over scope '/subscriptions/.../resourceGroups/...'".
+        /// Checks at the resource-group scope when it exists (the exact scope the install writes to), otherwise at
+        /// the subscription scope. Permissions are inherited, so a subscription-level grant is detected at the RG
+        /// scope too. Logs only; never throws.
+        /// </summary>
+        async Task VerifyInstallerCanAssignRoles(ResourceGroupResource testRg, bool azCredsValid)
+        {
+            if (!azCredsValid)
+            {
+                // No usable subscription / credentials - already reported above; nothing to check against.
+                return;
+            }
+
+            var installerErrs = Config.InstallerAccount?.GetValidationErrors();
+            if (installerErrs == null || installerErrs.Count > 0)
+            {
+                _logger.LogInformation("Skipping installer role-assignment permission check - installer account details are incomplete.");
+                return;
+            }
+
+            if (Config.Subscription == null || !Config.Subscription.IsValidSubscription)
+            {
+                _logger.LogInformation("Skipping installer role-assignment permission check - no valid subscription is configured.");
+                return;
+            }
+
+            string scopeId;
+            string scopeDescription;
+            if (testRg != null)
+            {
+                scopeId = testRg.Id.ToString();
+                scopeDescription = $"resource group '{Config.ResourceGroupName}'";
+            }
+            else
+            {
+                scopeId = $"/subscriptions/{Config.Subscription.SubId}";
+                scopeDescription = $"subscription '{Config.Subscription.DisplayName}'";
+            }
+
+            _logger.LogInformation($"Checking the installer account can create Azure role assignments on {scopeDescription}...");
+
+            var creds = new ClientSecretCredential(Config.InstallerAccount.DirectoryId, Config.InstallerAccount.ClientId, Config.InstallerAccount.Secret);
+            var result = await RbacPermissionProbe.CanAssignRolesAsync(scopeId, creds);
+
+            switch (result.Status)
+            {
+                case RbacAssignmentProbeStatus.CanAssignRoles:
+                    _logger.LogInformation($"Installer account can create role assignments on {scopeDescription} - the RBAC assignment step should succeed.");
+                    break;
+
+                case RbacAssignmentProbeStatus.CannotAssignRoles:
+                    _logger.LogError(
+                        $"The installer account ('{Config.InstallerAccount.ClientId}') does NOT have permission to create Azure role assignments " +
+                        $"(action '{RbacPermissionProbe.RoleAssignmentWriteAction}') on {scopeDescription}. " +
+                        $"The install will fail part-way through with an error like \"...does not have authorization to perform action " +
+                        $"'Microsoft.Authorization/roleAssignments/write' over scope '/subscriptions/.../resourceGroups/...'\". " +
+                        $"Grant the installer app registration the 'Owner' or 'User Access Administrator' (or 'Role Based Access Control Administrator') role " +
+                        $"on {scopeDescription} (or the subscription) and re-run. Note: 'Contributor' is NOT sufficient - it explicitly excludes role-assignment writes.");
+                    break;
+
+                case RbacAssignmentProbeStatus.TransportFailure:
+                    var guidance = PrivateNetworkGuidance.IsPrivateNetworkOnly(Config)
+                        ? PrivateNetworkGuidance.BuildVmOnVNetGuidance("checking installer role-assignment permissions", Config.NetworkConfig?.VNetName)
+                        : "Check DNS / network / firewall connectivity from this host to 'management.azure.com'.";
+                    _logger.LogError($"Could not check installer role-assignment permissions - Azure Resource Manager was unreachable ({result.Message}). " + guidance);
+                    break;
+
+                default:
+                    _logger.LogWarning(
+                        $"Could not determine whether the installer account can create role assignments on {scopeDescription}: {result.Message} " +
+                        $"Ensure the installer account has 'Owner' or 'User Access Administrator' before installing.");
                     break;
             }
         }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/RbacPermissionProbe.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/RbacPermissionProbe.cs
@@ -1,0 +1,196 @@
+using Azure.Core;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure
+{
+    /// <summary>Outcome of an installer-account RBAC role-assignment permission probe.</summary>
+    public enum RbacAssignmentProbeStatus
+    {
+        /// <summary>The account is allowed to create role assignments (Owner / User Access Administrator / RBAC Administrator / equivalent).</summary>
+        CanAssignRoles,
+
+        /// <summary>The account is NOT allowed to create role assignments - the install will fail at the RBAC step.</summary>
+        CannotAssignRoles,
+
+        /// <summary>Azure Resource Manager could not be reached at all (DNS / network / firewall transport failure).</summary>
+        TransportFailure,
+
+        /// <summary>Some other, unexpected error occurred and the permission could not be determined.</summary>
+        OtherError
+    }
+
+    /// <summary>Result of <see cref="RbacPermissionProbe.CanAssignRolesAsync"/>.</summary>
+    public class RbacAssignmentProbeResult
+    {
+        public RbacAssignmentProbeResult(RbacAssignmentProbeStatus status, string message)
+        {
+            Status = status;
+            Message = message;
+        }
+
+        public RbacAssignmentProbeStatus Status { get; }
+        public string Message { get; }
+    }
+
+    /// <summary>
+    /// A single <c>Microsoft.Authorization/permissions</c> entry: the control-plane actions a role grants
+    /// (<see cref="Actions"/>) or explicitly excludes (<see cref="NotActions"/>) for the caller at a scope.
+    /// </summary>
+    public class RbacPermissionEntry
+    {
+        [JsonProperty("actions")]
+        public List<string> Actions { get; set; } = new List<string>();
+
+        [JsonProperty("notActions")]
+        public List<string> NotActions { get; set; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Pre-flight check that the installer service principal is actually allowed to create Azure RBAC role
+    /// assignments (<c>Microsoft.Authorization/roleAssignments/write</c>) at the deployment scope. This pre-empts
+    /// the mid-install failure where <see cref="InstallTasks.RoleAssignmentTask"/> aborts with
+    /// "...does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/write' over
+    /// scope '/subscriptions/.../resourceGroups/...'", which happens when the installer account only has e.g.
+    /// Contributor instead of Owner / User Access Administrator.
+    /// <para>
+    /// It asks Azure Resource Manager for the caller's effective permissions at the scope
+    /// (<c>GET .../{scope}/providers/Microsoft.Authorization/permissions</c>) and evaluates them with Azure RBAC
+    /// wildcard semantics, so an Owner ("*"), User Access Administrator ("Microsoft.Authorization/*") or custom
+    /// role all pass, while Contributor (which excludes role-assignment writes via <c>notActions</c>) and Reader fail.
+    /// </para>
+    /// </summary>
+    public static class RbacPermissionProbe
+    {
+        /// <summary>The control-plane action the installer needs in order to create RBAC role assignments.</summary>
+        public const string RoleAssignmentWriteAction = "Microsoft.Authorization/roleAssignments/write";
+
+        /// <summary>GA api-version for the Microsoft.Authorization "List permissions" operation.</summary>
+        private const string PermissionsApiVersion = "2022-04-01";
+
+        private static readonly string[] ArmScopes = new[] { "https://management.azure.com/.default" };
+
+        /// <summary>
+        /// Determine whether the supplied credential can create role assignments at <paramref name="scopeId"/>.
+        /// <paramref name="scopeId"/> is an ARM scope path beginning with '/', e.g.
+        /// <c>/subscriptions/{subId}/resourceGroups/{rg}</c> or <c>/subscriptions/{subId}</c>. Never throws.
+        /// </summary>
+        public static async Task<RbacAssignmentProbeResult> CanAssignRolesAsync(string scopeId, TokenCredential credential, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(scopeId)) throw new ArgumentException($"'{nameof(scopeId)}' cannot be null or empty.", nameof(scopeId));
+            if (credential == null) throw new ArgumentNullException(nameof(credential));
+
+            try
+            {
+                var permissions = await GetEffectivePermissionsAsync(scopeId.Trim(), credential, cancellationToken);
+                if (ActionIsAllowed(RoleAssignmentWriteAction, permissions))
+                {
+                    return new RbacAssignmentProbeResult(RbacAssignmentProbeStatus.CanAssignRoles,
+                        "Installer account can create role assignments at the deployment scope.");
+                }
+
+                return new RbacAssignmentProbeResult(RbacAssignmentProbeStatus.CannotAssignRoles,
+                    $"Installer account is not granted '{RoleAssignmentWriteAction}' at the deployment scope.");
+            }
+            catch (Exception ex) when (TransportFailureDetector.IsTransportOrDnsFailure(ex, out var leaf))
+            {
+                return new RbacAssignmentProbeResult(RbacAssignmentProbeStatus.TransportFailure, leaf);
+            }
+            catch (Exception ex)
+            {
+                return new RbacAssignmentProbeResult(RbacAssignmentProbeStatus.OtherError, ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Call the ARM "List permissions" endpoint for the caller at the given scope, following paging.
+        /// Uses the same ARM-REST + bearer-token pattern as the rest of the install engine.
+        /// </summary>
+        private static async Task<List<RbacPermissionEntry>> GetEffectivePermissionsAsync(string scopeId, TokenCredential credential, CancellationToken cancellationToken)
+        {
+            var token = await credential.GetTokenAsync(new TokenRequestContext(ArmScopes), cancellationToken);
+
+            var all = new List<RbacPermissionEntry>();
+            var url = $"https://management.azure.com{scopeId}/providers/Microsoft.Authorization/permissions?api-version={PermissionsApiVersion}";
+
+            using (var http = new HttpClient())
+            {
+                http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+
+                while (!string.IsNullOrEmpty(url))
+                {
+                    using (var response = await http.GetAsync(url, cancellationToken))
+                    {
+                        var body = await response.Content.ReadAsStringAsync();
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            throw new InvalidOperationException(
+                                $"Azure Resource Manager returned {(int)response.StatusCode} ({response.ReasonPhrase}) listing permissions for scope '{scopeId}': {body}");
+                        }
+
+                        var page = JsonConvert.DeserializeObject<PermissionsListResponse>(body);
+                        if (page?.Value != null)
+                        {
+                            all.AddRange(page.Value);
+                        }
+                        url = page?.NextLink;
+                    }
+                }
+            }
+
+            return all;
+        }
+
+        /// <summary>
+        /// True when <paramref name="action"/> is permitted by any of the supplied permission entries, applying
+        /// Azure RBAC semantics: an entry grants the action when one of its <see cref="RbacPermissionEntry.Actions"/>
+        /// matches AND none of its <see cref="RbacPermissionEntry.NotActions"/> matches.
+        /// </summary>
+        public static bool ActionIsAllowed(string action, IEnumerable<RbacPermissionEntry> permissions)
+        {
+            if (string.IsNullOrEmpty(action) || permissions == null) return false;
+
+            foreach (var permission in permissions)
+            {
+                if (permission == null) continue;
+
+                var granted = permission.Actions != null && permission.Actions.Any(pattern => WildcardMatches(action, pattern));
+                if (!granted) continue;
+
+                var excluded = permission.NotActions != null && permission.NotActions.Any(pattern => WildcardMatches(action, pattern));
+                if (!excluded) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Azure RBAC wildcard match (case-insensitive). A '*' in <paramref name="pattern"/> matches any sequence
+        /// of characters, including '/', so e.g. "*", "Microsoft.Authorization/*" and "Microsoft.Authorization/*/Write"
+        /// all match "Microsoft.Authorization/roleAssignments/write".
+        /// </summary>
+        public static bool WildcardMatches(string action, string pattern)
+        {
+            if (string.IsNullOrEmpty(action) || string.IsNullOrEmpty(pattern)) return false;
+
+            var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+            return Regex.IsMatch(action, regex, RegexOptions.IgnoreCase);
+        }
+
+        private class PermissionsListResponse
+        {
+            [JsonProperty("value")]
+            public List<RbacPermissionEntry> Value { get; set; }
+
+            [JsonProperty("nextLink")]
+            public string NextLink { get; set; }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/RbacPermissionProbeTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/RbacPermissionProbeTests.cs
@@ -1,0 +1,151 @@
+using CloudInstallEngine.Azure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// Pure-logic tests for <see cref="RbacPermissionProbe"/>'s evaluation of whether an account can create
+    /// role assignments (the installer "Test Configuration" pre-flight check). No network is required - the live
+    /// ARM call is exercised separately; these cover the Azure RBAC wildcard / notActions matching that decides
+    /// the pass/fail, using the real built-in role permission sets (Owner, User Access Administrator, RBAC
+    /// Administrator, Contributor, Reader).
+    /// </summary>
+    [TestClass]
+    public class RbacPermissionProbeTests
+    {
+        private const string WriteAction = RbacPermissionProbe.RoleAssignmentWriteAction; // Microsoft.Authorization/roleAssignments/write
+
+        private static RbacPermissionEntry Entry(string[] actions, string[] notActions = null) =>
+            new RbacPermissionEntry
+            {
+                Actions = new List<string>(actions),
+                NotActions = new List<string>(notActions ?? new string[0])
+            };
+
+        #region WildcardMatches
+
+        [TestMethod]
+        public void WildcardMatches_StarMatchesEverything()
+        {
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "*"));
+        }
+
+        [TestMethod]
+        public void WildcardMatches_ProviderWildcardsMatch()
+        {
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/*"));
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/roleAssignments/*"));
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/*/Write"));
+        }
+
+        [TestMethod]
+        public void WildcardMatches_ExactMatchIsCaseInsensitive()
+        {
+            Assert.IsTrue(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/roleAssignments/WRITE"));
+        }
+
+        [TestMethod]
+        public void WildcardMatches_NonMatchingPatterns()
+        {
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, "*/read"));
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Storage/*"));
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, "Microsoft.Authorization/roleDefinitions/write"));
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, ""));
+            Assert.IsFalse(RbacPermissionProbe.WildcardMatches(WriteAction, null));
+        }
+
+        #endregion
+
+        #region ActionIsAllowed - built-in roles
+
+        [TestMethod]
+        public void Owner_CanAssignRoles()
+        {
+            // Owner: actions ["*"], no notActions.
+            var perms = new[] { Entry(new[] { "*" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void UserAccessAdministrator_CanAssignRoles()
+        {
+            var perms = new[] { Entry(new[] { "*/read", "Microsoft.Authorization/*", "Microsoft.Support/*" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void RbacAdministrator_CanAssignRoles()
+        {
+            // Role Based Access Control Administrator (abridged): grants roleAssignments writes explicitly.
+            var perms = new[] { Entry(new[] { "Microsoft.Authorization/roleAssignments/write", "Microsoft.Authorization/roleAssignments/delete", "*/read" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void Contributor_CannotAssignRoles()
+        {
+            // Contributor: actions ["*"] but notActions excludes Authorization writes/deletes - the canonical
+            // failure mode this whole feature is designed to catch.
+            var perms = new[] { Entry(
+                new[] { "*" },
+                new[] { "Microsoft.Authorization/*/Delete", "Microsoft.Authorization/*/Write", "Microsoft.Authorization/elevateAccess/Action" }) };
+            Assert.IsFalse(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void Reader_CannotAssignRoles()
+        {
+            var perms = new[] { Entry(new[] { "*/read" }) };
+            Assert.IsFalse(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void CustomRole_WithExactAction_CanAssignRoles()
+        {
+            var perms = new[] { Entry(new[] { "Microsoft.Authorization/roleAssignments/write", "Microsoft.Resources/deployments/*" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        #endregion
+
+        #region ActionIsAllowed - multiple roles & edge cases
+
+        [TestMethod]
+        public void MultipleRoles_AnyGrantingEntryWins()
+        {
+            // Reader + a custom role that grants the write -> allowed.
+            var perms = new[]
+            {
+                Entry(new[] { "*/read" }),
+                Entry(new[] { "Microsoft.Authorization/roleAssignments/*" })
+            };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        [TestMethod]
+        public void ContributorPlusUserAccessAdministrator_CanAssignRoles()
+        {
+            // Contributor excludes the write, but a separate User Access Administrator assignment grants it.
+            var contributor = Entry(new[] { "*" }, new[] { "Microsoft.Authorization/*/Write", "Microsoft.Authorization/*/Delete" });
+            var userAccessAdmin = Entry(new[] { "*/read", "Microsoft.Authorization/*" });
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, new[] { contributor, userAccessAdmin }));
+        }
+
+        [TestMethod]
+        public void EmptyOrNullPermissions_NotAllowed()
+        {
+            Assert.IsFalse(RbacPermissionProbe.ActionIsAllowed(WriteAction, new RbacPermissionEntry[0]));
+            Assert.IsFalse(RbacPermissionProbe.ActionIsAllowed(WriteAction, null));
+        }
+
+        [TestMethod]
+        public void NullEntriesAreSkipped()
+        {
+            var perms = new RbacPermissionEntry[] { null, Entry(new[] { "*" }) };
+            Assert.IsTrue(RbacPermissionProbe.ActionIsAllowed(WriteAction, perms));
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -164,6 +164,7 @@
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
     <Compile Include="InstallTests\KeyVaultFirewallConfigTaskTests.cs" />
+    <Compile Include="InstallTests\RbacPermissionProbeTests.cs" />
     <Compile Include="InstallTests\TeamsUserActivityReportUrlTests.cs" />
     <Compile Include="InstallTests\SpoInstallTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
## Summary

Promotes the current `dev` line (testing build **1653**) to a new **stable** release. Two installer-focused improvements since Stable build 1650, both aimed at deployments that were failing or aborting part-way through.

## Admin impact

- **Pre-flight RBAC permission check (#147).** The installer "Test Configuration" now verifies up-front that the installer account can create Azure role assignments (`Microsoft.Authorization/roleAssignments/write`). This is the cause of mid-install failures like *"...does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/write' over scope '/subscriptions/.../resourceGroups/...'"*. When the account can't, the check reports a precise fix: grant the installer app registration **Owner** or **User Access Administrator** (or **Role Based Access Control Administrator**) — **Contributor is not sufficient**.

- **Runbook "different kind" install abort fixed (#148/#149).** When an existing Azure Automation runbook had a different runtime kind, the install aborted with *"Update runbook with definition of different runbook kind is not allowed"*. The installer now deletes and recreates the runbook as PowerShell 7.2, with a proactive check plus a reactive retry. Two things to know:
  - Deleting a runbook removes its **job history** and any **manually-created schedule-to-runbook links** — after the install, re-link the recreated runbook to its schedule. The installer logs a warning to this effect.
  - Runbook deployment is now **non-critical**: if it still fails, the install **completes anyway** (the profiling runbooks are a secondary feature and can be fixed separately) instead of aborting the whole deployment.

## Validation

- `dev` **Tests** and **Release build** green on the tip (`7c757f1`).
- 14 new unit tests cover the RBAC pass/fail logic (Owner/UAA/RBAC-Admin pass; Contributor/Reader fail). The runbook fix has both a proactive kind check and a reactive delete-and-retry safety net.

## Included

PRs #147, #149.

## Note

Supersedes the still-draft **Stable build 1650** (never published) — this release contains everything 1650 had plus the two fixes above.
