### PR TITLE
Show Teams calls webhook subscription status on the homepage

### DIFF
--- a/src/AnalyticsEngine/Web/Models/SystemStatus.cs
+++ b/src/AnalyticsEngine/Web/Models/SystemStatus.cs
@@ -3,10 +3,14 @@ using Azure.Messaging.ServiceBus;
 using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Redis;
+using DataUtils;
 using Newtonsoft.Json;
+using System;
 using System.Data.Entity;
 using System.Linq;
+using System.Runtime.Caching;
 using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.Calls;
 
 namespace Web.AnalyticsWeb.Models
 {
@@ -61,6 +65,18 @@ namespace Web.AnalyticsWeb.Models
         public string WebAppBaseURL { get; set; }
         public bool YammerAuth { get; set; }
 
+        /// <summary>Whether the Teams calls import is switched on for this deployment.</summary>
+        public bool CallsImportEnabled { get; set; }
+
+        /// <summary>Status of the Graph call-records webhook subscription that drives the Teams calls import.</summary>
+        public CallWebhookSubscriptionState CallWebhookState { get; set; }
+
+        /// <summary>When the call-records webhook subscription expires (only set when it is active).</summary>
+        public DateTimeOffset? CallWebhookExpiry { get; set; }
+
+        /// <summary>Extra detail for the webhook status, e.g. the error message when it couldn't be checked.</summary>
+        public string CallWebhookStatusDetail { get; set; }
+
         #endregion
 
         internal async static Task<SystemStatus> LoadFrom(AnalyticsEntitiesContext db, CacheConnectionManager cache)
@@ -104,8 +120,105 @@ namespace Web.AnalyticsWeb.Models
                 : ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString).Endpoint.ToString();
             status.CognitiveServiceEnabled = config.IsValidCognitiveConfig;
             status.WebAppBaseURL = config.WebAppURL;
+
+            await status.LoadCallWebhookStatus(config);
+
             return status;
         }
+
+        /// <summary>
+        /// Works out the state of the Teams call-records webhook subscription for display on the
+        /// homepage. If calls import is off there is nothing to check; otherwise it asks Microsoft
+        /// Graph (via the same <see cref="CallWebhook"/> the importer uses) whether a matching
+        /// subscription is currently registered, and when it expires. The Graph result is cached
+        /// briefly so we don't call Graph on every page load, and any failure is caught so a Graph
+        /// error never breaks the homepage.
+        /// </summary>
+        private async Task LoadCallWebhookStatus(AppConfig config)
+        {
+            this.CallsImportEnabled = config.ImportJobSettings != null && config.ImportJobSettings.Calls;
+
+            if (!this.CallsImportEnabled)
+            {
+                this.CallWebhookState = CallWebhookSubscriptionState.Disabled;
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(config.WebAppURL))
+            {
+                this.CallWebhookState = CallWebhookSubscriptionState.Error;
+                this.CallWebhookStatusDetail = "WebAppURL is not configured, so the webhook subscription URL can't be determined.";
+                return;
+            }
+
+            // Build the notification URL exactly as the importer web-job does when it registers the
+            // subscription, so the lookup matches the subscription Graph actually holds.
+            var webhookUrlString = config.WebAppURL + "api/CallRecordWebhook";
+
+            // A Graph call on every homepage load would be wasteful and rate-limitable, so cache the
+            // outcome for a few minutes. Errors are intentionally NOT cached, so a transient Graph
+            // failure recovers on the next page load.
+            var cacheKey = "CallWebhookStatus::" + webhookUrlString;
+            if (MemoryCache.Default.Get(cacheKey) is CachedCallWebhookStatus cached)
+            {
+                this.CallWebhookState = cached.State;
+                this.CallWebhookExpiry = cached.Expiry;
+                this.CallWebhookStatusDetail = cached.Detail;
+                return;
+            }
+
+            try
+            {
+                var telemetry = new AnalyticsLogger(config.AppInsightsConnectionString, nameof(SystemStatus));
+                var callWebhook = new CallWebhook(config, telemetry);
+                var info = await callWebhook.GetCallRecordsSubscriptionInfo(new Uri(webhookUrlString));
+
+                if (info.Exists)
+                {
+                    this.CallWebhookState = CallWebhookSubscriptionState.Active;
+                    this.CallWebhookExpiry = info.ExpirationDateTime;
+                }
+                else
+                {
+                    this.CallWebhookState = CallWebhookSubscriptionState.Missing;
+                }
+
+                MemoryCache.Default.Set(
+                    cacheKey,
+                    new CachedCallWebhookStatus { State = this.CallWebhookState, Expiry = this.CallWebhookExpiry, Detail = this.CallWebhookStatusDetail },
+                    DateTimeOffset.UtcNow.AddMinutes(5));
+            }
+            catch (Exception ex)
+            {
+                this.CallWebhookState = CallWebhookSubscriptionState.Error;
+                this.CallWebhookStatusDetail = ex.Message;
+            }
+        }
+
+        private class CachedCallWebhookStatus
+        {
+            public CallWebhookSubscriptionState State { get; set; }
+            public DateTimeOffset? Expiry { get; set; }
+            public string Detail { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// State of the Teams call-records webhook subscription, surfaced on the homepage.
+    /// </summary>
+    public enum CallWebhookSubscriptionState
+    {
+        /// <summary>Teams calls import is switched off, so no subscription is expected.</summary>
+        Disabled,
+
+        /// <summary>A matching call-records subscription is active in Microsoft Graph.</summary>
+        Active,
+
+        /// <summary>Calls import is on but no matching subscription was found (the importer registers/renews it each cycle).</summary>
+        Missing,
+
+        /// <summary>Calls import is on but the subscription status couldn't be checked (e.g. a Graph error).</summary>
+        Error,
     }
 
     public class UnknownConfigSystemStatus : SystemStatus

--- a/src/AnalyticsEngine/Web/Views/Home/Index.cshtml
+++ b/src/AnalyticsEngine/Web/Views/Home/Index.cshtml
@@ -45,6 +45,46 @@
         </td>
     </tr>
     <tr>
+        <td class="header">Teams Calls Import</td>
+        <td>
+            @if (Model.CallsImportEnabled)
+            {
+                <span>Enabled</span>
+            }
+            else
+            {
+                <span>Disabled - Teams call records are not being imported</span>
+            }
+        </td>
+    </tr>
+    <tr>
+        <td class="header">Calls Webhook Subscription</td>
+        <td>
+            @if (Model.CallWebhookState == Web.AnalyticsWeb.Models.CallWebhookSubscriptionState.Active)
+            {
+                <span style="color: green; font-weight: bold;">Active</span>
+                if (Model.CallWebhookExpiry.HasValue)
+                {
+                    <text> &ndash; renews automatically; current subscription expires @Model.CallWebhookExpiry.Value.UtcDateTime.ToString("u") (UTC)</text>
+                }
+            }
+            else if (Model.CallWebhookState == Web.AnalyticsWeb.Models.CallWebhookSubscriptionState.Missing)
+            {
+                <span style="color: #b00; font-weight: bold;">No active subscription found</span>
+                <div>The importer web-job registers and renews this on every import cycle. If it stays missing, check the importer web-job is running and that its app registration has the <code>CallRecords.Read.All</code> Microsoft Graph application permission.</div>
+            }
+            else if (Model.CallWebhookState == Web.AnalyticsWeb.Models.CallWebhookSubscriptionState.Error)
+            {
+                <span style="color: #b00; font-weight: bold;">Couldn't check</span>
+                <div>@Model.CallWebhookStatusDetail</div>
+            }
+            else
+            {
+                <span>Not applicable - Teams calls import is disabled</span>
+            }
+        </td>
+    </tr>
+    <tr>
         <td class="header">SQL Server</td>
         <td>
             @Model.WebAppConfigSQL

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallRecordSubscriptionInfo.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallRecordSubscriptionInfo.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
+{
+    /// <summary>
+    /// Read-only snapshot of the Teams call-records webhook subscription in Microsoft Graph,
+    /// used to display webhook health (e.g. on the web homepage). Returned by
+    /// <see cref="CallWebhook.GetCallRecordsSubscriptionInfo(System.Uri)"/>.
+    /// </summary>
+    public class CallRecordSubscriptionInfo
+    {
+        /// <summary>
+        /// Whether a matching <c>/communications/callRecords</c> subscription currently exists for
+        /// this deployment's webhook notification URL.
+        /// </summary>
+        public bool Exists { get; set; }
+
+        /// <summary>Graph subscription id, when one exists.</summary>
+        public string SubscriptionId { get; set; }
+
+        /// <summary>
+        /// When the subscription expires. Graph caps call-record subscriptions at ~3 days, so the
+        /// importer web-job renews it on every import cycle.
+        /// </summary>
+        public DateTimeOffset? ExpirationDateTime { get; set; }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
@@ -38,32 +38,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         // Grep-friendly tag so the calls-webhook lifecycle is easy to filter in App Insights traces.
         private const string LOG_TAG = "[Calls Webhook]";
 
+        // The Graph resource path we subscribe to for Teams call records.
+        private const string CALL_RECORDS_RESOURCE = "/communications/callRecords";
+
         public async Task CreateOrUpdateWebhook(Uri webAppUrl, string secret)
         {
             // https://docs.microsoft.com/en-us/graph/api/resources/webhooks?view=graph-rest-1.0
-            const string CALL_TYPE = "/communications/callRecords";
-
-            // Walk every subscriptions page; default Graph page size may not include the existing
-            // call-record subscription when tenant subscription count is high.
-            var matchingSubs = new List<Subscription>();
-            var firstPage = await this.Client.Subscriptions.GetAsync();
-            if (firstPage != null)
-            {
-                var iterator = PageIterator<Subscription, SubscriptionCollectionResponse>.CreatePageIterator(
-                    this.Client,
-                    firstPage,
-                    sub =>
-                    {
-                        if (sub.Resource == CALL_TYPE && sub.NotificationUrl == webAppUrl.ToString())
-                        {
-                            matchingSubs.Add(sub);
-                        }
-
-                        return true;
-                    });
-
-                await iterator.IterateAsync();
-            }
+            var matchingSubs = await FindCallRecordsSubscriptions(webAppUrl);
 
             if (matchingSubs.Count == 0)
             {
@@ -73,7 +54,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                     var result = await this.Client.Subscriptions.PostAsync(new Subscription()
                     {
                         NotificationUrl = webAppUrl.ToString(),
-                        Resource = CALL_TYPE,
+                        Resource = CALL_RECORDS_RESOURCE,
                         ClientState = secret,
                         ChangeType = "created",
                         ExpirationDateTime = DateTime.UtcNow.AddDays(2)        // the max Graph will permit - https://docs.microsoft.com/en-us/graph/api/resources/subscription?view=graph-rest-beta#properties
@@ -106,6 +87,65 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                     throw;
                 }
             }
+        }
+
+        /// <summary>
+        /// Walk every subscriptions page (the default Graph page size may not include the
+        /// call-records subscription when the tenant has many subscriptions) and return those
+        /// matching the call-records resource for this web-app's notification URL.
+        /// </summary>
+        private async Task<List<Subscription>> FindCallRecordsSubscriptions(Uri webAppUrl)
+        {
+            var matchingSubs = new List<Subscription>();
+            var firstPage = await this.Client.Subscriptions.GetAsync();
+            if (firstPage != null)
+            {
+                var iterator = PageIterator<Subscription, SubscriptionCollectionResponse>.CreatePageIterator(
+                    this.Client,
+                    firstPage,
+                    sub =>
+                    {
+                        if (sub.Resource == CALL_RECORDS_RESOURCE && sub.NotificationUrl == webAppUrl.ToString())
+                        {
+                            matchingSubs.Add(sub);
+                        }
+
+                        return true;
+                    });
+
+                await iterator.IterateAsync();
+            }
+
+            return matchingSubs;
+        }
+
+        /// <summary>
+        /// Read-only check of the current call-records webhook subscription, for status display
+        /// (e.g. the web homepage). Does NOT create or renew anything. Returns whether a matching
+        /// subscription currently exists and, if so, when it expires. Any Graph error is allowed to
+        /// propagate so the caller can surface it as an explicit "couldn't check" state.
+        /// </summary>
+        public async Task<CallRecordSubscriptionInfo> GetCallRecordsSubscriptionInfo(Uri webAppUrl)
+        {
+            var matchingSubs = await FindCallRecordsSubscriptions(webAppUrl);
+
+            // If more than one matches (shouldn't normally happen), report the one that expires
+            // latest - that's the subscription keeping the webhook alive.
+            var current = matchingSubs
+                .OrderByDescending(s => s.ExpirationDateTime ?? DateTimeOffset.MinValue)
+                .FirstOrDefault();
+
+            if (current == null)
+            {
+                return new CallRecordSubscriptionInfo { Exists = false };
+            }
+
+            return new CallRecordSubscriptionInfo
+            {
+                Exists = true,
+                SubscriptionId = current.Id,
+                ExpirationDateTime = current.ExpirationDateTime,
+            };
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Graph\Teams\TeamTokenManager.cs" />
     <Compile Include="Graph\UsageReports\AbstractDailyActivityLoader.cs" />
     <Compile Include="Graph\Calls\CallQueueProcessor.cs" />
+    <Compile Include="Graph\Calls\CallRecordSubscriptionInfo.cs" />
     <Compile Include="Graph\Calls\CallWebhook.cs" />
     <Compile Include="Graph\Teams\ChannelMessagesLoader.cs" />
     <Compile Include="Graph\Teams\Extensions\GraphUserExtensions.cs" />


### PR DESCRIPTION
## What & why
The service homepage showed the call webhook **endpoint** and a "test webhook" link, but nothing about whether the Teams calls webhook **subscription** is actually live in Microsoft Graph. This adds that status so admins can tell at a glance whether Teams call records are flowing.

Closes #151

## Changes
- **`CallWebhook`** (engine): extracted the subscription paging + match logic out of `CreateOrUpdateWebhook` into a shared private `FindCallRecordsSubscriptions(Uri)`, and added a read-only `GetCallRecordsSubscriptionInfo(Uri)` that returns a small `CallRecordSubscriptionInfo` DTO (`Exists`, `SubscriptionId`, `ExpirationDateTime`). No change to the create/renew behaviour.
- **`SystemStatus`** (web model): new `CallsImportEnabled`, `CallWebhookState` (`Disabled` / `Active` / `Missing` / `Error`), `CallWebhookExpiry`, `CallWebhookStatusDetail`. Populated in `LoadFrom` by reusing the same `CallWebhook` the importer uses, so the lookup matches the subscription the web-job registers (`<WebAppURL>api/CallRecordWebhook`). The Graph result is cached for 5 minutes (so the homepage doesn''t call Graph on every load) and any Graph failure is caught so it can never break the homepage.
- **`Index.cshtml`**: two new rows in *System Configuration* — "Teams Calls Import" (Enabled/Disabled) and "Calls Webhook Subscription" (Active + expiry / no subscription found / couldn''t check / not applicable).

## States shown
| Condition | Shown |
|-|-|
| Calls import off | Not applicable - Teams calls import is disabled |
| Subscription present | Active - expires `<utc>` |
| Import on, no subscription | No active subscription found (+ how to fix: importer running + `CallRecords.Read.All`) |
| Graph query failed | Couldn''t check (+ error detail) |

## Testing
- Full solution build via VS2022/18 MSBuild: **Build succeeded, 0 errors**.
- Read-only feature: the homepage status check never creates/renews subscriptions (that stays the importer''s job).

## Notes
- No installer code touched (no `Installer` label needed).
- Per-load Graph cost is bounded by the 5-minute cache.
