### PR TITLE
Install Log: capture full installer log + view it in a modal

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -73,6 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseInstallProcessClasses.cs" />
+    <Compile Include="InstallLogCapturingLogger.cs" />
     <Compile Include="InstallerLogs.cs" />
     <Compile Include="InstallerTasks\JobTasks\HybridWorkerGroupTask.cs" />
     <Compile Include="InstallerTasks\JobTasks\ProfilingScriptsLocateTask.cs" />

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
@@ -17,7 +17,9 @@ namespace App.ControlPanel.Engine
         public BaseInstallProcess(SolutionInstallConfig config, ILogger logger)
         {
             this.Config = config;
-            _logger = logger;
+            // Tee everything logged during the install into _installLogEvents so the full log can be
+            // registered into sys_configs.messages, while still forwarding to the on-screen logger.
+            _logger = new InstallLogCapturingLogger(logger, _installLogEvents);
         }
 
         protected List<InstallLogEventArgs> _installLogEvents = new List<InstallLogEventArgs>();

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallLogCapturingLogger.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallLogCapturingLogger.cs
@@ -1,0 +1,40 @@
+﻿using App.ControlPanel.Engine.Models;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+
+namespace App.ControlPanel.Engine
+{
+    /// <summary>
+    /// Decorates an <see cref="ILogger"/> so that every install message is also captured into a list,
+    /// while still forwarding to the inner logger (e.g. the on-screen install log). The captured list is
+    /// what gets registered into <c>sys_configs.messages</c> as the full installer log for that run.
+    /// </summary>
+    internal class InstallLogCapturingLogger : ILogger
+    {
+        private readonly ILogger _inner;
+        private readonly List<InstallLogEventArgs> _captured;
+
+        public InstallLogCapturingLogger(ILogger inner, List<InstallLogEventArgs> captured)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _captured = captured ?? throw new ArgumentNullException(nameof(captured));
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => _inner.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            // Forward to the real logger first (UI / event log) so behaviour is unchanged.
+            _inner.Log(logLevel, eventId, state, exception, formatter);
+
+            if (formatter == null) return;
+            var text = formatter(state, exception);
+            if (string.IsNullOrEmpty(text)) return;
+
+            _captured.Add(new InstallLogEventArgs { Text = text, IsError = logLevel >= LogLevel.Error });
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/InstallLogPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/InstallLogPage.tsx
@@ -9,6 +9,13 @@ import {
   PopoverTrigger,
   PopoverSurface,
   Card,
+  Dialog,
+  DialogTrigger,
+  DialogSurface,
+  DialogTitle,
+  DialogBody,
+  DialogContent,
+  DialogActions,
   Table,
   TableHeader,
   TableHeaderCell,
@@ -20,7 +27,7 @@ import {
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
-import { DocumentText16Regular } from '@fluentui/react-icons';
+import { DocumentText16Regular, TextBulletListSquare16Regular } from '@fluentui/react-icons';
 import { fetchInstallLog } from '../api/installLogApi';
 import type { InstallLogEntry } from '../types/installLog';
 import Spinner from '../components/Spinner';
@@ -46,8 +53,25 @@ const useStyles = makeStyles({
     wordBreak: 'break-word',
     color: tokens.colorNeutralForeground2,
   },
+  logViewer: {
+    fontFamily: 'Consolas, Menlo, Monaco, "Courier New", monospace',
+    fontSize: tokens.fontSizeBase200,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    userSelect: 'text',
+    margin: 0,
+    padding: '12px',
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground3,
+    maxHeight: '70vh',
+    overflow: 'auto',
+  },
   card: {
     marginTop: '16px',
+  },
+  dialogSurface: {
+    maxWidth: '90vw',
+    width: '900px',
   },
 });
 
@@ -124,7 +148,30 @@ export default function InstallLogPage() {
                   </TableCell>
                   <TableCell>{e.installedByUser || '—'}</TableCell>
                   <TableCell>
-                    <span className={styles.messages}>{e.messages || '—'}</span>
+                    {e.messages ? (
+                      <Dialog>
+                        <DialogTrigger disableButtonEnhancement>
+                          <Button appearance="subtle" size="small" icon={<TextBulletListSquare16Regular />}>
+                            View log
+                          </Button>
+                        </DialogTrigger>
+                        <DialogSurface className={styles.dialogSurface}>
+                          <DialogBody>
+                            <DialogTitle>Install log — {new Date(e.dateApplied).toLocaleString()}</DialogTitle>
+                            <DialogContent>
+                              <pre className={styles.logViewer}>{e.messages}</pre>
+                            </DialogContent>
+                            <DialogActions>
+                              <DialogTrigger disableButtonEnhancement>
+                                <Button appearance="primary">Close</Button>
+                              </DialogTrigger>
+                            </DialogActions>
+                          </DialogBody>
+                        </DialogSurface>
+                      </Dialog>
+                    ) : (
+                      <Text style={{ color: tokens.colorNeutralForeground3 }}>—</Text>
+                    )}
                   </TableCell>
                   <TableCell>
                     {e.configJson ? (


### PR DESCRIPTION
## Description
Fixes the **Install Log** tab where the *Messages* column was always blank and a tiny text cell made no sense for a long installer log.

- **Installer:**  + '_installLogEvents' +  was declared but never populated, so  + 'sys_configs.messages' +  was always empty. New  + 'InstallLogCapturingLogger' +  tees the engine logger into that list, so the full install log is registered (column is  + '
varchar(max)' + ).
- **Web (admin-app):** Messages column is now a **View log** link opening a large modal viewer (monospace, scrollable); shows — when there's no data.

Low priority; nobody relies on it yet. SPA build passes.

## Type of Change
- [x] Bug fix
- [x] UI/UX improvement