### PR TITLE
Add in-app lite Reports tab (usage charts per enabled import)

### DIFF
--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -1,0 +1,532 @@
+using Common.Entities;
+using Common.Entities.Config;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Runtime.Caching;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Web.AnalyticsWeb.Models;
+
+namespace Web.AnalyticsWeb.Controllers
+{
+    /// <summary>
+    /// Powers the SPA's "Reports" tab - a lightweight, in-app version of the Power BI reports that
+    /// needs no extra deployment. Each report area maps to an import: the area is only offered when
+    /// that import is enabled (<see cref="Areas"/>), and each area returns a small set of weekly
+    /// time-series / bar charts over a configurable window (default 3 months).
+    ///
+    /// Design notes:
+    /// - Queries hit the BASE tables directly (never the vw* views, which don't scale and are being
+    ///   removed). All aggregation (weekly bucketing, distinct counts) happens in SQL.
+    /// - Every chart runs on its own short-timeout context, in parallel, and degrades to a per-chart
+    ///   error rather than failing the whole area - the heavy tables (hits, audit_events) have no
+    ///   dedicated date index, so a weekly GROUP BY can scan on a large tenant. The result is cached
+    ///   briefly (like the home-page counts) so reloads are instant.
+    /// - Weeks are bucketed to their Monday (matching the C# spine) with day arithmetic:
+    ///   DATEADD(DAY, -(DATEDIFF(DAY, 0, col) % 7), CAST(col AS date)). 1900-01-01 is a Monday,
+    ///   so "days since then % 7" is 0 on Mondays; this is independent of DATEFIRST / language.
+    ///   (SQL Server's DATEDIFF(WEEK, ...) instead splits weeks on Sunday, which would push each
+    ///   Sunday's rows into the next week's bucket, so we avoid it.)
+    /// </summary>
+    [Authorize]
+    [RoutePrefix("api/Reports")]
+    public class ReportsAPIController : ApiController
+    {
+        // A single slow weekly scan would otherwise run until Azure App Service kills the HTTP
+        // request (~230s) -> 500. Cap each query so it degrades to a per-chart error instead.
+        private const int QueryTimeoutSecs = 25;
+
+        private const int DefaultMonths = 3;
+        private const int MaxMonths = 24;
+
+        private const string CacheKeyPrefix = "Reports::Area::";
+
+        // GET: api/Reports/areas
+        // Which report areas are available, based on the enabled imports.
+        [HttpGet]
+        [Route("areas")]
+        public IHttpActionResult Areas()
+        {
+            var s = new AppConfig().ImportJobSettings ?? new ImportTaskSettings();
+
+            return Ok(new ReportAreasModel
+            {
+                Copilot = s.Copilot,
+                Usage = s.GraphUsageReports,
+                SpoAudit = s.ActivityLog,
+                WebTraffic = s.WebTraffic,
+                Calls = s.Calls,
+                Emails = s.SentEmails,
+            });
+        }
+
+        // GET: api/Reports/copilot?months=3
+        [HttpGet]
+        [Route("copilot")]
+        public Task<IHttpActionResult> Copilot(int months = DefaultMonths) => AreaAsync("copilot", months);
+
+        // GET: api/Reports/usage?months=3
+        [HttpGet]
+        [Route("usage")]
+        public Task<IHttpActionResult> Usage(int months = DefaultMonths) => AreaAsync("usage", months);
+
+        // GET: api/Reports/spo-audit?months=3
+        [HttpGet]
+        [Route("spo-audit")]
+        public Task<IHttpActionResult> SpoAudit(int months = DefaultMonths) => AreaAsync("spo-audit", months);
+
+        // GET: api/Reports/web-traffic?months=3
+        [HttpGet]
+        [Route("web-traffic")]
+        public Task<IHttpActionResult> WebTraffic(int months = DefaultMonths) => AreaAsync("web-traffic", months);
+
+        // GET: api/Reports/calls?months=3
+        [HttpGet]
+        [Route("calls")]
+        public Task<IHttpActionResult> Calls(int months = DefaultMonths) => AreaAsync("calls", months);
+
+        // GET: api/Reports/emails?months=3
+        [HttpGet]
+        [Route("emails")]
+        public Task<IHttpActionResult> Emails(int months = DefaultMonths) => AreaAsync("emails", months);
+
+        /// <summary>
+        /// Builds (or serves from cache) the charts for one area over the requested window.
+        /// </summary>
+        private async Task<IHttpActionResult> AreaAsync(string area, int months)
+        {
+            if (months < 1) months = DefaultMonths;
+            if (months > MaxMonths) months = MaxMonths;
+
+            var cacheKey = CacheKeyPrefix + area + "::" + months;
+            if (MemoryCache.Default.Get(cacheKey) is ReportAreaData cached)
+            {
+                return Ok(cached);
+            }
+
+            // Monday-aligned window: the first week is the Monday on/before "months ago", and every
+            // SQL bucket is Monday-aligned too, so the spine and the data line up exactly.
+            var today = DateTime.UtcNow.Date;
+            var firstMonday = MondayOf(today.AddMonths(-months));
+            var weekSpine = WeekSpine(firstMonday, MondayOf(today));
+
+            var model = new ReportAreaData { Area = area, Months = months, FromWeek = firstMonday };
+
+            List<Task<ReportChart>> chartTasks;
+            switch (area)
+            {
+                case "copilot":
+                    chartTasks = CopilotCharts(firstMonday, weekSpine);
+                    break;
+                case "usage":
+                    chartTasks = UsageCharts(firstMonday, weekSpine);
+                    break;
+                case "spo-audit":
+                    chartTasks = SpoAuditCharts(firstMonday, weekSpine);
+                    break;
+                case "web-traffic":
+                    chartTasks = WebTrafficCharts(firstMonday, weekSpine);
+                    break;
+                case "calls":
+                    chartTasks = CallsCharts(firstMonday, weekSpine);
+                    break;
+                case "emails":
+                    chartTasks = EmailsCharts(firstMonday, weekSpine);
+                    break;
+                default:
+                    return NotFound();
+            }
+
+            await Task.WhenAll(chartTasks);
+            model.Charts = chartTasks.Select(t => t.Result).ToList();
+
+            // Cache even when some charts errored so reloads are instant rather than re-running the
+            // heavy scans; the per-chart error is itself the diagnostic.
+            MemoryCache.Default.Set(cacheKey, model, DateTimeOffset.UtcNow.AddSeconds(60));
+            return Ok(model);
+        }
+
+        #region Per-area chart definitions
+
+        // Copilot interactions are dated via the joined audit event's time_stamp (copilot_chats has
+        // no date column of its own), mirroring the profiling compile.
+        private static List<Task<ReportChart>> CopilotCharts(DateTime from, List<DateTime> weekSpine)
+        {
+            const string join = "FROM dbo.copilot_chats AS c JOIN dbo.audit_events AS au ON c.event_id = au.id WHERE au.time_stamp >= @from";
+
+            var wb = WeekBucket("au.time_stamp");
+
+            var interactions =
+                $"SELECT {wb} AS WeekStart, CAST(COUNT(*) AS float) AS Value\r\n" +
+                join + "\r\n" +
+                $"GROUP BY {wb} ORDER BY WeekStart;";
+
+            var users =
+                $"SELECT {wb} AS WeekStart, CAST(COUNT(DISTINCT au.user_id) AS float) AS Value\r\n" +
+                join + "\r\n" +
+                $"GROUP BY {wb} ORDER BY WeekStart;";
+
+            var hosts =
+                "SELECT TOP 8 ISNULL(c.app_host, '(unknown)') AS Label, CAST(COUNT(*) AS float) AS Value\r\n" +
+                join + "\r\n" +
+                "GROUP BY ISNULL(c.app_host, '(unknown)') ORDER BY Value DESC;";
+
+            return new List<Task<ReportChart>>
+            {
+                RunTimeSeriesAsync("copilot-interactions", "Copilot interactions per week",
+                    "Total Microsoft 365 Copilot interactions each week.", "Interactions", "Interactions", interactions, from, weekSpine),
+                RunTimeSeriesAsync("copilot-users", "Active Copilot users per week",
+                    "Distinct users with at least one Copilot interaction each week.", "Users", "Active users", users, from, weekSpine),
+                RunCategoryAsync("copilot-hosts", "Interactions by app",
+                    "Where Copilot is being used across the window (top apps).", "Interactions", hosts, from),
+            };
+        }
+
+        // One line per workload. Each user activity-log table has one row per user per report date;
+        // a user is "active in week W" when their last_activity_date falls in W (deduped across the
+        // repeated daily reports by COUNT(DISTINCT user_id)). The scan is bounded by the indexed
+        // [date] column so a big tenant doesn't scan the whole table.
+        private static List<Task<ReportChart>> UsageCharts(DateTime from, List<DateTime> weekSpine)
+        {
+            var workloads = new[]
+            {
+                new { Table = "dbo.teams_user_activity_log", Name = "Teams" },
+                new { Table = "dbo.outlook_user_activity_log", Name = "Outlook" },
+                new { Table = "dbo.onedrive_user_activity_log", Name = "OneDrive" },
+                new { Table = "dbo.sharepoint_user_activity_log", Name = "SharePoint" },
+                new { Table = "dbo.yammer_user_activity_log", Name = "Viva Engage" },
+            };
+
+            var wb = WeekBucket("last_activity_date");
+            var series = workloads.Select(w => new SeriesQuery
+            {
+                Name = w.Name,
+                Body =
+                    $"SELECT {wb} AS WeekStart, CAST(COUNT(DISTINCT user_id) AS float) AS Value\r\n" +
+                    $"FROM {w.Table} WHERE [date] >= @from AND last_activity_date >= @from\r\n" +
+                    $"GROUP BY {wb} ORDER BY WeekStart;"
+            }).ToList();
+
+            return new List<Task<ReportChart>>
+            {
+                RunMultiTimeSeriesAsync("usage-active-users", "Weekly active users by workload",
+                    "Distinct users active each week in each Microsoft 365 workload.", "Active users", series, from, weekSpine),
+            };
+        }
+
+        // SharePoint / OneDrive audit events = audit_events joined to event_meta_sharepoint (which is
+        // what makes an audit event a SharePoint one; audit_events also holds other workloads).
+        private static List<Task<ReportChart>> SpoAuditCharts(DateTime from, List<DateTime> weekSpine)
+        {
+            const string join = "FROM dbo.audit_events AS au JOIN dbo.event_meta_sharepoint AS sp ON au.id = sp.event_id WHERE au.time_stamp >= @from";
+
+            var wb = WeekBucket("au.time_stamp");
+            var ops =
+                $"SELECT {wb} AS WeekStart, CAST(COUNT(*) AS float) AS Value\r\n" +
+                join + "\r\n" +
+                $"GROUP BY {wb} ORDER BY WeekStart;";
+
+            var byType =
+                "SELECT TOP 10 ISNULL(eo.operation_name, '(unknown)') AS Label, CAST(COUNT(*) AS float) AS Value\r\n" +
+                "FROM dbo.audit_events AS au JOIN dbo.event_meta_sharepoint AS sp ON au.id = sp.event_id\r\n" +
+                "LEFT JOIN dbo.event_operations AS eo ON au.operation_id = eo.id WHERE au.time_stamp >= @from\r\n" +
+                "GROUP BY ISNULL(eo.operation_name, '(unknown)') ORDER BY Value DESC;";
+
+            return new List<Task<ReportChart>>
+            {
+                RunTimeSeriesAsync("spo-operations", "File activity per week",
+                    "SharePoint & OneDrive audit operations each week.", "Operations", "Operations", ops, from, weekSpine),
+                RunCategoryAsync("spo-by-type", "Activity by operation",
+                    "The most common SharePoint & OneDrive operations across the window.", "Operations", byType, from),
+            };
+        }
+
+        // Web traffic captured by the page tracker: hits (page views), joined to sessions -> users
+        // for distinct visitors.
+        private static List<Task<ReportChart>> WebTrafficCharts(DateTime from, List<DateTime> weekSpine)
+        {
+            var wbHits = WeekBucket("hit_timestamp");
+            var views =
+                $"SELECT {wbHits} AS WeekStart, CAST(COUNT(*) AS float) AS Value\r\n" +
+                "FROM dbo.hits WHERE hit_timestamp >= @from\r\n" +
+                $"GROUP BY {wbHits} ORDER BY WeekStart;";
+
+            var wbH = WeekBucket("h.hit_timestamp");
+            var visitors =
+                $"SELECT {wbH} AS WeekStart, CAST(COUNT(DISTINCT s.user_id) AS float) AS Value\r\n" +
+                "FROM dbo.hits AS h JOIN dbo.sessions AS s ON h.session_id = s.id WHERE h.hit_timestamp >= @from\r\n" +
+                $"GROUP BY {wbH} ORDER BY WeekStart;";
+
+            return new List<Task<ReportChart>>
+            {
+                RunTimeSeriesAsync("web-page-views", "Page views per week",
+                    "Total tracked page views each week.", "Page views", "Page views", views, from, weekSpine),
+                RunTimeSeriesAsync("web-visitors", "Unique visitors per week",
+                    "Distinct users seen on tracked pages each week.", "Visitors", "Unique visitors", visitors, from, weekSpine),
+            };
+        }
+
+        private static List<Task<ReportChart>> CallsCharts(DateTime from, List<DateTime> weekSpine)
+        {
+            var wb = WeekBucket("[start]");
+            var calls =
+                $"SELECT {wb} AS WeekStart, CAST(COUNT(*) AS float) AS Value\r\n" +
+                "FROM dbo.call_records WHERE [start] >= @from\r\n" +
+                $"GROUP BY {wb} ORDER BY WeekStart;";
+
+            var minutes =
+                $"SELECT {wb} AS WeekStart, CAST(SUM(CAST(DATEDIFF(SECOND, [start], [end]) AS bigint)) / 60.0 AS float) AS Value\r\n" +
+                "FROM dbo.call_records WHERE [start] >= @from\r\n" +
+                $"GROUP BY {wb} ORDER BY WeekStart;";
+
+            return new List<Task<ReportChart>>
+            {
+                RunTimeSeriesAsync("calls-count", "Teams calls per week",
+                    "Number of Teams calls started each week.", "Calls", "Calls", calls, from, weekSpine),
+                RunTimeSeriesAsync("calls-minutes", "Call minutes per week",
+                    "Total Teams call duration each week (minutes).", "Minutes", "Minutes", minutes, from, weekSpine),
+            };
+        }
+
+        private static List<Task<ReportChart>> EmailsCharts(DateTime from, List<DateTime> weekSpine)
+        {
+            var wb = WeekBucket("sent_date");
+            var emails =
+                $"SELECT {wb} AS WeekStart, CAST(COUNT(*) AS float) AS Value\r\n" +
+                "FROM dbo.sent_emails WHERE sent_date >= @from\r\n" +
+                $"GROUP BY {wb} ORDER BY WeekStart;";
+
+            return new List<Task<ReportChart>>
+            {
+                RunTimeSeriesAsync("emails-sent", "Emails sent per week",
+                    "Sent emails imported from mailboxes each week.", "Emails", "Emails sent", emails, from, weekSpine),
+            };
+        }
+
+        #endregion
+
+        #region Query runners
+
+        /// <summary>Runs a single-series weekly query and gap-fills missing weeks with zero.</summary>
+        private static async Task<ReportChart> RunTimeSeriesAsync(string key, string title, string description,
+            string valueLabel, string seriesName, string body, DateTime from, List<DateTime> weekSpine)
+        {
+            var chart = new ReportChart
+            {
+                Key = key,
+                Title = title,
+                Description = description,
+                Type = "timeseries",
+                ValueLabel = valueLabel,
+                Sql = DisplaySql(body, from),
+            };
+
+            try
+            {
+                var rows = await QueryWeeksAsync(body, from);
+                chart.Series = new List<ReportSeries>
+                {
+                    new ReportSeries { Name = seriesName, Points = FillWeeks(weekSpine, rows) },
+                };
+            }
+            catch (Exception ex)
+            {
+                chart.Error = InnermostMessage(ex);
+            }
+
+            return chart;
+        }
+
+        /// <summary>Runs one weekly query per series and combines them into a single multi-line chart.</summary>
+        private static async Task<ReportChart> RunMultiTimeSeriesAsync(string key, string title, string description,
+            string valueLabel, List<SeriesQuery> series, DateTime from, List<DateTime> weekSpine)
+        {
+            var chart = new ReportChart
+            {
+                Key = key,
+                Title = title,
+                Description = description,
+                Type = "timeseries",
+                ValueLabel = valueLabel,
+                // Show one representative query; each series uses the same shape against its own table.
+                Sql = "-- One query per workload (below is representative); the chart runs one per series.\r\n" +
+                      DisplaySql(series.First().Body, from),
+            };
+
+            var results = new List<ReportSeries>();
+            string firstError = null;
+
+            // Sequentially per series keeps a bounded number of concurrent contexts (the area itself
+            // already runs in parallel with other areas' charts); each is a light indexed-range scan.
+            foreach (var sq in series)
+            {
+                try
+                {
+                    var rows = await QueryWeeksAsync(sq.Body, from);
+                    results.Add(new ReportSeries { Name = sq.Name, Points = FillWeeks(weekSpine, rows) });
+                }
+                catch (Exception ex)
+                {
+                    if (firstError == null) firstError = InnermostMessage(ex);
+                }
+            }
+
+            if (results.Count > 0)
+            {
+                chart.Series = results;
+            }
+            else
+            {
+                chart.Error = firstError ?? "No data.";
+            }
+
+            return chart;
+        }
+
+        /// <summary>Runs a categorical (bar) query - label + value rows, already ordered by the query.</summary>
+        private static async Task<ReportChart> RunCategoryAsync(string key, string title, string description,
+            string valueLabel, string body, DateTime from)
+        {
+            var chart = new ReportChart
+            {
+                Key = key,
+                Title = title,
+                Description = description,
+                Type = "bar",
+                ValueLabel = valueLabel,
+                Sql = DisplaySql(body, from),
+            };
+
+            try
+            {
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    db.Database.CommandTimeout = QueryTimeoutSecs;
+                    var rows = await db.Database
+                        .SqlQuery<CategoryRow>(body, new SqlParameter("@from", from))
+                        .ToListAsync();
+                    chart.Categories = rows
+                        .Select(r => new ReportCategory { Label = r.Label, Value = r.Value })
+                        .ToList();
+                }
+            }
+            catch (Exception ex)
+            {
+                chart.Error = InnermostMessage(ex);
+            }
+
+            return chart;
+        }
+
+        /// <summary>Executes a weekly (WeekStart, Value) query on its own short-timeout context.</summary>
+        private static async Task<List<WeekValueRow>> QueryWeeksAsync(string body, DateTime from)
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                db.Database.CommandTimeout = QueryTimeoutSecs;
+                return await db.Database
+                    .SqlQuery<WeekValueRow>(body, new SqlParameter("@from", from))
+                    .ToListAsync();
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// SQL expression that buckets a datetime column to the Monday on/before it (matching the
+        /// C# <see cref="MondayOf"/> spine). Uses day arithmetic, not DATEDIFF(WEEK, ...), because
+        /// SQL Server's week grouping starts on Sunday and would push Sunday rows into the next
+        /// week. 1900-01-01 is a Monday, so DATEDIFF(DAY, 0, col) % 7 == 0 exactly on Mondays.
+        /// The column name is a compile-time constant, so there is no injection surface.
+        /// </summary>
+        private static string WeekBucket(string col)
+        {
+            return $"DATEADD(DAY, -(DATEDIFF(DAY, 0, {col}) % 7), CAST({col} AS date))";
+        }
+
+        /// <summary>The Monday of the week containing <paramref name="d"/> (weeks start Monday).</summary>
+        private static DateTime MondayOf(DateTime d)
+        {
+            // DayOfWeek: Sunday=0..Saturday=6. (+6)%7 maps Monday->0, Sunday->6, so we step back to Monday.
+            return d.Date.AddDays(-(((int)d.DayOfWeek + 6) % 7));
+        }
+
+        /// <summary>All Mondays from <paramref name="firstMonday"/> to <paramref name="lastMonday"/> inclusive.</summary>
+        private static List<DateTime> WeekSpine(DateTime firstMonday, DateTime lastMonday)
+        {
+            var weeks = new List<DateTime>();
+            for (var w = firstMonday; w <= lastMonday; w = w.AddDays(7))
+            {
+                weeks.Add(w);
+            }
+            return weeks;
+        }
+
+        /// <summary>Projects query rows onto the full week spine, filling gaps with zero.</summary>
+        private static List<ReportTimePoint> FillWeeks(List<DateTime> weekSpine, List<WeekValueRow> rows)
+        {
+            var byWeek = new Dictionary<DateTime, double>();
+            foreach (var r in rows)
+            {
+                byWeek[r.WeekStart.Date] = r.Value;
+            }
+
+            return weekSpine
+                .Select(w => new ReportTimePoint
+                {
+                    WeekStart = w,
+                    Value = byWeek.TryGetValue(w, out var v) ? v : 0,
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Wraps the executed query body with a runnable <c>DECLARE @from</c> so the SQL shown in the
+        /// popover can be pasted straight into SSMS. The executed query uses a SqlParameter, not this
+        /// string, so there is no injection surface (the body is built from compile-time constants).
+        /// </summary>
+        private static string DisplaySql(string body, DateTime from)
+        {
+            return $"DECLARE @from datetime = '{from:yyyy-MM-dd}';\r\n" + body;
+        }
+
+        /// <summary>EF wraps SQL errors; the innermost message (the SqlException) is the useful one.</summary>
+        private static string InnermostMessage(Exception ex)
+        {
+            var e = ex;
+            while (e.InnerException != null)
+            {
+                e = e.InnerException;
+            }
+            return e.Message;
+        }
+
+        /// <summary>A named series and the weekly query that produces it (used by the usage chart).</summary>
+        private sealed class SeriesQuery
+        {
+            public string Name { get; set; }
+            public string Body { get; set; }
+        }
+
+        /// <summary>Shape for a weekly (WeekStart, Value) raw SQL result.</summary>
+        private sealed class WeekValueRow
+        {
+            public DateTime WeekStart { get; set; }
+            public double Value { get; set; }
+        }
+
+        /// <summary>Shape for a categorical (Label, Value) raw SQL result.</summary>
+        private sealed class CategoryRow
+        {
+            public string Label { get; set; }
+            public double Value { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -40,7 +40,11 @@ namespace Web.AnalyticsWeb.Controllers
         private const int QueryTimeoutSecs = 25;
 
         private const int DefaultMonths = 3;
-        private const int MaxMonths = 24;
+
+        // This is a "basic activity" view, not a full analytics tool, so the window is capped at 6
+        // months. That keeps the charts light and, once the base-table date columns are indexed,
+        // makes the window a real cost lever (a shorter period then reads proportionally less).
+        private const int MaxMonths = 6;
 
         private const string CacheKeyPrefix = "Reports::Area::";
 

--- a/src/AnalyticsEngine/Web/Models/ReportsModels.cs
+++ b/src/AnalyticsEngine/Web/Models/ReportsModels.cs
@@ -1,0 +1,134 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Web.AnalyticsWeb.Models
+{
+    /// <summary>
+    /// Which "lite report" areas are available for this deployment, based on the enabled imports
+    /// (<c>config.ImportJobSettings</c>). The SPA renders a sub-tab per area, but only for the
+    /// areas flagged <c>true</c> here - there's no point charting Copilot usage on a deployment
+    /// that never imports Copilot data, for example.
+    /// </summary>
+    public class ReportAreasModel
+    {
+        /// <summary>Microsoft 365 Copilot interactions (Audit.General import).</summary>
+        [JsonProperty("copilot")]
+        public bool Copilot { get; set; }
+
+        /// <summary>Microsoft 365 usage reports (Graph usage-report import: Teams/Outlook/OneDrive/SharePoint/Viva Engage).</summary>
+        [JsonProperty("usage")]
+        public bool Usage { get; set; }
+
+        /// <summary>SharePoint &amp; OneDrive file activity (Audit.SharePoint import).</summary>
+        [JsonProperty("spoAudit")]
+        public bool SpoAudit { get; set; }
+
+        /// <summary>Website traffic captured by the SharePoint page tracker (WebTraffic import).</summary>
+        [JsonProperty("webTraffic")]
+        public bool WebTraffic { get; set; }
+
+        /// <summary>Teams calls (call-records import).</summary>
+        [JsonProperty("calls")]
+        public bool Calls { get; set; }
+
+        /// <summary>Sent emails (mailbox import).</summary>
+        [JsonProperty("emails")]
+        public bool Emails { get; set; }
+    }
+
+    /// <summary>One point of a weekly time series: the (Monday) start of the week and its value.</summary>
+    public class ReportTimePoint
+    {
+        [JsonProperty("weekStart")]
+        public DateTime WeekStart { get; set; }
+
+        [JsonProperty("value")]
+        public double Value { get; set; }
+    }
+
+    /// <summary>A named line in a time-series chart (e.g. one workload, or "Page views").</summary>
+    public class ReportSeries
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("points")]
+        public List<ReportTimePoint> Points { get; set; } = new List<ReportTimePoint>();
+    }
+
+    /// <summary>One bar of a categorical chart (e.g. an app host, or an operation type).</summary>
+    public class ReportCategory
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("value")]
+        public double Value { get; set; }
+    }
+
+    /// <summary>
+    /// A single chart in a report area. It is either a weekly <c>timeseries</c> (populated
+    /// <see cref="Series"/>) or a categorical <c>bar</c> chart (populated <see cref="Categories"/>).
+    /// <see cref="Sql"/> is the query behind it (shown in the same SQL popover the other admin
+    /// pages use) and <see cref="Error"/> is set when the query failed or timed out, so one heavy
+    /// chart degrades to a message rather than failing the whole area (mirrors ProfilingStatus).
+    /// </summary>
+    public class ReportChart
+    {
+        /// <summary>Stable identifier (used as a React key).</summary>
+        [JsonProperty("key")]
+        public string Key { get; set; }
+
+        /// <summary>Chart heading shown to the admin.</summary>
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        /// <summary>Short description of what the chart shows.</summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary><c>timeseries</c> or <c>bar</c>.</summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>Unit label for the value axis / tooltip, e.g. "Interactions".</summary>
+        [JsonProperty("valueLabel")]
+        public string ValueLabel { get; set; }
+
+        /// <summary>The series (one or more) for a <c>timeseries</c> chart; null for a bar chart.</summary>
+        [JsonProperty("series")]
+        public List<ReportSeries> Series { get; set; }
+
+        /// <summary>The bars for a <c>bar</c> chart; null for a time-series chart.</summary>
+        [JsonProperty("categories")]
+        public List<ReportCategory> Categories { get; set; }
+
+        /// <summary>The SQL that produced this chart, for the admin to copy and run.</summary>
+        [JsonProperty("sql")]
+        public string Sql { get; set; }
+
+        /// <summary>Set when the query failed/timed out; the chart data is then empty.</summary>
+        [JsonProperty("error")]
+        public string Error { get; set; }
+    }
+
+    /// <summary>The set of charts for one report area over the requested window.</summary>
+    public class ReportAreaData
+    {
+        /// <summary>The area key, e.g. "copilot".</summary>
+        [JsonProperty("area")]
+        public string Area { get; set; }
+
+        /// <summary>The window in months these charts cover.</summary>
+        [JsonProperty("months")]
+        public int Months { get; set; }
+
+        /// <summary>The (Monday) start of the earliest week charted.</summary>
+        [JsonProperty("fromWeek")]
+        public DateTime FromWeek { get; set; }
+
+        [JsonProperty("charts")]
+        public List<ReportChart> Charts { get; set; } = new List<ReportChart>();
+    }
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/README.md
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/README.md
@@ -41,6 +41,7 @@ analytics. If `SiteTokenAPI` can't return a token, the SPA falls back to client-
 | `o365AnalyticsSystemStatusAPI` | `api/SystemStatus` | System status / configuration for the Home page. |
 | `o365AnalyticsInstallLogAPI` | `api/InstallLog` | Install log (config history from `sys_configs`) for the Install Log page. |
 | `o365AnalyticsProfilingStatusAPI` | `api/ProfilingStatus` | Profiling data freshness + paged `profiling.TraceLogs` for the Profiling page. |
+| `o365AnalyticsReportsAPI` | `api/Reports` | Lite in-app reports: enabled areas (`/areas`) + weekly usage charts per area (`/copilot`, `/usage`, `/spo-audit`, `/web-traffic`, `/calls`, `/emails`). |
 
 ## Local development
 

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/index.html
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/index.html
@@ -28,6 +28,7 @@
     window.o365AnalyticsSystemStatusAPI = baseUrl + "api/SystemStatus";
     window.o365AnalyticsInstallLogAPI = baseUrl + "api/InstallLog";
     window.o365AnalyticsProfilingStatusAPI = baseUrl + "api/ProfilingStatus";
+    window.o365AnalyticsReportsAPI = baseUrl + "api/Reports";
     window.o365AnalyticsHealthAPI = baseUrl + "api/Health";
   </script>
 </head>

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/App.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/App.tsx
@@ -15,6 +15,7 @@ import Spinner from './components/Spinner';
 
 // Code-split the pages so each route is a separate chunk (smaller initial load).
 const HomePage = lazy(() => import('./pages/HomePage'));
+const ReportsPage = lazy(() => import('./pages/ReportsPage'));
 const TeamsPermissionsPage = lazy(() => import('./pages/TeamsPermissionsPage'));
 const UserLookupPage = lazy(() => import('./pages/UserLookupPage'));
 const ProfilingStatusPage = lazy(() => import('./pages/ProfilingStatusPage'));
@@ -59,17 +60,19 @@ export default function App() {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const selectedTab = location.pathname.startsWith('/teams')
-    ? 'teams'
-    : location.pathname.startsWith('/user-lookup')
-      ? 'user-lookup'
-      : location.pathname.startsWith('/profiling')
-        ? 'profiling'
-        : location.pathname.startsWith('/install-log')
-          ? 'install-log'
-          : location.pathname.startsWith('/health')
-            ? 'health'
-            : 'home';
+  const selectedTab = location.pathname.startsWith('/reports')
+    ? 'reports'
+    : location.pathname.startsWith('/teams')
+      ? 'teams'
+      : location.pathname.startsWith('/user-lookup')
+        ? 'user-lookup'
+        : location.pathname.startsWith('/profiling')
+          ? 'profiling'
+          : location.pathname.startsWith('/install-log')
+            ? 'install-log'
+            : location.pathname.startsWith('/health')
+              ? 'health'
+              : 'home';
 
   const onTabSelect: SelectTabEventHandler = (_event, data) => {
     navigate(`/${data.value}`);
@@ -98,6 +101,7 @@ export default function App() {
       <div className={styles.tabBar}>
         <TabList selectedValue={selectedTab} onTabSelect={onTabSelect} size="large">
           <Tab value="home">Home</Tab>
+          <Tab value="reports">Reports</Tab>
           <Tab value="teams">Teams Permissions</Tab>
           <Tab value="user-lookup">User Data Lookup</Tab>
           <Tab value="profiling">Profiling</Tab>
@@ -117,6 +121,7 @@ export default function App() {
           <Routes>
             <Route path="/" element={<Navigate to="/home" replace />} />
             <Route path="/home" element={<HomePage />} />
+            <Route path="/reports" element={<ReportsPage />} />
             <Route path="/teams" element={<TeamsPermissionsPage />} />
             <Route path="/user-lookup" element={<UserLookupPage />} />
             <Route path="/profiling" element={<ProfilingStatusPage />} />

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/api/reportsApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/api/reportsApi.ts
@@ -1,0 +1,35 @@
+import type { ReportAreaData, ReportAreaKey, ReportAreas } from '../types/reports';
+
+const baseUrl = (): string =>
+  window.o365AnalyticsReportsAPI ?? `${window.location.origin}/api/Reports`;
+
+/** Which report areas are enabled for this deployment (drives the visible sub-tabs). */
+export async function fetchReportAreas(): Promise<ReportAreas> {
+  const response = await fetch(`${baseUrl()}/areas`, {
+    method: 'GET',
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Couldn't load report areas (${response.status}).`);
+  }
+
+  return response.json() as Promise<ReportAreas>;
+}
+
+/** Fetch the weekly charts for one report area over the given window (months). */
+export async function fetchReportArea(area: ReportAreaKey, months: number): Promise<ReportAreaData> {
+  const url = `${baseUrl()}/${area}?months=${encodeURIComponent(months)}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Couldn't load the ${area} report (${response.status}).`);
+  }
+
+  return response.json() as Promise<ReportAreaData>;
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/CategoryBarChart.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/CategoryBarChart.tsx
@@ -1,0 +1,90 @@
+import { makeStyles, tokens, Text } from '@fluentui/react-components';
+import type { ReportCategory } from '../../types/reports';
+import { formatValue, seriesColor } from './chartCommon';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    width: '100%',
+    paddingTop: '4px',
+  },
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(90px, 160px) 1fr auto',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  label: {
+    color: tokens.colorNeutralForeground2,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  track: {
+    position: 'relative',
+    height: '18px',
+    borderRadius: tokens.borderRadiusSmall,
+    backgroundColor: tokens.colorNeutralBackground3,
+    overflow: 'hidden',
+  },
+  bar: {
+    height: '100%',
+    borderRadius: tokens.borderRadiusSmall,
+    minWidth: '2px',
+    transition: 'width 200ms ease',
+  },
+  value: {
+    fontVariantNumeric: 'tabular-nums',
+    textAlign: 'right',
+    minWidth: '48px',
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '24px 0',
+    textAlign: 'center',
+  },
+});
+
+type CategoryBarChartProps = {
+  categories: ReportCategory[];
+  /** Unit shown in the row title tooltip, e.g. "Interactions". */
+  valueLabel: string;
+};
+
+/**
+ * A dependency-free horizontal bar chart for "top N" categorical data (e.g. Copilot usage by app,
+ * SharePoint activity by operation). Bars are sized relative to the largest value and coloured from
+ * the shared palette so they line up with the time-series charts.
+ */
+export default function CategoryBarChart({ categories, valueLabel }: CategoryBarChartProps) {
+  const styles = useStyles();
+
+  if (categories.length === 0) {
+    return <div className={styles.empty}>No data for this period.</div>;
+  }
+
+  const max = Math.max(...categories.map((c) => c.value), 1);
+
+  return (
+    <div className={styles.root}>
+      {categories.map((c, i) => {
+        const pct = Math.max(1, (c.value / max) * 100);
+        return (
+          <div className={styles.row} key={c.label} title={`${c.label}: ${formatValue(c.value)} ${valueLabel}`}>
+            <Text size={200} className={styles.label}>
+              {c.label}
+            </Text>
+            <div className={styles.track}>
+              <div className={styles.bar} style={{ width: `${pct}%`, backgroundColor: seriesColor(i) }} />
+            </div>
+            <Text size={200} weight="semibold" className={styles.value}>
+              {formatValue(c.value)}
+            </Text>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/TimeSeriesChart.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/TimeSeriesChart.tsx
@@ -1,0 +1,278 @@
+import { useMemo, useRef, useState } from 'react';
+import { makeStyles, tokens, Text } from '@fluentui/react-components';
+import type { ReportSeries } from '../../types/reports';
+import {
+  formatCompact,
+  formatValue,
+  formatWeek,
+  formatWeekLong,
+  niceTicks,
+  seriesColor,
+} from './chartCommon';
+
+// Logical (viewBox) geometry. The SVG scales to the container width, keeping these coordinates.
+const W = 960;
+const MARGIN = { top: 16, right: 18, bottom: 44, left: 52 };
+
+const useStyles = makeStyles({
+  root: {
+    position: 'relative',
+    width: '100%',
+  },
+  svg: {
+    width: '100%',
+    height: 'auto',
+    display: 'block',
+    overflow: 'visible',
+  },
+  axisText: {
+    fill: tokens.colorNeutralForeground3,
+    fontSize: '13px',
+  },
+  legend: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '4px 16px',
+    marginTop: '8px',
+  },
+  legendItem: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+  },
+  swatch: {
+    width: '12px',
+    height: '12px',
+    borderRadius: '2px',
+    flexShrink: 0,
+  },
+  tooltip: {
+    position: 'absolute',
+    top: '4px',
+    pointerEvents: 'none',
+    transform: 'translateX(-50%)',
+    backgroundColor: tokens.colorNeutralBackground1,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow8,
+    padding: '8px 10px',
+    minWidth: '120px',
+    zIndex: 2,
+  },
+  tooltipRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+  },
+  tooltipLabel: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '24px 0',
+    textAlign: 'center',
+  },
+});
+
+type TimeSeriesChartProps = {
+  series: ReportSeries[];
+  /** Unit shown in the tooltip, e.g. "Interactions". */
+  valueLabel: string;
+  height?: number;
+};
+
+/**
+ * A dependency-free multi-series line chart for weekly report data. Renders an SVG that scales to
+ * its container, with a "nice" y-axis, thinned week labels, and an interactive hover tooltip that
+ * reads out every series' value for the hovered week.
+ */
+export default function TimeSeriesChart({ series, valueLabel, height = 300 }: TimeSeriesChartProps) {
+  const styles = useStyles();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [hover, setHover] = useState<{ index: number; xPx: number } | null>(null);
+
+  // The x-axis (weeks) comes from the first series; the server gap-fills every series onto the
+  // same weekly spine, so all series share these week starts.
+  const weeks = series[0]?.points.map((p) => p.weekStart) ?? [];
+  const n = weeks.length;
+
+  const H = height;
+  const plotLeft = MARGIN.left;
+  const plotRight = W - MARGIN.right;
+  const plotTop = MARGIN.top;
+  const plotBottom = H - MARGIN.bottom;
+  const plotW = plotRight - plotLeft;
+  const plotH = plotBottom - plotTop;
+
+  const { max, ticks } = useMemo(() => {
+    let dataMax = 0;
+    for (const s of series) {
+      for (const p of s.points) {
+        if (p.value > dataMax) dataMax = p.value;
+      }
+    }
+    return niceTicks(dataMax);
+  }, [series]);
+
+  if (n === 0) {
+    return <div className={styles.empty}>No data for this period.</div>;
+  }
+
+  const x = (i: number): number => (n === 1 ? plotLeft + plotW / 2 : plotLeft + (plotW * i) / (n - 1));
+  const y = (v: number): number => plotBottom - (plotH * v) / max;
+
+  // Thin the x labels so they don't collide: aim for ~9 labels, always keeping the first and last.
+  const labelStep = Math.max(1, Math.ceil(n / 9));
+  const showLabel = (i: number): boolean => i === 0 || i === n - 1 || i % labelStep === 0;
+
+  const onMove = (e: React.MouseEvent): void => {
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const relX = e.clientX - rect.left;
+    const logicalX = (relX / rect.width) * W;
+    let index = n === 1 ? 0 : Math.round(((logicalX - plotLeft) / plotW) * (n - 1));
+    index = Math.max(0, Math.min(n - 1, index));
+    // Snap the tooltip to the data point (nicer than following the raw cursor).
+    const xPx = (x(index) / W) * rect.width;
+    setHover({ index, xPx });
+  };
+
+  const clearHover = (): void => setHover(null);
+
+  const showLegend = series.length > 1;
+  const tooltipLeft = hover ? Math.max(70, Math.min((rootRef.current?.clientWidth ?? W) - 70, hover.xPx)) : 0;
+
+  return (
+    <div className={styles.root} ref={rootRef}>
+      <svg
+        className={styles.svg}
+        viewBox={`0 0 ${W} ${H}`}
+        role="img"
+        aria-label={`${valueLabel} per week`}
+      >
+        {/* Gridlines + y-axis labels */}
+        {ticks.map((t) => (
+          <g key={`grid-${t}`}>
+            <line
+              x1={plotLeft}
+              x2={plotRight}
+              y1={y(t)}
+              y2={y(t)}
+              stroke={tokens.colorNeutralStroke2}
+              strokeWidth={1}
+            />
+            <text
+              className={styles.axisText}
+              x={plotLeft - 8}
+              y={y(t)}
+              textAnchor="end"
+              dominantBaseline="middle"
+            >
+              {formatCompact(t)}
+            </text>
+          </g>
+        ))}
+
+        {/* x-axis baseline */}
+        <line
+          x1={plotLeft}
+          x2={plotRight}
+          y1={plotBottom}
+          y2={plotBottom}
+          stroke={tokens.colorNeutralStroke1}
+          strokeWidth={1}
+        />
+
+        {/* x-axis (week) labels */}
+        {weeks.map((wk, i) =>
+          showLabel(i) ? (
+            <text
+              key={`xl-${wk}`}
+              className={styles.axisText}
+              x={x(i)}
+              y={plotBottom + 18}
+              textAnchor="middle"
+            >
+              {formatWeek(wk)}
+            </text>
+          ) : null,
+        )}
+
+        {/* Hover guide */}
+        {hover && (
+          <line
+            x1={x(hover.index)}
+            x2={x(hover.index)}
+            y1={plotTop}
+            y2={plotBottom}
+            stroke={tokens.colorNeutralStroke1}
+            strokeWidth={1}
+            strokeDasharray="4 3"
+          />
+        )}
+
+        {/* Series lines + points */}
+        {series.map((s, si) => {
+          const color = seriesColor(si);
+          const path = s.points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${x(i)} ${y(p.value)}`).join(' ');
+          return (
+            <g key={s.name}>
+              <path d={path} fill="none" stroke={color} strokeWidth={2.5} strokeLinejoin="round" strokeLinecap="round" />
+              {s.points.map((p, i) =>
+                hover?.index === i ? (
+                  <circle key={`pt-${s.name}-${i}`} cx={x(i)} cy={y(p.value)} r={5} fill={color} stroke={tokens.colorNeutralBackground1} strokeWidth={2} />
+                ) : n <= 16 ? (
+                  <circle key={`pt-${s.name}-${i}`} cx={x(i)} cy={y(p.value)} r={2.5} fill={color} />
+                ) : null,
+              )}
+            </g>
+          );
+        })}
+
+        {/* Transparent overlay to capture hover across the whole plot */}
+        <rect
+          x={plotLeft}
+          y={plotTop}
+          width={plotW}
+          height={plotH}
+          fill="transparent"
+          onMouseMove={onMove}
+          onMouseLeave={clearHover}
+        />
+      </svg>
+
+      {hover && (
+        <div className={styles.tooltip} style={{ left: tooltipLeft }}>
+          <Text size={200} weight="semibold" block style={{ marginBottom: 4 }}>
+            {formatWeekLong(weeks[hover.index])}
+          </Text>
+          {series.map((s, si) => (
+            <div key={s.name} className={styles.tooltipRow}>
+              <span className={styles.tooltipLabel}>
+                <span className={styles.swatch} style={{ backgroundColor: seriesColor(si) }} />
+                <Text size={200}>{series.length > 1 ? s.name : valueLabel}</Text>
+              </span>
+              <Text size={200} weight="semibold">
+                {formatValue(s.points[hover.index]?.value ?? 0)}
+              </Text>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showLegend && (
+        <div className={styles.legend}>
+          {series.map((s, si) => (
+            <span key={s.name} className={styles.legendItem}>
+              <span className={styles.swatch} style={{ backgroundColor: seriesColor(si) }} />
+              <Text size={200}>{s.name}</Text>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/chartCommon.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/chartCommon.ts
@@ -1,0 +1,97 @@
+// Shared helpers for the lightweight SVG report charts. Kept dependency-free (no charting library)
+// so the admin SPA stays small and there is nothing extra to deploy.
+
+/**
+ * Categorical palette for chart series / bars. Saturated Fluent-family colours that read well on
+ * the app's light theme (webLightTheme). Series cycle through these in order.
+ */
+export const CHART_PALETTE = [
+  '#0f6cbd', // brand blue
+  '#d13438', // red
+  '#107c10', // green
+  '#8764b8', // purple
+  '#ca5010', // orange
+  '#008272', // teal
+  '#c19c00', // gold
+  '#5c2e91', // dark purple
+] as const;
+
+/** Colour for the series/bar at index i (cycles through the palette). */
+export function seriesColor(i: number): string {
+  return CHART_PALETTE[i % CHART_PALETTE.length];
+}
+
+/** Compact number for axis labels: 1234 -> "1.2k", 2_500_000 -> "2.5M". */
+export function formatCompact(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1e9) return `${trim(n / 1e9)}B`;
+  if (abs >= 1e6) return `${trim(n / 1e6)}M`;
+  if (abs >= 1e3) return `${trim(n / 1e3)}k`;
+  return String(Math.round(n));
+}
+
+function trim(n: number): string {
+  // One decimal place, but drop a trailing ".0".
+  return n.toFixed(1).replace(/\.0$/, '');
+}
+
+/** Full number for tooltips (e.g. "1,234"; fractional values keep up to one decimal). */
+export function formatValue(n: number): string {
+  const rounded = Number.isInteger(n) ? n : Math.round(n * 10) / 10;
+  return rounded.toLocaleString();
+}
+
+/** Week-start ISO date -> short label like "14 Apr". */
+export function formatWeek(iso: string): string {
+  // The week starts are UTC date-only values (Kind=Utc, serialised with a trailing Z), so format
+  // them in UTC - otherwise a Monday renders as the previous Sunday for viewers west of UTC.
+  return new Date(iso).toLocaleDateString(undefined, { day: 'numeric', month: 'short', timeZone: 'UTC' });
+}
+
+/** Week-start ISO date -> longer label like "Mon 14 Apr 2026" (tooltip header). */
+export function formatWeekLong(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/**
+ * "Nice" y-axis maximum and evenly-spaced ticks (including 0) for a given data max, so the axis
+ * ends on a round number. Always returns at least [0, 1] so an all-zero chart still renders.
+ */
+export function niceTicks(dataMax: number, targetTicks = 4): { max: number; ticks: number[] } {
+  if (!Number.isFinite(dataMax) || dataMax <= 0) {
+    return { max: 1, ticks: [0, 1] };
+  }
+
+  const step = niceNum(dataMax / targetTicks, true);
+  const max = Math.ceil(dataMax / step) * step;
+  const ticks: number[] = [];
+  for (let v = 0; v <= max + step / 2; v += step) {
+    ticks.push(Math.round(v * 1e6) / 1e6);
+  }
+  return { max, ticks };
+}
+
+/** Rounds a range to a "nice" 1/2/5 * 10^n value. */
+function niceNum(range: number, round: boolean): number {
+  const exp = Math.floor(Math.log10(range));
+  const frac = range / Math.pow(10, exp);
+  let nice: number;
+  if (round) {
+    if (frac < 1.5) nice = 1;
+    else if (frac < 3) nice = 2;
+    else if (frac < 7) nice = 5;
+    else nice = 10;
+  } else {
+    if (frac <= 1) nice = 1;
+    else if (frac <= 2) nice = 2;
+    else if (frac <= 5) nice = 5;
+    else nice = 10;
+  }
+  return nice * Math.pow(10, exp);
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/global.d.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/global.d.ts
@@ -24,6 +24,8 @@ declare global {
     o365AnalyticsInstallLogAPI: string;
     /** Base endpoint for the profiling status (data freshness + trace logs) API. */
     o365AnalyticsProfilingStatusAPI: string;
+    /** Base endpoint for the lite in-app Reports API (enabled areas + weekly usage charts). */
+    o365AnalyticsReportsAPI: string;
     /** Endpoint for the system-health ("is it working?") API. */
     o365AnalyticsHealthAPI: string;
   }

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
@@ -36,7 +36,6 @@ const MONTH_OPTIONS = [
   { value: 1, label: 'Last month' },
   { value: 3, label: 'Last 3 months' },
   { value: 6, label: 'Last 6 months' },
-  { value: 12, label: 'Last 12 months' },
 ];
 
 const useStyles = makeStyles({

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Title3,
+  Body1,
+  Text,
+  Card,
+  Select,
+  Tab,
+  TabList,
+  MessageBar,
+  MessageBarBody,
+  Button,
+  makeStyles,
+  tokens,
+  type SelectTabEventHandler,
+} from '@fluentui/react-components';
+import { ArrowClockwise16Regular } from '@fluentui/react-icons';
+import { fetchReportAreas, fetchReportArea } from '../api/reportsApi';
+import type { ReportAreaData, ReportAreaKey, ReportAreas } from '../types/reports';
+import Spinner from '../components/Spinner';
+import SqlPopover from '../components/SqlPopover';
+import TimeSeriesChart from '../components/charts/TimeSeriesChart';
+import CategoryBarChart from '../components/charts/CategoryBarChart';
+
+/** The report areas in display order, with the enabled-flag they map to and their friendly copy. */
+const AREA_DEFS: { flag: keyof ReportAreas; key: ReportAreaKey; label: string; blurb: string }[] = [
+  { flag: 'copilot', key: 'copilot', label: 'Copilot', blurb: 'Microsoft 365 Copilot adoption and usage.' },
+  { flag: 'usage', key: 'usage', label: 'Microsoft 365 usage', blurb: 'Weekly active users across Microsoft 365 workloads.' },
+  { flag: 'spoAudit', key: 'spo-audit', label: 'SharePoint & OneDrive', blurb: 'File activity from the audit log.' },
+  { flag: 'webTraffic', key: 'web-traffic', label: 'Website traffic', blurb: 'Page views and visitors from the page tracker.' },
+  { flag: 'calls', key: 'calls', label: 'Teams calls', blurb: 'Teams call volume and duration.' },
+  { flag: 'emails', key: 'emails', label: 'Emails', blurb: 'Sent email volume.' },
+];
+
+const MONTH_OPTIONS = [
+  { value: 1, label: 'Last month' },
+  { value: 3, label: 'Last 3 months' },
+  { value: 6, label: 'Last 6 months' },
+  { value: 12, label: 'Last 12 months' },
+];
+
+const useStyles = makeStyles({
+  header: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  controls: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+  },
+  intro: {
+    marginTop: '8px',
+  },
+  subTabs: {
+    marginTop: '16px',
+  },
+  cards: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    marginTop: '16px',
+  },
+  chartCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  chartHead: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  chartBody: {
+    marginTop: '8px',
+  },
+});
+
+/**
+ * Reports tab: a lightweight, in-app version of the Power BI reports. Shows a sub-tab per report
+ * area, but only for the areas whose import is enabled, and charts each area's usage over a
+ * configurable window (default the last 3 months). Data comes from api/Reports.
+ */
+export default function ReportsPage() {
+  const styles = useStyles();
+
+  const [areas, setAreas] = useState<ReportAreas | null>(null);
+  const [areasError, setAreasError] = useState<string | null>(null);
+  const [areasLoading, setAreasLoading] = useState(true);
+
+  const [months, setMonths] = useState(3);
+  const [selectedArea, setSelectedArea] = useState<ReportAreaKey | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setAreasLoading(true);
+    setAreasError(null);
+    fetchReportAreas()
+      .then((a) => {
+        if (!cancelled) setAreas(a);
+      })
+      .catch((e) => {
+        if (!cancelled) setAreasError(e instanceof Error ? e.message : 'Failed to load report areas.');
+      })
+      .finally(() => {
+        if (!cancelled) setAreasLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const enabledAreas = useMemo(
+    () => (areas ? AREA_DEFS.filter((d) => areas[d.flag]) : []),
+    [areas],
+  );
+
+  // Default the selection to the first enabled area once we know which areas exist.
+  useEffect(() => {
+    if (enabledAreas.length === 0) {
+      setSelectedArea(null);
+      return;
+    }
+    setSelectedArea((current) =>
+      current && enabledAreas.some((a) => a.key === current) ? current : enabledAreas[0].key,
+    );
+  }, [enabledAreas]);
+
+  const onTabSelect: SelectTabEventHandler = (_e, data) => setSelectedArea(data.value as ReportAreaKey);
+
+  return (
+    <div>
+      <div className={styles.header}>
+        <div>
+          <Title3>Reports</Title3>
+          <Body1 block className={styles.intro}>
+            A quick, built-in view of how your Microsoft 365 usage is trending. Each section below appears only when its
+            data is being imported.
+          </Body1>
+        </div>
+        <div className={styles.controls}>
+          <Text size={200} className={styles.muted}>
+            Period
+          </Text>
+          <Select
+            value={String(months)}
+            onChange={(_e, data) => setMonths(Number(data.value))}
+            aria-label="Reporting period"
+          >
+            {MONTH_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+
+      {areasLoading && (
+        <div style={{ textAlign: 'center', padding: '32px' }}>
+          <Spinner size={80} label="Loading reports..." />
+        </div>
+      )}
+
+      {areasError && (
+        <MessageBar intent="error" style={{ marginTop: '16px' }}>
+          <MessageBarBody>{areasError}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {!areasLoading && !areasError && enabledAreas.length === 0 && (
+        <MessageBar intent="info" style={{ marginTop: '16px' }}>
+          <MessageBarBody>
+            No reports are available yet because no data imports are enabled. Enable one or more imports (Copilot, usage
+            reports, SharePoint activity, website traffic, Teams calls or emails) in the installer to see reports here.
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      {!areasLoading && enabledAreas.length > 0 && selectedArea && (
+        <>
+          {enabledAreas.length > 1 && (
+            <div className={styles.subTabs}>
+              <TabList selectedValue={selectedArea} onTabSelect={onTabSelect}>
+                {enabledAreas.map((a) => (
+                  <Tab key={a.key} value={a.key}>
+                    {a.label}
+                  </Tab>
+                ))}
+              </TabList>
+            </div>
+          )}
+
+          <ReportAreaView
+            key={selectedArea}
+            area={selectedArea}
+            months={months}
+            blurb={enabledAreas.find((a) => a.key === selectedArea)?.blurb ?? ''}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Fetches and renders the charts for a single report area over the chosen window. */
+function ReportAreaView({ area, months, blurb }: { area: ReportAreaKey; months: number; blurb: string }) {
+  const styles = useStyles();
+
+  const [data, setData] = useState<ReportAreaData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchReportArea(area, months)
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load the report.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [area, months, reloadKey]);
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: 'center', padding: '32px' }}>
+        <Spinner size={64} label="Loading charts..." />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <MessageBar intent="error" style={{ marginTop: '16px' }}>
+        <MessageBarBody>{error}</MessageBarBody>
+      </MessageBar>
+    );
+  }
+
+  if (!data) return null;
+
+  const fromLabel = new Date(data.fromWeek).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  return (
+    <div className={styles.cards}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap' }}>
+        <Text size={200} className={styles.muted}>
+          {blurb} Weeks from {fromLabel} to now.
+        </Text>
+        <Button
+          appearance="subtle"
+          size="small"
+          icon={<ArrowClockwise16Regular />}
+          onClick={() => setReloadKey((k) => k + 1)}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {data.charts.map((chart) => (
+        <Card key={chart.key} className={styles.chartCard}>
+          <div className={styles.chartHead}>
+            <div>
+              <Text weight="semibold" size={400}>
+                {chart.title}
+              </Text>
+              <Text size={200} block className={styles.muted}>
+                {chart.description}
+              </Text>
+            </div>
+            <SqlPopover sql={chart.sql} title="SQL behind this chart" />
+          </div>
+
+          <div className={styles.chartBody}>
+            {chart.error ? (
+              <MessageBar intent="warning">
+                <MessageBarBody>Couldn't load this chart: {chart.error}</MessageBarBody>
+              </MessageBar>
+            ) : chart.type === 'timeseries' && chart.series ? (
+              <TimeSeriesChart series={chart.series} valueLabel={chart.valueLabel} />
+            ) : chart.type === 'bar' && chart.categories ? (
+              <CategoryBarChart categories={chart.categories} valueLabel={chart.valueLabel} />
+            ) : (
+              <Text className={styles.muted}>No data for this period.</Text>
+            )}
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
@@ -1,0 +1,61 @@
+// Mirrors Web/Models/ReportsModels.cs (returned by api/Reports).
+
+/** Which report areas are available, based on the enabled imports. */
+export interface ReportAreas {
+  copilot: boolean;
+  usage: boolean;
+  spoAudit: boolean;
+  webTraffic: boolean;
+  calls: boolean;
+  emails: boolean;
+}
+
+/** One point of a weekly series: the (Monday) week start (ISO date) and its value. */
+export interface ReportTimePoint {
+  weekStart: string;
+  value: number;
+}
+
+/** A named line in a time-series chart. */
+export interface ReportSeries {
+  name: string;
+  points: ReportTimePoint[];
+}
+
+/** One bar of a categorical chart. */
+export interface ReportCategory {
+  label: string;
+  value: number;
+}
+
+export type ReportChartType = 'timeseries' | 'bar';
+
+/** A single chart: a weekly `timeseries` (series set) or a `bar` chart (categories set). */
+export interface ReportChart {
+  key: string;
+  title: string;
+  description: string;
+  type: ReportChartType;
+  valueLabel: string;
+  series: ReportSeries[] | null;
+  categories: ReportCategory[] | null;
+  sql: string;
+  error: string | null;
+}
+
+/** The set of charts for one report area over the requested window. */
+export interface ReportAreaData {
+  area: string;
+  months: number;
+  fromWeek: string;
+  charts: ReportChart[];
+}
+
+/** A report area key, as used in the api/Reports/{area} route. */
+export type ReportAreaKey =
+  | 'copilot'
+  | 'usage'
+  | 'spo-audit'
+  | 'web-traffic'
+  | 'calls'
+  | 'emails';

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -184,6 +184,7 @@
     <Compile Include="Controllers\ImportConfigController.cs" />
     <Compile Include="Controllers\InstallLogAPIController.cs" />
     <Compile Include="Controllers\ProfilingStatusAPIController.cs" />
+    <Compile Include="Controllers\ReportsAPIController.cs" />
     <Compile Include="Controllers\CallRecordWebhookController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\SiteTokenAPIController.cs" />
@@ -197,6 +198,7 @@
     <Compile Include="Models\AuthTeamRequest.cs" />
     <Compile Include="Models\InstallLogModels.cs" />
     <Compile Include="Models\ProfilingStatusModels.cs" />
+    <Compile Include="Models\ReportsModels.cs" />
     <Compile Include="Models\SystemStatus.cs" />
     <Compile Include="Models\Health\HealthModels.cs" />
     <Compile Include="Models\Health\HealthService.cs" />


### PR DESCRIPTION
## What this adds

A new **Reports** tab in the admin web app — a lightweight, in-app version of the Power BI reports that needs **no extra deployment**. It gives operators a quick view of how Microsoft 365 usage is trending, right inside the admin site.

Each **report area only appears when its data import is enabled**, so you never see an empty section for data you aren't collecting:

| Sub-tab | Shown when this import is on | Charts |
| --- | --- | --- |
| Copilot | Copilot | Interactions/week, active users/week, top apps |
| Microsoft 365 usage | Graph usage reports | Weekly active users per workload (Teams, Outlook, OneDrive, SharePoint, Viva Engage) |
| SharePoint & OneDrive | SharePoint activity (audit) | File operations/week, activity by operation type |
| Website traffic | Website traffic tracker | Page views/week, unique visitors/week |
| Teams calls | Teams calls | Calls/week, call minutes/week |
| Emails | Sent emails | Emails sent/week |

The reporting window is **configurable** (last 1 / 3 / 6 months, default 3 months), and every series is grouped by week. Each chart has a "SQL" popover so an admin can see and re-run the exact query behind it, matching the other admin pages.

## How it works

- **Backend:** a new `[Authorize]` `api/Reports` controller. `api/Reports/areas` returns which areas are enabled (from the import settings); the per-area endpoints return the weekly chart data. Queries hit the **base tables directly** (no `vw*` views), and bucket to Monday-start weeks.
- **Safe on large tenants:** each chart runs on its own short-timeout database context, in parallel, and **degrades to a per-chart "couldn't load" message rather than failing the whole page**, with a brief cache — the same pattern the Profiling page already uses. The heavy tables (`hits`, `audit_events`, usage logs) have no dedicated date index, so on a very large tenant an individual chart may occasionally time out and show that message instead of hanging the request.
- **Frontend:** dependency-free **SVG charts** (a multi-series line chart with hover tooltips, and a horizontal bar chart) so the SPA stays small and there's nothing new to ship.

## Validation

- Admin SPA build (`tsc --noEmit && vite build`) ✅
- `Web` project build (MSBuild) ✅
- Reviewed for correctness; fixed two issues found in review:
  - Weekly bucketing now aligns to **Monday** (SQL Server's `DATEDIFF(WEEK, ...)` splits weeks on Sunday) — verified against SQL Server that every weekday maps to the correct Monday.
  - Week labels are formatted in **UTC** so a Monday always renders as a Monday regardless of the viewer's timezone.

Part of milestone **In-app Lite Reports**.

