### PR TITLE
Clean assembly binding redirects and trim redundant PackageReferences

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel/App.ControlPanel.WinForms.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel/App.ControlPanel.WinForms.csproj
@@ -382,44 +382,11 @@
     <Content Include="Resources\Redis.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity">
-      <Version>1.21.0</Version>
-    </PackageReference>
     <PackageReference Include="Azure.ResourceManager.Resources">
       <Version>1.11.2</Version>
     </PackageReference>
-    <PackageReference Include="Azure.Security.KeyVault.Secrets">
-      <Version>4.11.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Azure.KeyVault.Core">
-      <Version>3.0.5</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>10.0.8</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <Version>5.2.9</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens">
-      <Version>8.18.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>6.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.Targets">
-      <Version>5.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime">
-      <Version>2.3.24</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure">
-      <Version>3.3.19</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication">
-      <Version>2.4.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM">
-      <Version>16.1.27313.12011</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.4</Version>
@@ -450,9 +417,6 @@
     </PackageReference>
     <PackageReference Include="System.Text.Json">
       <Version>10.0.8</Version>
-    </PackageReference>
-    <PackageReference Include="WindowsAzure.Storage">
-      <Version>9.3.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/AnalyticsEngine/App.ControlPanel/App.Template.config
+++ b/src/AnalyticsEngine/App.ControlPanel/App.Template.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 
@@ -20,25 +20,21 @@
 
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+				<assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
-					<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
+				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
+				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
+				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -48,30 +44,21 @@
 				<assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
-				<assemblyIdentity name="Azure.ResourceManager" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<assemblyIdentity name="Azure.ResourceManager" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Azure.ResourceManager.Resources" culture="neutral" publicKeyToken="92742159e12e44c8" />
-				<bindingRedirect oldVersion="0.0.0.0-1.4.0.0" newVersion="1.4.0.0" />
+				<assemblyIdentity name="Azure.ResourceManager.Resources" publicKeyToken="92742159e12e44c8" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.11.2.0" newVersion="1.11.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Services.AppAuthentication" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.6.2.0" newVersion="1.6.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -117,55 +104,38 @@
 				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.UserSecrets" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-			</dependentAssembly>
-
-			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.83.1.0" newVersion="4.83.1.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
+				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
@@ -182,12 +152,10 @@
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-3.0.5.0" newVersion="3.0.5.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
@@ -196,18 +164,14 @@
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
@@ -216,8 +180,6 @@
 				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
@@ -226,7 +188,6 @@
 				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-9.3.2.0" newVersion="9.3.2.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
@@ -235,29 +196,26 @@
 				<assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
@@ -266,59 +224,46 @@
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.ResourceManager.ServiceBus" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Azure.Amqp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Primitives" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Configuration.ConfigurationManager" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.IO.Hashing" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
-
-
-
-
-
-
-
-
-
-
-
 		</assemblyBinding>
 	</runtime>
 

--- a/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
+++ b/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 		<!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
@@ -24,49 +24,44 @@
 
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
 			</dependentAssembly>
-			
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
+				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
+				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
+				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
+				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -76,44 +71,33 @@
 				<assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.Formatting" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Http" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-9.3.2.0" newVersion="9.3.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Azure.ResourceManager" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<assemblyIdentity name="Azure.ResourceManager" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Services.AppAuthentication" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.6.2.0" newVersion="1.6.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -159,47 +143,33 @@
 				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.UserSecrets" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-			</dependentAssembly>
-
-			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
+				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -217,7 +187,6 @@
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-3.0.5.0" newVersion="3.0.5.0" />
@@ -226,104 +195,79 @@
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.83.1.0" newVersion="4.83.1.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
-			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.ResourceManager.ServiceBus" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
 			</dependentAssembly>
-
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Azure.Amqp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Primitives" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Configuration.ConfigurationManager" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.IO.Hashing" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
-
-</assemblyBinding>
+		</assemblyBinding>
 		
 	</runtime>
 

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -272,9 +272,6 @@
     <Content Include="Resources\TestJourneys\Test Journey 2 PageViews.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AngleSharp">
-      <Version>0.17.1</Version>
-    </PackageReference>
     <PackageReference Include="Azure.AI.TextAnalytics">
       <Version>5.3.0</Version>
     </PackageReference>
@@ -296,9 +293,6 @@
     <PackageReference Include="Azure.Storage.Blobs">
       <Version>12.26.0</Version>
     </PackageReference>
-    <PackageReference Include="BCrypt.Net-Next">
-      <Version>4.0.3</Version>
-    </PackageReference>
     <PackageReference Include="EntityFramework">
       <Version>6.5.2</Version>
     </PackageReference>
@@ -317,12 +311,6 @@
     <PackageReference Include="Microsoft.Azure.KeyVault.Core">
       <Version>3.0.5</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bcl.HashCode">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Data.Services.Client">
-      <Version>5.8.5</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration">
       <Version>10.0.8</Version>
     </PackageReference>
@@ -335,27 +323,6 @@
     <PackageReference Include="Microsoft.Graph">
       <Version>6.1.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel">
-      <Version>7.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <Version>5.2.9</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
-      <Version>8.18.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>6.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.Targets">
-      <Version>5.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime">
-      <Version>2.3.24</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure">
-      <Version>3.3.19</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.SharePointOnline.CSOM">
       <Version>16.1.27313.12011</Version>
     </PackageReference>
@@ -367,9 +334,6 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.4</Version>
-    </PackageReference>
-    <PackageReference Include="SharePointPnPCoreOnline">
-      <Version>3.28.2012</Version>
     </PackageReference>
     <PackageReference Include="System.Data.SqlClient">
       <Version>4.9.1</Version>
@@ -395,14 +359,8 @@
     <PackageReference Include="System.Security.Cryptography.X509Certificates">
       <Version>4.3.2</Version>
     </PackageReference>
-    <PackageReference Include="System.Security.Principal">
-      <Version>4.3.0</Version>
-    </PackageReference>
     <PackageReference Include="System.Text.Json">
       <Version>10.0.8</Version>
-    </PackageReference>
-    <PackageReference Include="WindowsAzure.Storage">
-      <Version>9.3.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/src/AnalyticsEngine/Web/Web.Template.config
+++ b/src/AnalyticsEngine/Web/Web.Template.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=169433
@@ -33,2218 +33,270 @@
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Mvc" culture="neutral" publicKeyToken="31bf3856ad364e35"/>
+				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Azure.Amqp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Configuration.ConfigurationManager" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.IO.Hashing" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
-
-
-</assemblyBinding>
-		
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
+				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="AngleSharp" culture="neutral" publicKeyToken="e83494dcdc6d31ea" />
+				<assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Azure.Core" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Azure.Identity" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Azure.Identity" culture="neutral" publicKeyToken="92742159e12e44c8" />
-				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Azure.ResourceManager" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<assemblyIdentity name="Azure.ResourceManager" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.ClientModel" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.Formatting" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Http" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.KeyVault.Core" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-3.0.5.0" newVersion="3.0.5.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Edm" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.OData" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Services.Client" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.UserSecrets" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
+				<assemblyIdentity name="Microsoft.Extensions.WebEncoders" publicKeyToken="adb9793829ddae60" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.8.0" newVersion="10.0.8.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.UserSecrets" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Options" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Primitives" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.WebEncoders" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Graph" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Graph.Core" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Serialization.Form" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Serialization.Json" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Serialization.Text" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Bcl.HashCode" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.WinHttpHandler" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Identity.Client" culture="neutral" publicKeyToken="0a613f4dd989e8ae" />
+				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.83.1.0" newVersion="4.83.1.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Logging" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Tokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Buffers" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Pipelines" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Memory" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Memory.Data" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Numerics.Vectors" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Security.AccessControl" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Security.Cryptography.ProtectedData" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Security.Principal.Windows" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Security.Principal.Windows" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Channels" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Tasks.Extensions" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
 			</dependentAssembly>
-		
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-9.3.2.0" newVersion="9.3.2.0" />
 			</dependentAssembly>
-		
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Formats.Asn1" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Hashing" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-				<bindingRedirect oldVersion="0.0.0.0-9.0.0.12" newVersion="9.0.0.12" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-
-
-</assemblyBinding>
+		</assemblyBinding>
 
 
 	</runtime>

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -59,21 +59,6 @@
     <PackageReference Include="System.ClientModel">
       <Version>1.13.0</Version>
     </PackageReference>
-    <PackageReference Include="Azure.Core">
-      <Version>1.57.0</Version>
-    </PackageReference>
-    <PackageReference Include="Azure.Identity">
-      <Version>1.21.0</Version>
-    </PackageReference>
-    <PackageReference Include="BCrypt.Net-Next">
-      <Version>4.0.3</Version>
-    </PackageReference>
-    <PackageReference Include="EntityFramework">
-      <Version>6.5.2</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.22.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.3.0</Version>
     </PackageReference>
@@ -95,9 +80,6 @@
     <PackageReference Include="Microsoft.Graph.Core">
       <Version>4.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
-      <Version>8.18.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb">
       <Version>4.2.3</Version>
     </PackageReference>
@@ -106,9 +88,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.OpenIdConnect">
       <Version>4.2.3</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.SharePointOnline.CSOM">
-      <Version>16.1.27313.12011</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.4</Version>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
 	<appSettings />
@@ -12,18 +12,14 @@
 		<gcAllowVeryLargeObjects enabled="true"/>
 		
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
+				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.83.1.0" newVersion="4.83.1.0" />
@@ -44,229 +40,118 @@
 				<assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-			
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
-			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0" />
+				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
 			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
-			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0"/>
-			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Services.AppAuthentication" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.6.2.0" newVersion="1.6.2.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Graph.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Authentication.Azure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Http.HttpClientLibrary" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Serialization.Form" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Serialization.Json" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Serialization.Multipart" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Kiota.Serialization.Text" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
-			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.UserSecrets" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Primitives" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.ClientModel" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Memory" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Tasks.Extensions" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Logging" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 		</assemblyBinding>
 	</runtime>
 </configuration>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/WebJob.AppInsightsImporter.csproj
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/WebJob.AppInsightsImporter.csproj
@@ -160,15 +160,6 @@
     <Content Include="Generated\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BCrypt.Net-Next">
-      <Version>4.0.3</Version>
-    </PackageReference>
-    <PackageReference Include="EntityFramework">
-      <Version>6.5.2</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.22.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration">
       <Version>10.0.8</Version>
     </PackageReference>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 		<!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
@@ -29,100 +29,52 @@
 
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
+				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
-
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.57.0.0" newVersion="1.57.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Identity" publicKeyToken="92742159e12e44c8" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0" />
-			</dependentAssembly>
-
-
-			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
-				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.Formatting" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Http" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-				<bindingRedirect oldVersion="0.0.0.0-9.3.2.0" newVersion="9.3.2.0" />
+				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Azure.ResourceManager" culture="neutral" publicKeyToken="92742159e12e44c8" />
-				<bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.ClientModel" culture="neutral" publicKeyToken="92742159e12e44c8" />
+				<assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-			</dependentAssembly>
-
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Services.AppAuthentication" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.6.2.0" newVersion="1.6.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Graph" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -168,47 +120,41 @@
 				<assemblyIdentity name="System.Net.Http.WinHttpHandler" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.7" newVersion="10.0.0.7" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.UserSecrets" publicKeyToken="adb9793829ddae60" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
+				<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -226,7 +172,6 @@
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-3.0.5.0" newVersion="3.0.5.0" />
@@ -235,84 +180,66 @@
 				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.83.1.0" newVersion="4.83.1.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
 			</dependentAssembly>
-
 			<dependentAssembly>
 				<assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Azure.Amqp" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+				<assemblyIdentity name="Microsoft.Azure.Amqp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Primitives" culture="neutral" publicKeyToken="adb9793829ddae60" />
+				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Configuration.ConfigurationManager" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+				<assemblyIdentity name="System.Configuration.ConfigurationManager" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
-
-
-
-
-
-
-
-
-
-
 		</assemblyBinding>
 		
 	</runtime>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/WebJob.Office365ActivityImporter.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/WebJob.Office365ActivityImporter.csproj
@@ -153,24 +153,6 @@
     <PackageReference Include="System.ClientModel">
       <Version>1.13.0</Version>
     </PackageReference>
-    <PackageReference Include="Azure.Identity">
-      <Version>1.21.0</Version>
-    </PackageReference>
-    <PackageReference Include="Azure.Security.KeyVault.Certificates">
-      <Version>4.9.0</Version>
-    </PackageReference>
-    <PackageReference Include="Azure.Security.KeyVault.Secrets">
-      <Version>4.11.0</Version>
-    </PackageReference>
-    <PackageReference Include="BCrypt.Net-Next">
-      <Version>4.0.3</Version>
-    </PackageReference>
-    <PackageReference Include="EntityFramework">
-      <Version>6.5.2</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.22.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core">
       <Version>3.0.5</Version>
     </PackageReference>
@@ -185,15 +167,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Graph.Core">
       <Version>4.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
-      <Version>8.18.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime">
-      <Version>2.3.24</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure">
-      <Version>3.3.19</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.4</Version>


### PR DESCRIPTION
## What & why

Two related cleanups of the .NET Framework entry projects (`WebJob.Office365ActivityImporter`, `WebJob.AppInsightsImporter`, `Web`, `App.ControlPanel.WinForms`, `Tests.UnitTests`). No behavioural change — the deployed assembly set is byte-identical.

### 1. Clean `assemblyBinding` in the template configs
Each project's `App/Web.Template.config` accumulated binding redirects (copy-pasted across projects) for assemblies it doesn't actually deploy. Pruned each to only the redirects for assemblies in that project's real output closure.

| Project | Entries | Change |
|---|---|---|
| Web | 435 → 66 | collapsed **47 duplicated** `assemblyBinding` blocks |
| AppInsights | 55 → 35 | dropped 19 (Graph/Kiota/OData…) + de-duped `Azure.Identity` |
| O365 | 62 → 53 | dropped 9 (WindowsAzure.Storage/WebApi/OData…) |
| ControlPanel | 64 → 61 | dropped 3 |
| Tests | 65 → 61 | dropped 3 |

Also fixed 4 stale `newVersion` values that pointed at versions not on disk (latent `FileLoadException` risk): `Config.EnvironmentVariables`/`UserSecrets` `6.0.0.1 → 10.0.0.8`, `Azure.ResourceManager.Resources` `1.4.0.0 → 1.11.2.0`, `Microsoft.Extensions.WebEncoders` `10.0.0.8 → 10.0.8.0`.

### 2. Trim redundant direct `PackageReference`s
Removed **45** direct NuGet references that are unused in each project's own source and flow in transitively from the Engine/Common project references (AppInsights 3, O365 9, Web 7, ControlPanel 12, Tests 14). Kept direct refs the code actually uses (Newtonsoft.Json, Microsoft.Graph, EntityFramework/CSOM in Tests, the OWIN host in Web) and the `Microsoft.Extensions.*` packages that pin the 10.0.8 stack (removing them downgrades the shared Extensions assemblies).

## Note on generated configs
`App.config` / `Web.config` are git-ignored build artifacts generated from the `*.Template.config` files via the `TransformXml` build step, so only the templates and `.csproj` files are changed here.

## Validation
- Full solution **rebuilds clean** (VS 2022/18 MSBuild, Debug).
- A side-effect-free AppDomain **binding probe** loaded every deployed assembly in all five apps and force-resolved every compiled-against reference under each app's real generated config → **zero `FileLoadException`s**.
- Every `PackageReference` removal was gated on the deployed DLL closure staying **byte-identical**.
- Unit tests pass.

## Labels
`migration needed` — touches deployed `*.config` binding redirects and project dependency manifests.
