### PR TITLE
Speed up Copilot file-context import + cut per-record log flooding

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
@@ -96,6 +96,34 @@ namespace DataUtils
         }
 
         /// <summary>
+        /// True only if the copilot doc context id looks like a SharePoint/OneDrive URL we could resolve to a
+        /// file via Graph. Filters out contexts that can never be an SPO file - e.g. https://securitycopilot.microsoft.com,
+        /// other non-SharePoint hosts, and local file paths (C:\...\Olk\Attachments\...) - so we don't fire a
+        /// doomed Graph lookup for them on every import.
+        /// </summary>
+        public static bool IsResolvableSpoFileUrl(string copilotDocContextId)
+        {
+            if (string.IsNullOrWhiteSpace(copilotDocContextId))
+            {
+                return false;
+            }
+            if (!IsValidAbsoluteUrl(copilotDocContextId))
+            {
+                return false;
+            }
+            var uri = new Uri(copilotDocContextId);
+
+            // Excludes file:// (local paths like C:\Users\...\Olk\Attachments), mailto:, etc.
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            {
+                return false;
+            }
+
+            // SharePoint Online and OneDrive for Business are always *.sharepoint.com (incl. -my.sharepoint.com).
+            return uri.Host.EndsWith(".sharepoint.com", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
         /// To form path required by https://learn.microsoft.com/en-us/graph/api/site-get
         /// From "https://test.sharepoint.com/sites/test" returns "test.sharepoint.com:/sites/test"
         /// Or, from root site "https://test.sharepoint.com" returns "root"

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeSpoGraphClient.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeSpoGraphClient.cs
@@ -1,0 +1,79 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using Microsoft.Graph.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory fake of <see cref="ISpoGraphClient"/> so the resolution logic in GraphFileMetadataLoader can
+    /// be unit tested without a live Graph client. Each call is counted, and each response is overridable per test.
+    /// </summary>
+    public class FakeSpoGraphClient : ISpoGraphClient
+    {
+        public int GetOnlineMeetingCalls { get; private set; }
+        public int GetUserDriveCalls { get; private set; }
+        public int GetSiteDriveCalls { get; private set; }
+        public int GetSiteCalls { get; private set; }
+        public int GetListItemByIdCalls { get; private set; }
+        public int FindListItemByWebUrlCalls { get; private set; }
+        public int GetUserCalls { get; private set; }
+
+        public int TotalCalls => GetOnlineMeetingCalls + GetUserDriveCalls + GetSiteDriveCalls + GetSiteCalls
+            + GetListItemByIdCalls + FindListItemByWebUrlCalls + GetUserCalls;
+
+        private static Drive DriveWithIds => new Drive { SharePointIds = new SharepointIds { SiteId = "site-guid", ListId = "list-guid" } };
+
+        public Func<string, string, OnlineMeeting> OnGetOnlineMeeting = (userId, meetingId) =>
+            new OnlineMeeting { Id = meetingId, Subject = "unit test meeting", CreationDateTime = DateTimeOffset.UtcNow };
+        public Func<string, Drive> OnGetUserDrive = upn => DriveWithIds;
+        public Func<string, Drive> OnGetSiteDrive = siteIdentifier => DriveWithIds;
+        public Func<string, Site> OnGetSite = siteIdentifier => new Site { Id = siteIdentifier, WebUrl = "https://contoso.sharepoint.com/sites/x" };
+        public Func<string, string, string, ListItem> OnGetListItemById = (siteId, listId, itemId) =>
+            new ListItem { WebUrl = "https://contoso.sharepoint.com/sites/x/Shared Documents/file.docx" };
+        public Func<string, string, string, ListItem> OnFindListItemByWebUrl = (siteId, listId, webUrl) => new ListItem { WebUrl = webUrl };
+        public Func<string, User> OnGetUser = userId => new User { Id = "user-guid" };
+
+        public Task<OnlineMeeting> GetOnlineMeetingAsync(string userId, string meetingId)
+        {
+            GetOnlineMeetingCalls++;
+            return Task.FromResult(OnGetOnlineMeeting(userId, meetingId));
+        }
+
+        public Task<Drive> GetUserDriveAsync(string upn)
+        {
+            GetUserDriveCalls++;
+            return Task.FromResult(OnGetUserDrive(upn));
+        }
+
+        public Task<Drive> GetSiteDriveAsync(string siteIdentifier)
+        {
+            GetSiteDriveCalls++;
+            return Task.FromResult(OnGetSiteDrive(siteIdentifier));
+        }
+
+        public Task<Site> GetSiteAsync(string siteIdentifier)
+        {
+            GetSiteCalls++;
+            return Task.FromResult(OnGetSite(siteIdentifier));
+        }
+
+        public Task<ListItem> GetListItemByIdAsync(string siteId, string listId, string itemId)
+        {
+            GetListItemByIdCalls++;
+            return Task.FromResult(OnGetListItemById(siteId, listId, itemId));
+        }
+
+        public Task<ListItem> FindListItemByWebUrlAsync(string siteId, string listId, string webUrl)
+        {
+            FindListItemByWebUrlCalls++;
+            return Task.FromResult(OnFindListItemByWebUrl(siteId, listId, webUrl));
+        }
+
+        public Task<User> GetUserAsync(string userId)
+        {
+            GetUserCalls++;
+            return Task.FromResult(OnGetUser(userId));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphFileMetadataLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphFileMetadataLoaderTests.cs
@@ -1,0 +1,130 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using DataUtils;
+using Microsoft.Graph.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the Copilot file/meeting resolution *logic*, exercised against a fake ISpoGraphClient
+    /// (no live Graph). These cover the early-reject, negative caching and driveItemId-vs-URL branches added
+    /// for import performance.
+    /// </summary>
+    [TestClass]
+    public class GraphFileMetadataLoaderTests
+    {
+        private static GraphFileMetadataLoader NewLoader(FakeSpoGraphClient fake)
+            => new GraphFileMetadataLoader(fake, AnalyticsLogger.ConsoleOnlyTracer());
+
+        [TestMethod]
+        public async Task GetSpoFileInfo_NonSharePointHost_SkipsGraphEntirely()
+        {
+            var fake = new FakeSpoGraphClient();
+            var loader = NewLoader(fake);
+
+            var result = await loader.GetSpoFileInfo("https://securitycopilot.microsoft.com", "user@contoso.com");
+
+            Assert.IsNull(result);
+            Assert.AreEqual(0, fake.TotalCalls, "A non-SharePoint context must not trigger any Graph call");
+        }
+
+        [TestMethod]
+        public async Task GetSpoFileInfo_LocalFilePath_SkipsGraphEntirely()
+        {
+            var fake = new FakeSpoGraphClient();
+            var loader = NewLoader(fake);
+
+            var result = await loader.GetSpoFileInfo(@"C:\Users\x\AppData\Local\Microsoft\Olk\Attachments\file.pdf", "user@contoso.com");
+
+            Assert.IsNull(result);
+            Assert.AreEqual(0, fake.TotalCalls, "A local file path must not trigger any Graph call");
+        }
+
+        [TestMethod]
+        public async Task GetSpoFileInfo_WithDriveItemId_ResolvesViaListItemByIdNotEnumeration()
+        {
+            var fake = new FakeSpoGraphClient
+            {
+                OnGetListItemById = (s, l, i) => new ListItem { WebUrl = "https://contoso.sharepoint.com/sites/x/Shared Documents/Report.docx" }
+            };
+            var loader = NewLoader(fake);
+
+            var ctx = "https://contoso.sharepoint.com/sites/x/_layouts/15/Doc.aspx?sourcedoc=%7B0D86F64F-8435-430C-8979-FF46C00F7ACB%7D&file=Report.docx";
+            var result = await loader.GetSpoFileInfo(ctx, "user@contoso.com");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Report.docx", result.Filename);
+            Assert.AreEqual("docx", result.Extension);
+            Assert.AreEqual(1, fake.GetListItemByIdCalls);
+            Assert.AreEqual(0, fake.FindListItemByWebUrlCalls, "With a driveItemId we must NOT enumerate the whole list");
+        }
+
+        [TestMethod]
+        public async Task GetSpoFileInfo_WithoutDriveItemId_ResolvesViaWebUrlSearch()
+        {
+            var ctx = "https://contoso.sharepoint.com/sites/x/Shared Documents/General/Notes.xlsx";
+            var fake = new FakeSpoGraphClient
+            {
+                OnFindListItemByWebUrl = (s, l, url) => new ListItem { WebUrl = url }
+            };
+            var loader = NewLoader(fake);
+
+            var result = await loader.GetSpoFileInfo(ctx, "user@contoso.com");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("xlsx", result.Extension);
+            Assert.AreEqual(1, fake.FindListItemByWebUrlCalls);
+            Assert.AreEqual(0, fake.GetListItemByIdCalls);
+        }
+
+        [TestMethod]
+        public async Task GetSpoFileInfo_MySiteUrl_ResolvesViaUserDrive()
+        {
+            var ctx = "https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/Plan.docx";
+            var fake = new FakeSpoGraphClient
+            {
+                OnFindListItemByWebUrl = (s, l, url) => new ListItem { WebUrl = url }
+            };
+            var loader = NewLoader(fake);
+
+            var result = await loader.GetSpoFileInfo(ctx, "user@contoso.com");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, fake.GetUserDriveCalls, "OneDrive (-my) contexts resolve via the user's drive");
+            Assert.AreEqual(0, fake.GetSiteDriveCalls, "OneDrive contexts must not use the site drive path");
+        }
+
+        [TestMethod]
+        public async Task GetSpoFileInfo_UnresolvableContext_IsCachedAndNotRetried()
+        {
+            var ctx = "https://contoso.sharepoint.com/sites/x/Shared Documents/Missing.docx";
+            var fake = new FakeSpoGraphClient
+            {
+                OnFindListItemByWebUrl = (s, l, url) => null   // never matches
+            };
+            var loader = NewLoader(fake);
+
+            var first = await loader.GetSpoFileInfo(ctx, "user@contoso.com");
+            var second = await loader.GetSpoFileInfo(ctx, "user@contoso.com");
+
+            Assert.IsNull(first);
+            Assert.IsNull(second);
+            Assert.AreEqual(1, fake.FindListItemByWebUrlCalls, "A context that failed to resolve must not be re-resolved within the session");
+        }
+
+        [TestMethod]
+        public async Task GetMeetingInfo_ResolvesViaGraph()
+        {
+            var fake = new FakeSpoGraphClient();
+            var loader = NewLoader(fake);
+
+            var result = await loader.GetMeetingInfo("19:meeting_abc@thread.v2", "user-guid");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("unit test meeting", result.Subject);
+            Assert.AreEqual(1, fake.GetOnlineMeetingCalls);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphStringUtilsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphStringUtilsTests.cs
@@ -74,5 +74,23 @@ namespace Tests.UnitTests
                 "0D86F64F-8435-430C-8979-FF46C00F7ACB");
         }
 
+        [TestMethod]
+        public void IsResolvableSpoFileUrl()
+        {
+            // SharePoint / OneDrive URLs we can resolve via Graph
+            Assert.IsTrue(StringUtils.IsResolvableSpoFileUrl("https://contoso.sharepoint.com/sites/x/Shared%20Documents/General/report.docx"));
+            Assert.IsTrue(StringUtils.IsResolvableSpoFileUrl("https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/plan.docx"));
+            // Unicode (Greek) file names must be handled, not rejected
+            Assert.IsTrue(StringUtils.IsResolvableSpoFileUrl("https://contoso.sharepoint.com/sites/example/Shared Documents/Καλημέρα κόσμε.pdf"));
+
+            // Contexts that can never be a SharePoint file -> must be rejected before any Graph call
+            Assert.IsFalse(StringUtils.IsResolvableSpoFileUrl("https://securitycopilot.microsoft.com"));
+            Assert.IsFalse(StringUtils.IsResolvableSpoFileUrl(@"C:\Users\x\AppData\Local\Microsoft\Olk\Attachments\file.pdf"));
+            Assert.IsFalse(StringUtils.IsResolvableSpoFileUrl("https://example.com/some/file.docx"));
+            Assert.IsFalse(StringUtils.IsResolvableSpoFileUrl(null));
+            Assert.IsFalse(StringUtils.IsResolvableSpoFileUrl(""));
+            Assert.IsFalse(StringUtils.IsResolvableSpoFileUrl("not a url"));
+        }
+
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="DBLookupCacheDuplicateKeyErrorTests.cs" />
     <Compile Include="DBLookupCacheTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeUserMetadataLoader.cs" />
+    <Compile Include="GraphFileMetadataLoaderTests.cs" />
     <Compile Include="GraphStringUtilsTests.cs" />
     <Compile Include="DataCleanupTests.cs" />
     <Compile Include="DuplicateUrlTests.cs" />
@@ -126,6 +127,7 @@
     <Compile Include="CopilotTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeCopilotEventAdaptor.cs" />
     <Compile Include="FakeLoaderClasses\FakeAggregateWeeklyUsageReportLoader.cs" />
+    <Compile Include="FakeLoaderClasses\FakeSpoGraphClient.cs" />
     <Compile Include="FakeLoaderClasses\MockUserGroupsCache.cs" />
     <Compile Include="LookupCacheBatchProcessingTests.cs" />
     <Compile Include="OutlookUserActivityLoaderTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -113,7 +113,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
 
             if (eventMeetings > 0 || eventFiles > 0 || eventChats > 0)
             {
-                _logger.LogInformation($"Event {baseOfficeEvent.Id}: staged {eventChats} chat(s), {eventMeetings} meeting(s), {eventFiles} file(s).");
+                _logger.LogDebug($"Event {baseOfficeEvent.Id}: staged {eventChats} chat(s), {eventMeetings} meeting(s), {eventFiles} file(s).");
             }
             else
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphCaches.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphCaches.cs
@@ -1,5 +1,4 @@
-﻿using DataUtils;
-using Microsoft.Graph;
+using DataUtils;
 using Microsoft.Graph.Models;
 using System.Threading.Tasks;
 
@@ -7,33 +6,33 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
 {
     public abstract class GraphCache<T> : ObjectByIdCache<T> where T : class
     {
-        protected readonly GraphServiceClient _graphServiceClient;
+        protected readonly ISpoGraphClient _spoGraphClient;
 
-        protected GraphCache(GraphServiceClient graphServiceClient)
+        protected GraphCache(ISpoGraphClient spoGraphClient)
         {
-            _graphServiceClient = graphServiceClient;
+            _spoGraphClient = spoGraphClient;
         }
     }
     public class SiteGraphCache : GraphCache<Site>
     {
-        public SiteGraphCache(GraphServiceClient graphServiceClient) : base(graphServiceClient)
+        public SiteGraphCache(ISpoGraphClient spoGraphClient) : base(spoGraphClient)
         {
         }
 
         public override async Task<Site> Load(string id)
         {
-            return await _graphServiceClient.Sites[id].GetAsync();
+            return await _spoGraphClient.GetSiteAsync(id);
         }
     }
     public class UserGraphCache : GraphCache<User>
     {
-        public UserGraphCache(GraphServiceClient graphServiceClient) : base(graphServiceClient)
+        public UserGraphCache(ISpoGraphClient spoGraphClient) : base(spoGraphClient)
         {
         }
 
         public override async Task<User> Load(string id)
         {
-            return await _graphServiceClient.Users[id].GetAsync();
+            return await _spoGraphClient.GetUserAsync(id);
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
@@ -4,6 +4,7 @@ using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using Microsoft.Graph.Models.ODataErrors;
 using System;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
 
@@ -14,17 +15,25 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
     /// </summary>
     public class GraphFileMetadataLoader : ICopilotMetadataLoader
     {
-        private readonly GraphServiceClient _graphServiceClient;
+        private readonly ISpoGraphClient _spoGraphClient;
         private readonly SiteGraphCache _siteGraphCache;
         private readonly UserGraphCache _userGraphCache;
         private readonly ILogger _logger;
 
+        // Copilot context ids that resolved to nothing this session - don't waste Graph calls re-resolving them.
+        private readonly ConcurrentDictionary<string, byte> _unresolvableContextIds = new ConcurrentDictionary<string, byte>();
+
         public GraphFileMetadataLoader(GraphServiceClient graphServiceClient, ILogger logger)
+            : this(new GraphSpoClient(graphServiceClient), logger)
         {
-            _graphServiceClient = graphServiceClient;
+        }
+
+        public GraphFileMetadataLoader(ISpoGraphClient spoGraphClient, ILogger logger)
+        {
+            _spoGraphClient = spoGraphClient;
             _logger = logger;
-            _siteGraphCache = new SiteGraphCache(graphServiceClient);
-            _userGraphCache = new UserGraphCache(graphServiceClient);
+            _siteGraphCache = new SiteGraphCache(spoGraphClient);
+            _userGraphCache = new UserGraphCache(spoGraphClient);
         }
 
         public async Task<MeetingMetadata> GetMeetingInfo(string meetingId, string userGuid)
@@ -32,7 +41,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             // Requires OnlineMeetings.Read.All and https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy#configure-application-access-policy
             try
             {
-                var meeting = await _graphServiceClient.Users[userGuid].OnlineMeetings[meetingId].GetAsync();
+                var meeting = await _spoGraphClient.GetOnlineMeetingAsync(userGuid, meetingId);
 
                 return new MeetingMetadata(meeting);
             }
@@ -43,8 +52,33 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             }
         }
 
-        // Example: https://m365cp123890-my.sharepoint.com/personal/sambetts_m365cp123890_onmicrosoft_com/_layouts/15/Doc.aspx?sourcedoc=%7B0D86F64F-8435-430C-8979-FF46C00F7ACB%7D&file=Presentation.pptx&action=edit&mobileredirect=true
         public async Task<SpoDocumentFileInfo> GetSpoFileInfo(string copilotDocContextId, string eventUpn)
+        {
+            // Skip anything that can't be a SharePoint/OneDrive file (securitycopilot.microsoft.com, local
+            // Outlook attachment paths, other hosts) before doing any Graph work - these fail on every import.
+            if (!StringUtils.IsResolvableSpoFileUrl(copilotDocContextId))
+            {
+                _logger.LogDebug("Copilot context '{ctx}' is not a resolvable SharePoint/OneDrive URL; skipping Graph lookup", copilotDocContextId);
+                return null;
+            }
+
+            // Don't re-resolve a context we've already failed to resolve this session.
+            if (_unresolvableContextIds.ContainsKey(copilotDocContextId))
+            {
+                _logger.LogDebug("Copilot context '{ctx}' was already unresolvable this session; skipping Graph lookup", copilotDocContextId);
+                return null;
+            }
+
+            var result = await ResolveSpoFileInfoAsync(copilotDocContextId, eventUpn);
+            if (result == null)
+            {
+                _unresolvableContextIds.TryAdd(copilotDocContextId, 0);
+            }
+            return result;
+        }
+
+        // Example: https://m365cp123890-my.sharepoint.com/personal/sambetts_m365cp123890_onmicrosoft_com/_layouts/15/Doc.aspx?sourcedoc=%7B0D86F64F-8435-430C-8979-FF46C00F7ACB%7D&file=Presentation.pptx&action=edit&mobileredirect=true
+        private async Task<SpoDocumentFileInfo> ResolveSpoFileInfoAsync(string copilotDocContextId, string eventUpn)
         {
             var siteUrl = StringUtils.GetSiteUrl(copilotDocContextId);
             if (siteUrl == null) return null;
@@ -77,56 +111,30 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             }
             var driveItemId = StringUtils.GetDriveItemId(copilotDocContextId);
 
-            ListItem item = null;
             var site = await _siteGraphCache.GetResourceOrNullIfNotExists(spSiteId);
             if (driveItemId != null)
             {
                 try
                 {
-                    item = await _graphServiceClient.Sites[spSiteId].Lists[spListId].Items[driveItemId]
-                        .GetAsync(rc => { rc.QueryParameters.Expand = new[] { "fields" }; });
+                    var item = await _spoGraphClient.GetListItemByIdAsync(spSiteId, spListId, driveItemId);
+                    return new SpoDocumentFileInfo(item, site);
                 }
                 catch (ODataError ex)
                 {
                     _logger.LogWarning(ex, "Error getting file info for copilotDocContextId {copilotDocContextId}", copilotDocContextId);
                     return null;
                 }
-
-                return new SpoDocumentFileInfo(item, site);
             }
             else
             {
-                // We might have a direct URL as the copilot context ID, so we need to search for the item in the list.
+                // We might have a direct URL as the copilot context ID, so search the list for a matching item.
                 // Example: https://contoso-my.sharepoint.com/personal/alex_contoso_onmicrosoft_com/Documents/MyDoc.docx
                 try
                 {
-                    // Currently we can't filter by webUrl, so we have to get all items and filter client side.
-                    // Walk all pages so we can still resolve file context in large lists.
-                    var firstPage = await _graphServiceClient.Sites[spSiteId].Lists[spListId].Items
-                        .GetAsync(rc => { rc.QueryParameters.Select = new[] { "id", "webUrl" }; });
-                    if (firstPage?.Value != null)
+                    var matchedItem = await _spoGraphClient.FindListItemByWebUrlAsync(spSiteId, spListId, copilotDocContextId);
+                    if (matchedItem != null)
                     {
-                        ListItem matchedItem = null;
-                        var iterator = PageIterator<ListItem, ListItemCollectionResponse>.CreatePageIterator(
-                            _graphServiceClient,
-                            firstPage,
-                            i =>
-                            {
-                                if (i.WebUrl == copilotDocContextId)
-                                {
-                                    matchedItem = i;
-                                    return false;
-                                }
-
-                                return true;
-                            });
-
-                        await iterator.IterateAsync();
-
-                        if (matchedItem != null)
-                        {
-                            return new SpoDocumentFileInfo(matchedItem, site);
-                        }
+                        return new SpoDocumentFileInfo(matchedItem, site);
                     }
                 }
                 catch (ODataError ex)
@@ -151,8 +159,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             // Needs Files.Read.All
             try
             {
-                return await _graphServiceClient.Users[eventUpn].Drive
-                    .GetAsync(rc => { rc.QueryParameters.Select = new[] { "SharePointIds" }; })
+                return await _spoGraphClient.GetUserDriveAsync(eventUpn)
                     ?? throw new ArgumentOutOfRangeException(eventUpn);
             }
             catch (ODataError ex)
@@ -175,8 +182,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             Drive siteDrive = null;
             try
             {
-                siteDrive = await _graphServiceClient.Sites[siteAddress].Drive
-                    .GetAsync(rc => { rc.QueryParameters.Select = new[] { "SharePointIds" }; })
+                siteDrive = await _spoGraphClient.GetSiteDriveAsync(siteAddress)
                     ?? throw new ArgumentOutOfRangeException(siteAddress);
             }
             catch (ODataError)
@@ -190,7 +196,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                 Site site = null;
                 try
                 {
-                    site = await _graphServiceClient.Sites[siteAddress].GetAsync() ?? throw new ArgumentOutOfRangeException(siteAddress);
+                    site = await _spoGraphClient.GetSiteAsync(siteAddress) ?? throw new ArgumentOutOfRangeException(siteAddress);
                 }
                 catch (ODataError ex)
                 {
@@ -202,8 +208,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     try
                     {
                         // Try one more time using site ID
-                        siteDrive = await _graphServiceClient.Sites[site.Id].Drive
-                            .GetAsync(rc => { rc.QueryParameters.Select = new[] { "SharePointIds" }; })
+                        siteDrive = await _spoGraphClient.GetSiteDriveAsync(site.Id)
                             ?? throw new ArgumentOutOfRangeException(siteAddress);
                     }
                     catch (ODataError)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SpoGraphClient.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SpoGraphClient.cs
@@ -1,0 +1,96 @@
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using System.Threading.Tasks;
+
+namespace ActivityImporter.Engine.ActivityAPI.Copilot
+{
+    /// <summary>
+    /// Thin abstraction over the individual Microsoft Graph calls needed to resolve Copilot file/meeting
+    /// context metadata. Exists so the resolution *logic* in <see cref="GraphFileMetadataLoader"/> (which
+    /// branch to take, early-rejects, caching) can be unit-tested against a fake instead of a live Graph
+    /// client. The real implementation (<see cref="GraphSpoClient"/>) is a pass-through - all decision making
+    /// lives in the loader.
+    /// </summary>
+    public interface ISpoGraphClient
+    {
+        Task<OnlineMeeting> GetOnlineMeetingAsync(string userId, string meetingId);
+
+        /// <summary>A user's OneDrive (with SharePointIds populated).</summary>
+        Task<Drive> GetUserDriveAsync(string upn);
+
+        /// <summary>A site's default document library drive (with SharePointIds populated). Accepts a site id or a host:/path address.</summary>
+        Task<Drive> GetSiteDriveAsync(string siteIdentifier);
+
+        /// <summary>A site by id or by host:/path address.</summary>
+        Task<Site> GetSiteAsync(string siteIdentifier);
+
+        /// <summary>A single list item by its id (fields expanded).</summary>
+        Task<ListItem> GetListItemByIdAsync(string siteId, string listId, string itemId);
+
+        /// <summary>Find a list item whose WebUrl matches, or null if none. Encapsulates paging so it can be optimised later.</summary>
+        Task<ListItem> FindListItemByWebUrlAsync(string siteId, string listId, string webUrl);
+
+        Task<User> GetUserAsync(string userId);
+    }
+
+    /// <summary>
+    /// Live Microsoft Graph implementation of <see cref="ISpoGraphClient"/>. Deliberately contains no logic
+    /// beyond issuing the Graph request so that all testable behaviour stays in the loader.
+    /// </summary>
+    public class GraphSpoClient : ISpoGraphClient
+    {
+        private readonly GraphServiceClient _graphServiceClient;
+
+        public GraphSpoClient(GraphServiceClient graphServiceClient)
+        {
+            _graphServiceClient = graphServiceClient;
+        }
+
+        public Task<OnlineMeeting> GetOnlineMeetingAsync(string userId, string meetingId)
+            => _graphServiceClient.Users[userId].OnlineMeetings[meetingId].GetAsync();
+
+        public Task<Drive> GetUserDriveAsync(string upn)
+            => _graphServiceClient.Users[upn].Drive.GetAsync(rc => { rc.QueryParameters.Select = new[] { "SharePointIds" }; });
+
+        public Task<Drive> GetSiteDriveAsync(string siteIdentifier)
+            => _graphServiceClient.Sites[siteIdentifier].Drive.GetAsync(rc => { rc.QueryParameters.Select = new[] { "SharePointIds" }; });
+
+        public Task<Site> GetSiteAsync(string siteIdentifier)
+            => _graphServiceClient.Sites[siteIdentifier].GetAsync();
+
+        public Task<ListItem> GetListItemByIdAsync(string siteId, string listId, string itemId)
+            => _graphServiceClient.Sites[siteId].Lists[listId].Items[itemId].GetAsync(rc => { rc.QueryParameters.Expand = new[] { "fields" }; });
+
+        public async Task<ListItem> FindListItemByWebUrlAsync(string siteId, string listId, string webUrl)
+        {
+            // Currently we can't server-side filter list items by webUrl, so we page and match client side.
+            // Walk all pages so we can still resolve file context in large lists.
+            var firstPage = await _graphServiceClient.Sites[siteId].Lists[listId].Items
+                .GetAsync(rc => { rc.QueryParameters.Select = new[] { "id", "webUrl" }; });
+            if (firstPage?.Value == null)
+            {
+                return null;
+            }
+
+            ListItem matchedItem = null;
+            var iterator = PageIterator<ListItem, ListItemCollectionResponse>.CreatePageIterator(
+                _graphServiceClient,
+                firstPage,
+                i =>
+                {
+                    if (i.WebUrl == webUrl)
+                    {
+                        matchedItem = i;
+                        return false;
+                    }
+                    return true;
+                });
+
+            await iterator.IterateAsync();
+            return matchedItem;
+        }
+
+        public Task<User> GetUserAsync(string userId)
+            => _graphServiceClient.Users[userId].GetAsync();
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/PowerPlatformAuditLogFilter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/PowerPlatformAuditLogFilter.cs
@@ -30,7 +30,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 return true;
             }
 
-            logger?.LogInformation($"PowerPlatform: skipping Power Automate event with non-run operation '{operation}'. Only flow-run operations are persisted - extend ActivityImportConstants.PowerPlatformOps.FlowRunOps if this should be tracked.");
+            logger?.LogDebug($"PowerPlatform: skipping Power Automate event with non-run operation '{operation}'. Only flow-run operations are persisted - extend ActivityImportConstants.PowerPlatformOps.FlowRunOps if this should be tracked.");
             return false;
         }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/PowerPlatformAuditLogContent.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/PowerPlatformAuditLogContent.cs
@@ -261,7 +261,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
                 var isShare = ActivityImportConstants.PowerPlatformOps.IsPowerAppShareOp(Operation);
                 if (!isLaunch && !isShare)
                 {
-                    logger?.LogInformation($"PowerPlatform admin activity: ignoring PowerApp event with unsupported operation '{Operation}' (id='{Id}'). Only LaunchPowerApp + share operations are persisted today.");
+                    logger?.LogDebug($"PowerPlatform admin activity: ignoring PowerApp event with unsupported operation '{Operation}' (id='{Id}'). Only LaunchPowerApp + share operations are persisted today.");
                     return null;
                 }
                 return ToPowerAppsContent(logger, isShare);
@@ -273,11 +273,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
 
             if (string.IsNullOrEmpty(resourceType))
             {
-                logger?.LogInformation($"PowerPlatform admin activity: skipping record - no '{ActivityImportConstants.PowerPlatformProps.ResourceType}' property, so this event is not tied to a tracked Power App or Cloud Flow resource (operation='{Operation}', id='{Id}'). This is expected for operations like ApiEndpointCallEvent and connector-only events.");
+                logger?.LogDebug($"PowerPlatform admin activity: skipping record - no '{ActivityImportConstants.PowerPlatformProps.ResourceType}' property, so this event is not tied to a tracked Power App or Cloud Flow resource (operation='{Operation}', id='{Id}'). This is expected for operations like ApiEndpointCallEvent and connector-only events.");
             }
             else
             {
-                logger?.LogInformation($"PowerPlatform admin activity: skipping record with unsupported resource type '{resourceType}' - only PowerApp and CloudFlow are persisted today (operation='{Operation}', id='{Id}').");
+                logger?.LogDebug($"PowerPlatform admin activity: skipping record with unsupported resource type '{resourceType}' - only PowerApp and CloudFlow are persisted today (operation='{Operation}', id='{Id}').");
             }
             return null;
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -69,6 +69,7 @@
     <Compile Include="ActivityAPI\Copilot\CostEstimate\Models.cs" />
     <Compile Include="ActivityAPI\Copilot\GraphCaches.cs" />
     <Compile Include="ActivityAPI\Copilot\GraphFileMetadataLoader.cs" />
+    <Compile Include="ActivityAPI\Copilot\SpoGraphClient.cs" />
     <Compile Include="ActivityAPI\Copilot\Models.cs" />
     <Compile Include="ActivityAPI\Copilot\StagingClasses.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\PowerPlatformAuditEventManager.cs" />


### PR DESCRIPTION
## Why

Two things from an importer trace analysis at large-tenant scale:

1. **The Copilot file/meeting resolution logic wasn't unit-testable.** `ICopilotMetadataLoader` abstracts the *whole* resolution, so the test fakes replaced all of it — the real logic in `GraphFileMetadataLoader` (URL parsing, driveItem-vs-URL branch, the full-list enumeration) only ran against live Graph.
2. **Per-record log flooding.** ~48k PowerPlatform "skipping record" lines and ~15k Copilot "Event … staged" lines per run — >90% of the trace volume — at `Information` level.

## What changed

**Abstraction (enables testing):** new `ISpoGraphClient` wraps the individual Graph calls; `GraphSpoClient` is the thin live implementation (all decision-making stays in the loader). `GraphFileMetadataLoader` and the two Graph caches now depend on the interface, with a back-compat `GraphServiceClient` constructor so existing call sites are unchanged. Tests inject a `FakeSpoGraphClient`.

**Copilot file-context perf:**
- **Early-reject** contexts that can never be a SharePoint/OneDrive file — `securitycopilot.microsoft.com`, local Outlook attachment paths (`C:\…\Olk\…`), any non-`*.sharepoint.com` host — *before any Graph call*, via a new pure `StringUtils.IsResolvableSpoFileUrl`. In the analysed run ~1,400 contexts hit Graph every cycle only to fail.
- **Negative cache**: a context that resolves to nothing isn't re-resolved for the rest of the session.

**Log noise:** the high-volume per-record PowerPlatform "skipping/ignoring" lines and the per-event Copilot "staged" line moved from `Information` → `Debug` (still available when debugging, off by default).

## Testing

- **New** `GraphFileMetadataLoaderTests` (via `FakeSpoGraphClient`, no live Graph): non-SharePoint host → **0 Graph calls**; local file path → 0 Graph calls; driveItemId present → resolves via `GetListItemById`, **not** list enumeration; direct URL → resolves via web-URL search; OneDrive (`-my`) → resolves via the user's drive; unresolvable context → cached and **not retried**; meeting → resolves.
- **New** `StringUtils.IsResolvableSpoFileUrl` test, incl. a Greek/Unicode URL (`…/Καλημέρα κόσμε.pdf`).
- Existing `CopilotEventManagerEdgeCaseTests` (11) still pass — the abstraction + log change don't regress the event manager.
- Built with VS 2022/18 MSBuild.

## Not included (follow-up)

- Replacing the client-side **full-list enumeration** in `FindListItemByWebUrlAsync` with a path-addressed lookup — the abstraction now makes this a localised, testable change.
- Bounded-concurrency for per-event resolution.
