### PR TITLE
Redact SQL password from installer/upgrade logs

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/DatabaseUpgrader.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/DatabaseUpgrader.cs
@@ -19,7 +19,7 @@ namespace App.ControlPanel.Engine
             var buildLabel = Common.Entities.BuildConstants.BuildLabel;
 
             log?.Invoke($"Build '{buildLabel}' - begin database upgrade.");
-            log?.Invoke($"[{DateTime.Now}]: Connecting to database @ '{initInfo.ConnectionString}' with Entity Framework context initializer set to 'MigrateDatabaseToLatestVersion'...");
+            log?.Invoke($"[{DateTime.Now}]: Connecting to database @ '{StringUtils.RedactSqlConnectionString(initInfo.ConnectionString)}' with Entity Framework context initializer set to 'MigrateDatabaseToLatestVersion'...");
 
             // Update schema with EF migration
             try

--- a/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -569,6 +570,39 @@ namespace DataUtils
             return statements
                 .Where(x => !string.IsNullOrWhiteSpace(x))
                 .Select(x => x.Trim(' ', '\n'));
+        }
+
+        /// <summary>
+        /// Marker written in place of any password so logs never leak SQL credentials.
+        /// </summary>
+        public const string RedactedSecretMarker = "***REDACTED***";
+
+        /// <summary>
+        /// Returns a copy of a SQL connection string that is safe to write to logs: any password
+        /// (Password / pwd) is replaced with <see cref="RedactedSecretMarker"/>. Server, database,
+        /// user id and other non-secret keys are preserved so logs remain useful for diagnostics.
+        /// </summary>
+        public static string RedactSqlConnectionString(string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                return connectionString;
+            }
+
+            try
+            {
+                var builder = new SqlConnectionStringBuilder(connectionString);
+                if (!string.IsNullOrEmpty(builder.Password))
+                {
+                    builder.Password = RedactedSecretMarker;
+                }
+                return builder.ConnectionString;
+            }
+            catch
+            {
+                // Not a parseable SQL connection string; fall back to a key-based regex so we never leak a password.
+                return Regex.Replace(connectionString, @"(?i)\b(password|pwd)\s*=\s*[^;]*", $"$1={RedactedSecretMarker}");
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataUtilsTests.cs
@@ -698,6 +698,38 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public void RedactSqlConnectionStringTests()
+        {
+            // The exact shape leaked in installer logs before redaction (issue: plain-text password in logs).
+            const string connStr = "data source=mdona365sql.database.windows.net;initial catalog=officeanalytics;" +
+                "persist security info=True;user id=sqladmin;password=Cambiame03.;MultipleActiveResultSets=True;Connection Timeout=120";
+
+            var cleaned = StringUtils.RedactSqlConnectionString(connStr);
+
+            // Password is gone; non-secret diagnostics preserved.
+            Assert.IsFalse(cleaned.Contains("Cambiame03."), "Plain-text password must never appear in a redacted string");
+            Assert.IsTrue(cleaned.Contains(StringUtils.RedactedSecretMarker));
+            Assert.IsTrue(cleaned.Contains("mdona365sql.database.windows.net"));
+            Assert.IsTrue(cleaned.Contains("officeanalytics"));
+            Assert.IsTrue(cleaned.Contains("sqladmin"));
+
+            // 'pwd' alias is redacted too.
+            Assert.IsFalse(StringUtils.RedactSqlConnectionString("Server=s;Database=d;Uid=u;Pwd=secretpass;").Contains("secretpass"));
+
+            // No password -> non-secret content (server name) preserved; builder normalizes Server->Data Source.
+            var noPwd = StringUtils.RedactSqlConnectionString("Server=s;Database=d;Integrated Security=true;");
+            Assert.IsTrue(noPwd.Contains("Data Source=s"));
+            Assert.IsTrue(noPwd.Contains("Initial Catalog=d"));
+
+            // Null / empty inputs are passed through, not thrown on.
+            Assert.IsNull(StringUtils.RedactSqlConnectionString(null));
+            Assert.AreEqual(string.Empty, StringUtils.RedactSqlConnectionString(string.Empty));
+
+            // Unparseable garbage still gets the password stripped via the regex fallback.
+            Assert.IsFalse(StringUtils.RedactSqlConnectionString("garbage password=topsecret rubbish").Contains("topsecret"));
+        }
+
+        [TestMethod]
         public void IsJson()
         {
             Assert.IsFalse(StringUtils.IsJson("false"));


### PR DESCRIPTION
## Problem
The installer's database-upgrade step logged the full EF connection string, leaking the SQL user password in plain text (installer logs + Windows event log):

`Connecting to database @ 'data source=...;user id=sqladmin;password=Cambiame03.;...'`

## Fix
- Add `StringUtils.RedactSqlConnectionString` (DataUtils): parses with `SqlConnectionStringBuilder` and masks `Password`/`pwd` with `***REDACTED***`; server, database and user id are kept for diagnostics. Regex fallback redacts the password even on unparseable strings.
- Apply it on the `DatabaseUpgrader` "Connecting to database" log line.
- Unit tests in `DataUtilsTests.RedactSqlConnectionStringTests`.

## Verify
Built `Tests.UnitTests` (Debug) and ran `RedactSqlConnectionStringTests` + `FindValueForProp` - both pass.