### PR TITLE
Suppress CS0618 (System.Data.SqlClient obsolete) build warnings in DataUtils

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/DataUtils.csproj
+++ b/src/AnalyticsEngine/Common/DataUtils/DataUtils.csproj
@@ -2,6 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <!--
+      Suppress CS0618 for this project. As a netstandard2.0 library it references the
+      System.Data.SqlClient *NuGet package*, whose types (SqlConnection, SqlException,
+      SqlConnectionStringBuilder, ...) are marked [Obsolete] in favour of Microsoft.Data.SqlClient.
+      We intentionally stay on System.Data.SqlClient because EF6 (used across the solution) has no
+      official Microsoft.Data.SqlClient provider and mandates the System.Data.SqlClient provider, so
+      the obsolete usage here is deliberate. (.NET Framework consumers use the in-box, non-obsolete
+      System.Data.SqlClient and don't warn.) See issue for context.
+    -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
 


### PR DESCRIPTION
## What

Removes the **CS0618** obsolete-API build warnings (64 occurrences in stable build 1654 / dev test build 1657), all from `Common/DataUtils`, by adding `<NoWarn>$(NoWarn);CS0618</NoWarn>` to `DataUtils.csproj`.

## Why NoWarn (not a driver migration)

`DataUtils` (netstandard2.0) references the `System.Data.SqlClient` **NuGet package**, whose types (`SqlConnection`, `SqlException`, `SqlConnectionStringBuilder`) are `[Obsolete]` -> "use Microsoft.Data.SqlClient". We deliberately keep `System.Data.SqlClient` because **EF6 has no official `Microsoft.Data.SqlClient` provider** and mandates it across the solution (provider registrations in every `*.config`, `SetExecutionStrategy("System.Data.SqlClient", ...)`, and `SqlBulkCopy` over EF connections). A real migration would mean EF6 -> EF Core, which is out of scope. The .NET Framework projects use the **in-box** `System.Data.SqlClient` (not obsolete) and never warned.

## Verification

`DataUtils.csproj` Release rebuild: **0 warnings, 0 errors** (previously 64x CS0618).

## Database changes

None.

## Out of scope

- MSB3247 assembly-version-conflict (binding-redirect) warnings.

Closes #159
