### PR TITLE
Fix Copilot agent attribution for named agents without an AgentId (e.g. Cowork)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotTests.cs
@@ -1,4 +1,4 @@
-﻿using ActivityImporter.Engine.ActivityAPI.Copilot;
+using ActivityImporter.Engine.ActivityAPI.Copilot;
 using Common.Entities;
 using DataUtils;
 using Microsoft.Extensions.Logging;
@@ -1203,6 +1203,150 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
+        /// First-party named agents (e.g. Copilot Cowork) carry an AgentName and AppIdentity but no AgentId
+        /// and no TargetAgentName. For a vetted first-party AppIdentity (allow-list), AgentId should fall back
+        /// to AppIdentity so the agent still gets dimensioned (the copilot_agents upsert keys on agent_id; a null
+        /// id imports the chat but drops agent attribution). Non-vetted AppIdentities are covered by the guard test.
+        /// </summary>
+        [TestMethod]
+        public void CopilotAuditLogContent_FromJson_UsesAppIdentityAsAgentIdWhenNamePresentButNoId()
+        {
+            // Arrange - the shape of a real "Copilot Cowork" CopilotInteraction record.
+            var appIdentity = "Copilot.M365Copilot.CoworkChat";
+            var json = $@"{{
+                ""AgentName"": ""Copilot Cowork"",
+                ""AppIdentity"": ""{appIdentity}"",
+                ""OrganizationId"": ""00000000-0000-0000-0000-000000000000"",
+                ""CopilotEventData"": {{
+                    ""AppHost"": ""cowork"",
+                    ""AccessedResources"": [],
+                    ""Contexts"": []
+                }}
+            }}";
+
+            // Act
+            var result = CopilotAuditLogContent.FromJson(json);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Copilot Cowork", result.AgentName, "AgentName from the record should be preserved");
+            Assert.AreEqual(appIdentity, result.AgentId, "AgentId should fall back to AppIdentity so the agent is dimensioned");
+        }
+
+        /// <summary>
+        /// Guard for the allow-list: a named agent with no AgentId whose AppIdentity is NOT a vetted first-party
+        /// identity must keep agent_id NULL (pre-PR #180 behaviour), rather than absorbing an unverified
+        /// AgentName + AppIdentity combination as a synthetic agent.
+        /// </summary>
+        [TestMethod]
+        public void CopilotAuditLogContent_FromJson_DoesNotUseAppIdentityAsAgentIdWhenNotVettedFirstParty()
+        {
+            // Arrange - a first-party-style named agent (e.g. a SharePoint "summarizer-agent") whose
+            // AppIdentity is outside the allow-list and unverified as a stable per-agent key.
+            var json = @"{
+                ""AgentName"": ""summarizer-agent"",
+                ""AppIdentity"": ""SomeUnverified.App.Identity"",
+                ""CopilotEventData"": {
+                    ""AppHost"": ""SharePoint"",
+                    ""AccessedResources"": [],
+                    ""Contexts"": []
+                }
+            }";
+
+            // Act
+            var result = CopilotAuditLogContent.FromJson(json);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("summarizer-agent", result.AgentName, "AgentName from the record should be preserved");
+            Assert.IsNull(result.AgentId, "AgentId must stay NULL for an AppIdentity outside the vetted first-party allow-list");
+        }
+
+        /// <summary>
+        /// Documents the intended many-to-one behaviour: two interactions for the same first-party experience
+        /// that carry the same (vetted) AppIdentity but different AgentName strings resolve to the SAME AgentId,
+        /// so they dimension to a single copilot_agents row rather than fragmenting.
+        /// </summary>
+        [TestMethod]
+        public void CopilotAuditLogContent_FromJson_SameFirstPartyAppIdentityDifferentNamesResolveToSameAgentId()
+        {
+            // Arrange - same AppIdentity, two different display names (e.g. localisation / word-order variants).
+            var appIdentity = "Copilot.M365Copilot.CoworkChat";
+            var jsonA = $@"{{
+                ""AgentName"": ""Copilot Cowork"",
+                ""AppIdentity"": ""{appIdentity}"",
+                ""CopilotEventData"": {{ ""AppHost"": ""cowork"", ""AccessedResources"": [], ""Contexts"": [] }}
+            }}";
+            var jsonB = $@"{{
+                ""AgentName"": ""Cowork"",
+                ""AppIdentity"": ""{appIdentity}"",
+                ""CopilotEventData"": {{ ""AppHost"": ""cowork"", ""AccessedResources"": [], ""Contexts"": [] }}
+            }}";
+
+            // Act
+            var a = CopilotAuditLogContent.FromJson(jsonA);
+            var b = CopilotAuditLogContent.FromJson(jsonB);
+
+            // Assert
+            Assert.AreEqual(appIdentity, a.AgentId);
+            Assert.AreEqual(appIdentity, b.AgentId);
+            Assert.AreEqual(a.AgentId, b.AgentId, "Same first-party AppIdentity must yield one shared AgentId regardless of name");
+        }
+
+        /// <summary>
+        /// De-fragmentation: Microsoft emits the same SharePoint agent both as "SharePointAgents.Declarative.SPO_..."
+        /// and as bare "SPO_...". Both must normalise to the same canonical bare SPO_ id so the agent is dimensioned
+        /// once, not twice (otherwise the same agent produces duplicate copilot_agents rows).
+        /// </summary>
+        [TestMethod]
+        public void CopilotAuditLogContent_FromJson_NormalizesSharePointDeclarativeAgentIdToBareSpoId()
+        {
+            // Arrange
+            var bareId = "SPO_M2U2ZGNkExampleItemId_01ABCDEF";
+            var jsonPrefixed = $@"{{
+                ""AgentName"": ""Contoso Proposals Agent"",
+                ""AgentId"": ""SharePointAgents.Declarative.{bareId}"",
+                ""CopilotEventData"": {{ ""AppHost"": ""SharePoint"", ""AccessedResources"": [], ""Contexts"": [] }}
+            }}";
+            var jsonBare = $@"{{
+                ""AgentName"": ""Contoso Proposals Agent"",
+                ""AgentId"": ""{bareId}"",
+                ""CopilotEventData"": {{ ""AppHost"": ""SharePoint"", ""AccessedResources"": [], ""Contexts"": [] }}
+            }}";
+
+            // Act
+            var prefixed = CopilotAuditLogContent.FromJson(jsonPrefixed);
+            var bare = CopilotAuditLogContent.FromJson(jsonBare);
+
+            // Assert
+            Assert.AreEqual(bareId, prefixed.AgentId, "SharePointAgents.Declarative. wrapper should be stripped to the bare SPO_ id");
+            Assert.AreEqual(bareId, bare.AgentId, "A bare SPO_ id should be left unchanged");
+            Assert.AreEqual(prefixed.AgentId, bare.AgentId, "Both id variants must resolve to a single canonical agent id");
+        }
+
+        /// <summary>
+        /// Normalisation must not touch ids that are not the SharePoint wrapper form - declarative Copilot Studio
+        /// ids (and other schemes) are left exactly as-is.
+        /// </summary>
+        [TestMethod]
+        public void CopilotAuditLogContent_FromJson_NormalizeAgentIdLeavesOtherIdsUnchanged()
+        {
+            // Arrange - a declarative Copilot Studio agent id supplied explicitly.
+            var declarativeId = "CopilotStudio.Declarative.T_11111111-1111-1111-1111-111111111111.22222222-2222-2222-2222-222222222222";
+            var json = $@"{{
+                ""AgentName"": ""Contoso Risk Agent"",
+                ""AgentId"": ""{declarativeId}"",
+                ""CopilotEventData"": {{ ""AppHost"": ""Office"", ""AccessedResources"": [], ""Contexts"": [] }}
+            }}";
+
+            // Act
+            var result = CopilotAuditLogContent.FromJson(json);
+
+            // Assert
+            Assert.AreEqual(declarativeId, result.AgentId, "Non-SharePoint-wrapper ids must be left unchanged by normalisation");
+        }
+
+        /// <summary>
         /// Tests that existing AgentName and AgentId values are not overwritten when they are already present
         /// </summary>
         [TestMethod]
@@ -1416,6 +1560,88 @@ namespace Tests.UnitTests
             Assert.AreEqual(targetAgentName, result.AgentName, "AgentName should be set from TargetAgentName");
             Assert.AreEqual(agentId, result.AgentId, "AgentId from JSON should be preserved, not overwritten by AppIdentity");
             Assert.IsNull(result.IsCustomAgent, "IsCustomAgent should always be null from FromJson");
+        }
+
+        /// <summary>
+        /// Newer schema: a custom engine agent (TargetAgentName) with no explicit AgentId should take its id from
+        /// CopilotEventData.TargetPlatformAgentId in preference to the AppIdentity fallback.
+        /// </summary>
+        [TestMethod]
+        public void CopilotAuditLogContent_FromJson_TargetAgentNamePrefersTargetPlatformAgentIdOverAppIdentity()
+        {
+            // Arrange - both TargetPlatformAgentId (new) and AppIdentity (old) present, no explicit AgentId.
+            var targetPlatformAgentId = "T_33333333-3333-3333-3333-333333333333";
+            var json = $@"{{
+                ""AppIdentity"": ""Copilot.Studio.Default-someorg-someagent"",
+                ""CopilotEventData"": {{
+                    ""AppHost"": ""Office"",
+                    ""AccessedResources"": [],
+                    ""Contexts"": [],
+                    ""TargetAgentName"": ""Contoso Proofreader"",
+                    ""TargetPlatformAgentId"": ""{targetPlatformAgentId}""
+                }}
+            }}";
+
+            // Act
+            var result = CopilotAuditLogContent.FromJson(json);
+
+            // Assert
+            Assert.AreEqual("Contoso Proofreader", result.AgentName, "AgentName should be set from TargetAgentName");
+            Assert.AreEqual(targetPlatformAgentId, result.AgentId, "AgentId should prefer TargetPlatformAgentId over AppIdentity");
+        }
+
+        /// <summary>
+        /// Older schema fallback: when CopilotEventData.TargetPlatformAgentId is absent, a custom engine agent with
+        /// no explicit AgentId still falls back to AppIdentity, exactly as before.
+        /// </summary>
+        [TestMethod]
+        public void CopilotAuditLogContent_FromJson_TargetAgentNameFallsBackToAppIdentityWhenNoTargetPlatformAgentId()
+        {
+            // Arrange - no TargetPlatformAgentId and no explicit AgentId.
+            var appIdentity = "Copilot.Studio.Default-someorg-someagent";
+            var json = $@"{{
+                ""AppIdentity"": ""{appIdentity}"",
+                ""CopilotEventData"": {{
+                    ""AppHost"": ""Teams"",
+                    ""AccessedResources"": [],
+                    ""Contexts"": [],
+                    ""TargetAgentName"": ""CustomEngineAgent""
+                }}
+            }}";
+
+            // Act
+            var result = CopilotAuditLogContent.FromJson(json);
+
+            // Assert
+            Assert.AreEqual("CustomEngineAgent", result.AgentName, "AgentName should be set from TargetAgentName");
+            Assert.AreEqual(appIdentity, result.AgentId, "AgentId should fall back to AppIdentity when TargetPlatformAgentId is absent");
+        }
+
+        /// <summary>
+        /// An explicit AgentId still wins over CopilotEventData.TargetPlatformAgentId for a custom engine agent.
+        /// </summary>
+        [TestMethod]
+        public void CopilotAuditLogContent_FromJson_TargetAgentNamePreservesExplicitAgentIdOverTargetPlatformAgentId()
+        {
+            // Arrange - explicit AgentId present alongside TargetPlatformAgentId.
+            var explicitAgentId = "CopilotStudio.Declarative.T_33333333-3333-3333-3333-333333333333.publication-guid";
+            var json = $@"{{
+                ""AgentId"": ""{explicitAgentId}"",
+                ""CopilotEventData"": {{
+                    ""AppHost"": ""Office"",
+                    ""AccessedResources"": [],
+                    ""Contexts"": [],
+                    ""TargetAgentName"": ""Contoso Proofreader"",
+                    ""TargetPlatformAgentId"": ""T_33333333-3333-3333-3333-333333333333""
+                }}
+            }}";
+
+            // Act
+            var result = CopilotAuditLogContent.FromJson(json);
+
+            // Assert
+            Assert.AreEqual("Contoso Proofreader", result.AgentName, "AgentName should be set from TargetAgentName");
+            Assert.AreEqual(explicitAgentId, result.AgentId, "Explicit AgentId should be preserved over TargetPlatformAgentId");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CopilotAuditLogContent.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CopilotAuditLogContent.cs
@@ -118,7 +118,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
             // so we don't silently absorb arbitrary future AgentName + AppIdentity combinations whose AppIdentity
             // may not be a stable per-agent key - which could merge distinct agents onto one id or fragment one
             // agent across ids. Records that don't match the allow-list keep agent_id NULL, exactly as before.
-            // See issue #144 / PR #180.
+            // See PR #180.
             if (!string.IsNullOrEmpty(thisAuditLogReport.AgentName) &&
                 string.IsNullOrEmpty(thisAuditLogReport.AgentId) &&
                 IsVettedFirstPartyAppIdentity(thisAuditLogReport.AppIdentity))

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CopilotAuditLogContent.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/CopilotAuditLogContent.cs
@@ -66,10 +66,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
             {
                 // TargetAgentName indicates a custom engine agent
                 thisAuditLogReport.AgentName = targetAgentName;
-                // If AgentId is not set, use AppIdentity as the identifier
+                // If AgentId is not set, identify the agent from the payload. Newer audit records carry an explicit
+                // per-agent id in CopilotEventData.TargetPlatformAgentId (e.g. "T_{guid}" Copilot Studio, "P_{guid}",
+                // "BuiltIn_..." or short first-party ids like "OutlookDraft"); prefer it. Older records don't include
+                // it, so fall back to AppIdentity exactly as before.
                 if (string.IsNullOrEmpty(thisAuditLogReport.AgentId))
                 {
-                    thisAuditLogReport.AgentId = thisAuditLogReport.AppIdentity;
+                    var targetPlatformAgentId = thisAuditLogReport.CopilotEventData?.TargetPlatformAgentId;
+                    thisAuditLogReport.AgentId = !string.IsNullOrEmpty(targetPlatformAgentId)
+                        ? targetPlatformAgentId
+                        : thisAuditLogReport.AppIdentity;
                 }
             }
             else if (string.IsNullOrEmpty(thisAuditLogReport.AgentName) &&
@@ -103,6 +109,29 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
                 }
             }
 
+            // First-party named agents (e.g. Copilot Cowork, AppIdentity "Copilot.M365Copilot.CoworkChat")
+            // carry an AgentName but no AgentId and no TargetAgentName, so neither branch above set an id.
+            // Promote AppIdentity to AgentId so the agent is dimensioned in copilot_agents (the agents upsert
+            // keys on agent_id, so without an id the interaction imports but shows as unattributed / agent_id NULL).
+            //
+            // Restricted to a vetted allow-list of first-party AppIdentity prefixes (IsVettedFirstPartyAppIdentity)
+            // so we don't silently absorb arbitrary future AgentName + AppIdentity combinations whose AppIdentity
+            // may not be a stable per-agent key - which could merge distinct agents onto one id or fragment one
+            // agent across ids. Records that don't match the allow-list keep agent_id NULL, exactly as before.
+            // See issue #144 / PR #180.
+            if (!string.IsNullOrEmpty(thisAuditLogReport.AgentName) &&
+                string.IsNullOrEmpty(thisAuditLogReport.AgentId) &&
+                IsVettedFirstPartyAppIdentity(thisAuditLogReport.AppIdentity))
+            {
+                thisAuditLogReport.AgentId = thisAuditLogReport.AppIdentity;
+            }
+
+            // Normalise the resolved id (from any branch above or the raw payload) to a single canonical form so
+            // the same logical agent is not split across id variants. Microsoft emits some agents under more than
+            // one id string - notably SharePoint agents as both "SharePointAgents.Declarative.SPO_..." and bare
+            // "SPO_..." - which would otherwise create duplicate copilot_agents rows and double-count usage.
+            thisAuditLogReport.AgentId = NormalizeAgentId(thisAuditLogReport.AgentId);
+
             if (!string.IsNullOrEmpty(thisAuditLogReport.AgentName))
             {
                 // Calculate cost from the parsed event for agents
@@ -115,6 +144,66 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
             }
 
             return thisAuditLogReport;
+        }
+
+        /// <summary>
+        /// Vetted first-party AppIdentity prefixes whose AppIdentity is known to be a stable, agent-specific
+        /// identifier. Only these are promoted to AgentId when a named agent arrives without its own AgentId
+        /// (see <see cref="FromJson"/>). Keep this list conservative: add a prefix only after confirming from
+        /// real payloads that its AppIdentity is a stable per-agent key, not a shared app-level or volatile value.
+        /// </summary>
+        internal static readonly string[] FirstPartyNamedAgentAppIdentityPrefixes = new[]
+        {
+            "Copilot.M365Copilot.",   // e.g. "Copilot.M365Copilot.CoworkChat" (Copilot Cowork)
+        };
+
+        private const string SharePointDeclarativeAgentIdPrefix = "SharePointAgents.Declarative.";
+
+        /// <summary>
+        /// True when <paramref name="appIdentity"/> starts with a vetted first-party prefix from
+        /// <see cref="FirstPartyNamedAgentAppIdentityPrefixes"/> and can therefore safely be used as an AgentId.
+        /// </summary>
+        internal static bool IsVettedFirstPartyAppIdentity(string appIdentity)
+        {
+            if (string.IsNullOrEmpty(appIdentity))
+            {
+                return false;
+            }
+
+            foreach (var prefix in FirstPartyNamedAgentAppIdentityPrefixes)
+            {
+                if (appIdentity.StartsWith(prefix, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Collapses redundant agent id variants to a single canonical form so the same logical agent is not
+        /// dimensioned twice. Currently strips the "SharePointAgents.Declarative." wrapper prefix from SharePoint
+        /// agent ids, whose canonical identity is the bare "SPO_..." item id (Microsoft emits both forms for the
+        /// same agent). Null/empty and all other ids are returned unchanged.
+        /// </summary>
+        internal static string NormalizeAgentId(string agentId)
+        {
+            if (string.IsNullOrEmpty(agentId))
+            {
+                return agentId;
+            }
+
+            if (agentId.StartsWith(SharePointDeclarativeAgentIdPrefix, System.StringComparison.OrdinalIgnoreCase))
+            {
+                var remainder = agentId.Substring(SharePointDeclarativeAgentIdPrefix.Length);
+                if (remainder.StartsWith("SPO_", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return remainder;
+                }
+            }
+
+            return agentId;
         }
 
         public override async Task<bool> ProcessExtendedProperties(SaveSession sessionContext, CommonAuditEvent relatedAuditEvent, ILogger logger)
@@ -150,6 +239,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
         /// The name of the target custom engine agent. Present when the interaction involves a custom engine agent.
         /// </summary>
         public string TargetAgentName { get; set; }
+
+        /// <summary>
+        /// Explicit identifier of the target (custom engine) agent that handled the interaction, present in newer
+        /// Copilot audit records alongside <see cref="TargetAgentName"/>. Observed forms include "T_{guid}"
+        /// (Copilot Studio), "P_{guid}", "BuiltIn_{name}" and short first-party ids such as "OutlookDraft".
+        /// Preferred over AppIdentity as the AgentId for custom engine agents when no explicit AgentId is present.
+        /// </summary>
+        public string TargetPlatformAgentId { get; set; }
 
         /// <summary>
         /// Identifier of the Copilot conversation thread the interaction belongs to.


### PR DESCRIPTION
## Title

Fix Copilot agent attribution for named agents without an AgentId (e.g. Cowork)

## Type of Change

- [x] Bug fix

## Description

Copilot `CopilotInteraction` audit records for first-party **named** agents — e.g. **Copilot Cowork** (`AppIdentity = "Copilot.M365Copilot.CoworkChat"`) — carry an `AgentName` ("Copilot Cowork") but **no `AgentId`** and no `TargetAgentName`.

`CopilotAuditLogContent.FromJson` only backfilled `AgentId` from `AppIdentity` in two cases: when `TargetAgentName` is set, or when **both** `AgentName` and `AgentId` are empty (the Copilot Studio `Copilot.Studio.Default-{OrgId}-{name}` fallback). A record with a populated `AgentName` but an empty `AgentId` hit neither branch, so `AgentId` stayed `null`.

Downstream, the agents upsert only inserts `WHERE imports.agent_id IS NOT NULL` (`common_upsert_copilot_agents.sql`), so no `copilot_agents` row was created and `copilot_chats.agent_id` resolved to `NULL`. Net effect: the interaction was **imported** (a `copilot_chats` row with `app_host = "cowork"`, credit estimate and messages) but showed as **unattributed** in any agent-based reporting.

### Fix

In `FromJson`, fall back `AgentId = AppIdentity` whenever there is an `AgentName` but no `AgentId` (mirroring the existing `TargetAgentName` branch). Named agents like Cowork now get a stable id (`Copilot.M365Copilot.CoworkChat`), so `copilot_agents` gets the row and the chat links to it. Records that already carry an explicit `AgentId` are untouched, and generic Copilot interactions (no `AgentName`) still have `agent_id = NULL` as before.

Adds `CopilotAuditLogContent_FromJson_UsesAppIdentityAsAgentIdWhenNamePresentButNoId`, built from a real Cowork payload. The existing agent-extraction tests (`ExtractsAgentFromAppIdentity`, `PreservesExistingAgentValues`, and the `TargetAgentName` ones) still pass.

**Note:** this fixes **new** imports. Existing already-imported Cowork chats (with `agent_id = NULL`) are not retroactively linked — a separate backfill migration would be needed if desired.

## Related issue(s)

- N/A — found while reviewing a Purview audit-log `CopilotInteraction` for Copilot Cowork.

## Check list

- [x] Related issue / work item is attached
- [x] Changes are tested
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)

---

## Update — revised approach & follow-ups

After the original description above, the change was validated against representative Copilot audit payloads, which showed the raw agent-id space is heterogeneous and can exhibit both **collision** (one id → multiple names) and **fragmentation** (one agent → multiple id strings). Two follow-up changes harden the behaviour.

### 1. Constrain the AppIdentity→AgentId fallback + de-fragment SharePoint ids

**Supersedes the broad fallback described above.** Instead of promoting `AppIdentity` to `AgentId` for *any* named-but-id-less record, it is now restricted to a vetted **allow-list** of first-party AppIdentity prefixes (`IsVettedFirstPartyAppIdentity`), seeded with `Copilot.M365Copilot.` (covers Cowork). Records whose `AppIdentity` is **not** vetted keep `agent_id = NULL` exactly as before — so we don't silently absorb arbitrary future `AgentName` + `AppIdentity` combinations whose `AppIdentity` may not be a stable per-agent key (which could merge distinct agents onto one id, or fragment one agent across ids). The allow-list is a one-line extension point as more first-party identities are verified.

Also adds `NormalizeAgentId`, which collapses the redundant `SharePointAgents.Declarative.` wrapper to the canonical bare `SPO_…` id. Some SharePoint agents are emitted under both `SharePointAgents.Declarative.SPO_…` and bare `SPO_…`, which dimensions the same agent twice; normalising fixes that double-count for new imports.

New tests: allow-list guard (non-vetted → `NULL`), same-AppIdentity/different-name collision resolves to one id, `SPO_` normalization, and a no-op check for other id schemes.

### 2. Use `TargetPlatformAgentId` for custom-engine agents (newer schema)

Newer `CopilotInteraction` payloads carry an explicit per-agent id in `CopilotEventData.TargetPlatformAgentId` (forms include `T_<guid>` Copilot Studio, `P_<guid>`, `BuiltIn_…`, and short first-party ids like `OutlookDraft`) alongside `TargetAgentName` — but `FromJson` previously ignored it and keyed custom-engine agents off the indirect outer `AppIdentity`.

For a custom-engine agent (`TargetAgentName`) with no explicit `AgentId`, the id is now resolved with this priority:

`explicit AgentId` → `TargetPlatformAgentId` (new) → `AppIdentity` (old fallback) → `null`

This is **backward-compatible**: older payloads have no `TargetPlatformAgentId`, so they fall back to `AppIdentity` exactly as before. New tests cover: prefers `TargetPlatformAgentId` over `AppIdentity`, explicit `AgentId` still wins, and falls back to `AppIdentity` when `TargetPlatformAgentId` is absent.

### Example payloads now parsed correctly

All examples below are synthetic; they mirror the unit tests in `CopilotTests.cs`.

**1. First-party named agent (e.g. Copilot Cowork) — promoted via the vetted allow-list**
```json
{
  "AgentName": "Copilot Cowork",
  "AppIdentity": "Copilot.M365Copilot.CoworkChat",
  "CopilotEventData": { "AppHost": "cowork", "AccessedResources": [], "Contexts": [] }
}
```
→ `AgentName = "Copilot Cowork"`, `AgentId = "Copilot.M365Copilot.CoworkChat"` — previously `AgentId = null`, so the chat imported but showed as unattributed.

**2. Custom-engine agent, newer schema — id taken from `TargetPlatformAgentId`**
```json
{
  "CopilotEventData": {
    "AppHost": "Office",
    "TargetAgentName": "Contoso Proofreader",
    "TargetPlatformAgentId": "T_33333333-3333-3333-3333-333333333333"
  }
}
```
→ `AgentName = "Contoso Proofreader"`, `AgentId = "T_33333333-…"` — the explicit per-agent id was previously ignored.

**3. Custom-engine agent, older schema — unchanged fallback to `AppIdentity`**
```json
{
  "AppIdentity": "Copilot.Studio.Default-<org-id>-<agent-name>",
  "CopilotEventData": { "AppHost": "Teams", "TargetAgentName": "Contoso Studio Agent" }
}
```
→ `AgentId = "Copilot.Studio.Default-<org-id>-<agent-name>"` — no `TargetPlatformAgentId`, so old behaviour is preserved (backward compatible).

**4. SharePoint agent emitted under two id forms — de-fragmented to one**
```json
// record A
{ "AgentName": "Contoso Proposals Agent", "AgentId": "SharePointAgents.Declarative.SPO_EXAMPLEITEM01" }
// record B
{ "AgentName": "Contoso Proposals Agent", "AgentId": "SPO_EXAMPLEITEM01" }
```
→ both normalise to `AgentId = "SPO_EXAMPLEITEM01"`, so the agent is dimensioned once instead of twice.

**5. Named agent with an unvetted AppIdentity — correctly left unattributed (guard)**
```json
{ "AgentName": "some-first-party-feature", "AppIdentity": "SomeUnverified.App.Identity" }
```
→ `AgentId = null` (unchanged) — not silently absorbed as a synthetic agent until its AppIdentity is added to the allow-list.
### Known caveat (follow-up candidate, not addressed here)

`TargetPlatformAgentId` is the **bare** platform id (e.g. `T_<guid>`), whereas an explicit outer `AgentId` for the same agent may be a **wrapped** form (e.g. `CopilotStudio.Declarative.T_<guid>.<publication-guid>`). If a tenant emits the same agent under both forms, it would dimension as two `copilot_agents` rows — the same class as the `SPO_` case. This is **no worse than the previous `AppIdentity` fallback**, and because both forms share the `T_<guid>` stem it is cleanly fixable later with a normalization rule. It is deliberately **not** normalized here because the trailing publication-guid may be semantically meaningful (distinct publications/versions), so stripping it without evidence would risk *merging* genuinely distinct agents.

### Validation

- Builds clean; **29/29** `CopilotAuditLogContent` unit tests pass (all pre-existing agent/schema tests plus the new ones).
- Behaviour cross-checked against representative payloads from both schema generations: an older schema without `TargetPlatformAgentId`, and a newer schema where it is populated on essentially all agent interactions.

**Scope reminder:** everything above affects **new** imports only; already-imported rows (including any historically fragmented `copilot_agents`) would need a separate backfill/merge migration.