### PR TITLE
Don't fail install when Key Vault writes are blocked by tenant Azure Policy

### DIFF
--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultFirewallConfigTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultFirewallConfigTask.cs
@@ -95,8 +95,18 @@ namespace CloudInstallEngine.Azure.InstallTasks
             _logger.LogInformation($"Enabling Key Vault '{vault.Data.Name}' firewall: default action 'Deny', bypass 'AzureServices', {ruleSet.IPRules.Count} IP rule(s), {ruleSet.VirtualNetworkRules.Count} virtual-network rule(s).");
 
             var patch = new KeyVaultPatch { Properties = new KeyVaultPatchProperties { NetworkRuleSet = ruleSet } };
-            var updated = await vault.UpdateAsync(patch);
-            return updated.Value;
+            try
+            {
+                var updated = await vault.UpdateAsync(patch);
+                return updated.Value;
+            }
+            catch (global::Azure.RequestFailedException ex) when (KeyVaultTask.IsDisallowedByPolicy(ex))
+            {
+                // Tenant Azure Policy denies writes to Microsoft.KeyVault/vaults. The vault already
+                // exists and is usable; firewall allow-listing is best-effort, so reuse it as-is.
+                _logger.LogWarning($"Could not allow-list IPs on key vault '{vault.Data.Name}': the write was disallowed by Azure Policy. Reusing the existing firewall configuration; ensure the installer and App Service IPs already have access, or grant a policy exemption and re-run.");
+                return vault;
+            }
         }
 
         List<string> GetAppServiceOutboundIps(string appServiceName)

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -88,13 +88,44 @@ namespace CloudInstallEngine.Azure.InstallTasks
                             NetworkRuleSet = KeyVaultFirewallConfigTask.BuildFirewallRuleSet(r.Data.Properties.NetworkRuleSet, null, null)
                         }
                     };
-                    var updateResult = await r.UpdateAsync(patch);
-                    r = updateResult.Value;
+                    try
+                    {
+                        var updateResult = await r.UpdateAsync(patch);
+                        r = updateResult.Value;
+                    }
+                    catch (RequestFailedException ex) when (IsDisallowedByPolicy(ex))
+                    {
+                        // Some tenants attach a "Not allowed resource types" Azure Policy to the
+                        // management group that denies any write to Microsoft.KeyVault/vaults. The
+                        // vault already exists and is usable, so this update is best-effort hardening
+                        // (public network access + firewall) — reuse the vault as-is rather than abort
+                        // an otherwise-successful install. Network hardening should stay best-effort here.
+                        _logger.LogWarning($"Key vault '{r.Data.Name}' already exists but updating its network settings (public access '{desiredAccess}', firewall) was disallowed by Azure Policy. Reusing the existing vault as-is and skipping the network hardening. To apply these settings, grant a policy exemption for the vault and re-run the installer.");
+                    }
                 }
 
-                await EnsureTagsOnExisting(r.Data.Tags, r.GetTagResource());
+                try
+                {
+                    await EnsureTagsOnExisting(r.Data.Tags, r.GetTagResource());
+                }
+                catch (RequestFailedException ex) when (IsDisallowedByPolicy(ex))
+                {
+                    // Tagging is also a write to the vault and can be blocked by the same policy; tags
+                    // are cosmetic, so skip them rather than fail the install.
+                    _logger.LogWarning($"Could not tag existing key vault '{r.Data.Name}': the write was disallowed by Azure Policy. Continuing without updating tags.");
+                }
             }
             return r;
+        }
+
+        /// <summary>
+        /// True when an Azure Resource Manager write was rejected by an Azure Policy "deny" effect
+        /// (e.g. a "Not allowed resource types" initiative that blocks Microsoft.KeyVault/vaults).
+        /// Surfaces as HTTP 403 with error code "RequestDisallowedByPolicy".
+        /// </summary>
+        public static bool IsDisallowedByPolicy(RequestFailedException ex)
+        {
+            return ex.Status == 403 && string.Equals(ex.ErrorCode, "RequestDisallowedByPolicy", StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/KeyVaultFirewallConfigTaskTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/KeyVaultFirewallConfigTaskTests.cs
@@ -1,3 +1,4 @@
+using Azure;
 using Azure.ResourceManager.KeyVault.Models;
 using CloudInstallEngine.Azure.InstallTasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -72,6 +73,23 @@ namespace Tests.UnitTests.InstallTests
 
             Assert.AreEqual(1, ruleSet.VirtualNetworkRules.Count);
             Assert.AreEqual(true, ruleSet.VirtualNetworkRules.Single().IgnoreMissingVnetServiceEndpoint);
+        }
+
+        [TestMethod]
+        public void IsDisallowedByPolicy_Detects403PolicyDenial()
+        {
+            // "Not allowed resource types" Azure Policy denial: a 403 the installer must
+            // treat as best-effort (reuse the existing vault) rather than a fatal install error.
+            var ex = new RequestFailedException(403, "Resource was disallowed by policy.", "RequestDisallowedByPolicy", null);
+            Assert.IsTrue(KeyVaultTask.IsDisallowedByPolicy(ex));
+        }
+
+        [TestMethod]
+        public void IsDisallowedByPolicy_IgnoresOther403sAndStatuses()
+        {
+            // A plain RBAC 403 (Forbidden) or any other status must NOT be swallowed as a policy denial.
+            Assert.IsFalse(KeyVaultTask.IsDisallowedByPolicy(new RequestFailedException(403, "Forbidden", "Forbidden", null)));
+            Assert.IsFalse(KeyVaultTask.IsDisallowedByPolicy(new RequestFailedException(409, "Conflict", "RequestDisallowedByPolicy", null)));
         }
     }
 }


### PR DESCRIPTION
## Problem
A customer install aborted at **get/create key vault** even though the Key Vault already existed and was fully usable. Their tenant attaches a management-group Azure Policy *"Not allowed resource types"* that denies any write to `Microsoft.KeyVault/vaults`, so the PATCH to set public-access + Deny firewall returned `403 RequestDisallowedByPolicy`. Because that task is critical, the whole install died — for what is only best-effort hardening.

## Fix
- `KeyVaultTask` (existing-vault path): the network-settings PATCH **and** tag update now catch `403 RequestDisallowedByPolicy`, log a clear warning, and reuse the vault as-is. Vault *creation* stays critical (can't run without one).
- `KeyVaultFirewallConfigTask` (already non-critical): same graceful catch so it warns instead of erroring.
- New shared helper `KeyVaultTask.IsDisallowedByPolicy`. Plain RBAC 403s / other statuses are **not** swallowed.

## Tests
2 new + existing KeyVault tests pass; CloudInstallEngine + Tests.UnitTests build green.

No DB/config/permissions change -> no migration.