### PR TITLE
Fix Profiling Data freshness 500 timeout on large tenants

### DIFF
--- a/src/AnalyticsEngine/Web/Controllers/ProfilingStatusAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ProfilingStatusAPIController.cs
@@ -29,6 +29,13 @@ namespace Web.AnalyticsWeb.Controllers
         private const int MaxPageSize = 200;
         private const string FreshnessCacheKey = "ProfilingStatus::Freshness";
 
+        // Per-query SQL timeout for the freshness MIN/MAX queries. AnalyticsEntitiesContext sets an
+        // infinite command timeout (for long importer/migration work), but here a single slow scan
+        // would otherwise run until Azure App Service kills the HTTP request (~230s) -> 500. Cap each
+        // query so it degrades to a per-row error instead, and run them in parallel so one heavy
+        // table (e.g. the Copilot/audit_events join) can't push the whole page past the limit.
+        private const int FreshnessQueryTimeoutSecs = 20;
+
         // Raw activity-log tables that feed the profiling compile. All inherit a [date] column with
         // an IX_date index, so MIN/MAX are cheap index seeks even on a ~200k-user tenant. The first
         // six are the headline workloads; teams_user_device_usage_log and platform_user_activity_log
@@ -58,34 +65,44 @@ namespace Web.AnalyticsWeb.Controllers
                 return Ok(cached);
             }
 
-            using (var db = new AnalyticsEntitiesContext())
+            var model = new ProfilingStatusModel();
+
+            // Each query opens its own short-timeout context and they run in parallel: EF6 contexts
+            // aren't thread-safe so we can't share one across concurrent queries, and parallelism
+            // keeps the worst case ~FreshnessQueryTimeoutSecs (not the sum of all of them).
+
+            // Compiled profiling output tables (built by the runbooks). Note the date column differs:
+            // ActivitiesWeekly uses MetricDate, the other two use [date].
+            var compiledTasks = new[]
             {
-                var model = new ProfilingStatusModel();
+                GetRangeAsync("weekly-activities", "Weekly activities (rows)", "[profiling].[ActivitiesWeekly]", "[MetricDate]"),
+                GetRangeAsync("weekly-activity-columns", "Weekly activities (columns)", "[profiling].[ActivitiesWeeklyColumns]", "[date]"),
+                GetRangeAsync("weekly-usage", "Weekly usage", "[profiling].[UsageWeekly]", "[date]"),
+            };
 
-                // Compiled profiling output tables (built by the runbooks). Note the date column
-                // differs: ActivitiesWeekly uses MetricDate, the other two use [date].
-                model.CompiledProfiling.Add(await GetRangeAsync(db, "weekly-activities", "Weekly activities (rows)", "[profiling].[ActivitiesWeekly]", "[MetricDate]"));
-                model.CompiledProfiling.Add(await GetRangeAsync(db, "weekly-activity-columns", "Weekly activities (columns)", "[profiling].[ActivitiesWeeklyColumns]", "[date]"));
-                model.CompiledProfiling.Add(await GetRangeAsync(db, "weekly-usage", "Weekly usage", "[profiling].[UsageWeekly]", "[date]"));
+            var activityTasks = ActivityTables
+                .Select(t => GetRangeAsync(t.Key, t.Label, t.Table, "[date]"))
+                .ToList();
 
-                foreach (var t in ActivityTables)
-                {
-                    model.ActivityTables.Add(await GetRangeAsync(db, t.Key, t.Label, t.Table, "[date]"));
-                }
+            // Copilot interactions feed the compile too (usp_UpsertCopilot) but have no date column of
+            // their own - the runbook dates them by the joined audit event's time_stamp, so we mirror
+            // that. This join MIN/MAX is the heaviest of these queries on a big tenant (audit_events is
+            // large), which is exactly why the timeout above matters: it degrades to a per-row error.
+            var copilotTask = RunRangeAsync("copilot-interactions", "Copilot interactions",
+                "dbo.copilot_chats (via dbo.audit_events)",
+                "SELECT MIN(au.time_stamp) AS MinDate, MAX(au.time_stamp) AS MaxDate " +
+                "FROM dbo.copilot_chats AS c JOIN dbo.audit_events AS au ON c.event_id = au.id;");
 
-                // Copilot interactions feed the compile too (usp_UpsertCopilot) but have no date
-                // column of their own - the runbook dates them by the joined audit event's
-                // time_stamp, so we mirror that exactly. This join MIN/MAX is the heaviest of these
-                // queries on a big tenant (audit_events is large), but the whole response is cached
-                // for 60s below so it only runs occasionally.
-                model.ActivityTables.Add(await RunRangeAsync(db, "copilot-interactions", "Copilot interactions",
-                    "dbo.copilot_chats (via dbo.audit_events)",
-                    "SELECT MIN(au.time_stamp) AS MinDate, MAX(au.time_stamp) AS MaxDate " +
-                    "FROM dbo.copilot_chats AS c JOIN dbo.audit_events AS au ON c.event_id = au.id;"));
+            await Task.WhenAll(compiledTasks.Concat(activityTasks).Concat(new[] { copilotTask }));
 
-                MemoryCache.Default.Set(FreshnessCacheKey, model, DateTimeOffset.UtcNow.AddSeconds(60));
-                return Ok(model);
-            }
+            model.CompiledProfiling.AddRange(compiledTasks.Select(t => t.Result));
+            model.ActivityTables.AddRange(activityTasks.Select(t => t.Result));
+            model.ActivityTables.Add(copilotTask.Result);
+
+            // Cache even when some rows errored/timed out so reloads are instant rather than
+            // re-running the slow scans; the per-row error itself is the diagnostic.
+            MemoryCache.Default.Set(FreshnessCacheKey, model, DateTimeOffset.UtcNow.AddSeconds(60));
+            return Ok(model);
         }
 
         // GET: api/ProfilingStatus/tracelogs?page=0&pageSize=50
@@ -135,28 +152,33 @@ namespace Web.AnalyticsWeb.Controllers
         /// Runs a MIN/MAX-date query against one table and packages the result (or the error). The
         /// table/column names are compile-time constants, not user input, so there's no injection risk.
         /// </summary>
-        private static Task<DateRangeStatModel> GetRangeAsync(AnalyticsEntitiesContext db, string key, string label, string table, string dateColumn)
+        private static Task<DateRangeStatModel> GetRangeAsync(string key, string label, string table, string dateColumn)
         {
             var sql = $"SELECT MIN({dateColumn}) AS MinDate, MAX({dateColumn}) AS MaxDate FROM {table};";
-            return RunRangeAsync(db, key, label, table, sql);
+            return RunRangeAsync(key, label, table, sql);
         }
 
         /// <summary>
         /// Runs an arbitrary "SELECT MIN(...) AS MinDate, MAX(...) AS MaxDate ..." query (used for
         /// sources whose date isn't a plain column, e.g. Copilot, which is dated via a joined audit
         /// event) and packages the result or the error. SQL is built from constants, not user input.
+        /// Opens its own context with a short command timeout so a slow scan can't hang the request.
         /// </summary>
-        private static async Task<DateRangeStatModel> RunRangeAsync(AnalyticsEntitiesContext db, string key, string label, string table, string sql)
+        private static async Task<DateRangeStatModel> RunRangeAsync(string key, string label, string table, string sql)
         {
             var stat = new DateRangeStatModel { Key = key, Label = label, Table = table, Sql = sql };
 
             try
             {
-                var result = (await db.Database.SqlQuery<DateRangeResult>(sql).ToListAsync()).FirstOrDefault();
-                if (result != null)
+                using (var db = new AnalyticsEntitiesContext())
                 {
-                    stat.From = result.MinDate;
-                    stat.To = result.MaxDate;
+                    db.Database.CommandTimeout = FreshnessQueryTimeoutSecs;
+                    var result = (await db.Database.SqlQuery<DateRangeResult>(sql).ToListAsync()).FirstOrDefault();
+                    if (result != null)
+                    {
+                        stat.From = result.MinDate;
+                        stat.To = result.MaxDate;
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Fixes #173.

## Problem
`GET /api/ProfilingStatus` (Data freshness) ran ~12 MIN/MAX queries **sequentially** with `AnalyticsEntitiesContext`'s **infinite** `CommandTimeout`. The Copilot/`audit_events` join scans a huge table on large tenants, so the request ran past Azure App Service's ~230s limit -> 500. The 60s cache was only set on full success, so reloads re-ran the whole scan forever.

## Fix
- Each MIN/MAX query opens its own context with a **20s** `CommandTimeout` and they run **in parallel** (EF6 contexts aren't thread-safe) -> worst case ~20s, not the sum.
- Slow/missing tables degrade to the existing per-row error instead of a 500.
- Cache the model even when some rows errored so reloads are instant.

## Verify
Web project builds clean (Debug). Behaviour: a heavy table now returns a timeout error in its row; the rest render; reload is cached.