### PR TITLE
Fix System.Text.Json binding redirect (6.0.0.11 -> 10.0.0.8) in Common.Entities

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/App.Config
+++ b/src/AnalyticsEngine/Common/Entities/App.Config
@@ -25,7 +25,7 @@
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>
 					<assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-					<bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11"/>
+					<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
 				</dependentAssembly>
 			</assemblyBinding>
 		</assemblyBinding>


### PR DESCRIPTION
## What

Bumps the `System.Text.Json` assembly binding redirect in `Common\Entities\App.Config` from `6.0.0.11` to `10.0.0.8`.

`diff
- <bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11"/>
+ <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
`

## Why

`Common.Entities` references **System.Text.Json 10.0.8** (assembly `10.0.0.8`) via `PackageReference`, but its `App.Config` still redirected to `6.0.0.11` — so a rebuild emitted the MSB3277 assembly-version conflict note:

> Consider app.config remapping of assembly "System.Text.Json" ... from Version "6.0.0.11" to Version "10.0.0.8" ... to solve conflict and get rid of warning.

PR #193 corrected this exact redirect in the other five class libraries (`App.ControlPanel.Engine`, `WebJob.Office365ActivityImporter.Engine`, `Common/DataUtils`, `Common/CloudInstallEngine`, `WebJob.AppInsightsImporter.Engine`) but **missed `Common.Entities`** — it was the only remaining library still on `6.0.0.11`.

## Verification

- Rebuilt `Entities` (VS 2022 MSBuild): **Build succeeded, 0 warnings, 0 errors**; the `Consider app.config remapping` / MSB3277 note is gone.
- `Common.Entities` has a **static** `App.Config` (no `App.Template.config` / TransformXml), so it is the source of truth and edited directly.
