### PR TITLE
Standardise ILogger variable names to _logger / logger

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -1,4 +1,4 @@
-﻿using App.ControlPanel.Engine.Entities;
+using App.ControlPanel.Engine.Entities;
 using App.ControlPanel.Engine.Models;
 using Azure.Identity;
 using Azure.ResourceManager;
@@ -654,9 +654,9 @@ namespace App.ControlPanel.Engine
         {
             try
             {
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var auth = new ActivityAPIAppIndentityOAuthContext(telemetry, clientId, tenantId, clientSecret, null, false);
-                var httpClient = new ConfidentialClientApplicationThrottledHttpClient(auth, false, telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var auth = new ActivityAPIAppIndentityOAuthContext(logger, clientId, tenantId, clientSecret, null, false);
+                var httpClient = new ConfidentialClientApplicationThrottledHttpClient(auth, false, logger);
                 // This will start an auth & activity subscription read, which will fail if error with account and/or permissions
                 var downloadSession = await ActivitySubscriptionManager.GetActiveSubscriptions(tenantId, _logger, httpClient);
             }
@@ -672,16 +672,16 @@ namespace App.ControlPanel.Engine
 
         async Task VerifyTeamsAndUserActivityImport(string clientId, string tenantId, string clientSecret)
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-            var auth = new GraphAppIndentityOAuthContext(telemetry, clientId, tenantId, clientSecret, null, false);
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var auth = new GraphAppIndentityOAuthContext(logger, clientId, tenantId, clientSecret, null, false);
             await auth.InitClientCredential();
 
             var graphClient = new Microsoft.Graph.GraphServiceClient(auth.Creds);
 
-            var teamsUserUsageLoader = new TeamsUserUsageLoader(new WebJob.Office365ActivityImporter.Engine.Graph.ManualGraphCallClient(auth, telemetry),
+            var teamsUserUsageLoader = new TeamsUserUsageLoader(new WebJob.Office365ActivityImporter.Engine.Graph.ManualGraphCallClient(auth, logger),
                 new NoUsersHaveGroupsUserGroupsCache(_logger),
                 new Common.Entities.Config.UserGroupsFilterModel(string.Empty),
-                telemetry);
+                logger);
 
             // Usage reports
             if (Config.SolutionConfig.ImportTaskSettings.GraphUsageReports)

--- a/src/AnalyticsEngine/Common/DataUtils/CognitiveExtensions.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/CognitiveExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Azure;
+using Azure;
 using Azure.AI.TextAnalytics;
 using Azure.Identity;
 using Microsoft.Extensions.Logging;
@@ -267,7 +267,7 @@ namespace DataUtils
         /// Loads Azure Cognitive data for a message. Routes calls through
         /// <see cref="CognitiveServicesClient"/> so key-auth failures auto-retry with RBAC.
         /// </summary>
-        public static async Task<List<TextAnalysisResult<T>>> GetCognitiveDataStats<T>(this IEnumerable<TextAnalysisSample<T>> inputData, CognitiveServicesClient client, ILogger telemetry) where T : class
+        public static async Task<List<TextAnalysisResult<T>>> GetCognitiveDataStats<T>(this IEnumerable<TextAnalysisSample<T>> inputData, CognitiveServicesClient client, ILogger logger) where T : class
         {
             if (inputData == null || inputData.Count() == 0) return null;
             if (client == null) return null;
@@ -304,7 +304,7 @@ namespace DataUtils
                         }
                         catch (RequestFailedException ex)
                         {
-                            telemetry.LogError(ex, $"Couldn't detect languages: cognitive services error - {ex.Message}");
+                            logger.LogError(ex, $"Couldn't detect languages: cognitive services error - {ex.Message}");
                             return new List<DetectLanguageResult>();
                         }
                     }
@@ -318,7 +318,7 @@ namespace DataUtils
             }
             catch (RequestFailedException ex)
             {
-                telemetry.LogError(ex, $"Couldn't detect languages: cognitive services error - {ex.Message}");
+                logger.LogError(ex, $"Couldn't detect languages: cognitive services error - {ex.Message}");
                 return null;
             }
             if (validInput.Count == 0) return null;
@@ -378,12 +378,12 @@ namespace DataUtils
                 }
                 catch (RequestFailedException ex)
                 {
-                    telemetry.LogError(ex, $"Cognitive services error {ex.Message}");
+                    logger.LogError(ex, $"Cognitive services error {ex.Message}");
                     return null;
                 }
                 if (sentimentSuccess)
                 {
-                    telemetry.LogInformation($"Sentiment results for chat messages: {allAnalyzeSentimentResults.Count} documents processed");
+                    logger.LogInformation($"Sentiment results for chat messages: {allAnalyzeSentimentResults.Count} documents processed");
 
                     foreach (var sentimentResult in allAnalyzeSentimentResults)
                     {
@@ -403,12 +403,12 @@ namespace DataUtils
                             }
                             else
                             {
-                                telemetry.LogError($"Error in sentiment analysis for message: {originalInput.Text}");
+                                logger.LogError($"Error in sentiment analysis for message: {originalInput.Text}");
                             }
                         }
                         else
                         {
-                            telemetry.LogWarning($"Error in sentiment analysis for message {sentimentResult.Id}. Original message not found.");
+                            logger.LogWarning($"Error in sentiment analysis for message {sentimentResult.Id}. Original message not found.");
                         }
                     }
                 }

--- a/src/AnalyticsEngine/Common/DataUtils/ConsoleApp.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/ConsoleApp.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace DataUtils
@@ -9,9 +9,9 @@ namespace DataUtils
     public class ConsoleApp
     {
 
-        public static void WebjobWait(ILogger telemetry)
+        public static void WebjobWait(ILogger logger)
         {
-            telemetry.LogInformation("Waiting 10 mins...");
+            logger.LogInformation("Waiting 10 mins...");
             System.Threading.Thread.Sleep(600000); // 10 mins
         }
 

--- a/src/AnalyticsEngine/Common/DataUtils/Http/ConfidentialClientApplicationThrottledHttpClient.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/ConfidentialClientApplicationThrottledHttpClient.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core;
+using Azure.Core;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
@@ -13,12 +13,12 @@ namespace DataUtils.Http
     /// </summary>
     public class ConfidentialClientApplicationThrottledHttpClient : AutoThrottleHttpClient
     {
-        public ConfidentialClientApplicationThrottledHttpClient(HttpMessageHandler server, ILogger debugTracer) : base(server, debugTracer)
+        public ConfidentialClientApplicationThrottledHttpClient(HttpMessageHandler server, ILogger logger) : base(server, logger)
         {
         }
 
-        public ConfidentialClientApplicationThrottledHttpClient(ImportAppIndentityOAuthContext appIndentity, bool ignoreRetryHeader, ILogger debugTracer)
-            : base(ignoreRetryHeader, debugTracer, new ConfidentialClientApplicationHttpHandler(appIndentity))
+        public ConfidentialClientApplicationThrottledHttpClient(ImportAppIndentityOAuthContext appIndentity, bool ignoreRetryHeader, ILogger logger)
+            : base(ignoreRetryHeader, logger, new ConfidentialClientApplicationHttpHandler(appIndentity))
         {
         }
     }

--- a/src/AnalyticsEngine/Common/DataUtils/Http/HttpClientExtensions.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/HttpClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -8,12 +8,12 @@ namespace DataUtils.Http
 {
     public static class HttpClientExtensions
     {
-        public static async Task<HttpResponseMessage> GetAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, ILogger debugTracer)
+        public static async Task<HttpResponseMessage> GetAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, ILogger logger)
         {
             // Default to return when full content is read
-            return await httpClient.GetAsyncWithThrottleRetries(url, HttpCompletionOption.ResponseContentRead, debugTracer);
+            return await httpClient.GetAsyncWithThrottleRetries(url, HttpCompletionOption.ResponseContentRead, logger);
         }
-        public static async Task<HttpResponseMessage> GetAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, HttpCompletionOption completionOption, ILogger debugTracer)
+        public static async Task<HttpResponseMessage> GetAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, HttpCompletionOption completionOption, ILogger logger)
         {
             if (httpClient is null)
             {
@@ -25,9 +25,9 @@ namespace DataUtils.Http
                 throw new ArgumentException($"'{nameof(url)}' cannot be null or empty.", nameof(url));
             }
 
-            if (debugTracer is null)
+            if (logger is null)
             {
-                throw new ArgumentNullException(nameof(debugTracer));
+                throw new ArgumentNullException(nameof(logger));
             }
 
             var response = await httpClient.ExecuteHttpCallWithThrottleRetries(async () => await httpClient.GetAsync(url, completionOption), url);
@@ -36,7 +36,7 @@ namespace DataUtils.Http
             return response;
         }
 
-        public static async Task<HttpResponseMessage> PostAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, object body, ILogger debugTracer)
+        public static async Task<HttpResponseMessage> PostAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, object body, ILogger logger)
         {
             if (httpClient is null)
             {
@@ -48,9 +48,9 @@ namespace DataUtils.Http
                 throw new ArgumentException($"'{nameof(url)}' cannot be null or empty.", nameof(url));
             }
 
-            if (debugTracer is null)
+            if (logger is null)
             {
-                throw new ArgumentNullException(nameof(debugTracer));
+                throw new ArgumentNullException(nameof(logger));
             }
 
             var payload = Newtonsoft.Json.JsonConvert.SerializeObject(body);

--- a/src/AnalyticsEngine/Common/DataUtils/Http/OAuthContext.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/OAuthContext.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core;
+using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Logging;
 using System;
@@ -22,7 +22,7 @@ namespace DataUtils.Http
         private readonly bool _useClientCertificate;
         private System.Security.Cryptography.X509Certificates.X509Certificate2 _clientAppCert = null;
 
-        public ImportAppIndentityOAuthContext(ILogger telemetry, string clientId, string tenantId, string clientSecret, string keyVaultUrl, bool useClientCertificate)
+        public ImportAppIndentityOAuthContext(ILogger logger, string clientId, string tenantId, string clientSecret, string keyVaultUrl, bool useClientCertificate)
         {
             if (string.IsNullOrEmpty(clientId))
             {
@@ -44,7 +44,7 @@ namespace DataUtils.Http
             _clientSecret = clientSecret;
             _keyVaultUrl = keyVaultUrl;
             _useClientCertificate = useClientCertificate;
-            Telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            Telemetry = logger ?? throw new ArgumentNullException(nameof(logger));
 
         }
 

--- a/src/AnalyticsEngine/Common/DataUtils/JobTimer.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/JobTimer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using static DataUtils.AnalyticsLogger;
@@ -10,13 +10,13 @@ namespace DataUtils
     /// </summary>
     public class JobTimer
     {
-        private readonly AnalyticsLogger _tracer;
+        private readonly AnalyticsLogger _logger;
         private readonly string _operationName;
         private readonly Stopwatch _sw;
 
-        public JobTimer(AnalyticsLogger tracer, string operationName)
+        public JobTimer(AnalyticsLogger logger, string operationName)
         {
-            _tracer = tracer;
+            _logger = logger;
             _operationName = operationName;
             _sw = new Stopwatch();
         }
@@ -37,7 +37,7 @@ namespace DataUtils
         public string PrintElapsed()
         {
             var s = ToString();
-            _tracer.LogInformation(s);
+            _logger.LogInformation(s);
             return s;
         }
         public string StopAndPrintElapsed()
@@ -45,7 +45,7 @@ namespace DataUtils
             _sw.Stop();
 
             var s = ToString();
-            _tracer.LogInformation(s);
+            _logger.LogInformation(s);
             _sw.Reset();
             return s;
         }
@@ -56,7 +56,7 @@ namespace DataUtils
             {
                 { "context", StopAndPrintElapsed() }
             };
-            _tracer.TrackEvent(analyticsEvent, context);
+            _logger.TrackEvent(analyticsEvent, context);
         }
     }
 }

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
@@ -19,16 +19,16 @@ namespace DataUtils.Sql.Inserts
         #region Constructor & Privates
 
         private readonly string _connectionString;
-        private readonly ILogger _telemetry;
+        private readonly ILogger _logger;
         private InsertBatchTypeFieldCache<T> _batchTypeFieldCache = null;
 
         // Count of rows dropped during the current save because a value was wider than its staging
         // column. Written from parallel insert threads via Interlocked, reset per SaveToStagingTable.
         private int _rowsSkippedTooWide = 0;
-        public InsertBatch(string connectionString, ILogger telemetry)
+        public InsertBatch(string connectionString, ILogger logger)
         {
             _connectionString = connectionString;
-            _telemetry = telemetry;
+            _logger = logger;
             _batchTypeFieldCache = new InsertBatchTypeFieldCache<T>();
         }
 
@@ -79,13 +79,13 @@ namespace DataUtils.Sql.Inserts
 
                 // Import in parallel
                 await loader.ProcessListInParallel(Rows,
-                    async (threadListChunk, threadIndex) => await ProcessChunkAsync(tempTableName, _telemetry, threadListChunk, threadIndex),
-                    threads => _telemetry.LogInformation($"Inserting {Rows.Count.ToString("n0")} records into {tempTableName}, across {threads} thread(s)..."));
+                    async (threadListChunk, threadIndex) => await ProcessChunkAsync(tempTableName, _logger, threadListChunk, threadIndex),
+                    threads => _logger.LogInformation($"Inserting {Rows.Count.ToString("n0")} records into {tempTableName}, across {threads} thread(s)..."));
 
                 // Tell operators if we dropped any rows because a value was too wide for its column.
                 if (_rowsSkippedTooWide > 0)
                 {
-                    _telemetry.LogWarning($"{_rowsSkippedTooWide.ToString("n0")} of {Rows.Count.ToString("n0")} record(s) were NOT staged into {tempTableName} because a column value was longer than that staging column allows; data for those rows is missing from this import (everything else was saved). See the 'Skipping over-width record' messages above for the offending column(s). For SharePoint URLs longer than urls.full_url (nvarchar(850)) see issue #122 / #127.");
+                    _logger.LogWarning($"{_rowsSkippedTooWide.ToString("n0")} of {Rows.Count.ToString("n0")} record(s) were NOT staged into {tempTableName} because a column value was longer than that staging column allows; data for those rows is missing from this import (everything else was saved). See the 'Skipping over-width record' messages above for the offending column(s). For SharePoint URLs longer than urls.full_url (nvarchar(850)) see issue #122 / #127.");
                 }
 
                 // Merge with supplied SQL
@@ -110,7 +110,7 @@ namespace DataUtils.Sql.Inserts
             }
         }
 
-        private async Task ProcessChunkAsync(string tempTableName, ILogger telemetry, List<T> threadListChunk, int chunkIdx)
+        private async Task ProcessChunkAsync(string tempTableName, ILogger logger, List<T> threadListChunk, int chunkIdx)
         {
             using (var chunkSqlConnection = new SqlConnection(_connectionString))
             {
@@ -172,7 +172,7 @@ namespace DataUtils.Sql.Inserts
                         // every retry as a "poison batch". For SharePoint URLs longer than the
                         // urls.full_url-width nvarchar(850) columns see issue #122 / #127.
                         Interlocked.Increment(ref _rowsSkippedTooWide);
-                        _telemetry.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. Continuing with the rest of the batch.");
+                        _logger.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. Continuing with the rest of the batch.");
                         continue;
                     }
 
@@ -186,12 +186,12 @@ namespace DataUtils.Sql.Inserts
                         // didn't predict it (e.g. a column whose declared width we couldn't parse).
                         // Skip just this row so one bad value can't poison the whole batch.
                         Interlocked.Increment(ref _rowsSkippedTooWide);
-                        _telemetry.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. SQL error {ex.Number}: {ex.Message}. Continuing with the rest of the batch.");
+                        _logger.LogError($"Skipping over-width record for staging table {tempTableName}: {BuildRowDiagnostic(insertObj, true)}. SQL error {ex.Number}: {ex.Message}. Continuing with the rest of the batch.");
                         continue;
                     }
                     catch (SqlException ex)
                     {
-                        _telemetry.LogCritical($"Failed to insert record into {tempTableName} - {sqlInsert} | row: {BuildRowDiagnostic(insertObj, false)} | SQL error {ex.Number}: {ex.Message}");
+                        _logger.LogCritical($"Failed to insert record into {tempTableName} - {sqlInsert} | row: {BuildRowDiagnostic(insertObj, false)} | SQL error {ex.Number}: {ex.Message}");
                         throw;
                     }
                 }

--- a/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
+++ b/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using Common.Entities.Entities;
 using Common.Entities.Entities.AuditLog;
 using Common.Entities.Entities.Teams;
@@ -73,17 +73,17 @@ namespace Common.Entities
         /// <summary>
         /// Outputs the changes to be made & then calls SaveChangesAsync
         /// </summary>
-        public void PrintChangesAndSaveToSQL(ILogger telemetry)
+        public void PrintChangesAndSaveToSQL(ILogger logger)
         {
             var adds = this.ChangeTracker.Entries().Where(e => e.State == EntityState.Added).ToList();
             var mods = this.ChangeTracker.Entries().Where(e => e.State == EntityState.Modified).ToList();
             if (adds.Count > 0 || mods.Count > 0)
             {
-                telemetry.LogInformation($"Saving changes to SQL. Inserts: {adds.Count}, updates: {mods.Count}...");
+                logger.LogInformation($"Saving changes to SQL. Inserts: {adds.Count}, updates: {mods.Count}...");
             }
             else
             {
-                telemetry.LogInformation("No changes to commit to SQL.");
+                logger.LogInformation("No changes to commit to SQL.");
             }
 
             this.SaveChanges();

--- a/src/AnalyticsEngine/Common/Entities/Config/AppConnectionStrings.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConnectionStrings.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Configuration;
 using System.Linq;
@@ -8,10 +8,10 @@ namespace Common.Entities.Config
 
     public class AppConnectionStrings
     {
-        public bool TestSQLSettings(ILogger debugTracer)
+        public bool TestSQLSettings(ILogger logger)
         {
             // Test DB conectivity
-            debugTracer.LogInformation("Testing SQL config...");
+            logger.LogInformation("Testing SQL config...");
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -19,16 +19,16 @@ namespace Common.Entities.Config
                 {
                     int count = (from allHits in db.hits
                                  select allHits).Count();
-                    debugTracer.LogInformation($"Found {count.ToString("n0")} hits in table already. Test passed!");
+                    logger.LogInformation($"Found {count.ToString("n0")} hits in table already. Test passed!");
                 }
                 catch (System.Data.Entity.Core.EntityException ex)
                 {
-                    HandleSqlTestException(ex, debugTracer);
+                    HandleSqlTestException(ex, logger);
                     return false;
                 }
                 catch (System.Data.SqlClient.SqlException ex)
                 {
-                    HandleSqlTestException(ex, debugTracer);
+                    HandleSqlTestException(ex, logger);
                     return false;
                 }
             }
@@ -37,10 +37,10 @@ namespace Common.Entities.Config
         }
 
 
-        void HandleSqlTestException(Exception ex, ILogger debugTracer)
+        void HandleSqlTestException(Exception ex, ILogger logger)
         {
-            debugTracer.LogInformation("Fatal error connecting to configured SQL:");
-            debugTracer.LogError(ex, ex.Message);
+            logger.LogInformation("Fatal error connecting to configured SQL:");
+            logger.LogError(ex, ex.Message);
 
             Console.WriteLine("Check your SQL configuration in the .config file / App Service settings.");
         }

--- a/src/AnalyticsEngine/Common/Entities/EFInsertBatch.cs
+++ b/src/AnalyticsEngine/Common/Entities/EFInsertBatch.cs
@@ -1,4 +1,4 @@
-﻿using DataUtils.Sql.Inserts;
+using DataUtils.Sql.Inserts;
 using Microsoft.Extensions.Logging;
 using System.Data.Entity;
 
@@ -9,8 +9,8 @@ namespace Common.Entities
     /// </summary>
     public class EFInsertBatch<T> : InsertBatch<T> where T : class
     {
-        public EFInsertBatch(DbContext context, ILogger debugTracer) :
-            base(context.Database.Connection.ConnectionString, debugTracer)
+        public EFInsertBatch(DbContext context, ILogger logger) :
+            base(context.Database.Connection.ConnectionString, logger)
         {
         }
     }

--- a/src/AnalyticsEngine/Common/Entities/Redis/TeamsRedisManager.cs
+++ b/src/AnalyticsEngine/Common/Entities/Redis/TeamsRedisManager.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
@@ -65,7 +65,7 @@ namespace Common.Entities.Redis.Teams
             }
         }
 
-        public static async Task SetTeamChannelDeltaTokenInfo(this CacheConnectionManager connectionManager, string teamId, string channelId, TeamChannelDeltaTokenInfo refreshTokenInfo, ILogger telemetry)
+        public static async Task SetTeamChannelDeltaTokenInfo(this CacheConnectionManager connectionManager, string teamId, string channelId, TeamChannelDeltaTokenInfo refreshTokenInfo, ILogger logger)
         {
             if (connectionManager is null)
             {
@@ -87,13 +87,13 @@ namespace Common.Entities.Redis.Teams
                 throw new ArgumentNullException(nameof(refreshTokenInfo));
             }
 
-            telemetry.LogInformation($"Updated cached delta token for channel '{channelId}' in team '{teamId}'");
+            logger.LogInformation($"Updated cached delta token for channel '{channelId}' in team '{teamId}'");
             await connectionManager.SetString(GetRedisTeamChannelKey(teamId, channelId), JsonConvert.SerializeObject(refreshTokenInfo));
         }
 
-        public static async Task RemoveTeamChannelDeltaToken(this CacheConnectionManager connectionManager, string teamId, string channelId, ILogger telemetry)
+        public static async Task RemoveTeamChannelDeltaToken(this CacheConnectionManager connectionManager, string teamId, string channelId, ILogger logger)
         {
-            telemetry.LogInformation($"Removed cached delta token for channel '{channelId}' in team '{teamId}'");
+            logger.LogInformation($"Removed cached delta token for channel '{channelId}' in team '{teamId}'");
             await connectionManager.DeleteString(GetRedisTeamChannelKey(teamId, channelId));
         }
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/ActivityAPIStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/ActivityAPIStressTest.cs
@@ -45,7 +45,7 @@ namespace Tests.FakeDataGen.StressTests
                 _memoryMonitor.Start();
                 var stopwatch = Stopwatch.StartNew();
 
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
                 var saveManager = new FakeActivityReportPersistenceManager();
 
                 long totalItems = 0;
@@ -60,7 +60,7 @@ namespace Tests.FakeDataGen.StressTests
                         }
 
                         var importer = new FakeActivityImporterForStress(
-                            telemetry,
+                            logger,
                             maxSavesPerBatch,
                             reportsPerLoad,
                             reportsPerTimeSlot,

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeActivityImporterForStress.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/FakeLoaders/FakeActivityImporterForStress.cs
@@ -12,9 +12,9 @@ namespace Tests.FakeDataGen.StressTests.FakeLoaders
         private FakeContentMetaDataLoaderForStress _contentMetaDataLoader;
         private FakeActivitySubscriptionManagerForStress _activitySubscriptionManager;
 
-        public FakeActivityImporterForStress(AnalyticsLogger telemetry, int maxSavesPerBatch,
+        public FakeActivityImporterForStress(AnalyticsLogger logger, int maxSavesPerBatch,
             int reportsPerLoad, int reportsPerTimeSlot, int timeSlotCount)
-            : base(FakeAppConfigFactory.Create(), telemetry, maxSavesPerBatch)
+            : base(FakeAppConfigFactory.Create(), logger, maxSavesPerBatch)
         {
             _reportLoader = new FakeActivityReportLoaderForStress(reportsPerLoad);
             _contentMetaDataLoader = new FakeContentMetaDataLoaderForStress(reportsPerTimeSlot, timeSlotCount);

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
@@ -91,7 +91,7 @@ namespace Tests.FakeDataGen.StressTests
                 _memoryMonitor.UpdatePeak();
 
                 // 2) Build importer wired up with the fake loader + sentiment scorer.
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
                 var appConfig = FakeAppConfigFactory.Create();
                 var fakeLoader = new FakeSentEmailSourceLoader(
                     messagesPerUser: messagesPerUser,
@@ -107,7 +107,7 @@ namespace Tests.FakeDataGen.StressTests
                     : NullSentEmailSentimentScorer.Instance;
 
                 var importer = new SentEmailImporter(
-                    telemetry,
+                    logger,
                     appConfig,
                     fakeLoader,
                     sentimentScorer,

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImporterTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImporterTests.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities;
 using Common.Entities.Entities.AuditLog;
@@ -118,12 +118,12 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task FakeInMemoryImportTests()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
 
             var saveManager = new FakeActivityReportPersistenceManager();
             for (int i = 1; i < 1000; i++)
             {
-                var testLoader = new FakeActivityImporter(i, new AppConfig(), telemetry);
+                var testLoader = new FakeActivityImporter(i, new AppConfig(), logger);
 
                 var reportSaveStats = await testLoader.LoadReportsAndSave(saveManager);
                 var expected = i * reportSaveStats.ForTimeSlots.Count;
@@ -671,8 +671,8 @@ Event found in API, doesn't find it in cache, assumes it's a new ignored event, 
             // Get settings
             var s = GetSettings();
 
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-            var auth = new ActivityAPIAppIndentityOAuthContext(telemetry, s.ClientID, s.TenantGUID.ToString(), s.ClientSecret, s.KeyVaultUrl, s.UseClientCertificate);
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var auth = new ActivityAPIAppIndentityOAuthContext(logger, s.ClientID, s.TenantGUID.ToString(), s.ClientSecret, s.KeyVaultUrl, s.UseClientCertificate);
 
 
             var config = new HttpConfiguration();
@@ -684,9 +684,9 @@ Event found in API, doesn't find it in cache, assumes it's a new ignored event, 
             {
                 db.Database.ExecuteSqlCommand("TRUNCATE TABLE TestingSubscriptions");
             }
-            using (var fakeClient = new ConfidentialClientApplicationThrottledHttpClient(server, telemetry))
+            using (var fakeClient = new ConfidentialClientApplicationThrottledHttpClient(server, logger))
             {
-                var importer = new ActivitySubscriptionManager(s, telemetry, fakeClient);
+                var importer = new ActivitySubscriptionManager(s, logger, fakeClient);
 
                 var active = await importer.GetActiveSubscriptionContentTypes();
 
@@ -715,19 +715,18 @@ Event found in API, doesn't find it in cache, assumes it's a new ignored event, 
             config.MapHttpAttributeRoutes();
             HttpServer server = new HttpServer(config);
 
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
 
             // Start new download session
-            using (var fakeClient = new ConfidentialClientApplicationThrottledHttpClient(server, telemetry))
+            using (var fakeClient = new ConfidentialClientApplicationThrottledHttpClient(server, logger))
             {
-                var importer = new ActivityWebImporter(fakeClient, s, telemetry);
+                var importer = new ActivityWebImporter(fakeClient, s, logger);
 
                 // Download all the things & get stats.
 
-                var logger = AnalyticsLogger.ConsoleOnlyTracer();
                 var stats = await importer.LoadReportsAndSave(new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(logger), logger, new AppConfig()));
 
-                var contentMetaDataLoader = new WebContentMetaDataLoader(telemetry, fakeClient, s);
+                var contentMetaDataLoader = new WebContentMetaDataLoader(logger, fakeClient, s);
 
                 // Each activity call should return X activities per page of results, + another page
                 var timeChunks = contentMetaDataLoader.GetScanningTimeChunksFromNow();

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImportTests.cs
@@ -1,4 +1,4 @@
-﻿using Azure;
+using Azure;
 using Azure.AI.TextAnalytics;
 using Common.Entities;
 using Common.Entities.Config;
@@ -942,7 +942,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task PageExitEventSave()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             using (var db = new AnalyticsEntitiesContext())
             {
                 var hitsToSave = new PageViewCollection();
@@ -982,8 +982,8 @@ namespace Tests.UnitTests
                     });
 
                 }
-                await hitsToSave.SaveToSQL(db, telemetry);
-                await pageStatsToSave.SaveHitsUpdatesToSQL(telemetry, db);
+                await hitsToSave.SaveToSQL(db, logger);
+                await pageStatsToSave.SaveHitsUpdatesToSQL(logger, db);
                 var lastHitAfterTest = await db.hits.OrderByDescending(h => h.ID).Take(1).FirstOrDefaultAsync();
 
                 // Load & verify
@@ -1005,13 +1005,13 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task ClickCollectionEventSave()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             using (var db = new AnalyticsEntitiesContext())
             {
                 var clicksToSave = new CustomEventsResultCollection();
 
                 // Test empty
-                await clicksToSave.SaveClicksToSQL(telemetry, db);
+                await clicksToSave.SaveClicksToSQL(logger, db);
 
                 // Insert required hit & session for clicks to work
                 var testUser = new User { UserPrincipalName = "testuser" + DateTime.Now.Ticks };
@@ -1042,7 +1042,7 @@ namespace Tests.UnitTests
                     });
                 }
 
-                await clicksToSave.SaveAllEventTypesToSql(telemetry, new AppConfig());
+                await clicksToSave.SaveAllEventTypesToSql(logger, new AppConfig());
                 var lastClickAfterTest = await db.Clicks.OrderByDescending(h => h.ID).Take(1).FirstOrDefaultAsync() ?? new Common.Entities.Entities.WebTraffic.Clicks() { ID = int.MaxValue };
 
                 // Load & verify
@@ -1077,7 +1077,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task ClickEventDuplicateSave()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             using (var db = new AnalyticsEntitiesContext())
             {
                 var clicksToSave = new CustomEventsResultCollection();
@@ -1118,7 +1118,7 @@ namespace Tests.UnitTests
                     AppInsightsTimestamp = dt,
                 });
 
-                await clicksToSave.SaveAllEventTypesToSql(telemetry, new AppConfig());
+                await clicksToSave.SaveAllEventTypesToSql(logger, new AppConfig());
                 clicksToSave.Rows.Clear();
 
                 // Duplicate in new save set
@@ -1136,22 +1136,22 @@ namespace Tests.UnitTests
                 });
 
                 // Make sure doesn't crash
-                await clicksToSave.SaveAllEventTypesToSql(telemetry, new AppConfig());
+                await clicksToSave.SaveAllEventTypesToSql(logger, new AppConfig());
             }
         }
 
         [TestMethod]
         public async Task ClickEventEdgeCaseTests()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             using (var db = new AnalyticsEntitiesContext())
             {
                 var randoTestName = "TestName" + DateTime.Now.Ticks;
                 db.Clicks.RemoveRange(db.Clicks.ToList());
                 await db.SaveChangesAsync();
 
-                await TestEdgeClicks(db, telemetry, randoTestName, null);
-                await TestEdgeClicks(db, telemetry, randoTestName, null);     // Use existing lookup
+                await TestEdgeClicks(db, logger, randoTestName, null);
+                await TestEdgeClicks(db, logger, randoTestName, null);     // Use existing lookup
 
                 // Generate 4k(ish) string
                 var sb = "";
@@ -1159,12 +1159,12 @@ namespace Tests.UnitTests
                 {
                     sb += ("a");
                 }
-                await TestEdgeClicks(db, telemetry, randoTestName, sb);
+                await TestEdgeClicks(db, logger, randoTestName, sb);
 
             }
         }
 
-        private async Task TestEdgeClicks(AnalyticsEntitiesContext db, ILogger telemetry, string randoTestName, string classname)
+        private async Task TestEdgeClicks(AnalyticsEntitiesContext db, ILogger logger, string randoTestName, string classname)
         {
             var clicksToSave = new CustomEventsResultCollection();
 
@@ -1193,7 +1193,7 @@ namespace Tests.UnitTests
             var expectedClicks = clicksToSave.Rows.Count;
 
             // Shave
-            await clicksToSave.SaveClicksToSQL(telemetry, db);
+            await clicksToSave.SaveClicksToSQL(logger, db);
 
             var lastClickAfterTest = await db.Clicks.OrderByDescending(h => h.ID).Take(1).FirstOrDefaultAsync() ?? new Common.Entities.Entities.WebTraffic.Clicks() { ID = int.MaxValue };
 

--- a/src/AnalyticsEngine/Tests.UnitTests/CallRecordTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CallRecordTests.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using DataUtils;
 using Microsoft.Graph;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -94,11 +94,11 @@ namespace Tests.UnitTests
             var failedGroupCall = JsonConvert.DeserializeObject<CallRecordDTO>(Resources.TeamsCall_Failed_Call);
             var p2pCall = JsonConvert.DeserializeObject<CallRecordDTO>(Resources.TeamsCall_Peer2PeerCall);
 
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
 
             var config = new Common.Entities.Config.AppConfig();
             var auth = new WebJob.Office365ActivityImporter.Engine.GraphAppIndentityOAuthContext
-                (telemetry, config.ClientID,
+                (logger, config.ClientID,
                 config.TenantGUID.ToString(),
                 config.ClientSecret,
                 config.KeyVaultUrl,
@@ -109,9 +109,9 @@ namespace Tests.UnitTests
             var teamsLoadContext = new TeamsLoadContext(new GraphServiceClient(auth.Creds));
 
             // Populate email addresses using demo v4 tenant context. Won't work with any other environment.
-            await call3way.PopulateEmailAddresses(teamsLoadContext, config.TenantGUID.ToString(), telemetry);
-            await failedGroupCall.PopulateEmailAddresses(teamsLoadContext, config.TenantGUID.ToString(), telemetry);
-            await p2pCall.PopulateEmailAddresses(teamsLoadContext, config.TenantGUID.ToString(), telemetry);
+            await call3way.PopulateEmailAddresses(teamsLoadContext, config.TenantGUID.ToString(), logger);
+            await failedGroupCall.PopulateEmailAddresses(teamsLoadContext, config.TenantGUID.ToString(), logger);
+            await p2pCall.PopulateEmailAddresses(teamsLoadContext, config.TenantGUID.ToString(), logger);
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -131,9 +131,9 @@ namespace Tests.UnitTests
                 db.SaveChanges();
 
                 var context = new TeamsAndCallsDBLookupManager(db);
-                var call3wayDB = await call3way.SaveOrReplaceCallRecord(context, telemetry);
-                var failedGroupCallDB = await failedGroupCall.SaveOrReplaceCallRecord(context, telemetry);
-                var p2pCallDB = await p2pCall.SaveOrReplaceCallRecord(context, telemetry);
+                var call3wayDB = await call3way.SaveOrReplaceCallRecord(context, logger);
+                var failedGroupCallDB = await failedGroupCall.SaveOrReplaceCallRecord(context, logger);
+                var p2pCallDB = await p2pCall.SaveOrReplaceCallRecord(context, logger);
 
                 // DTOs always include a session for initiator too (Teams endpoint). 
                 // For a group call, that means x2 sessions for initiator user (user -> endpoint; endpoint -> user) - something we ignore

--- a/src/AnalyticsEngine/Tests.UnitTests/DBLookupCacheDuplicateKeyErrorTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DBLookupCacheDuplicateKeyErrorTests.cs
@@ -35,8 +35,8 @@ namespace Tests.UnitTests
             using (var db = new AnalyticsEntitiesContext())
             {
                 db.Configuration.AutoDetectChangesEnabled = false;
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 // BATCH 1: Create first user with this location
@@ -116,8 +116,8 @@ namespace Tests.UnitTests
 
             using (var db = new AnalyticsEntitiesContext())
             {
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 // BATCH 1: Create location
@@ -217,8 +217,8 @@ namespace Tests.UnitTests
             using (var db = new AnalyticsEntitiesContext())
             {
                 db.Configuration.AutoDetectChangesEnabled = false;
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 var allUsers = new System.Collections.Generic.List<User>();
@@ -330,10 +330,10 @@ namespace Tests.UnitTests
             {
                 db.Configuration.AutoDetectChangesEnabled = false;
 
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
                 var cache = new UserMetadataCache(db);
-                var batchProcessor = new UserBatchProcessor(telemetry);
-                var dataMapper = new UserDataMapper(telemetry, cache);
+                var batchProcessor = new UserBatchProcessor(logger);
+                var dataMapper = new UserDataMapper(logger, cache);
 
                 // Simulate InsertMissingUsers workflow
                 const int BATCH_SIZE = 50;
@@ -464,8 +464,8 @@ namespace Tests.UnitTests
             using (var db = new AnalyticsEntitiesContext())
             {
                 db.Configuration.AutoDetectChangesEnabled = false;
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 // Act - Process 3 batches of 500 users each, all with same department
@@ -493,7 +493,7 @@ namespace Tests.UnitTests
                     // THE FIX: Preserve lookups across batches
                     batchProcessor.DetachAllEntitiesExceptLookups(db);
 
-                    telemetry.LogInformation($"Completed batch {batchNum + 1}/{NUM_BATCHES}");
+                    logger.LogInformation($"Completed batch {batchNum + 1}/{NUM_BATCHES}");
                 }
 
                 // Assert - Should have exactly ONE department despite 1500 users

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeActivityImporter.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeActivityImporter.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 
@@ -10,10 +10,10 @@ namespace Tests.UnitTests.FakeLoaderClasses
         private FakeActivityReportLoader _reportLoader;
         private FakeContentMetaDataLoader _contentMetaDataLoader;
         private FakeActivitySubscriptionManager _activitySubscriptionManager;
-        public FakeActivityImporter(int reportsWanted, AppConfig settings, AnalyticsLogger telemetry) : base(settings, telemetry, 1)
+        public FakeActivityImporter(int reportsWanted, AppConfig settings, AnalyticsLogger logger) : base(settings, logger, 1)
         {
             _reportLoader = new FakeActivityReportLoader(1);
-            _contentMetaDataLoader = new FakeContentMetaDataLoader(telemetry, settings, reportsWanted);
+            _contentMetaDataLoader = new FakeContentMetaDataLoader(logger, settings, reportsWanted);
             _activitySubscriptionManager = new FakeActivitySubscriptionManager();
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAggregateWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAggregateWeeklyUsageReportLoader.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using System;
@@ -13,7 +13,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
     {
         private readonly string _fakeUrlForLoadSiteResult;
 
-        public FakeSPSiteIdToUrlCache(Common.Entities.AnalyticsEntitiesContext db, ILogger debugTracer, string fakeUrlForLoadSiteResult) : base(db, debugTracer)
+        public FakeSPSiteIdToUrlCache(Common.Entities.AnalyticsEntitiesContext db, ILogger logger, string fakeUrlForLoadSiteResult) : base(db, logger)
         {
             _fakeUrlForLoadSiteResult = fakeUrlForLoadSiteResult;
         }
@@ -28,7 +28,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
     {
         bool _hasSaved = false;
         int _loadCount = 0;
-        public MultiPageFakeWeeklyUsageReportLoader(ILogger telemetry) : base(telemetry) { }
+        public MultiPageFakeWeeklyUsageReportLoader(ILogger logger) : base(logger) { }
         public override string ReportGraphURL => "fake URL";
 
         public override Task<AggregateResourceUsageDetail<FakeStats>> LoadReportDataForUrl(string requestUrl)
@@ -84,7 +84,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
     {
         bool _hasSaved = false;
         int _loadCount = 0;
-        public SundayOrNotFakeWeeklyUsageReportLoader(ILogger telemetry) : base(telemetry) { }
+        public SundayOrNotFakeWeeklyUsageReportLoader(ILogger logger) : base(logger) { }
         public override string ReportGraphURL => "fake pagable URL";
 
         public override Task<AggregateResourceUsageDetail<FakeStats>> LoadReportDataForUrl(string requestUrl)

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeContentMetaDataLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeContentMetaDataLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -11,7 +11,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
     {
         private readonly int _reportsSummaryCountWanted;
 
-        public FakeContentMetaDataLoader(ILogger debugTracer, AppConfig settings, int reportsCountWanted) : base(debugTracer, settings)
+        public FakeContentMetaDataLoader(ILogger logger, AppConfig settings, int reportsCountWanted) : base(logger, settings)
         {
             _reportsSummaryCountWanted = reportsCountWanted;
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserAppLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserAppLoader.cs
@@ -1,4 +1,4 @@
-﻿using DataUtils;
+using DataUtils;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -11,7 +11,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
         private readonly int _fakeUserCount;
         private bool _haveThrownUserNotFound = false;
 
-        public FakeUserAppLoader(AnalyticsLogger telemetry, int fakeUserCount) : base(telemetry)
+        public FakeUserAppLoader(AnalyticsLogger logger, int fakeUserCount) : base(logger)
         {
             _fakeUserCount = fakeUserCount;
         }
@@ -48,7 +48,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
 
         public override Task Save(Dictionary<string, List<FakeUserApp>> usersAndApps)
         {
-            _telemetry.LogInformation($"Faking save for {usersAndApps.Count} users and apps");
+            _logger.LogInformation($"Faking save for {usersAndApps.Count} users and apps");
             return Task.CompletedTask;
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphImportTests.cs
@@ -51,14 +51,14 @@ namespace Tests.UnitTests
         [TestCategory("Integration")]
         public async Task MessageImportTests()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
-            var auth = new GraphAppIndentityOAuthContext(telemetry, config.ClientID, config.TenantGUID.ToString(), config.ClientSecret, config.KeyVaultUrl, config.UseClientCertificate);
+            var auth = new GraphAppIndentityOAuthContext(logger, config.ClientID, config.TenantGUID.ToString(), config.ClientSecret, config.KeyVaultUrl, config.UseClientCertificate);
 
             await auth.InitClientCredential();
             var graphClient = new GraphServiceClient(auth.Creds);
 
-            var finder = new TeamsFinder(telemetry, config, graphClient);
+            var finder = new TeamsFinder(logger, config, graphClient);
             var allGroups = await finder.FindGroupsWithTeamToCrawl(TeamsCrawlConfig.AllGroupsConfig);
 
             Assert.IsTrue(allGroups.Count > 0, "No teams found to load messages for");
@@ -66,7 +66,7 @@ namespace Tests.UnitTests
             using (var db = new AnalyticsEntitiesContext())
             {
                 var context = new TeamsLoadContext(graphClient);
-                var team = await O365Team.LoadTeamFull(allGroups[0], context, telemetry, config, db);
+                var team = await O365Team.LoadTeamFull(allGroups[0], context, logger, config, db);
                 var channel = team.Channels.First();
                 var user = new Identity { Id = team.OwnerUserAccounts[0].Id };
 
@@ -119,13 +119,13 @@ namespace Tests.UnitTests
                     channel.Messages = new List<ChatMessage>();
                 }
                 channel.Messages.Add(msgRoot);
-                channel.CalculateAndSetNewMessagesAndReactions(channel.Messages, DateTime.Now.AddDays(-7), telemetry);
+                channel.CalculateAndSetNewMessagesAndReactions(channel.Messages, DateTime.Now.AddDays(-7), logger);
 
                 // Rebuild reactions from msgs now we have fake messages
                 await team.ProcessAllReactionsFromMessages(context, channel);
 
 
-                var sqlTeam = await team.SaveToSQL(new TeamsAndCallsDBLookupManager(db), config, telemetry);
+                var sqlTeam = await team.SaveToSQL(new TeamsAndCallsDBLookupManager(db), config, logger);
                 Assert.IsNotNull(sqlTeam);
 
                 // Check we see reactions & stats
@@ -178,7 +178,7 @@ namespace Tests.UnitTests
         public async Task CallQueueProcessorTest()
         {
             const int CALLS_TO_ADD = 10;
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
 
             var httpConfig = new HttpConfiguration();
             httpConfig.MapHttpAttributeRoutes();
@@ -194,7 +194,7 @@ namespace Tests.UnitTests
             using (var db = new AnalyticsEntitiesContext())
             {
                 var callCountInitial = await db.CallRecords.CountAsync();
-                using (var client = new ManualGraphCallClient(server, telemetry))
+                using (var client = new ManualGraphCallClient(server, logger))
                 {
                     using (var callProcessor = await CallQueueProcessor.GetCallQueueProcessor(config,
                         config.TenantGUID.ToString(), client))
@@ -212,7 +212,7 @@ namespace Tests.UnitTests
                         {
                             var newCallId = Guid.NewGuid();
                             var change = new GraphChangeNotification { ResourceData = new Common.Entities.Models.ResourceData { Id = newCallId.ToString() } };
-                            await CallQueueProcessor.AddChangeMsgToQueue(new List<GraphChangeNotification> { change }, telemetry, sbSender);
+                            await CallQueueProcessor.AddChangeMsgToQueue(new List<GraphChangeNotification> { change }, logger, sbSender);
                             testIds.Add(newCallId.ToString());
                         }
 
@@ -267,26 +267,26 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task LoadAllPagesWithThrottleRetriesTest()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
 
             var config = new HttpConfiguration();
             config.MapHttpAttributeRoutes();
             var server = new HttpServer(config);
 
-            using (var client = new ManualGraphCallClient(server, telemetry))
+            using (var client = new ManualGraphCallClient(server, logger))
             {
-                await TestPageResponse(client, telemetry, 100, 10);
-                await TestPageResponse(client, telemetry, 100, 1);
-                await TestPageResponse(client, telemetry, 102, 10);
-                await TestPageResponse(client, telemetry, 1000, 10);
+                await TestPageResponse(client, logger, 100, 10);
+                await TestPageResponse(client, logger, 100, 1);
+                await TestPageResponse(client, logger, 102, 10);
+                await TestPageResponse(client, logger, 1000, 10);
 
             }
         }
 
-        private async Task TestPageResponse(ManualGraphCallClient client, ILogger telemetry, int v1, int v2)
+        private async Task TestPageResponse(ManualGraphCallClient client, ILogger logger, int v1, int v2)
         {
             var url = FakePageableResultsController.GetUrl(0, v1, v2);
-            var results = await client.LoadAllPagesWithThrottleRetries<FakePagedResult>(url, telemetry);
+            var results = await client.LoadAllPagesWithThrottleRetries<FakePagedResult>(url, logger);
 
             Assert.IsTrue(results.Count == v1);
         }
@@ -410,12 +410,12 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task AllTeamsLoadTest()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var authConfig = new AppConfig();
-            var auth = new GraphAppIndentityOAuthContext(telemetry, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
+            var auth = new GraphAppIndentityOAuthContext(logger, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
             await auth.InitClientCredential();
 
-            var importer = new TeamsImporter(telemetry, new AppConfig(), new GraphServiceClient(auth.Creds));
+            var importer = new TeamsImporter(logger, new AppConfig(), new GraphServiceClient(auth.Creds));
 
             // Use a filter for tests?
             const string SEP = ";";

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using DataUtils;
@@ -25,14 +25,14 @@ namespace Tests.UnitTests
         public async Task SPSiteIdToUrlCacheTests()
         {
             // Run all activity imports for test
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
 
             using (var db = new AnalyticsEntitiesContext())
             {
                 // Test the cache with new site URL & ID
                 var fakeId = $"fake id {DateTime.Now.Ticks}";
                 var fakeUrlNew = $"fake URL {DateTime.Now.Ticks}";
-                var siteUrlCache = new FakeSPSiteIdToUrlCache(db, telemetry, fakeUrlNew);
+                var siteUrlCache = new FakeSPSiteIdToUrlCache(db, logger, fakeUrlNew);
                 var site1 = await siteUrlCache.Load(fakeId);
 
                 var dbRecord = db.sites.Where(s => s.SiteId == fakeId).SingleOrDefault();
@@ -46,7 +46,7 @@ namespace Tests.UnitTests
                 await db.SaveChangesAsync();
 
                 // Load the site with a new fake ID. Currently in the DB it doesn't have an ID
-                var siteUrlCache2 = new FakeSPSiteIdToUrlCache(db, telemetry, fakeUrlExisting);
+                var siteUrlCache2 = new FakeSPSiteIdToUrlCache(db, logger, fakeUrlExisting);
                 var site2 = await siteUrlCache2.Load($"fake id2 {DateTime.Now.Ticks}");
                 Assert.IsNotNull(site2);
                 Assert.AreEqual(fakeUrlExisting, site2.SiteUrl);
@@ -60,33 +60,33 @@ namespace Tests.UnitTests
         public async Task AllO365ActivityTests()
         {
             // Run all activity imports for test
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var authConfig = new AppConfig();
 
-            var graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(telemetry, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
+            var graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(logger, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
             await graphAppIndentityOAuthContext.InitClientCredential();
 
             var graphClient = new Microsoft.Graph.GraphServiceClient(graphAppIndentityOAuthContext.Creds);
-            var graphImporter = new GraphImporter(telemetry, new NoUsersHaveGroupsUserGroupsCache(telemetry), graphAppIndentityOAuthContext, graphClient, authConfig);
+            var graphImporter = new GraphImporter(logger, new NoUsersHaveGroupsUserGroupsCache(logger), graphAppIndentityOAuthContext, graphClient, authConfig);
 
-            await graphImporter.GetAndSaveActivityReportsMultiThreaded(1, new ManualGraphCallClient(graphAppIndentityOAuthContext, telemetry),
-                new NoUsersHaveGroupsUserGroupsCache(telemetry), new UserGroupsFilterModel());
+            await graphImporter.GetAndSaveActivityReportsMultiThreaded(1, new ManualGraphCallClient(graphAppIndentityOAuthContext, logger),
+                new NoUsersHaveGroupsUserGroupsCache(logger), new UserGroupsFilterModel());
         }
 
         [TestMethod]
         public async Task SharePointSitesUsageLoaderTest()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var authConfig = new AppConfig();
 
-            var graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(telemetry, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
+            var graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(logger, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
 
             await graphAppIndentityOAuthContext.InitClientCredential();
             var graphClient = new Microsoft.Graph.GraphServiceClient(graphAppIndentityOAuthContext.Creds);
             using (var db = new AnalyticsEntitiesContext())
             {
-                var siteUrlCache = new GraphSPSiteIdToUrlCache(graphClient, db, telemetry);
-                var loader = new SharePointSitesWeeklyUsageReportLoader(db, new ManualGraphCallClient(graphAppIndentityOAuthContext, telemetry), telemetry, siteUrlCache);
+                var siteUrlCache = new GraphSPSiteIdToUrlCache(graphClient, db, logger);
+                var loader = new SharePointSitesWeeklyUsageReportLoader(db, new ManualGraphCallClient(graphAppIndentityOAuthContext, logger), logger, siteUrlCache);
 
                 // Override/fake the last refresh date to be today
                 var data = await loader.LoadReportData();
@@ -104,8 +104,8 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task SundayOrNotFakeUsageLoaderTest()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-            var loader = new SundayOrNotFakeWeeklyUsageReportLoader(telemetry);
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var loader = new SundayOrNotFakeWeeklyUsageReportLoader(logger);
 
             // First time we load, we return a report that's not a sunday
             var saves = await loader.LoadAndSaveLastWeeksReportsIfRefreshOnDay(DayOfWeek.Sunday);
@@ -119,8 +119,8 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task MultiPageFakeUsageLoaderTest()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-            var loader = new MultiPageFakeWeeklyUsageReportLoader(telemetry);
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var loader = new MultiPageFakeWeeklyUsageReportLoader(logger);
 
             // We should have two items, each one loaded on a seperate page
             var fakeData = await loader.LoadReportData();
@@ -135,8 +135,8 @@ namespace Tests.UnitTests
         [TestMethod]
         public void TeamsUserUsageLoader_DurationsUseTotalSecondsNotComponent()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-            var loader = new TestableTeamsUserUsageLoader(telemetry);
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var loader = new TestableTeamsUserUsageLoader(logger);
 
             var page = new TeamsUserActivityUserDetail
             {
@@ -159,7 +159,7 @@ namespace Tests.UnitTests
         /// </summary>
         private class TestableTeamsUserUsageLoader : TeamsUserUsageLoader
         {
-            public TestableTeamsUserUsageLoader(ILogger telemetry) : base(null, null, null, telemetry) { }
+            public TestableTeamsUserUsageLoader(ILogger logger) : base(null, null, null, logger) { }
 
             public GlobalTeamsUserUsageLog Populate(TeamsUserActivityUserDetail page)
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/LookupCacheBatchProcessingTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LookupCacheBatchProcessingTests.cs
@@ -31,8 +31,8 @@ namespace Tests.UnitTests
             {
                 db.Configuration.AutoDetectChangesEnabled = false;
 
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 int usersProcessed = 0;
@@ -124,8 +124,8 @@ namespace Tests.UnitTests
 
             using (var db = new AnalyticsEntitiesContext())
             {
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 // Create department in first batch
@@ -168,8 +168,8 @@ namespace Tests.UnitTests
 
             using (var db = new AnalyticsEntitiesContext())
             {
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 // Create all lookup types
@@ -239,8 +239,8 @@ namespace Tests.UnitTests
             {
                 db.Configuration.AutoDetectChangesEnabled = false;
 
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 var random = new Random();
@@ -314,8 +314,8 @@ namespace Tests.UnitTests
             {
                 db.Configuration.AutoDetectChangesEnabled = false;
 
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var batchProcessor = new UserBatchProcessor(telemetry);
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var batchProcessor = new UserBatchProcessor(logger);
                 var cache = new UserMetadataCache(db);
 
                 // Batch 1

--- a/src/AnalyticsEngine/Tests.UnitTests/OutlookUserActivityLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/OutlookUserActivityLoaderTests.cs
@@ -19,7 +19,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task OutlookUserActivityLoader_SaveLoadedReportsToSql_BasicInsertTest()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -27,8 +27,8 @@ namespace Tests.UnitTests
                 db.Configuration.LazyLoadingEnabled = false;
 
                 // Prepare loader (ManualGraphCallClient not needed because we will inject data directly)
-                var groupsCache = new NoUsersHaveGroupsUserGroupsCache(telemetry);
-                var loader = new OutlookUserActivityLoader(null, groupsCache, new UserGroupsFilterModel("FakeGroup1;FakeGroup2"), telemetry);
+                var groupsCache = new NoUsersHaveGroupsUserGroupsCache(logger);
+                var loader = new OutlookUserActivityLoader(null, groupsCache, new UserGroupsFilterModel("FakeGroup1;FakeGroup2"), logger);
 
                 // Fake single-day activity page for a unique user
                 var testDate = DateTime.UtcNow.Date.AddDays(-2); // Use date unlikely to be current day to avoid partial real data

--- a/src/AnalyticsEngine/Tests.UnitTests/Program.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/Program.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils;
 using Microsoft.ApplicationInsights;
 using System;
@@ -30,14 +30,14 @@ namespace Tests.UnitTests
 
         private static async Task DoThing()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
 
-            var testLoader = new FakeActivityImporter(100, new AppConfig(), telemetry);
+            var testLoader = new FakeActivityImporter(100, new AppConfig(), logger);
 
-            var t = new JobTimer(telemetry, "Soyve");
+            var t = new JobTimer(logger, "Soyve");
             t.Start();
             Console.WriteLine("Saving data...");
-            await testLoader.LoadReportsAndSave(new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(telemetry), telemetry, new AppConfig()));
+            await testLoader.LoadReportsAndSave(new ActivityReportSqlPersistenceManager(new AllowAllFilterConfig(), new NoUsersHaveGroupsUserGroupsCache(logger), logger, new AppConfig()));
 
             t.StopAndPrintElapsed();
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/UsageStatsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UsageStatsTests.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Identity;
+using Azure.Identity;
 using Common.Entities;
 using Common.Entities.Installer;
 using DataUtils;
@@ -26,9 +26,9 @@ namespace Tests.UnitTests
         public async Task UsageStatsReporterFakeAdaptorTest()
         {
             var tenantId = Guid.NewGuid();
-            var tracer = AnalyticsLogger.ConsoleOnlyTracer();
-            var r = new UsageStatsManager(new ShittyUsageStatsReporterAdaptor(tracer, tenantId),
-                new ShittyDatesLoader(tracer), new FakeStatsUploader(tracer, true), tracer);
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var r = new UsageStatsManager(new ShittyUsageStatsReporterAdaptor(logger, tenantId),
+                new ShittyDatesLoader(logger), new FakeStatsUploader(logger, true), logger);
 
 
             var result = await r.ProcessAndFailSilently(); // Crash GetLastSettings
@@ -111,12 +111,12 @@ namespace Tests.UnitTests
         public async Task UsageStatsReporterRealTests()
         {
             var tenantId = Guid.NewGuid();
-            var tracer = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             using (var db = new AnalyticsEntitiesContext())
             {
                 // Fake "last uploaded". Also test
                 var randoDate = DateTime.UtcNow.AddYears(-12);
-                var sqlStatsAdaptor = new SqlUsageStatsBuilder(db, tracer, tenantId);
+                var sqlStatsAdaptor = new SqlUsageStatsBuilder(db, logger, tenantId);
                 var redisDatesAdaptor = new RedisStatsDatesLoader(new Common.Entities.Config.AppConfig());
 
                 await redisDatesAdaptor.RegisterLastUploadDt(randoDate);
@@ -128,7 +128,7 @@ namespace Tests.UnitTests
                 await db.SaveChangesAsync();
 
                 // Do everything for real except actually upload stats
-                var r = new UsageStatsManager(sqlStatsAdaptor, redisDatesAdaptor, new FakeStatsUploader(tracer, false), tracer);
+                var r = new UsageStatsManager(sqlStatsAdaptor, redisDatesAdaptor, new FakeStatsUploader(logger, false), logger);
 
                 var result = await r.ProcessAndUploadStats();   // Won't work because no config saved in DB
                 Assert.IsFalse(result);
@@ -269,17 +269,17 @@ namespace Tests.UnitTests
             // End-to-end: the SAME loader instance threaded through two UsageStatsManager
             // invocations (simulating two import cycles) should let the first through and
             // suppress the second via MIN_WAIT.
-            var tracer = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var tenantId = Guid.NewGuid();
-            var uploader = new FakeStatsUploader(tracer, false);
+            var uploader = new FakeStatsUploader(logger, false);
 
             // Single shared loader, mirroring Program.cs hoisting it outside the loop.
             var sharedLoader = new InMemoryStatsDatesLoader();
 
-            var mgr1 = new UsageStatsManager(new AlwaysWorksUsageStatsBuilder(tracer, tenantId), sharedLoader, uploader, tracer);
+            var mgr1 = new UsageStatsManager(new AlwaysWorksUsageStatsBuilder(logger, tenantId), sharedLoader, uploader, logger);
             Assert.IsTrue(await mgr1.ProcessAndUploadStats(), "First cycle should upload.");
 
-            var mgr2 = new UsageStatsManager(new AlwaysWorksUsageStatsBuilder(tracer, tenantId), sharedLoader, uploader, tracer);
+            var mgr2 = new UsageStatsManager(new AlwaysWorksUsageStatsBuilder(logger, tenantId), sharedLoader, uploader, logger);
             Assert.IsFalse(await mgr2.ProcessAndUploadStats(), "Second cycle (same loader) must be throttled by cycle 1's RegisterLastUploadDt.");
         }
 
@@ -290,13 +290,13 @@ namespace Tests.UnitTests
             // saved BaseSolutionInstallConfig. Pin that kill switch end-to-end: the manager
             // must NOT call the uploader, and ProcessAndUploadStats must return false so the
             // caller knows no upload happened.
-            var tracer = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var tenantId = Guid.NewGuid();
             var loader = new InMemoryStatsDatesLoader();
             var uploader = new CountingStatsUploader();
 
-            var builder = new AlwaysWorksUsageStatsBuilder(tracer, tenantId, allowTelemetry: false);
-            var mgr = new UsageStatsManager(builder, loader, uploader, tracer);
+            var builder = new AlwaysWorksUsageStatsBuilder(logger, tenantId, allowTelemetry: false);
+            var mgr = new UsageStatsManager(builder, loader, uploader, logger);
 
             var result = await mgr.ProcessAndUploadStats();
 
@@ -311,17 +311,17 @@ namespace Tests.UnitTests
             // The uploader contract is "no URL or no secret = configuration error, throw". This is
             // by design: UsageStatsManager.ProcessAndFailSilently catches the throw and logs a
             // warning, but no upload happens. Pin both halves of that contract.
-            var tracer = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var model = AnonUsageStatsModelLoader.Load(Guid.NewGuid(), null);
 
-            using (var uploader = new WebApiStatsUploader(string.Empty, string.Empty, tracer))
+            using (var uploader = new WebApiStatsUploader(string.Empty, string.Empty, logger))
             {
                 await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                     async () => await uploader.UploadToServer(model),
                     "Empty URL + empty secret must throw — caller (ProcessAndFailSilently) relies on this to skip uploading when the operator hasn't configured StatsApiUrl/StatsApiSecret.");
             }
 
-            using (var uploader = new WebApiStatsUploader("https://stats.example/", string.Empty, tracer))
+            using (var uploader = new WebApiStatsUploader("https://stats.example/", string.Empty, logger))
             {
                 await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                     async () => await uploader.UploadToServer(model),
@@ -335,11 +335,11 @@ namespace Tests.UnitTests
             // End-to-end: a misconfigured uploader must NOT escape ProcessAndFailSilently. The
             // importer's main loop calls ProcessAndFailSilently exactly so transient/config
             // failures in telemetry never break the import cycle.
-            var tracer = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var tenantId = Guid.NewGuid();
-            using (var uploader = new WebApiStatsUploader(string.Empty, string.Empty, tracer))
+            using (var uploader = new WebApiStatsUploader(string.Empty, string.Empty, logger))
             {
-                var mgr = new UsageStatsManager(new AlwaysWorksUsageStatsBuilder(tracer, tenantId), new InMemoryStatsDatesLoader(), uploader, tracer);
+                var mgr = new UsageStatsManager(new AlwaysWorksUsageStatsBuilder(logger, tenantId), new InMemoryStatsDatesLoader(), uploader, logger);
                 var result = await mgr.ProcessAndFailSilently();
                 Assert.IsFalse(result, "ProcessAndFailSilently must report failure but not throw when the uploader is misconfigured.");
             }
@@ -352,7 +352,7 @@ namespace Tests.UnitTests
     {
         private readonly bool _allowTelemetry;
 
-        public AlwaysWorksUsageStatsBuilder(ILogger tracer, Guid tenantId, bool allowTelemetry = true) : base(tracer, tenantId)
+        public AlwaysWorksUsageStatsBuilder(ILogger logger, Guid tenantId, bool allowTelemetry = true) : base(logger, tenantId)
         {
             _allowTelemetry = allowTelemetry;
         }
@@ -382,13 +382,13 @@ namespace Tests.UnitTests
     // It crashes, a lot. By design. 
     internal class ShittyDatesLoader : IStatsDatesLoader
     {
-        private readonly ILogger _tracer;
+        private readonly ILogger _logger;
         private bool _returnNullGetLastUploadDt = true;
         private bool _crashRegisterLastUploadDt = true;
 
-        public ShittyDatesLoader(ILogger tracer)
+        public ShittyDatesLoader(ILogger logger)
         {
-            _tracer = tracer;
+            _logger = logger;
         }
 
         public Task<DateTime?> GetLastUploadDt()
@@ -399,7 +399,7 @@ namespace Tests.UnitTests
                 DateTime? dtNull = null;
                 return Task.FromResult(dtNull);
             }
-            _tracer.LogInformation($"{UsageStatsManager.LOG_PREFIX}got pretend stats uploaded date/time");
+            _logger.LogInformation($"{UsageStatsManager.LOG_PREFIX}got pretend stats uploaded date/time");
 
             DateTime? dt = DateTime.Now.AddDays(-2);
             return Task.FromResult(dt);
@@ -413,7 +413,7 @@ namespace Tests.UnitTests
                 throw new Exception();
             }
 
-            _tracer.LogInformation($"{UsageStatsManager.LOG_PREFIX}pretend registered last stats upload date/time");
+            _logger.LogInformation($"{UsageStatsManager.LOG_PREFIX}pretend registered last stats upload date/time");
             return Task.CompletedTask;
         }
     }
@@ -425,7 +425,7 @@ namespace Tests.UnitTests
         private bool _crashLoadUsageStatsModel = true;
         private bool _crashSaveUsageStatsModelToDatabase = true;
 
-        public ShittyUsageStatsReporterAdaptor(ILogger tracer, Guid tenantId) : base(tracer, tenantId)
+        public ShittyUsageStatsReporterAdaptor(ILogger logger, Guid tenantId) : base(logger, tenantId)
         {
         }
 
@@ -436,7 +436,7 @@ namespace Tests.UnitTests
                 _crashGetLastSettings = false;
                 throw new Exception("Test crash");
             }
-            _tracer.LogInformation($"{UsageStatsManager.LOG_PREFIX}got pretend last solution settings");
+            _logger.LogInformation($"{UsageStatsManager.LOG_PREFIX}got pretend last solution settings");
 
             return Task.FromResult(new BaseSolutionInstallConfig() { AllowTelemetry = true }); ;
         }
@@ -448,7 +448,7 @@ namespace Tests.UnitTests
                 _crashLoadUsageStatsModel = false;
                 throw new Exception();
             }
-            _tracer.LogInformation($"{UsageStatsManager.LOG_PREFIX}pretend generated latest stats");
+            _logger.LogInformation($"{UsageStatsManager.LOG_PREFIX}pretend generated latest stats");
 
             return Task.FromResult(AnonUsageStatsModelLoader.Load(_tenantId, lastSettings));
         }
@@ -461,7 +461,7 @@ namespace Tests.UnitTests
                 _crashSaveUsageStatsModelToDatabase = false;
                 throw new Exception("crashed saving stats to DB");
             }
-            _tracer.LogInformation($"{UsageStatsManager.LOG_PREFIX}pretend saved stats to DB");
+            _logger.LogInformation($"{UsageStatsManager.LOG_PREFIX}pretend saved stats to DB");
 
             return Task.CompletedTask;
         }
@@ -470,12 +470,12 @@ namespace Tests.UnitTests
 
     internal class FakeStatsUploader : IStatsUploader
     {
-        private readonly ILogger _tracer;
+        private readonly ILogger _logger;
         private bool _crashUploadToServer = true;
 
-        public FakeStatsUploader(ILogger tracer, bool crashFirstTime)
+        public FakeStatsUploader(ILogger logger, bool crashFirstTime)
         {
-            _tracer = tracer;
+            _logger = logger;
             _crashUploadToServer = crashFirstTime;
         }
 
@@ -486,7 +486,7 @@ namespace Tests.UnitTests
                 _crashUploadToServer = false;
                 throw new Exception("crashed uploading to server");
             }
-            _tracer.LogInformation($"{UsageStatsManager.LOG_PREFIX}pretend uploaded to stats");
+            _logger.LogInformation($"{UsageStatsManager.LOG_PREFIX}pretend uploaded to stats");
 
             return Task.CompletedTask;
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/UserImportCaseSensitivityTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserImportCaseSensitivityTests.cs
@@ -41,7 +41,7 @@ namespace Tests.UnitTests
             // Pre-existing DB user has lowercase UPN; Graph returns same UPN in MixedCase.
             // Without LOWER() on the column, the EF reload query relies on the CI collation
             // for the match - this asserts that path still works.
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var ticks = DateTime.Now.Ticks;
@@ -77,7 +77,7 @@ namespace Tests.UnitTests
                 };
 
                 var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser });
-                var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+                var updater = new UserMetadataUpdater(logger, config, fakeLoader);
                 await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
                 using (var verifyDb = new AnalyticsEntitiesContext())
@@ -119,7 +119,7 @@ namespace Tests.UnitTests
             // Validates the H1+H3 refactor end-to-end: dropping .ToLower() from
             // the dictionary key build AND the per-Graph-user lookup, and reusing
             // the same dictionary across SKUs.
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var ticks = DateTime.Now.Ticks;
@@ -172,7 +172,7 @@ namespace Tests.UnitTests
                 };
 
                 var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
-                var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+                var updater = new UserMetadataUpdater(logger, config, fakeLoader);
                 await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
                 using (var verifyDb = new AnalyticsEntitiesContext())
@@ -216,7 +216,7 @@ namespace Tests.UnitTests
             // (built once and reused). This test runs an import with TWO SKUs covering
             // the same user to verify the second SKU iteration still resolves the user
             // against the hoisted dictionary.
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var ticks = DateTime.Now.Ticks;
@@ -256,7 +256,7 @@ namespace Tests.UnitTests
                 };
 
                 var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
-                var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+                var updater = new UserMetadataUpdater(logger, config, fakeLoader);
                 await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
                 using (var verifyDb = new AnalyticsEntitiesContext())

--- a/src/AnalyticsEngine/Tests.UnitTests/UserImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserImportTests.cs
@@ -36,19 +36,19 @@ namespace Tests.UnitTests
         //[TestMethod]
         public async Task UserAppLoaderRealTest()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
-            var auth = new GraphAppIndentityOAuthContext(telemetry, config.ClientID, config.TenantGUID.ToString(), config.ClientSecret, config.KeyVaultUrl, config.UseClientCertificate);
+            var auth = new GraphAppIndentityOAuthContext(logger, config.ClientID, config.TenantGUID.ToString(), config.ClientSecret, config.KeyVaultUrl, config.UseClientCertificate);
 
             await auth.InitClientCredential();
             var graphClient = new GraphServiceClient(auth.Creds);
 
             // Do a users import first so we have users in the users table to read apps for
-            var userUpdater = new UserMetadataUpdater(telemetry, config, auth.Creds, new ManualGraphCallClient(auth, telemetry));
+            var userUpdater = new UserMetadataUpdater(logger, config, auth.Creds, new ManualGraphCallClient(auth, logger));
             await userUpdater.InsertAndUpdateDatabaseFromExternalUsers();
 
-            var updater = new UserAppLogUpdater(telemetry, new AppConfig());
-            var sucess = await updater.UpdateUserInstalledApps(graphClient, new NoUsersHaveGroupsUserGroupsCache(telemetry), new UserGroupsFilterModel());
+            var updater = new UserAppLogUpdater(logger, new AppConfig());
+            var sucess = await updater.UpdateUserInstalledApps(graphClient, new NoUsersHaveGroupsUserGroupsCache(logger), new UserGroupsFilterModel());
             Assert.IsTrue(sucess);
         }
 
@@ -58,15 +58,15 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserAppSqlSaveTest()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var authConfig = new AppConfig();
-            var auth = new GraphAppIndentityOAuthContext(telemetry, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
+            var auth = new GraphAppIndentityOAuthContext(logger, authConfig.ClientID, authConfig.TenantGUID.ToString(), authConfig.ClientSecret, authConfig.KeyVaultUrl, authConfig.UseClientCertificate);
 
             await auth.InitClientCredential();
             var graphClient = new GraphServiceClient(auth.Creds);
             using (var db = new AnalyticsEntitiesContext())
             {
-                var userAppsLoader = new GraphAndSqlUserAppLoader(db, telemetry, graphClient);
+                var userAppsLoader = new GraphAndSqlUserAppLoader(db, logger, graphClient);
 
                 var testUser = new Common.Entities.User { AzureAdId = Guid.NewGuid().ToString(), UserPrincipalName = $"teamsappsuser{DateTime.Now.Ticks}@unitesting.local" };
                 db.users.Add(testUser);
@@ -133,8 +133,8 @@ namespace Tests.UnitTests
                 var graphUser = graphUsers.Value[0];
 
                 // Run updater; force full load
-                var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
-                var userUpdater = new UserMetadataUpdater(telemetry, authConfig, auth.Creds, new ManualGraphCallClient(auth, telemetry));
+                var logger = AnalyticsLogger.ConsoleOnlyTracer();
+                var userUpdater = new UserMetadataUpdater(logger, authConfig, auth.Creds, new ManualGraphCallClient(auth, logger));
                 await userUpdater.UserLoader.DeltaValueProvider.ClearDeltaToken();
 
                 await userUpdater.InsertAndUpdateDatabaseFromExternalUsers();

--- a/src/AnalyticsEngine/Tests.UnitTests/UserLookupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserLookupTests.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.LookupCaches;
 using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -46,7 +46,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task GraphAndSqlUserAppLoader_ExcludesDisabledUsers()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var tick = DateTime.Now.Ticks;
             var enabledUpn = $"appsloader-enabled-{tick}@contoso.com";
             var disabledUpn = $"appsloader-disabled-{tick}@contoso.com";
@@ -64,7 +64,7 @@ namespace Tests.UnitTests
 
                 try
                 {
-                    var loader = new GraphAndSqlUserAppLoader(db, telemetry, null);
+                    var loader = new GraphAndSqlUserAppLoader(db, logger, null);
                     var upns = await loader.GetUserEmailAddressesToFindAppsFor();
 
                     Assert.IsTrue(upns.Contains(enabledUpn), "Enabled user should be included");

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterBasicTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterBasicTests.cs
@@ -22,12 +22,12 @@ namespace Tests.UnitTests
         public void UserMetadataUpdater_Constructor_WithInjectedLoader_SetsLoaderCorrectly()
         {
             // Arrange
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
 
             // Act
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             // Assert
             Assert.IsNotNull(updater.UserLoader);
@@ -40,10 +40,10 @@ namespace Tests.UnitTests
         public void UserMetadataUpdater_GetDbUsersFromGraphUsers_ReturnsMatchingUsers()
         {
             // Arrange
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             var graphUsers = new List<GraphUser>
             {
@@ -73,10 +73,10 @@ namespace Tests.UnitTests
         public void UserMetadataUpdater_GetDbUsersFromGraphUsers_IgnoresNullOrEmptyUPN()
         {
             // Arrange
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             var graphUsers = new List<GraphUser>
             {
@@ -101,10 +101,10 @@ namespace Tests.UnitTests
         [TestMethod]
         public void UserMetadataUpdater_GetDbUsersFromGraphUsers_EmptyLists_ReturnsEmpty()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             var result = updater.GetDbUsersFromGraphUsers(new List<GraphUser>(), new List<Common.Entities.User>());
 
@@ -114,10 +114,10 @@ namespace Tests.UnitTests
         [TestMethod]
         public void UserMetadataUpdater_GetDbUsersFromGraphUsers_NoMatchingUsers_ReturnsEmpty()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             var graphUsers = new List<GraphUser>
             {
@@ -137,10 +137,10 @@ namespace Tests.UnitTests
         [TestMethod]
         public void UserMetadataUpdater_GetDbUsersFromGraphUsers_CaseInsensitiveUPNMatch()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             var graphUsers = new List<GraphUser>
             {
@@ -165,10 +165,10 @@ namespace Tests.UnitTests
         [TestMethod]
         public void UserMetadataUpdater_UpdateDbUserFromGraphUser_CopiesBasicProperties()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             var graphUser = new GraphUser
             {
@@ -192,10 +192,10 @@ namespace Tests.UnitTests
         [TestMethod]
         public void UserMetadataUpdater_UpdateDbUserFromGraphUser_HandlesNullValues()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             var graphUser = new GraphUser
             {
@@ -225,10 +225,10 @@ namespace Tests.UnitTests
         [TestMethod]
         public void UserMetadataUpdater_UpdateDbUserFromGraphUser_OverwritesExistingValues()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             var dbUser = new Common.Entities.User
             {
@@ -264,7 +264,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_DeltaProvider_ClearsTokenWhenNoActiveUsers()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser>());
 

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterInsertTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterInsertTests.cs
@@ -21,7 +21,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_InsertMissingUsers_InsertsNewUsersOnly()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var graphUsers = new List<GraphUser>
@@ -32,7 +32,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -68,7 +68,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_InsertMissingUsers_IgnoresUsersWithoutUPN()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var graphUsers = new List<GraphUser>
@@ -79,7 +79,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -103,7 +103,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_InsertMissingUsers_CaseInsensitiveUPNComparison()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var graphUsers = new List<GraphUser>
@@ -112,7 +112,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -133,7 +133,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_InsertMissingUsers_UpdatesUserMetadata()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -153,7 +153,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -183,7 +183,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_InsertMissingUsers_HandlesLargeNumberOfUsers()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var graphUsers = new List<GraphUser>();
@@ -198,7 +198,7 @@ namespace Tests.UnitTests
             }
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -221,10 +221,10 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_InsertMissingUsers_EmptyGraphUsersList_ReturnsEmpty()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var fakeLoader = new FakeUserMetadataLoader();
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -237,7 +237,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_InsertMissingUsers_AllUsersAlreadyExist_ReturnsEmpty()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var graphUsers = new List<GraphUser>
@@ -253,7 +253,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -266,7 +266,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_DuplicateUPNInGraphUsers_HandledGracefully()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -292,7 +292,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterLicenseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterLicenseTests.cs
@@ -23,7 +23,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_UserLicenseChange_DatabaseReflectsChange()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -68,7 +68,7 @@ namespace Tests.UnitTests
             var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { initialSkuId, usersWithInitialSku } };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, initialSkus, fakeUsersBySku);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -85,7 +85,7 @@ namespace Tests.UnitTests
             var updatedFakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { newSkuId, usersWithNewSku } };
 
             var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, updatedSkus, updatedFakeUsersBySku);
-            var updaterWithNewLicense = new UserMetadataUpdater(telemetry, config, updatedFakeLoader);
+            var updaterWithNewLicense = new UserMetadataUpdater(logger, config, updatedFakeLoader);
             await updaterWithNewLicense.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
@@ -101,7 +101,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_AllLicensesRemoved_DatabaseReflectsRemoval()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -130,7 +130,7 @@ namespace Tests.UnitTests
             var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { skuId, usersWithSku } };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -141,7 +141,7 @@ namespace Tests.UnitTests
 
             var emptySkus = new List<SubscribedSku>();
             var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, emptySkus, new Dictionary<Guid, List<Microsoft.Graph.Models.User>>());
-            var updaterNoLicenses = new UserMetadataUpdater(telemetry, config, updatedFakeLoader);
+            var updaterNoLicenses = new UserMetadataUpdater(logger, config, updatedFakeLoader);
             await updaterNoLicenses.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
@@ -155,7 +155,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_MultipleLicensesSimultaneous_AllLicensesSaved()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"multilicenseuser{DateTime.Now.Ticks}@test.com";
@@ -176,7 +176,7 @@ namespace Tests.UnitTests
             var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { sku1Id, new List<Microsoft.Graph.Models.User> { graphUserObject } }, { sku2Id, new List<Microsoft.Graph.Models.User> { graphUserObject } } };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -192,7 +192,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_MultipleUsersWithDifferentLicenses_AllProcessedCorrectly()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var user1Upn = $"batchuser1{timestamp}@test.com"; var user2Upn = $"batchuser2{timestamp}@test.com"; var user3Upn = $"batchuser3{timestamp}@test.com";
@@ -224,7 +224,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers, skus, fakeUsersBySku);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -244,7 +244,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_NoUsersWithLicense_LicenseTypeRemains()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"orphanlicenseuser{DateTime.Now.Ticks}@test.com";
@@ -262,7 +262,7 @@ namespace Tests.UnitTests
             var skus = new List<SubscribedSku> { new SubscribedSku { SkuId = skuId, SkuPartNumber = skuPartNumber } };
             var fakeUsersBySku = new Dictionary<Guid, List<Microsoft.Graph.Models.User>> { { skuId, new List<Microsoft.Graph.Models.User> { new Microsoft.Graph.Models.User { UserPrincipalName = userUpn, Id = userId } } } };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             int licenseTypeId;
@@ -274,7 +274,7 @@ namespace Tests.UnitTests
 
             var emptySkus = new List<SubscribedSku>();
             var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, emptySkus, new Dictionary<Guid, List<Microsoft.Graph.Models.User>>());
-            var updaterNoLicenses = new UserMetadataUpdater(telemetry, config, updatedFakeLoader);
+            var updaterNoLicenses = new UserMetadataUpdater(logger, config, updatedFakeLoader);
             await updaterNoLicenses.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
@@ -287,7 +287,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_UserPerLicenseMode_ReadUserSkusTrue()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"peruser_lic{DateTime.Now.Ticks}@test.com";
@@ -300,7 +300,7 @@ namespace Tests.UnitTests
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, fakeSkus: null);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -326,7 +326,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_TwoSkusSameDisplayName_DoesNotThrowDuplicateKey()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -366,7 +366,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             // Should NOT throw. Before the fix this throws a DbUpdateException with the
             // SQL "Cannot insert duplicate key row ... IX_license_type_id_user_id".
@@ -401,7 +401,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_GraphReturnsDuplicateUserForSingleSku_DoesNotThrowDuplicateKey()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -441,7 +441,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
@@ -468,7 +468,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_DuplicateSubscribedSku_DoesNotThrowDuplicateKey()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -505,7 +505,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser }, skus, fakeUsersBySku);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
@@ -533,7 +533,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_PerUserLicenses_TwoSkusSameDisplayName_DoesNotThrowDuplicateKey()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -574,7 +574,7 @@ namespace Tests.UnitTests
                 fakeUsersBySku: null,
                 fakeLicenseDetails: fakeLicenseDetails);
 
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
@@ -602,7 +602,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_LicenseProcessingThrows_DeltaTokenNotAdvanced()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -634,7 +634,7 @@ namespace Tests.UnitTests
             fakeLoader.SimulatedNewDeltaToken = "delta-that-must-NOT-be-saved";
             fakeLoader.OnLoadUsersBySku = _ => throw new InvalidOperationException("simulated Graph failure during license import");
 
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 async () => await updater.InsertAndUpdateDatabaseFromExternalUsers(),
@@ -653,7 +653,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_SuccessfulImport_DeltaTokenCommitted()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var userId = Guid.NewGuid().ToString();
@@ -679,7 +679,7 @@ namespace Tests.UnitTests
             const string newDelta = "delta-after-successful-import";
             fakeLoader.SimulatedNewDeltaToken = newDelta;
 
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             var persistedDelta = await fakeLoader.DeltaValueProvider.GetDeltaToken();
@@ -710,7 +710,7 @@ namespace Tests.UnitTests
             // existing DB users plus newly inserted ones), so both A and B end up
             // with the correct licence row.
 
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
 
             var tick = DateTime.Now.Ticks;
@@ -763,7 +763,7 @@ namespace Tests.UnitTests
                 emptyUsersBySku);
             fakeLoader.SimulatedNewDeltaToken = $"delta-after-run-1-{tick}";
 
-            await new UserMetadataUpdater(telemetry, config, fakeLoader)
+            await new UserMetadataUpdater(logger, config, fakeLoader)
                 .InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -806,7 +806,7 @@ namespace Tests.UnitTests
             fakeLoader.DeltaUsersOverride = new List<GraphUser> { userAGraph };
             fakeLoader.SimulatedNewDeltaToken = $"delta-after-run-2-{tick}";
 
-            await new UserMetadataUpdater(telemetry, config, fakeLoader)
+            await new UserMetadataUpdater(logger, config, fakeLoader)
                 .InsertAndUpdateDatabaseFromExternalUsers();
 
             // -------- Assert: BOTH users have the licence row, not just user A. --------

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterManagerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterManagerTests.cs
@@ -22,7 +22,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_ManagerChanged_DatabaseReflectsChange()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var userUpn = $"employeemanager{timestamp}@test.com";
@@ -43,7 +43,7 @@ namespace Tests.UnitTests
             var employee = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = manager1Id } } };
 
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { manager1, manager2, employee });
-            await new UserMetadataUpdater(telemetry, config, fakeLoader).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, fakeLoader).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -54,7 +54,7 @@ namespace Tests.UnitTests
 
             var employeeWithNewManager = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = manager2Id } } };
             var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { manager1, manager2, employeeWithNewManager });
-            await new UserMetadataUpdater(telemetry, config, updatedFakeLoader).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, updatedFakeLoader).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
             {
@@ -67,7 +67,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_ManagerRemoved_DatabaseReflectsRemoval()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var employeeUpn = $"emp_mgr_removed{timestamp}@test.com";
@@ -84,7 +84,7 @@ namespace Tests.UnitTests
             var manager = new GraphUser { UserPrincipalName = managerUpn, Id = managerId, AccountEnabled = true, Mail = managerUpn };
             var employee = new GraphUser { UserPrincipalName = employeeUpn, Id = employeeId, AccountEnabled = true, Mail = employeeUpn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = managerId } } };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { manager, employee })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { manager, employee })).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -93,7 +93,7 @@ namespace Tests.UnitTests
             }
 
             var employeeNoManager = new GraphUser { UserPrincipalName = employeeUpn, Id = employeeId, AccountEnabled = true, Mail = employeeUpn, ManagerInfo = new List<ManagerInfo>() };
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { manager, employeeNoManager })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { manager, employeeNoManager })).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
             {
@@ -106,7 +106,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_MultipleManagersInChain_AllRelationshipsCorrect()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var user0Upn = $"chain_emp{timestamp}@test.com"; var user1Upn = $"chain_mgr1{timestamp}@test.com";
@@ -128,7 +128,7 @@ namespace Tests.UnitTests
                 new GraphUser { UserPrincipalName = user3Upn, Id = user3Id, AccountEnabled = true, Mail = user3Upn }
             };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -146,7 +146,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_NewlyInsertedUserAsManager_NoDuplicateKeyError()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var existingUserUpn = $"existingemployee{timestamp}@test.com";
@@ -160,12 +160,12 @@ namespace Tests.UnitTests
                 if (usersToClean.Any()) { cleanupDb.users.RemoveRange(usersToClean); await cleanupDb.SaveChangesAsync(); }
             }
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = existingUserUpn, Id = existingUserId, AccountEnabled = true, Mail = existingUserUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = existingUserUpn, Id = existingUserId, AccountEnabled = true, Mail = existingUserUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
 
             var existingUserWithNewManager = new GraphUser { UserPrincipalName = existingUserUpn, Id = existingUserId, AccountEnabled = true, Mail = existingUserUpn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = newManagerId } } };
             var newManager = new GraphUser { UserPrincipalName = newManagerUpn, Id = newManagerId, AccountEnabled = true, Mail = newManagerUpn };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { newManager, existingUserWithNewManager })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { newManager, existingUserWithNewManager })).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
             {
@@ -180,7 +180,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_ExistingUserManagerUpdatedToNewlyInsertedUser_NoDuplicateKeyInBatchProcessing()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var existingEmployeeUpn = $"existingemployee{timestamp}@test.com";
@@ -194,12 +194,12 @@ namespace Tests.UnitTests
                 if (usersToClean.Any()) { cleanupDb.users.RemoveRange(usersToClean); await cleanupDb.SaveChangesAsync(); }
             }
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = existingEmployeeUpn, Id = existingEmployeeId, AccountEnabled = true, Mail = existingEmployeeUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = existingEmployeeUpn, Id = existingEmployeeId, AccountEnabled = true, Mail = existingEmployeeUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
 
             var newManager = new GraphUser { UserPrincipalName = newManagerUpn, Id = newManagerId, AccountEnabled = true, Mail = newManagerUpn };
             var existingEmployeeWithManager = new GraphUser { UserPrincipalName = existingEmployeeUpn, Id = existingEmployeeId, AccountEnabled = true, Mail = existingEmployeeUpn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = newManagerId } } };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { newManager, existingEmployeeWithManager })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { newManager, existingEmployeeWithManager })).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
             {
@@ -212,7 +212,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_ProductionScenario_ExistingUserWithNewlyInsertedManagerChain_NoDuplicateKey()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var existingEmployeeUpn = $"carmen_adebafernandez{timestamp}@elcorteingles.es";
@@ -228,7 +228,7 @@ namespace Tests.UnitTests
                 if (usersToClean.Any()) { cleanupDb.users.RemoveRange(usersToClean); await cleanupDb.SaveChangesAsync(); }
             }
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = existingEmployeeUpn, Id = existingEmployeeId, AccountEnabled = true, Mail = existingEmployeeUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = existingEmployeeUpn, Id = existingEmployeeId, AccountEnabled = true, Mail = existingEmployeeUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
 
             var step2Users = new List<GraphUser>
             {
@@ -237,7 +237,7 @@ namespace Tests.UnitTests
                 new GraphUser { UserPrincipalName = existingEmployeeUpn, Id = existingEmployeeId, AccountEnabled = true, Mail = existingEmployeeUpn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = newManager1Id } } }
             };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(step2Users)).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(step2Users)).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
             {
@@ -251,7 +251,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_LargeScaleBatching_ReloadedEntitiesRemainTracked()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var existingUserUpn = $"existing_carmen{timestamp}@test.com"; var newMgr1Upn = $"newmgr1_{timestamp}@test.com"; var newMgr2Upn = $"newmgr2_{timestamp}@test.com";
@@ -263,7 +263,7 @@ namespace Tests.UnitTests
                 if (usersToClean.Any()) { cleanupDb.users.RemoveRange(usersToClean); await cleanupDb.SaveChangesAsync(); }
             }
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = existingUserUpn, Id = existingUserId, AccountEnabled = true, Mail = existingUserUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = existingUserUpn, Id = existingUserId, AccountEnabled = true, Mail = existingUserUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
 
             var loader2 = new FakeUserMetadataLoader(new List<GraphUser>
             {
@@ -271,7 +271,7 @@ namespace Tests.UnitTests
                 new GraphUser { UserPrincipalName = newMgr1Upn, Id = newMgr1Id, AccountEnabled = true, Mail = newMgr1Upn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = newMgr2Id } } },
                 new GraphUser { UserPrincipalName = existingUserUpn, Id = existingUserId, AccountEnabled = true, Mail = existingUserUpn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = newMgr1Id } } }
             });
-            await new UserMetadataUpdater(telemetry, config, loader2).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, loader2).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -285,7 +285,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_NewUserManagerInSameBatch_WorksCorrectly()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var userAUpn = $"usera_employee{timestamp}@elcorteingles.es";
@@ -304,7 +304,7 @@ namespace Tests.UnitTests
                 new GraphUser { UserPrincipalName = veronicaUpn, Id = veronicaId, AccountEnabled = true, Mail = veronicaUpn }
             };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -317,7 +317,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_BugRepro_CrossBatchManagerRelationships_NoDuplicateKey()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var manager1Id = Guid.NewGuid().ToString(); var manager1Upn = $"manager1_{timestamp}@test.com";
@@ -339,7 +339,7 @@ namespace Tests.UnitTests
                 new GraphUser { UserPrincipalName = manager2Upn, Id = manager2Id, AccountEnabled = true, Mail = manager2Upn }
             };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -353,7 +353,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_BugRepro_ManyUsersCrossBatch_ManagersAtEnd()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             const int numEmployees = 10; const int numManagers = 10;
@@ -378,7 +378,7 @@ namespace Tests.UnitTests
                 graphUsers.Add(new GraphUser { UserPrincipalName = managerUpns[i], Id = managerIds[i], AccountEnabled = true, Mail = managerUpns[i] });
             }
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -396,7 +396,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_BugRepro_UntrackedManagerEntity_SameBatch_WorksCorrectly()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var employeeUpn = $"employee_untracked_mgr_test{timestamp}@test.com";
@@ -415,7 +415,7 @@ namespace Tests.UnitTests
                 new GraphUser { UserPrincipalName = managerUpn, Id = managerId, AccountEnabled = true, Mail = managerUpn }
             };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -428,7 +428,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_BugRepro_MultipleRealBatches_NoDuplicateKey()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             const int numManagers = 100; const int numEmployees = 510;
@@ -453,7 +453,7 @@ namespace Tests.UnitTests
                 graphUsers.Add(new GraphUser { UserPrincipalName = managerUpns[i], Id = managerIds[i], AccountEnabled = true, Mail = managerUpns[i] });
             }
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(graphUsers)).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
             {
@@ -465,7 +465,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_ManagerAadIdMismatch_NoDuplicateKeyError()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var managerUpn = $"jorge_sancheztamayo{timestamp}@elcorteingles.es";
@@ -480,7 +480,7 @@ namespace Tests.UnitTests
                 if (usersToClean.Any()) { cleanupDb.users.RemoveRange(usersToClean); await cleanupDb.SaveChangesAsync(); }
             }
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = managerUpn, Id = managerOldAadId, AccountEnabled = true, Mail = managerUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(new List<GraphUser> { new GraphUser { UserPrincipalName = managerUpn, Id = managerOldAadId, AccountEnabled = true, Mail = managerUpn } })).InsertAndUpdateDatabaseFromExternalUsers();
 
             var step2Users = new List<GraphUser>
             {
@@ -488,7 +488,7 @@ namespace Tests.UnitTests
                 new GraphUser { UserPrincipalName = employeeUpn, Id = employeeId, AccountEnabled = true, Mail = employeeUpn, ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = managerNewAadId } } }
             };
 
-            await new UserMetadataUpdater(telemetry, config, new FakeUserMetadataLoader(step2Users)).InsertAndUpdateDatabaseFromExternalUsers();
+            await new UserMetadataUpdater(logger, config, new FakeUserMetadataLoader(step2Users)).InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterMetadataTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterMetadataTests.cs
@@ -21,7 +21,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_UserDeactivated_AccountEnabledUpdated()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"deactivateduser{DateTime.Now.Ticks}@test.com";
@@ -34,7 +34,7 @@ namespace Tests.UnitTests
 
             var graphUserActive = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUserActive });
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -45,7 +45,7 @@ namespace Tests.UnitTests
 
             var graphUserDeactivated = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = false, Mail = userUpn };
             var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUserDeactivated });
-            var updaterDeactivated = new UserMetadataUpdater(telemetry, config, updatedFakeLoader);
+            var updaterDeactivated = new UserMetadataUpdater(logger, config, updatedFakeLoader);
             await updaterDeactivated.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
@@ -59,7 +59,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_MetadataChanged_DatabaseReflectsChanges()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"metadatachangeuser{DateTime.Now.Ticks}@test.com";
@@ -72,7 +72,7 @@ namespace Tests.UnitTests
 
             var graphUserInitial = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, Department = "IT", JobTitle = "Developer", OfficeLocation = "Building 1", PostalCode = "12345" };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUserInitial });
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -86,7 +86,7 @@ namespace Tests.UnitTests
 
             var graphUserUpdated = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, Department = "HR", JobTitle = "Manager", OfficeLocation = "Building 2", PostalCode = "67890" };
             var updatedFakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUserUpdated });
-            var updaterUpdated = new UserMetadataUpdater(telemetry, config, updatedFakeLoader);
+            var updaterUpdated = new UserMetadataUpdater(logger, config, updatedFakeLoader);
             await updaterUpdated.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
@@ -103,7 +103,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_SameUserReimported_NoChangesOrDuplicates()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"reimportuser{DateTime.Now.Ticks}@test.com";
@@ -116,7 +116,7 @@ namespace Tests.UnitTests
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, Department = "IT", PostalCode = "12345" };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser });
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             DateTime? firstImportTime;
@@ -127,7 +127,7 @@ namespace Tests.UnitTests
             }
 
             var fakeLoader2 = new FakeUserMetadataLoader(new List<GraphUser> { graphUser });
-            var updater2 = new UserMetadataUpdater(telemetry, config, fakeLoader2);
+            var updater2 = new UserMetadataUpdater(logger, config, fakeLoader2);
             await updater2.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
@@ -141,7 +141,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_AllMetadataFields_PopulatedCorrectly()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"fullmetadata{DateTime.Now.Ticks}@test.com";
@@ -154,7 +154,7 @@ namespace Tests.UnitTests
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, Department = "Engineering", JobTitle = "Senior Developer", OfficeLocation = "Building A", PostalCode = "98052", Country = "United States", State = "Washington", CompanyName = "Contoso", UsageLocation = "US" };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser });
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -175,7 +175,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_MetadataClearedToNull_DatabaseReflectsNullValues()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"clearedmeta{DateTime.Now.Ticks}@test.com";
@@ -188,7 +188,7 @@ namespace Tests.UnitTests
 
             var graphUserWithMeta = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, Department = "IT", JobTitle = "Dev", OfficeLocation = "HQ", PostalCode = "12345" };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUserWithMeta });
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -200,7 +200,7 @@ namespace Tests.UnitTests
 
             var graphUserNoMeta = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, Department = null, JobTitle = null, OfficeLocation = null, PostalCode = null };
             var updatedLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUserNoMeta });
-            var updater2 = new UserMetadataUpdater(telemetry, config, updatedLoader);
+            var updater2 = new UserMetadataUpdater(logger, config, updatedLoader);
             await updater2.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var finalVerifyDb = new AnalyticsEntitiesContext())
@@ -217,7 +217,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_WhitespaceInMetadataFields_TrimmedCorrectly()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var userId = Guid.NewGuid().ToString();
             var userUpn = $"whitespacemeta{DateTime.Now.Ticks}@test.com";
@@ -230,7 +230,7 @@ namespace Tests.UnitTests
 
             var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn, Department = "  Engineering  ", JobTitle = "  Developer  ", OfficeLocation = "  HQ  ", Country = "  USA  ", State = "  WA  ", CompanyName = "  Contoso  ", UsageLocation = "  US  " };
             var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser });
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())
@@ -250,7 +250,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task UserMetadataUpdater_SharedMetadataValues_ReusesSameLookupEntities()
         {
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var timestamp = DateTime.Now.Ticks;
             var user1Upn = $"shared_meta1_{timestamp}@test.com";
@@ -269,7 +269,7 @@ namespace Tests.UnitTests
             };
 
             var fakeLoader = new FakeUserMetadataLoader(graphUsers);
-            var updater = new UserMetadataUpdater(telemetry, config, fakeLoader);
+            var updater = new UserMetadataUpdater(logger, config, fakeLoader);
             await updater.InsertAndUpdateDatabaseFromExternalUsers();
 
             using (var verifyDb = new AnalyticsEntitiesContext())

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterPerformanceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterPerformanceTests.cs
@@ -36,7 +36,7 @@ namespace Tests.UnitTests
         public async Task UserMetadataUpdater_Update1000ExistingUsers_WithSkus_Performance()
         {
             const int USER_COUNT = 1000;
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var testPrefix = $"perfsku{DateTime.Now.Ticks}";
 
@@ -49,13 +49,13 @@ namespace Tests.UnitTests
             {
                 // --- Phase 1: Insert ---
                 var insertLoader = new FakeUserMetadataLoader(graphUsers, fakeSkus);
-                var insertUpdater = new UserMetadataUpdater(telemetry, config, insertLoader);
+                var insertUpdater = new UserMetadataUpdater(logger, config, insertLoader);
 
                 var insertSw = Stopwatch.StartNew();
                 await insertUpdater.InsertAndUpdateDatabaseFromExternalUsers();
                 insertSw.Stop();
 
-                telemetry.LogInformation($"PERF: Insert {USER_COUNT} users took {insertSw.ElapsedMilliseconds}ms");
+                logger.LogInformation($"PERF: Insert {USER_COUNT} users took {insertSw.ElapsedMilliseconds}ms");
 
                 // Verify insert
                 using (var db = new AnalyticsEntitiesContext())
@@ -76,13 +76,13 @@ namespace Tests.UnitTests
                 }
 
                 var updateLoader = new FakeUserMetadataLoader(updatedGraphUsers, fakeSkus);
-                var updateUpdater = new UserMetadataUpdater(telemetry, config, updateLoader);
+                var updateUpdater = new UserMetadataUpdater(logger, config, updateLoader);
 
                 var updateSw = Stopwatch.StartNew();
                 await updateUpdater.InsertAndUpdateDatabaseFromExternalUsers();
                 updateSw.Stop();
 
-                telemetry.LogInformation($"PERF: Update {USER_COUNT} existing users took {updateSw.ElapsedMilliseconds}ms");
+                logger.LogInformation($"PERF: Update {USER_COUNT} existing users took {updateSw.ElapsedMilliseconds}ms");
 
                 // Verify correctness
                 using (var db = new AnalyticsEntitiesContext())
@@ -107,7 +107,7 @@ namespace Tests.UnitTests
                 Assert.IsTrue(updateSw.ElapsedMilliseconds < 60000,
                     $"Update took {updateSw.ElapsedMilliseconds}ms, expected under 60000ms");
 
-                telemetry.LogInformation($"=== Results: Insert={insertSw.ElapsedMilliseconds}ms, Update={updateSw.ElapsedMilliseconds}ms ===");
+                logger.LogInformation($"=== Results: Insert={insertSw.ElapsedMilliseconds}ms, Update={updateSw.ElapsedMilliseconds}ms ===");
             }
             finally
             {
@@ -123,7 +123,7 @@ namespace Tests.UnitTests
         public async Task UserMetadataUpdater_Update1000ExistingUsers_WithoutSkus_Performance()
         {
             const int USER_COUNT = 1000;
-            var telemetry = AnalyticsLogger.ConsoleOnlyTracer();
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
             var config = new AppConfig();
             var testPrefix = $"perfnosku{DateTime.Now.Ticks}";
 
@@ -134,13 +134,13 @@ namespace Tests.UnitTests
             {
                 // --- Phase 1: Insert ---
                 var insertLoader = new FakeUserMetadataLoader(graphUsers);
-                var insertUpdater = new UserMetadataUpdater(telemetry, config, insertLoader);
+                var insertUpdater = new UserMetadataUpdater(logger, config, insertLoader);
 
                 var insertSw = Stopwatch.StartNew();
                 await insertUpdater.InsertAndUpdateDatabaseFromExternalUsers();
                 insertSw.Stop();
 
-                telemetry.LogInformation($"PERF (no SKU): Insert {USER_COUNT} users took {insertSw.ElapsedMilliseconds}ms");
+                logger.LogInformation($"PERF (no SKU): Insert {USER_COUNT} users took {insertSw.ElapsedMilliseconds}ms");
 
                 // --- Phase 2: Re-generate users with modified metadata ---
                 var updatedGraphUsers = GenerateGraphUsers(USER_COUNT, testPrefix);
@@ -152,13 +152,13 @@ namespace Tests.UnitTests
                 }
 
                 var updateLoader = new FakeUserMetadataLoader(updatedGraphUsers);
-                var updateUpdater = new UserMetadataUpdater(telemetry, config, updateLoader);
+                var updateUpdater = new UserMetadataUpdater(logger, config, updateLoader);
 
                 var updateSw = Stopwatch.StartNew();
                 await updateUpdater.InsertAndUpdateDatabaseFromExternalUsers();
                 updateSw.Stop();
 
-                telemetry.LogInformation($"PERF (no SKU): Update {USER_COUNT} existing users took {updateSw.ElapsedMilliseconds}ms");
+                logger.LogInformation($"PERF (no SKU): Update {USER_COUNT} existing users took {updateSw.ElapsedMilliseconds}ms");
 
                 // Verify correctness
                 using (var db = new AnalyticsEntitiesContext())
@@ -180,7 +180,7 @@ namespace Tests.UnitTests
                 Assert.IsTrue(updateSw.ElapsedMilliseconds < 120000,
                     $"Update took {updateSw.ElapsedMilliseconds}ms, expected under 120000ms");
 
-                telemetry.LogInformation($"=== Results (no SKU): Insert={insertSw.ElapsedMilliseconds}ms, Update={updateSw.ElapsedMilliseconds}ms ===");
+                logger.LogInformation($"=== Results (no SKU): Insert={insertSw.ElapsedMilliseconds}ms, Update={updateSw.ElapsedMilliseconds}ms ===");
             }
             finally
             {

--- a/src/AnalyticsEngine/Web/Controllers/CallRecordWebhookController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/CallRecordWebhookController.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus;
 using Common.Entities.Config;
 using Common.Entities.Models;
 using DataUtils;
@@ -20,12 +20,12 @@ namespace Web.AnalyticsWeb.Controllers
         public async Task<HttpResponseMessage> Post([FromBody] GraphChangeNotificationList changeMsg, string validationToken = "")
         {
             var config = new AppConfig();
-            var telemetry = new AnalyticsLogger(config.AppInsightsConnectionString, nameof(CallRecordWebhookController));
+            var logger = new AnalyticsLogger(config.AppInsightsConnectionString, nameof(CallRecordWebhookController));
 
             // Test ping from Graph?
             if (!string.IsNullOrEmpty(validationToken))
             {
-                telemetry.LogInformation($"{nameof(CallRecordWebhookController)}: test ping from Graph received.");
+                logger.LogInformation($"{nameof(CallRecordWebhookController)}: test ping from Graph received.");
                 var pingTestResponse = new HttpResponseMessage(HttpStatusCode.OK);
                 pingTestResponse.Content = new StringContent(validationToken, System.Text.Encoding.UTF8, "text/plain");
                 return pingTestResponse;
@@ -45,12 +45,12 @@ namespace Web.AnalyticsWeb.Controllers
                     else invalidChangeMsgs++;
 
                 }
-                telemetry.LogInformation($"{nameof(CallRecordWebhookController)} invoked. {changes.Count} valid changes; {invalidChangeMsgs} invalid changes.");
+                logger.LogInformation($"{nameof(CallRecordWebhookController)} invoked. {changes.Count} valid changes; {invalidChangeMsgs} invalid changes.");
 
                 // Service Bus is required to dispatch call notifications. If it's not configured, the calls feature is disabled.
                 if (string.IsNullOrWhiteSpace(config.ConnectionStrings.ServiceBusConnectionString))
                 {
-                    telemetry.LogError($"{nameof(CallRecordWebhookController)}: Service Bus is not configured. Teams call notifications cannot be processed. Enable Service Bus in the installer to use the Teams calls import.");
+                    logger.LogError($"{nameof(CallRecordWebhookController)}: Service Bus is not configured. Teams call notifications cannot be processed. Enable Service Bus in the installer to use the Teams calls import.");
                     return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
                     {
                         Content = new StringContent("Service Bus is not configured on this deployment; Teams call notifications are disabled.", System.Text.Encoding.UTF8, "text/plain")
@@ -68,12 +68,12 @@ namespace Web.AnalyticsWeb.Controllers
                 {
                     try
                     {
-                        await CallQueueProcessor.AddChangeMsgToQueue(changes, telemetry, sbSender);
+                        await CallQueueProcessor.AddChangeMsgToQueue(changes, logger, sbSender);
                     }
                     catch (ServiceBusException ex)
                     {
-                        telemetry.TrackException(ex);
-                        telemetry.LogError($"Error adding change messages to queue: {ex.Message}");
+                        logger.TrackException(ex);
+                        logger.LogError($"Error adding change messages to queue: {ex.Message}");
                         return new HttpResponseMessage(HttpStatusCode.InternalServerError);
                     }
                 }
@@ -89,7 +89,7 @@ namespace Web.AnalyticsWeb.Controllers
             }
             else
             {
-                telemetry.LogInformation($"{nameof(CallRecordWebhookController)} invoked with invalid body.");
+                logger.LogInformation($"{nameof(CallRecordWebhookController)} invoked with invalid body.");
                 var errResponse = new HttpResponseMessage(HttpStatusCode.BadRequest);
                 errResponse.Content = new StringContent($"Could not find {nameof(GraphChangeNotificationList)} in body",
                     System.Text.Encoding.UTF8, "text/plain");

--- a/src/AnalyticsEngine/Web/Models/SystemStatus.cs
+++ b/src/AnalyticsEngine/Web/Models/SystemStatus.cs
@@ -1,4 +1,4 @@
-﻿using App.ControlPanel.Engine;
+using App.ControlPanel.Engine;
 using Azure.Messaging.ServiceBus;
 using Common.Entities;
 using Common.Entities.Config;
@@ -159,8 +159,8 @@ namespace Web.AnalyticsWeb.Models
 
             try
             {
-                var telemetry = new AnalyticsLogger(config.AppInsightsConnectionString, nameof(SystemStatus));
-                var callWebhook = new CallWebhook(config, telemetry);
+                var logger = new AnalyticsLogger(config.AppInsightsConnectionString, nameof(SystemStatus));
+                var callWebhook = new CallWebhook(config, logger);
                 var info = await callWebhook.GetCallRecordsSubscriptionInfo(new Uri(webhookUrlString));
 
                 if (info.Exists)

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/Abstract.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/Abstract.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -43,7 +43,7 @@ namespace WebJob.AppInsightsImporter.Engine
 
     public abstract class AppInsightsQueryResultCollection<T> where T : BaseAppInsightsQueryResult
     {
-        protected readonly ILogger _debugTracer;
+        protected readonly ILogger _logger;
 
         protected abstract T Build(List<object> rowColumnVals, Dictionary<int, PropertyInfo> propDic);
 
@@ -52,9 +52,9 @@ namespace WebJob.AppInsightsImporter.Engine
         /// <summary>
         /// Construct from AppInsights table, which is a 2d collection of rows & columns, into a typed collection of objects of T
         /// </summary>
-        protected AppInsightsQueryResultCollection(AppInsightsTable fromTable, DateTime fromWhen, ILogger debugTracer)
+        protected AppInsightsQueryResultCollection(AppInsightsTable fromTable, DateTime fromWhen, ILogger logger)
         {
-            _debugTracer = debugTracer;
+            _logger = logger;
 
             // Build column map of properties we can set
             var propDic = new Dictionary<int, PropertyInfo>();
@@ -91,7 +91,7 @@ namespace WebJob.AppInsightsImporter.Engine
                 catch (Exception ex)
                 {
                     // Log and continue so a single malformed row doesn't drop the whole batch
-                    _debugTracer?.LogWarning($"Failed to deserialise {typeof(T).Name} row: {ex.Message}");
+                    _logger?.LogWarning($"Failed to deserialise {typeof(T).Name} row: {ex.Message}");
                 }
                 if (record != null)
                 {

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/CustomEvents/CustomEventsResultCollection.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/CustomEvents/CustomEventsResultCollection.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Extensions.Logging;
@@ -18,7 +18,7 @@ namespace WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents
         }
 
 
-        public CustomEventsResultCollection(AppInsightsTable fromTable, DateTime fromWhen, ILogger debugTracer) : base(fromTable, fromWhen, debugTracer)
+        public CustomEventsResultCollection(AppInsightsTable fromTable, DateTime fromWhen, ILogger logger) : base(fromTable, fromWhen, logger)
         {
         }
 
@@ -59,7 +59,7 @@ namespace WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents
         /// <summary>
         /// Apply hit patches, save searches & clicks
         /// </summary>
-        public async Task SaveAllEventTypesToSql(AnalyticsLogger telemetry, AppConfig config)
+        public async Task SaveAllEventTypesToSql(AnalyticsLogger logger, AppConfig config)
         {
             using (var database = new AnalyticsEntitiesContext())
             {
@@ -69,19 +69,19 @@ namespace WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents
                 // Each section runs inside its own isolation boundary (see SaveSectionSafe). A failure
                 // in one section (e.g. a page-update that trips a DbUpdateException) is logged in full
                 // but never aborts the sibling sections nor escapes to stall the whole importer.
-                var hitUpdatesCount = await SaveSectionSafe(telemetry, "Hit updates",
-                    () => this.SaveHitsUpdatesToSQL(telemetry, database));
+                var hitUpdatesCount = await SaveSectionSafe(logger, "Hit updates",
+                    () => this.SaveHitsUpdatesToSQL(logger, database));
 
-                var searchesInserted = await SaveSectionSafe(telemetry, "Searches",
-                    () => this.SaveSearchesToSQL(telemetry, database));
+                var searchesInserted = await SaveSectionSafe(logger, "Searches",
+                    () => this.SaveSearchesToSQL(logger, database));
 
-                var pagesUpdated = await SaveSectionSafe(telemetry, "Page updates",
-                    () => this.SavePageUpdatesToSQL(telemetry, config));
+                var pagesUpdated = await SaveSectionSafe(logger, "Page updates",
+                    () => this.SavePageUpdatesToSQL(logger, config));
 
-                var clicks = await SaveSectionSafe(telemetry, "Clicks",
-                    () => this.SaveClicksToSQL(telemetry, database));
+                var clicks = await SaveSectionSafe(logger, "Clicks",
+                    () => this.SaveClicksToSQL(logger, database));
 
-                telemetry.LogInformation($"Event save summary: {hitUpdatesCount:n0} hit-updates, {searchesInserted:n0} searches, {pagesUpdated:n0} page-updates, {clicks:n0} clicks");
+                logger.LogInformation($"Event save summary: {hitUpdatesCount:n0} hit-updates, {searchesInserted:n0} searches, {pagesUpdated:n0} page-updates, {clicks:n0} clicks");
             }
         }
 
@@ -91,9 +91,9 @@ namespace WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents
         /// TrackException, but never propagates - so a single bad section can neither abort its sibling
         /// sections nor escape up the call stack and stall the whole importer.
         /// </summary>
-        private static async Task<int> SaveSectionSafe(AnalyticsLogger telemetry, string sectionName, Func<Task<int>> saveAction)
+        private static async Task<int> SaveSectionSafe(AnalyticsLogger logger, string sectionName, Func<Task<int>> saveAction)
         {
-            var timer = new JobTimer(telemetry, sectionName);
+            var timer = new JobTimer(logger, sectionName);
             timer.Start();
             try
             {
@@ -107,9 +107,9 @@ namespace WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents
             }
             catch (Exception ex)
             {
-                telemetry.TrackException(ex);
-                telemetry.LogError($"Failed importing '{sectionName}' section: {CommonExceptionHandler.GetErrorText(ex)}. Skipping this section and continuing.");
-                telemetry.LogError($"Exception detail: {ex}");
+                logger.TrackException(ex);
+                logger.LogError($"Failed importing '{sectionName}' section: {CommonExceptionHandler.GetErrorText(ex)}. Skipping this section and continuing.");
+                logger.LogError($"Exception detail: {ex}");
                 return 0;
             }
         }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/PageViewClasses.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/PageViewClasses.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ namespace WebJob.AppInsightsImporter.Engine.ApiImporter
         public PageViewAppInsightsQueryResult() : base()
         {
         }
-        public PageViewAppInsightsQueryResult(List<object> rowColumnVals, Dictionary<int, PropertyInfo> propDic, ILogger debugTracer) : base(rowColumnVals, propDic)
+        public PageViewAppInsightsQueryResult(List<object> rowColumnVals, Dictionary<int, PropertyInfo> propDic, ILogger logger) : base(rowColumnVals, propDic)
         {
             if (string.IsNullOrEmpty(this.CustomDimensionsJson))
             {
@@ -26,11 +26,11 @@ namespace WebJob.AppInsightsImporter.Engine.ApiImporter
                 }
                 catch (JsonException)
                 {
-                    debugTracer.LogWarning($"Couldn't deserialise page-view custom event data: invalid Json (JsonException)");
+                    logger.LogWarning($"Couldn't deserialise page-view custom event data: invalid Json (JsonException)");
                 }
                 catch (ArgumentException)
                 {
-                    debugTracer.LogWarning($"Couldn't deserialise page-view custom event data: invalid Json (ArgumentException)");
+                    logger.LogWarning($"Couldn't deserialise page-view custom event data: invalid Json (ArgumentException)");
                 }
             }
         }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/PageViewCollection.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/APIResponseParsers/PageViewCollection.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -10,13 +10,13 @@ namespace WebJob.AppInsightsImporter.Engine.ApiImporter
 
         public PageViewCollection() { }
 
-        public PageViewCollection(AppInsightsTable fromTable, DateTime fromWhen, ILogger debugTracer) : base(fromTable, fromWhen, debugTracer)
+        public PageViewCollection(AppInsightsTable fromTable, DateTime fromWhen, ILogger logger) : base(fromTable, fromWhen, logger)
         {
         }
 
         protected override PageViewAppInsightsQueryResult Build(List<object> rowColumnVals, Dictionary<int, PropertyInfo> propDic)
         {
-            return new PageViewAppInsightsQueryResult(rowColumnVals, propDic, _debugTracer);
+            return new PageViewAppInsightsQueryResult(rowColumnVals, propDic, _logger);
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsAPIClient.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsAPIClient.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core;
+using Azure.Core;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
@@ -36,7 +36,7 @@ namespace WebJob.AppInsightsImporter.Engine
         /// <param name="appInsightsConnectionString">The Application Insights connection string. The ApplicationId is parsed from it for use in the query URL.</param>
         /// <param name="credential">A TokenCredential (e.g. ClientSecretCredential) for Entra ID authentication.</param>
         /// <param name="debugTracer">Logger instance.</param>
-        public AppInsightsAPIClient(string appInsightsConnectionString, TokenCredential credential, ILogger debugTracer)
+        public AppInsightsAPIClient(string appInsightsConnectionString, TokenCredential credential, ILogger logger)
         {
             if (string.IsNullOrEmpty(appInsightsConnectionString))
             {
@@ -53,7 +53,7 @@ namespace WebJob.AppInsightsImporter.Engine
 
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            _logger = debugTracer;
+            _logger = logger;
         }
 
         #endregion

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Identity;
+using Azure.Identity;
 using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
@@ -20,12 +20,12 @@ namespace WebJob.AppInsightsImporter.Engine
     public class AppInsightsImporter
     {
         private readonly AppConfig _importConfig;
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
 
-        public AppInsightsImporter(AppConfig importConfig, AnalyticsLogger telemetry)
+        public AppInsightsImporter(AppConfig importConfig, AnalyticsLogger logger)
         {
             _importConfig = importConfig;
-            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task ImportAndSave(bool saveRestResponses, int? daysBeforeOverride)
@@ -45,11 +45,11 @@ namespace WebJob.AppInsightsImporter.Engine
             {
                 // Delete duplicate hits 1st. It also creates the page-request-ID index
                 await ImportDbHacks.CleanDuplicateHitsAndCreateIX_PageRequestID(db);
-                _telemetry.LogInformation($"Startup: duplicate-hit cleanup completed in {sw.Elapsed.TotalSeconds:N1}s");
+                _logger.LogInformation($"Startup: duplicate-hit cleanup completed in {sw.Elapsed.TotalSeconds:N1}s");
 
                 sw.Restart();
                 var filterUrls = await SiteFilterLoader.Load(db);
-                _telemetry.LogInformation($"Startup: loaded {filterUrls.Count} URL filters in {sw.Elapsed.TotalSeconds:N1}s");
+                _logger.LogInformation($"Startup: loaded {filterUrls.Count} URL filters in {sw.Elapsed.TotalSeconds:N1}s");
 
                 var newestHit = await db.hits.OrderByDescending(h => h.hit_timestamp).Take(1).FirstOrDefaultAsync();
 
@@ -60,14 +60,14 @@ namespace WebJob.AppInsightsImporter.Engine
                 // Rewind start-date a wee bit just to make sure we get edge hits...
                 startDate = startDate.AddMinutes(-1);
 
-                var jobTimer = new JobTimer(_telemetry, "Hits import");
+                var jobTimer = new JobTimer(_logger, "Hits import");
                 if (newestHit != null)
                 {
-                    _telemetry.LogInformation($"Requesting data from AppInsights from {startDate} (newest hit is from {newestHit.hit_timestamp})...");
+                    _logger.LogInformation($"Requesting data from AppInsights from {startDate} (newest hit is from {newestHit.hit_timestamp})...");
                 }
                 else
                 {
-                    _telemetry.LogInformation($"Requesting data from AppInsights from {startDate} (no hits yet to start from previous)...");
+                    _logger.LogInformation($"Requesting data from AppInsights from {startDate} (no hits yet to start from previous)...");
                 }
 
                 // Import page-views first
@@ -75,13 +75,13 @@ namespace WebJob.AppInsightsImporter.Engine
                     this._importConfig.TenantGUID.ToString(),
                     this._importConfig.ClientID,
                     this._importConfig.ClientSecret);
-                using (var ai = new AppInsightsAPIClient(this._importConfig.AppInsightsConnectionString, credential, _telemetry))
+                using (var ai = new AppInsightsAPIClient(this._importConfig.AppInsightsConnectionString, credential, _logger))
                 {
 
                     // UTC to match App Insights' UTC timestamps (see startDate above).
                     var endDate = DateTime.UtcNow;
                     var daysToRead = startDate.EachDay(endDate).ToList();
-                    _telemetry.LogInformation($"Importing hits for {daysToRead.Count} days...");
+                    _logger.LogInformation($"Importing hits for {daysToRead.Count} days...");
                     var totalDays = 0;
                     var totalPageViews = 0;
                     var totalEvents = 0;
@@ -89,7 +89,7 @@ namespace WebJob.AppInsightsImporter.Engine
                     {
                         totalDays++;
                         var dayTimer = Stopwatch.StartNew();
-                        _telemetry.LogInformation($"Importing day {totalDays}/{daysToRead.Count}: {d.ToString("yyyy-MM-dd")}...");
+                        _logger.LogInformation($"Importing day {totalDays}/{daysToRead.Count}: {d.ToString("yyyy-MM-dd")}...");
 
                         // Fetch page-views and custom events for the same day in parallel.
                         // Both are independent read-only API calls with no shared state.
@@ -104,11 +104,11 @@ namespace WebJob.AppInsightsImporter.Engine
 
                             pageViewsResult = await pageViewsTask;
                             events = await eventsTask;
-                            _telemetry.LogInformation($"API fetch completed in {sw.Elapsed.TotalSeconds:N1}s - {pageViewsResult.Rows.Count:n0} page-views, {events.Rows.Count:n0} events");
+                            _logger.LogInformation($"API fetch completed in {sw.Elapsed.TotalSeconds:N1}s - {pageViewsResult.Rows.Count:n0} page-views, {events.Rows.Count:n0} events");
                         }
                         catch (Exception ex)
                         {
-                            _telemetry.LogError(ex, $"Got fatal exception downloading from Application Insights REST: {ex.Message}");
+                            _logger.LogError(ex, $"Got fatal exception downloading from Application Insights REST: {ex.Message}");
 #if DEBUG
                             throw;
 #else
@@ -120,7 +120,7 @@ namespace WebJob.AppInsightsImporter.Engine
                         {
                             var earliest = pageViewsResult.Rows.OrderBy(v => v.Timestamp).Take(1).First();
                             var latest = pageViewsResult.Rows.OrderByDescending(v => v.Timestamp).Take(1).First();
-                            _telemetry.LogInformation($"Hits range: {earliest.Timestamp:yyyy-MM-dd HH:mm:ss.ff} to {latest.Timestamp:yyyy-MM-dd HH:mm:ss.ff}");
+                            _logger.LogInformation($"Hits range: {earliest.Timestamp:yyyy-MM-dd HH:mm:ss.ff} to {latest.Timestamp:yyyy-MM-dd HH:mm:ss.ff}");
                         }
 
                         if (pageViewsResult.Rows.Count > 0 || events.Rows.Count > 0)
@@ -129,12 +129,12 @@ namespace WebJob.AppInsightsImporter.Engine
                             try
                             {
                                 sw.Restart();
-                                await pageViewsResult.SaveToSQL(db, _telemetry, filterUrls);
-                                _telemetry.LogInformation($"Page-views SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
+                                await pageViewsResult.SaveToSQL(db, _logger, filterUrls);
+                                _logger.LogInformation($"Page-views SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
 
                                 sw.Restart();
-                                await events.SaveAllEventTypesToSql(_telemetry, _importConfig);
-                                _telemetry.LogInformation($"Events SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
+                                await events.SaveAllEventTypesToSql(_logger, _importConfig);
+                                _logger.LogInformation($"Events SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
                             }
                             catch (Exception ex)
                             {
@@ -144,9 +144,9 @@ namespace WebJob.AppInsightsImporter.Engine
                                 // SqlException-only catch used to let any other exception escape, which
                                 // permanently stuck the importer re-processing the same day). Log the
                                 // full error, record it, and carry on with the next day.
-                                _telemetry.TrackException(ex);
-                                _telemetry.LogError($"Failed saving data for day {d:yyyy-MM-dd}: {CommonExceptionHandler.GetErrorText(ex)}. Skipping this day and continuing.");
-                                _telemetry.LogError($"Exception detail: {ex}");
+                                _logger.TrackException(ex);
+                                _logger.LogError($"Failed saving data for day {d:yyyy-MM-dd}: {CommonExceptionHandler.GetErrorText(ex)}. Skipping this day and continuing.");
+                                _logger.LogError($"Exception detail: {ex}");
                                 if (Debugger.IsAttached)
                                 {
                                     throw;
@@ -156,15 +156,15 @@ namespace WebJob.AppInsightsImporter.Engine
 
                             totalPageViews += pageViewsResult.Rows.Count;
                             totalEvents += events.Rows.Count;
-                            _telemetry.LogInformation($"Day {d:yyyy-MM-dd} completed in {dayTimer.Elapsed.TotalSeconds:N1}s - saved {pageViewsResult.Rows.Count:n0} page-views, {events.Rows.Count:n0} events");
+                            _logger.LogInformation($"Day {d:yyyy-MM-dd} completed in {dayTimer.Elapsed.TotalSeconds:N1}s - saved {pageViewsResult.Rows.Count:n0} page-views, {events.Rows.Count:n0} events");
                         }
                         else
                         {
-                            _telemetry.LogInformation($"Day {d:yyyy-MM-dd} completed in {dayTimer.Elapsed.TotalSeconds:N1}s - no new data.");
+                            _logger.LogInformation($"Day {d:yyyy-MM-dd} completed in {dayTimer.Elapsed.TotalSeconds:N1}s - no new data.");
                         }
                     }
 
-                    _telemetry.LogInformation($"Import loop finished: {totalDays} days processed, {totalPageViews:n0} total page-views, {totalEvents:n0} total events");
+                    _logger.LogInformation($"Import loop finished: {totalDays} days processed, {totalPageViews:n0} total page-views, {totalEvents:n0} total events");
                 }
 
                 // Track finished event 

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageCommentsExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageCommentsExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
@@ -10,9 +10,9 @@ namespace WebJob.AppInsightsImporter.Engine.PageUpdates
 {
     public static class PageCommentsExtensions
     {
-        public static async Task Save(this List<PageCommentTemp> comments, AnalyticsEntitiesContext db, ILogger debugTracer)
+        public static async Task Save(this List<PageCommentTemp> comments, AnalyticsEntitiesContext db, ILogger logger)
         {
-            var commentsToInsert = new EFInsertBatch<PageCommentTemp>(db, debugTracer);
+            var commentsToInsert = new EFInsertBatch<PageCommentTemp>(db, logger);
             commentsToInsert.Rows.AddRange(comments);
 
             var mergeSql = Resources.Migrate_New_Comments.Replace("${STAGING_TABLE_COMMENTS}", PageCommentTemp.STAGING_TABLENAME);

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
@@ -1,4 +1,4 @@
-﻿using Azure;
+using Azure;
 using Azure.AI.TextAnalytics;
 using Common.Entities;
 using Common.Entities.Config;
@@ -25,17 +25,17 @@ namespace WebJob.AppInsightsImporter.Engine
     /// </summary>
     public class PageUpdateManager
     {
-        private readonly ILogger _debugTracer;
+        private readonly ILogger _logger;
         private readonly int _chunkSize;
         private readonly CognitiveServicesClient _cognitiveClient = null;
         private readonly AppConfig _config;
 
-        public PageUpdateManager(ILogger debugTracer, AppConfig config) : this(debugTracer, 1000, config)
+        public PageUpdateManager(ILogger logger, AppConfig config) : this(logger, 1000, config)
         {
         }
-        public PageUpdateManager(ILogger debugTracer, int chunkSize, AppConfig config)
+        public PageUpdateManager(ILogger logger, int chunkSize, AppConfig config)
         {
-            _debugTracer = debugTracer ?? throw new ArgumentNullException(nameof(debugTracer));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _chunkSize = chunkSize;
             _config = config;
             if (chunkSize < 0)
@@ -48,7 +48,7 @@ namespace WebJob.AppInsightsImporter.Engine
             // is set and auto-falls back to RBAC (ClientSecretCredential) on 403
             // AuthenticationTypeDisabled so we still work when key auth is disabled on the resource.
             var cognitiveConfig = _config ?? new AppConfig();
-            _cognitiveClient = cognitiveConfig.CreateCognitiveServicesClient(debugTracer);
+            _cognitiveClient = cognitiveConfig.CreateCognitiveServicesClient(logger);
         }
 
         public async Task<List<string>> SaveAll(IEnumerable<PageUpdateEventAppInsightsQueryResult> pageUpdateEvents)
@@ -91,7 +91,7 @@ namespace WebJob.AppInsightsImporter.Engine
                 }
             }
 
-            _debugTracer.LogInformation($"Updated {uniqueUpdatedUrls.Count} URLs from {pageUpdateEvents.Count()} page-update events");
+            _logger.LogInformation($"Updated {uniqueUpdatedUrls.Count} URLs from {pageUpdateEvents.Count()} page-update events");
 
             return uniqueUpdatedUrls;
         }
@@ -102,7 +102,7 @@ namespace WebJob.AppInsightsImporter.Engine
         async Task SaveChunk(List<PageUpdateEventAppInsightsQueryResult> chunk, List<string> updatedUrls)
         {
 #if DEBUG
-            _debugTracer.LogInformation($"DEBUG: Updating {chunk.Count} URLs on new thread");
+            _logger.LogInformation($"DEBUG: Updating {chunk.Count} URLs on new thread");
 #endif
             using (var context = new AnalyticsEntitiesContext())
             {
@@ -161,7 +161,7 @@ namespace WebJob.AppInsightsImporter.Engine
                         // likely culprit is an uncaught DbUpdateException from a comment/like whose user or
                         // language insert fails - which previously escaped every catch above it and stalled
                         // the importer for months. Log the full error, skip this URL, and keep going.
-                        _debugTracer.LogError(ex, $"Failed applying page-update metadata for URL '{urlToUpdate.FullUrl}': {CommonExceptionHandler.GetErrorText(ex)}. Skipping this URL.");
+                        _logger.LogError(ex, $"Failed applying page-update metadata for URL '{urlToUpdate.FullUrl}': {CommonExceptionHandler.GetErrorText(ex)}. Skipping this URL.");
                     }
                 }
 
@@ -171,16 +171,16 @@ namespace WebJob.AppInsightsImporter.Engine
                 }
                 catch (SqlException ex)
                 {
-                    _debugTracer.LogError(ex, $"SQL exception '{ex.Message}' when saving page updates for this chunk.");
+                    _logger.LogError(ex, $"SQL exception '{ex.Message}' when saving page updates for this chunk.");
                 }
                 catch (DbUpdateException ex)
                 {
-                    _debugTracer.LogError(ex, $"DbUpdate exception '{CommonExceptionHandler.GetErrorText(ex)}' when saving page updates for this chunk.");
+                    _logger.LogError(ex, $"DbUpdate exception '{CommonExceptionHandler.GetErrorText(ex)}' when saving page updates for this chunk.");
                 }
             }
 
 #if DEBUG
-            _debugTracer.LogDebug($"DEBUG: Updated {chunk.Count} URLs on new thread");
+            _logger.LogDebug($"DEBUG: Updated {chunk.Count} URLs on new thread");
 #endif
         }
 
@@ -216,7 +216,7 @@ namespace WebJob.AppInsightsImporter.Engine
             {
                 var cognitiveResults = await newComments.Keys
                     .ToTextAnalysisSampleList()
-                    .GetCognitiveDataStats(_cognitiveClient, _debugTracer);
+                    .GetCognitiveDataStats(_cognitiveClient, _logger);
 
                 if (cognitiveResults != null)
                 {
@@ -238,7 +238,7 @@ namespace WebJob.AppInsightsImporter.Engine
             }
 
             // Save new comments via staging table
-            await newComments.Values.ToList().Save(db, _debugTracer);
+            await newComments.Values.ToList().Save(db, _logger);
 
             // Page likes
             var pageLikeUpdatesMade = await ProcessCustomAppInsightsEvents(correspondingPageUpdate.CustomProperties.Likes, urlExistingLikes, async (UserBasedCustomAIEvent like, string email) =>
@@ -281,7 +281,7 @@ namespace WebJob.AppInsightsImporter.Engine
                 }
                 else
                 {
-                    _debugTracer.LogError($"WARNING: Invalid comment/like metadata in event: {eventVal}");
+                    _logger.LogError($"WARNING: Invalid comment/like metadata in event: {eventVal}");
                 }
             }
 
@@ -335,7 +335,7 @@ namespace WebJob.AppInsightsImporter.Engine
             }
             catch (DbUpdateException ex)
             {
-                _debugTracer.LogError(ex, $"DbUpdate exception '{CommonExceptionHandler.GetErrorText(ex)}' when saving page updates for this chunk.");
+                _logger.LogError(ex, $"DbUpdate exception '{CommonExceptionHandler.GetErrorText(ex)}' when saving page updates for this chunk.");
                 return false;
             }
 
@@ -362,7 +362,7 @@ namespace WebJob.AppInsightsImporter.Engine
                         }
                         catch (DbUpdateException ex)
                         {
-                            _debugTracer.LogError(ex, $"ERROR: DbUpdate exception '{CommonExceptionHandler.GetErrorText(ex)}' when saving page updates for this chunk.");
+                            _logger.LogError(ex, $"ERROR: DbUpdate exception '{CommonExceptionHandler.GetErrorText(ex)}' when saving page updates for this chunk.");
                             return false;
                         }
                     }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/HitUpdatesSqlExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/HitUpdatesSqlExtension.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
@@ -9,14 +9,14 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
 {
     public static class HitUpdatesSqlExtension
     {
-        public static async Task<int> SaveHitsUpdatesToSQL(this CustomEventsResultCollection eventList, ILogger telemetry, AnalyticsEntitiesContext database)
+        public static async Task<int> SaveHitsUpdatesToSQL(this CustomEventsResultCollection eventList, ILogger logger, AnalyticsEntitiesContext database)
         {
             if (eventList.Rows.Count == 0)
             {
                 return 0;
             }
 
-            var updatesToInsert = new EFInsertBatch<HitUpdate>(database, telemetry);
+            var updatesToInsert = new EFInsertBatch<HitUpdate>(database, logger);
             foreach (var item in eventList.Rows)
             {
                 if (item is PageExitEventAppInsightsQueryResult)

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageClicksSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageClicksSaveExtension.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
@@ -12,9 +12,9 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
         /// <summary>
         /// Save hits to staging table & then import all to real hits + lookups
         /// </summary>
-        public static async Task<int> SaveClicksToSQL(this CustomEventsResultCollection events, ILogger telemetry, AnalyticsEntitiesContext database)
+        public static async Task<int> SaveClicksToSQL(this CustomEventsResultCollection events, ILogger logger, AnalyticsEntitiesContext database)
         {
-            var logsToInsert = new EFInsertBatch<ClickTempEntity>(database, telemetry);
+            var logsToInsert = new EFInsertBatch<ClickTempEntity>(database, logger);
 
             // Only process click events
             foreach (var p in events.Rows)
@@ -28,7 +28,7 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
                     }
                     else
                     {
-                        telemetry.LogWarning("Found invalid click data");
+                        logger.LogWarning("Found invalid click data");
                     }
                 }
             }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageUpdatesSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageUpdatesSaveExtension.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities;
 using DataUtils;
@@ -13,11 +13,11 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
     public static class PageUpdatesSaveExtension
     {
 
-        public static async Task<int> SavePageUpdatesToSQL(this CustomEventsResultCollection eventList, ILogger debugTracer, AppConfig config)
+        public static async Task<int> SavePageUpdatesToSQL(this CustomEventsResultCollection eventList, ILogger logger, AppConfig config)
         {
             if (eventList.Rows.Count == 0) return 0;
 
-            var updateManager = new PageUpdateManager(debugTracer, config);
+            var updateManager = new PageUpdateManager(logger, config);
 
             // Filter from custom events which are page-updates
             var pageUpdates = eventList.Rows

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageViewsSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageViewsSaveExtension.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using System;
@@ -17,7 +17,7 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
         /// <summary>
         /// Save hits to staging table & then import all to real hits + lookups
         /// </summary>
-        public static async Task SaveToSQL(this PageViewCollection pageViews, AnalyticsEntitiesContext database, ILogger telemetry, List<FilterUrlConfig> filterUrls)
+        public static async Task SaveToSQL(this PageViewCollection pageViews, AnalyticsEntitiesContext database, ILogger logger, List<FilterUrlConfig> filterUrls)
         {
             var sw = Stopwatch.StartNew();
 
@@ -29,7 +29,7 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
             var duplicateCount = 0;
             var outOfScopeCount = 0;
 
-            var logsToInsert = new EFInsertBatch<HitTempEntity>(database, telemetry);
+            var logsToInsert = new EFInsertBatch<HitTempEntity>(database, logger);
             foreach (var pv in pageViews.Rows.Where(p => p.CustomProperties?.PageRequestId != null))
             {
                 var hitIsNew = pv.CustomProperties.PageRequestId != Guid.Empty && pageRequestIdProcessed.Add(pv.CustomProperties.PageRequestId.Value);
@@ -55,26 +55,26 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
 
             if (outOfScopeCount > 0)
             {
-                telemetry.LogInformation($"Filtered {outOfScopeCount} out-of-scope URLs.");
+                logger.LogInformation($"Filtered {outOfScopeCount} out-of-scope URLs.");
             }
             if (duplicateCount > 0)
             {
-                telemetry.LogInformation($"Skipped {duplicateCount} duplicate page-request IDs.");
+                logger.LogInformation($"Skipped {duplicateCount} duplicate page-request IDs.");
             }
 
-            telemetry.LogInformation($"Staging {logsToInsert.Rows.Count:n0} hits for SQL import (filtered from {pageViews.Rows.Count:n0} raw page-views in {sw.Elapsed.TotalSeconds:N1}s)...");
+            logger.LogInformation($"Staging {logsToInsert.Rows.Count:n0} hits for SQL import (filtered from {pageViews.Rows.Count:n0} raw page-views in {sw.Elapsed.TotalSeconds:N1}s)...");
 
             sw.Restart();
             const int MAX_HITS_PER_THREAD = 1000;
             await logsToInsert.SaveToStagingTable(MAX_HITS_PER_THREAD, FixScript(Resources.Migrate_Hits_Import_into_Hits));
 
-            telemetry.LogInformation($"Hits batch imported and merged in {sw.Elapsed.TotalSeconds:N1}s.");
+            logger.LogInformation($"Hits batch imported and merged in {sw.Elapsed.TotalSeconds:N1}s.");
         }
 
 
-        public static async Task SaveToSQL(this PageViewCollection pageViews, AnalyticsEntitiesContext database, ILogger telemetry)
+        public static async Task SaveToSQL(this PageViewCollection pageViews, AnalyticsEntitiesContext database, ILogger logger)
         {
-            await SaveToSQL(pageViews, database, telemetry, new List<FilterUrlConfig>());
+            await SaveToSQL(pageViews, database, logger, new List<FilterUrlConfig>());
         }
 
 

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SearchesSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SearchesSaveExtension.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -14,7 +14,7 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
     public static class SearchesSaveExtension
     {
 
-        public static async Task<int> SaveSearchesToSQL(this CustomEventsResultCollection eventList, ILogger debugTracer, AnalyticsEntitiesContext database)
+        public static async Task<int> SaveSearchesToSQL(this CustomEventsResultCollection eventList, ILogger logger, AnalyticsEntitiesContext database)
         {
             if (eventList.Rows.Count == 0)
             {
@@ -35,7 +35,7 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
                 return 0;
             }
 
-            debugTracer.LogInformation($"Processing {searches.Count.ToString("n0")} searches...");
+            logger.LogInformation($"Processing {searches.Count.ToString("n0")} searches...");
             var sw = Stopwatch.StartNew();
 
             // Read default connection-string
@@ -79,13 +79,13 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
                         await cmd.ExecuteNonQueryAsync();
                     }
 
-                    debugTracer.LogInformation($"Inserted {searches.Count:n0} searches into staging in {sw.Elapsed.TotalSeconds:N1}s. Running merge script...");
+                    logger.LogInformation($"Inserted {searches.Count:n0} searches into staging in {sw.Elapsed.TotalSeconds:N1}s. Running merge script...");
                     sw.Restart();
 
                     // Run script to copy to proper tables
                     var searchesInserted = await db.Database.ExecuteSqlCommandAsync(FixSearchScript(Resources.Migrate_Searches_Import));
 
-                    debugTracer.LogInformation($"Search merge completed in {sw.Elapsed.TotalSeconds:N1}s - {searchesInserted:n0} new rows.");
+                    logger.LogInformation($"Search merge completed in {sw.Elapsed.TotalSeconds:N1}s - {searchesInserted:n0} new rows.");
                     return searchesInserted;
                 }
             }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/Program.cs
@@ -61,7 +61,7 @@ namespace WebJob.AppInsightsImporter
 
             var config = new AppConfig();
 
-            var telemetry = new AnalyticsLogger(config.AppInsightsConnectionString, "AppInsightsImporter");
+            var logger = new AnalyticsLogger(config.AppInsightsConnectionString, "AppInsightsImporter");
 
             // If no command line override was supplied, fall back to the config/app-setting value (if any).
             // The command line argument takes precedence over the config value.
@@ -71,22 +71,22 @@ namespace WebJob.AppInsightsImporter
                 Console.WriteLine($"Using ReadHitsDaysBeforeToday='{daysBeforeReadOverride}' from app configuration.");
             }
 
-            bool validConfig = ValidateAndPrintConfig(config, telemetry);
+            bool validConfig = ValidateAndPrintConfig(config, logger);
             if (validConfig)
             {
                 Console.WriteLine();
-                telemetry.LogInformation("Starting Application Insights import.");
+                logger.LogInformation("Starting Application Insights import.");
             }
             else
             {
-                telemetry.LogInformation("\nCheck settings & restart app.");
+                logger.LogInformation("\nCheck settings & restart app.");
                 runAgain = false;
             }
 
             // Should we even be running?
             if (!importJobSettings.WebTraffic)
             {
-                telemetry.LogWarning("WARNING: Web-traffic import is disabled in app configuration. Stopping here until the app is restarted.");
+                logger.LogWarning("WARNING: Web-traffic import is disabled in app configuration. Stopping here until the app is restarted.");
                 while (true)
                 {
                     System.Threading.Thread.Sleep(int.MaxValue);
@@ -97,10 +97,10 @@ namespace WebJob.AppInsightsImporter
             {
                 while (runAgain)
                 {
-                    var importCycleTimer = new JobTimer(telemetry, Process.GetCurrentProcess().ProcessName);
+                    var importCycleTimer = new JobTimer(logger, Process.GetCurrentProcess().ProcessName);
                     importCycleTimer.Start();
 
-                    var importer = new Engine.AppInsightsImporter(config, telemetry);
+                    var importer = new Engine.AppInsightsImporter(config, logger);
                     if (daysBeforeReadOverride > 0)
                     {
                         importer.ImportAndSave(saveRestResponses, daysBeforeReadOverride).Wait();
@@ -121,20 +121,20 @@ namespace WebJob.AppInsightsImporter
 
                     if (runAgain)
                     {
-                        ConsoleApp.WebjobWait(telemetry);
+                        ConsoleApp.WebjobWait(logger);
                     }
                 }
             }
             catch (Exception ex)
             {
-                telemetry.TrackException(ex);
+                logger.TrackException(ex);
 
                 // ex is normally an AggregateException from the .Wait() above, whose Message is just
                 // "One or more errors occurred." - useless on its own. Log the unwrapped inner-exception
                 // chain and the full stack so the real failure is visible in the WebJob console & traces,
                 // not only in the AppInsights 'exceptions' table.
-                telemetry.LogError($"Got uncaught exception importing & saving data from Application Insights: {CommonExceptionHandler.GetErrorText(ex)}");
-                telemetry.LogError($"Exception detail: {ex}");
+                logger.LogError($"Got uncaught exception importing & saving data from Application Insights: {CommonExceptionHandler.GetErrorText(ex)}");
+                logger.LogError($"Exception detail: {ex}");
 
 #if DEBUG
                 throw;
@@ -169,17 +169,17 @@ namespace WebJob.AppInsightsImporter
         /// Output the config and check it's good.
         /// </summary>
         /// <returns>If the config is valid</returns>
-        private static bool ValidateAndPrintConfig(AppConfig settings, ILogger telemetry)
+        private static bool ValidateAndPrintConfig(AppConfig settings, ILogger logger)
         {
-            ConsoleApp.PrintStartupAndLoggingConfig(settings.ConnectionStrings.DatabaseConnectionString, settings.BuildLabel, settings.UserGroupsFilter, telemetry);
+            ConsoleApp.PrintStartupAndLoggingConfig(settings.ConnectionStrings.DatabaseConnectionString, settings.BuildLabel, settings.UserGroupsFilter, logger);
 
             // Have config object test
 
-            settings.ConnectionStrings.TestSQLSettings(telemetry);
+            settings.ConnectionStrings.TestSQLSettings(logger);
 
             if (string.IsNullOrEmpty(settings.AppInsightsConnectionString))
             {
-                telemetry.LogInformation("Critical: no Application Insights connection string found - can't continue. Run the latest installer again to reset configuration.");
+                logger.LogInformation("Critical: no Application Insights connection string found - can't continue. Run the latest installer again to reset configuration.");
                 return false;
             }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Abstract.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Abstract.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils;
 using DataUtils.Http;
 
@@ -6,12 +6,12 @@ namespace WebJob.Office365ActivityImporter.Engine
 {
     public abstract class AbstractApiLoader
     {
-        protected readonly AnalyticsLogger _telemetry;
+        protected readonly AnalyticsLogger _logger;
         protected readonly AppConfig _settings;
 
-        protected AbstractApiLoader(AnalyticsLogger telemetry, AppConfig settings)
+        protected AbstractApiLoader(AnalyticsLogger logger, AppConfig settings)
         {
-            this._telemetry = telemetry;
+            this._logger = logger;
             this._settings = settings;
         }
     }
@@ -19,8 +19,8 @@ namespace WebJob.Office365ActivityImporter.Engine
     public abstract class AbstractActivityApiLoaderWithHttpClient : AbstractApiLoader
     {
         protected ConfidentialClientApplicationThrottledHttpClient _httpClient;
-        protected AbstractActivityApiLoaderWithHttpClient(AnalyticsLogger telemetry, ConfidentialClientApplicationThrottledHttpClient httpClient, AppConfig settings)
-            : base(telemetry, settings)
+        protected AbstractActivityApiLoaderWithHttpClient(AnalyticsLogger logger, ConfidentialClientApplicationThrottledHttpClient httpClient, AppConfig settings)
+            : base(logger, settings)
         {
             _httpClient = httpClient;
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils;
 using System;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
         private int _reportSummariesProcessed = 0;
         private int _lastReportedPercentDone = 0;
 
-        public ActivityImporter(AppConfig settings, AnalyticsLogger telemetry, int maxSavesPerBatch) : base(telemetry, settings)
+        public ActivityImporter(AppConfig settings, AnalyticsLogger logger, int maxSavesPerBatch) : base(logger, settings)
         {
             _maxSavesPerBatch = maxSavesPerBatch;
         }
@@ -32,7 +32,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
 
         public async Task<ImportStat> LoadReportsAndSave(IActivityReportPersistenceManager activityReportPersistenceManager)
         {
-            var timer = new JobTimer(_telemetry, "Audit events import");
+            var timer = new JobTimer(_logger, "Audit events import");
             timer.Start();
 
             var active = await ActivitySubscriptionManager.EnsureActiveSubscriptionContentTypesActive();
@@ -72,13 +72,13 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
 #if DEBUG
             Console.WriteLine($"DEBUG: Got {allStats.Total.ToString("N0")} reports from {allSummaries.Count.ToString("N0")} summary reports");
 #endif
-            _telemetry.LogInformation($"Audit events import: Got {allStats.Total.ToString("N0")} audit events from {allSummaries.Count.ToString("N0")} summary reports. " +
+            _logger.LogInformation($"Audit events import: Got {allStats.Total.ToString("N0")} audit events from {allSummaries.Count.ToString("N0")} summary reports. " +
                 $"{allStats.Imported} imported, {allStats.ProcessedAlready} processed already, {allStats.URLsOutOfScope} URLs out of scope of SharePoint site import whitelist (org_urls)");
 
             // Log warning if there were download errors
             if (allStats.MetadataDownloadErrors > 0 || allStats.ReportDownloadErrors > 0)
             {
-                _telemetry.LogWarning($"Audit events import: DOWNLOAD ERRORS DETECTED - {allStats.MetadataDownloadErrors} metadata download failures, " +
+                _logger.LogWarning($"Audit events import: DOWNLOAD ERRORS DETECTED - {allStats.MetadataDownloadErrors} metadata download failures, " +
                     $"{allStats.ReportDownloadErrors} report download failures. Some data may be missing from this import cycle. " +
                     $"These items will be retried on the next import cycle.");
             }
@@ -108,7 +108,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
             // Load in parallel & call parent func on listBatchProcessor to save
             await loader.ProcessListInParallel(reportSummaries.OrderByDescending(j => j.Created),
                 async (threadListChunk, threadIndex) => await ProcessSummaryChunkAsync(threadListChunk, listBatchProcessor, activityReportLoader),
-                    threads => _telemetry.LogInformation($"Audit events import: full-loading activity reports from {reportSummaries.Count.ToString("n0")} links, across {threads.ToString("n0")} thread(s)..."));
+                    threads => _logger.LogInformation($"Audit events import: full-loading activity reports from {reportSummaries.Count.ToString("n0")} links, across {threads.ToString("n0")} thread(s)..."));
 
             await listBatchProcessor.Flush();
         }
@@ -134,7 +134,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                             int pcDone = Convert.ToInt32(Math.Round(percentDone, 0));
                             if (_lastReportedPercentDone < pcDone)
                             {
-                                _telemetry.LogInformation($"Audit events import: processed {pcDone.ToString("n0")}% activity report data...");
+                                _logger.LogInformation($"Audit events import: processed {pcDone.ToString("n0")}% activity report data...");
                                 _lastReportedPercentDone = pcDone;
                             }
                         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using DataUtils.Sql;
@@ -28,7 +28,7 @@ namespace WebJob.Office365ActivityImporter.Engine
     {
         private readonly AuditFilterConfig _filterConfig;
         private readonly UserGroupsCache _userGroupsCache;
-        private readonly ILogger _telemetry;
+        private readonly ILogger _logger;
         private readonly AppConfig _appConfig;
         private string _defaultConnectionString = null;
         private UserGroupsFilterModel _userGroupsFilter = null;
@@ -41,11 +41,11 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// </summary>
         private static SemaphoreSlim _sqlSaveSemaphore = new SemaphoreSlim(1);      // Make sure we're only saving one thread at a time
 
-        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger telemetry, AppConfig appConfig)
+        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig)
         {
             _filterConfig = filterConfig;
             _userGroupsCache = userGroupsCache;
-            _telemetry = telemetry;
+            _logger = logger;
             _appConfig = appConfig;
             _userGroupsFilter = new UserGroupsFilterModel(appConfig.UserGroupsFilter);
         }
@@ -114,7 +114,7 @@ namespace WebJob.Office365ActivityImporter.Engine
         private async Task<ImportStat> SaveToSqlAllTheThings(ActivityReportSet activities, AnalyticsEntitiesContext db, SqlConnection con, ActivityImportCache cache)
         {
             var listOfActivitiesSavedToSQL = new ConcurrentBag<AbstractAuditLogContent>();
-            var logsToInsert = new EFInsertBatch<AuditLogTempEntity>(db, _telemetry);
+            var logsToInsert = new EFInsertBatch<AuditLogTempEntity>(db, _logger);
             // Sequential dedup within this set: a HashSet gives O(1) Contains. The previous
             // ConcurrentBag.Contains was O(n) per row (an O(n^2) scan over a large activity set).
             var processedIds = new HashSet<Guid>();
@@ -139,7 +139,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                         else
                         {
                             result = SaveResultEnum.UserOutOfScope;
-                            _telemetry.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
+                            _logger.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
                         }
                     }
                     else
@@ -158,7 +158,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                     else if (result == SaveResultEnum.ProcessedAlready) stats.ProcessedAlready++;
                     else if (result == SaveResultEnum.UrlOutOfScope) stats.URLsOutOfScope++;
                     else if (result == SaveResultEnum.UserOutOfScope) stats.UsersOutOfScope++;
-                    else _telemetry.LogError($"Unexpected log result for log {abtractLog.Id}");
+                    else _logger.LogError($"Unexpected log result for log {abtractLog.Id}");
 
                     processedIds.Add(abtractLog.Id);
                 }
@@ -175,7 +175,7 @@ namespace WebJob.Office365ActivityImporter.Engine
             #region Add Extra Metadata
 
             // Add metadata the traditional way with EF. By now should have all the sites saved. 
-            var saveSession = new SaveSession(_telemetry, db, _appConfig);
+            var saveSession = new SaveSession(_logger, db, _appConfig);
             await saveSession.Init();
 
             int metaSaveIdx = 0, changesMadeCount = 0;
@@ -220,7 +220,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                         metaSaveIdx++;
                         continue;
                     }
-                    var changesMade = await log.ProcessExtendedProperties(saveSession, savedEvent, _telemetry);
+                    var changesMade = await log.ProcessExtendedProperties(saveSession, savedEvent, _logger);
                     if (changesMade)
                         changesMadeCount++;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivitySubscriptionManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivitySubscriptionManager.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils;
 using DataUtils.Http;
 using Microsoft.Extensions.Logging;
@@ -14,8 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
 {
     public class ActivitySubscriptionManager : AbstractActivityApiLoaderWithHttpClient, IActivitySubscriptionManager
     {
-        public ActivitySubscriptionManager(AppConfig settings, AnalyticsLogger telemetry, ConfidentialClientApplicationThrottledHttpClient httpClient)
-            : base(telemetry, httpClient, settings)
+        public ActivitySubscriptionManager(AppConfig settings, AnalyticsLogger logger, ConfidentialClientApplicationThrottledHttpClient httpClient)
+            : base(logger, httpClient, settings)
         {
         }
 
@@ -48,7 +48,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                         }
                         catch (HttpRequestException)
                         {
-                            _telemetry.LogError("Can't create subscription. Check service-account permissions to Office 365 Activity API & that audit-log is turned on for tenant. https://docs.microsoft.com/en-gb/microsoft-365/compliance/turn-audit-log-search-on-or-off?view=o365-worldwide");
+                            _logger.LogError("Can't create subscription. Check service-account permissions to Office 365 Activity API & that audit-log is turned on for tenant. https://docs.microsoft.com/en-gb/microsoft-365/compliance/turn-audit-log-search-on-or-off?view=o365-worldwide");
                             throw;
                         }
 
@@ -59,7 +59,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                     catch (HttpRequestException ex)
                     {
                         // If we can't create it report the error
-                        _telemetry.LogInformation($"Subscription for '{configuredContentType}' could not be found or created - {ex.Message}. Check the configuration file & app permissions in Azure AD.");
+                        _logger.LogInformation($"Subscription for '{configuredContentType}' could not be found or created - {ex.Message}. Check the configuration file & app permissions in Azure AD.");
                         throw;
                     }
                 }
@@ -96,11 +96,11 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 {
                     if (sub.status.ToLower() != "enabled")
                     {
-                        _telemetry.LogInformation(string.Format("Subscription for '{0}' is already in place, but not enabled.", contentType));
+                        _logger.LogInformation(string.Format("Subscription for '{0}' is already in place, but not enabled.", contentType));
                     }
                     else
                     {
-                        _telemetry.LogInformation(string.Format("Subscription for '{0}' is already in place and enabled.", contentType));
+                        _logger.LogInformation(string.Format("Subscription for '{0}' is already in place and enabled.", contentType));
                         validContentTypes.Add(contentType);
                     }
                 }
@@ -114,7 +114,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
         /// </summary>
         public async Task<ApiSubscription[]> GetActiveSubscriptions()
         {
-            return await GetActiveSubscriptions(_settings.TenantGUID.ToString(), _telemetry, _httpClient);
+            return await GetActiveSubscriptions(_settings.TenantGUID.ToString(), _logger, _httpClient);
         }
 
         // To allow installer to call this method without needing an AppConfig

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/AuditFilterConfig.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/AuditFilterConfig.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Extensions.Logging;
@@ -54,17 +54,17 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
             };
         }
 
-        public void Print(ILogger telemetry)
+        public void Print(ILogger logger)
         {
             foreach (var url in this.OrgUrlConfigs)
             {
                 if (url.ExactSiteMatch)
                 {
-                    telemetry.LogInformation($"+{url.Url} (exact match)");
+                    logger.LogInformation($"+{url.Url} (exact match)");
                 }
                 else
                 {
-                    telemetry.LogInformation($"+{url.Url} (*)");
+                    logger.LogInformation($"+{url.Url} (*)");
                 }
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
@@ -1,4 +1,4 @@
-﻿using DataUtils.Http;
+using DataUtils.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -20,14 +20,14 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
     public class ActivityReportWebLoader : IActivityReportLoader<ActivityReportInfo>
     {
         private AutoThrottleHttpClient _httpClient;
-        private readonly ILogger _telemetry;
+        private readonly ILogger _logger;
         private readonly string _tenantId;
         private int _reportDownloadErrors = 0;
 
-        public ActivityReportWebLoader(AutoThrottleHttpClient httpClient, ILogger telemetry, string tenantId)
+        public ActivityReportWebLoader(AutoThrottleHttpClient httpClient, ILogger logger, string tenantId)
         {
             _httpClient = httpClient;
-            _telemetry = telemetry;
+            _logger = logger;
             _tenantId = tenantId;
         }
 
@@ -47,12 +47,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
             HttpResponseMessage response = null;
             try
             {
-                response = await _httpClient.GetAsyncWithThrottleRetries(newUri, _telemetry);
+                response = await _httpClient.GetAsyncWithThrottleRetries(newUri, _logger);
             }
             catch (HttpRequestException ex)
             {
                 Interlocked.Increment(ref _reportDownloadErrors);
-                _telemetry.LogError(ex, $"Got error '{ex.Message}' downloading {metadata.ContentUri}. Will try again on next cycle.");
+                _logger.LogError(ex, $"Got error '{ex.Message}' downloading {metadata.ContentUri}. Will try again on next cycle.");
                 return new WebActivityReportSet();
             }
 
@@ -100,7 +100,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                                 // A single malformed object will desync the reader; bail out of the stream
                                 // so we don't accidentally mis-parse subsequent siblings.
                                 Interlocked.Increment(ref _reportDownloadErrors);
-                                _telemetry.LogWarning($"Invalid JSON object in stream from URL '{newUri}': {ex.Message}. Aborting stream for this batch.");
+                                _logger.LogWarning($"Invalid JSON object in stream from URL '{newUri}': {ex.Message}. Aborting stream for this batch.");
                                 break;
                             }
 
@@ -111,13 +111,13 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                 catch (OutOfMemoryException)
                 {
                     Interlocked.Increment(ref _reportDownloadErrors);
-                    _telemetry.LogError($"Out of memory streaming response from {metadata.ContentUri}. Will try again on next cycle.");
+                    _logger.LogError($"Out of memory streaming response from {metadata.ContentUri}. Will try again on next cycle.");
                     return new WebActivityReportSet();
                 }
                 catch (JsonReaderException ex)
                 {
                     Interlocked.Increment(ref _reportDownloadErrors);
-                    _telemetry.LogWarning($"Invalid JSON response for URL '{newUri}': {ex.Message}. Ignoring");
+                    _logger.LogWarning($"Invalid JSON response for URL '{newUri}': {ex.Message}. Ignoring");
                     return new WebActivityReportSet();
                 }
 
@@ -147,12 +147,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                     var fileName = $"audit_trace_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}_{Guid.NewGuid():N}_{DateTime.UtcNow.Ticks % 1000000}.json";
                     var fullPath = Path.Combine(AuditTraceConfig.TraceDirectory, fileName);
                     File.WriteAllText(fullPath, logJson);
-                    _telemetry.LogInformation($"TRACE: Saved matching audit log to '{fullPath}'.");
+                    _logger.LogInformation($"TRACE: Saved matching audit log to '{fullPath}'.");
 
                 }
                 catch (Exception ex)
                 {
-                    _telemetry.LogWarning($"TRACE: Failed to write trace audit log file: {ex.Message}");
+                    _logger.LogWarning($"TRACE: Failed to write trace audit log file: {ex.Message}");
                 }
             }
             #endregion
@@ -177,16 +177,16 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
             // thin IO + batching layer.
             try
             {
-                thisAuditLogReport = AuditLogContentDispatcher.Dispatch(reportItem, logBase, _telemetry);
+                thisAuditLogReport = AuditLogContentDispatcher.Dispatch(reportItem, logBase, _logger);
             }
             catch (JsonReaderException ex)
             {
-                _telemetry.LogWarning($"Failed to deserialize {logBase.Workload} log: {ex.Message}");
+                _logger.LogWarning($"Failed to deserialize {logBase.Workload} log: {ex.Message}");
                 return;
             }
             catch (JsonSerializationException ex)
             {
-                _telemetry.LogWarning($"Failed to deserialize {logBase.Workload} log: {ex.Message}");
+                _logger.LogWarning($"Failed to deserialize {logBase.Workload} log: {ex.Message}");
                 return;
             }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityWebImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityWebImporter.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils;
 using DataUtils.Http;
 
@@ -14,27 +14,27 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         private WebContentMetaDataLoader _contentMetaDataLoader;
         private ActivitySubscriptionManager _activitySubscriptionManager;
 
-        public ActivityWebImporter(AppConfig settings, AnalyticsLogger telemetry, int maxSavesPerBatch) : base(settings, telemetry, maxSavesPerBatch)
+        public ActivityWebImporter(AppConfig settings, AnalyticsLogger logger, int maxSavesPerBatch) : base(settings, logger, maxSavesPerBatch)
         {
-            var auth = new ActivityAPIAppIndentityOAuthContext(telemetry, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
-            var httpClient = new ConfidentialClientApplicationThrottledHttpClient(auth, false, telemetry);
-            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, telemetry, settings.TenantGUID.ToString());
-            _contentMetaDataLoader = new WebContentMetaDataLoader(telemetry, httpClient, settings);
-            _activitySubscriptionManager = new ActivitySubscriptionManager(settings, telemetry, httpClient);
+            var auth = new ActivityAPIAppIndentityOAuthContext(logger, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
+            var httpClient = new ConfidentialClientApplicationThrottledHttpClient(auth, false, logger);
+            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, logger, settings.TenantGUID.ToString());
+            _contentMetaDataLoader = new WebContentMetaDataLoader(logger, httpClient, settings);
+            _activitySubscriptionManager = new ActivitySubscriptionManager(settings, logger, httpClient);
         }
 
 
         /// <summary>
         /// Unit tests constructors
         /// </summary>
-        public ActivityWebImporter(ConfidentialClientApplicationThrottledHttpClient httpClient, AppConfig settings, AnalyticsLogger telemetry, int maxSavesPerBatch) : base(settings, telemetry, maxSavesPerBatch)
+        public ActivityWebImporter(ConfidentialClientApplicationThrottledHttpClient httpClient, AppConfig settings, AnalyticsLogger logger, int maxSavesPerBatch) : base(settings, logger, maxSavesPerBatch)
         {
-            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, telemetry, settings.TenantGUID.ToString());
-            _contentMetaDataLoader = new WebContentMetaDataLoader(telemetry, httpClient, settings);
-            _activitySubscriptionManager = new ActivitySubscriptionManager(settings, telemetry, httpClient);
+            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, logger, settings.TenantGUID.ToString());
+            _contentMetaDataLoader = new WebContentMetaDataLoader(logger, httpClient, settings);
+            _activitySubscriptionManager = new ActivitySubscriptionManager(settings, logger, httpClient);
         }
-        public ActivityWebImporter(ConfidentialClientApplicationThrottledHttpClient fakeClient, AppConfig s, AnalyticsLogger telemetry) :
-            this(fakeClient, s, telemetry, 1)
+        public ActivityWebImporter(ConfidentialClientApplicationThrottledHttpClient fakeClient, AppConfig s, AnalyticsLogger logger) :
+            this(fakeClient, s, logger, 1)
         {
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ContentMetaDataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ContentMetaDataLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
@@ -15,12 +15,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
     /// </summary>
     public abstract class ContentMetaDataLoader<SUMMARYTYPE>
     {
-        protected readonly ILogger _telemetry;
+        protected readonly ILogger _logger;
         protected readonly AppConfig _settings;
 
-        protected ContentMetaDataLoader(ILogger telemetry, AppConfig settings)
+        protected ContentMetaDataLoader(ILogger logger, AppConfig settings)
         {
-            _telemetry = telemetry;
+            _logger = logger;
             _settings = settings;
         }
 
@@ -58,12 +58,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
 
             if (timeChunks.Count == 0)
             {
-                _telemetry.LogWarning("Audit events import: ERROR: Could not download activity - no time-chunks for activity scanning using configured values.");
+                _logger.LogWarning("Audit events import: ERROR: Could not download activity - no time-chunks for activity scanning using configured values.");
             }
             else
             {
                 // https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference
-                _telemetry.LogInformation($"Audit events import: getting changes summary from Office 365 Activity API from '{timeChunks.First().Start}' to '{timeChunks.Last().End}'...");
+                _logger.LogInformation($"Audit events import: getting changes summary from Office 365 Activity API from '{timeChunks.First().Start}' to '{timeChunks.Last().End}'...");
 
                 int batchId = 0;
                 var downloadListThreads = new List<Task<List<SUMMARYTYPE>>>();

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/WebContentMetaDataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/WebContentMetaDataLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -20,7 +20,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
         private readonly ConfidentialClientApplicationThrottledHttpClient _httpClient;
         private int _metadataDownloadErrors = 0;
 
-        public WebContentMetaDataLoader(ILogger telemetry, ConfidentialClientApplicationThrottledHttpClient httpClient, AppConfig settings) : base(telemetry, settings)
+        public WebContentMetaDataLoader(ILogger logger, ConfidentialClientApplicationThrottledHttpClient httpClient, AppConfig settings) : base(logger, settings)
         {
             _httpClient = httpClient;
         }
@@ -68,7 +68,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 string nextPageUri = null;
 
                 // Get this batch
-                using (var response = await _httpClient.GetAsyncWithThrottleRetries(currentUri, _telemetry))
+                using (var response = await _httpClient.GetAsyncWithThrottleRetries(currentUri, _logger))
                 {
                     // Read the content.  
                     var responseFromServer = await response.Content.ReadAsStringAsync();
@@ -85,10 +85,10 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                     catch (HttpRequestException ex)
                     {
                         Interlocked.Increment(ref _metadataDownloadErrors);
-                        _telemetry.LogError(ex, $"Error downloading metadata {currentUri} with error '{ex.Message}'. " +
+                        _logger.LogError(ex, $"Error downloading metadata {currentUri} with error '{ex.Message}'. " +
                             $"If this happens every time, this may be an issue. Ignoring for now.");
 #if DEBUG
-                        _telemetry.LogInformation("DEBUG: Response body was:\n" + responseFromServer);
+                        _logger.LogInformation("DEBUG: Response body was:\n" + responseFromServer);
 #endif
                         break; // Exit the loop on error
                     }
@@ -114,7 +114,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                         }
                         catch (JsonSerializationException)
                         {
-                            _telemetry.LogError($"Could not deserialise to list of {nameof(ActivityReportInfo)} response: '{responseFromServer}'");
+                            _logger.LogError($"Could not deserialise to list of {nameof(ActivityReportInfo)} response: '{responseFromServer}'");
                         }
                     }
                 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CallRecord/CallRecordDTO.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CallRecord/CallRecordDTO.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core;
+using Azure.Core;
 using Common.Entities;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -33,7 +33,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
         /// <summary>
         /// Load a Call Record from Graph, using call ID
         /// </summary>
-        public static async Task<CallRecordDTO> LoadFromGraphByID(string callId, ManualGraphCallClient manualClient, TeamsLoadContext teamsLoadContext, ILogger telemetry, string thisTenantId)
+        public static async Task<CallRecordDTO> LoadFromGraphByID(string callId, ManualGraphCallClient manualClient, TeamsLoadContext teamsLoadContext, ILogger logger, string thisTenantId)
         {
             string callJsonText = string.Empty;
             var callDTO = await manualClient.GetAsyncWithThrottleRetries<CallRecordDTO>($"https://graph.microsoft.com/v1.0/communications/callRecords/{callId}?$expand=sessions($expand=segments)",
@@ -41,14 +41,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
 
             if (callDTO == null)
             {
-                telemetry.LogWarning($"Got null/unparseable response loading call record '{callId}'. Skipping.");
+                logger.LogWarning($"Got null/unparseable response loading call record '{callId}'. Skipping.");
                 return null;
             }
 
             callDTO.JsonText = callJsonText;
 
             // Find email addresses for user IDs
-            await callDTO.PopulateEmailAddresses(teamsLoadContext, thisTenantId, telemetry);
+            await callDTO.PopulateEmailAddresses(teamsLoadContext, thisTenantId, logger);
 
 
             return callDTO;
@@ -57,24 +57,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
         /// <summary>
         /// Debug testing method
         /// </summary>
-        public static async Task<CallRecord> SaveNewCallToDB(string callId, ManualGraphCallClient manualClient, TokenCredential graphServiceClientAuthenticationProvider, ILogger telemetry, string thisTenantId)
+        public static async Task<CallRecord> SaveNewCallToDB(string callId, ManualGraphCallClient manualClient, TokenCredential graphServiceClientAuthenticationProvider, ILogger logger, string thisTenantId)
         {
             var teamsLoadContext = new TeamsLoadContext(new GraphServiceClient(graphServiceClientAuthenticationProvider));
 
-            var newCall = await LoadFromGraphByID(callId, manualClient, teamsLoadContext, telemetry, thisTenantId);
+            var newCall = await LoadFromGraphByID(callId, manualClient, teamsLoadContext, logger, thisTenantId);
 
-            telemetry.LogInformation($"Response payload from Graph:\n{newCall.JsonText}");
+            logger.LogInformation($"Response payload from Graph:\n{newCall.JsonText}");
 
-            telemetry.LogInformation("\nSaving call to SQL...");
+            logger.LogInformation("\nSaving call to SQL...");
             using (var db = new AnalyticsEntitiesContext())
             {
-                return await newCall.SaveOrReplaceCallRecord(new TeamsAndCallsDBLookupManager(db), telemetry);
+                return await newCall.SaveOrReplaceCallRecord(new TeamsAndCallsDBLookupManager(db), logger);
             }
         }
 
         static SemaphoreSlim saveCallRecordSemaphoreSlim = new SemaphoreSlim(1, 1);
 
-        public async Task<CallRecord> SaveOrReplaceCallRecord(TeamsAndCallsDBLookupManager context, ILogger telemetry)
+        public async Task<CallRecord> SaveOrReplaceCallRecord(TeamsAndCallsDBLookupManager context, ILogger logger)
         {
             // Make sure we only save call records one at a time
             await saveCallRecordSemaphoreSlim.WaitAsync();
@@ -88,7 +88,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
                 {
                     if (existingCallRecord != null)
                     {
-                        telemetry.LogWarning($"Detected previous call in database with Graph ID '{this.GraphCallID}'. Replacing with this call data.");
+                        logger.LogWarning($"Detected previous call in database with Graph ID '{this.GraphCallID}'. Replacing with this call data.");
 
                         await existingCallRecord.DeleteAll(context.Database);
                     }
@@ -143,7 +143,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
                         }
                         else
                         {
-                            telemetry.LogInformation($"Found a session ID '{session.GraphCallID}' without a caller/callee email address. Skipping session.");
+                            logger.LogInformation($"Found a session ID '{session.GraphCallID}' without a caller/callee email address. Skipping session.");
                         }
                     }
 
@@ -230,39 +230,39 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
         }
 
 
-        public async Task PopulateEmailAddresses(TeamsLoadContext teamsLoadContext, string thisTenantId, ILogger telemetry)
+        public async Task PopulateEmailAddresses(TeamsLoadContext teamsLoadContext, string thisTenantId, ILogger logger)
         {
             if (Sessions != null)
             {
                 foreach (var callSession in this.Sessions)
                 {
-                    await PopuplateCallerEmail(callSession.Callee, teamsLoadContext, thisTenantId, telemetry);
-                    await PopuplateCallerEmail(callSession.Caller, teamsLoadContext, thisTenantId, telemetry);
+                    await PopuplateCallerEmail(callSession.Callee, teamsLoadContext, thisTenantId, logger);
+                    await PopuplateCallerEmail(callSession.Caller, teamsLoadContext, thisTenantId, logger);
                 }
             }
 
             if (this.Organizer != null)
             {
-                this.OrganizerEmail = await GetEmailAddress(this.Organizer, teamsLoadContext, telemetry);
+                this.OrganizerEmail = await GetEmailAddress(this.Organizer, teamsLoadContext, logger);
             }
         }
 
-        private static async Task PopuplateCallerEmail(ParticipantEndpointDTO callee, TeamsLoadContext teamsLoadContext, string thisTenantId, ILogger telemetry)
+        private static async Task PopuplateCallerEmail(ParticipantEndpointDTO callee, TeamsLoadContext teamsLoadContext, string thisTenantId, ILogger logger)
         {
             if (callee?.Identity?.User != null)
             {
                 if (callee.Identity.User.TenantId == thisTenantId)
                 {
-                    callee.UserEmailAddress = await GetEmailAddress(callee.Identity, teamsLoadContext, telemetry);
+                    callee.UserEmailAddress = await GetEmailAddress(callee.Identity, teamsLoadContext, logger);
                 }
                 else
                 {
-                    telemetry.LogInformation($"Ignoring external user from tenant Id {callee.Identity.User.TenantId}");
+                    logger.LogInformation($"Ignoring external user from tenant Id {callee.Identity.User.TenantId}");
                 }
             }
         }
 
-        private static async Task<string> GetEmailAddress(IdentitySetDTO callee, TeamsLoadContext teamsLoadContext, ILogger telemetry)
+        private static async Task<string> GetEmailAddress(IdentitySetDTO callee, TeamsLoadContext teamsLoadContext, ILogger logger)
         {
             Microsoft.Graph.Models.User graphUser = null;
             try
@@ -273,7 +273,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
             {
                 if (ex.Message.Contains("Request_ResourceNotFound"))
                 {
-                    telemetry.LogInformation($"Cannot find user with id '{callee?.User?.Id} in tenant '{callee?.User?.TenantId}' - user not found.");
+                    logger.LogInformation($"Cannot find user with id '{callee?.User?.Id} in tenant '{callee?.User?.TenantId}' - user not found.");
                     return string.Empty;
                 }
                 else

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ExceptionHandler.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ExceptionHandler.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core;
+using Azure.Core;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Net;
@@ -9,20 +9,20 @@ namespace WebJob.Office365ActivityImporter.Engine
     public class ExceptionHandler
     {
         [Obsolete]
-        public static bool IsThrottlingError(HttpRequestException ex, HttpResponseMessage response, ILogger telemetry)
+        public static bool IsThrottlingError(HttpRequestException ex, HttpResponseMessage response, ILogger logger)
         {
             if (response == null)
             {
                 return false;
             }
             Console.WriteLine($"Got {nameof(HttpRequestException)}. Error = " + ex.Message);
-            if (ex.InnerException != null) telemetry.LogError(ex, "Inner exception = " + ex.InnerException.Message);
+            if (ex.InnerException != null) logger.LogError(ex, "Inner exception = " + ex.InnerException.Message);
 
             string errBody = string.Empty;
             try
             {
                 errBody = response.Content.ReadAsStringAsync().Result;
-                telemetry.LogError("Error Body = " + errBody);
+                logger.LogError("Error Body = " + errBody);
             }
             catch (ObjectDisposedException)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallQueueProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallQueueProcessor.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Identity; // Added for ClientSecretCredential
+using Azure.Identity; // Added for ClientSecretCredential
 using Azure.Messaging.ServiceBus;
 using Common.Entities;
 using Common.Entities.Config;
@@ -28,7 +28,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         private ServiceBusClient _sbClient;
         private ServiceBusProcessor _processor;
         private TeamsLoadContext _teamsLoadContext;
-        private ILogger _telemetry;
+        private ILogger _logger;
         private ImportAppIndentityOAuthContext _auth;
         private string _thisTenantId = null;
         private ManualGraphCallClient _graphCallClient;
@@ -65,9 +65,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         private CallQueueProcessor(AppConfig config, string thisTenantId)
         {
             // Use seperate telemetry context from rest of the importer
-            _telemetry = new AnalyticsLogger(config.AppInsightsConnectionString, "Office365CallsImporter");
+            _logger = new AnalyticsLogger(config.AppInsightsConnectionString, "Office365CallsImporter");
 
-            _auth = new GraphAppIndentityOAuthContext(_telemetry, config.ClientID, config.TenantGUID.ToString(), config.ClientSecret, config.KeyVaultUrl, config.UseClientCertificate);
+            _auth = new GraphAppIndentityOAuthContext(_logger, config.ClientID, config.TenantGUID.ToString(), config.ClientSecret, config.KeyVaultUrl, config.UseClientCertificate);
             this._thisTenantId = thisTenantId;
 
             // Always authenticate to Service Bus with Entra ID RBAC (the runtime service principal) -
@@ -75,7 +75,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             // connection string's Endpoint, so existing installs keep their current config; the shared
             // access key in it is ignored. The runtime SP needs the "Azure Service Bus Data Owner" role
             // on the namespace (assigned by the installer). See issue #138.
-            _telemetry.LogInformation("Initializing ServiceBusClient using Entra ID RBAC (no SAS keys).");
+            _logger.LogInformation("Initializing ServiceBusClient using Entra ID RBAC (no SAS keys).");
             var sbProps = ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString);
             _sbClient = CreateRbacServiceBusClient(config);
             _processor = _sbClient.CreateProcessor(sbProps.EntityPath, new ServiceBusProcessorOptions
@@ -123,7 +123,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             // Use manual graph call client if provided (for testing), or create a new one if not
             if (manualGraphCallClient == null)
             {
-                _graphCallClient = new ManualGraphCallClient(_auth, _telemetry);
+                _graphCallClient = new ManualGraphCallClient(_auth, _logger);
             }
             else
             {
@@ -154,15 +154,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             await _processor.StartProcessingAsync();
             if (_processor.IsProcessing)
             {
-                _telemetry.LogInformation("ServiceBus client: Now listening for service-bus messages.");
+                _logger.LogInformation("ServiceBus client: Now listening for service-bus messages.");
             }
             else
             {
-                _telemetry.LogWarning("ServiceBus client: Not listening for service-bus messages?");
+                _logger.LogWarning("ServiceBus client: Not listening for service-bus messages?");
             }
         }
 
-        public static async Task AddChangeMsgToQueue(List<GraphChangeNotification> changes, ILogger telemetry, ServiceBusSender sbSender)
+        public static async Task AddChangeMsgToQueue(List<GraphChangeNotification> changes, ILogger logger, ServiceBusSender sbSender)
         {
             foreach (var change in changes)
             {
@@ -170,11 +170,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
 
                 if (!string.IsNullOrEmpty(callId))
                 {
-                    telemetry.LogInformation($"New call POSTed from Graph with ID '{callId}'");
+                    logger.LogInformation($"New call POSTed from Graph with ID '{callId}'");
                 }
                 else
                 {
-                    telemetry.LogInformation($"New call POSTed from Graph with unknown ID. Adding to service-bus queue anyway.");
+                    logger.LogInformation($"New call POSTed from Graph with unknown ID. Adding to service-bus queue anyway.");
                 }
 
                 var json = JsonConvert.SerializeObject(change);
@@ -189,7 +189,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         {
             string msgBody = args.Message.Body.ToString();
 
-            _telemetry.LogInformation($"New message received from ServiceBus with ID '{args.Message.MessageId}'.");
+            _logger.LogInformation($"New message received from ServiceBus with ID '{args.Message.MessageId}'.");
 
             GraphChangeNotification change = null;
             try
@@ -198,7 +198,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             }
             catch (Exception ex)
             {
-                _telemetry.LogError(ex, $"Error deserialising body '{msgBody}' from ServiceBus. Exception: {ex.Message}");
+                _logger.LogError(ex, $"Error deserialising body '{msgBody}' from ServiceBus. Exception: {ex.Message}");
             }
             if (change == null)
             {
@@ -217,7 +217,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                 }
                 catch (Exception ex)
                 {
-                    _telemetry.LogError(ex, $"ServiceBus processing error: processing call notification with msg body '{msgBody}'. Exception: {ex.Message}");
+                    _logger.LogError(ex, $"ServiceBus processing error: processing call notification with msg body '{msgBody}'. Exception: {ex.Message}");
                 }
             }
             if (success)
@@ -226,11 +226,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                 try
                 {
                     await args.CompleteMessageAsync(args.Message);
-                    _telemetry.LogInformation($"Succesfully processed & completed ServiceBus message ID '{args.Message.MessageId}'");
+                    _logger.LogInformation($"Succesfully processed & completed ServiceBus message ID '{args.Message.MessageId}'");
                 }
                 catch (ServiceBusException ex)
                 {
-                    _telemetry.LogError(ex, $"Couldn't complete ServiceBus message '{args.Message.MessageId}': " + ex.Message);
+                    _logger.LogError(ex, $"Couldn't complete ServiceBus message '{args.Message.MessageId}': " + ex.Message);
 #if DEBUG
                     throw;
 #endif
@@ -239,7 +239,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             else
             {
                 // Leave for processing later
-                _telemetry.LogInformation($"Abandoning ServiceBus message ID '{args.Message.MessageId}' as import was NOT succesful");
+                _logger.LogInformation($"Abandoning ServiceBus message ID '{args.Message.MessageId}' as import was NOT succesful");
                 await args.AbandonMessageAsync(args.Message);
             }
         }
@@ -252,7 +252,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             {
                 CallProcessed?.Invoke(this, EventArgs.Empty);
 
-                _telemetry.LogInformation($"Added call ID '{call.GraphCallID}' to database from ServiceBus.");
+                _logger.LogInformation($"Added call ID '{call.GraphCallID}' to database from ServiceBus.");
                 return true;
             }
             else
@@ -267,23 +267,23 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             string callId = change?.ResourceData.Id;
             if (string.IsNullOrEmpty(callId))
             {
-                _telemetry.LogInformation("ServiceBus error: couldn't find call ID in JSon. Ignoring event.");
+                _logger.LogInformation("ServiceBus error: couldn't find call ID in JSon. Ignoring event.");
                 return null;
             }
 
             CallRecordDTO callResponse = null;
             using (var db = new AnalyticsEntitiesContext())
             {
-                callResponse = await CallRecordDTO.LoadFromGraphByID(callId, _graphCallClient, _teamsLoadContext, this._telemetry, this._thisTenantId);
+                callResponse = await CallRecordDTO.LoadFromGraphByID(callId, _graphCallClient, _teamsLoadContext, this._logger, this._thisTenantId);
                 if (callResponse == null)
                 {
-                    _telemetry.LogWarning($"Could not load call record '{callId}' from Graph. Skipping.");
+                    _logger.LogWarning($"Could not load call record '{callId}' from Graph. Skipping.");
                     return null;
                 }
 
                 if (!string.IsNullOrEmpty(callResponse.OrganizerEmail))
                 {
-                    await callResponse.SaveOrReplaceCallRecord(new TeamsAndCallsDBLookupManager(db), _telemetry);
+                    await callResponse.SaveOrReplaceCallRecord(new TeamsAndCallsDBLookupManager(db), _logger);
                 }
             }
 
@@ -293,16 +293,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
 
         Task ExceptionReceivedHandler(ProcessErrorEventArgs args)
         {
-            _telemetry.LogError(args.Exception, args.Exception.Message);
+            _logger.LogError(args.Exception, args.Exception.Message);
             // Log the full exception (type + message + stack) as text too: the AppInsights ILogger
             // adapter formats only the message and drops the Exception argument above, so otherwise the
             // stack never reaches the trace logs (why a bare 401 showed up with "no exception logged").
-            _telemetry.LogError($"ServiceBus processor encountered an exception: {args.Exception}");
+            _logger.LogError($"ServiceBus processor encountered an exception: {args.Exception}");
 
-            _telemetry.LogError("Exception context for troubleshooting:");
-            _telemetry.LogError($"- Namespace: {args.FullyQualifiedNamespace}");
-            _telemetry.LogError($"- Entity Path: {args.EntityPath}");
-            _telemetry.LogError($"- Error Source: {Enum.GetName(typeof(ServiceBusErrorSource), args.ErrorSource)}");
+            _logger.LogError("Exception context for troubleshooting:");
+            _logger.LogError($"- Namespace: {args.FullyQualifiedNamespace}");
+            _logger.LogError($"- Entity Path: {args.EntityPath}");
+            _logger.LogError($"- Error Source: {Enum.GetName(typeof(ServiceBusErrorSource), args.ErrorSource)}");
             return Task.CompletedTask;
         }
 
@@ -321,7 +321,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             }
             catch (Exception ex)
             {
-                _telemetry?.LogError(ex, $"Error during {nameof(CallQueueProcessor)} dispose: {ex.Message}");
+                _logger?.LogError(ex, $"Error during {nameof(CallQueueProcessor)} dispose: {ex.Message}");
             }
             GC.SuppressFinalize(this);
         }
@@ -333,7 +333,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
             {
                 if (_processor.IsProcessing)
                 {
-                    _telemetry.LogInformation("ServiceBus client: Service-bus processor stopped.");
+                    _logger.LogInformation("ServiceBus client: Service-bus processor stopped.");
                     await _processor.StopProcessingAsync();
                 }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Identity;
+using Azure.Identity;
 using Common.Entities.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
@@ -20,14 +20,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         public GraphServiceClient Client { get; set; }
         public ILogger Telemetry { get; set; }
 
-        public CallWebhook(AppConfig o365DownloadSettings, ILogger telemetry)
-            : this(o365DownloadSettings?.TenantGUID.ToString(), o365DownloadSettings?.ClientID, o365DownloadSettings?.ClientSecret, telemetry) { }
+        public CallWebhook(AppConfig o365DownloadSettings, ILogger logger)
+            : this(o365DownloadSettings?.TenantGUID.ToString(), o365DownloadSettings?.ClientID, o365DownloadSettings?.ClientSecret, logger) { }
 
-        public CallWebhook(string tenantId, string clientId, string secret, ILogger telemetry)
+        public CallWebhook(string tenantId, string clientId, string secret, ILogger logger)
         {
             var cred = new ClientSecretCredential(tenantId, clientId, secret);
 
-            this.Telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            this.Telemetry = logger ?? throw new ArgumentNullException(nameof(logger));
             this.Client = new GraphServiceClient(cred);
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/DeltaValueProvider.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/DeltaValueProvider.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using Common.Entities.Redis;
 using DataUtils;
 using System.Threading.Tasks;
@@ -20,17 +20,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     public class InProcessDeltaValueProvider : IDeltaValueProvider
     {
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
         private string _deltaToken;
-        public InProcessDeltaValueProvider(DataUtils.AnalyticsLogger telemetry)
+        public InProcessDeltaValueProvider(DataUtils.AnalyticsLogger logger)
         {
-            _telemetry = telemetry;
+            _logger = logger;
         }
 
         public Task ClearDeltaToken()
         {
             _deltaToken = null;
-            _telemetry.LogWarning($"Cleared in-memory delta token for tenant.");
+            _logger.LogWarning($"Cleared in-memory delta token for tenant.");
             return Task.CompletedTask;
         }
 
@@ -38,18 +38,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         {
             if (string.IsNullOrEmpty(_deltaToken))
             {
-                _telemetry.LogWarning($"No in-memory delta token found.");
+                _logger.LogWarning($"No in-memory delta token found.");
             }
             else
             {
-                _telemetry.LogInformation($"In-memory delta token found.");
+                _logger.LogInformation($"In-memory delta token found.");
             }
             return Task.FromResult(_deltaToken);
         }
 
         public Task SetDeltaToken(string deltaToken)
         {
-            _telemetry.LogInformation($"Setting in-memory delta token.");
+            _logger.LogInformation($"Setting in-memory delta token.");
             _deltaToken = deltaToken;
             return Task.CompletedTask;
         }
@@ -62,20 +62,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     {
         private readonly CacheConnectionManager _cacheConnectionManager;
         private readonly AppConfig _appConfig;
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
 
-        public RedisProcessDeltaValueProvider(AppConfig appConfig, DataUtils.AnalyticsLogger telemetry)
+        public RedisProcessDeltaValueProvider(AppConfig appConfig, DataUtils.AnalyticsLogger logger)
         {
             _cacheConnectionManager = CacheConnectionManager.GetConnectionManager(appConfig.ConnectionStrings.RedisConnectionString, tenantId: appConfig.TenantGUID.ToString(), clientId: appConfig.ClientID, clientSecret: appConfig.ClientSecret);
             _appConfig = appConfig;
-            _telemetry = telemetry;
+            _logger = logger;
         }
 
         public async Task ClearDeltaToken()
         {
             var REDIS_USER_DELTA_KEY = GetRedisUserDeltaCacheKey();
             await _cacheConnectionManager.DeleteString(REDIS_USER_DELTA_KEY);
-            _telemetry.LogWarning($"Cleared delta token for tenant {_appConfig.TenantGUID}.");
+            _logger.LogWarning($"Cleared delta token for tenant {_appConfig.TenantGUID}.");
         }
 
         public async Task<string> GetDeltaToken()
@@ -84,11 +84,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             var usersQueryDelta = await _cacheConnectionManager.GetString(REDIS_USER_DELTA_KEY);
             if (string.IsNullOrEmpty(usersQueryDelta))
             {
-                _telemetry.LogWarning($"No delta token found for tenant {_appConfig.TenantGUID}.");
+                _logger.LogWarning($"No delta token found for tenant {_appConfig.TenantGUID}.");
             }
             else
             {
-                _telemetry.LogInformation($"Delta token found for tenant {_appConfig.TenantGUID}.");
+                _logger.LogInformation($"Delta token found for tenant {_appConfig.TenantGUID}.");
             }
             return usersQueryDelta;
         }
@@ -96,7 +96,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         public async Task SetDeltaToken(string deltaToken)
         {
             var REDIS_USER_DELTA_KEY = GetRedisUserDeltaCacheKey();
-            _telemetry.LogInformation($"Setting delta token for tenant {_appConfig.TenantGUID}.");
+            _logger.LogInformation($"Setting delta token for tenant {_appConfig.TenantGUID}.");
             await _cacheConnectionManager.SetString(REDIS_USER_DELTA_KEY, deltaToken);
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/GraphSentEmailSourceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/GraphSentEmailSourceLoader.cs
@@ -32,18 +32,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
         private readonly ManualGraphCallClient _httpClient;
         private readonly IDeltaTokenStore _deltaTokenStore;
         private readonly ImportAppIndentityOAuthContext _appIdentity;
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
 
         public GraphSentEmailSourceLoader(
             ManualGraphCallClient httpClient,
             IDeltaTokenStore deltaTokenStore,
             ImportAppIndentityOAuthContext appIdentity,
-            AnalyticsLogger telemetry)
+            AnalyticsLogger logger)
         {
             _httpClient = httpClient;
             _deltaTokenStore = deltaTokenStore;
             _appIdentity = appIdentity;
-            _telemetry = telemetry;
+            _logger = logger;
         }
 
         public async Task<bool> HasMailReadAccessAsync()
@@ -62,7 +62,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
             }
             catch (Exception ex)
             {
-                _telemetry.LogWarning($"Could not verify Mail.Read permission on access token: {ex.Message}. Assuming access is not granted.");
+                _logger.LogWarning($"Could not verify Mail.Read permission on access token: {ex.Message}. Assuming access is not granted.");
                 return false;
             }
         }
@@ -77,7 +77,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
             var url = BuildDeltaUrl(user, deltaToken, includeBody);
 
             var messages = await _httpClient.LoadAllPagesPlusDeltaWithThrottleRetries<GraphSentMessage>(
-                url, _telemetry,
+                url, _logger,
                 async (deltaLink) =>
                 {
                     var thisPageDelta = StringUtils.ExtractCodeFromGraphUrl(deltaLink);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailImporter.cs
@@ -51,14 +51,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
         private int _deltaTokenWrites;
 
         public SentEmailImporter(
-            AnalyticsLogger telemetry,
+            AnalyticsLogger logger,
             AppConfig settings,
             ISentEmailSourceLoader sourceLoader,
             ISentEmailSentimentScorer sentimentScorer,
             Func<AnalyticsEntitiesContext> dbContextFactory = null,
             int userChunkSize = DefaultUserChunkSize,
             int graphLoadParallelism = DefaultGraphLoadParallelism)
-            : base(telemetry, settings)
+            : base(logger, settings)
         {
             _sourceLoader = sourceLoader ?? throw new ArgumentNullException(nameof(sourceLoader));
             _sentimentScorer = sentimentScorer ?? NullSentEmailSentimentScorer.Instance;
@@ -72,27 +72,27 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
         /// default Azure AI Language sentiment scorer (or a no-op when not configured).
         /// </summary>
         public SentEmailImporter(
-            AnalyticsLogger telemetry,
+            AnalyticsLogger logger,
             AppConfig settings,
             ManualGraphCallClient httpClient,
             IDeltaTokenStore deltaTokenStore,
             DataUtils.Http.ImportAppIndentityOAuthContext appIdentity)
             : this(
-                telemetry,
+                logger,
                 settings,
-                new GraphSentEmailSourceLoader(httpClient, deltaTokenStore, appIdentity, telemetry),
-                SentEmailSentimentScorerFactory.Create(settings, telemetry))
+                new GraphSentEmailSourceLoader(httpClient, deltaTokenStore, appIdentity, logger),
+                SentEmailSentimentScorerFactory.Create(settings, logger))
         {
         }
 
         public async Task ImportSentEmails()
         {
-            _telemetry.LogInformation("Starting sent emails import...");
+            _logger.LogInformation("Starting sent emails import...");
             var swTotal = Stopwatch.StartNew();
 
             if (!await _sourceLoader.HasMailReadAccessAsync())
             {
-                _telemetry.LogWarning(
+                _logger.LogWarning(
                     "Skipping sent emails import: the configured identity does not have Mail.Read permission. " +
                     "Grant Mail.Read (application) to the app registration to enable this import.");
                 return;
@@ -101,11 +101,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
             var users = await LoadUsersWithMailAsync();
             if (users.Count == 0)
             {
-                _telemetry.LogWarning("No users found with email addresses to scan for sent items.");
+                _logger.LogWarning("No users found with email addresses to scan for sent items.");
                 return;
             }
 
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"Found {users.Count} users with email addresses to scan for sent items. " +
                 $"Processing in chunks of {_userChunkSize} (Graph load parallelism: {_graphLoadParallelism}; " +
                 $"persistence uses single-connection multi-row SQL inserts to avoid unique-index deadlocks).");
@@ -116,7 +116,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                 // prior element, so chunking N users in slices of K costs O(N^2/K). At
                 // 200k users with K=25 that's ~800M wasted iterations just for slicing.
                 var chunk = users.GetRange(i, Math.Min(_userChunkSize, users.Count - i));
-                _telemetry.LogInformation(
+                _logger.LogInformation(
                     $"Processing user chunk {(i / _userChunkSize) + 1} of " +
                     $"{(users.Count + _userChunkSize - 1) / _userChunkSize} ({chunk.Count} users).");
 
@@ -155,7 +155,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
             var swPhase = Stopwatch.StartNew();
             var loaded = await LoadChunkInParallelAsync(users);
             swPhase.Stop();
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"  [chunk] graph load: {users.Count} users -> {loaded.Count} loaded in {swPhase.ElapsedMilliseconds}ms.");
             if (loaded.Count == 0)
                 return;
@@ -188,7 +188,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                 return;
 
             int totalCandidates = perUser.Sum(u => u.Candidates.Count);
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"  [chunk] built {totalCandidates} candidate messages across {perUser.Count} users; " +
                 $"distinct addresses: {allDistinctAddresses.Count}.");
 
@@ -204,7 +204,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                 addressIds = await BulkResolveAddressIdsAsync(db, allDistinctAddresses);
             }
             swPhase.Stop();
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"  [chunk] resolved {addressIds.Count} address ids in {swPhase.ElapsedMilliseconds}ms.");
 
             // ---- 3. Bulk existing-key check across the chunk ---------------------------
@@ -221,7 +221,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                 existingKeys = await FindExistingKeysAsync(db, allKeys);
             }
             swPhase.Stop();
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"  [chunk] existing-key check: {allKeys.Count} keys, {existingKeys.Count} already present, " +
                 $"in {swPhase.ElapsedMilliseconds}ms.");
 
@@ -240,12 +240,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
 
             // ---- 5. Single-connection persistence of SentEmail + recipient rows -------
             swPhase.Restart();
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"  [chunk] persisting {totalToInsert} new messages across {perUser.Count} users " +
                 "(serial multi-row INSERTs on one connection to avoid unique-index races)...");
             await PersistChunkAsync(perUser, addressIds, sentimentByMessageId);
             swPhase.Stop();
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"  [chunk] persistence done in {swPhase.ElapsedMilliseconds}ms.");
         }
 
@@ -269,13 +269,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                     catch (System.Net.Http.HttpRequestException ex)
                     {
                         Interlocked.Increment(ref _mailboxesFailed);
-                        _telemetry.LogWarning(
+                        _logger.LogWarning(
                             $"Could not access sent items for user '{user.UserPrincipalName}': {ex.Message}");
                     }
                     catch (Exception ex)
                     {
                         Interlocked.Increment(ref _mailboxesFailed);
-                        _telemetry.LogError(ex,
+                        _logger.LogError(ex,
                             $"Error loading sent emails for user '{user.UserPrincipalName}': {ex.Message}");
                     }
                     finally
@@ -371,14 +371,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                     }
                     catch (Exception ex)
                     {
-                        _telemetry.LogError(ex,
+                        _logger.LogError(ex,
                             $"  [persist] phase A failed at batch starting {i} (size {take}): {ex.GetBaseException().Message}");
                         throw;
                     }
 
                     parentsSaved += take;
                     Interlocked.Add(ref _messagesInserted, take);
-                    _telemetry.LogInformation(
+                    _logger.LogInformation(
                         $"  [persist] phase A: saved {parentsSaved}/{work.Count} parent rows " +
                         $"({swA.ElapsedMilliseconds}ms elapsed).");
                 }
@@ -411,20 +411,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                     }
                     catch (Exception ex)
                     {
-                        _telemetry.LogError(ex,
+                        _logger.LogError(ex,
                             $"  [persist] phase B failed at batch starting {i} (size {take}): {ex.GetBaseException().Message}");
                         throw;
                     }
 
                     recipientsSaved += take;
                     Interlocked.Add(ref _recipientsInserted, take);
-                    _telemetry.LogInformation(
+                    _logger.LogInformation(
                         $"  [persist] phase B: saved {recipientsSaved}/{totalRecipients} recipient rows " +
                         $"({swB.ElapsedMilliseconds}ms elapsed).");
                 }
                 swB.Stop();
 
-                _telemetry.LogInformation(
+                _logger.LogInformation(
                     $"  [persist] phase A: {parentsSaved} parents in {swA.ElapsedMilliseconds}ms; " +
                     $"phase B: {recipientsSaved} recipients in {swB.ElapsedMilliseconds}ms.");
             }
@@ -576,7 +576,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
 
         private void LogRunSummary(TimeSpan elapsed)
         {
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"Finished sent emails import in {elapsed:hh\\:mm\\:ss}. " +
                 $"Mailboxes scanned: {_mailboxesScanned} (failed: {_mailboxesFailed}). " +
                 $"Messages seen: {_messagesSeen}. Messages inserted: {_messagesInserted} " +

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailSentimentScorer.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailSentimentScorer.cs
@@ -23,12 +23,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
             new Regex("<[^>]+>", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         private readonly CognitiveServicesClient _client;
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
 
-        public AzureLanguageSentEmailSentimentScorer(CognitiveServicesClient client, AnalyticsLogger telemetry)
+        public AzureLanguageSentEmailSentimentScorer(CognitiveServicesClient client, AnalyticsLogger logger)
         {
             _client = client;
-            _telemetry = telemetry;
+            _logger = logger;
         }
 
         public bool IsEnabled => _client != null;
@@ -80,7 +80,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                     // Log the full error (with stack trace) but continue: sentiment is best-effort, so
                     // a failed batch must never fail the whole email import - the affected messages just
                     // get no score and the rest of the run proceeds.
-                    _telemetry.LogError(ex, $"Cognitive batch sentiment analysis failed for {docs.Count} message(s); continuing without scores for this batch.");
+                    _logger.LogError(ex, $"Cognitive batch sentiment analysis failed for {docs.Count} message(s); continuing without scores for this batch.");
                 }
             }
 
@@ -104,18 +104,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
     /// </summary>
     internal static class SentEmailSentimentScorerFactory
     {
-        public static ISentEmailSentimentScorer Create(AppConfig settings, AnalyticsLogger telemetry)
+        public static ISentEmailSentimentScorer Create(AppConfig settings, AnalyticsLogger logger)
         {
             if (settings == null || !settings.IsValidCognitiveConfig)
                 return NullSentEmailSentimentScorer.Instance;
 
             // Single CognitiveServicesClient per importer run: caches its inner TextAnalyticsClient
             // and auto-falls back to RBAC if the key auth call returns 403 AuthenticationTypeDisabled.
-            var client = settings.CreateCognitiveServicesClient(telemetry);
+            var client = settings.CreateCognitiveServicesClient(logger);
             if (client == null)
                 return NullSentEmailSentimentScorer.Instance;
 
-            return new AzureLanguageSentEmailSentimentScorer(client, telemetry);
+            return new AzureLanguageSentEmailSentimentScorer(client, logger);
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.ActivityReports;
 using Common.Entities.Config;
 using DataUtils;
@@ -27,8 +27,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         private readonly GraphAppIndentityOAuthContext _graphAppIndentityOAuthContext;
         private readonly GraphServiceClient _graphClient;
 
-        public GraphImporter(AnalyticsLogger telemetry, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings)
-            : base(telemetry, settings)
+        public GraphImporter(AnalyticsLogger logger, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings)
+            : base(logger, settings)
         {
             _userGroupsCache = userGroupsCache;
             _graphAppIndentityOAuthContext = graphAppIndentityOAuthContext;
@@ -41,25 +41,25 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// </summary>
         public async Task GetAndSaveAllGraphData(AppConfig settings)
         {
-            var httpClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _telemetry);
+            var httpClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _logger);
             var userGroupsFilter = new UserGroupsFilterModel(_settings.UserGroupsFilter);
 
-            var graphUserGroupsCache = new GraphUserGroupsCache(httpClient, _telemetry);
+            var graphUserGroupsCache = new GraphUserGroupsCache(httpClient, _logger);
 
             if (settings.ImportJobSettings.GraphUsersMetadata)
             {
-                var userMetadaTimer = new JobTimer(_telemetry, "User metadata refresh");
+                var userMetadaTimer = new JobTimer(_logger, "User metadata refresh");
                 userMetadaTimer.Start();
 
                 // Update Graph users first
-                var userUpdater = new UserMetadataUpdater(_telemetry, _settings, _graphAppIndentityOAuthContext.Creds, httpClient);
+                var userUpdater = new UserMetadataUpdater(_logger, _settings, _graphAppIndentityOAuthContext.Creds, httpClient);
                 await userUpdater.InsertAndUpdateDatabaseFromExternalUsers();
 
                 // Track finished event 
                 userMetadaTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
             }
             else
-                _telemetry.LogInformation("Skipping user metadata import", graphUserGroupsCache);
+                _logger.LogInformation("Skipping user metadata import", graphUserGroupsCache);
 
 
             using (var db = new AnalyticsEntitiesContext())
@@ -67,9 +67,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 // Process Teams data
                 if (settings.ImportJobSettings.GraphUserApps)
                 {
-                    var userAppsTimer = new JobTimer(_telemetry, "User Teams apps refresh");
+                    var userAppsTimer = new JobTimer(_logger, "User Teams apps refresh");
                     userAppsTimer.Start();
-                    var userAppsLogUpdater = new UserAppLogUpdater(_telemetry, _settings);
+                    var userAppsLogUpdater = new UserAppLogUpdater(_logger, _settings);
 
                     await userAppsLogUpdater.UpdateUserInstalledApps(_graphClient, graphUserGroupsCache, userGroupsFilter);
 
@@ -77,12 +77,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     userAppsTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
                 }
                 else
-                    _telemetry.LogInformation("Skipping user Teams apps import", graphUserGroupsCache);
+                    _logger.LogInformation("Skipping user Teams apps import", graphUserGroupsCache);
 
 
                 if (settings.ImportJobSettings.GraphUsageReports)
                 {
-                    var usageActivityTimer = new JobTimer(_telemetry, "Usage reports");
+                    var usageActivityTimer = new JobTimer(_logger, "Usage reports");
                     usageActivityTimer.Start();
 
                     // Global user activity report. Each thread creates own context.
@@ -95,14 +95,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     }
                 }
                 else
-                    _telemetry.LogInformation("Skipping usage reports import", graphUserGroupsCache);
+                    _logger.LogInformation("Skipping usage reports import", graphUserGroupsCache);
 
                 if (settings.ImportJobSettings.GraphTeams)
                 {
-                    var teamsTimer = new JobTimer(_telemetry, "Teams import");
+                    var teamsTimer = new JobTimer(_logger, "Teams import");
                     teamsTimer.Start();
 
-                    var teamsImporter = new TeamsImporter(_telemetry, _settings, _graphClient);
+                    var teamsImporter = new TeamsImporter(_logger, _settings, _graphClient);
 
                     var teamsConfig = await TeamsCrawlConfig.LoadFromDb(db);
                     await teamsImporter.RefreshAndSaveAllTeamsData(teamsConfig);
@@ -111,11 +111,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     teamsTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
                 }
                 else
-                    _telemetry.LogInformation("Skipping Teams import", graphUserGroupsCache);
+                    _logger.LogInformation("Skipping Teams import", graphUserGroupsCache);
 
                 if (settings.ImportJobSettings.SentEmails)
                 {
-                    var sentEmailsTimer = new JobTimer(_telemetry, "Sent emails import");
+                    var sentEmailsTimer = new JobTimer(_logger, "Sent emails import");
                     sentEmailsTimer.Start();
 
                     IDeltaTokenStore deltaTokenStore;
@@ -128,13 +128,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                         deltaTokenStore = new InMemoryDeltaTokenStore();
                     }
 
-                    var sentEmailImporter = new SentEmailImporter(_telemetry, _settings, httpClient, deltaTokenStore, _graphAppIndentityOAuthContext);
+                    var sentEmailImporter = new SentEmailImporter(_logger, _settings, httpClient, deltaTokenStore, _graphAppIndentityOAuthContext);
                     await sentEmailImporter.ImportSentEmails();
 
                     sentEmailsTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
                 }
                 else
-                    _telemetry.LogInformation("Skipping sent emails import", graphUserGroupsCache);
+                    _logger.LogInformation("Skipping sent emails import", graphUserGroupsCache);
 
             }
         }
@@ -164,18 +164,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             else
             {
-                _telemetry.LogWarning("No Redis connection string - cannot find last date for imported for activity reports.");
+                _logger.LogWarning("No Redis connection string - cannot find last date for imported for activity reports.");
             }
 
             var runImport = (lastImportedDate == null || DateTime.Now.Subtract(lastImportedDate.Value) > MIN_WAIT);
             if (_settings.ForceUsageReportsImport)
             {
-                _telemetry.LogInformation("ForceUsageReportsImport=true; bypassing recently-imported gate.");
+                _logger.LogInformation("ForceUsageReportsImport=true; bypassing recently-imported gate.");
                 runImport = true;
             }
             if (runImport)
             {
-                _telemetry.LogInformation($"Reading all activity reports from {daysBackMax} days back...");
+                _logger.LogInformation($"Reading all activity reports from {daysBackMax} days back...");
 
                 // Parallel-load all, each one with own DB context
                 var importTasks = new List<Task>();
@@ -183,40 +183,40 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 var lookupIdCache = new ConcurrentLookupDbIdsCache();
 
                 // Daily imports
-                var teamsUserUsageLoader = new TeamsUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserUsageLoader, daysBackMax, "Teams user activity", _telemetry, lookupIdCache));
+                var teamsUserUsageLoader = new TeamsUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserUsageLoader, daysBackMax, "Teams user activity", _logger, lookupIdCache));
 
-                var teamsUserDeviceLoader = new TeamsUserDeviceLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserDeviceLoader, daysBackMax, "Teams user device", _telemetry, lookupIdCache));
+                var teamsUserDeviceLoader = new TeamsUserDeviceLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserDeviceLoader, daysBackMax, "Teams user device", _logger, lookupIdCache));
 
-                var outlookLoader = new OutlookUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(outlookLoader, daysBackMax, "Outlook activity", _telemetry, lookupIdCache));
+                var outlookLoader = new OutlookUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(outlookLoader, daysBackMax, "Outlook activity", _logger, lookupIdCache));
 
-                var oneDriveUsageLoader = new OneDriveUsageLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUsageLoader, daysBackMax, "OneDrive usage", _telemetry, lookupIdCache));
+                var oneDriveUsageLoader = new OneDriveUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUsageLoader, daysBackMax, "OneDrive usage", _logger, lookupIdCache));
 
-                var oneDriveUserActivityLoader = new OneDriveUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUserActivityLoader, daysBackMax, "OneDrive activity", _telemetry, lookupIdCache));
+                var oneDriveUserActivityLoader = new OneDriveUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUserActivityLoader, daysBackMax, "OneDrive activity", _logger, lookupIdCache));
 
-                var sharePointUserActivityLoader = new SharePointUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(sharePointUserActivityLoader, daysBackMax, "SharePoint user activity", _telemetry, lookupIdCache));
+                var sharePointUserActivityLoader = new SharePointUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(sharePointUserActivityLoader, daysBackMax, "SharePoint user activity", _logger, lookupIdCache));
 
-                var yammerUserActivityLoader = new YammerUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerUserActivityLoader, daysBackMax, "Yammer user activity", _telemetry, lookupIdCache));
+                var yammerUserActivityLoader = new YammerUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(yammerUserActivityLoader, daysBackMax, "Yammer user activity", _logger, lookupIdCache));
 
-                var yammerGroupsActivityLoader = new YammerGroupUsageLoader(client, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerGroupsActivityLoader, daysBackMax, "Yammer group activity", _telemetry, lookupIdCache));
+                var yammerGroupsActivityLoader = new YammerGroupUsageLoader(client, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(yammerGroupsActivityLoader, daysBackMax, "Yammer group activity", _logger, lookupIdCache));
 
-                var yammerDeviceActivityLoader = new YammerDeviceUsageLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerDeviceActivityLoader, daysBackMax, "Yammer device activity", _telemetry, lookupIdCache));
+                var yammerDeviceActivityLoader = new YammerDeviceUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(yammerDeviceActivityLoader, daysBackMax, "Yammer device activity", _logger, lookupIdCache));
 
-                var userPlatActivityLoader = new AppPlatformUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _telemetry);
-                importTasks.Add(LoadAndSaveDailyImportReport(userPlatActivityLoader, daysBackMax, "Apps & platform activity", _telemetry, lookupIdCache));
+                var userPlatActivityLoader = new AppPlatformUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
+                importTasks.Add(LoadAndSaveDailyImportReport(userPlatActivityLoader, daysBackMax, "Apps & platform activity", _logger, lookupIdCache));
 
                 // Weekly imports
                 using (var db = new AnalyticsEntitiesContext())
                 {
-                    var sharePointSitesWeeklyUsageReportLoader = new SharePointSitesWeeklyUsageReportLoader(db, client, _telemetry, new GraphSPSiteIdToUrlCache(_graphClient, db, _telemetry));
+                    var sharePointSitesWeeklyUsageReportLoader = new SharePointSitesWeeklyUsageReportLoader(db, client, _logger, new GraphSPSiteIdToUrlCache(_graphClient, db, _logger));
 
                     importTasks.Add(sharePointSitesWeeklyUsageReportLoader.LoadAndSaveLastWeeksReportsIfRefreshOnDay(System.DayOfWeek.Sunday));
                     await Task.WhenAll(importTasks);
@@ -228,7 +228,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 {
                     if (!StringUtils.IsEmail(allTeamsData[0].UserPrincipalName))
                     {
-                        _telemetry.LogError($"IMPORTANT: Usage reports have associated user email concealed - we won't be able to link any activity back to users. See Office 365 Advanced Analytics Engine prerequisites.\n");
+                        _logger.LogError($"IMPORTANT: Usage reports have associated user email concealed - we won't be able to link any activity back to users. See Office 365 Advanced Analytics Engine prerequisites.\n");
                     }
                 }
 
@@ -238,12 +238,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     await lastImportedDateLoader.SaveDT();
                 }
 
-                _telemetry.LogInformation($"Activity reports imported. Will run again in {MIN_WAIT.TotalHours} hours");
+                _logger.LogInformation($"Activity reports imported. Will run again in {MIN_WAIT.TotalHours} hours");
                 return true;
             }
             else
             {
-                _telemetry.LogInformation($"Skipping activity reports as have processed recently (less than {MIN_WAIT.TotalHours} hours ago). " +
+                _logger.LogInformation($"Skipping activity reports as have processed recently (less than {MIN_WAIT.TotalHours} hours ago). " +
                     $"Will import again after {lastImportedDate.Value.Add(MIN_WAIT)}.");
                 return false;
             }
@@ -251,23 +251,23 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
         async Task<int> LoadAndSaveDailyImportReport<TReportDbType, TUserActivityUserDetail, TLookupType, CACHETYPE>
             (AbstractDailyActivityLoader<TReportDbType, TUserActivityUserDetail, TLookupType, CACHETYPE> abstractActivityLoader,
-            int daysBackMax, string thingWeAreImporting, ILogger telemetry, ConcurrentLookupDbIdsCache userEmailToDbIdCache)
+            int daysBackMax, string thingWeAreImporting, ILogger logger, ConcurrentLookupDbIdsCache userEmailToDbIdCache)
             where TReportDbType : AbstractUsageActivityLog, new()
             where TUserActivityUserDetail : AbstractActivityRecord<TLookupType>
             where TLookupType : AbstractEFEntity
             where CACHETYPE : DBLookupCache<TLookupType>
         {
-            telemetry.LogInformation($"Importing {thingWeAreImporting} reports...");
+            logger.LogInformation($"Importing {thingWeAreImporting} reports...");
             await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax);
 
             using (var db = new AnalyticsEntitiesContext())
             {
-                _telemetry.LogInformation($"{this.GetType().Name} read {abstractActivityLoader.LoadedReportPages.SelectMany(p => p.Value).Count().ToString("N0")} {thingWeAreImporting} records from Graph API");
+                _logger.LogInformation($"{this.GetType().Name} read {abstractActivityLoader.LoadedReportPages.SelectMany(p => p.Value).Count().ToString("N0")} {thingWeAreImporting} records from Graph API");
                 await abstractActivityLoader.SaveLoadedReportsToSql(userEmailToDbIdCache, DBLookupCache<TLookupType>.Create<CACHETYPE>(db));
             }
 
             var total = abstractActivityLoader.LoadedReportPages.SelectMany(r => r.Value).Count();
-            telemetry.LogInformation($"Imported {total.ToString("N0")} {thingWeAreImporting} reports.");
+            logger.LogInformation($"Imported {total.ToString("N0")} {thingWeAreImporting} reports.");
 
             return total;
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/ManualGraphCallClient.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/ManualGraphCallClient.cs
@@ -1,4 +1,4 @@
-﻿using DataUtils.Http;
+using DataUtils.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
@@ -14,10 +14,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     {
         #region Constructors
 
-        public ManualGraphCallClient(HttpMessageHandler server, ILogger debugTracer) : base(server, debugTracer)
+        public ManualGraphCallClient(HttpMessageHandler server, ILogger logger) : base(server, logger)
         {
         }
-        public ManualGraphCallClient(ImportAppIndentityOAuthContext appIndentity, ILogger debugTracer) : base(appIndentity, false, debugTracer)
+        public ManualGraphCallClient(ImportAppIndentityOAuthContext appIndentity, ILogger logger) : base(appIndentity, false, logger)
         {
         }
         #endregion

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/PageableGraphLoaderExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/PageableGraphLoaderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -7,21 +7,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
     public static class PageableGraphLoaderExtensions
     {
-        public static async Task<List<T>> LoadAllPagesWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger debugTracer)
+        public static async Task<List<T>> LoadAllPagesWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger logger)
         {
-            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, debugTracer, null);
+            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, logger, null);
 
             return results;
         }
 
-        public static async Task<List<T>> LoadAllPagesPlusDeltaWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger debugTracer, Func<string, Task> deltaTokenFunc)
+        public static async Task<List<T>> LoadAllPagesPlusDeltaWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger logger, Func<string, Task> deltaTokenFunc)
         {
-            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, debugTracer, deltaTokenFunc);
+            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, logger, deltaTokenFunc);
 
             return results;
         }
 
-        static async Task<List<T>> LoadPageableGraphResponseAllWithOptionalDelta<T>(ManualGraphCallClient client, string url, ILogger debugTracer, Func<string, Task> deltaTokenFunc)
+        static async Task<List<T>> LoadPageableGraphResponseAllWithOptionalDelta<T>(ManualGraphCallClient client, string url, ILogger logger, Func<string, Task> deltaTokenFunc)
         {
             var allResults = new List<T>();
 
@@ -41,17 +41,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 catch (System.Net.Http.HttpRequestException ex)
                 {
                     pageSuccess = false;
-                    debugTracer.LogError(ex, $"Got unexpected HTTP exception on page {pageCount}: {ex.Message}.");
+                    logger.LogError(ex, $"Got unexpected HTTP exception on page {pageCount}: {ex.Message}.");
 
                     // Transient error?
                     if (ex.Message != null && ex.Message.ToLower().Contains("gateway timeout"))
                     {
-                        debugTracer.LogInformation($"Got gateway timeout. Will retry page.");
+                        logger.LogInformation($"Got gateway timeout. Will retry page.");
                         await Task.Delay(1000);
                     }
                     else
                     {
-                        debugTracer.LogError(ex, $"Unexpected HTTP error. Will not retry page & returning results upto current page.");
+                        logger.LogError(ex, $"Unexpected HTTP error. Will not retry page & returning results upto current page.");
                         nextUrl = null;
                     }
                 }
@@ -63,7 +63,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     if (nextUrl != null)
                     {
                         pageCount++;
-                        debugTracer.LogInformation($"Loading {typeof(T).Name} results page #{pageCount}...");
+                        logger.LogInformation($"Loading {typeof(T).Name} results page #{pageCount}...");
                     }
                     else
                     {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
@@ -18,7 +18,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     public class GraphSPSiteIdToUrlCache : SPSiteIdToUrlCache
     {
         private readonly GraphServiceClient _graphServiceClient;
-        public GraphSPSiteIdToUrlCache(GraphServiceClient graphServiceClient, AnalyticsEntitiesContext db, ILogger debugTracer) : base(db, debugTracer)
+        public GraphSPSiteIdToUrlCache(GraphServiceClient graphServiceClient, AnalyticsEntitiesContext db, ILogger logger) : base(db, logger)
         {
             _graphServiceClient = graphServiceClient;
         }
@@ -37,12 +37,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     public abstract class SPSiteIdToUrlCache : ObjectByIdCache<SPSiteIdToUrl>
     {
         private readonly AnalyticsEntitiesContext _db;
-        private readonly ILogger _debugTracer;
+        private readonly ILogger _logger;
 
-        public SPSiteIdToUrlCache(AnalyticsEntitiesContext db, ILogger debugTracer)
+        public SPSiteIdToUrlCache(AnalyticsEntitiesContext db, ILogger logger)
         {
             _db = db;
-            _debugTracer = debugTracer;
+            _logger = logger;
         }
 
         public abstract Task<Microsoft.Graph.Models.Site> LoadSite(string id);
@@ -62,7 +62,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     };
                 }
                 var site = await LoadSite(id);
-                _debugTracer.LogInformation($"{nameof(SPSiteIdToUrlCache)}: Loaded site URL for {id}");
+                _logger.LogInformation($"{nameof(SPSiteIdToUrlCache)}: Loaded site URL for {id}");
 
                 // Cache in DB
                 var dbRecordBySiteUrl = await _db.sites.Where(s => s.UrlBase.ToLower() == site.WebUrl.ToLower()).SingleOrDefaultAsync();
@@ -89,13 +89,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             catch (ODataError ex) when (ex.ResponseStatusCode == (int)HttpStatusCode.NotFound)
             {
-                _debugTracer.LogWarning($"{nameof(SPSiteIdToUrlCache)}: Site with ID '{id}' not found");
+                _logger.LogWarning($"{nameof(SPSiteIdToUrlCache)}: Site with ID '{id}' not found");
 
                 return null;
             }
             catch (Exception ex)
             {
-                _debugTracer.LogError(ex, $"{nameof(SPSiteIdToUrlCache)}: Error loading site URL for {id}: {ex.Message}");
+                _logger.LogError(ex, $"{nameof(SPSiteIdToUrlCache)}: Error loading site URL for {id}: {ex.Message}");
                 return null;
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelMessagesLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelMessagesLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Redis;
+using Common.Entities.Redis;
 using Common.Entities.Redis.Teams;
 using DataUtils;
 using Microsoft.Extensions.Logging;
@@ -25,13 +25,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
         private readonly GraphServiceClient _client;
         private readonly CacheConnectionManager _cacheConnectionManager;
-        private readonly ILogger _telemetry;
+        private readonly ILogger _logger;
 
-        public ChannelMessagesLoader(GraphServiceClient client, CacheConnectionManager cacheConnectionManager, ILogger telemetry)
+        public ChannelMessagesLoader(GraphServiceClient client, CacheConnectionManager cacheConnectionManager, ILogger logger)
         {
             this._client = client;
             this._cacheConnectionManager = cacheConnectionManager;
-            this._telemetry = telemetry;
+            this._logger = logger;
         }
 
         /// <summary>
@@ -65,8 +65,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             {
                 if (ex.Error?.Code == "BadRequest" && channelDeltaInfo != null)
                 {
-                    await _cacheConnectionManager.RemoveTeamChannelDeltaToken(teamId, channel.Id, _telemetry);
-                    _telemetry.LogError(ex, $"Got bad request using delta token for messages. Removing from cache & will try full read next time.");
+                    await _cacheConnectionManager.RemoveTeamChannelDeltaToken(teamId, channel.Id, _logger);
+                    _logger.LogError(ex, $"Got bad request using delta token for messages. Removing from cache & will try full read next time.");
                 }
                 else throw;
             }
@@ -86,7 +86,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
                 if (iterator.State == PagingState.Paused)
                 {
-                    _telemetry.LogWarning($"Channel '{channel.DisplayName}' on Team '{teamId}': hit MAX_MESSAGES_PER_CHANNEL ({MAX_MESSAGES_PER_CHANNEL:N0}). Returning partial set of {rootMsgs.Count:N0} root messages.");
+                    _logger.LogWarning($"Channel '{channel.DisplayName}' on Team '{teamId}': hit MAX_MESSAGES_PER_CHANNEL ({MAX_MESSAGES_PER_CHANNEL:N0}). Returning partial set of {rootMsgs.Count:N0} root messages.");
                 }
 
                 if (!string.IsNullOrEmpty(iterator.Deltalink))
@@ -108,15 +108,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (channelDeltaInfo != null)
             {
-                _telemetry.LogInformation($"Loaded channel messages with last delta token for channel '{channel.DisplayName}' on Team '{teamId}'...");
+                _logger.LogInformation($"Loaded channel messages with last delta token for channel '{channel.DisplayName}' on Team '{teamId}'...");
             }
             else
             {
-                _telemetry.LogInformation($"Loaded channel messages (all) for channel '{channel.DisplayName}' on Team '{teamId}'...");
+                _logger.LogInformation($"Loaded channel messages (all) for channel '{channel.DisplayName}' on Team '{teamId}'...");
             }
 
             // Set new msg & reaction data on channel
-            channel.CalculateAndSetNewMessagesAndReactions(rootMsgs, channelDeltaInfo?.LastUpdated, _telemetry);
+            channel.CalculateAndSetNewMessagesAndReactions(rootMsgs, channelDeltaInfo?.LastUpdated, _logger);
 
             return newDelta;
         }
@@ -144,7 +144,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (iterator.State == PagingState.Paused)
             {
-                _telemetry.LogWarning($"Channel {channelId} msg {messageId}: hit MAX_REPLIES_PER_MESSAGE ({MAX_REPLIES_PER_MESSAGE:N0}). Returning partial reply list of {allReplies.Count:N0}.");
+                _logger.LogWarning($"Channel {channelId} msg {messageId}: hit MAX_REPLIES_PER_MESSAGE ({MAX_REPLIES_PER_MESSAGE:N0}). Returning partial reply list of {allReplies.Count:N0}.");
             }
 
             return allReplies;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/ChatMessageListExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/ChatMessageListExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using System;
@@ -14,7 +14,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// <summary>
         /// Generates stats where there aren't any already
         /// </summary>
-        public static async Task<List<MessageCognitiveStats>> GetMessagesStats(this List<ChannelWithReactions> channels, ILogger telemetry)
+        public static async Task<List<MessageCognitiveStats>> GetMessagesStats(this List<ChannelWithReactions> channels, ILogger logger)
         {
             var allStats = new List<MessageCognitiveStats>();
             if (channels is null)
@@ -24,7 +24,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             foreach (var channel in channels)
             {
-                var channelStats = await channel.Messages.GetCognitiveDataStats(telemetry, channel);
+                var channelStats = await channel.Messages.GetCognitiveDataStats(logger, channel);
                 allStats.AddRange(channelStats);
             }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Azure;
+using Azure;
 using Azure.AI.TextAnalytics;
 using Common.Entities;
 using Common.Entities.Config;
@@ -30,14 +30,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         private static CognitiveServicesClient _cachedCognitiveClient;
         private static bool _cognitiveClientBuilt;
 
-        private static CognitiveServicesClient GetOrBuildCognitiveClient(AppConfig cognitiveConfig, ILogger telemetry)
+        private static CognitiveServicesClient GetOrBuildCognitiveClient(AppConfig cognitiveConfig, ILogger logger)
         {
             if (_cognitiveClientBuilt) return _cachedCognitiveClient;
             lock (_cognitiveClientLock)
             {
                 if (!_cognitiveClientBuilt)
                 {
-                    _cachedCognitiveClient = cognitiveConfig.CreateCognitiveServicesClient(telemetry);
+                    _cachedCognitiveClient = cognitiveConfig.CreateCognitiveServicesClient(logger);
                     _cognitiveClientBuilt = true;
                 }
                 return _cachedCognitiveClient;
@@ -47,18 +47,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// Sets the "Messages" prop on each channel by reading each channel messages.
         /// </summary>
         public static async Task PopulateNewMessagesAndReactions(this List<ChannelWithReactions> channels, Team team, RefreshOAuthToken refreshToken,
-            CacheConnectionManager cacheConnectionManager, ILogger telemetry)
+            CacheConnectionManager cacheConnectionManager, ILogger logger)
         {
 
             foreach (var channel in channels)
             {
                 // Load stats. Will throw ChannelMessagesReadException if token is invalid
-                var channelDelta = await channel.GetChannelMessagesAndReactions(team, refreshToken, cacheConnectionManager, telemetry);
+                var channelDelta = await channel.GetChannelMessagesAndReactions(team, refreshToken, cacheConnectionManager, logger);
 
                 // Save delta token for next read
                 if (channelDelta != null)
                 {
-                    await cacheConnectionManager.SetTeamChannelDeltaTokenInfo(team.Id, channel.Id, channelDelta, telemetry);
+                    await cacheConnectionManager.SetTeamChannelDeltaTokenInfo(team.Id, channel.Id, channelDelta, logger);
                 }
             }
         }
@@ -67,7 +67,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// Save this channel stats. Channel object should be fully-loaded with tabs
         /// </summary>
         static async Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> GetChannelMessagesAndReactions(this ChannelWithReactions channel, Team parentTeam, RefreshOAuthToken refreshToken,
-            CacheConnectionManager cacheConnectionManager, ILogger telemetry)
+            CacheConnectionManager cacheConnectionManager, ILogger logger)
         {
             TeamsRedisManager.TeamChannelDeltaTokenInfo channelDeltaInfo = null;
 
@@ -79,7 +79,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 // IAuthenticationProvider that pins the supplied bearer token onto every request.
                 var _preCachedTokenClient = new GraphServiceClient(new BearerTokenAuthenticationProvider(refreshToken.AccessToken));
 
-                var channelMessagesLoader = new ChannelMessagesLoader(_preCachedTokenClient, cacheConnectionManager, telemetry);
+                var channelMessagesLoader = new ChannelMessagesLoader(_preCachedTokenClient, cacheConnectionManager, logger);
                 try
                 {
                     // Load msgs using user token
@@ -98,7 +98,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// <summary>
         /// Loads cognitive data for these messages. Messages may be on different dates, hence list of stats.
         /// </summary>
-        internal static async Task<List<MessageCognitiveStats>> GetCognitiveDataStats(this IEnumerable<ChatMessage> allChannelMsgs, ILogger telemetry, ChannelWithReactions parentChannel)
+        internal static async Task<List<MessageCognitiveStats>> GetCognitiveDataStats(this IEnumerable<ChatMessage> allChannelMsgs, ILogger logger, ChannelWithReactions parentChannel)
         {
             var allStatsAllDays = new List<MessageCognitiveStats>();
 
@@ -110,7 +110,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (!cognitiveConfig.IsValidCognitiveConfig)
             {
-                telemetry.LogWarning($"Cognitive config not valid. Cannot load cognitive stats for channel {parentChannel.DisplayName} ({parentChannel.Id}). Adding basic stats with no cognitive insights.");
+                logger.LogWarning($"Cognitive config not valid. Cannot load cognitive stats for channel {parentChannel.DisplayName} ({parentChannel.Id}). Adding basic stats with no cognitive insights.");
                 // No cognitive available. Add basic stats for all dates
                 foreach (var uniqueMsgDate in msgDates)
                 {
@@ -123,10 +123,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             // Use key auth when CognitiveKey is set, otherwise RBAC (ClientSecretCredential)
             // so we still work against resources that have key auth disabled. The wrapper
             // is cached per process and auto-falls back to RBAC on key-auth failure.
-            var client = GetOrBuildCognitiveClient(cognitiveConfig, telemetry);
+            var client = GetOrBuildCognitiveClient(cognitiveConfig, logger);
             if (client == null)
             {
-                telemetry.LogWarning($"Could not build cognitive client for channel {parentChannel.DisplayName} ({parentChannel.Id}). Adding basic stats with no cognitive insights.");
+                logger.LogWarning($"Could not build cognitive client for channel {parentChannel.DisplayName} ({parentChannel.Id}). Adding basic stats with no cognitive insights.");
                 foreach (var uniqueMsgDate in msgDates)
                 {
                     var msgsForDate = allChannelMsgs.GetByDate(uniqueMsgDate);
@@ -139,7 +139,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             {
                 // No log - generate new stats
                 var msgsForDate = allChannelMsgs.GetByDate(uniqueMsgDate);
-                var dateStats = await msgsForDate.LoadSameDayCognitiveDataStats(client, telemetry, parentChannel);
+                var dateStats = await msgsForDate.LoadSameDayCognitiveDataStats(client, logger, parentChannel);
                 allStatsAllDays.Add(dateStats);
             }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamsCognitiveExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamsCognitiveExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Azure.AI.TextAnalytics;
+using Azure.AI.TextAnalytics;
 using Common.Entities.Config;
 using Common.Entities.Redis;
 using DataUtils;
@@ -21,7 +21,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// Loads Azure Cognitive data for a message
         /// </summary>
         /// <returns>Stats and whether it was returned from redis or not</returns>
-        public static async Task<(MessageCognitiveStats, bool)> LoadCognitiveStatsFromCacheOrAI(this ChatMessage msg, CognitiveServicesClient client, ILogger telemetry, ChannelWithReactions parentChannel)
+        public static async Task<(MessageCognitiveStats, bool)> LoadCognitiveStatsFromCacheOrAI(this ChatMessage msg, CognitiveServicesClient client, ILogger logger, ChannelWithReactions parentChannel)
         {
             var stats = new MessageCognitiveStats(parentChannel, msg.CreatedDateTime.Value.DateTime);
 
@@ -51,7 +51,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (cachedResultsJson == null)
             {
-                var sentimentAndLang = await languageBatchInput.GetCognitiveDataStats(client, telemetry);
+                var sentimentAndLang = await languageBatchInput.GetCognitiveDataStats(client, logger);
 
                 var listProcessor = new ParallelCallsForSingleReturnListHander<string, ExtractKeyPhrasesResult>();
 
@@ -66,7 +66,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 if (sentimentAndLang == null)
                 {
                     // Message is an adaptive card or something not user generated
-                    telemetry.LogDebug($"Return empty stats for ChatMessage {msg.Id}. Message contains no user-genereated data in message.");
+                    logger.LogDebug($"Return empty stats for ChatMessage {msg.Id}. Message contains no user-genereated data in message.");
 
                     return (stats, false);
                 }
@@ -81,11 +81,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (fromCache)
             {
-                telemetry.LogInformation($"Loaded cognitive stats from cache for ChatMessage {msg.Id}");
+                logger.LogInformation($"Loaded cognitive stats from cache for ChatMessage {msg.Id}");
             }
             else
             {
-                telemetry.LogInformation($"Loaded cognitive stats from AI for ChatMessage {msg.Id}");
+                logger.LogInformation($"Loaded cognitive stats from AI for ChatMessage {msg.Id}");
             }
 
             // Compile stats
@@ -103,7 +103,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// <summary>
         /// Loads Azure Cognitive data for a message
         /// </summary>
-        public static async Task<MessageCognitiveStats> LoadSameDayCognitiveDataStats(this List<ChatMessage> msgsInChannel, CognitiveServicesClient client, ILogger telemetry, ChannelWithReactions parentChannel)
+        public static async Task<MessageCognitiveStats> LoadSameDayCognitiveDataStats(this List<ChatMessage> msgsInChannel, CognitiveServicesClient client, ILogger logger, ChannelWithReactions parentChannel)
         {
             if (msgsInChannel != null && msgsInChannel.Count > 0)
             {
@@ -116,7 +116,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 {
                     if (msg.CreatedDateTime.HasValue && msg.CreatedDateTime.Value.DateTime.Date == firstMsgDate.Date)
                     {
-                        var (statsResult, fromCache) = await msg.LoadCognitiveStatsFromCacheOrAI(client, telemetry, parentChannel);
+                        var (statsResult, fromCache) = await msg.LoadCognitiveStatsFromCacheOrAI(client, logger, parentChannel);
                         allStats.Add(statsResult);
                     }
                     else

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/O365Team.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/O365Team.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities;
 using Common.Entities.Redis.Teams;
@@ -72,12 +72,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
         #endregion
 
-        public async Task<TeamDefinition> SaveToSQL(TeamsAndCallsDBLookupManager lookupManager, AppConfig appConfig, ILogger telemetry)
+        public async Task<TeamDefinition> SaveToSQL(TeamsAndCallsDBLookupManager lookupManager, AppConfig appConfig, ILogger logger)
         {
             if (lookupManager is null) throw new ArgumentNullException(nameof(lookupManager));
-            if (telemetry is null) throw new ArgumentNullException(nameof(telemetry));
+            if (logger is null) throw new ArgumentNullException(nameof(logger));
 
-            telemetry.LogInformation($"Saving Team '{this.DisplayName}' to SQL...");
+            logger.LogInformation($"Saving Team '{this.DisplayName}' to SQL...");
 
             // Save to SQL if doesn't exist already
             var dbTeam = await lookupManager.GetOrCreateTeam(this.Id, this.DisplayName);
@@ -108,14 +108,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             // Channels
             var dbChannels = new List<TeamChannel>();
 
-            var teamTokenManager = new TeamTokenManager(this, appConfig, telemetry);
+            var teamTokenManager = new TeamTokenManager(this, appConfig, logger);
             foreach (var channel in this.Channels)
             {
                 var dbChannel = await channel.SaveToSql(lookupManager, dbTeam);
             }
 
             // Get & save channel stats for relevant chats found
-            var channelMessageStats = await this.Channels.GetMessagesStats(telemetry);
+            var channelMessageStats = await this.Channels.GetMessagesStats(logger);
             foreach (var channelStat in channelMessageStats)
             {
                 await channelStat.InsertOrAppendSqlStats(lookupManager, dbTeam);
@@ -163,22 +163,22 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             }
             catch (System.Data.Entity.Infrastructure.DbUpdateException ex)
             {
-                telemetry.LogError(ex, $"Got SQL exception saving Team: {ex.Message}. Will try again next cycle.");
-                await ClearChannelDeltaTokens(telemetry, appConfig);
+                logger.LogError(ex, $"Got SQL exception saving Team: {ex.Message}. Will try again next cycle.");
+                await ClearChannelDeltaTokens(logger, appConfig);
                 return null;
             }
 
             return dbTeam;
         }
 
-        async Task ClearChannelDeltaTokens(ILogger telemetry, AppConfig appConfig)
+        async Task ClearChannelDeltaTokens(ILogger logger, AppConfig appConfig)
         {
-            var teamTokenManager = new TeamTokenManager(this, appConfig, telemetry);
+            var teamTokenManager = new TeamTokenManager(this, appConfig, logger);
             foreach (var c in this.Channels)
             {
                 if (teamTokenManager.CacheConnectionManager != null)
                 {
-                    await teamTokenManager.CacheConnectionManager.RemoveTeamChannelDeltaToken(this.Id, c.Id, telemetry);
+                    await teamTokenManager.CacheConnectionManager.RemoveTeamChannelDeltaToken(this.Id, c.Id, logger);
                 }
             }
         }
@@ -186,7 +186,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// <summary>
         /// Loads all the Team child data, plus messages from the last channel log in the DB
         /// </summary>
-        public static async Task<O365Team> LoadTeamFull(Group parentGroup, TeamsLoadContext context, ILogger telemetry, AppConfig appConfig, AnalyticsEntitiesContext db)
+        public static async Task<O365Team> LoadTeamFull(Group parentGroup, TeamsLoadContext context, ILogger logger, AppConfig appConfig, AnalyticsEntitiesContext db)
         {
             var teamId = parentGroup.Id;
             // Get Team details from Graph and convert to our own class
@@ -209,14 +209,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 }
                 else
                 {
-                    telemetry.LogInformation($"Couldn't find owner with user ID '{groupOwner.Id}' for Team {fullTeam.DisplayName}");
+                    logger.LogInformation($"Couldn't find owner with user ID '{groupOwner.Id}' for Team {fullTeam.DisplayName}");
                 }
             }
 
 #if DEBUG
             Console.WriteLine($"\nReading team '{parentGroup.DisplayName}':");
 #endif
-            var members = await LoadAllGroupMembers(context.GraphClient, parentGroup.Id, telemetry);
+            var members = await LoadAllGroupMembers(context.GraphClient, parentGroup.Id, logger);
 
             foreach (var member in members)
             {
@@ -252,7 +252,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             }
 
 
-            var teamTokenManager = new TeamTokenManager(fullTeam, appConfig, telemetry);
+            var teamTokenManager = new TeamTokenManager(fullTeam, appConfig, logger);
 
             // Load tabs in each channel
             foreach (var channel in fullTeam.Channels)
@@ -261,7 +261,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 if (dbChannel == null && teamTokenManager.CacheConnectionManager != null)
                 {
                     // Clear delta cache if new channel in DB. Mainly for debug reasons but also if there's no channel, we need to make sure we ignore any delta code (just in case)
-                    await teamTokenManager.CacheConnectionManager.RemoveTeamChannelDeltaToken(fullTeam.Id, channel.Id, telemetry);
+                    await teamTokenManager.CacheConnectionManager.RemoveTeamChannelDeltaToken(fullTeam.Id, channel.Id, logger);
                 }
                 var tabsPage = await context.GraphClient.Teams[teamId].Channels[channel.Id].Tabs.GetAsync(rc =>
                 {
@@ -271,7 +271,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             }
 
             // Get token for Team
-            var teamRefreshOAuthToken = await teamTokenManager.GetRefreshToken(telemetry);
+            var teamRefreshOAuthToken = await teamTokenManager.GetRefreshToken(logger);
 
             // Update access-token stats for Team
             if (teamRefreshOAuthToken == null)
@@ -283,11 +283,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 // We have a token. Load channel msgs/replies/reactions
                 try
                 {
-                    await fullTeam.Channels.PopulateNewMessagesAndReactions(team, teamRefreshOAuthToken, teamTokenManager.CacheConnectionManager, telemetry);
+                    await fullTeam.Channels.PopulateNewMessagesAndReactions(team, teamRefreshOAuthToken, teamTokenManager.CacheConnectionManager, logger);
                 }
                 catch (ChannelMessagesReadException ex)
                 {
-                    telemetry.LogError(ex, $"Couldn't get channel messages via cached token. '{ex.Message}'. Deleting token.");
+                    logger.LogError(ex, $"Couldn't get channel messages via cached token. '{ex.Message}'. Deleting token.");
                     await teamTokenManager.CacheConnectionManager.RemoveTeamAuthToken(team.Id);
                     teamRefreshOAuthToken = null;
                 }
@@ -334,7 +334,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         }
         #endregion
 
-        private static async Task<List<DirectoryObject>> LoadAllGroupMembers(GraphServiceClient client, string groupId, ILogger telemetry)
+        private static async Task<List<DirectoryObject>> LoadAllGroupMembers(GraphServiceClient client, string groupId, ILogger logger)
         {
             // Safety cap on paging: at 200k-user scale a single group rarely exceeds ~50k members
             // but a runaway nextLink shouldn't ever fill memory unbounded. 200k members per group
@@ -358,7 +358,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (iterator.State == PagingState.Paused)
             {
-                telemetry.LogWarning($"Group {groupId}: hit MAX_MEMBERS ({MAX_MEMBERS:N0}). Returning partial list of {all.Count:N0} members.");
+                logger.LogWarning($"Group {groupId}: hit MAX_MEMBERS ({MAX_MEMBERS:N0}). Returning partial list of {all.Count:N0} members.");
             }
 
             return all;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using Common.Entities.Models;
 using Common.Entities.Redis;
 using Common.Entities.Redis.Teams;
@@ -29,7 +29,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         public O365Team Team { get; set; }
 
         static Lazy<Dictionary<O365Team, RefreshOAuthToken>> _cahedTokens = new Lazy<Dictionary<O365Team, RefreshOAuthToken>>(() => new Dictionary<O365Team, RefreshOAuthToken>());
-        public async Task<RefreshOAuthToken> GetRefreshToken(ILogger telemetry)
+        public async Task<RefreshOAuthToken> GetRefreshToken(ILogger logger)
         {
             if (CacheConnectionManager == null)
             {
@@ -58,12 +58,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 {
                     if (ex.Message.Contains("Bad Request"))
                     {
-                        telemetry.LogError(ex, $"Got error {ex.Message} trying to get access token for team. App registration configuration issue? Check reply URLs match");
+                        logger.LogError(ex, $"Got error {ex.Message} trying to get access token for team. App registration configuration issue? Check reply URLs match");
                     }
                     else
                     {
                         // Get access key failed. Delete key
-                        telemetry.LogError(ex, $"Got error {ex.Message} trying to get access token for team. Removing refresh-token from cache.");
+                        logger.LogError(ex, $"Got error {ex.Message} trying to get access token for team. Removing refresh-token from cache.");
                         await CacheConnectionManager.RemoveTeamAuthToken(this.Team.Id);
                     }
 
@@ -71,7 +71,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
                 if (success)
                 {
-                    telemetry.LogInformation($"Got refresh token for Team '{this.Team.DisplayName}'.");
+                    logger.LogInformation($"Got refresh token for Team '{this.Team.DisplayName}'.");
                 }
 
                 _cahedTokens.Value.Add(this.Team, teamToken);
@@ -80,7 +80,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             else
             {
-                telemetry.LogInformation($"Couldn't find token entry in redis for Team '{this.Team.DisplayName}', or refresh token is null.");
+                logger.LogInformation($"Couldn't find token entry in redis for Team '{this.Team.DisplayName}', or refresh token is null.");
             }
 
             return teamToken;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsFinder.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsFinder.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
@@ -17,7 +17,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
         private readonly GraphServiceClient _graphServiceClient;
 
-        public TeamsFinder(AnalyticsLogger telemetry, AppConfig settings, GraphServiceClient graphServiceClient) : base(telemetry, settings)
+        public TeamsFinder(AnalyticsLogger logger, AppConfig settings, GraphServiceClient graphServiceClient) : base(logger, settings)
         {
             this._graphServiceClient = graphServiceClient;
         }
@@ -33,7 +33,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             bool legacyAPIMode = true;
 
             var allGroupsWithTeams = new List<Group>();
-            _telemetry.LogInformation($"Searching for groups with a team attached...");
+            _logger.LogInformation($"Searching for groups with a team attached...");
 
             if (legacyAPIMode)
             {
@@ -61,7 +61,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                         }
                         if (!groupHasTeam)
                         {
-                            _telemetry.LogInformation($"Group name '{group.DisplayName}' has no Team associated.");
+                            _logger.LogInformation($"Group name '{group.DisplayName}' has no Team associated.");
                         }
                     }
                 }
@@ -76,7 +76,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             }
 
             // Do the needful
-            _telemetry.LogInformation($"Searching for groups with a team attached...");
+            _logger.LogInformation($"Searching for groups with a team attached...");
 
             var filteredTeams = new List<Group>();
             foreach (var g in allGroupsWithTeams)
@@ -87,7 +87,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 }
                 else
                 {
-                    _telemetry.LogInformation($"Excluding group '{g.DisplayName}' from crawl due to crawl configuration");
+                    _logger.LogInformation($"Excluding group '{g.DisplayName}' from crawl due to crawl configuration");
                 }
             }
 
@@ -116,7 +116,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (iterator.State == PagingState.Paused)
             {
-                _telemetry.LogWarning($"TeamsFinder: hit MAX_GROUPS ({MAX_GROUPS:N0}) walking groups. Returning partial list of {allGroups.Count:N0}.");
+                _logger.LogWarning($"TeamsFinder: hit MAX_GROUPS ({MAX_GROUPS:N0}) walking groups. Returning partial list of {allGroups.Count:N0}.");
             }
 
             return allGroups;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsImporter.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Extensions.Logging;
@@ -17,11 +17,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         private TeamsFinder _teamsFinder;
         private TeamsLoadContext _context;
 
-        public TeamsImporter(AnalyticsLogger telemetry, AppConfig settings, GraphServiceClient graphServiceClient) : base(telemetry, settings)
+        public TeamsImporter(AnalyticsLogger logger, AppConfig settings, GraphServiceClient graphServiceClient) : base(logger, settings)
         {
-            if (telemetry is null)
+            if (logger is null)
             {
-                throw new ArgumentNullException(nameof(telemetry));
+                throw new ArgumentNullException(nameof(logger));
             }
 
             if (settings is null)
@@ -35,7 +35,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             }
 
             _context = new TeamsLoadContext(graphServiceClient);
-            _teamsFinder = new TeamsFinder(telemetry, settings, graphServiceClient);
+            _teamsFinder = new TeamsFinder(logger, settings, graphServiceClient);
         }
 
         /// <summary>
@@ -55,8 +55,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             var loader = new ParallelListProcessor<Group>(MAX_TEAMS_PER_THREAD);
             await loader.ProcessListInParallel(targetGroups,
                 (threadListChunk, threadIndex) => LoadTeamsChunkThreaded(threadListChunk),
-                threads => _telemetry.LogInformation($"Loading & saving to SQL {targetGroups.Count} groups/teams over {threads} threads..."));
-            _telemetry.LogInformation($"Teams import complete.\n");
+                threads => _logger.LogInformation($"Loading & saving to SQL {targetGroups.Count} groups/teams over {threads} threads..."));
+            _logger.LogInformation($"Teams import complete.\n");
         }
 
         async Task LoadTeamsChunkThreaded(List<Group> groupsWithTeams)
@@ -78,11 +78,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             O365Team team = null;
             try
             {
-                team = await O365Team.LoadTeamFull(parentGroup, _context, _telemetry, _settings, lookupManager.Database);
+                team = await O365Team.LoadTeamFull(parentGroup, _context, _logger, _settings, lookupManager.Database);
             }
             catch (ODataError ex)
             {
-                _telemetry.LogError(ex, $"Couldn't load team from Group {parentGroup.DisplayName}: {ex.Message}");
+                _logger.LogError(ex, $"Couldn't load team from Group {parentGroup.DisplayName}: {ex.Message}");
             }
 
 
@@ -90,11 +90,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             {
                 try
                 {
-                    await team.SaveToSQL(lookupManager, _settings, _telemetry);
+                    await team.SaveToSQL(lookupManager, _settings, _logger);
                 }
                 catch (SqlException ex)
                 {
-                    _telemetry.LogError(ex, $"Couldn't save Group {parentGroup.DisplayName} to SQL: {ex.Message}");
+                    _logger.LogError(ex, $"Couldn't save Group {parentGroup.DisplayName} to SQL: {ex.Message}");
                 }
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.ActivityReports;
 using DataUtils;
 using Microsoft.Extensions.Logging;
@@ -23,7 +23,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         where CACHETYPE : DBLookupCache<TLookupType>
     {
         protected readonly ManualGraphCallClient _client;
-        internal AbstractDailyActivityLoader(ManualGraphCallClient client, ILogger telemetry) : base(telemetry)
+        internal AbstractDailyActivityLoader(ManualGraphCallClient client, ILogger logger) : base(logger)
         {
             _client = client;
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractUserDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractUserDailyActivityLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.ActivityReports;
+using Common.Entities.ActivityReports;
 using Common.Entities.Config;
 using Common.Entities.LookupCaches;
 using Microsoft.Extensions.Logging;
@@ -18,7 +18,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         private readonly UserGroupsCache _graphUserGroupsCache;
         private readonly UserGroupsFilterModel _userGroupsFilterModel;
 
-        internal AbstractUserDailyActivityLoader(ManualGraphCallClient client, UserGroupsCache graphUserGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry) : base(client, telemetry)
+        internal AbstractUserDailyActivityLoader(ManualGraphCallClient client, UserGroupsCache graphUserGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger) : base(client, logger)
         {
             _graphUserGroupsCache = graphUserGroupsCache;
             _userGroupsFilterModel = userGroupsFilterModel;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/ActivityReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/ActivityReportLoader.cs
@@ -1,13 +1,13 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     public abstract class ActivityReportLoader
     {
-        internal ActivityReportLoader(ILogger telemetry)
+        internal ActivityReportLoader(ILogger logger)
         {
-            this.Telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            this.Telemetry = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public abstract string ReportGraphURL { get; }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractAggregateWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractAggregateWeeklyUsageReportLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -15,7 +15,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
         protected readonly ManualGraphCallClient _client;
         protected readonly AnalyticsEntitiesContext _context;
 
-        protected GraphAndSqlAggregateWeeklyUsageReportLoader(AnalyticsEntitiesContext db, ManualGraphCallClient client, ILogger telemetry) : base(telemetry)
+        protected GraphAndSqlAggregateWeeklyUsageReportLoader(AnalyticsEntitiesContext db, ManualGraphCallClient client, ILogger logger) : base(logger)
         {
             _client = client;
             _context = db;
@@ -36,7 +36,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
     /// </summary>
     public abstract class AbstractAggregateWeeklyUsageReportLoader<T> : ActivityReportLoader where T : BaseAggregateItemStats
     {
-        public AbstractAggregateWeeklyUsageReportLoader(ILogger telemetry) : base(telemetry)
+        public AbstractAggregateWeeklyUsageReportLoader(ILogger logger) : base(logger)
         {
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/SharePointSitesWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/SharePointSitesWeeklyUsageReportLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Entities.UsageReports;
 using Common.Entities.LookupCaches.Discrete;
 using Microsoft.Extensions.Logging;
@@ -18,8 +18,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
         private readonly SPSiteIdToUrlCache _sPSiteIdToUrlCache;
         private readonly SiteCache _siteCache;
 
-        public SharePointSitesWeeklyUsageReportLoader(AnalyticsEntitiesContext db, ManualGraphCallClient client, ILogger telemetry, SPSiteIdToUrlCache sPSiteIdToUrlCache)
-            : base(db, client, telemetry)
+        public SharePointSitesWeeklyUsageReportLoader(AnalyticsEntitiesContext db, ManualGraphCallClient client, ILogger logger, SPSiteIdToUrlCache sPSiteIdToUrlCache)
+            : base(db, client, logger)
         {
             _sPSiteIdToUrlCache = sPSiteIdToUrlCache;
             _siteCache = new SiteCache(_context);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AppPlatformUserActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AppPlatformUserActivityLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -12,8 +12,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     // https://learn.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-beta
     public class AppPlatformUserActivityLoader : AbstractUserDailyActivityLoader<AppPlatformUserActivityLog, AppPlatformUserActivityDetail>
     {
-        public AppPlatformUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public AppPlatformUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OneDriveUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OneDriveUsageLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -12,8 +12,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveusageaccountdetail?view=graph-rest-beta
     public class OneDriveUsageLoader : AbstractUserDailyActivityLoader<OneDriveUsageLog, OneDriveUsageDetail>
     {
-        public OneDriveUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public OneDriveUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
         protected override void PopulateReportSpecificMetadata(OneDriveUsageLog todaysLog, OneDriveUsageDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OneDriveUserActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OneDriveUserActivityLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -12,8 +12,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveactivityuserdetail?view=graph-rest-beta
     public class OneDriveUserActivityLoader : AbstractUserDailyActivityLoader<OneDriveUserActivityLog, OneDriveUserActivityDetail>
     {
-        public OneDriveUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public OneDriveUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
         protected override void PopulateReportSpecificMetadata(OneDriveUserActivityLog todaysLog, OneDriveUserActivityDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OutlookUserActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/OutlookUserActivityLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -11,8 +11,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     public class OutlookUserActivityLoader : AbstractUserDailyActivityLoader<OutlookUsageActivityLog, OutlookUserActivityUserDetail>
     {
-        public OutlookUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public OutlookUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
         protected override void PopulateReportSpecificMetadata(OutlookUsageActivityLog todaysLog, OutlookUserActivityUserDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/SharePointUserActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/SharePointUserActivityLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -12,8 +12,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveactivityuserdetail?view=graph-rest-beta
     public class SharePointUserActivityLoader : AbstractUserDailyActivityLoader<SharePointUserActivityLog, SharePointUserActivityDetail>
     {
-        public SharePointUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public SharePointUserActivityLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
         protected override void PopulateReportSpecificMetadata(SharePointUserActivityLog todaysLog, SharePointUserActivityDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserDeviceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserDeviceLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -14,8 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     /// </summary>
     public class TeamsUserDeviceLoader : AbstractUserDailyActivityLoader<GlobalTeamsUserDeviceUsageLog, TeamsDeviceUsageUserDetail>
     {
-        public TeamsUserDeviceLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public TeamsUserDeviceLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/TeamsUserUsageLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -11,8 +11,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
     public class TeamsUserUsageLoader : AbstractUserDailyActivityLoader<GlobalTeamsUserUsageLog, TeamsUserActivityUserDetail>
     {
-        public TeamsUserUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public TeamsUserUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
         protected override void PopulateReportSpecificMetadata(GlobalTeamsUserUsageLog todaysLog, TeamsUserActivityUserDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerDeviceUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerDeviceUsageLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -14,8 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     /// </summary>
     public class YammerDeviceUsageLoader : AbstractUserDailyActivityLoader<YammerDeviceActivityLog, YammerDeviceActivityDetail>
     {
-        public YammerDeviceUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public YammerDeviceUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
         protected override void PopulateReportSpecificMetadata(YammerDeviceActivityLog todaysLog, YammerDeviceActivityDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerGroupUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerGroupUsageLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Entities;
 using Common.Entities.Entities.Teams;
 using Common.Entities.LookupCaches;
@@ -14,8 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     /// </summary>
     public class YammerGroupUsageLoader : AbstractDailyActivityLoader<YammerGroupActivityLog, YammerGroupActivityDetail, YammerGroup, YammerGroupCache>
     {
-        public YammerGroupUsageLoader(ManualGraphCallClient client, ILogger telemetry)
-            : base(client, telemetry)
+        public YammerGroupUsageLoader(ManualGraphCallClient client, ILogger logger)
+            : base(client, logger)
         {
         }
         protected override void PopulateReportSpecificMetadata(YammerGroupActivityLog todaysLog, YammerGroupActivityDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerUserUsageLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/YammerUserUsageLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
 using Microsoft.Extensions.Logging;
@@ -14,8 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     /// </summary>
     public class YammerUserUsageLoader : AbstractUserDailyActivityLoader<YammerUserActivityLog, YammerUserActivityUserDetail>
     {
-        public YammerUserUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger telemetry)
-            : base(client, userGroupsCache, userGroupsFilterModel, telemetry)
+        public YammerUserUsageLoader(ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel, ILogger logger)
+            : base(client, userGroupsCache, userGroupsFilterModel, logger)
         {
         }
         protected override void PopulateReportSpecificMetadata(YammerUserActivityLog todaysLog, YammerUserActivityUserDetail userActivityReportPage)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/GraphUserLoader.cs
@@ -18,7 +18,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     {
         private readonly ManualGraphCallClient _httpClient;
         private readonly IDeltaValueProvider _deltaValueProvider;
-        private readonly ILogger _telemetry;
+        private readonly ILogger _logger;
         private readonly GraphServiceClient _graphServiceClient;
 
         // Buffer the delta token returned by Graph during the most recent
@@ -31,11 +31,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         private string _pendingDeltaToken;
         private bool _hasPendingDeltaToken;
 
-        public GraphUserLoader(ManualGraphCallClient httpClient, IDeltaValueProvider deltaValueProvider, ILogger telemetry, GraphServiceClient graphServiceClient)
+        public GraphUserLoader(ManualGraphCallClient httpClient, IDeltaValueProvider deltaValueProvider, ILogger logger, GraphServiceClient graphServiceClient)
         {
             this._httpClient = httpClient;
             _deltaValueProvider = deltaValueProvider;
-            this._telemetry = telemetry;
+            this._logger = logger;
             this._graphServiceClient = graphServiceClient;
         }
 
@@ -66,7 +66,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             _pendingDeltaToken = null;
             _hasPendingDeltaToken = false;
 
-            var results = await _httpClient.LoadAllPagesPlusDeltaWithThrottleRetries<GraphUser>(initialDeltaUrl, _telemetry,
+            var results = await _httpClient.LoadAllPagesPlusDeltaWithThrottleRetries<GraphUser>(initialDeltaUrl, _logger,
                 (deltaLink) =>
                 {
                     // Buffer the new delta in memory. It will only be persisted to
@@ -80,11 +80,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
             if (string.IsNullOrEmpty(usersQueryDelta))
             {
-                _telemetry.LogInformation($"User import - read {results.Count.ToString("N0")} users (all) from Graph API");
+                _logger.LogInformation($"User import - read {results.Count.ToString("N0")} users (all) from Graph API");
             }
             else
             {
-                _telemetry.LogInformation($"User import - read {results.Count.ToString("N0")} updated users from Graph API, using last delta.");
+                _logger.LogInformation($"User import - read {results.Count.ToString("N0")} updated users from Graph API, using last delta.");
             }
 
             // Graph for some reason gives duplicates; filter that out.
@@ -133,15 +133,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             {
                 if (ex.ResponseStatusCode == (int)System.Net.HttpStatusCode.Forbidden)
                 {
-                    _telemetry.LogError($"User import - couldn't load SKUs for org - {ex.Message}. Ensure 'Organization.Read.All' in granted.");
+                    _logger.LogError($"User import - couldn't load SKUs for org - {ex.Message}. Ensure 'Organization.Read.All' in granted.");
                 }
                 else
                 {
-                    _telemetry.LogError(ex, $"User import - couldn't load SKUs for org - {ex.Message}");
+                    _logger.LogError(ex, $"User import - couldn't load SKUs for org - {ex.Message}");
                 }
 
                 // If we can't get tenant SKUs to find all users by, we can get SKUs per user instead, but this can be very slow.
-                _telemetry.LogWarning($"User import - will load SKUs directly from each user instead. This will be slow.");
+                _logger.LogWarning($"User import - will load SKUs directly from each user instead. This will be slow.");
                 return null;
             }
         }
@@ -178,10 +178,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
             if (iterator.State == PagingState.Paused)
             {
-                _telemetry.LogWarning($"User import - hit MAX_USERS_PER_SKU ({MAX_USERS_PER_SKU:N0}) walking users for SKU {skuId}. Returning partial result of {allUsersWithSku.Count:N0} users.");
+                _logger.LogWarning($"User import - hit MAX_USERS_PER_SKU ({MAX_USERS_PER_SKU:N0}) walking users for SKU {skuId}. Returning partial result of {allUsersWithSku.Count:N0} users.");
             }
 
-            _telemetry.LogDebug($"SKU {skuId} loaded {allUsersWithSku.Count:N0} users");
+            _logger.LogDebug($"SKU {skuId} loaded {allUsersWithSku.Count:N0} users");
 
             return allUsersWithSku;
         }
@@ -198,7 +198,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             catch (ODataError ex)
             {
-                _telemetry.LogError(ex, $"User import - couldn't load service-plans for user ID '{userId}' - {ex.Message}");
+                _logger.LogError(ex, $"User import - couldn't load service-plans for user ID '{userId}' - {ex.Message}");
                 return null;
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/AbstractUserAppLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/AbstractUserAppLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Config;
+using Common.Entities.Config;
 using DataUtils;
 using System;
 using System.Collections.Generic;
@@ -12,14 +12,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
     /// </summary>
     public abstract class AbstractUserAppLoader<APPTYPE>
     {
-        protected readonly AnalyticsLogger _telemetry;
+        protected readonly AnalyticsLogger _logger;
 
         private int _totalSaves = 0;
         private int _lastReportedPercentDone = 0;
 
-        public AbstractUserAppLoader(AnalyticsLogger telemetry)
+        public AbstractUserAppLoader(AnalyticsLogger logger)
         {
-            _telemetry = telemetry;
+            _logger = logger;
         }
 
         public abstract TimeSpan GetDelay(int throttledAttempts);
@@ -34,7 +34,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
 
         public async Task<int> LoadAndSave(UserGroupsCache userGroupsCache, UserGroupsFilterModel filter)
         {
-            var timer = new JobTimer(_telemetry, "User Apps load");
+            var timer = new JobTimer(_logger, "User Apps load");
             timer.Start();
 
             _totalSaves = 0;
@@ -49,7 +49,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                     // Check if the user is in the filter
                     if (filter != null && !await userGroupsCache.IsInGroupsFilter(usersEmailResult, filter))
                     {
-                        _telemetry.LogInformation($"User Apps Load - '{usersEmailResult}' is not in the filter groups, skipping...");
+                        _logger.LogInformation($"User Apps Load - '{usersEmailResult}' is not in the filter groups, skipping...");
                         continue;
                     }
                     usersEmailsToUpdate.Add(usersEmailResult);
@@ -73,7 +73,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
             }
             else
             {
-                _telemetry.LogWarning("User Apps Load - no users to process");
+                _logger.LogWarning("User Apps Load - no users to process");
             }
 
             timer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
@@ -95,7 +95,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
             while (true)
             {
                 var testUser = userEmails[userNotFoundCount];
-                _telemetry.LogInformation($"User Apps Load - testing API permissions for 'TeamsAppInstallation.ReadForUser.All' read with '{testUser}'...");
+                _logger.LogInformation($"User Apps Load - testing API permissions for 'TeamsAppInstallation.ReadForUser.All' read with '{testUser}'...");
                 try
                 {
                     success = await TestReadPermissionsForUser(testUser);
@@ -109,7 +109,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                 {
                     // The user we tried with doesn't exist. We still don't know if we have access or not, so try with another
                     userNotFoundCount++;
-                    _telemetry.LogWarning($"User Apps Load - '{testUser}' wasn't found...");
+                    _logger.LogWarning($"User Apps Load - '{testUser}' wasn't found...");
                     if (userNotFoundCount == userEmails.Count)
                     {
                         // We've run out of email addresses to test. Give up. 
@@ -120,7 +120,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                 // If we didn't have a success it'll be because the user wasn't found
                 if (success)
                 {
-                    _telemetry.LogInformation($"User Apps Load - 'TeamsAppInstallation.ReadForUser.All' permissions verified");
+                    _logger.LogInformation($"User Apps Load - 'TeamsAppInstallation.ReadForUser.All' permissions verified");
                     return true;
                 }
             }
@@ -186,7 +186,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                 int pcDone = Convert.ToInt32(Math.Round(percentDone, 0));
                 if (_lastReportedPercentDone < pcDone)
                 {
-                    _telemetry.LogInformation($"User Apps Load: processed {pcDone.ToString("n0")}% of users for Teams Apps...");
+                    _logger.LogInformation($"User Apps Load: processed {pcDone.ToString("n0")}% of users for Teams Apps...");
                     _lastReportedPercentDone = pcDone;
                 }
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/GraphAndSqlUserAppLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/GraphAndSqlUserAppLoader.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
@@ -31,7 +31,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
 
         private readonly AnalyticsEntitiesContext _db;
         private readonly GraphServiceClient _graphClient;
-        public GraphAndSqlUserAppLoader(AnalyticsEntitiesContext db, AnalyticsLogger telemetry, GraphServiceClient graphClient) : base(telemetry)
+        public GraphAndSqlUserAppLoader(AnalyticsEntitiesContext db, AnalyticsLogger logger, GraphServiceClient graphClient) : base(logger)
         {
             _db = db;
             _graphClient = graphClient;
@@ -46,7 +46,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                                     && !string.IsNullOrEmpty(u.UserPrincipalName) && u.UserPrincipalName.Contains("@") && !u.UserPrincipalName.Contains("#ext#"))
                                 .ToListAsync();
 
-            _telemetry.LogInformation($"User Apps Load - updating Teams Apps for {usersWithLicenses.Count.ToString("N0")} users...");
+            _logger.LogInformation($"User Apps Load - updating Teams Apps for {usersWithLicenses.Count.ToString("N0")} users...");
 
             return usersWithLicenses.Select(u => u.UserPrincipalName).ToList();
         }
@@ -65,17 +65,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
             {
                 if (ex.ResponseStatusCode == (int)HttpStatusCode.Forbidden)
                 {
-                    _telemetry.LogError(ex, $"User Apps Load - access denied reading user Teams Apps. Check 'TeamsAppInstallation.ReadForUser.All' is granted.");
+                    _logger.LogError(ex, $"User Apps Load - access denied reading user Teams Apps. Check 'TeamsAppInstallation.ReadForUser.All' is granted.");
                     throw new AccessDeniedToTeamsAppsException();
                 }
                 else if (ex.ResponseStatusCode == (int)HttpStatusCode.NotFound)
                 {
-                    _telemetry.LogError($"User Apps Load - user not found reading user Teams Apps.");
+                    _logger.LogError($"User Apps Load - user not found reading user Teams Apps.");
                     throw new UserNotFoundException();
                 }
                 else
                 {
-                    _telemetry.LogError(ex, "Unexpected error reading installed Teams apps for user");
+                    _logger.LogError(ex, "Unexpected error reading installed Teams apps for user");
                     // Permissions test failed but not for permissions. Blow up. 
                     throw;
                 }
@@ -123,7 +123,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
 
                 if (i > 0 && i % REPORT_EVERY == 0)
                 {
-                    _telemetry.LogInformation($"User Apps Load - user {i.ToString("N0")}/{emailAddresses.Count.ToString("N0")} Teams app info loaded from Graph");
+                    _logger.LogInformation($"User Apps Load - user {i.ToString("N0")}/{emailAddresses.Count.ToString("N0")} Teams app info loaded from Graph");
                 }
 
                 i++;
@@ -168,12 +168,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
                     }
                     else if (response.StatusCode == HttpStatusCode.NotFound)
                     {
-                        _telemetry.LogWarning($"User Apps Load - user with ID '{r.Key}' not found in configured tenant");
+                        _logger.LogWarning($"User Apps Load - user with ID '{r.Key}' not found in configured tenant");
                     }
                     else
                     {
                         // Usually means user has no Teams license
-                        _telemetry.LogWarning($"User Apps Load - got unexpected error on batch response for user with ID '{r.Key}'. Check user has Teams license? HTTP response: {response.StatusCode}.");
+                        _logger.LogWarning($"User Apps Load - got unexpected error on batch response for user with ID '{r.Key}'. Check user has Teams license? HTTP response: {response.StatusCode}.");
                     }
                 }
 
@@ -245,7 +245,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.User.UserApps
 
         public override async Task Save(Dictionary<string, List<UserTeamApp>> pendingSave)
         {
-            var logsToInsert = new EFInsertBatch<UserAppLogTempEntity>(_db, _telemetry);
+            var logsToInsert = new EFInsertBatch<UserAppLogTempEntity>(_db, _logger);
 
             // Add user + apps to flat temp table
             foreach (var userAndState in pendingSave)
@@ -309,7 +309,7 @@ insert into teams_addons_user_installed_log(addon_id, user_id, date)
             }
             catch (System.Data.SqlClient.SqlException ex)
             {
-                _telemetry.LogError(ex, $"User Apps Load - got SQL error saving user apps");
+                _logger.LogError(ex, $"User Apps Load - got SQL error saving user apps");
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/UserAppLogUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserApps/UserAppLogUpdater.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Graph;
@@ -13,7 +13,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     public class UserAppLogUpdater : AbstractApiLoader
     {
-        public UserAppLogUpdater(AnalyticsLogger telemetry, AppConfig settings) : base(telemetry, settings)
+        public UserAppLogUpdater(AnalyticsLogger logger, AppConfig settings) : base(logger, settings)
         {
         }
 
@@ -21,7 +21,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         {
             using (var db = new AnalyticsEntitiesContext())
             {
-                var l = new GraphAndSqlUserAppLoader(db, _telemetry, graphClient);
+                var l = new GraphAndSqlUserAppLoader(db, _logger, graphClient);
 
                 await l.LoadAndSave(graphUserGroupsCache, filter);
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserBatchProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserBatchProcessor.cs
@@ -15,12 +15,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     internal class UserBatchProcessor
     {
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
         private const int DEFAULT_BATCH_SIZE = 500;
 
-        public UserBatchProcessor(AnalyticsLogger telemetry)
+        public UserBatchProcessor(AnalyticsLogger logger)
         {
-            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             Func<GraphUser, Common.Entities.User, Task> updateAction,
             int batchSize = DEFAULT_BATCH_SIZE)
         {
-            _telemetry.LogInformation($"User import - updating {userUpnsToProcess.Count.ToString("N0")} existing users in batches...");
+            _logger.LogInformation($"User import - updating {userUpnsToProcess.Count.ToString("N0")} existing users in batches...");
 
             int processedCount = 0;
             // userUpnsToProcess is OrdinalIgnoreCase so we no longer need .ToLower() per Graph user.
@@ -104,7 +104,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 await db.SaveChangesAsync();
 
                 processedCount += batch.Count;
-                _telemetry.LogInformation($"User import - processed batch {processedCount.ToString("N0")}/{batchedGraphUsers.Count.ToString("N0")} existing users");
+                _logger.LogInformation($"User import - processed batch {processedCount.ToString("N0")}/{batchedGraphUsers.Count.ToString("N0")} existing users");
 
                 // Clear change tracker to release memory, but preserve lookups
                 DetachAllEntitiesExceptLookups(db);
@@ -256,7 +256,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             if (graphUsersToUpdate.Count == 0)
                 return 0;
 
-            _telemetry.LogInformation($"User import - bulk updating {graphUsersToUpdate.Count.ToString("N0")} existing users...");
+            _logger.LogInformation($"User import - bulk updating {graphUsersToUpdate.Count.ToString("N0")} existing users...");
 
             // Pre-warm all lookup caches so every value has a DB ID
             var lookupMaps = await PreWarmLookupCaches(db, graphUsersToUpdate, userMetaCache);
@@ -280,7 +280,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 }
 
                 totalProcessed += batchCount;
-                _telemetry.LogInformation($"User import - bulk updated {totalProcessed.ToString("N0")}/{graphUsersToUpdate.Count.ToString("N0")} existing users");
+                _logger.LogInformation($"User import - bulk updated {totalProcessed.ToString("N0")}/{graphUsersToUpdate.Count.ToString("N0")} existing users");
             }
 
             return totalProcessed;
@@ -333,7 +333,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             foreach (var n in companySet)
                 maps.CompanyNames[n] = await cache.CompanyNameCache.GetOrCreateNewResource(n, new CompanyName { Name = n });
 
-            _telemetry.LogInformation(
+            _logger.LogInformation(
                 $"User import - pre-warmed lookup caches: {deptSet.Count} departments, {titleSet.Count} titles, " +
                 $"{officeSet.Count} offices, {usageSet.Count} usage locations, {countrySet.Count} countries, " +
                 $"{stateSet.Count} states, {companySet.Count} companies");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
@@ -13,13 +13,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     internal class UserDataMapper
     {
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
         private readonly UserMetadataCache _userMetaCache;
         private Dictionary<string, GraphUser> _graphUsersByAadId;
 
-        public UserDataMapper(AnalyticsLogger telemetry, UserMetadataCache userMetaCache)
+        public UserDataMapper(AnalyticsLogger logger, UserMetadataCache userMetaCache)
         {
-            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _userMetaCache = userMetaCache ?? throw new ArgumentNullException(nameof(userMetaCache));
         }
 
@@ -256,7 +256,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     }
                     else
                     {
-                        _telemetry.LogWarning($"Couldn't find manager with AAD ID {graphUser.DefaultManagerInfo?.Id} in Graph cache or DB");
+                        _logger.LogWarning($"Couldn't find manager with AAD ID {graphUser.DefaultManagerInfo?.Id} in Graph cache or DB");
                     }
                 }
                 else

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserInsertProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserInsertProcessor.cs
@@ -17,14 +17,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     internal class UserInsertProcessor
     {
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
         private readonly UserBatchProcessor _batchProcessor;
         private const int BULK_INSERT_BATCH_SIZE = 10000;
         private const int METADATA_BATCH_SIZE = 500;
 
-        public UserInsertProcessor(AnalyticsLogger telemetry, UserBatchProcessor batchProcessor)
+        public UserInsertProcessor(AnalyticsLogger logger, UserBatchProcessor batchProcessor)
         {
-            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _batchProcessor = batchProcessor ?? throw new ArgumentNullException(nameof(batchProcessor));
         }
 
@@ -41,7 +41,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             UserLicenseProcessor licenseProcessor,
             Func<AnalyticsEntitiesContext, GraphUser, List<GraphUser>, List<Common.Entities.User>, Common.Entities.User, bool, Dictionary<string, Common.Entities.User>, Task> updateAction)
         {
-            _telemetry.LogInformation($"User import - Inserting missing users (two-phase: bulk insert + metadata enrichment)...");
+            _logger.LogInformation($"User import - Inserting missing users (two-phase: bulk insert + metadata enrichment)...");
 
             // Create HashSet for O(1) lookup of existing DB users.
             // OrdinalIgnoreCase comparer handles case so we don't need .ToLower() on the keys
@@ -62,7 +62,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 }
             }
 
-            _telemetry.LogInformation($"User import - Found {usersToInsert.Count.ToString("N0")} new users to insert");
+            _logger.LogInformation($"User import - Found {usersToInsert.Count.ToString("N0")} new users to insert");
 
             if (usersToInsert.Count == 0)
             {
@@ -70,12 +70,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // PHASE 1: Fast bulk insert with minimal data
-            _telemetry.LogInformation($"User import - Phase 1: Starting bulk insert of {usersToInsert.Count.ToString("N0")} users...");
+            _logger.LogInformation($"User import - Phase 1: Starting bulk insert of {usersToInsert.Count.ToString("N0")} users...");
             await BulkInsertUsers(db, usersToInsert, BULK_INSERT_BATCH_SIZE);
-            _telemetry.LogInformation($"User import - Phase 1: Bulk insert completed");
+            _logger.LogInformation($"User import - Phase 1: Bulk insert completed");
 
             // PHASE 2: Load inserted users and enrich with metadata
-            _telemetry.LogInformation($"User import - Phase 2: Starting metadata enrichment for {usersToInsert.Count.ToString("N0")} new users (existing users will be updated separately)...");
+            _logger.LogInformation($"User import - Phase 2: Starting metadata enrichment for {usersToInsert.Count.ToString("N0")} new users (existing users will be updated separately)...");
             var insertedUserUpns = usersToInsert.Select(u => u.UserPrincipalName).ToList();
             var insertedDbUsers = await EnrichInsertedUsersWithMetadata(
                 db,
@@ -87,14 +87,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 userMetaCache,
                 updateAction);
 
-            _telemetry.LogInformation($"User import - Phase 2: Metadata enrichment completed for {insertedDbUsers.Count.ToString("N0")} new users");
+            _logger.LogInformation($"User import - Phase 2: Metadata enrichment completed for {insertedDbUsers.Count.ToString("N0")} new users");
 
             // Cleanup
             existingUpns.Clear();
             usersToInsert.Clear();
             insertedUserUpns.Clear();
 
-            _telemetry.LogInformation($"User import - Completed inserting and enriching {insertedDbUsers.Count.ToString("N0")} new users");
+            _logger.LogInformation($"User import - Completed inserting and enriching {insertedDbUsers.Count.ToString("N0")} new users");
 
             return insertedDbUsers;
         }
@@ -134,7 +134,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 }
 
                 totalInserted += batch.Count;
-                _telemetry.LogInformation($"User import - Bulk inserted {totalInserted.ToString("N0")}/{graphUsers.Count.ToString("N0")} users to SQL");
+                _logger.LogInformation($"User import - Bulk inserted {totalInserted.ToString("N0")}/{graphUsers.Count.ToString("N0")} users to SQL");
 
                 dataTable.Clear();
                 dataTable.Dispose();
@@ -265,7 +265,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 var estimatedTotalMs = elapsedMs / percentDone * 100;
                 var remainingMs = estimatedTotalMs - elapsedMs;
                 var remaining = TimeSpan.FromMilliseconds(remainingMs);
-                _telemetry.LogInformation($"User import - Enriched metadata for {enrichedUsers.Count.ToString("N0")}/{insertedUserUpns.Count.ToString("N0")} new users ({percentDone:F1}% done, estimated {remaining.Hours}h {remaining.Minutes}m {remaining.Seconds}s remaining)");
+                _logger.LogInformation($"User import - Enriched metadata for {enrichedUsers.Count.ToString("N0")}/{insertedUserUpns.Count.ToString("N0")} new users ({percentDone:F1}% done, estimated {remaining.Hours}h {remaining.Minutes}m {remaining.Seconds}s remaining)");
 
                 // Clear change tracker to free memory after each batch
                 _batchProcessor.DetachAllEntitiesExceptLookups(db);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserLicenseProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserLicenseProcessor.cs
@@ -15,7 +15,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     internal class UserLicenseProcessor
     {
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
         private readonly OfficeLicenseNameResolver _officeLicenseNameResolver;
         private readonly IUserMetadataLoader _userLoader;
         private readonly UserMetadataCache _userMetaCache;
@@ -23,11 +23,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         private const int SKU_BATCH_SIZE = 1000;
 
         public UserLicenseProcessor(
-            AnalyticsLogger telemetry,
+            AnalyticsLogger logger,
             IUserMetadataLoader userLoader,
             UserMetadataCache userMetaCache)
         {
-            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _userLoader = userLoader ?? throw new ArgumentNullException(nameof(userLoader));
             _userMetaCache = userMetaCache ?? throw new ArgumentNullException(nameof(userMetaCache));
             _officeLicenseNameResolver = new OfficeLicenseNameResolver();
@@ -44,7 +44,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             // Remove all existing license lookups for these users via direct SQL for performance.
             // EF RemoveRange generates individual DELETE statements per entity which is extremely
             // slow for large user counts (10+ hours for ~187K users). A single SQL DELETE is instant.
-            _telemetry.LogInformation($"User import - removing old license lookups for {graphFoundDbUsers.Count.ToString("N0")} users");
+            _logger.LogInformation($"User import - removing old license lookups for {graphFoundDbUsers.Count.ToString("N0")} users");
 
             // Detach all tracked license lookups from EF before the SQL delete so the
             // change-tracker doesn't try to re-process rows that no longer exist.
@@ -146,7 +146,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 }
             }
 
-            _telemetry.LogInformation($"User import - Found {relevantDbUsers.Count.ToString("N0")} users in SQL for SKU Part Number '{sku.SkuPartNumber}' from {usersWithSku.Count.ToString("N0")} Graph users.");
+            _logger.LogInformation($"User import - Found {relevantDbUsers.Count.ToString("N0")} users in SQL for SKU Part Number '{sku.SkuPartNumber}' from {usersWithSku.Count.ToString("N0")} Graph users.");
 
             // Get license type once for all users
             var licence = await GetLicenseType(sku.SkuPartNumber);
@@ -186,7 +186,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
                 if ((i + batch.Count) % 5000 == 0 || i + batch.Count >= relevantDbUsers.Count)
                 {
-                    _telemetry.LogInformation($"User {(i + batch.Count).ToString("N0")} / {relevantDbUsers.Count.ToString("N0")} processed for licenses.");
+                    _logger.LogInformation($"User {(i + batch.Count).ToString("N0")} / {relevantDbUsers.Count.ToString("N0")} processed for licenses.");
                 }
 
                 // Clear batch list to free memory
@@ -195,7 +195,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
             if (duplicatesSkipped > 0)
             {
-                _telemetry.LogInformation($"User import - Skipped {duplicatesSkipped.ToString("N0")} duplicate license lookups for SKU '{sku.SkuPartNumber}' (display-name '{licence.Name}' already assigned via another SKU).");
+                _logger.LogInformation($"User import - Skipped {duplicatesSkipped.ToString("N0")} duplicate license lookups for SKU '{sku.SkuPartNumber}' (display-name '{licence.Name}' already assigned via another SKU).");
             }
 
             // Clear list to free memory. Do NOT clear dbUsersByUpn here - it is owned by
@@ -251,7 +251,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             var productName = _officeLicenseNameResolver.GetDisplayNameFor(skuPartNumber);
             if (string.IsNullOrEmpty(productName))
             {
-                _telemetry.LogWarning($"User import - unexpected SKU part-number '{skuPartNumber}'. Couldn't find a corresponding display-name.");
+                _logger.LogWarning($"User import - unexpected SKU part-number '{skuPartNumber}'. Couldn't find a corresponding display-name.");
 
                 // Set display name as SKU ID
                 productName = skuPartNumber;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core;
+using Azure.Core;
 using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
@@ -26,19 +26,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         private UserLicenseProcessor _licenseProcessor;
         private UserDataMapper _dataMapper;
 
-        public UserMetadataUpdater(AnalyticsLogger telemetry, AppConfig settings, TokenCredential creds, ManualGraphCallClient manualGraphCallClient)
-            : base(telemetry, settings)
+        public UserMetadataUpdater(AnalyticsLogger logger, AppConfig settings, TokenCredential creds, ManualGraphCallClient manualGraphCallClient)
+            : base(logger, settings)
         {
             IDeltaValueProvider deltaProvider = null;
             if (!string.IsNullOrEmpty(settings.ConnectionStrings.RedisConnectionString))
             {
-                deltaProvider = new RedisProcessDeltaValueProvider(settings, telemetry);
-                telemetry.LogInformation($"User import - using Redis for delta token cache.");
+                deltaProvider = new RedisProcessDeltaValueProvider(settings, logger);
+                logger.LogInformation($"User import - using Redis for delta token cache.");
             }
             else
             {
-                telemetry.LogInformation($"User import - no redis found configured, using in-process cache for delta token.");
-                deltaProvider = new InProcessDeltaValueProvider(telemetry);
+                logger.LogInformation($"User import - no redis found configured, using in-process cache for delta token.");
+                deltaProvider = new InProcessDeltaValueProvider(logger);
             }
 
             // v4 used graphClient.HttpProvider.OverallTimeout = 1h directly. HttpProvider is gone
@@ -47,15 +47,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             // default 100s timeout - the explicit 1h timeout is load-bearing.
             var graphServiceClient = GraphServiceClientFactory.CreateWithTimeout(creds, TimeSpan.FromHours(1));
 
-            _userLoader = new GraphUserLoader(manualGraphCallClient, deltaProvider, _telemetry, graphServiceClient);
+            _userLoader = new GraphUserLoader(manualGraphCallClient, deltaProvider, _logger, graphServiceClient);
             InitializeHelpers();
         }
 
         /// <summary>
         /// Constructor with injectable user loader for testing and alternate implementations
         /// </summary>
-        public UserMetadataUpdater(AnalyticsLogger telemetry, AppConfig settings, IUserMetadataLoader userLoader)
-            : base(telemetry, settings)
+        public UserMetadataUpdater(AnalyticsLogger logger, AppConfig settings, IUserMetadataLoader userLoader)
+            : base(logger, settings)
         {
             _userLoader = userLoader;
             InitializeHelpers();
@@ -63,8 +63,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
         private void InitializeHelpers()
         {
-            _batchProcessor = new UserBatchProcessor(_telemetry);
-            _insertProcessor = new UserInsertProcessor(_telemetry, _batchProcessor);
+            _batchProcessor = new UserBatchProcessor(_logger);
+            _insertProcessor = new UserInsertProcessor(_logger, _batchProcessor);
         }
 
         public IUserMetadataLoader UserLoader => _userLoader;
@@ -83,10 +83,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 db.Configuration.AutoDetectChangesEnabled = false;
 
                 _userMetaCache = new UserMetadataCache(db);
-                _licenseProcessor = new UserLicenseProcessor(_telemetry, _userLoader, _userMetaCache);
-                _dataMapper = new UserDataMapper(_telemetry, _userMetaCache);
+                _licenseProcessor = new UserLicenseProcessor(_logger, _userLoader, _userMetaCache);
+                _dataMapper = new UserDataMapper(_logger, _userMetaCache);
 
-                _telemetry.LogInformation($"{DateTime.Now.ToShortTimeString()} User import - start");
+                _logger.LogInformation($"{DateTime.Now.ToShortTimeString()} User import - start");
 
                 // If we have no active users, assume new install so clear delta key
                 var activeUserCount = await db.users.Where(u => u.AccountEnabled.HasValue && u.AccountEnabled.Value == true).CountAsync();
@@ -97,7 +97,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
                 // Load from Graph & update delta code once done
                 var allActiveGraphUsers = await _userLoader.LoadAllActiveUsers();
-                _telemetry.LogInformation($"User import - loaded {allActiveGraphUsers.Count.ToString("N0")} users from Graph");
+                _logger.LogInformation($"User import - loaded {allActiveGraphUsers.Count.ToString("N0")} users from Graph");
 
                 // Pre-build dictionary for O(1) graph user lookups by AAD ID (avoids O(n) scans per user in manager resolution)
                 _dataMapper.SetGraphUserLookup(allActiveGraphUsers);
@@ -114,7 +114,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 var allDbUsers = skus == null
                     ? await db.users.AsNoTracking().Include(u => u.LicenseLookups).ToListAsync()
                     : await db.users.AsNoTracking().ToListAsync();
-                _telemetry.LogInformation($"User import - loaded {allDbUsers.Count.ToString("N0")} users from database");
+                _logger.LogInformation($"User import - loaded {allDbUsers.Count.ToString("N0")} users from database");
 
                 // Create lookup dictionaries for performance - pre-allocate capacity
                 var dbUsersByUpn = new Dictionary<string, Common.Entities.User>(allDbUsers.Count, StringComparer.OrdinalIgnoreCase);
@@ -137,13 +137,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
                 // Insert any user we've not seen so far
                 var insertedDbUsers = await InsertMissingUsers(db, allActiveGraphUsers, graphMentionedExistingDbUsers, skus == null);
-                _telemetry.LogInformation($"User import - Insert phase completed. {insertedDbUsers.Count.ToString("N0")} new users inserted.");
+                _logger.LogInformation($"User import - Insert phase completed. {insertedDbUsers.Count.ToString("N0")} new users inserted.");
 
                 // Reload newly inserted users WITH TRACKING and update dictionaries
                 // This ensures they're properly tracked when used as managers in ProcessExistingUsersInBatches
                 if (insertedDbUsers.Count > 0)
                 {
-                    _telemetry.LogInformation($"User import - Reloading {insertedDbUsers.Count.ToString("N0")} newly inserted users with tracking for manager relationships...");
+                    _logger.LogInformation($"User import - Reloading {insertedDbUsers.Count.ToString("N0")} newly inserted users with tracking for manager relationships...");
 
                     // Collect UPNs as Graph delivers them. SQL Server's default code-first
                     // collation (Latin1_General_CI_AS) is case-insensitive, so we no longer
@@ -235,7 +235,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 // path (no per-user Graph calls needed for licenses).
                 // When SKUs are NOT available we must fall back to the EF-per-entity
                 // path because each user needs individual Graph license queries.
-                _telemetry.LogInformation($"User import - Starting metadata update for {notInsertedUpns.Count.ToString("N0")} existing users...");
+                _logger.LogInformation($"User import - Starting metadata update for {notInsertedUpns.Count.ToString("N0")} existing users...");
                 int existingUsersUpdated = 0;
                 try
                 {
@@ -261,11 +261,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                             async (graphUser, dbUser) => await UpdateDbUserWithGraphData(db, graphUser, allActiveGraphUsers, new List<Common.Entities.User>(), dbUser, true, dbUsersByAadId),
                             BATCH_SIZE);
                     }
-                    _telemetry.LogInformation($"User import - Completed metadata update for {existingUsersUpdated.ToString("N0")} existing users");
+                    _logger.LogInformation($"User import - Completed metadata update for {existingUsersUpdated.ToString("N0")} existing users");
                 }
                 catch (Exception ex)
                 {
-                    _telemetry.LogError($"User import - ERROR updating existing users: {ex.Message}");
+                    _logger.LogError($"User import - ERROR updating existing users: {ex.Message}");
                     throw;
                 }
 
@@ -312,7 +312,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     }
 
                     allDbUsersForLicenseRefresh = new List<Common.Entities.User>(combinedById.Values);
-                    _telemetry.LogInformation($"User import - licence refresh will cover {allDbUsersForLicenseRefresh.Count.ToString("N0")} DB users (entire population, not just delta).");
+                    _logger.LogInformation($"User import - licence refresh will cover {allDbUsersForLicenseRefresh.Count.ToString("N0")} DB users (entire population, not just delta).");
                 }
 
                 // Can we update SKUs for users on batch (ie Organization.Read.All granted)?
@@ -322,13 +322,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     // instead of the User navigation property, so the entities do not
                     // need to be tracked by EF.
                     await _licenseProcessor.ProcessSKUsForAllUsers(skus, allDbUsersForLicenseRefresh, db);
-                    _telemetry.LogInformation($"User import - updated user license information from {skus.Count.ToString("N0")} tenant SKUs");
+                    _logger.LogInformation($"User import - updated user license information from {skus.Count.ToString("N0")} tenant SKUs");
 
                     db.ChangeTracker.DetectChanges();
                     await db.SaveChangesAsync();
                 }
 
-                _telemetry.LogInformation($"{DateTime.Now.ToShortTimeString()} User import - complete. Inserted {insertedDbUsers.Count.ToString("N0")} new users, updated metadata for {existingUsersUpdated.ToString("N0")} existing users (from {allActiveGraphUsers.Count.ToString("N0")} Graph users)");
+                _logger.LogInformation($"{DateTime.Now.ToShortTimeString()} User import - complete. Inserted {insertedDbUsers.Count.ToString("N0")} new users, updated metadata for {existingUsersUpdated.ToString("N0")} existing users (from {allActiveGraphUsers.Count.ToString("N0")} Graph users)");
 
                 // All insert/metadata/license work succeeded. Now and ONLY now is it
                 // safe to persist the new Graph delta token. If any of the previous
@@ -372,11 +372,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             if (_dataMapper == null)
             {
-                _dataMapper = new UserDataMapper(_telemetry, _userMetaCache);
+                _dataMapper = new UserDataMapper(_logger, _userMetaCache);
             }
             if (_licenseProcessor == null)
             {
-                _licenseProcessor = new UserLicenseProcessor(_telemetry, _userLoader, _userMetaCache);
+                _licenseProcessor = new UserLicenseProcessor(_logger, _userLoader, _userMetaCache);
             }
 
             return await _insertProcessor.InsertMissingUsers(
@@ -399,7 +399,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             // Ensure mapper is initialized
             if (_dataMapper == null && _userMetaCache != null)
             {
-                _dataMapper = new UserDataMapper(_telemetry, _userMetaCache);
+                _dataMapper = new UserDataMapper(_logger, _userMetaCache);
             }
 
             if (_dataMapper != null)
@@ -434,7 +434,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             // Ensure mapper is initialized
             if (_dataMapper == null && _userMetaCache != null)
             {
-                _dataMapper = new UserDataMapper(_telemetry, _userMetaCache);
+                _dataMapper = new UserDataMapper(_logger, _userMetaCache);
             }
 
             // If mapper is available, use it; otherwise do direct mapping

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/OAuthContext.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/OAuthContext.cs
@@ -1,4 +1,4 @@
-﻿using DataUtils.Http;
+using DataUtils.Http;
 using Microsoft.Extensions.Logging;
 
 namespace WebJob.Office365ActivityImporter.Engine
@@ -8,8 +8,8 @@ namespace WebJob.Office365ActivityImporter.Engine
     /// </summary>
     public class GraphAppIndentityOAuthContext : ImportAppIndentityOAuthContext
     {
-        public GraphAppIndentityOAuthContext(ILogger telemetry, string clientId, string tenantId, string clientSecret, string keyVaultUrl, bool useClientCertificate) :
-            base(telemetry, clientId, tenantId, clientSecret, keyVaultUrl, useClientCertificate)
+        public GraphAppIndentityOAuthContext(ILogger logger, string clientId, string tenantId, string clientSecret, string keyVaultUrl, bool useClientCertificate) :
+            base(logger, clientId, tenantId, clientSecret, keyVaultUrl, useClientCertificate)
         { }
 
         public override string ResourceURL => "https://graph.microsoft.com/.default";
@@ -20,8 +20,8 @@ namespace WebJob.Office365ActivityImporter.Engine
     /// </summary>
     public class ActivityAPIAppIndentityOAuthContext : ImportAppIndentityOAuthContext
     {
-        public ActivityAPIAppIndentityOAuthContext(ILogger telemetry, string clientId, string tenantId, string clientSecret, string keyVaultUrl, bool useClientCertificate) :
-            base(telemetry, clientId, tenantId, clientSecret, keyVaultUrl, useClientCertificate)
+        public ActivityAPIAppIndentityOAuthContext(ILogger logger, string clientId, string tenantId, string clientSecret, string keyVaultUrl, bool useClientCertificate) :
+            base(logger, clientId, tenantId, clientSecret, keyVaultUrl, useClientCertificate)
         { }
 
         public override string ResourceURL => "https://manage.office.com/.default";

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/BaseClasses.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/BaseClasses.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities.Installer;
+using Common.Entities.Installer;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
@@ -9,12 +9,12 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
 
     public abstract class BaseUsageStatsBuilder
     {
-        protected readonly ILogger _tracer;
+        protected readonly ILogger _logger;
         protected readonly Guid _tenantId;
 
-        protected BaseUsageStatsBuilder(ILogger tracer, Guid tenantId)
+        protected BaseUsageStatsBuilder(ILogger logger, Guid tenantId)
         {
-            _tracer = tracer;
+            _logger = logger;
             _tenantId = tenantId;
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/SqlUsageStatsBuilder.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/SqlUsageStatsBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Installer;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -17,7 +17,7 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
     public class SqlUsageStatsBuilder : BaseUsageStatsBuilder
     {
         private readonly AnalyticsEntitiesContext _db;
-        public SqlUsageStatsBuilder(AnalyticsEntitiesContext db, ILogger tracer, Guid tenantId) : base(tracer, tenantId)
+        public SqlUsageStatsBuilder(AnalyticsEntitiesContext db, ILogger logger, Guid tenantId) : base(logger, tenantId)
         {
             _db = db;
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/UsageStatsManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/UsageStatsManager.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -13,15 +13,15 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
         private readonly BaseUsageStatsBuilder _statsBuilder;
         private readonly IStatsDatesLoader _statsDatesLoader;
         private readonly IStatsUploader _statsUploader;
-        private readonly ILogger _tracer;
+        private readonly ILogger _logger;
         private static TimeSpan MIN_WAIT = TimeSpan.FromDays(1);
 
-        public UsageStatsManager(BaseUsageStatsBuilder statsBuilder, IStatsDatesLoader statsDatesLoader, IStatsUploader statsUploader, ILogger tracer)
+        public UsageStatsManager(BaseUsageStatsBuilder statsBuilder, IStatsDatesLoader statsDatesLoader, IStatsUploader statsUploader, ILogger logger)
         {
             _statsBuilder = statsBuilder;
             _statsDatesLoader = statsDatesLoader;
             _statsUploader = statsUploader;
-            _tracer = tracer;
+            _logger = logger;
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
             }
             catch (Exception ex)
             {
-                _tracer.LogWarning($"{LOG_PREFIX}error uploading anonymised runtime stats - {ex.Message}");
+                _logger.LogWarning($"{LOG_PREFIX}error uploading anonymised runtime stats - {ex.Message}");
                 return false;
             }
         }
@@ -52,41 +52,41 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
                     {
                         if (lastStatsUpload.HasValue)
                         {
-                            _tracer.LogInformation($"{LOG_PREFIX}Last usage report was uploaded {lastStatsUpload.Value} - uploading new report now");
+                            _logger.LogInformation($"{LOG_PREFIX}Last usage report was uploaded {lastStatsUpload.Value} - uploading new report now");
                         }
                         else
                         {
-                            _tracer.LogInformation($"{LOG_PREFIX}no last telemetry date found in redis - uploading new report now");
+                            _logger.LogInformation($"{LOG_PREFIX}no last telemetry date found in redis - uploading new report now");
                         }
 
                         var latestStats = await _statsBuilder.LoadUsageStatsModel(lastSettings);
                         if (latestStats != null)
                         {
                             await _statsUploader.UploadToServer(latestStats);
-                            _tracer.LogInformation($"{LOG_PREFIX}uploaded stats to server");
+                            _logger.LogInformation($"{LOG_PREFIX}uploaded stats to server");
 
                             await _statsBuilder.SaveUsageStatsModelToDatabase(latestStats);
-                            _tracer.LogInformation($"{LOG_PREFIX}saved latest stats to database - see table 'sys_telemetry_reports'");
+                            _logger.LogInformation($"{LOG_PREFIX}saved latest stats to database - see table 'sys_telemetry_reports'");
 
                             // Remember last upload dt
                             await _statsDatesLoader.RegisterLastUploadDt();
                             return true;
                         }
                         else
-                            _tracer.LogInformation($"{LOG_PREFIX}Invalid stats loaded from system. Will ignore.");
+                            _logger.LogInformation($"{LOG_PREFIX}Invalid stats loaded from system. Will ignore.");
                     }
                     else
                     {
-                        _tracer.LogInformation($"{LOG_PREFIX}usage reports are disabled");
+                        _logger.LogInformation($"{LOG_PREFIX}usage reports are disabled");
                     }
                 }
                 else
                 {
-                    _tracer.LogInformation($"{LOG_PREFIX}telemetry stats uploaded recently (less than {MIN_WAIT.TotalHours} hours ago) - skipping for now");
+                    _logger.LogInformation($"{LOG_PREFIX}telemetry stats uploaded recently (less than {MIN_WAIT.TotalHours} hours ago) - skipping for now");
                 }
             }
             else
-                _tracer.LogInformation($"{LOG_PREFIX}invalid solution configuration found in DB. Cannot continue.");
+                _logger.LogInformation($"{LOG_PREFIX}invalid solution configuration found in DB. Cannot continue.");
             return false;
         }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/WebApiStatsUploader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/WebApiStatsUploader.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Net.Http;
@@ -17,13 +17,13 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
 
         private readonly string _url;
         private readonly string _statsApiSecret;
-        private readonly ILogger _debugTracer;
+        private readonly ILogger _logger;
 
-        public WebApiStatsUploader(string url, string statsApiSecret, ILogger debugTracer)
+        public WebApiStatsUploader(string url, string statsApiSecret, ILogger logger)
         {
             _url = url;
             _statsApiSecret = statsApiSecret;
-            _debugTracer = debugTracer;
+            _logger = logger;
         }
 
         public void Dispose()
@@ -41,16 +41,16 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
                 var response = await _httpClient.PostAsync(_url, content);
                 if (response.IsSuccessStatusCode)
                 {
-                    _debugTracer.LogInformation($"Uploaded stats to {_url}");
+                    _logger.LogInformation($"Uploaded stats to {_url}");
                 }
                 else
                 {
-                    _debugTracer.LogError($"Can't upload stats to API - server returned unexpected response {response.StatusCode}");
+                    _logger.LogError($"Can't upload stats to API - server returned unexpected response {response.StatusCode}");
                 }
             }
             else
             {
-                _debugTracer.LogInformation($"Can't upload stats to API - invalid API configuration");
+                _logger.LogInformation($"Can't upload stats to API - invalid API configuration");
                 throw new InvalidOperationException("Can't upload stats to API - invalid API configuration");
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -1,4 +1,4 @@
-﻿// All rights reserved.
+// All rights reserved.
 // THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY
 // KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
@@ -81,7 +81,7 @@ namespace WebJob.Office365ActivityImporter
 #endif
 
             // Create new telemetry client with AppInsights key
-            var telemetry = new AnalyticsLogger(configuredSettings.AppInsightsConnectionString, "Office365ActivityImporter");
+            var logger = new AnalyticsLogger(configuredSettings.AppInsightsConnectionString, "Office365ActivityImporter");
 
             // Verify config
             var webhookUrl = configuredSettings.WebAppURL + "api/CallRecordWebhook";
@@ -113,15 +113,15 @@ namespace WebJob.Office365ActivityImporter
                     if (args.Length >= argIdx + 2)
                     {
                         // Import a single call ID
-                        telemetry.LogInformation($"Detected '{ActivityImportConstants.PARAM_CALL_ID}' parameter value. Importing single call-record from Graph and exiting.");
+                        logger.LogInformation($"Detected '{ActivityImportConstants.PARAM_CALL_ID}' parameter value. Importing single call-record from Graph and exiting.");
                         var nextArg = args[argIdx + 1];
 
-                        var auth = new GraphAppIndentityOAuthContext(telemetry, configuredSettings.ClientID, configuredSettings.TenantGUID.ToString(), configuredSettings.ClientSecret, configuredSettings.KeyVaultUrl, configuredSettings.UseClientCertificate);
+                        var auth = new GraphAppIndentityOAuthContext(logger, configuredSettings.ClientID, configuredSettings.TenantGUID.ToString(), configuredSettings.ClientSecret, configuredSettings.KeyVaultUrl, configuredSettings.UseClientCertificate);
 
                         var newCall = await Engine.Entities.Serialisation.CallRecordDTO.SaveNewCallToDB(
                             nextArg,
-                            new Engine.Graph.ManualGraphCallClient(auth, telemetry),
-                            auth.Creds, telemetry, configuredSettings.TenantGUID.ToString());
+                            new Engine.Graph.ManualGraphCallClient(auth, logger),
+                            auth.Creds, logger, configuredSettings.TenantGUID.ToString());
 
                         ConsoleApp.BombOut(false);
                     }
@@ -161,10 +161,10 @@ namespace WebJob.Office365ActivityImporter
             }
 
             // Output program
-            PrintStartupDetails(configuredSettings, telemetry);
+            PrintStartupDetails(configuredSettings, logger);
 
             // Test DB
-            TestDB(telemetry);
+            TestDB(logger);
 
             // Loop forever?
             var runAgain = true;
@@ -181,23 +181,23 @@ namespace WebJob.Office365ActivityImporter
             }
             else
             {
-                telemetry.LogInformation("No Redis connection string configured - using in-memory throttle for stats upload (the MIN_WAIT window resets each time the WebJob process restarts).");
+                logger.LogInformation("No Redis connection string configured - using in-memory throttle for stats upload (the MIN_WAIT window resets each time the WebJob process restarts).");
                 statsDatesLoader = new InMemoryStatsDatesLoader();
             }
 
             // Run app
             while (runAgain)
             {
-                var importCycleTimer = new JobTimer(telemetry, Process.GetCurrentProcess().ProcessName);
+                var importCycleTimer = new JobTimer(logger, Process.GetCurrentProcess().ProcessName);
                 importCycleTimer.Start();
-                var tasks = new ProgramTasks(telemetry, configuredSettings);
+                var tasks = new ProgramTasks(logger, configuredSettings);
 
                 // Start listening for SB messages & register notifications web-hook with Graph 
                 if (webHookUrl != null && configuredSettings.ImportJobSettings.Calls)
                 {
                     if (string.IsNullOrWhiteSpace(configuredSettings.ConnectionStrings.ServiceBusConnectionString))
                     {
-                        telemetry.LogCritical("Teams calls import is enabled but Service Bus is not configured. Skipping Call Queue import & webhook validation. Re-run the installer with Service Bus enabled, or disable the Calls import.");
+                        logger.LogCritical("Teams calls import is enabled but Service Bus is not configured. Skipping Call Queue import & webhook validation. Re-run the installer with Service Bus enabled, or disable the Calls import.");
                     }
                     else
                     {
@@ -207,14 +207,14 @@ namespace WebJob.Office365ActivityImporter
                         }
                         catch (Exception ex)
                         {
-                            telemetry.TrackException(ex);
-                            telemetry.LogCritical($"Got exception on {nameof(ProgramTasks.ProcessCallQueueAndWebhook)}: {ex.Message}");
+                            logger.TrackException(ex);
+                            logger.LogCritical($"Got exception on {nameof(ProgramTasks.ProcessCallQueueAndWebhook)}: {ex.Message}");
                         }
                     }
                 }
                 else
                 {
-                    telemetry.LogInformation("Skipping Call Queue import & webhook validation.");
+                    logger.LogInformation("Skipping Call Queue import & webhook validation.");
                 }
 
                 try
@@ -224,8 +224,8 @@ namespace WebJob.Office365ActivityImporter
                 }
                 catch (Exception ex)
                 {
-                    telemetry.TrackException(ex);
-                    telemetry.LogCritical($"Got exception on {nameof(ProgramTasks.GetGraphTeamsAndUserData)}: {ex.Message}");
+                    logger.TrackException(ex);
+                    logger.LogCritical($"Got exception on {nameof(ProgramTasks.GetGraphTeamsAndUserData)}: {ex.Message}");
 #if DEBUG
                     throw;
 #endif
@@ -244,14 +244,14 @@ namespace WebJob.Office365ActivityImporter
                     }
                     catch (Exception ex)
                     {
-                        telemetry.TrackException(ex);
+                        logger.TrackException(ex);
                         Console.WriteLine($"Got exception on {nameof(ProgramTasks.DownloadActivityData)}: {ex.Message}");
                     }
 #endif
                 }
                 else
                 {
-                    telemetry.LogInformation("Skipping Activity API import.");
+                    logger.LogInformation("Skipping Activity API import.");
                 }
 
 #if DEBUG
@@ -270,17 +270,17 @@ namespace WebJob.Office365ActivityImporter
                 // its "last uploaded" timestamp across cycles.
                 using (var db = new AnalyticsEntitiesContext())
                 {
-                    var sqlUsageBuilder = new SqlUsageStatsBuilder(db, telemetry, configuredSettings.TenantGUID);
-                    using (var statsUploader = new WebApiStatsUploader(configuredSettings.StatsApiUrl, configuredSettings.StatsApiSecret, telemetry))
+                    var sqlUsageBuilder = new SqlUsageStatsBuilder(db, logger, configuredSettings.TenantGUID);
+                    using (var statsUploader = new WebApiStatsUploader(configuredSettings.StatsApiUrl, configuredSettings.StatsApiSecret, logger))
                     {
-                        var stats = new UsageStatsManager(sqlUsageBuilder, statsDatesLoader, statsUploader, telemetry);
+                        var stats = new UsageStatsManager(sqlUsageBuilder, statsDatesLoader, statsUploader, logger);
                         await stats.ProcessAndFailSilently();
                     }
                 }
 
                 if (runAgain)
                 {
-                    ConsoleApp.WebjobWait(telemetry);
+                    ConsoleApp.WebjobWait(logger);
                 }
             } // Go around again?
 
@@ -291,9 +291,9 @@ namespace WebJob.Office365ActivityImporter
         /// <summary>
         /// Tests the SQL DB configured. Bombs out if a problem
         /// </summary>
-        private static void TestDB(ILogger debugTracer)
+        private static void TestDB(ILogger logger)
         {
-            debugTracer.LogInformation("Testing SQL configuration...");
+            logger.LogInformation("Testing SQL configuration...");
 
             using (AnalyticsEntitiesContext db = new AnalyticsEntitiesContext())
             {
@@ -301,11 +301,11 @@ namespace WebJob.Office365ActivityImporter
                 {
                     int count = (from allDownloads in db.AuditEventsCommon
                                  select allDownloads).Count();
-                    debugTracer.LogInformation($"Found {count.ToString("n0")} events in table already. Test passed!");
+                    logger.LogInformation($"Found {count.ToString("n0")} events in table already. Test passed!");
                 }
                 catch (System.Data.SqlClient.SqlException ex)
                 {
-                    debugTracer.LogError(ex, $"Got a SQL error: {ex.Message}");
+                    logger.LogError(ex, $"Got a SQL error: {ex.Message}");
                     ConsoleApp.BombOut(true);
                 }
             }
@@ -314,18 +314,18 @@ namespace WebJob.Office365ActivityImporter
         /// <summary>
         /// Confirm and validate settings
         /// </summary>
-        private static void PrintStartupDetails(AppConfig settings, ILogger telemetry)
+        private static void PrintStartupDetails(AppConfig settings, ILogger logger)
         {
-            ConsoleApp.PrintStartupAndLoggingConfig(settings.ConnectionStrings.DatabaseConnectionString, settings.BuildLabel, settings.UserGroupsFilter, telemetry);
+            ConsoleApp.PrintStartupAndLoggingConfig(settings.ConnectionStrings.DatabaseConnectionString, settings.BuildLabel, settings.UserGroupsFilter, logger);
 
             var efConnectionString = ConfigurationManager.ConnectionStrings["SPOInsightsEntities"].ConnectionString;
             var sqlConnectionInfo = new System.Data.SqlClient.SqlConnectionStringBuilder(efConnectionString);
 
-            telemetry.LogInformation("\nConfigured values:");
+            logger.LogInformation("\nConfigured values:");
 
-            telemetry.LogInformation($"Destination SQL Server='{sqlConnectionInfo.DataSource}', DB='{sqlConnectionInfo.InitialCatalog}'.");
-            telemetry.LogInformation($"Azure AD tenant='{settings.TenantDomain}, client ID='{settings.ClientID}'.");
-            telemetry.LogInformation($"Days back to check for events from Activity API='{settings.DaysBeforeNowToDownload}'.");
+            logger.LogInformation($"Destination SQL Server='{sqlConnectionInfo.DataSource}', DB='{sqlConnectionInfo.InitialCatalog}'.");
+            logger.LogInformation($"Azure AD tenant='{settings.TenantDomain}, client ID='{settings.ClientID}'.");
+            logger.LogInformation($"Days back to check for events from Activity API='{settings.DaysBeforeNowToDownload}'.");
 
             // Print & verify O365 workloads to import
             var validWorkloadsConfig = false;
@@ -336,17 +336,17 @@ namespace WebJob.Office365ActivityImporter
                 if (workloadsInConfig.Length > 0)
                 {
                     validWorkloadsConfig = true;
-                    telemetry.LogInformation("\nConfigured workloads to import:");
+                    logger.LogInformation("\nConfigured workloads to import:");
                     foreach (var workload in workloadsInConfig)
                     {
-                        telemetry.LogInformation($"+{workload}");
+                        logger.LogInformation($"+{workload}");
                     }
                     Console.WriteLine();
                 }
             }
             if (!validWorkloadsConfig)
             {
-                telemetry.LogError("CONFIG ERROR: No Office 365 workloads found in configuration key 'ContentTypesListAsString'!");
+                logger.LogError("CONFIG ERROR: No Office 365 workloads found in configuration key 'ContentTypesListAsString'!");
                 ConsoleApp.BombOut(true);
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Extensions.Logging;
@@ -24,15 +24,15 @@ namespace WebJob.Office365ActivityImporter
         private bool _isInitialized = false;
         private GraphServiceClient _graphClient = null;
         private readonly GraphAppIndentityOAuthContext _graphAppIndentityOAuthContext;
-        private readonly AnalyticsLogger _telemetry;
+        private readonly AnalyticsLogger _logger;
         private readonly AppConfig _settings;
         private ManualGraphCallClient _manualGraphCallClient = null;
         private GraphUserGroupsCache _graphUserGroupsCache = null;
 
-        public ProgramTasks(AnalyticsLogger telemetry, AppConfig settings)
+        public ProgramTasks(AnalyticsLogger logger, AppConfig settings)
         {
-            _graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(telemetry, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
-            _telemetry = telemetry;
+            _graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(logger, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
+            _logger = logger;
             _settings = settings;
         }
 
@@ -43,8 +43,8 @@ namespace WebJob.Office365ActivityImporter
             // Fire and forget calls SB receiver
             _ = callQueueProcessor.BeginProcessCallsQueue();
 
-            _telemetry.LogInformation("Verifying call webhook subscription.");
-            var callWebhook = new CallWebhook(_settings, _telemetry);
+            _logger.LogInformation("Verifying call webhook subscription.");
+            var callWebhook = new CallWebhook(_settings, _logger);
             await callWebhook.CreateOrUpdateWebhook(webHookUrl, _settings.ClientSecret);
 
         }
@@ -54,11 +54,11 @@ namespace WebJob.Office365ActivityImporter
         /// </summary>
         internal async Task GetGraphTeamsAndUserData()
         {
-            _telemetry.LogInformation("Starting Teams & Graph import.");
+            _logger.LogInformation("Starting Teams & Graph import.");
 
             await InitAuth();
 
-            var graphReader = new GraphImporter(_telemetry, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings);
+            var graphReader = new GraphImporter(_logger, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings);
 
             try
             {
@@ -69,17 +69,17 @@ namespace WebJob.Office365ActivityImporter
                 // Don't make a drama if Graph permissions aren't assigned yet.
                 if (ex.ResponseStatusCode == (int)HttpStatusCode.Forbidden)
                 {
-                    _telemetry.LogWarning("ERROR: Can't access Teams user data - are application permissions configured correctly?");
+                    _logger.LogWarning("ERROR: Can't access Teams user data - are application permissions configured correctly?");
                     return;
                 }
                 else
                 {
-                    _telemetry.LogError(ex, ex.Message);
+                    _logger.LogError(ex, ex.Message);
                     throw;
                 }
             }
 
-            _telemetry.LogInformation("Finished Graph API import tasks.");
+            _logger.LogInformation("Finished Graph API import tasks.");
         }
 
         async Task InitAuth()
@@ -90,8 +90,8 @@ namespace WebJob.Office365ActivityImporter
             }
             await _graphAppIndentityOAuthContext.InitClientCredential();
             _graphClient = GraphServiceClientFactory.CreateWithTimeout(_graphAppIndentityOAuthContext.Creds, TimeSpan.FromHours(1));
-            _manualGraphCallClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _telemetry);
-            _graphUserGroupsCache = new GraphUserGroupsCache(_manualGraphCallClient, _telemetry);
+            _manualGraphCallClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _logger);
+            _graphUserGroupsCache = new GraphUserGroupsCache(_manualGraphCallClient, _logger);
 
 
             _isInitialized = true;
@@ -114,37 +114,37 @@ namespace WebJob.Office365ActivityImporter
 
                 if (spFilterList.OrgUrlConfigs.Count == 0)
                 {
-                    _telemetry.LogCritical("FATAL ERROR: No org URLs found in database! " +
+                    _logger.LogCritical("FATAL ERROR: No org URLs found in database! " +
                         "This means everything would be ignored for SharePoint audit data. Add at least one URL to the org_urls table for this to work.");
 
                     return;
 
                 }
 
-                _telemetry.LogInformation("\nBeginning import. Filtering for SharePoint events below these URLs:");
+                _logger.LogInformation("\nBeginning import. Filtering for SharePoint events below these URLs:");
 
                 // Print URLs
-                spFilterList.Print(_telemetry);
+                spFilterList.Print(_logger);
                 Console.WriteLine();
 
-                _telemetry.LogInformation($"Starting activity import for {spFilterList.OrgUrlConfigs.Count} url filters");
+                _logger.LogInformation($"Starting activity import for {spFilterList.OrgUrlConfigs.Count} url filters");
 
                 // Start new O365 activity download session
                 // Reduced from 20000 to 5000, then to 2000 to prevent OutOfMemoryException with large datasets
                 const int MAX_IMPORTS_PER_BATCH = 2000;
-                var importer = new ActivityWebImporter(_settings, _telemetry, MAX_IMPORTS_PER_BATCH);
+                var importer = new ActivityWebImporter(_settings, _logger, MAX_IMPORTS_PER_BATCH);
 
-                var sqlAdaptor = new ActivityReportSqlPersistenceManager(spFilterList, _graphUserGroupsCache, _telemetry, _settings);
+                var sqlAdaptor = new ActivityReportSqlPersistenceManager(spFilterList, _graphUserGroupsCache, _logger, _settings);
                 try
                 {
                     var stats = await importer.LoadReportsAndSave(sqlAdaptor);
 
                     // Output stats
-                    _telemetry.LogInformation($"Finished activity import. Time taken in = {DateTime.Now.Subtract(startTime).TotalMinutes.ToString("N2")} minutes. Stats: {stats}");
+                    _logger.LogInformation($"Finished activity import. Time taken in = {DateTime.Now.Subtract(startTime).TotalMinutes.ToString("N2")} minutes. Stats: {stats}");
                 }
                 catch (System.Net.Http.HttpRequestException ex)
                 {
-                    _telemetry.LogError(ex, $"Got unexpected exception importing activity: {ex.Message}");
+                    _logger.LogError(ex, $"Got unexpected exception importing activity: {ex.Message}");
                 }
             }
         }


### PR DESCRIPTION
## What & why

Refresh `ILogger` variable naming to be **type-based and consistent**, per the convention that `ILogger` members are `_logger` and parameters/locals are `logger`.

Previously the same `ILogger` was named four different ways across the codebase:

| Legacy name | Files | → |
|---|---|---|
| `_debugTracer` / `debugTracer` | 21 | `_logger` / `logger` |
| `_tracer` / `tracer` | 6 | `_logger` / `logger` |
| `_telemetry` / `telemetry` | 95 | `_logger` / `logger` |

`_inner` is **kept** in the two `ILogger` *decorator* classes (`InstallSummary`, `InstallLogCapturingLogger`) since it denotes the wrapped instance, not the type.

## How

Renamed with a Roslyn identifier-token rewriter (not find/replace), so only real identifiers change. The domain word **"telemetry" is deliberately preserved** everywhere it isn't an `ILogger` variable:
- log-message strings (e.g. *"no last telemetry date found in redis"*, *"telemetry stats uploaded recently"*)
- `AllowTelemetry`, `AnalyticsLogger`, `TelemetrySaveAdaptor`, `sys_telemetry_reports`
- `TelemetryClient` variables (`AppInsights`/`appInsights`) and comments

A DEBUG pass plus a `!DEBUG` pass were run so conditionally-compiled code (`#if !DEBUG` in the Office365 importer) is covered too. One duplicate `AnalyticsLogger.ConsoleOnlyTracer()` local in `ActivityImporterTests` that the rename surfaced was collapsed.

## Scope
114 files, +1073 / −1074 (pure rename; the −1 is the duplicate-local cleanup). No behavioural change.

## Validation
- Full solution **builds clean in Debug and Release** (Release specifically validates the `#if !DEBUG` path).
- Unit tests pass.
