### PR TITLE
Parallelize audit+Copilot metadata resolution outside the SQL save lock

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotPrewarmExtractionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotPrewarmExtractionTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests the Copilot file-context extraction used to pre-warm Graph metadata resolution outside the SQL
+    /// lock. Must mirror CopilotAuditEventManager's context handling (first file context only; meeting ends
+    /// processing; chat is additive, not a file).
+    /// </summary>
+    [TestClass]
+    public class CopilotPrewarmExtractionTests
+    {
+        private static CopilotAuditLogContent CopilotEvent(string upn, params Context[] contexts)
+            => new CopilotAuditLogContent
+            {
+                UserId = upn,
+                CopilotEventData = new CopilotEventData { Contexts = contexts.ToList() }
+            };
+
+        private static Context File(string id) => new Context { Id = id, Type = "file" };
+        private static Context Chat(string id) => new Context { Id = id, Type = ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_CHAT };
+        private static Context Meeting(string id) => new Context { Id = id, Type = ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING };
+
+        [TestMethod]
+        public void ExtractsFirstFileContextWithUpn()
+        {
+            var acts = new List<AbstractAuditLogContent>
+            {
+                CopilotEvent("a@contoso.com", File("https://contoso.sharepoint.com/sites/x/a.docx"))
+            };
+            var result = ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts);
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("a@contoso.com", result["https://contoso.sharepoint.com/sites/x/a.docx"]);
+        }
+
+        [TestMethod]
+        public void ChatOnlyEventsYieldNoFileContext()
+        {
+            var acts = new List<AbstractAuditLogContent> { CopilotEvent("a@contoso.com", Chat("19:chat@thread.v2")) };
+            Assert.AreEqual(0, ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts).Count);
+        }
+
+        [TestMethod]
+        public void MeetingContextEndsProcessingWithNoFile()
+        {
+            // Meeting first -> break -> no file resolved (mirrors the manager's meeting-takes-priority behaviour).
+            var acts = new List<AbstractAuditLogContent>
+            {
+                CopilotEvent("a@contoso.com", Meeting("19:meeting@thread.v2"), File("https://contoso.sharepoint.com/sites/x/a.docx"))
+            };
+            Assert.AreEqual(0, ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts).Count);
+        }
+
+        [TestMethod]
+        public void ChatBeforeFileStillResolvesFile()
+        {
+            var acts = new List<AbstractAuditLogContent>
+            {
+                CopilotEvent("a@contoso.com", Chat("19:chat@thread.v2"), File("https://contoso.sharepoint.com/sites/x/a.docx"))
+            };
+            var result = ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts);
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result.ContainsKey("https://contoso.sharepoint.com/sites/x/a.docx"));
+        }
+
+        [TestMethod]
+        public void DuplicateContextIdsAreDeduped()
+        {
+            var url = "https://contoso.sharepoint.com/sites/x/a.docx";
+            var acts = new List<AbstractAuditLogContent>
+            {
+                CopilotEvent("a@contoso.com", File(url)),
+                CopilotEvent("b@contoso.com", File(url))
+            };
+            var result = ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts);
+            Assert.AreEqual(1, result.Count, "Same context id across events resolves once");
+        }
+
+        [TestMethod]
+        public void NonCopilotActivitiesIgnored()
+        {
+            var acts = new List<AbstractAuditLogContent> { new SharePointAuditLogContent() };
+            Assert.AreEqual(0, ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts).Count);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeSpoGraphClient.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeSpoGraphClient.cs
@@ -16,11 +16,11 @@ namespace Tests.UnitTests.FakeLoaderClasses
         public int GetSiteDriveCalls { get; private set; }
         public int GetSiteCalls { get; private set; }
         public int GetListItemByIdCalls { get; private set; }
-        public int FindListItemByWebUrlCalls { get; private set; }
+        public int GetDriveItemByUrlCalls { get; private set; }
         public int GetUserCalls { get; private set; }
 
         public int TotalCalls => GetOnlineMeetingCalls + GetUserDriveCalls + GetSiteDriveCalls + GetSiteCalls
-            + GetListItemByIdCalls + FindListItemByWebUrlCalls + GetUserCalls;
+            + GetListItemByIdCalls + GetDriveItemByUrlCalls + GetUserCalls;
 
         private static Drive DriveWithIds => new Drive { SharePointIds = new SharepointIds { SiteId = "site-guid", ListId = "list-guid" } };
 
@@ -31,7 +31,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
         public Func<string, Site> OnGetSite = siteIdentifier => new Site { Id = siteIdentifier, WebUrl = "https://contoso.sharepoint.com/sites/x" };
         public Func<string, string, string, ListItem> OnGetListItemById = (siteId, listId, itemId) =>
             new ListItem { WebUrl = "https://contoso.sharepoint.com/sites/x/Shared Documents/file.docx" };
-        public Func<string, string, string, ListItem> OnFindListItemByWebUrl = (siteId, listId, webUrl) => new ListItem { WebUrl = webUrl };
+        public Func<string, DriveItem> OnGetDriveItemByUrl = url => new DriveItem { WebUrl = url };
         public Func<string, User> OnGetUser = userId => new User { Id = "user-guid" };
 
         public Task<OnlineMeeting> GetOnlineMeetingAsync(string userId, string meetingId)
@@ -64,10 +64,10 @@ namespace Tests.UnitTests.FakeLoaderClasses
             return Task.FromResult(OnGetListItemById(siteId, listId, itemId));
         }
 
-        public Task<ListItem> FindListItemByWebUrlAsync(string siteId, string listId, string webUrl)
+        public Task<DriveItem> GetDriveItemByUrlAsync(string url)
         {
-            FindListItemByWebUrlCalls++;
-            return Task.FromResult(OnFindListItemByWebUrl(siteId, listId, webUrl));
+            GetDriveItemByUrlCalls++;
+            return Task.FromResult(OnGetDriveItemByUrl(url));
         }
 
         public Task<User> GetUserAsync(string userId)

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphFileMetadataLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphFileMetadataLoaderTests.cs
@@ -58,16 +58,16 @@ namespace Tests.UnitTests
             Assert.AreEqual("Report.docx", result.Filename);
             Assert.AreEqual("docx", result.Extension);
             Assert.AreEqual(1, fake.GetListItemByIdCalls);
-            Assert.AreEqual(0, fake.FindListItemByWebUrlCalls, "With a driveItemId we must NOT enumerate the whole list");
+            Assert.AreEqual(0, fake.GetDriveItemByUrlCalls, "With a driveItemId we resolve by id, not via the /shares URL path");
         }
 
         [TestMethod]
-        public async Task GetSpoFileInfo_WithoutDriveItemId_ResolvesViaWebUrlSearch()
+        public async Task GetSpoFileInfo_WithoutDriveItemId_ResolvesViaSharesApiNotEnumeration()
         {
             var ctx = "https://contoso.sharepoint.com/sites/x/Shared Documents/General/Notes.xlsx";
             var fake = new FakeSpoGraphClient
             {
-                OnFindListItemByWebUrl = (s, l, url) => new ListItem { WebUrl = url }
+                OnGetDriveItemByUrl = url => new DriveItem { WebUrl = url }
             };
             var loader = NewLoader(fake);
 
@@ -75,7 +75,7 @@ namespace Tests.UnitTests
 
             Assert.IsNotNull(result);
             Assert.AreEqual("xlsx", result.Extension);
-            Assert.AreEqual(1, fake.FindListItemByWebUrlCalls);
+            Assert.AreEqual(1, fake.GetDriveItemByUrlCalls, "A direct-URL context resolves in one /shares call");
             Assert.AreEqual(0, fake.GetListItemByIdCalls);
         }
 
@@ -85,7 +85,7 @@ namespace Tests.UnitTests
             var ctx = "https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/Plan.docx";
             var fake = new FakeSpoGraphClient
             {
-                OnFindListItemByWebUrl = (s, l, url) => new ListItem { WebUrl = url }
+                OnGetDriveItemByUrl = url => new DriveItem { WebUrl = url }
             };
             var loader = NewLoader(fake);
 
@@ -102,7 +102,7 @@ namespace Tests.UnitTests
             var ctx = "https://contoso.sharepoint.com/sites/x/Shared Documents/Missing.docx";
             var fake = new FakeSpoGraphClient
             {
-                OnFindListItemByWebUrl = (s, l, url) => null   // never matches
+                OnGetDriveItemByUrl = url => null   // never resolves
             };
             var loader = NewLoader(fake);
 
@@ -111,7 +111,48 @@ namespace Tests.UnitTests
 
             Assert.IsNull(first);
             Assert.IsNull(second);
-            Assert.AreEqual(1, fake.FindListItemByWebUrlCalls, "A context that failed to resolve must not be re-resolved within the session");
+            Assert.AreEqual(1, fake.GetDriveItemByUrlCalls, "A context that failed to resolve must not be re-resolved within the run");
+        }
+
+        [TestMethod]
+        public async Task GetSpoFileInfo_ResolvedContext_IsPositivelyCachedAcrossCalls()
+        {
+            var ctx = "https://contoso.sharepoint.com/sites/x/Shared Documents/General/Report.docx";
+            var fake = new FakeSpoGraphClient
+            {
+                OnGetDriveItemByUrl = url => new DriveItem { WebUrl = url }
+            };
+            var loader = NewLoader(fake);
+
+            var first = await loader.GetSpoFileInfo(ctx, "user@contoso.com");
+            var second = await loader.GetSpoFileInfo(ctx, "user@contoso.com");
+
+            Assert.IsNotNull(first);
+            Assert.IsNotNull(second);
+            Assert.AreEqual("Report.docx", second.Filename);
+            // Same run-scoped loader: the second call is a pure cache hit (no repeat Graph resolution).
+            Assert.AreEqual(1, fake.GetDriveItemByUrlCalls, "A resolved context must be cached and not re-resolved");
+            Assert.AreEqual(1, fake.GetSiteDriveCalls, "Site drive resolution should also happen only once");
+        }
+
+        [TestMethod]
+        public async Task GetSpoFileInfo_MySiteContext_CachedPerUserNotAliasedAcrossUsers()
+        {
+            // A personal OneDrive ("-my") file is resolved through the event user's own drive, so two different
+            // users referencing the same URL must resolve independently (not share a cached result), while the
+            // same user twice must be a cache hit.
+            var ctx = "https://contoso-my.sharepoint.com/personal/alice_contoso_com/Documents/Shared.docx";
+            var fake = new FakeSpoGraphClient
+            {
+                OnGetDriveItemByUrl = url => new DriveItem { WebUrl = url }
+            };
+            var loader = NewLoader(fake);
+
+            await loader.GetSpoFileInfo(ctx, "alice@contoso.com");
+            await loader.GetSpoFileInfo(ctx, "alice@contoso.com");   // same user -> cache hit
+            await loader.GetSpoFileInfo(ctx, "bob@contoso.com");     // different user -> resolves again
+
+            Assert.AreEqual(2, fake.GetUserDriveCalls, "My-site contexts must cache per user: 1 for alice (cached on repeat) + 1 for bob");
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -35,6 +35,7 @@
     <Compile Include="CopilotAuditLogContentSchemaTests.cs" />
     <Compile Include="CopilotEventManagerAccessedResourcesTests.cs" />
     <Compile Include="CopilotEventManagerEdgeCaseTests.cs" />
+    <Compile Include="CopilotPrewarmExtractionTests.cs" />
     <Compile Include="CopilotEventManagerSaveTests.cs" />
     <Compile Include="CopilotTestBase.cs" />
     <Compile Include="PageUpdateManagerPerfTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -1,8 +1,10 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
 using Common.Entities;
 using Common.Entities.Config;
 using DataUtils;
 using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -40,6 +42,16 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// Single-permit; held only for the duration of <c>CommitAll</c>'s SQL phase.
         /// </summary>
         private static SemaphoreSlim _sqlSaveSemaphore = new SemaphoreSlim(1);      // Make sure we're only saving one thread at a time
+
+        // Run-scoped Copilot Graph metadata loader, shared across every batch so its Graph caches (resolved
+        // files, users, sites, and unresolvable contexts) persist for the whole import instead of being rebuilt
+        // per batch. Lazily built once; best-effort (null on failure -> each SaveSession falls back to its own).
+        private ICopilotMetadataLoader _sharedCopilotLoader;
+        private bool _sharedCopilotLoaderTried;
+        private readonly SemaphoreSlim _sharedLoaderInitLock = new SemaphoreSlim(1, 1);
+
+        // How many Copilot file contexts to resolve concurrently while pre-warming the cache (outside the SQL lock).
+        private const int PrewarmConcurrency = 8;
 
         public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig)
         {
@@ -83,6 +95,17 @@ namespace WebJob.Office365ActivityImporter.Engine
 #endif
             var allStats = new ImportStat();
 
+            // Warm the run-scoped Copilot Graph metadata cache in PARALLEL, before taking the single-permit SQL
+            // lock. The per-event ProcessExtendedProperties pass below runs serially inside that lock, and for
+            // Copilot file events it calls Graph (network). Resolving those ahead of time - overlapping across
+            // batches and within a batch - turns the in-lock calls into cache hits, so the lock is held only for
+            // SQL work, not network round-trips.
+            var sharedLoader = await GetSharedCopilotLoaderAsync();
+            if (sharedLoader != null)
+            {
+                await PrewarmCopilotFileMetadataAsync(activities, sharedLoader);
+            }
+
             // Allow only one save at a time otherwise we'll get errors when we try and create the temp table without clearing it down 1st
             await _sqlSaveSemaphore.WaitAsync();
 
@@ -95,7 +118,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                     using (var db = new AnalyticsEntitiesContext(con))
                     {
                         // Add all activity data to staging table
-                        var stats = await SaveToSqlAllTheThings(activities, db, con, cache);
+                        var stats = await SaveToSqlAllTheThings(activities, db, con, cache, sharedLoader);
                         allStats.AddStats(stats);
                     }
                 }
@@ -109,9 +132,107 @@ namespace WebJob.Office365ActivityImporter.Engine
         }
 
         /// <summary>
+        /// Lazily build the run-scoped Copilot metadata loader (once). Best-effort: on any failure (e.g. no Graph
+        /// creds in a test) returns null and callers fall back to the per-session loader. Thread-safe.
+        /// </summary>
+        private async Task<ICopilotMetadataLoader> GetSharedCopilotLoaderAsync()
+        {
+            if (_sharedCopilotLoaderTried)
+            {
+                return _sharedCopilotLoader;
+            }
+            await _sharedLoaderInitLock.WaitAsync();
+            try
+            {
+                if (!_sharedCopilotLoaderTried)
+                {
+                    try
+                    {
+                        var auth = new GraphAppIndentityOAuthContext(_logger, _appConfig.ClientID, _appConfig.TenantGUID.ToString(), _appConfig.ClientSecret, _appConfig.KeyVaultUrl, _appConfig.UseClientCertificate);
+                        await auth.InitClientCredential();
+                        _sharedCopilotLoader = new GraphFileMetadataLoader(new GraphServiceClient(auth.Creds), _logger);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Could not build a run-scoped Copilot metadata loader; falling back to per-batch loaders.");
+                        _sharedCopilotLoader = null;
+                    }
+                    _sharedCopilotLoaderTried = true;
+                }
+            }
+            finally
+            {
+                _sharedLoaderInitLock.Release();
+            }
+            return _sharedCopilotLoader;
+        }
+
+        /// <summary>
+        /// Resolve the file metadata for this batch's Copilot file contexts concurrently, warming the shared
+        /// loader's cache. Errors are swallowed - the authoritative resolution + logging happens in the serial
+        /// ProcessExtendedProperties pass (this only pre-populates the cache).
+        /// </summary>
+        private async Task PrewarmCopilotFileMetadataAsync(ActivityReportSet activities, ICopilotMetadataLoader loader)
+        {
+            var fileContexts = ExtractCopilotFileContexts(activities);
+            if (fileContexts.Count == 0) return;
+
+            using (var throttle = new SemaphoreSlim(PrewarmConcurrency))
+            {
+                var tasks = fileContexts.Select(async kvp =>
+                {
+                    await throttle.WaitAsync();
+                    try
+                    {
+                        await loader.GetSpoFileInfo(kvp.Key, kvp.Value);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Copilot metadata prewarm failed for context {ctx} (will retry in the serial pass)", kvp.Key);
+                    }
+                    finally
+                    {
+                        throttle.Release();
+                    }
+                });
+                await Task.WhenAll(tasks);
+            }
+        }
+
+        /// <summary>
+        /// The distinct (fileContextId -> eventUpn) map to pre-resolve for a batch. Mirrors
+        /// <c>CopilotAuditEventManager</c>: only the first file-type context per event is used; a Teams meeting
+        /// context ends file processing for that event; Teams chat contexts are additive (not files).
+        /// </summary>
+        internal static Dictionary<string, string> ExtractCopilotFileContexts(IEnumerable<AbstractAuditLogContent> activities)
+        {
+            var fileContexts = new Dictionary<string, string>();
+            foreach (var copilot in activities.OfType<CopilotAuditLogContent>())
+            {
+                var contexts = copilot.CopilotEventData?.Contexts;
+                if (contexts == null) continue;
+                foreach (var context in contexts)
+                {
+                    if (context == null) continue;
+                    // Type is checked before the id guard so a (typically non-null) meeting/chat context
+                    // controls flow exactly as CopilotAuditEventManager does, even if its id were null.
+                    if (context.Type == ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING) break;   // meeting ends file/meeting processing
+                    if (context.Type == ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_CHAT) continue;   // chat is additive, not a file
+                    // First file-type context for this event (a null-id file resolves to nothing, so skip it but still stop).
+                    if (context.Id != null && !fileContexts.ContainsKey(context.Id))
+                    {
+                        fileContexts[context.Id] = copilot.UserId;
+                    }
+                    break;
+                }
+            }
+            return fileContexts;
+        }
+
+        /// <summary>
         /// Fill up staging table & return import result
         /// </summary>
-        private async Task<ImportStat> SaveToSqlAllTheThings(ActivityReportSet activities, AnalyticsEntitiesContext db, SqlConnection con, ActivityImportCache cache)
+        private async Task<ImportStat> SaveToSqlAllTheThings(ActivityReportSet activities, AnalyticsEntitiesContext db, SqlConnection con, ActivityImportCache cache, ICopilotMetadataLoader sharedCopilotLoader)
         {
             var listOfActivitiesSavedToSQL = new ConcurrentBag<AbstractAuditLogContent>();
             var logsToInsert = new EFInsertBatch<AuditLogTempEntity>(db, _logger);
@@ -174,8 +295,9 @@ namespace WebJob.Office365ActivityImporter.Engine
 
             #region Add Extra Metadata
 
-            // Add metadata the traditional way with EF. By now should have all the sites saved. 
-            var saveSession = new SaveSession(_logger, db, _appConfig);
+            // Add metadata the traditional way with EF. By now should have all the sites saved.
+            // Pass the run-scoped Copilot loader so per-event Graph resolution hits the cache warmed above.
+            var saveSession = new SaveSession(_logger, db, _appConfig, sharedCopilotLoader);
             await saveSession.Init();
 
             int metaSaveIdx = 0, changesMadeCount = 0;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
@@ -21,7 +21,15 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         private readonly ILogger _logger;
 
         // Copilot context ids that resolved to nothing this session - don't waste Graph calls re-resolving them.
-        private readonly ConcurrentDictionary<string, byte> _unresolvableContextIds = new ConcurrentDictionary<string, byte>();
+        // Case-insensitive so a failed prewarm (keyed off the raw event UserId) isn't re-attempted in the serial
+        // pass under a differently-cased UPN (UPNs are case-insensitive).
+        private readonly ConcurrentDictionary<string, byte> _unresolvableContextIds =
+            new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+
+        // Positive cache of resolved file info, keyed by copilot doc context id. Run-scoped: the same file
+        // context recurs across many audit batches, so caching avoids repeat Graph resolution every batch.
+        private readonly ConcurrentDictionary<string, SpoDocumentFileInfo> _fileInfoByContext =
+            new ConcurrentDictionary<string, SpoDocumentFileInfo>(StringComparer.OrdinalIgnoreCase);
 
         public GraphFileMetadataLoader(GraphServiceClient graphServiceClient, ILogger logger)
             : this(new GraphSpoClient(graphServiceClient), logger)
@@ -62,20 +70,40 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                 return null;
             }
 
-            // Don't re-resolve a context we've already failed to resolve this session.
-            if (_unresolvableContextIds.ContainsKey(copilotDocContextId))
+            // Cache key: a personal OneDrive ("-my") file is resolved through the *event user's* own drive, so
+            // the result is user-specific - key those per (context, upn). A shared-site file is resolved
+            // independently of the user, so key those by context alone (dedupes across all users who touched it).
+            var cacheKey = FileCacheKey(copilotDocContextId, eventUpn);
+
+            // Already resolved this context earlier in the run? Return the cached result (no Graph call).
+            if (_fileInfoByContext.TryGetValue(cacheKey, out var cached))
             {
-                _logger.LogDebug("Copilot context '{ctx}' was already unresolvable this session; skipping Graph lookup", copilotDocContextId);
+                return cached;
+            }
+
+            // Don't re-resolve a context we've already failed to resolve this run.
+            if (_unresolvableContextIds.ContainsKey(cacheKey))
+            {
+                _logger.LogDebug("Copilot context '{ctx}' was already unresolvable this run; skipping Graph lookup", copilotDocContextId);
                 return null;
             }
 
             var result = await ResolveSpoFileInfoAsync(copilotDocContextId, eventUpn);
             if (result == null)
             {
-                _unresolvableContextIds.TryAdd(copilotDocContextId, 0);
+                _unresolvableContextIds.TryAdd(cacheKey, 0);
+            }
+            else
+            {
+                _fileInfoByContext.TryAdd(cacheKey, result);
             }
             return result;
         }
+
+        // Personal OneDrive ("-my") files depend on the event user's drive, so include the upn in the key;
+        // shared-site files don't, so key by context alone.
+        private static string FileCacheKey(string copilotDocContextId, string eventUpn)
+            => StringUtils.IsMySiteUrl(copilotDocContextId) ? copilotDocContextId + "\n" + (eventUpn ?? string.Empty) : copilotDocContextId;
 
         // Example: https://m365cp123890-my.sharepoint.com/personal/sambetts_m365cp123890_onmicrosoft_com/_layouts/15/Doc.aspx?sourcedoc=%7B0D86F64F-8435-430C-8979-FF46C00F7ACB%7D&file=Presentation.pptx&action=edit&mobileredirect=true
         private async Task<SpoDocumentFileInfo> ResolveSpoFileInfoAsync(string copilotDocContextId, string eventUpn)
@@ -127,19 +155,20 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             }
             else
             {
-                // We might have a direct URL as the copilot context ID, so search the list for a matching item.
+                // We might have a direct URL as the copilot context ID. Resolve it straight to a driveItem via
+                // the Graph /shares endpoint (one call) instead of paging the whole document library to URL-match.
                 // Example: https://contoso-my.sharepoint.com/personal/alex_contoso_onmicrosoft_com/Documents/MyDoc.docx
                 try
                 {
-                    var matchedItem = await _spoGraphClient.FindListItemByWebUrlAsync(spSiteId, spListId, copilotDocContextId);
-                    if (matchedItem != null)
+                    var driveItem = await _spoGraphClient.GetDriveItemByUrlAsync(copilotDocContextId);
+                    if (driveItem != null)
                     {
-                        return new SpoDocumentFileInfo(matchedItem, site);
+                        return new SpoDocumentFileInfo(driveItem, site);
                     }
                 }
                 catch (ODataError ex)
                 {
-                    _logger.LogWarning(ex, "Error getting items info for list {spListId} on site {siteUrl}", spListId, siteUrl);
+                    _logger.LogWarning(ex, "Error resolving driveItem for copilotDocContextId {copilotDocContextId}", copilotDocContextId);
                     return null;
                 }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SpoGraphClient.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SpoGraphClient.cs
@@ -1,5 +1,6 @@
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
+using System;
 using System.Threading.Tasks;
 
 namespace ActivityImporter.Engine.ActivityAPI.Copilot
@@ -27,8 +28,11 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         /// <summary>A single list item by its id (fields expanded).</summary>
         Task<ListItem> GetListItemByIdAsync(string siteId, string listId, string itemId);
 
-        /// <summary>Find a list item whose WebUrl matches, or null if none. Encapsulates paging so it can be optimised later.</summary>
-        Task<ListItem> FindListItemByWebUrlAsync(string siteId, string listId, string webUrl);
+        /// <summary>
+        /// Resolve a full SharePoint/OneDrive URL directly to its driveItem via the Graph /shares endpoint,
+        /// or null if it can't be resolved. One call - avoids paging an entire document library to URL-match.
+        /// </summary>
+        Task<DriveItem> GetDriveItemByUrlAsync(string url);
 
         Task<User> GetUserAsync(string userId);
     }
@@ -61,33 +65,13 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         public Task<ListItem> GetListItemByIdAsync(string siteId, string listId, string itemId)
             => _graphServiceClient.Sites[siteId].Lists[listId].Items[itemId].GetAsync(rc => { rc.QueryParameters.Expand = new[] { "fields" }; });
 
-        public async Task<ListItem> FindListItemByWebUrlAsync(string siteId, string listId, string webUrl)
+        public Task<DriveItem> GetDriveItemByUrlAsync(string url)
         {
-            // Currently we can't server-side filter list items by webUrl, so we page and match client side.
-            // Walk all pages so we can still resolve file context in large lists.
-            var firstPage = await _graphServiceClient.Sites[siteId].Lists[listId].Items
-                .GetAsync(rc => { rc.QueryParameters.Select = new[] { "id", "webUrl" }; });
-            if (firstPage?.Value == null)
-            {
-                return null;
-            }
-
-            ListItem matchedItem = null;
-            var iterator = PageIterator<ListItem, ListItemCollectionResponse>.CreatePageIterator(
-                _graphServiceClient,
-                firstPage,
-                i =>
-                {
-                    if (i.WebUrl == webUrl)
-                    {
-                        matchedItem = i;
-                        return false;
-                    }
-                    return true;
-                });
-
-            await iterator.IterateAsync();
-            return matchedItem;
+            // https://learn.microsoft.com/en-us/graph/api/shares-get - encode the URL as an unpadded base64url
+            // "u!" share id, then read its driveItem. Resolves any SPO/OneDrive URL in one call.
+            var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(url));
+            var shareId = "u!" + base64.TrimEnd('=').Replace('/', '_').Replace('+', '-');
+            return _graphServiceClient.Shares[shareId].DriveItem.GetAsync();
         }
 
         public Task<User> GetUserAsync(string userId)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/SaveSession.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/SaveSession.cs
@@ -18,11 +18,22 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
     {
         private CopilotAuditEventManager _copilotEventResolver = null;
         private PowerPlatformAuditEventManager _powerPlatformEventResolver = null;
-        private readonly GraphAppIndentityOAuthContext _authContext;
+        private GraphAppIndentityOAuthContext _authContext;
+        private readonly ICopilotMetadataLoader _injectedCopilotLoader;
         private readonly ILogger _logger;
         private readonly AppConfig _appConfig;
 
         public SaveSession(ILogger logger, AnalyticsEntitiesContext db, AppConfig appConfig)
+            : this(logger, db, appConfig, null)
+        {
+        }
+
+        /// <summary>
+        /// <paramref name="copilotLoader"/> (optional) lets the caller inject a run-scoped Copilot metadata
+        /// loader so its Graph caches persist across every batch. When null, a per-session loader is created
+        /// (original behaviour).
+        /// </summary>
+        public SaveSession(ILogger logger, AnalyticsEntitiesContext db, AppConfig appConfig, ICopilotMetadataLoader copilotLoader)
         {
             _logger = logger;
             this.Database = db;
@@ -31,13 +42,21 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
 
             this.SharePointLookupManager = new SharePointLookupManager(Database);
             this.StreamLookupManager = new StreamLookupManager(Database);
-            _authContext = new GraphAppIndentityOAuthContext(logger, appConfig.ClientID, appConfig.TenantGUID.ToString(), appConfig.ClientSecret, appConfig.KeyVaultUrl, appConfig.UseClientCertificate);
+            _injectedCopilotLoader = copilotLoader;
+            if (copilotLoader == null)
+            {
+                _authContext = new GraphAppIndentityOAuthContext(logger, appConfig.ClientID, appConfig.TenantGUID.ToString(), appConfig.ClientSecret, appConfig.KeyVaultUrl, appConfig.UseClientCertificate);
+            }
         }
 
         internal async Task Init()
         {
-            await _authContext.InitClientCredential();
-            var loader = new GraphFileMetadataLoader(new GraphServiceClient(_authContext.Creds), _logger);
+            ICopilotMetadataLoader loader = _injectedCopilotLoader;
+            if (loader == null)
+            {
+                await _authContext.InitClientCredential();
+                loader = new GraphFileMetadataLoader(new GraphServiceClient(_authContext.Creds), _logger);
+            }
             _copilotEventResolver = new CopilotAuditEventManager(_appConfig.ConnectionStrings.DatabaseConnectionString, loader, _logger);
             _powerPlatformEventResolver = new PowerPlatformAuditEventManager(_appConfig.ConnectionStrings.DatabaseConnectionString, _logger);
         }


### PR DESCRIPTION
## What

Parallelizes the **audit + Copilot metadata** import phase, which became the dominant bottleneck on large tenants after the earlier SharePoint Site Usage / daily-usage / throttle fixes landed in the last testing build.

### The problem

`ActivityReportSqlPersistenceManager.CommitAllToSQL` takes a single-permit SQL save lock (`_sqlSaveSemaphore`) and then, inside that lock, runs the per-event `ProcessExtendedProperties` pass **serially**. For Copilot file events that pass resolves file metadata via **synchronous Graph calls** — so every network round-trip was serialized behind the SQL lock. On top of that, each batch built a brand-new `GraphFileMetadataLoader` + `GraphServiceClient`, so the Graph caches (files, users, sites) were **thrown away and rebuilt per batch**. Downloads were already parallel; the *save* side was not.

### The fix (A + B + C)

- **A — Run-scoped caching + threading.** A single Copilot metadata loader is now shared across every batch for the whole import, so its Graph caches (resolved files, users, sites, and unresolvable contexts) persist instead of being rebuilt per batch. Adds a positive file-info cache keyed per context (per-user for personal OneDrive `-my` files so results are never aliased across users). `SaveSession` gained an optional injected-loader constructor and falls back to the original per-session loader when none is supplied (e.g. in tests without Graph creds).
- **B — One-call URL resolution.** A full SharePoint/OneDrive URL is now resolved straight to its `driveItem` via the Graph `/shares` endpoint (a single `u!`-base64url call) instead of paging an **entire document library** and matching `WebUrl` client-side. Removes the old `FindListItemByWebUrlAsync` enumeration.
- **C — Parallel pre-warm.** Before taking the SQL lock, a batch's Copilot file contexts are resolved **concurrently** (`SemaphoreSlim(8)`), warming the shared cache. The subsequent in-lock pass then hits the cache, so the lock is held only for SQL work, not network round-trips. Pre-warm is best-effort (errors swallowed and logged at Debug); the serial pass remains the authoritative resolver.

The context-selection logic is extracted into a testable static `ExtractCopilotFileContexts` that faithfully mirrors `CopilotAuditEventManager` (a Teams *meeting* context ends file processing, a Teams *chat* context is additive/not a file, and only the first file context per event is used). The negative cache is made case-insensitive so a failed pre-warm isn't re-attempted under a differently-cased UPN.

## Why it matters

An operator running the importer on a large tenant should see the audit + Copilot phase spend its time on SQL rather than waiting on serialized Graph calls, and stop re-resolving the same files every batch. Combined with the earlier fixes this continues to pull total run time down and reduces Graph load.

## Tests

- New `CopilotPrewarmExtractionTests` (6) cover the extraction rules: first file context captured with the event UPN, chat-only ⇒ no file, meeting ends processing, chat-before-file still resolves, duplicate context ids deduped, non-Copilot activities ignored.
- New `GraphFileMetadataLoaderTests` (2) cover the positive cache (a resolved context is a pure cache hit on repeat; site-drive resolved once) and per-user `-my` caching (same user ⇒ hit, different user ⇒ resolves again — never aliased).
- Existing loader tests updated for the `/shares` path (no library enumeration).
- Local: test project + importer exe compile clean; **118** Copilot + StringUtils tests pass (incl. the DB-backed `CopilotAuditEventManager` suites) plus 15 loader/extraction tests. No customer data in the diff (synthetic `contoso` only).

## Scope / safety

- No schema or migration changes.
- Backward compatible: `SaveSession`'s original 3-arg constructor is preserved; a null shared loader ⇒ per-session behaviour (unchanged).
- Pre-warm failures never fail the import — authoritative resolution + warnings still happen in the serial pass.
