### PR TITLE
Fix System.Text.Json binding redirect (6.0.0.11 -> 10.0.0.8) in library app.configs

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/app.config
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/app.config
@@ -7,7 +7,7 @@
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>
 					<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-					<bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11"/>
+					<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
 				</dependentAssembly>
 			</assemblyBinding>
 		</assemblyBinding>

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/app.config
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.ResourceManager" publicKeyToken="92742159e12e44c8" culture="neutral" />

--- a/src/AnalyticsEngine/Common/DataUtils/app.config
+++ b/src/AnalyticsEngine/Common/DataUtils/app.config
@@ -26,7 +26,7 @@
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>
 					<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-					<bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11"/>
+					<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
 				</dependentAssembly>
 			</assemblyBinding>
 		</assemblyBinding>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/app.config
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/app.config
@@ -21,7 +21,7 @@
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>
 					<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-					<bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11"/>
+					<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
 				</dependentAssembly>
 			</assemblyBinding>
 		</assemblyBinding>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/App.config
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/App.config
@@ -21,7 +21,7 @@
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>
 					<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-					<bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11"/>
+					<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
 				</dependentAssembly>
 			</assemblyBinding>
 		</assemblyBinding>


### PR DESCRIPTION
## What
Updates the `System.Text.Json` assembly binding redirect from `6.0.0.11` to `10.0.0.8` in the five class-library `app.config` files:

- `App.ControlPanel.Engine`
- `WebJob.Office365ActivityImporter.Engine`
- `Common/DataUtils`
- `Common/CloudInstallEngine`
- `WebJob.AppInsightsImporter.Engine`

## Why
These projects reference `System.Text.Json` 10.0.8 (assembly version `10.0.0.8`) but their `app.config` still redirected to `6.0.0.11`, producing the MSB3277 assembly-version-conflict build warning (*"Consider app.config remapping of assembly System.Text.Json ... from Version 6.0.0.11 to Version 10.0.0.8"*).

## Notes
These five libraries have **no** `App.Template.config` / `TransformXml` step, so their `app.config` is the source of truth and is edited directly. The template-driven projects (App.ControlPanel, Tests.UnitTests, Web, WebJob.AppInsightsImporter, WebJob.Office365ActivityImporter) were already at `10.0.0.8` in both template and generated config.

Verified with a targeted build of `Common/DataUtils` — no System.Text.Json / MSB3277 warning.
