### PR TITLE
Cap the Graph 'retry-after' throttle back-off to bound stalls

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/Http/AutoThrottleHttpClient.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/AutoThrottleHttpClient.cs
@@ -17,6 +17,7 @@ namespace DataUtils.Http
         private DateTime? _nextCallEarliestTime = null;
         private int _concurrentCalls = 0, _throttledCalls = 0, _completedCalls = 0;
         private int _maxRetries = 10;
+        private int _maxRetryAfterWaitSeconds = 180;
         private object _concurrentCallsObj = new object(), _throttledCallsObject = new object(), _completedCallsObject = new object(), _maxRetriesObj = new object();
 
 
@@ -98,8 +99,19 @@ namespace DataUtils.Http
                     var waitValue = response.GetRetryAfterHeaderSeconds();
                     if (!ignoreRetryHeader && waitValue.HasValue)
                     {
-                        secondsToWait = waitValue.Value;
-                        _logger.LogInformation($"{THROTTLE_ERROR} for {url}. Waiting to retry for attempt #{retries}, {secondsToWait} seconds (from 'retry-after' header)...");
+                        // Honour 'retry-after', but cap it: a single very large (or buggy) value would otherwise
+                        // block this thread for that entire duration (we saw multi-minute stalls in usage-report
+                        // paging). Capping breaks one huge sleep into shorter, observable waits + retries.
+                        var cap = MaxRetryAfterWaitSeconds;
+                        secondsToWait = Math.Min(waitValue.Value, cap);
+                        if (waitValue.Value > cap)
+                        {
+                            _logger.LogWarning($"{THROTTLE_ERROR} for {url}. 'retry-after' header asked for {waitValue.Value}s; capping wait at {cap}s for attempt #{retries}.");
+                        }
+                        else
+                        {
+                            _logger.LogInformation($"{THROTTLE_ERROR} for {url}. Waiting to retry for attempt #{retries}, {secondsToWait} seconds (from 'retry-after' header)...");
+                        }
                     }
                     else
                     {
@@ -156,6 +168,28 @@ namespace DataUtils.Http
                 lock (_maxRetriesObj)
                 {
                     _maxRetries = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Upper bound (seconds) on how long a single 'retry-after' back-off will sleep. A very large or buggy
+        /// header value would otherwise stall the calling thread for its whole duration.
+        /// </summary>
+        public int MaxRetryAfterWaitSeconds
+        {
+            get
+            {
+                lock (_maxRetriesObj)
+                {
+                    return _maxRetryAfterWaitSeconds;
+                }
+            }
+            set
+            {
+                lock (_maxRetriesObj)
+                {
+                    _maxRetryAfterWaitSeconds = value;
                 }
             }
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/AutoThrottleHttpClientTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AutoThrottleHttpClientTests.cs
@@ -1,0 +1,69 @@
+using DataUtils;
+using DataUtils.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class AutoThrottleHttpClientTests
+    {
+        /// <summary>
+        /// A very large 'retry-after' value must be capped at MaxRetryAfterWaitSeconds rather than sleeping the
+        /// calling thread for the whole duration - the fix that prevents a single throttling response from
+        /// stalling an import for minutes/hours.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_CapsLargeRetryAfter()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var handler = new SequencedThrottleHandler(retryAfterSeconds: 3600); // server asks for a full hour
+
+            using (var client = new AutoThrottleHttpClient(handler, logger))
+            {
+                client.MaxRetryAfterWaitSeconds = 1; // cap low so the test is fast
+
+                var sw = Stopwatch.StartNew();
+                var response = await client.ExecuteHttpCallWithThrottleRetries(
+                    () => client.GetAsync("https://example.test/throttled"),
+                    "https://example.test/throttled");
+                sw.Stop();
+
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                Assert.AreEqual(2, handler.CallCount, "Should have retried exactly once after the capped wait");
+                Assert.IsTrue(sw.Elapsed.TotalSeconds < 30,
+                    $"Back-off should be capped near 1s (not the 3600s the header asked for) - was {sw.Elapsed.TotalSeconds:F1}s");
+            }
+        }
+
+        /// <summary>Returns 429 with a Retry-After header on the first call, then 200 OK.</summary>
+        private class SequencedThrottleHandler : HttpMessageHandler
+        {
+            private int _callCount;
+            private readonly int _retryAfterSeconds;
+            public int CallCount => _callCount;
+
+            public SequencedThrottleHandler(int retryAfterSeconds)
+            {
+                _retryAfterSeconds = retryAfterSeconds;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var call = Interlocked.Increment(ref _callCount);
+                if (call == 1)
+                {
+                    var throttled = new HttpResponseMessage((HttpStatusCode)429);
+                    throttled.Headers.TryAddWithoutValidation("Retry-After", _retryAfterSeconds.ToString());
+                    return Task.FromResult(throttled);
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -163,6 +163,7 @@
     <Compile Include="FakeLoaderClasses\FakeActivitySubscriptionManager.cs" />
     <Compile Include="FakeLoaderClasses\FakeUserAppLoader.cs" />
     <Compile Include="GraphUsageReportImportTests.cs" />
+    <Compile Include="AutoThrottleHttpClientTests.cs" />
     <Compile Include="GraphImportTests.cs" />
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />


### PR DESCRIPTION
## Why

`AutoThrottleHttpClient.ExecuteHttpCallWithThrottleRetries` honoured the Graph `Retry-After` header on a 429 by sleeping for **exactly** that many seconds, with **no upper bound**:

```csharp
secondsToWait = waitValue.Value;   // whatever the header says
```

A single large value — or repeated multi-minute ones during a throttling storm — stalls the calling thread for that entire duration. This is a contributor to the long silent gaps seen during Graph usage-report paging (observed ~10-minute back-offs, and multi-hour quiet stretches across concurrent loaders).

## What changed

Cap the back-off at a configurable `MaxRetryAfterWaitSeconds` (default **180s**):

- If the header asks for **more** than the cap, wait the cap and retry (a `Warning` is logged). Breaking one huge sleep into shorter, observable waits + retries bounds the worst-case single-call stall to `MaxRetries × cap`.
- If the header is **within** the cap, it's honoured unchanged.
- The existing no-header exponential back-off and `MaxRetries` behaviour are untouched.

### Deliberately not included

**No extra Graph concurrency.** Graph throttles per-app, so parallelising the per-site URL resolution (or usage-report paging) harder would *increase* throttling, not reduce it. The DB-side of the site-URL cache (`.ToLower()` non-SARGable scan) was already fixed separately.

## Testing

- `ExecuteHttpCallWithThrottleRetries_CapsLargeRetryAfter`: a fake handler returns `429` with `Retry-After: 3600` once, then `200`. With the cap set low the call completes in ~1s and retries exactly once — i.e. it does **not** sleep the hour the header asked for.
- Built with VS 2022/18 MSBuild.
