### PR TITLE
Optimise SharePoint Site Usage import (fixes ~7.4h import bottleneck)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAggregateWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAggregateWeeklyUsageReportLoader.cs
@@ -132,4 +132,28 @@ namespace Tests.UnitTests.FakeLoaderClasses
         public string RandoId { get; set; }
         public override string OfficeUniqueIdField => RandoId;
     }
+
+    /// <summary>
+    /// Throws from the save loop so tests can verify the base class still calls EndSaveAsync (which, for the
+    /// real SharePoint loader, restores EF auto change-detection) via its finally block.
+    /// </summary>
+    internal class ThrowingFakeWeeklyUsageReportLoader : AbstractAggregateWeeklyUsageReportLoader<FakeStats>
+    {
+        public bool EndSaveCalled { get; private set; }
+        public ThrowingFakeWeeklyUsageReportLoader(ILogger logger) : base(logger) { }
+        public override string ReportGraphURL => "fake throwing URL";
+        public override string ReportName => "Throwing Fake Usage";
+
+        public override Task<AggregateResourceUsageDetail<FakeStats>> LoadReportDataForUrl(string requestUrl)
+            => Task.FromResult(new AggregateResourceUsageDetail<FakeStats> { Stats = new List<FakeStats>() });
+
+        protected override Task<DateTime?> GetLastStoredResultFor(FakeStats item) => Task.FromResult<DateTime?>(null);
+        protected override Task CommitAllChanges() => Task.CompletedTask;
+        protected override Task AddItemToSaveList(FakeStats item) => throw new InvalidOperationException("boom");
+        protected override Task EndSaveAsync()
+        {
+            EndSaveCalled = true;
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
@@ -176,6 +176,99 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
+        /// Two report rows for the same *new* site in one run must map to a single created site (the
+        /// _newSitesByUrl reuse branch), not insert the site twice.
+        /// </summary>
+        [TestMethod]
+        public async Task SharePointSitesUsageLoader_DuplicateNewSiteInSameRun_CreatesOneSite()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var thisSunday = new DateTime(2024, 2, 25);
+            var url = $"https://contoso.sharepoint.com/sites/dup-{DateTime.Now.Ticks}";
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var loader = new SharePointSitesWeeklyUsageReportLoader(db, null, logger, null);
+                var data = new List<SharePointSiteUsageDetail>
+                {
+                    new SharePointSiteUsageDetail { SiteUrl = url, FileCount = 1 },
+                    new SharePointSiteUsageDetail { SiteUrl = url, FileCount = 2 },
+                };
+                data[0].ReportRefreshDate = thisSunday;
+                data[1].ReportRefreshDate = thisSunday;
+
+                var saved = await loader.SaveLoadedReportsIfRefreshOnDay(DayOfWeek.Sunday, data);
+                Assert.AreEqual(2, saved);
+            }
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var sites = await db.sites.Where(s => s.UrlBase == url).ToListAsync();
+                Assert.AreEqual(1, sites.Count, "The two same-URL rows must map to a single new site, not duplicate sites");
+                var rows = await db.SharePointSiteStats.Where(s => s.Site.UrlBase == url).ToListAsync();
+                Assert.AreEqual(2, rows.Count, "Both weekly rows should attach to the one site");
+            }
+        }
+
+        /// <summary>
+        /// A report URL whose case differs from the stored site URL must still resolve to the existing site
+        /// (the URL dictionaries are OrdinalIgnoreCase, matching SQL Server's case-insensitive collation),
+        /// so we don't create a duplicate site.
+        /// </summary>
+        [TestMethod]
+        public async Task SharePointSitesUsageLoader_MatchesExistingSiteUrlCaseInsensitively()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var thisSunday = new DateTime(2024, 2, 25);
+            var lastSunday = new DateTime(2024, 2, 18);
+            var storedUrl = $"https://contoso.sharepoint.com/sites/CaseTest-{DateTime.Now.Ticks}";
+            var reportUrl = storedUrl.ToUpperInvariant();   // same site, different case (as Graph might return)
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var site = new Site { UrlBase = storedUrl };
+                db.sites.Add(site);
+                db.SharePointSiteStats.Add(new SharePointSitesFileWeeklyStats { Site = site, ForWeekEnding = lastSunday });
+                await db.SaveChangesAsync();
+
+                var loader = new SharePointSitesWeeklyUsageReportLoader(db, null, logger, null);
+                var data = new List<SharePointSiteUsageDetail> { new SharePointSiteUsageDetail { SiteUrl = reportUrl } };
+                data[0].ReportRefreshDate = thisSunday;
+
+                var saved = await loader.SaveLoadedReportsIfRefreshOnDay(DayOfWeek.Sunday, data);
+                Assert.AreEqual(1, saved, "The newer week should be saved");
+            }
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                // SQL collation is case-insensitive, so this returns every site CI-equal to storedUrl - a
+                // duplicate insert (with the upper-cased URL) would make this 2.
+                var sites = await db.sites.Where(s => s.UrlBase == storedUrl).ToListAsync();
+                Assert.AreEqual(1, sites.Count, "Case-differing report URL must reuse the existing site, not create a duplicate");
+                var siteId = sites[0].ID;
+                var rows = await db.SharePointSiteStats.Where(s => s.SiteId == siteId).ToListAsync();
+                Assert.AreEqual(2, rows.Count, "Existing site should now have the old and the new week");
+            }
+        }
+
+        /// <summary>
+        /// The base save loop must call EndSaveAsync in its finally even when the save throws - for the real
+        /// SharePoint loader that is what restores EF auto change-detection on the (possibly reused) context.
+        /// </summary>
+        [TestMethod]
+        public async Task SaveLoadedReportsIfRefreshOnDay_CallsEndSaveEvenWhenSaveThrows()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var loader = new ThrowingFakeWeeklyUsageReportLoader(logger);
+            var data = new List<FakeStats> { new FakeStats { RandoId = "1", ReportRefreshDateString = "2024-02-25" } }; // a Sunday
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => loader.SaveLoadedReportsIfRefreshOnDay(DayOfWeek.Sunday, data));
+
+            Assert.IsTrue(loader.EndSaveCalled, "EndSaveAsync must run in the finally even when the save loop throws");
+        }
+
+        /// <summary>
         /// Tests the saving on the right day of week logic works
         /// </summary>
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
@@ -1,10 +1,13 @@
 using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
+using Common.Entities.Entities.UsageReports;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
@@ -95,6 +98,80 @@ namespace Tests.UnitTests
                     item.ReportRefreshDate = DateTime.Now;
                 }
                 await loader.SaveLoadedReportsIfRefreshOnDay(DateTime.Now.DayOfWeek, data);
+            }
+        }
+
+        /// <summary>
+        /// Regression for the bulk-preload / change-tracking rewrite of the SharePoint Site Usage save loop.
+        /// Verifies the day-of-week gate, "only save when newer than last stored", existing-site FK reuse,
+        /// new-site creation, and that EF auto change-detection is restored afterwards - all without any
+        /// per-site DB round-trip. Runs SaveLoadedReportsIfRefreshOnDay directly (no Graph client needed).
+        /// </summary>
+        [TestMethod]
+        public async Task SharePointSitesUsageLoader_SavesNewReusesExistingAndSkipsCurrent()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+
+            // 2024-02-25 is a Sunday; 2024-02-18 the Sunday before.
+            var thisSunday = new DateTime(2024, 2, 25);
+            var lastSunday = new DateTime(2024, 2, 18);
+            Assert.AreEqual(DayOfWeek.Sunday, thisSunday.DayOfWeek);
+
+            var suffix = DateTime.Now.Ticks.ToString();
+            var urlExistingStale = $"https://contoso.sharepoint.com/sites/stale-{suffix}";
+            var urlExistingCurrent = $"https://contoso.sharepoint.com/sites/current-{suffix}";
+            var urlBrandNew = $"https://contoso.sharepoint.com/sites/new-{suffix}";
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                // Existing site whose latest stored week is older than this Sunday -> should get a new row (reusing the site FK).
+                var siteStale = new Site { UrlBase = urlExistingStale };
+                db.sites.Add(siteStale);
+                db.SharePointSiteStats.Add(new SharePointSitesFileWeeklyStats { Site = siteStale, ForWeekEnding = lastSunday });
+
+                // Existing site already stored for this Sunday -> should be skipped (no duplicate).
+                var siteCurrent = new Site { UrlBase = urlExistingCurrent };
+                db.sites.Add(siteCurrent);
+                db.SharePointSiteStats.Add(new SharePointSitesFileWeeklyStats { Site = siteCurrent, ForWeekEnding = thisSunday });
+                await db.SaveChangesAsync();
+
+                var loader = new SharePointSitesWeeklyUsageReportLoader(db, null, logger, null);
+                var data = new List<SharePointSiteUsageDetail>
+                {
+                    new SharePointSiteUsageDetail { SiteUrl = urlExistingStale, FileCount = 10 },
+                    new SharePointSiteUsageDetail { SiteUrl = urlExistingCurrent, FileCount = 20 },
+                    new SharePointSiteUsageDetail { SiteUrl = urlBrandNew, FileCount = 30 },
+                    // Not a Sunday refresh -> must be ignored entirely.
+                    new SharePointSiteUsageDetail { SiteUrl = urlBrandNew, FileCount = 99, ReportRefreshDateString = "2024-02-24" },
+                };
+                data[0].ReportRefreshDate = thisSunday;
+                data[1].ReportRefreshDate = thisSunday;
+                data[2].ReportRefreshDate = thisSunday;
+
+                var saved = await loader.SaveLoadedReportsIfRefreshOnDay(DayOfWeek.Sunday, data);
+
+                // Only the stale-existing and the brand-new site should have been saved.
+                Assert.AreEqual(2, saved, "Should save the stale-existing and the brand-new site, and skip the already-current one and the non-Sunday row");
+
+                // Auto change-detection must be back on for anyone reusing this context.
+                Assert.IsTrue(db.Configuration.AutoDetectChangesEnabled, "AutoDetectChangesEnabled must be restored after the save");
+            }
+
+            // Re-open a fresh context to assert what actually landed in the DB.
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var staleRows = await db.SharePointSiteStats.Where(s => s.Site.UrlBase == urlExistingStale).ToListAsync();
+                Assert.AreEqual(2, staleRows.Count, "Existing stale site should now have both the old and the new week");
+                Assert.IsTrue(staleRows.Any(r => r.ForWeekEnding == thisSunday), "New week row should exist for the stale site");
+
+                var currentRows = await db.SharePointSiteStats.Where(s => s.Site.UrlBase == urlExistingCurrent).ToListAsync();
+                Assert.AreEqual(1, currentRows.Count, "Already-current site must not get a duplicate row");
+
+                var newSite = await db.sites.SingleOrDefaultAsync(s => s.UrlBase == urlBrandNew);
+                Assert.IsNotNull(newSite, "Brand-new site should have been created");
+                var newRows = await db.SharePointSiteStats.Where(s => s.Site.UrlBase == urlBrandNew).ToListAsync();
+                Assert.AreEqual(1, newRows.Count, "Brand-new site should have exactly one week row (the non-Sunday row is ignored)");
+                Assert.AreEqual(30, newRows[0].FileCount);
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
@@ -59,8 +59,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         {
             try
             {
-                // Try finding from the database 1st so we go easy on Graph
-                var dbRecordBySiteId = await _db.sites.Where(s => s.SiteId.ToLower() == id.ToLower()).SingleOrDefaultAsync();
+                // Try finding from the database 1st so we go easy on Graph.
+                // Compare directly (no .ToLower()): SQL Server's default collation is case-insensitive,
+                // and LOWER() on the column makes the predicate non-SARGable, forcing a full scan of sites.
+                var dbRecordBySiteId = await _db.sites.Where(s => s.SiteId == id).SingleOrDefaultAsync();
                 if (dbRecordBySiteId != null)
                 {
                     return new SPSiteIdToUrl
@@ -73,7 +75,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 _logger.LogInformation($"{nameof(SPSiteIdToUrlCache)}: Loaded site URL for {id}");
 
                 // Cache in DB
-                var dbRecordBySiteUrl = await _db.sites.Where(s => s.UrlBase.ToLower() == site.WebUrl.ToLower()).SingleOrDefaultAsync();
+                var dbRecordBySiteUrl = await _db.sites.Where(s => s.UrlBase == site.WebUrl).SingleOrDefaultAsync();
                 if (dbRecordBySiteUrl != null)
                 {
                     dbRecordBySiteUrl.SiteId = id;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractAggregateWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractAggregateWeeklyUsageReportLoader.cs
@@ -88,43 +88,73 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
 
         public async Task<int> SaveLoadedReportsIfRefreshOnDay(DayOfWeek uptoDay, IEnumerable<T> data)
         {
-            var itemsSaved = 0;
-            foreach (var item in data)
+            // Materialise once so we can both hand the full set to BeginSaveAsync (for bulk pre-loading)
+            // and iterate it below.
+            var items = data as IReadOnlyList<T> ?? data.ToList();
+
+            // Give subclasses a chance to bulk-load existing state in a single query instead of doing a
+            // per-item DB round-trip in GetLastStoredResultFor / AddItemToSaveList. For large tenants this
+            // is the difference between one query and tens of thousands (one per site).
+            await BeginSaveAsync(items);
+
+            try
             {
-                // Only save new data if it's on our day of the week
-                if (item.ReportRefreshDate.DayOfWeek == uptoDay)
+                var itemsSaved = 0;
+                var alreadyUpToDate = 0;
+                var notRefreshedOnDay = 0;
+
+                foreach (var item in items)
                 {
-                    // What's the last date we have stored for this item?  
-                    var itemLastDate = await GetLastStoredResultFor(item);
-                    if (!itemLastDate.HasValue || itemLastDate.Value < item.ReportRefreshDate)
+                    // Only save new data if it's on our day of the week
+                    if (item.ReportRefreshDate.DayOfWeek == uptoDay)
                     {
-                        Telemetry.LogInformation($"Saving {ReportName} for ID '{item.OfficeUniqueIdField}' as report was refreshed on {item.ReportRefreshDateString} (a {uptoDay})");
-                        await AddItemToSaveList(item);
-                        itemsSaved++;
+                        // What's the last date we have stored for this item?
+                        var itemLastDate = await GetLastStoredResultFor(item);
+                        if (!itemLastDate.HasValue || itemLastDate.Value < item.ReportRefreshDate)
+                        {
+                            await AddItemToSaveList(item);
+                            itemsSaved++;
+                        }
+                        else
+                        {
+                            alreadyUpToDate++;
+                        }
                     }
                     else
                     {
-                        Telemetry.LogInformation($"Not saving {ReportName} for ID '{item.OfficeUniqueIdField}' as last saved report was refreshed on {itemLastDate.Value.ToString("dd-MM-yyyy")} " +
-                            $"and this report was refreshed on {item.ReportRefreshDate.ToString("dd-MM-yyyy")}");
+                        notRefreshedOnDay++;
                     }
                 }
-                else
-                {
-                    Telemetry.LogInformation($"Not saving {ReportName} for ID '{item.OfficeUniqueIdField}' as report was refreshed for this item on {item.ReportRefreshDateString} (a {item.ReportRefreshDate.DayOfWeek})");
-                }
-            }
 
-            if (itemsSaved > 0)
-            {
-                Telemetry.LogInformation($"Saving {itemsSaved} items to SQL for {ReportName} reports");
-                await CommitAllChanges();
+                // Per-item logging here produced one INFO trace per report row (tens of thousands for a
+                // large SharePoint tenant), which floods App Insights and slows the run. Log a summary instead.
+                Telemetry.LogInformation($"{ReportName}: considered {items.Count} item(s) - saving {itemsSaved} new weekly report(s); " +
+                    $"{alreadyUpToDate} already up to date; {notRefreshedOnDay} not refreshed on a {uptoDay}.");
+
+                if (itemsSaved > 0)
+                {
+                    Telemetry.LogInformation($"Saving {itemsSaved} items to SQL for {ReportName} reports");
+                    await CommitAllChanges();
+                }
+                return itemsSaved;
             }
-            else
+            finally
             {
-                Telemetry.LogInformation($"Finished processing {ReportName} reports. No weekly reports to save");
+                await EndSaveAsync();
             }
-            return itemsSaved;
         }
+
+        /// <summary>
+        /// Called once before the save loop with every item under consideration. Override to bulk pre-load
+        /// existing DB state (and e.g. tune change-tracking) so per-item lookups become in-memory. Default: no-op.
+        /// </summary>
+        protected virtual Task BeginSaveAsync(IReadOnlyList<T> allItems) => Task.CompletedTask;
+
+        /// <summary>
+        /// Called once after the save loop (in a finally) so overrides can restore any state changed in
+        /// <see cref="BeginSaveAsync"/> even when nothing was saved. Default: no-op.
+        /// </summary>
+        protected virtual Task EndSaveAsync() => Task.CompletedTask;
 
         public abstract Task<AggregateResourceUsageDetail<T>> LoadReportDataForUrl(string requestUrl);
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/SharePointSitesWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/SharePointSitesWeeklyUsageReportLoader.cs
@@ -1,6 +1,5 @@
 using Common.Entities;
 using Common.Entities.Entities.UsageReports;
-using Common.Entities.LookupCaches.Discrete;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -16,13 +15,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
     public class SharePointSitesWeeklyUsageReportLoader : GraphAndSqlAggregateWeeklyUsageReportLoader<SharePointSiteUsageDetail>
     {
         private readonly SPSiteIdToUrlCache _sPSiteIdToUrlCache;
-        private readonly SiteCache _siteCache;
+
+        // Bulk-loaded once in BeginSaveAsync so the per-site save loop needs no DB round-trips:
+        private Dictionary<string, DateTime?> _lastStoredWeekByUrl;   // existing latest week_ending per site URL
+        private Dictionary<string, int> _existingSiteIdByUrl;         // existing site PK per site URL
+        private Dictionary<string, Site> _newSitesByUrl;              // sites created during this run (reused for repeats)
 
         public SharePointSitesWeeklyUsageReportLoader(AnalyticsEntitiesContext db, ManualGraphCallClient client, ILogger logger, SPSiteIdToUrlCache sPSiteIdToUrlCache)
             : base(db, client, logger)
         {
             _sPSiteIdToUrlCache = sPSiteIdToUrlCache;
-            _siteCache = new SiteCache(_context);
         }
 
         public override async Task<IEnumerable<SharePointSiteUsageDetail>> LoadReportData()
@@ -56,27 +58,82 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
 
         public override string ReportName => "SharePoint Site Usage";
 
-        protected override async Task<DateTime?> GetLastStoredResultFor(SharePointSiteUsageDetail item)
+        /// <summary>
+        /// One-time bulk pre-load so the save loop does zero per-site DB round-trips, and disable EF change
+        /// auto-detection so adding tens of thousands of rows to the context stays O(n) instead of O(n^2).
+        /// </summary>
+        protected override async Task BeginSaveAsync(IReadOnlyList<SharePointSiteUsageDetail> allItems)
         {
-            var latestLog = await _context.SharePointSiteStats.Where(s => s.Site.UrlBase == item.SiteUrl).OrderByDescending(s => s.ForWeekEnding).FirstOrDefaultAsync();
-            if (latestLog != null)
+            // All known sites (lightweight projection, not tracked) keyed by URL.
+            var existingSites = await _context.sites.AsNoTracking()
+                .Select(s => new { s.ID, s.UrlBase })
+                .ToListAsync();
+
+            _existingSiteIdByUrl = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var urlBySiteId = new Dictionary<int, string>();
+            foreach (var s in existingSites)
             {
-                return latestLog.ForWeekEnding;
+                if (!string.IsNullOrEmpty(s.UrlBase))
+                {
+                    _existingSiteIdByUrl[s.UrlBase] = s.ID;
+                    urlBySiteId[s.ID] = s.UrlBase;
+                }
             }
-            return null;
+
+            // Latest stored week per site in ONE grouped query (replaces the per-site top-1 query that
+            // previously ran once per site - the dominant cost of this import at ~1 query/site).
+            var latestPerSite = await _context.SharePointSiteStats
+                .GroupBy(s => s.SiteId)
+                .Select(g => new { SiteId = g.Key, Latest = g.Max(s => s.ForWeekEnding) })
+                .ToListAsync();
+
+            _lastStoredWeekByUrl = new Dictionary<string, DateTime?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var row in latestPerSite)
+            {
+                if (urlBySiteId.TryGetValue(row.SiteId, out var url))
+                {
+                    // Keep the greatest week across any sites resolving to the same URL (matches the previous
+                    // OrderByDescending(ForWeekEnding).First() semantics).
+                    if (!_lastStoredWeekByUrl.TryGetValue(url, out var existing)
+                        || (row.Latest.HasValue && (!existing.HasValue || row.Latest.Value > existing.Value)))
+                    {
+                        _lastStoredWeekByUrl[url] = row.Latest;
+                    }
+                }
+            }
+
+            _newSitesByUrl = new Dictionary<string, Site>(StringComparer.OrdinalIgnoreCase);
+            _context.Configuration.AutoDetectChangesEnabled = false;
+        }
+
+        protected override Task EndSaveAsync()
+        {
+            // Always restore, even when nothing was saved, since the context may be reused.
+            _context.Configuration.AutoDetectChangesEnabled = true;
+            return Task.CompletedTask;
+        }
+
+        protected override Task<DateTime?> GetLastStoredResultFor(SharePointSiteUsageDetail item)
+        {
+            DateTime? lastStored = null;
+            if (!string.IsNullOrEmpty(item.SiteUrl) && _lastStoredWeekByUrl != null)
+            {
+                _lastStoredWeekByUrl.TryGetValue(item.SiteUrl, out lastStored);
+            }
+            return Task.FromResult(lastStored);
         }
 
         protected override async Task CommitAllChanges()
         {
+            // Auto-detect is off during the bulk add; run it once here so the pending inserts are picked up.
+            _context.ChangeTracker.DetectChanges();
             await _context.SaveChangesAsync();
         }
 
-        protected override async Task AddItemToSaveList(SharePointSiteUsageDetail item)
+        protected override Task AddItemToSaveList(SharePointSiteUsageDetail item)
         {
-            var site = await _siteCache.GetOrCreateNewResource(item.SiteUrl, new Site { UrlBase = item.SiteUrl });
             var newLog = new SharePointSitesFileWeeklyStats
             {
-                Site = site,
                 ForWeekEnding = item.ReportRefreshDate,
                 ActiveFileCount = item.ActiveFileCount,
                 AnonymousLinkCount = item.AnonymousLinkCount,
@@ -91,7 +148,27 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
                 VisitedPageCount = item.VisitedPageCount
             };
 
+            if (_existingSiteIdByUrl.TryGetValue(item.SiteUrl, out var existingSiteId))
+            {
+                // Existing site: set the FK directly, no need to load/track the Site entity.
+                newLog.SiteId = existingSiteId;
+            }
+            else if (_newSitesByUrl.TryGetValue(item.SiteUrl, out var newSite))
+            {
+                // A site we already created earlier in this same run.
+                newLog.Site = newSite;
+            }
+            else
+            {
+                // Brand-new site: add it (tracked) and attach via navigation so EF inserts it and fills the FK.
+                var site = new Site { UrlBase = item.SiteUrl };
+                _context.sites.Add(site);
+                _newSitesByUrl[item.SiteUrl] = site;
+                newLog.Site = site;
+            }
+
             _context.SharePointSiteStats.Add(newLog);
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Why

Analysis of a large-tenant importer run (App Insights trace export) showed a full import taking **~23.4 h** — dangerously close to the 24 h cycle. The single biggest phase was **SharePoint Site Usage: ~7.4 h to save ~17,500 sites**, single-threaded, with individual saves stalling for up to **2.1 h** as the run progressed.

## Root causes

- **N+1 queries** — `GetLastStoredResultFor` ran one EF query *per site* (~17.5k round-trips).
- **EF6 O(n²) change tracking** — all new rows were buffered in a single context with `AutoDetectChanges` on, so `DetectChanges` degraded quadratically. This is why individual saves stalled for longer and longer (multi-hour) later in the run.
- **Log flooding** — one INFO trace per site (~17.5k lines/run) into App Insights.
- **Non-SARGable lookups** — `SPSiteIdToUrlCache` compared indexed `sites` columns with `.ToLower()`, forcing a full table scan per lookup.

## Changes

- **Bulk pre-load** the latest stored week + site IDs in **2 queries** up front; the save loop then reads from in-memory dictionaries instead of hitting the DB per site.
- **Fix the change-tracking spiral** — disable `AutoDetectChangesEnabled` during the bulk add, run a single `DetectChanges()` before commit, and always restore it in a `finally`. Existing sites now set the FK directly (no per-site `Site` load/track).
- **Replace ~17.5k per-site INFO logs** with a single summary line.
- **Drop `.ToLower()`** in `SPSiteIdToUrlCache` so the `SiteId` / `UrlBase` lookups are SARGable (SQL Server's default collation is already case-insensitive).
- Added `BeginSaveAsync` / `EndSaveAsync` hooks on the base aggregate loader (default no-op, so other weekly loaders are unaffected).

## Impact

The ~7.4 h SharePoint Site Usage phase should drop to a few minutes; combined with the URL-cache fix, a full import run should clear the 24 h cycle comfortably. **No schema changes.** Save semantics are unchanged — it still only saves reports newer than the last stored week, on the configured refresh day.

## Testing

- New DB-backed regression test `SharePointSitesUsageLoader_SavesNewReusesExistingAndSkipsCurrent` — covers existing-site FK reuse, skip-when-already-current, new-site creation, non-Sunday gating, and change-tracking restore.
- Existing `SPSiteIdToUrlCacheTests` (DB-backed, validates the `.ToLower()` removal), `SundayOrNotFakeUsageLoaderTest`, `MultiPageFakeUsageLoaderTest` all pass.
- Built with VS 2022/18 MSBuild.

## Not included (follow-up)

The overnight Copilot per-event file-context resolution (`GraphFileMetadataLoader.GetSpoFileInfo` enumerates an entire SharePoint list client-side when a context has no `driveItemId`) is a larger, higher-risk change and is left for a separate PR.

## Performance measurement (before/after)

Benchmarked the changed save path (`SaveLoadedReportsIfRefreshOnDay`) against LocalDB — seed N sites + an older weekly stat each, then time the weekly save. Same benchmark on `dev` (old) vs this branch (new):

| Sites | Old (dev) | New | Speed-up |
|------:|----------:|----:|---------:|
| 2,000 | 9.13 s | 0.73 s | ~12x |
| 8,000 | 134.65 s | 2.69 s | ~50x |

Old scales **O(n^2)** (4x sites -> ~15x time — the N+1 per-site query plus EF change-tracking growth); new scales **~O(n)** (4x sites -> ~3.7x time). The gap widens with scale, so at the production ~17,493 sites the divergence is much larger.

These LocalDB numbers *understate* the real win: local round-trips are sub-millisecond, whereas in production each N+1 query carried ~0.67 s of latency (17,493 x 0.67 s ≈ 3.3 h for that loop alone) — which is why the observed run was ~7.4 h.
