### PR TITLE
Make Tests.FakeDataGen users realistic (varied countries, richer metadata, multi-domain)

### DIFF
--- a/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotUserManager.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotUserManager.cs
@@ -1,7 +1,9 @@
 using Common.Entities;
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
+using Tests.FakeDataGen.Seeding;
 
 namespace Tests.FakeDataGen.Copilot
 {
@@ -31,21 +33,35 @@ namespace Tests.FakeDataGen.Copilot
 
             Console.WriteLine($"Creating {count} test users with {copilotLicensePercentage}% having Copilot licenses...");
 
-            // Create users
+            // Look-up caches so each distinct metadata value is created once and the same instance
+            // is reused (keeps FKs coherent and lets us group users by company for the hierarchy).
+            var deptCache = new Dictionary<string, UserDepartment>(StringComparer.OrdinalIgnoreCase);
+            var companyCache = new Dictionary<string, CompanyName>(StringComparer.OrdinalIgnoreCase);
+            var jobCache = new Dictionary<string, UserJobTitle>(StringComparer.OrdinalIgnoreCase);
+            var stateCache = new Dictionary<string, StateOrProvince>(StringComparer.OrdinalIgnoreCase);
+            var countryCache = new Dictionary<string, CountryOrRegion>(StringComparer.OrdinalIgnoreCase);
+            var officeCache = new Dictionary<string, UserOfficeLocation>(StringComparer.OrdinalIgnoreCase);
+            var usageCache = new Dictionary<string, UserUsageLocation>(StringComparer.OrdinalIgnoreCase);
+
+            // Create users with realistic, internally-consistent metadata spread across domains.
             for (int i = 0; i < count; i++)
             {
-                // Get or create a random department
-                var departmentName = CopilotActivityGeneratorConfig.DepartmentNames[_random.Next(CopilotActivityGeneratorConfig.DepartmentNames.Length)];
-                var department = GetOrCreateDepartment(db, departmentName);
-
-                var upn = $"testuser{i}@contoso.com";
+                var profile = SeedDataCatalogue.NextUserProfile(_random);
+                var upn = SeedDataCatalogue.BuildUpn("testuser", i);
                 var user = new User
                 {
                     UserPrincipalName = upn,
                     Mail = upn,
-                    Department = department,
-                    AccountEnabled = true,
-                    AzureAdId = Guid.NewGuid().ToString()
+                    AccountEnabled = profile.AccountEnabled,
+                    AzureAdId = Guid.NewGuid().ToString(),
+                    PostalCode = profile.PostalCode ?? string.Empty,
+                    Department = GetOrCreateLookup(db, db.UserDepartments, deptCache, profile.Department),
+                    CompanyName = GetOrCreateLookup(db, db.CompanyNames, companyCache, profile.Company),
+                    JobTitle = GetOrCreateLookup(db, db.UserJobTitles, jobCache, profile.JobTitle),
+                    StateOrProvince = GetOrCreateLookup(db, db.StateOrProvinces, stateCache, profile.StateOrProvince),
+                    UserCountry = GetOrCreateLookup(db, db.CountryOrRegions, countryCache, profile.Country),
+                    OfficeLocation = GetOrCreateLookup(db, db.UserOfficeLocations, officeCache, profile.OfficeLocation),
+                    UsageLocation = GetOrCreateLookup(db, db.UserUsageLocations, usageCache, profile.UsageLocation)
                 };
                 db.users.Add(user);
                 users.Add(user);
@@ -56,6 +72,8 @@ namespace Tests.FakeDataGen.Copilot
             int usersWithCopilot = AssignLicensesToUsers(db, users, copilotLicense, e5License, e3License, copilotLicensePercentage);
 
             Console.WriteLine($"Assigned Copilot licenses to {usersWithCopilot}/{count} users ({(usersWithCopilot * 100.0 / count):F1}%)");
+
+            AssignManagers(db, users);
 
             return users;
         }
@@ -90,16 +108,49 @@ namespace Tests.FakeDataGen.Copilot
             return usersWithCopilot;
         }
 
-        private UserDepartment GetOrCreateDepartment(AnalyticsEntitiesContext db, string departmentName)
+        /// <summary>
+        /// Resolves (or lazily creates) a named lookup row, caching the instance so each distinct
+        /// value is created once and shared across every user that references it.
+        /// </summary>
+        private static T GetOrCreateLookup<T>(AnalyticsEntitiesContext db, DbSet<T> set,
+            Dictionary<string, T> cache, string name) where T : AbstractEFEntityWithName, new()
         {
-            var department = db.UserDepartments.FirstOrDefault(d => d.Name == departmentName);
-            if (department == null)
+            if (name == null) return null;
+            if (cache.TryGetValue(name, out var cached)) return cached;
+
+            var existing = set.FirstOrDefault(x => x.Name == name);
+            if (existing == null)
             {
-                department = new UserDepartment { Name = departmentName };
-                db.UserDepartments.Add(department);
+                existing = new T { Name = name };
+                set.Add(existing);
                 db.SaveChanges();
             }
-            return department;
+            cache[name] = existing;
+            return existing;
+        }
+
+        /// <summary>
+        /// Gives the generated users a realistic reporting hierarchy: within each company a small
+        /// fraction are managers (left top-level) and everyone else reports to one of them.
+        /// </summary>
+        private void AssignManagers(AnalyticsEntitiesContext db, List<User> users)
+        {
+            if (users.Count < 2) return;
+
+            foreach (var group in users.GroupBy(u => u.CompanyName))
+            {
+                var list = group.ToList();
+                if (list.Count < 2) continue;
+
+                int managerCount = Math.Max(1, (int)Math.Round(list.Count * 0.1));
+                managerCount = Math.Min(managerCount, list.Count - 1);
+                var managers = list.Take(managerCount).ToList();
+                for (int i = managerCount; i < list.Count; i++)
+                {
+                    list[i].ManagerId = managers[_random.Next(managers.Count)].ID;
+                }
+            }
+            db.SaveChanges();
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/README.md
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/README.md
@@ -62,7 +62,12 @@ Tests.FakeDataGen/
 
 `Seeding` is intentionally shared: every data generator and stress test that
 needs prerequisite metadata calls `UserMetadataSeeder` so the same lookup tables,
-departments, license catalogue, etc. are populated everywhere.
+departments, license catalogue, etc. are populated everywhere. Users are made as
+realistic as a live tenant: `SeedDataCatalogue` assigns each user a coherent geo
+locale (country / state / city / office / usage location / postal code all agree,
+across 21 countries incl. non-Latin values), a job title that fits its department,
+a company, a realistic account-enabled state, a UPN on one of several tenant
+domains, and a manager in their own company.
 
 ## Data generation
 
@@ -71,7 +76,9 @@ departments, license catalogue, etc. are populated everywhere.
 `CopilotActivityGenerator` inserts:
 
 - License types (Copilot, E5, E3, Business Premium, Exchange Online) if missing.
-- 10 test users with random departments, mail attributes, and license
+- Test users with coherent, realistic metadata (country / state / city / office /
+  usage location / postal code, department + fitting job title, company, account
+  state) spread across several email domains and a manager hierarchy, plus license
   assignments (configurable Copilot percentage).
 - Copilot chat events (configurable count) tagged with a mix of standard and
   custom agents, plus the matching `audit_events` + meeting / file metadata

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Seeding/SeedDataCatalogue.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Seeding/SeedDataCatalogue.cs
@@ -1,53 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Tests.FakeDataGen.Seeding
 {
     /// <summary>
     /// Shared seed data used to populate users, lookup tables, and license catalogues.
     /// Centralised so every data generator and stress test pre-loads the same metadata.
+    ///
+    /// The goal is data that is as realistic as a live tenant: users span many countries,
+    /// their geography is internally consistent (country / state / city / office / usage
+    /// location / postal code all agree), job titles fit their department, they live on a
+    /// handful of different email domains and a realistic minority have disabled accounts.
+    /// Some values are deliberately non-Latin (Greek "Αττική", Japanese "東京都", accented
+    /// "São Paulo" / "Zürich") so Unicode round-trips are exercised by the fake data too.
     /// </summary>
     public static class SeedDataCatalogue
     {
-        public static readonly string[] Departments =
+        /// <summary>Fraction of seeded users whose account is disabled (leavers / suspended).</summary>
+        public const double DisabledAccountFraction = 0.07;
+
+        // ---------------------------------------------------------------------
+        // Email domains
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// A handful of tenant domains users are spread across (multi-domain tenants are the
+        /// norm after acquisitions / rebrands). Assignment is deterministic by user index via
+        /// <see cref="DomainForIndex"/> so a seeder and any code that rebuilds the same UPNs
+        /// (e.g. an event catalogue that must join back to the seeded users) always agree.
+        /// </summary>
+        public static readonly string[] Domains =
         {
-            "Engineering", "Marketing", "Sales", "Finance", "Human Resources", "Legal",
-            "Operations", "Product", "Design", "Customer Support", "IT", "Research & Development"
+            "contoso.com", "fabrikam.com", "northwindtraders.com",
+            "adventure-works.com", "woodgrovebank.com", "tailspintoys.com"
+        };
+
+        /// <summary>Deterministic domain for a user index (stable across processes / reruns).</summary>
+        public static string DomainForIndex(int index)
+        {
+            int i = ((index % Domains.Length) + Domains.Length) % Domains.Length;
+            return Domains[i];
+        }
+
+        /// <summary>
+        /// Builds a user principal name. When <paramref name="domainOverride"/> is null the
+        /// domain is chosen deterministically from <see cref="Domains"/> by index, giving a
+        /// realistic multi-domain spread that every caller reproduces identically.
+        /// </summary>
+        public static string BuildUpn(string prefix, int index, string domainOverride = null)
+        {
+            return $"{prefix}{index}@{domainOverride ?? DomainForIndex(index)}";
+        }
+
+        // ---------------------------------------------------------------------
+        // Geography - each locale is internally consistent
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// A single, coherent place a user can belong to. Assigning a whole locale at once
+        /// keeps country / state / city / office / usage location / postal code consistent,
+        /// instead of picking each column independently (which produced impossible people
+        /// such as "United States / Bavaria / Tokyo / ES").
+        /// </summary>
+        public sealed class GeoLocale
+        {
+            public string Country { get; }
+            public string StateOrProvince { get; }
+            public string City { get; }
+            public string OfficeLocation { get; }
+            public string UsageLocation { get; }
+            private readonly Func<Random, string> _postalCode;
+
+            public GeoLocale(string country, string stateOrProvince, string city,
+                string officeLocation, string usageLocation, Func<Random, string> postalCode)
+            {
+                Country = country;
+                StateOrProvince = stateOrProvince;
+                City = city;
+                OfficeLocation = officeLocation;
+                UsageLocation = usageLocation;
+                _postalCode = postalCode;
+            }
+
+            /// <summary>A freshly-formatted, country-appropriate postal code (empty where a country has none).</summary>
+            public string NewPostalCode(Random random) => _postalCode?.Invoke(random) ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Worldwide set of coherent locales (21 countries across every populated continent).
+        /// Multiple offices in the same country are separate entries so city / office / postal
+        /// code stay consistent with each other.
+        /// </summary>
+        public static readonly GeoLocale[] Locales =
+        {
+            // United States
+            new GeoLocale("United States", "Washington", "Redmond", "Redmond/B33", "US", r => "980" + D(r, 2)),
+            new GeoLocale("United States", "Washington", "Redmond", "Redmond/B25", "US", r => "980" + D(r, 2)),
+            new GeoLocale("United States", "California", "Mountain View", "MountainView/MV1", "US", r => "9403" + D(r, 1)),
+            new GeoLocale("United States", "New York", "New York", "NewYork/NY1", "US", r => "100" + D(r, 2)),
+            new GeoLocale("United States", "Texas", "Austin", "Austin/AU1", "US", r => "787" + D(r, 2)),
+            new GeoLocale("United States", "Massachusetts", "Cambridge", "Cambridge/CB1", "US", r => "021" + D(r, 2)),
+            // United Kingdom
+            new GeoLocale("United Kingdom", "Greater London", "London", "London/PV", "GB", r => $"SW{D(r, 1)}{L(r)} {D(r, 1)}{L(r)}{L(r)}"),
+            new GeoLocale("United Kingdom", "Scotland", "Edinburgh", "Edinburgh/ED1", "GB", r => $"EH{D(r, 1)} {D(r, 1)}{L(r)}{L(r)}"),
+            // Ireland
+            new GeoLocale("Ireland", "Leinster", "Dublin", "Dublin/D2", "IE", r => $"D{D(r, 2)} {L(r)}{D(r, 1)}{L(r)}{D(r, 1)}"),
+            // Germany
+            new GeoLocale("Germany", "Bavaria", "Munich", "Munich/MU1", "DE", r => "80" + D(r, 3)),
+            new GeoLocale("Germany", "Berlin", "Berlin", "Berlin/BE1", "DE", r => "10" + D(r, 3)),
+            // France
+            new GeoLocale("France", "Île-de-France", "Paris", "Paris/IS1", "FR", r => "750" + D(r, 2)),
+            // Spain
+            new GeoLocale("Spain", "Community of Madrid", "Madrid", "Madrid/MA1", "ES", r => "280" + D(r, 2)),
+            new GeoLocale("Spain", "Catalonia", "Barcelona", "Barcelona/BA1", "ES", r => "080" + D(r, 2)),
+            // Netherlands
+            new GeoLocale("Netherlands", "North Holland", "Amsterdam", "Amsterdam/AM1", "NL", r => $"10{D(r, 2)} {L(r)}{L(r)}"),
+            // Italy
+            new GeoLocale("Italy", "Lombardy", "Milan", "Milan/MI1", "IT", r => "201" + D(r, 2)),
+            // Switzerland
+            new GeoLocale("Switzerland", "Zürich", "Zürich", "Zurich/ZH1", "CH", r => "80" + D(r, 2)),
+            // Sweden
+            new GeoLocale("Sweden", "Stockholm", "Stockholm", "Stockholm/ST1", "SE", r => $"1{D(r, 2)} {D(r, 2)}"),
+            // Poland
+            new GeoLocale("Poland", "Masovia", "Warsaw", "Warsaw/WA1", "PL", r => $"00-{D(r, 3)}"),
+            // Greece (Unicode state)
+            new GeoLocale("Greece", "Αττική", "Athens", "Athens/AT1", "GR", r => $"1{D(r, 2)} {D(r, 2)}"),
+            // Canada
+            new GeoLocale("Canada", "Ontario", "Toronto", "Toronto/TO1", "CA", r => $"M{D(r, 1)}{L(r)} {D(r, 1)}{L(r)}{D(r, 1)}"),
+            new GeoLocale("Canada", "British Columbia", "Vancouver", "Vancouver/VA1", "CA", r => $"V{D(r, 1)}{L(r)} {D(r, 1)}{L(r)}{D(r, 1)}"),
+            // Brazil (accented city / state)
+            new GeoLocale("Brazil", "São Paulo", "São Paulo", "SaoPaulo/SP1", "BR", r => $"0{D(r, 4)}-{D(r, 3)}"),
+            // Mexico (accented state)
+            new GeoLocale("Mexico", "Ciudad de México", "Mexico City", "MexicoCity/MX1", "MX", r => "0" + D(r, 4)),
+            // India
+            new GeoLocale("India", "Karnataka", "Bengaluru", "Bengaluru/BG1", "IN", r => "5600" + D(r, 2)),
+            new GeoLocale("India", "Maharashtra", "Mumbai", "Mumbai/MB1", "IN", r => "4000" + D(r, 2)),
+            // Japan (Unicode prefecture)
+            new GeoLocale("Japan", "東京都", "Tokyo", "Tokyo/TK1", "JP", r => $"1{D(r, 2)}-{D(r, 4)}"),
+            // Australia
+            new GeoLocale("Australia", "New South Wales", "Sydney", "Sydney/SY1", "AU", r => "20" + D(r, 2)),
+            new GeoLocale("Australia", "Victoria", "Melbourne", "Melbourne/ME1", "AU", r => "30" + D(r, 2)),
+            // Singapore
+            new GeoLocale("Singapore", "Central Region", "Singapore", "Singapore/SG1", "SG", r => D(r, 6)),
+            // United Arab Emirates (no postal code system)
+            new GeoLocale("United Arab Emirates", "Dubai", "Dubai", "Dubai/DU1", "AE", r => string.Empty),
+            // South Africa
+            new GeoLocale("South Africa", "Gauteng", "Johannesburg", "Johannesburg/JO1", "ZA", r => D(r, 4)),
+        };
+
+        // ---------------------------------------------------------------------
+        // Departments -> plausible job titles (a title always fits its department)
+        // ---------------------------------------------------------------------
+
+        public static readonly (string Department, string[] Titles)[] DepartmentJobTitles =
+        {
+            ("Engineering", new[] { "Software Engineer", "Senior Software Engineer", "Principal Engineer", "Engineering Manager", "DevOps Engineer", "Site Reliability Engineer", "QA Engineer", "Technical Lead" }),
+            ("Product", new[] { "Product Manager", "Senior Product Manager", "Group Product Manager", "Product Owner", "Director of Product" }),
+            ("Design", new[] { "UX Designer", "UX Researcher", "Product Designer", "Design Lead" }),
+            ("Sales", new[] { "Account Executive", "Sales Development Representative", "Sales Manager", "Regional Sales Director", "Solutions Engineer" }),
+            ("Marketing", new[] { "Marketing Specialist", "Content Marketing Manager", "Product Marketing Manager", "SEO Analyst", "Chief Marketing Officer" }),
+            ("Finance", new[] { "Financial Analyst", "Accountant", "Finance Manager", "Controller", "Chief Financial Officer" }),
+            ("Human Resources", new[] { "HR Generalist", "Technical Recruiter", "People Operations Manager", "HR Business Partner" }),
+            ("Legal", new[] { "Corporate Counsel", "Paralegal", "Compliance Manager", "General Counsel" }),
+            ("Operations", new[] { "Operations Analyst", "Operations Manager", "Program Manager", "Chief Operating Officer" }),
+            ("Customer Support", new[] { "Support Engineer", "Customer Success Manager", "Support Team Lead", "Technical Account Manager" }),
+            ("IT", new[] { "IT Support Specialist", "Systems Administrator", "Network Engineer", "IT Manager", "Chief Information Security Officer" }),
+            ("Research & Development", new[] { "Research Scientist", "Applied Scientist", "Data Scientist", "Data Analyst", "R&D Lead" }),
+            ("Executive", new[] { "Chief Executive Officer", "Chief Technology Officer", "VP of Engineering", "VP of Sales", "Executive Assistant" }),
         };
 
         public static readonly string[] Companies =
         {
             "Contoso Ltd", "Fabrikam Inc", "Northwind Traders", "Adventure Works",
-            "Woodgrove Bank", "Tailspin Toys", "Litware Inc", "Proseware"
+            "Woodgrove Bank", "Tailspin Toys", "Litware Inc", "Proseware Inc",
+            "Wingtip Toys", "Alpine Ski House", "Trey Research", "Margie's Travel",
+            "Graphic Design Institute", "Lucerne Publishing"
         };
 
-        public static readonly string[] JobTitles =
-        {
-            "Software Engineer", "Senior Developer", "Product Manager", "Data Analyst",
-            "UX Designer", "DevOps Engineer", "Solutions Architect", "Business Analyst",
-            "Project Manager", "QA Engineer", "Technical Lead", "VP of Engineering",
-            "Marketing Specialist", "Account Executive", "Support Engineer"
-        };
+        // Derived lookup arrays (distinct, insertion order preserved) so existing consumers
+        // that expect a flat string[] keep working while the data stays coherent.
+        public static readonly string[] Departments;
+        public static readonly string[] JobTitles;
+        public static readonly string[] Countries;
+        public static readonly string[] StatesOrProvinces;
+        public static readonly string[] OfficeLocations;
+        public static readonly string[] UsageLocations;
 
-        public static readonly string[] StatesOrProvinces =
+        static SeedDataCatalogue()
         {
-            "Washington", "California", "Texas", "New York", "Massachusetts",
-            "Greater London", "Île-de-France", "Bavaria", "Catalonia", "New South Wales"
-        };
-
-        public static readonly string[] Countries =
-        {
-            "United States", "United Kingdom", "Germany", "France", "Spain",
-            "Australia", "Canada", "Japan", "Ireland", "Netherlands"
-        };
-
-        public static readonly string[] OfficeLocations =
-        {
-            "Redmond/B33", "Redmond/B25", "London/PV", "Munich/MU1", "Paris/IS1",
-            "Dublin/D2", "Sydney/SY1", "Tokyo/TK1", "Madrid/MA1", "Toronto/TO1"
-        };
-
-        public static readonly string[] UsageLocations =
-        {
-            "US", "GB", "DE", "FR", "ES", "AU", "CA", "JP", "IE", "NL"
-        };
+            Departments = DepartmentJobTitles.Select(d => d.Department).ToArray();
+            JobTitles = DistinctInOrder(DepartmentJobTitles.SelectMany(d => d.Titles));
+            Countries = DistinctInOrder(Locales.Select(l => l.Country));
+            StatesOrProvinces = DistinctInOrder(Locales.Select(l => l.StateOrProvince));
+            OfficeLocations = DistinctInOrder(Locales.Select(l => l.OfficeLocation));
+            UsageLocations = DistinctInOrder(Locales.Select(l => l.UsageLocation));
+        }
 
         /// <summary>
         /// License catalogue used by data generators and stress tests. SKU IDs reference:
@@ -58,10 +206,83 @@ namespace Tests.FakeDataGen.Seeding
             ("Microsoft 365 Copilot",          "Microsoft_365_Copilot"),
             ("Office 365 E5",                  "ENTERPRISEPREMIUM"),
             ("Office 365 E3",                  "ENTERPRISEPACK"),
+            ("Office 365 E1",                  "STANDARDPACK"),
             ("Microsoft 365 Business Premium", "SPB"),
+            ("Microsoft 365 F3",               "SPE_F1"),
             ("Exchange Online Plan 1",         "EXCHANGESTANDARD"),
             ("Power BI Pro",                   "POWER_BI_PRO"),
-            ("Power Automate Premium",         "POWERAUTOMATE_ATTENDED_RPA")
+            ("Power Automate Premium",         "POWERAUTOMATE_ATTENDED_RPA"),
+            ("Visio Plan 2",                   "VISIOCLIENT"),
+            ("Project Plan 3",                 "PROJECTPROFESSIONAL")
         };
+
+        // ---------------------------------------------------------------------
+        // Coherent per-user profile
+        // ---------------------------------------------------------------------
+
+        /// <summary>A single, internally-consistent, realistic set of user metadata.</summary>
+        public sealed class UserProfile
+        {
+            public string Country { get; set; }
+            public string StateOrProvince { get; set; }
+            public string City { get; set; }
+            public string OfficeLocation { get; set; }
+            public string UsageLocation { get; set; }
+            public string PostalCode { get; set; }
+            public string Department { get; set; }
+            public string JobTitle { get; set; }
+            public string Company { get; set; }
+            public bool AccountEnabled { get; set; }
+        }
+
+        /// <summary>
+        /// Produces one coherent, realistic profile: a whole geo locale, a department with a
+        /// job title that fits it, a company, a country-appropriate postal code and a realistic
+        /// account-enabled state (a small minority are disabled).
+        /// </summary>
+        public static UserProfile NextUserProfile(Random random)
+        {
+            var locale = Locales[random.Next(Locales.Length)];
+            var dept = DepartmentJobTitles[random.Next(DepartmentJobTitles.Length)];
+            return new UserProfile
+            {
+                Country = locale.Country,
+                StateOrProvince = locale.StateOrProvince,
+                City = locale.City,
+                OfficeLocation = locale.OfficeLocation,
+                UsageLocation = locale.UsageLocation,
+                PostalCode = locale.NewPostalCode(random),
+                Department = dept.Department,
+                JobTitle = dept.Titles[random.Next(dept.Titles.Length)],
+                Company = Companies[random.Next(Companies.Length)],
+                AccountEnabled = random.NextDouble() >= DisabledAccountFraction
+            };
+        }
+
+        // ---------------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------------
+
+        private static string[] DistinctInOrder(IEnumerable<string> values)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var ordered = new List<string>();
+            foreach (var value in values)
+            {
+                if (value != null && seen.Add(value)) ordered.Add(value);
+            }
+            return ordered.ToArray();
+        }
+
+        /// <summary>Returns <paramref name="n"/> random decimal digits as a string.</summary>
+        private static string D(Random random, int n)
+        {
+            var chars = new char[n];
+            for (int i = 0; i < n; i++) chars[i] = (char)('0' + random.Next(10));
+            return new string(chars);
+        }
+
+        /// <summary>Returns a random uppercase A-Z letter (for UK / Canada / NL style postal codes).</summary>
+        private static char L(Random random) => (char)('A' + random.Next(26));
     }
 }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Seeding/UserMetadataSeeder.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Seeding/UserMetadataSeeder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
+using System.Text;
 
 namespace Tests.FakeDataGen.Seeding
 {
@@ -96,21 +97,50 @@ namespace Tests.FakeDataGen.Seeding
         }
 
         /// <summary>
-        /// Inserts <paramref name="count"/> users with random metadata FK ids drawn from
-        /// the lookup tables (which must already be seeded via <see cref="EnsureMetadataLookups"/>).
+        /// Reads a single lookup table into a case-insensitive name -&gt; id map so callers can
+        /// resolve the specific value a coherent <see cref="SeedDataCatalogue.UserProfile"/>
+        /// asked for (rather than picking a random id and breaking geo consistency).
+        /// </summary>
+        public static Dictionary<string, int> LoadLookupIdsByName(SqlConnection conn, string tableName)
+        {
+            var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = $"SELECT id, name FROM [{tableName}];";
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        if (!reader.IsDBNull(1)) map[reader.GetString(1)] = reader.GetInt32(0);
+                    }
+                }
+            }
+            return map;
+        }
+
+        /// <summary>
+        /// Inserts <paramref name="count"/> users with realistic, internally-consistent metadata
+        /// drawn from <see cref="SeedDataCatalogue"/>: a coherent geo locale (country / state / city
+        /// / office / usage location / postal code all agree), a job title that fits the department,
+        /// a company, a realistic account-enabled state, and a UPN spread across several tenant
+        /// domains. After insertion a manager hierarchy is built via <see cref="AssignManagers"/>.
+        /// The lookup tables must already be seeded via <see cref="EnsureMetadataLookups"/>.
         /// Returns the id + UPN of every user that was actually inserted; users whose UPN already
         /// exists are skipped silently.
+        ///
+        /// When <paramref name="upnDomain"/> is null (the default) users are spread deterministically
+        /// across <see cref="SeedDataCatalogue.Domains"/> by index; pass a value to force a single domain.
         /// </summary>
         public static List<SeededUser> SeedUsers(SqlConnection conn, int count, Random random,
-            string upnPrefix = "stressuser", string upnDomain = "contoso.com")
+            string upnPrefix = "stressuser", string upnDomain = null)
         {
-            var departments = LoadLookupIds(conn, "user_departments");
-            var companies = LoadLookupIds(conn, "user_company_name");
-            var jobTitles = LoadLookupIds(conn, "user_job_titles");
-            var states = LoadLookupIds(conn, "user_state_or_province");
-            var countries = LoadLookupIds(conn, "user_country_or_region");
-            var offices = LoadLookupIds(conn, "user_office_locations");
-            var usages = LoadLookupIds(conn, "user_usage_locations");
+            var departments = LoadLookupIdsByName(conn, "user_departments");
+            var companies = LoadLookupIdsByName(conn, "user_company_name");
+            var jobTitles = LoadLookupIdsByName(conn, "user_job_titles");
+            var states = LoadLookupIdsByName(conn, "user_state_or_province");
+            var countries = LoadLookupIdsByName(conn, "user_country_or_region");
+            var offices = LoadLookupIdsByName(conn, "user_office_locations");
+            var usages = LoadLookupIdsByName(conn, "user_usage_locations");
 
             var inserted = new List<SeededUser>(count);
 
@@ -119,10 +149,10 @@ namespace Tests.FakeDataGen.Seeding
                 cmd.CommandText = @"
 IF NOT EXISTS (SELECT 1 FROM users WHERE user_name = @upn)
 BEGIN
-    INSERT INTO users (user_name, mail, azure_ad_id, account_enabled, last_updated,
+    INSERT INTO users (user_name, mail, azure_ad_id, account_enabled, last_updated, postalcode,
                        department_id, company_name_id, job_title_id,
                        state_or_province_id, country_or_region_id, office_location_id, usage_location_id)
-    VALUES (@upn, @mail, @aad, 1, @lastUpdated,
+    VALUES (@upn, @mail, @aad, @enabled, @lastUpdated, @postal,
             @dept, @company, @job, @state, @country, @office, @usage);
     SELECT CAST(SCOPE_IDENTITY() AS INT);
 END
@@ -132,7 +162,9 @@ ELSE
                 var pUpn = cmd.Parameters.Add("@upn", SqlDbType.NVarChar, 400);
                 var pMail = cmd.Parameters.Add("@mail", SqlDbType.NVarChar, 400);
                 var pAad = cmd.Parameters.Add("@aad", SqlDbType.NVarChar, 400);
+                var pEnabled = cmd.Parameters.Add("@enabled", SqlDbType.Bit);
                 var pLastUpdated = cmd.Parameters.Add("@lastUpdated", SqlDbType.DateTime);
+                var pPostal = cmd.Parameters.Add("@postal", SqlDbType.NVarChar, 50);
                 var pDept = cmd.Parameters.Add("@dept", SqlDbType.Int);
                 var pCompany = cmd.Parameters.Add("@company", SqlDbType.Int);
                 var pJob = cmd.Parameters.Add("@job", SqlDbType.Int);
@@ -143,18 +175,21 @@ ELSE
 
                 for (int i = 0; i < count; i++)
                 {
-                    var upn = $"{upnPrefix}{i}@{upnDomain}";
+                    var profile = SeedDataCatalogue.NextUserProfile(random);
+                    var upn = SeedDataCatalogue.BuildUpn(upnPrefix, i, upnDomain);
                     pUpn.Value = upn;
                     pMail.Value = upn;
                     pAad.Value = Guid.NewGuid().ToString();
+                    pEnabled.Value = profile.AccountEnabled;
                     pLastUpdated.Value = DateTime.UtcNow;
-                    pDept.Value = PickOrDbNull(departments, random);
-                    pCompany.Value = PickOrDbNull(companies, random);
-                    pJob.Value = PickOrDbNull(jobTitles, random);
-                    pState.Value = PickOrDbNull(states, random);
-                    pCountry.Value = PickOrDbNull(countries, random);
-                    pOffice.Value = PickOrDbNull(offices, random);
-                    pUsage.Value = PickOrDbNull(usages, random);
+                    pPostal.Value = string.IsNullOrEmpty(profile.PostalCode) ? (object)DBNull.Value : profile.PostalCode;
+                    pDept.Value = LookupOrDbNull(departments, profile.Department);
+                    pCompany.Value = LookupOrDbNull(companies, profile.Company);
+                    pJob.Value = LookupOrDbNull(jobTitles, profile.JobTitle);
+                    pState.Value = LookupOrDbNull(states, profile.StateOrProvince);
+                    pCountry.Value = LookupOrDbNull(countries, profile.Country);
+                    pOffice.Value = LookupOrDbNull(offices, profile.OfficeLocation);
+                    pUsage.Value = LookupOrDbNull(usages, profile.UsageLocation);
 
                     var newIdObj = cmd.ExecuteScalar();
                     if (newIdObj != null && newIdObj != DBNull.Value)
@@ -163,6 +198,10 @@ ELSE
                     }
                 }
             }
+
+            // Give the tenant a realistic reporting hierarchy (people report to a manager in
+            // their own company). Keyed on the UPN prefix so it spans every domain we just used.
+            AssignManagers(conn, upnPrefix, random);
 
             return inserted;
         }
@@ -213,6 +252,89 @@ IF NOT EXISTS (SELECT 1 FROM user_license_type_lookups WHERE user_id = @userId A
         }
 
         /// <summary>
+        /// Builds a realistic reporting hierarchy across users whose UPN starts with
+        /// <paramref name="upnPrefix"/> (matched across every domain). Within each company a
+        /// small fraction are made managers (left top-level); everyone else reports to a random
+        /// manager in the same company. Only touches users whose <c>manager_id</c> is still NULL,
+        /// so it is idempotent and safe to re-run.
+        ///
+        /// Scale note (tenants of ~200k users): the reporting pairs are applied with set-based,
+        /// parameter-chunked <c>UPDATE ... FROM (VALUES ...)</c> statements (~500 pairs each, well
+        /// under SQL Server's 2100-parameter limit) rather than one round-trip per user, so a full
+        /// tenant is assigned in a few hundred statements instead of hundreds of thousands.
+        /// </summary>
+        public static int AssignManagers(SqlConnection conn, string upnPrefix, Random random,
+            double managerFraction = 0.1)
+        {
+            // Load candidate users (this generator's prefix, no manager yet), grouped by company
+            // so nobody reports across company boundaries. Company -1 means "no company set".
+            var byCompany = new Dictionary<int, List<int>>();
+            var total = 0;
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = @"SELECT id, company_name_id FROM users
+WHERE manager_id IS NULL AND user_name LIKE @prefix + '%';";
+                cmd.Parameters.Add("@prefix", SqlDbType.NVarChar, 400).Value = upnPrefix;
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        int id = reader.GetInt32(0);
+                        int companyId = reader.IsDBNull(1) ? -1 : reader.GetInt32(1);
+                        if (!byCompany.TryGetValue(companyId, out var list))
+                        {
+                            list = new List<int>();
+                            byCompany[companyId] = list;
+                        }
+                        list.Add(id);
+                        total++;
+                    }
+                }
+            }
+            if (total < 2) return 0;
+
+            // Decide who reports to whom (in memory).
+            var assignments = new List<KeyValuePair<int, int>>(total);
+            foreach (var kvp in byCompany)
+            {
+                var users = kvp.Value;
+                if (users.Count < 2) continue; // a lone user in a company has nobody to report to
+
+                int managerCount = Math.Max(1, (int)Math.Round(users.Count * managerFraction));
+                managerCount = Math.Min(managerCount, users.Count - 1); // always leave at least one report
+                var managers = users.GetRange(0, managerCount);
+                for (int i = managerCount; i < users.Count; i++)
+                {
+                    assignments.Add(new KeyValuePair<int, int>(users[i], managers[random.Next(managers.Count)]));
+                }
+            }
+            if (assignments.Count == 0) return 0;
+
+            // Apply set-based in parameter-bounded chunks (2 params per pair).
+            const int chunkPairs = 500;
+            int updated = 0;
+            for (int start = 0; start < assignments.Count; start += chunkPairs)
+            {
+                int take = Math.Min(chunkPairs, assignments.Count - start);
+                using (var cmd = conn.CreateCommand())
+                {
+                    var sb = new StringBuilder("UPDATE u SET manager_id = v.mgr FROM users u JOIN (VALUES ");
+                    for (int i = 0; i < take; i++)
+                    {
+                        if (i > 0) sb.Append(',');
+                        sb.Append($"(@u{i},@m{i})");
+                        cmd.Parameters.Add($"@u{i}", SqlDbType.Int).Value = assignments[start + i].Key;
+                        cmd.Parameters.Add($"@m{i}", SqlDbType.Int).Value = assignments[start + i].Value;
+                    }
+                    sb.Append(") AS v(id, mgr) ON u.id = v.id;");
+                    cmd.CommandText = sb.ToString();
+                    updated += cmd.ExecuteNonQuery();
+                }
+            }
+            return updated;
+        }
+
+        /// <summary>
         /// Inserts each value into <paramref name="tableName"/> if a row with that name
         /// does not already exist. Used for all single-column "[id, name]" lookup tables.
         /// </summary>
@@ -232,10 +354,10 @@ IF NOT EXISTS (SELECT 1 FROM [{tableName}] WHERE name = @name)
             }
         }
 
-        private static object PickOrDbNull(IList<int> ids, Random random)
+        private static object LookupOrDbNull(Dictionary<string, int> map, string name)
         {
-            if (ids == null || ids.Count == 0) return DBNull.Value;
-            return ids[random.Next(ids.Count)];
+            if (name != null && map.TryGetValue(name, out var id)) return id;
+            return DBNull.Value;
         }
     }
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotStressTest.cs
@@ -279,7 +279,7 @@ WHERE u.user_name = @upn;";
         private static List<string> BuildUserCatalogue(int count)
         {
             var list = new List<string>(count);
-            for (int i = 0; i < count; i++) list.Add($"stressuser{i}@contoso.com");
+            for (int i = 0; i < count; i++) list.Add(SeedDataCatalogue.BuildUpn("stressuser", i));
             return list;
         }
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
@@ -33,16 +33,6 @@ namespace Tests.FakeDataGen.StressTests
         private static readonly string[] AppOperations = { "LaunchPowerApp", "EditPowerApp", "PublishPowerApp", "CreatePowerApp" };
         private static readonly string[] FlowOperations = { "FlowRunStarted", "FlowRunCompleted", "EditFlow", "CreateFlow" };
 
-        // Names for lookup tables / license catalogue come from shared seed data
-        // so every stress test and data generator populates the same metadata.
-        private static string[] Departments => SeedDataCatalogue.Departments;
-        private static string[] Companies => SeedDataCatalogue.Companies;
-        private static string[] JobTitles => SeedDataCatalogue.JobTitles;
-        private static string[] StatesOrProvinces => SeedDataCatalogue.StatesOrProvinces;
-        private static string[] Countries => SeedDataCatalogue.Countries;
-        private static string[] OfficeLocations => SeedDataCatalogue.OfficeLocations;
-        private static string[] UsageLocations => SeedDataCatalogue.UsageLocations;
-
         protected override StressTestResult Execute()
         {
             Console.WriteLine("\n=== Power Platform Event Import Stress Test ===\n");
@@ -395,8 +385,9 @@ namespace Tests.FakeDataGen.StressTests
         }
 
         /// <summary>
-        /// Inserts the prerequisite users (with departments, companies, job titles) + audit_events rows
-        /// so FKs are satisfied when CommitAllChanges runs.
+        /// Inserts the prerequisite users (with coherent geography, department + fitting job title,
+        /// company, postal code and account state) + audit_events rows so FKs are satisfied when
+        /// CommitAllChanges runs. A realistic reporting hierarchy is added once the users exist.
         /// </summary>
         private void InsertPrerequisiteAuditEvents(string connectionString, List<(Guid Id, string Upn, string Operation, DateTime TimeStamp)> eventIds)
         {
@@ -425,9 +416,10 @@ namespace Tests.FakeDataGen.StressTests
                     cmd.CommandText = @"
 IF NOT EXISTS (SELECT 1 FROM users WHERE user_name = @upn)
 BEGIN
-    INSERT INTO users (user_name, department_id, company_name_id, job_title_id,
+    INSERT INTO users (user_name, mail, azure_ad_id, account_enabled, postalcode,
+                       department_id, company_name_id, job_title_id,
                        state_or_province_id, country_or_region_id, office_location_id, usage_location_id)
-    SELECT @upn, d.id, c.id, j.id, s.id, co.id, o.id, u.id
+    SELECT @upn, @mail, @aad, @enabled, @postal, d.id, c.id, j.id, s.id, co.id, o.id, u.id
     FROM user_departments d, user_company_name c, user_job_titles j,
          user_state_or_province s, user_country_or_region co,
          user_office_locations o, user_usage_locations u
@@ -438,6 +430,10 @@ END
 ELSE
     SELECT 0;";
                     var pUpn = cmd.Parameters.Add("@upn", System.Data.SqlDbType.NVarChar, 400);
+                    var pMail = cmd.Parameters.Add("@mail", System.Data.SqlDbType.NVarChar, 400);
+                    var pAad = cmd.Parameters.Add("@aad", System.Data.SqlDbType.NVarChar, 400);
+                    var pEnabled = cmd.Parameters.Add("@enabled", System.Data.SqlDbType.Bit);
+                    var pPostal = cmd.Parameters.Add("@postal", System.Data.SqlDbType.NVarChar, 50);
                     var pDept = cmd.Parameters.Add("@dept", System.Data.SqlDbType.NVarChar, 100);
                     var pCompany = cmd.Parameters.Add("@company", System.Data.SqlDbType.NVarChar, 100);
                     var pJob = cmd.Parameters.Add("@job", System.Data.SqlDbType.NVarChar, 100);
@@ -450,14 +446,19 @@ ELSE
                     {
                         if (seenUsers.Add(ev.Upn))
                         {
+                            var profile = SeedDataCatalogue.NextUserProfile(random);
                             pUpn.Value = ev.Upn;
-                            pDept.Value = Departments[random.Next(Departments.Length)];
-                            pCompany.Value = Companies[random.Next(Companies.Length)];
-                            pJob.Value = JobTitles[random.Next(JobTitles.Length)];
-                            pState.Value = StatesOrProvinces[random.Next(StatesOrProvinces.Length)];
-                            pCountry.Value = Countries[random.Next(Countries.Length)];
-                            pOffice.Value = OfficeLocations[random.Next(OfficeLocations.Length)];
-                            pUsage.Value = UsageLocations[random.Next(UsageLocations.Length)];
+                            pMail.Value = ev.Upn;
+                            pAad.Value = Guid.NewGuid().ToString();
+                            pEnabled.Value = profile.AccountEnabled;
+                            pPostal.Value = string.IsNullOrEmpty(profile.PostalCode) ? (object)DBNull.Value : profile.PostalCode;
+                            pDept.Value = profile.Department;
+                            pCompany.Value = profile.Company;
+                            pJob.Value = profile.JobTitle;
+                            pState.Value = profile.StateOrProvince;
+                            pCountry.Value = profile.Country;
+                            pOffice.Value = profile.OfficeLocation;
+                            pUsage.Value = profile.UsageLocation;
                             var inserted = Convert.ToInt32(cmd.ExecuteScalar());
                             if (inserted == 1)
                             {
@@ -534,6 +535,10 @@ WHERE u.user_name = @upn;";
                         cmd.ExecuteNonQuery();
                     }
                 }
+
+                // Give these prerequisite users a realistic reporting hierarchy too (people report
+                // to a manager in their own company). Keyed on the shared "stressuser" UPN prefix.
+                UserMetadataSeeder.AssignManagers(conn, "stressuser", random);
             }
         }
 
@@ -547,7 +552,7 @@ WHERE u.user_name = @upn;";
         private static List<(string Upn, string AadId)> BuildUserCatalogue(int count)
         {
             var list = new List<(string, string)>(count);
-            for (int i = 0; i < count; i++) list.Add(($"stressuser{i}@contoso.com", Guid.NewGuid().ToString()));
+            for (int i = 0; i < count; i++) list.Add((SeedDataCatalogue.BuildUpn("stressuser", i), Guid.NewGuid().ToString()));
             return list;
         }
     }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
@@ -182,21 +182,21 @@ namespace Tests.FakeDataGen.StressTests
             // or job title is empty. Uses the same idempotent helper and catalogue as the other
             // stress tests so all of them populate identical metadata.
             var random = new Random(123);
-            List<int> departmentIds, jobTitleIds, companyIds, stateIds, countryIds, officeIds, usageIds;
+            Dictionary<string, int> departments, jobTitles, companies, states, countries, offices, usages;
             using (var conn = new SqlConnection(connectionString))
             {
                 conn.Open();
                 UserMetadataSeeder.EnsureMetadataLookups(conn);
-                departmentIds = UserMetadataSeeder.LoadLookupIds(conn, "user_departments");
-                jobTitleIds = UserMetadataSeeder.LoadLookupIds(conn, "user_job_titles");
-                companyIds = UserMetadataSeeder.LoadLookupIds(conn, "user_company_name");
-                stateIds = UserMetadataSeeder.LoadLookupIds(conn, "user_state_or_province");
-                countryIds = UserMetadataSeeder.LoadLookupIds(conn, "user_country_or_region");
-                officeIds = UserMetadataSeeder.LoadLookupIds(conn, "user_office_locations");
-                usageIds = UserMetadataSeeder.LoadLookupIds(conn, "user_usage_locations");
+                departments = UserMetadataSeeder.LoadLookupIdsByName(conn, "user_departments");
+                jobTitles = UserMetadataSeeder.LoadLookupIdsByName(conn, "user_job_titles");
+                companies = UserMetadataSeeder.LoadLookupIdsByName(conn, "user_company_name");
+                states = UserMetadataSeeder.LoadLookupIdsByName(conn, "user_state_or_province");
+                countries = UserMetadataSeeder.LoadLookupIdsByName(conn, "user_country_or_region");
+                offices = UserMetadataSeeder.LoadLookupIdsByName(conn, "user_office_locations");
+                usages = UserMetadataSeeder.LoadLookupIdsByName(conn, "user_usage_locations");
             }
-            Console.WriteLine($"  Metadata lookups ready ({departmentIds.Count} departments, " +
-                              $"{jobTitleIds.Count} job titles) - assigning random metadata to seeded users.");
+            Console.WriteLine($"  Metadata lookups ready ({departments.Count} departments, " +
+                              $"{jobTitles.Count} job titles) - assigning coherent metadata to seeded users.");
 
             using (var db = dbFactory())
             {
@@ -215,22 +215,25 @@ namespace Tests.FakeDataGen.StressTests
 
                 for (int i = 0; i < userCount; i++)
                 {
-                    var upn = $"stress-user{i:D6}@stress.local";
+                    var upn = SeedDataCatalogue.BuildUpn("stress-user", i);
                     if (existingSet.Contains(upn))
                         continue;
 
+                    var profile = SeedDataCatalogue.NextUserProfile(random);
                     pending.Add(new User
                     {
                         UserPrincipalName = upn,
                         Mail = upn,
                         AzureAdId = Guid.NewGuid().ToString(),
-                        DepartmentId = PickOrNull(departmentIds, random),
-                        JobTitleId = PickOrNull(jobTitleIds, random),
-                        CompanyNameId = PickOrNull(companyIds, random),
-                        StateOrProvinceId = PickOrNull(stateIds, random),
-                        UserCountryId = PickOrNull(countryIds, random),
-                        OfficeLocationId = PickOrNull(officeIds, random),
-                        UsageLocationId = PickOrNull(usageIds, random)
+                        AccountEnabled = profile.AccountEnabled,
+                        PostalCode = profile.PostalCode ?? string.Empty,
+                        DepartmentId = LookupOrNull(departments, profile.Department),
+                        JobTitleId = LookupOrNull(jobTitles, profile.JobTitle),
+                        CompanyNameId = LookupOrNull(companies, profile.Company),
+                        StateOrProvinceId = LookupOrNull(states, profile.StateOrProvince),
+                        UserCountryId = LookupOrNull(countries, profile.Country),
+                        OfficeLocationId = LookupOrNull(offices, profile.OfficeLocation),
+                        UsageLocationId = LookupOrNull(usages, profile.UsageLocation)
                     });
 
                     if (pending.Count >= batch)
@@ -254,6 +257,14 @@ namespace Tests.FakeDataGen.StressTests
                 }
             }
 
+            // Build a realistic reporting hierarchy across the seeded users (managers are in the
+            // same company). Keyed on the "stress-user" prefix so it spans every domain used above.
+            using (var conn = new SqlConnection(connectionString))
+            {
+                conn.Open();
+                UserMetadataSeeder.AssignManagers(conn, "stress-user", random);
+            }
+
             sw.Stop();
             Console.WriteLine($"  Seeded {inserted:N0} new users in {sw.ElapsedMilliseconds:N0}ms " +
                               $"(existing stress users left untouched).");
@@ -266,13 +277,14 @@ namespace Tests.FakeDataGen.StressTests
         }
 
         /// <summary>
-        /// Picks a random id from a lookup id list, or null when the list is empty so the user's
-        /// FK column is left NULL rather than pointing at a non-existent row.
+        /// Resolves a metadata id from a coherent profile's value via a name -&gt; id map, or null
+        /// when the value isn't present so the user's FK column is left NULL rather than pointing
+        /// at a non-existent row.
         /// </summary>
-        private static int? PickOrNull(IList<int> ids, Random random)
+        private static int? LookupOrNull(Dictionary<string, int> map, string name)
         {
-            if (ids == null || ids.Count == 0) return null;
-            return ids[random.Next(ids.Count)];
+            if (name != null && map.TryGetValue(name, out var id)) return id;
+            return null;
         }
 
         private static long CountStressRows(Func<AnalyticsEntitiesContext> dbFactory)
@@ -370,8 +382,8 @@ namespace Tests.FakeDataGen.StressTests
                     "INNER JOIN sent_emails s ON s.id = r.sent_email_id " +
                     "WHERE s.graph_message_id LIKE 'stress-msg-%'");
                 db.Database.ExecuteSqlCommand("DELETE FROM sent_emails WHERE graph_message_id LIKE 'stress-msg-%'");
-                db.Database.ExecuteSqlCommand("DELETE FROM email_addresses WHERE address LIKE '%@stress.local' OR address LIKE 'recipient-%'");
-                db.Database.ExecuteSqlCommand("DELETE FROM users WHERE user_name LIKE 'stress-user%@stress.local'");
+                db.Database.ExecuteSqlCommand("DELETE FROM email_addresses WHERE address LIKE 'stress-user%' OR address LIKE 'recipient-%'");
+                db.Database.ExecuteSqlCommand("DELETE FROM users WHERE user_name LIKE 'stress-user%'");
             }
             sw.Stop();
             Console.WriteLine($"  Deleted in {sw.ElapsedMilliseconds:N0}ms.");


### PR DESCRIPTION
## What & why

Users generated by **Tests.FakeDataGen** were unrealistic: geo columns (country / state / office / usage location) were picked *independently*, producing impossible people (e.g. *United States / Bavaria / Tokyo / ES*); only 10 countries; `postalcode` and `manager_id` were never set; `account_enabled` was always `1`; and every user lived on a single `@contoso.com` / `@stress.local` domain.

This PR makes generated users **as real as a live tenant**, with a variety of countries and the metadata we weren't creating, spread across a few email domains.

## Changes

- **`SeedDataCatalogue`** — coherent `GeoLocale` set (**21 countries** across every continent, including non-Latin values `Αττική` / `東京都` / `São Paulo` / `Zürich`) so **country / state / city / office / usage location / postal code always agree**, with country-formatted postal-code generators (US ZIP, UK/CA/NL alphanumeric, JP, BR, UAE = none, …). Job titles now **fit their department**; expanded companies and license SKUs. New `Domains` + deterministic `DomainForIndex` / `BuildUpn`, and a coherent `UserProfile` / `NextUserProfile`.
- **Metadata we didn't create before**: `postalcode`, `manager_id` (a **same-company reporting hierarchy**), and `account_enabled` now varies (~7% disabled).
- **A few different email domains** — users spread deterministically across 6 tenant domains by index, so every call site that must join back on UPN (Copilot event catalogue, PowerPlatform, etc.) stays consistent.
- **`AssignManagers`** builds the hierarchy with set-based, parameter-chunked `UPDATE … (VALUES …)` (≤500 pairs/statement) — **scale-safe for ~200k-user tenants**, no per-row round-trips.
- Applied consistently across **all** user-creating paths: shared `UserMetadataSeeder.SeedUsers` (UserActivity + Copilot stress), `PowerPlatformStressTest`, `SentEmailImporterStressTest` (cleanup switched to prefix-based markers), and `CopilotUserManager`. README updated.

## Verification

- VS2022/18 MSBuild **build clean** (0 warnings / 0 errors in changed files).
- Code review agent: no significant issues (empirically verified UPN join consistency, the `AssignManagers` SQL on LocalDB, parameter limits, prefix cleanup, FK coherence, scale, and Unicode code points).
- Runtime check (reflection over the built assembly) over 2,000 profiles: **21 distinct countries**, coherent geo+postal per country (NL `1084 UI`, PL `00-430`, BR `02110-081`, CA `V0P 9S5`, UAE empty), job title fits department, `São Paulo` Unicode preserved, ~7.2% disabled, UPNs cycling across the 6 domains.

_No production/importer code changed — this only affects the fake-data generator/stress-test tooling._
