### PR TITLE
Fix audit-log import crash on transient HTTP timeout

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/Http/AutoThrottleHttpClient.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/AutoThrottleHttpClient.cs
@@ -79,8 +79,36 @@ namespace DataUtils.Http
                     }
                 }
 
-                // Get response but don't buffer full content (which will buffer overlflow for large files)
-                response = await httpAction();
+                // Get response but don't buffer full content (which will buffer overlflow for large files).
+                // A client-side timeout (HttpClient.Timeout elapsed) surfaces as a TaskCanceledException, and a
+                // transient socket/DNS blip as an HttpRequestException thrown from the call itself (before any
+                // response is received). Neither is an HTTP 429, so the status-code retry logic below would
+                // never see them - they'd propagate and, in the importers, abort a whole import section (or in
+                // DEBUG crash the process). Retry them here with a linear back-off, sharing the MaxRetries
+                // budget, then rethrow so a genuinely dead endpoint still surfaces to the caller's own handling.
+                try
+                {
+                    response = await httpAction();
+                }
+                catch (Exception ex) when (IsTransientException(ex))
+                {
+                    lock (_concurrentCallsObj)
+                    {
+                        _concurrentCalls--;
+                    }
+
+                    retries++;
+                    if (retries >= MaxRetries)
+                    {
+                        _logger.LogError(ex, $"Transient error calling {url}: '{ex.Message}'. Giving up after {MaxRetries} attempts.");
+                        throw;
+                    }
+
+                    secondsToWait = retries * 2;
+                    _logger.LogWarning($"Transient error calling {url}: '{ex.Message}'. Waiting {secondsToWait}s before retry (attempt #{retries} of {MaxRetries})...");
+                    Thread.Sleep(TimeSpan.FromSeconds(secondsToWait));
+                    continue;
+                }
 
                 lock (_concurrentCallsObj)
                 {
@@ -151,6 +179,17 @@ namespace DataUtils.Http
             }
 
             return response;
+        }
+
+        /// <summary>
+        /// Transient failures worth retrying at the HTTP layer: a client-side timeout (HttpClient.Timeout
+        /// elapsed) surfaces as a <see cref="TaskCanceledException"/>, and a transient socket/DNS failure as an
+        /// <see cref="HttpRequestException"/> thrown from the send itself. HTTP 429 is handled separately via the
+        /// response status code, so it is deliberately not included here.
+        /// </summary>
+        private static bool IsTransientException(Exception ex)
+        {
+            return ex is TaskCanceledException || ex is HttpRequestException;
         }
 
         #region Props

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityReportLoaderTimeoutTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityReportLoaderTimeoutTests.cs
@@ -41,6 +41,11 @@ namespace Tests.UnitTests
 
             using (var httpClient = new AutoThrottleHttpClient(new TimeoutHttpMessageHandler(), logger))
             {
+                // Don't retry - we're testing the loader's handling of a download that ultimately times out,
+                // not the AutoThrottleHttpClient retry loop (covered by AutoThrottleHttpClientTests). Retrying
+                // 10x with back-off would make this test take ~90s.
+                httpClient.MaxRetries = 1;
+
                 var loader = new ActivityReportWebLoader(httpClient, logger, Guid.Empty.ToString());
                 var metadata = new ActivityReportInfo { ContentUri = new Uri("https://contoso.example/audit/content") };
 

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityReportLoaderTimeoutTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityReportLoaderTimeoutTests.cs
@@ -1,0 +1,56 @@
+using DataUtils;
+using DataUtils.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Regression tests for the audit-log download loaders and HTTP timeouts.
+    ///
+    /// A single report/metadata download that timed out threw a <see cref="TaskCanceledException"/> that was
+    /// not caught by the loaders (they only handled <see cref="HttpRequestException"/>), so it propagated all
+    /// the way up through the parallel processor and crashed the whole Office 365 Activity import WebJob.
+    /// These tests assert that a timeout is now handled gracefully - logged, counted, and skipped - so the
+    /// import keeps going and the item is retried on the next cycle.
+    /// </summary>
+    [TestClass]
+    public class ActivityReportLoaderTimeoutTests
+    {
+        /// <summary>
+        /// Handler that mimics how <see cref="HttpClient"/> surfaces a timeout on .NET Framework: the request
+        /// completes as a cancelled task (<see cref="TaskCanceledException"/>).
+        /// </summary>
+        private sealed class TimeoutHttpMessageHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromException<HttpResponseMessage>(new TaskCanceledException("Simulated HTTP timeout."));
+            }
+        }
+
+        [TestMethod]
+        public async Task ActivityReportWebLoader_HttpTimeout_DoesNotCrash_AndCountsError()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+
+            using (var httpClient = new AutoThrottleHttpClient(new TimeoutHttpMessageHandler(), logger))
+            {
+                var loader = new ActivityReportWebLoader(httpClient, logger, Guid.Empty.ToString());
+                var metadata = new ActivityReportInfo { ContentUri = new Uri("https://contoso.example/audit/content") };
+
+                // Before the fix this threw TaskCanceledException and crashed the import.
+                var result = await loader.Load(metadata);
+
+                Assert.IsNotNull(result, "A timed-out download should return an (empty) report set, not throw.");
+                Assert.AreEqual(0, result.Count, "A timed-out download should yield no reports.");
+                Assert.AreEqual(1, loader.ReportDownloadErrorCount, "A timed-out download should be counted as a report download error so it is visible and retried next cycle.");
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/AutoThrottleHttpClientTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AutoThrottleHttpClientTests.cs
@@ -41,6 +41,58 @@ namespace Tests.UnitTests
             }
         }
 
+        /// <summary>
+        /// A client-side HTTP timeout surfaces as a TaskCanceledException. It is not an HTTP 429, so it must be
+        /// retried by the transient-error path (previously it propagated and aborted the whole import).
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_RetriesTransientTimeout_ThenSucceeds()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var handler = new TimeoutThenOkHandler(timeoutsBeforeSuccess: 1); // one timeout, then 200 OK
+
+            using (var client = new AutoThrottleHttpClient(handler, logger))
+            {
+                var response = await client.ExecuteHttpCallWithThrottleRetries(
+                    () => client.GetAsync("https://example.test/timeout"),
+                    "https://example.test/timeout");
+
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "A transient timeout should be retried and then succeed.");
+                Assert.AreEqual(2, handler.CallCount, "Should have retried exactly once after the timeout.");
+            }
+        }
+
+        /// <summary>
+        /// A genuinely dead endpoint (every call times out) must still surface to the caller after MaxRetries -
+        /// the retry loop must give up and rethrow rather than spin forever.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_GivesUpAndRethrows_OnPersistentTimeout()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var handler = new TimeoutThenOkHandler(timeoutsBeforeSuccess: int.MaxValue); // always times out
+
+            using (var client = new AutoThrottleHttpClient(handler, logger))
+            {
+                client.MaxRetries = 2; // keep the test fast
+
+                TaskCanceledException caught = null;
+                try
+                {
+                    await client.ExecuteHttpCallWithThrottleRetries(
+                        () => client.GetAsync("https://example.test/timeout"),
+                        "https://example.test/timeout");
+                }
+                catch (TaskCanceledException ex)
+                {
+                    caught = ex;
+                }
+
+                Assert.IsNotNull(caught, "A persistent timeout must be rethrown to the caller after MaxRetries.");
+                Assert.AreEqual(2, handler.CallCount, "Should have attempted exactly MaxRetries times before giving up.");
+            }
+        }
+
         /// <summary>Returns 429 with a Retry-After header on the first call, then 200 OK.</summary>
         private class SequencedThrottleHandler : HttpMessageHandler
         {
@@ -61,6 +113,32 @@ namespace Tests.UnitTests
                     var throttled = new HttpResponseMessage((HttpStatusCode)429);
                     throttled.Headers.TryAddWithoutValidation("Retry-After", _retryAfterSeconds.ToString());
                     return Task.FromResult(throttled);
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+
+        /// <summary>
+        /// Faults with a TaskCanceledException (how a client-side HTTP timeout surfaces) for the first N calls,
+        /// then returns 200 OK. Set <paramref name="timeoutsBeforeSuccess"/> to int.MaxValue to always time out.
+        /// </summary>
+        private class TimeoutThenOkHandler : HttpMessageHandler
+        {
+            private int _callCount;
+            private readonly int _timeoutsBeforeSuccess;
+            public int CallCount => _callCount;
+
+            public TimeoutThenOkHandler(int timeoutsBeforeSuccess)
+            {
+                _timeoutsBeforeSuccess = timeoutsBeforeSuccess;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var call = Interlocked.Increment(ref _callCount);
+                if (call <= _timeoutsBeforeSuccess)
+                {
+                    return Task.FromException<HttpResponseMessage>(new TaskCanceledException("Simulated HTTP timeout."));
                 }
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             }

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -110,6 +110,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActivityImporterTests.cs" />
+    <Compile Include="ActivityReportLoaderTimeoutTests.cs" />
     <Compile Include="ActivityReportSetMinMaxTests.cs" />
     <Compile Include="AppInsightsConnectionStringParserTests.cs" />
     <Compile Include="AppInsightsKqlGetWhereStringTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
@@ -55,6 +55,15 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                 _logger.LogError(ex, $"Got error '{ex.Message}' downloading {metadata.ContentUri}. Will try again on next cycle.");
                 return new WebActivityReportSet();
             }
+            catch (TaskCanceledException ex)
+            {
+                // An HTTP timeout (HttpClient.Timeout elapsed) surfaces as a cancelled task. Treat it like any
+                // other transient download failure - log it, count it, and skip this report so a single slow or
+                // hung request doesn't crash the whole audit-log import. The item is retried on the next cycle.
+                Interlocked.Increment(ref _reportDownloadErrors);
+                _logger.LogError(ex, $"Timed out downloading {metadata.ContentUri}: '{ex.Message}'. Will try again on next cycle.");
+                return new WebActivityReportSet();
+            }
 
             // Use 'using' to ensure response is disposed and memory is freed
             using (response)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/WebContentMetaDataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/WebContentMetaDataLoader.cs
@@ -67,55 +67,72 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
             {
                 string nextPageUri = null;
 
-                // Get this batch
-                using (var response = await _httpClient.GetAsyncWithThrottleRetries(currentUri, _logger))
+                // Get this batch. A timeout surfaces as a cancelled task (HttpClient.Timeout elapsed) and a
+                // persistent HTTP error surfaces as HttpRequestException once throttle-retries are exhausted;
+                // both are wrapped in the try so a single hung/failed page doesn't crash the whole import.
+                HttpResponseMessage response = null;
+                string responseFromServer = null;
+                try
                 {
-                    // Read the content.  
-                    var responseFromServer = await response.Content.ReadAsStringAsync();
+                    response = await _httpClient.GetAsyncWithThrottleRetries(currentUri, _logger);
+
+                    // Read the content.
+                    responseFromServer = await response.Content.ReadAsStringAsync();
+
+                    response.EnsureSuccessStatusCode();
+
+                    // More data to get for events?
+                    if (response.Headers.Contains(NEXT_PAGE_PARAM))
+                    {
+                        nextPageUri = response.Headers.GetValues(NEXT_PAGE_PARAM).First();
+                    }
+                }
+                catch (HttpRequestException ex)
+                {
+                    Interlocked.Increment(ref _metadataDownloadErrors);
+                    _logger.LogError(ex, $"Error downloading metadata {currentUri} with error '{ex.Message}'. " +
+                        $"If this happens every time, this may be an issue. Ignoring for now.");
+#if DEBUG
+                    _logger.LogInformation("DEBUG: Response body was:\n" + responseFromServer);
+#endif
+                    break; // Exit the loop on error
+                }
+                catch (TaskCanceledException ex)
+                {
+                    // HTTP timeout (HttpClient.Timeout elapsed) surfaces as a cancelled task. Treat it as a
+                    // transient download failure so a single hung request doesn't crash the whole import; the
+                    // metadata is retried on the next cycle.
+                    Interlocked.Increment(ref _metadataDownloadErrors);
+                    _logger.LogError(ex, $"Timed out downloading metadata {currentUri}: '{ex.Message}'. Will try again on next cycle.");
+                    break; // Exit the loop on error
+                }
+                finally
+                {
+                    response?.Dispose();
+                }
+
+                // Process the response for this URL
+                if (!string.IsNullOrEmpty(responseFromServer))
+                {
+                    // Deserialise the results from the HTTP response
                     try
                     {
-                        response.EnsureSuccessStatusCode();
+                        var responseMeta = JsonConvert.DeserializeObject<List<ActivityReportInfo>>(responseFromServer);
 
-                        // More data to get for events?
-                        if (response.Headers.Contains(NEXT_PAGE_PARAM))
+                        if (responseMeta != null && responseMeta.Count > 0)
                         {
-                            nextPageUri = response.Headers.GetValues(NEXT_PAGE_PARAM).First();
-                        }
-                    }
-                    catch (HttpRequestException ex)
-                    {
-                        Interlocked.Increment(ref _metadataDownloadErrors);
-                        _logger.LogError(ex, $"Error downloading metadata {currentUri} with error '{ex.Message}'. " +
-                            $"If this happens every time, this may be an issue. Ignoring for now.");
-#if DEBUG
-                        _logger.LogInformation("DEBUG: Response body was:\n" + responseFromServer);
-#endif
-                        break; // Exit the loop on error
-                    }
-
-                    // Process the response for this URL
-                    if (!string.IsNullOrEmpty(responseFromServer))
-                    {
-                        // Deserialise the results from the HTTP response
-                        try
-                        {
-                            var responseMeta = JsonConvert.DeserializeObject<List<ActivityReportInfo>>(responseFromServer);
-
-                            if (responseMeta != null && responseMeta.Count > 0)
+                            // Add our own batch ID variable to each response
+                            foreach (var metaData in responseMeta)
                             {
-                                // Add our own batch ID variable to each response
-                                foreach (var metaData in responseMeta)
-                                {
-                                    metaData.BatchID = batchId;
-                                }
-
-                                allResults.AddRange(responseMeta);
+                                metaData.BatchID = batchId;
                             }
+
+                            allResults.AddRange(responseMeta);
                         }
-                        catch (JsonSerializationException)
-                        {
-                            _logger.LogError($"Could not deserialise to list of {nameof(ActivityReportInfo)} response: '{responseFromServer}'");
-                        }
+                    }
+                    catch (JsonSerializationException)
+                    {
+                        _logger.LogError($"Could not deserialise to list of {nameof(ActivityReportInfo)} response: '{responseFromServer}'");
                     }
                 }
 


### PR DESCRIPTION
## Problem

The Office 365 Activity (audit log) import WebJob crashed with an unhandled `System.Threading.Tasks.TaskCanceledException` ("A task was canceled").

An HTTP timeout during a report/metadata download surfaces as a `TaskCanceledException` (that's how `HttpClient` reports a timeout). The shared throttle-retry HTTP client only retried HTTP **429**, and the download loaders only caught `HttpRequestException` — so a client-side timeout was neither retried nor caught. Because `ParallelListProcessor` deliberately re-throws chunk exceptions via `Task.WhenAll`, a single timed-out request propagated all the way up to `Program.Main` and killed the entire import.

Crash path: `ProgramTasks.DownloadActivityData` → `ActivityImporter.LoadReportsAndSave` → `ParallelListProcessor` → `ActivityReportWebLoader.Load` → `AutoThrottleHttpClient` (HTTP GET).

## Fix

### 1. Central resilience — `AutoThrottleHttpClient.ExecuteHttpCallWithThrottleRetries`
The shared throttle-retry loop now treats a client-side timeout (`TaskCanceledException`) or a transient socket/DNS failure (`HttpRequestException`) thrown by the HTTP call itself as retryable: it retries with a linear back-off, **sharing the existing `MaxRetries` budget**, then rethrows after exhaustion so a genuinely dead endpoint still surfaces to the caller. HTTP 429 handling is unchanged.

Because **every** `GetAsyncWithThrottleRetries` / `PostAsyncWithThrottleRetries` caller routes through this method, this single change makes the whole family resilient to transient timeouts — the audit report/metadata loaders **and** all the Graph manual-call loaders (weekly usage reports, pageable/delta loads, call records). It mirrors the pattern the App Insights importer already uses in its own `GetWithRetry`.

### 2. Graceful degradation in the loaders
- **`ActivityReportWebLoader.Load`** — added a `catch (TaskCanceledException)` alongside the existing `HttpRequestException` handler: log, increment `ReportDownloadErrorCount`, return an empty set, and retry on the next cycle (matches the existing transient-error pattern for `HttpRequestException` / `OutOfMemoryException` / `JsonReaderException`).
- **`WebContentMetaDataLoader.DownloadMetadata`** — the HTTP GET and content read were *outside* the `try` entirely, so both a timeout **and** a persistent HTTP error (after max 429 retries) could crash the job. Moved them inside the `try` and added the same graceful handling. Switched the `using` to a `finally`-dispose (behaviour-preserving — the code afterwards only uses the already-read string).

The two layers are complementary: the client retries transient blips; if a download *ultimately* fails, the loader logs/counts it and continues rather than aborting.

## Impact for operators

Previously a single slow/hung download during an import run would abort the whole audit-log import (and in a Debug build, kill the WebJob process). Now transient timeouts are retried automatically, and if one genuinely can't be fetched it's skipped (logged and rolled into the existing **"DOWNLOAD ERRORS DETECTED"** warning) and picked up on the next cycle. The import keeps going; no data is lost.

## Tests

- `ActivityReportLoaderTimeoutTests` — drives `ActivityReportWebLoader.Load` with a handler that throws `TaskCanceledException`; asserts no crash, empty result, `ReportDownloadErrorCount == 1`.
- `AutoThrottleHttpClientTests` — new cases: a transient timeout is retried and then succeeds; a persistent timeout gives up and rethrows after `MaxRetries`. The existing `Retry-After` capping test still passes.
- Engine + test project build clean (VS 2022 MSBuild); all four timeout/throttle tests pass via `vstest.console`.

No functional change to the success path, to HTTP 429 handling, or to existing `HttpRequestException` / JSON / out-of-memory handling.
