### PR TITLE
Use UTC for the App Insights importer scan window

### DIFF
--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
@@ -34,7 +34,10 @@ namespace WebJob.AppInsightsImporter.Engine
             DateTime? scanFromDateOverride = null;
             if (daysBeforeOverride.HasValue)
             {
-                scanFromDateOverride = DateTime.Now.AddDays(daysBeforeOverride.Value * -1);
+                // App Insights timestamps are UTC, so the scan window must be UTC too. Using local
+                // DateTime.Now on a non-UTC host shifts the day boundaries and the per-day KQL filter,
+                // missing or duplicating edge hits near midnight.
+                scanFromDateOverride = DateTime.UtcNow.AddDays(daysBeforeOverride.Value * -1);
             }
 
             var sw = Stopwatch.StartNew();
@@ -50,8 +53,9 @@ namespace WebJob.AppInsightsImporter.Engine
 
                 var newestHit = await db.hits.OrderByDescending(h => h.hit_timestamp).Take(1).FirstOrDefaultAsync();
 
-                // Figure out when to start. Either the debug override, or last hit (if there is one), or 31 days ago
-                var startDate = scanFromDateOverride.HasValue ? scanFromDateOverride.Value : newestHit?.hit_timestamp ?? DateTime.Now.AddDays(-31);
+                // Figure out when to start. Either the debug override, or last hit (if there is one), or 31 days ago.
+                // hit_timestamp is stored in UTC; DateTime.UtcNow keeps the fallback on the same clock.
+                var startDate = scanFromDateOverride.HasValue ? scanFromDateOverride.Value : newestHit?.hit_timestamp ?? DateTime.UtcNow.AddDays(-31);
 
                 // Rewind start-date a wee bit just to make sure we get edge hits...
                 startDate = startDate.AddMinutes(-1);
@@ -74,7 +78,8 @@ namespace WebJob.AppInsightsImporter.Engine
                 using (var ai = new AppInsightsAPIClient(this._importConfig.AppInsightsConnectionString, credential, _telemetry))
                 {
 
-                    var endDate = DateTime.Now;
+                    // UTC to match App Insights' UTC timestamps (see startDate above).
+                    var endDate = DateTime.UtcNow;
                     var daysToRead = startDate.EachDay(endDate).ToList();
                     _telemetry.LogInformation($"Importing hits for {daysToRead.Count} days...");
                     var totalDays = 0;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
@@ -134,7 +134,7 @@ namespace WebJob.AppInsightsImporter.Engine
                 // Get all URLs that have not been updated recently
                 var minusMetadataRefreshMinutes = _config.MetadataRefreshMinutes * -1;
                 var matchingUrlsNotUpdatedRecently = await context.urls
-                    .Where(u => urlsForPageUpdateChunk.Contains(u.FullUrl) && (u.MetadataLastRefreshed == null || u.MetadataLastRefreshed < DbFunctions.AddMinutes(DateTime.Now, minusMetadataRefreshMinutes)))
+                    .Where(u => urlsForPageUpdateChunk.Contains(u.FullUrl) && (u.MetadataLastRefreshed == null || u.MetadataLastRefreshed < DbFunctions.AddMinutes(DateTime.UtcNow, minusMetadataRefreshMinutes)))
                     .ToListAsync();
 
                 foreach (var urlToUpdate in matchingUrlsNotUpdatedRecently)


### PR DESCRIPTION
## What & why

The App Insights importer built its day-by-day scan window and the per-day KQL `timestamp` filter from `DateTime.Now` (local server time), while App Insights timestamps — and the stored `hits.hit_timestamp` — are UTC. On a non-UTC host this shifted the day boundaries and the filter, so edge hits near midnight could be missed or duplicated. Latent in production because Azure App Service defaults to UTC, but it affects local/dev runs and any host with `WEBSITE_TIME_ZONE` set.

The audit-log and Graph importers already use `DateTime.UtcNow`; this brings the App Insights importer in line.

## Changes

- **`AppInsightsImporter.cs`** — use `DateTime.UtcNow` for the days-before override, the 31-day fallback start, and `endDate`. `hit_timestamp` is already UTC, so the day loop and KQL window now match the data.
- **`PageUpdates/PageUpdateManager.cs`** — the "not updated recently" staleness query now compares `MetadataLastRefreshed` (written with `DateTime.UtcNow`) against `DateTime.UtcNow` instead of `DateTime.Now`.

`GetWhereString` deliberately keeps formatting the value directly (no `.ToUniversalTime()`): `hit_timestamp` reads back from SQL as `Kind=Unspecified`, so converting there would corrupt an already-UTC value. Fixing the source clocks is the correct approach.

## Validation

- Built `WebJob.AppInsightsImporter.Engine` in Release with VS18 MSBuild — succeeds (exit 0).

## Database changes

None.

## Docs

Wiki `Database Schema.md` gains a "Time zones" section documenting that all event/activity timestamps are stored in UTC.
