### PR TITLE
Add community health files for .NET Foundation eligibility

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,142 @@
+# Code of Conduct
+
+## Our adoption of the .NET Foundation Code of Conduct
+
+This project has adopted the
+[.NET Foundation Code of Conduct](https://dotnetfoundation.org/about/policies/code-of-conduct),
+which is based on the [Contributor Covenant](https://www.contributor-covenant.org/).
+The full text is reproduced below so that it is always available alongside the
+source code.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[conduct@dotnetfoundation.org](mailto:conduct@dotnetfoundation.org). All
+complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1],
+and from the [.NET Foundation Code of Conduct][dnf].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+[dnf]: https://dotnetfoundation.org/about/policies/code-of-conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to Microsoft 365 Advanced Analytics
+
+First off, thank you for taking the time to contribute! This project is part of
+the **Microsoft 365 & Power Platform Community (PnP)** and we welcome
+contributions of all kinds — code, documentation, bug reports, and ideas — from
+everyone.
+
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Reporting security issues
+
+Please **do not** open public issues for security vulnerabilities. Follow the
+process in our [Security Policy](SECURITY.md) instead.
+
+## Ways to contribute
+
+* **Report a bug** — open an issue using the *Bug report* template.
+* **Request a feature** — open an issue using the *Feature request* template.
+* **Improve the documentation** — the docs live in the
+  [project wiki](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki).
+* **Fix or build something** — pick up an existing issue (or open one to discuss
+  first) and send a pull request.
+
+For anything more than a trivial change, please open or comment on an issue
+first so we can agree on the approach before you invest time in a pull request.
+
+## Development environment
+
+This is a Windows-based .NET Framework solution. To build it you will need:
+
+* **Windows** — the installer is a WinForms app and several projects target
+  .NET Framework 4.8.
+* **Visual Studio 2022** (17.8 or later) with the *.NET desktop development*,
+  *ASP.NET and web development*, and *Azure development* workloads — or a
+  matching **MSBuild** install.
+* **Node.js** (LTS) — required to build the admin web app
+  (`src/AnalyticsEngine/Web/Scripts/admin-app`) and the SharePoint AI Tracker
+  (`src/SPO/AITracker`).
+* A SQL Server **LocalDB** instance for running the unit tests.
+
+A full end-to-end run also needs Azure resources (Azure SQL, App Service, Redis,
+and others). See the
+[Architecture & costs](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Architecture%20and%20Costs)
+and
+[Prerequisites](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Prerequisites)
+wiki pages for details.
+
+### Building
+
+Open `src/AnalyticsEngine/O365 Advanced Analytics Engine.sln` in Visual Studio
+and build, or from a Developer command prompt:
+
+```powershell
+cd src\AnalyticsEngine
+msbuild ".\O365 Advanced Analytics Engine.sln" /t:Restore
+msbuild ".\O365 Advanced Analytics Engine.sln" /t:Build /p:Configuration=Debug
+```
+
+> Note: building the solution with `dotnet build` is not supported — use Visual
+> Studio or MSBuild.
+
+### Running the tests
+
+Unit tests live in `src/AnalyticsEngine/Tests.UnitTests` and run against a local
+`(localdb)\MSSQLLocalDB` database (created and migrated automatically in Debug
+builds). Run them from Visual Studio Test Explorer or with
+`vstest.console.exe`. The CI test workflow
+(`.github/workflows/tests.yml`) runs on every pull request.
+
+## Coding conventions
+
+* Match the style of the surrounding code.
+* For C# work under `src/AnalyticsEngine/`, follow the conventions documented in
+  [`src/AnalyticsEngine/.github/copilot-instructions.md`](src/AnalyticsEngine/.github/copilot-instructions.md)
+  (for example database/column choices, NuGet and binding-redirect handling, and
+  EF migration rules).
+* Any text that can hold customer data (URLs, file names, user / display names,
+  free text) must support the full Unicode range — use `nvarchar`, never
+  `varchar`, in SQL and EF.
+* Keep performance in mind: the solution is expected to run against large
+  tenants (~200,000 users), so avoid patterns that scan or allocate per row.
+
+## Pull request process
+
+1. **Fork** the repository and create a feature branch.
+2. Base your work on, and open your pull request against, the **`dev`** branch
+   (not `main`) unless a maintainer asks otherwise.
+3. Make sure the solution builds and the unit tests pass.
+4. Write a clear PR description and **link the issue(s)** it addresses
+   (for example `Fixes #123`).
+5. Be responsive to review feedback — maintainers may request changes before
+   merging.
+
+## Licensing and contributor agreement
+
+This project is licensed under the [MIT License](LICENSE). By submitting a
+contribution, you agree that your contribution is licensed under the same terms
+and that you have the right to submit it.
+
+Should this project join the [.NET Foundation](https://dotnetfoundation.org/),
+contributors may be asked to sign the .NET Foundation
+[Contributor License Agreement (CLA)](https://cla.dotnetfoundation.org/); the CLA
+bot would then guide you through this automatically on your first pull request.
+
+Thank you for helping make Microsoft 365 Advanced Analytics better!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,71 @@
+# Security Policy
+
+The maintainers of **Microsoft 365 Advanced Analytics** take the security of the
+software seriously. This covers the data-collection engine (the Activity and App
+Insights importer web jobs), the admin web app, the Windows installer
+(`App.ControlPanel`), and the Power BI report templates in this repository.
+
+If you believe you have found a security vulnerability in this project, please
+report it to us privately as described below. **Please do not report security
+vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+## Supported versions
+
+Security fixes are provided for the most recent release published from the
+`main` branch. We always recommend running the latest available
+[release](https://github.com/pnp/Microsoft365-Analytics-Insights/releases).
+
+| Version                    | Supported                |
+| -------------------------- | ------------------------ |
+| Latest `main` release      | :white_check_mark:       |
+| Pre-release / `dev` builds | :white_check_mark: (best effort) |
+| Older releases             | :x:                      |
+
+## Reporting a vulnerability
+
+Please use **GitHub's private vulnerability reporting** for this repository:
+
+1. Go to the **Security** tab of the repository.
+2. Select **Report a vulnerability** ("Privately report a vulnerability").
+3. Provide a clear description, the affected component(s), and reproduction
+   steps.
+
+> **Maintainers:** if the "Report a vulnerability" button is not visible, enable
+> **Private vulnerability reporting** under *Settings → Code security and
+> analysis* so that reporters can use this channel.
+
+To help us triage quickly, please include where possible:
+
+* The component affected (importer web job, web app, installer, reports, etc.).
+* The type of issue (e.g. credential exposure, injection, privilege escalation,
+  insecure storage of secrets).
+* Step-by-step instructions to reproduce the issue.
+* Proof-of-concept or exploit code, if available.
+* The impact, including how an attacker might exploit the issue.
+
+Please **do not** include real tenant data, customer information, or live
+credentials / connection strings in your report — redact them or use
+placeholders.
+
+## What to expect
+
+* We aim to acknowledge new reports within **5 business days**.
+* We will keep you informed as we investigate and validate the issue.
+* We ask that you give us a reasonable opportunity to release a fix before any
+  public disclosure (coordinated disclosure).
+* We are happy to credit reporters in the release notes unless you prefer to
+  remain anonymous.
+
+## Scope
+
+This policy covers the source code and the build/release artifacts produced by
+this repository. It does **not** cover:
+
+* The security configuration of *your own* Azure subscription or Microsoft 365
+  tenant where you deploy the solution (for example how you scope service
+  principal permissions, secure your SQL database, or store secrets). See the
+  [wiki](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki) for
+  deployment and permissions guidance.
+* Vulnerabilities in third-party dependencies — please report those to the
+  relevant upstream project. A heads-up is still welcome so we can pick up the
+  update.


### PR DESCRIPTION
## What

Adds the three community health files required for **.NET Foundation project eligibility**:

- **CODE_OF_CONDUCT.md** — adopts the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/about/policies/code-of-conduct) (Contributor Covenant 2.1), enforcement via `conduct@dotnetfoundation.org`.
- **SECURITY.md** — private vulnerability reporting policy (via GitHub's "Report a vulnerability"), supported versions, and scope (excludes the deployer's own tenant/Azure config).
- **CONTRIBUTING.md** — ways to contribute, build/test steps (VS 2022 / MSBuild, LocalDB tests), coding conventions, and the `dev`-branch PR flow.

## Why

Closes the two hard gaps in the [.NET Foundation eligibility criteria](https://github.com/dotnet-foundation/projects#eligibility-criteria) (no Code of Conduct, no Security Policy) plus the missing contributing guide.

## Related repo settings (already applied)

- Private vulnerability reporting **enabled**
- GitHub Discussions **enabled**
- Repo homepage set to the wiki

## Still external (maintainer process, not in this PR)

- Submitting the .NET Foundation application
- CLA bot onboarding (handled during .NET Foundation onboarding)