### PR TITLE
Profiling: contributor doc + expanded test coverage

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/PROFILING.md
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/PROFILING.md
@@ -1,0 +1,210 @@
+# The SQL `profiling` subsystem — contributor guide
+
+> Audience: engineers working on the AnalyticsEngine solution.
+> Scope: what the `profiling.*` SQL schema is, how it is installed and run, and what
+> every object does. This is a *how-it-works* primer, not an admin/operator guide.
+
+Everything described here lives in **one file**:
+`App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql` (plus the two
+Ola-Hallengren maintenance scripts `Profiling-01-CommandExecute.sql` and
+`Profiling-02-IndexOptimize.sql`, which create `dbo.CommandExecute` / `dbo.IndexOptimize`).
+
+---
+
+## 1. What it is (in one paragraph)
+
+The product imports **raw per-user, per-day Microsoft 365 activity/usage** from the Graph
+usage reports and Copilot audit into `dbo.*_user_activity_log` tables (written by EF, see
+§4). The `profiling` schema is a **weekly roll-up layer** on top of that raw data: a set of
+stored procedures aggregate each ISO week (Mon–Sun) into three wide "weekly" tables that
+downstream **business-intelligence dashboards** (Power BI, external to this repo) read. It is
+a classic ELT batch: raw daily rows in → weekly aggregates out.
+
+It is deliberately **decoupled** from the importer: it is plain T-SQL, installed as a
+schema extension, and driven on a schedule by **Azure Automation runbooks**, not by the WebJob.
+
+---
+
+## 2. How it is installed
+
+- The installer runs **every `*.sql` in `SqlExtentions/`** (they are embedded resources) as
+  part of the database upgrade, **after** the EF Code-First migrations, in **alphabetical
+  order** — so `Profiling-01` → `02` → `03`. See `SqlExtentions/readme.md` and
+  `App.ControlPanel.Engine/DatabaseUpgrader.cs` (`CheckDbUpgraded`, custom-SQL step).
+- The scripts are **idempotent**: each object is guarded with `IF OBJECT_ID(...) IS NULL`
+  (create-if-absent for tables) or `DROP ... ; CREATE ...` (procs/views/functions), and
+  columns are added with `IF NOT EXISTS (... sys.columns ...)` `ALTER TABLE ADD`. You can
+  re-run the whole file safely on an existing database.
+- `usp_...` procedures cannot contain `GO`; the installer splits a file on `GO` and executes
+  each batch separately (a hack — see the readme). Keep `GO` only as batch separators.
+
+### Legacy cleanup block (lines ~119–181)
+The top of `Profiling-03` **drops** objects from earlier versions of this subsystem that no
+longer exist: `usp_CompileDaily`, `usp_Version`, `udf_GetLimitDate`, `tvf_ActivitiesBetweenDates`,
+`tvf_DuplicatedUsers`, `tvf_Version`, `usp_CompileWeek/Columns/Rows`, and the old
+`profiling.Activities` / `profiling.ActivitiesDaily` tables. If you see these names referenced
+anywhere, they are **historical** — the current pipeline does not use them.
+
+---
+
+## 3. How it is run (orchestration)
+
+Three PowerShell **Azure Automation runbooks** live in
+`WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/`. The installer
+(`ProfilingScriptsLocateTask` → `RunbookUploadTask`) uploads their bodies straight into the
+customer's Automation account as runbook drafts (it deliberately avoids a storage account so
+it works with public network access disabled).
+
+| Runbook | What it does | Key call |
+|---|---|---|
+| **`Weekly.ps1`** | The actual aggregation. Opens SQL, `EXEC [profiling].[usp_CompileWeekly] @WeeksToKeep`, 3-hour command timeout. Non-zero return ⇒ `Write-Error`. | `usp_CompileWeekly` |
+| **`Aggregation_Status.ps1`** | Monitoring only. Prints `profiling.*` + `*_activity_log` table row counts and the MIN/MAX dates of the three weekly tables. | 4 `SELECT`s |
+| **`Database_Maintenance.ps1`** | Index/stats maintenance via Ola Hallengren `dbo.IndexOptimize`, scoped to `%.profiling.%` (weekly) or `%.dbo.%_activity_log.%` (activitylog). | `dbo.IndexOptimize` |
+
+`@WeeksToKeep` and the SQL connection come from Automation variables/credentials.
+
+---
+
+## 4. Data flow
+
+```mermaid
+flowchart LR
+  subgraph Graph/Audit import (C#, EF)
+    A[Graph usage reports<br/>Copilot audit] -->|AbstractDailyActivityLoader<br/>DbSet.Add / SaveChangesAsync| B
+  end
+  subgraph dbo (raw, per user per day)
+    B[teams/onedrive/outlook/sharepoint/yammer_user_activity_log<br/>teams_user_device_usage_log, platform_user_activity_log,<br/>yammer_device_activity_log, copilot_chats + audit_events]
+  end
+  subgraph profiling (weekly roll-up, this subsystem)
+    B --> C[usp_CompileWeekly<br/>(Azure Automation, weekly)]
+    C --> D[usp_CompileActivityWeek]
+    C --> E[usp_CompileUsageWeek]
+    D -->|usp_Upsert* → #ActivitiesStaging| F[ActivitiesWeekly &#40;long&#41;<br/>ActivitiesWeeklyColumns &#40;wide&#41;]
+    E -->|usp_Upsert*Devices/M365Apps → #UsageStaging| G[UsageWeekly &#40;wide, BIT flags&#41;]
+  end
+  F --> H[External Power BI dashboards]
+  G --> H
+  F -. freshness only .-> I[ProfilingStatusAPIController<br/>Aggregation_Status.ps1]
+  G -. freshness only .-> I
+```
+
+**Important:** the raw `dbo.*_user_activity_log` tables are written by **EF**
+(`WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/*` →
+`AbstractDailyActivityLoader`), **not** by the `usp_Upsert*` procs. The `usp_Upsert*` procs
+read those tables; they are internal helpers of the compile pipeline.
+
+**Consumers:** nothing in *this repo* reads the aggregated values — only freshness
+(MIN/MAX date, row counts) is read by `ProfilingStatusAPIController` (the SPA "Profiling" tab)
+and `Aggregation_Status.ps1`. The metric data itself is consumed by **external BI**.
+
+---
+
+## 5. Object reference
+
+### Output tables (the product of the subsystem)
+
+| Table | Shape | Grain / PK | Notes |
+|---|---|---|---|
+| `profiling.ActivitiesWeekly` | **long / EAV** | `(user_id, MetricDate, Metric)` | One row per user × week × metric, `Sum INT`. `Metric VARCHAR(250)`. Indexed on `MetricDate`. |
+| `profiling.ActivitiesWeeklyColumns` | **wide** | `(user_id, date)` | ~70 `BIGINT` metric columns (OneDrive/Email/SPO/Teams/Yammer/**Copilot** + per-Copilot-app). Same data as `ActivitiesWeekly`, pivoted. Grown over time via `ALTER TABLE ADD` blocks. |
+| `profiling.UsageWeekly` | **wide, boolean** | `(user_id, date)` | ~50 `BIT` "did user use platform X this week" flags (Teams device, Office app×OS, Yammer device) + `Yammer Platform Count TINYINT`. |
+
+`ActivitiesWeekly` and `ActivitiesWeeklyColumns` are two representations of the **same** data
+(long vs wide); `UsageWeekly` is a separate boolean "platforms used" fact.
+
+### Views
+- `profiling.users` — the users "worth reporting on": enabled, has an Azure AD id, joined to
+  their license count. Wraps `dbo.users` + `dbo.user_license_type_lookups`.
+- `profiling.user_PostalCodes` — `DISTINCT postalcode` from `profiling.users`.
+
+### Support objects
+- `profiling.TraceLogs` (`Id, Datetime, Message`) + `profiling.usp_Trace(@Message, @p1..@p5)` —
+  the pipeline's own log. `usp_Trace` uses `FORMATMESSAGE` and inserts one row. This is the
+  **only** place compile progress/errors surface (see §6, error handling).
+- `profiling.udf_GetMonday(@date)` — returns the Monday of `@date`'s week (week bucketing).
+- `ut_*` **table types** (9) — schemas for the local table variables used inside `usp_Upsert*`
+  (e.g. `ut_teams_user_activity_log`, `ut_copilot_activities`). Only used internally.
+
+### Stored procedures
+
+**Orchestrator**
+- `usp_CompileWeekly(@WeeksToKeep, @All = 0)` — the entry point (called by `Weekly.ps1`):
+  1. `@ThisWeeksMonday` = Monday of `GETDATE() - 4 days` (the 4 days allow for M365 report
+     latency; the current partial week is never compiled).
+  2. `@RetentionDate` = `@ThisWeeksMonday - @WeeksToKeep` weeks.
+  3. Resume point `@LastDateInTables` = **MIN** of `MAX(date)` across the three weekly tables
+     (so a lagging table pulls the whole run back to re-fill it). `NULL` (or `@All=1`) ⇒ start
+     at `@RetentionDate`.
+  4. `WHILE @ThisWeeksMonday > @Monday`: `usp_CompileActivityWeek @Monday` then
+     `usp_CompileUsageWeek @Monday`, stepping forward 7 days.
+  5. **Retention**: `DELETE` rows older than `@RetentionDate` from all three tables.
+
+**Per-week compilers**
+- `usp_CompileActivityWeek(@Monday)` — builds a temp `#ActivitiesStaging`, calls the six
+  activity upserts (`usp_UpsertTeams/OneDrive/SharePoint/Outlook/Yammer/Copilot`, each
+  `@Monday..@Sunday`), then `usp_CompileWeekActivityColumns` and/or `usp_CompileWeekActivityRows`.
+  Guarded by `@ColumnsDone`/`@RowsDone` row-existence checks so each target is filled at most once.
+- `usp_CompileUsageWeek(@Monday)` — builds `#UsageStaging`, calls the three device/app upserts
+  (`usp_UpsertTeamsDevices/M365Apps/YammerDevices`), inserts into `UsageWeekly`. Guarded by a
+  `@ColumnsDone` check.
+- `usp_CompileWeekActivityColumns(@Monday)` — `INSERT ... SELECT` `#ActivitiesStaging` →
+  `ActivitiesWeeklyColumns` (wide → wide).
+- `usp_CompileWeekActivityRows(@Monday)` — `UNPIVOT`s `#ActivitiesStaging`'s ~58 metric columns
+  into `ActivitiesWeekly` (wide → long), `GROUP BY user_id, Metric`.
+
+**Upserts (staging populators)** — pattern: aggregate the source `dbo.*_activity_log` for
+`@StartDate..@EndDate` (`SUM ... GROUP BY user_id`) into a local `ut_*` table variable, then
+`UPDATE` matching rows in the staging temp table and `INSERT` the rest.
+- Activity: `usp_UpsertTeams`, `usp_UpsertOneDrive`, `usp_UpsertSharePoint`, `usp_UpsertOutlook`,
+  `usp_UpsertYammer`, `usp_UpsertCopilot`.
+- Usage: `usp_UpsertTeamsDevices`, `usp_UpsertM365Apps`, `usp_UpsertYammerDevices`.
+
+`usp_UpsertCopilot` is the most complex: it `PIVOT`s `dbo.copilot_chats` (joined to
+`dbo.audit_events` for the timestamp) by `app_host` into per-app counts, folds
+`bizchat + M365App → copilot_m365app` and `appchat + Office → copilot_office`, and separately
+counts chats/files/meetings via `dbo.copilot_event_files` / `dbo.copilot_event_meetings`.
+
+---
+
+## 6. Behaviours a contributor must know
+
+- **Week = Monday.** All bucketing is ISO-week via `udf_GetMonday`. Dates stored are the Monday.
+- **4-day latency.** `usp_CompileWeekly` never compiles the current week; it stops at the Monday
+  of `today-4`.
+- **Insert-once, resume-forward.** A week is compiled only if its target table has **no** rows
+  for that Monday. `usp_CompileWeekly` resumes from the least-advanced table. There is **no
+  update path** — once a week is written it is never recompiled (see critique).
+- **Retention** is enforced every run by the `DELETE`s at the end of `usp_CompileWeekly`
+  (`@WeeksToKeep` weeks kept).
+- **Error handling = trace-and-continue.** Every compile proc wraps its body in
+  `BEGIN TRY ... BEGIN CATCH` that writes `ERROR_MESSAGE()` to `profiling.TraceLogs` and
+  **does not re-raise**. So a failed week is logged but the run still returns success. The
+  Profiling tab / `TraceLogs` are the only place failures show up.
+- **Idempotent installer, idempotent compile** (via the row-existence guards). Re-running is safe.
+
+---
+
+## 7. How to run / test / observe
+
+- **Run** (prod): the `Weekly` Automation runbook (or `EXEC profiling.usp_CompileWeekly @WeeksToKeep = 53`).
+- **Test**: `Tests.UnitTests/ProfilingStoredProcedureTests.cs` seeds raw rows then calls
+  `profiling.usp_CompileActivityWeek @monday` and asserts on the weekly tables (needs LocalDB).
+- **Observe**:
+  - SPA **Profiling tab** → `GET api/ProfilingStatus` (per-table MIN/MAX date, source freshness)
+    and `GET api/ProfilingStatus/tracelogs` (paged `TraceLogs`, newest first).
+  - `Aggregation_Status.ps1` for table sizes + date coverage.
+
+---
+
+## 8. Gotchas when changing it
+
+- **Adding a metric column touches ~6 places consistently**: the `ALTER TABLE ADD` on
+  `ActivitiesWeeklyColumns`, the `#ActivitiesStaging` temp definition, the owning `usp_Upsert*`
+  (`ut_*` type + `INSERT`/`UPDATE` lists), the `usp_CompileWeekActivityColumns` insert+select
+  lists, and the `usp_CompileWeekActivityRows` `UNPIVOT` list. Miss one and you get a silent
+  gap or a swallowed error. There is no single source of truth for the column set.
+- **New Copilot `app_host` values** must be added to the `PIVOT` list in `usp_UpsertCopilot`
+  *and* the corresponding column plumbing above — unmapped hosts are silently dropped.
+- Keep everything `nvarchar`-safe and don't reintroduce `GO` inside a procedure body.
+- The `usp_Upsert*` procs reference the caller's temp table (`#ActivitiesStaging` /
+  `#UsageStaging`) by name — they only work when executed inside the matching `usp_Compile*Week`.

--- a/src/AnalyticsEngine/Tests.UnitTests/ProfilingStoredProcedureTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ProfilingStoredProcedureTests.cs
@@ -76,6 +76,9 @@ namespace Tests.UnitTests
                             DELETE FROM dbo.sharepoint_user_activity_log WHERE user_id IN ({userIdList});
                             DELETE FROM dbo.outlook_user_activity_log WHERE user_id IN ({userIdList});
                             DELETE FROM dbo.yammer_user_activity_log WHERE user_id IN ({userIdList});
+                            DELETE FROM dbo.teams_user_device_usage_log WHERE user_id IN ({userIdList});
+                            DELETE FROM dbo.platform_user_activity_log WHERE user_id IN ({userIdList});
+                            DELETE FROM dbo.yammer_device_activity_log WHERE user_id IN ({userIdList});
                             
                             -- Clean up copilot data
                             DELETE FROM dbo.copilot_chats 
@@ -87,6 +90,7 @@ namespace Tests.UnitTests
                             -- Clean up profiling tables
                             DELETE FROM profiling.ActivitiesWeekly WHERE user_id IN ({userIdList});
                             DELETE FROM profiling.ActivitiesWeeklyColumns WHERE user_id IN ({userIdList});
+                            DELETE FROM profiling.UsageWeekly WHERE user_id IN ({userIdList});
                             
                             -- Finally, remove the test users
                             DELETE FROM dbo.users WHERE id IN ({userIdList});";
@@ -371,6 +375,191 @@ namespace Tests.UnitTests
                 // Verify data for all users
                 var columnCount = await GetActivitiesWeeklyColumnsCount(db, monday);
                 Assert.AreEqual(3, columnCount, "Should have aggregated data for 3 users");
+            }
+        }
+
+        // =====================================================================
+        // Value-correctness tests. The tests above only assert that rows exist
+        // and that a metric NAME is present - but usp_CompileWeekActivityRows
+        // UNPIVOTs every column (including zeros), so every metric name is
+        // always present regardless of the data. These assert the actual
+        // aggregated numbers so a wrong SUM / date filter / column mapping fails.
+        // =====================================================================
+
+        [TestMethod]
+        public async Task UspCompileActivityWeek_TeamsData_ComputesExactWeeklySums()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var monday = TEST_MONDAY.AddDays(63);
+                var sunday = monday.AddDays(6);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupTestData(db, monday);
+                // Seeds 5,3,2,1,1,0,...,600,300,120,4,6,1 per day, for 7 days.
+                await InsertTeamsActivityTestData(db, TEST_USER_ID, monday, sunday);
+
+                await ExecuteStoredProcedure(db, "profiling.usp_CompileActivityWeek", monday);
+
+                // Long form (ActivitiesWeekly): value x 7 days.
+                Assert.AreEqual(35, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Teams Private Chats"));
+                Assert.AreEqual(21, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Teams Team Chats"));
+                Assert.AreEqual(14, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Teams Calls"));
+                Assert.AreEqual(4200, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Teams Audio Duration Seconds"));
+
+                // Wide form (ActivitiesWeeklyColumns) must equal the long form for the same metric.
+                Assert.AreEqual(35, await GetActivityColumnValue(db, monday, TEST_USER_ID, "Teams Private Chats"));
+                Assert.AreEqual(42, await GetActivityColumnValue(db, monday, TEST_USER_ID, "Teams Reply Messages"));
+            }
+        }
+
+        [TestMethod]
+        public async Task UspCompileActivityWeek_OtherWorkloads_ComputeExactWeeklySums()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var monday = TEST_MONDAY.AddDays(70);
+                var sunday = monday.AddDays(6);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupTestData(db, monday);
+                await InsertOneDriveActivityTestData(db, TEST_USER_ID, monday, sunday);   // 10,5,2,1
+                await InsertSharePointActivityTestData(db, TEST_USER_ID, monday, sunday);  // 15,8,3,2
+                await InsertOutlookActivityTestData(db, TEST_USER_ID, monday, sunday);     // 20,50,40,2,3
+                await InsertYammerActivityTestData(db, TEST_USER_ID, monday, sunday);      // 3,10,5
+
+                await ExecuteStoredProcedure(db, "profiling.usp_CompileActivityWeek", monday);
+
+                Assert.AreEqual(70, await GetActivityMetricSum(db, monday, TEST_USER_ID, "OneDrive Viewed/Edited"));
+                Assert.AreEqual(35, await GetActivityMetricSum(db, monday, TEST_USER_ID, "OneDrive Synced"));
+                Assert.AreEqual(105, await GetActivityMetricSum(db, monday, TEST_USER_ID, "SPO Viewed/Edited"));
+                Assert.AreEqual(140, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Emails Sent"));
+                Assert.AreEqual(350, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Emails Received"));
+                Assert.AreEqual(280, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Emails Read"));
+                Assert.AreEqual(21, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Yammer Posted"));
+                Assert.AreEqual(70, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Yammer Read"));
+            }
+        }
+
+        [TestMethod]
+        public async Task UspCompileActivityWeek_ExcludesActivityOutsideTheWeek()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var monday = TEST_MONDAY.AddDays(77);
+                var sunday = monday.AddDays(6);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupTestData(db, monday);
+                await CleanupTestData(db, monday.AddDays(7));
+
+                await InsertTeamsActivityTestData(db, TEST_USER_ID, monday, sunday);            // 7 in-week days
+                // One extra day in the FOLLOWING week - must NOT be counted in this week's compile.
+                await InsertTeamsActivityTestData(db, TEST_USER_ID, monday.AddDays(7), monday.AddDays(7));
+
+                await ExecuteStoredProcedure(db, "profiling.usp_CompileActivityWeek", monday);
+
+                // 5 private chats x 7 in-week days = 35 (NOT 40).
+                Assert.AreEqual(35, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Teams Private Chats"),
+                    "Activity dated outside the Mon-Sun window must be excluded from the week");
+
+                await CleanupTestData(db, monday.AddDays(7));
+            }
+        }
+
+        [TestMethod]
+        public async Task UspCompileActivityWeek_CopilotAppHosts_AreMappedAndFolded()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var monday = TEST_MONDAY.AddDays(84);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupTestData(db, monday);
+
+                // 2 Word, 1 Excel, and the two fold-pairs:
+                //   bizchat + M365App -> "Copilot App M365App";  appchat + Office -> "Copilot App Office".
+                await InsertCopilotChat(db, TEST_USER_ID, monday, "Word");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(1), "Word");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(1), "Excel");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(2), "bizchat");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(2), "M365App");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(3), "appchat");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(3), "Office");
+
+                await ExecuteStoredProcedure(db, "profiling.usp_CompileActivityWeek", monday);
+
+                Assert.AreEqual(7, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot Chats"), "Total Copilot chats");
+                Assert.AreEqual(2, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot App Word"));
+                Assert.AreEqual(1, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot App Excel"));
+                Assert.AreEqual(2, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot App M365App"), "bizchat + M365App fold together");
+                Assert.AreEqual(2, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot App Office"), "appchat + Office fold together");
+                // No files/meetings were seeded.
+                Assert.AreEqual(0, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot Files"));
+                Assert.AreEqual(0, await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot Meetings"));
+            }
+        }
+
+        // ---- usp_CompileUsageWeek / UsageWeekly - previously untested entirely ----
+
+        [TestMethod]
+        public async Task UspCompileUsageWeek_TeamsDeviceUsage_SetsWeeklyFlags()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var monday = TEST_MONDAY.AddDays(91);
+                var sunday = monday.AddDays(6);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupUsageTestData(db, monday);
+                // Each day: used_web=1, used_windows=1, used_ios=1 (mac/others 0).
+                await InsertTeamsDeviceUsageTestData(db, TEST_USER_ID, monday, sunday);
+
+                await ExecuteStoredProcedure(db, "profiling.usp_CompileUsageWeek", monday);
+
+                Assert.AreEqual(1, await GetUsageFlag(db, monday, TEST_USER_ID, "Teams Used Web"));
+                Assert.AreEqual(1, await GetUsageFlag(db, monday, TEST_USER_ID, "Teams Used Windows"));
+                Assert.AreEqual(1, await GetUsageFlag(db, monday, TEST_USER_ID, "Teams Used iOS"));
+                // "Teams Used Mobile" = win_phone OR ios OR android -> 1 because ios was used.
+                Assert.AreEqual(1, await GetUsageFlag(db, monday, TEST_USER_ID, "Teams Used Mobile"));
+                // Not used this week.
+                Assert.AreEqual(0, await GetUsageFlag(db, monday, TEST_USER_ID, "Teams Used Mac"));
+                Assert.AreEqual(0, await GetUsageFlag(db, monday, TEST_USER_ID, "Teams Used Android"));
+
+                await CleanupUsageTestData(db, monday);
+            }
+        }
+
+        // ---- usp_CompileWeekly orchestrator - retention / cleanup, previously untested ----
+
+        [TestMethod]
+        public async Task UspCompileWeekly_DeletesWeeksOlderThanRetention()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                // usp_CompileWeekly bases everything on the Monday of (today - 4 days).
+                var thisWeeksMonday = MondayOf(DateTime.Today.AddDays(-4));
+                var recentMonday = thisWeeksMonday.AddDays(-7);        // last completed week - inside retention
+                var oldMonday = thisWeeksMonday.AddDays(-7 * 20);      // 20 weeks back - outside a 4-week window
+                const int weeksToKeep = 4;
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupWeeklyRows(db, TEST_USER_ID);
+
+                // Seed a recent and an old week directly into all three weekly tables. Seeding the
+                // recent week into all three makes usp_CompileWeekly's resume point = recentMonday,
+                // so its compile loop does no work and we test the retention DELETE in isolation.
+                await SeedWeeklyRows(db, TEST_USER_ID, recentMonday);
+                await SeedWeeklyRows(db, TEST_USER_ID, oldMonday);
+
+                await ExecuteSql(db, $"EXEC profiling.usp_CompileWeekly @WeeksToKeep = {weeksToKeep}");
+
+                Assert.AreEqual(0, await CountWeeklyRows(db, TEST_USER_ID, oldMonday),
+                    "Weeks older than the retention window must be deleted");
+                Assert.IsTrue(await CountWeeklyRows(db, TEST_USER_ID, recentMonday) > 0,
+                    "Weeks inside the retention window must be kept");
+
+                await CleanupWeeklyRows(db, TEST_USER_ID);
             }
         }
 
@@ -677,6 +866,113 @@ namespace Tests.UnitTests
                     conn.Close();
                 }
             }
+        }
+
+        private async Task<long> GetActivityMetricSum(AnalyticsEntitiesContext db, DateTime monday, int userId, string metric)
+        {
+            return await ExecuteScalar<long>(db, $@"
+                SELECT ISNULL(SUM([Sum]), 0)
+                FROM profiling.ActivitiesWeekly
+                WHERE MetricDate = '{monday:yyyy-MM-dd}' AND user_id = {userId} AND Metric = '{metric}'");
+        }
+
+        private async Task<long> GetActivityColumnValue(AnalyticsEntitiesContext db, DateTime monday, int userId, string column)
+        {
+            return await ExecuteScalar<long>(db, $@"
+                SELECT ISNULL([{column}], 0)
+                FROM profiling.ActivitiesWeeklyColumns
+                WHERE date = '{monday:yyyy-MM-dd}' AND user_id = {userId}");
+        }
+
+        private async Task<int> GetUsageFlag(AnalyticsEntitiesContext db, DateTime monday, int userId, string column)
+        {
+            return await ExecuteScalar<int>(db, $@"
+                SELECT ISNULL(CAST([{column}] AS INT), 0)
+                FROM profiling.UsageWeekly
+                WHERE date = '{monday:yyyy-MM-dd}' AND user_id = {userId}");
+        }
+
+        private async Task InsertCopilotChat(AnalyticsEntitiesContext db, int userId, DateTime date, string appHost)
+        {
+            var eventId = await ExecuteScalar<Guid>(db, $@"
+                INSERT INTO dbo.audit_events (id, user_id, time_stamp, operation_id)
+                OUTPUT INSERTED.id
+                VALUES (NEWID(), {userId}, '{date:yyyy-MM-dd HH:mm:ss}', 1)");
+
+            await ExecuteSql(db, $@"
+                INSERT INTO dbo.copilot_chats (event_id, app_host)
+                VALUES ('{eventId}', '{appHost}')");
+        }
+
+        private async Task InsertTeamsDeviceUsageTestData(AnalyticsEntitiesContext db, int userId, DateTime startDate, DateTime endDate)
+        {
+            for (var date = startDate; date <= endDate; date = date.AddDays(1))
+            {
+                await ExecuteSql(db, $@"
+                    INSERT INTO dbo.teams_user_device_usage_log
+                    (user_id, date, used_web, used_mac, used_windows, used_linux, used_chrome_os,
+                     used_win_phone, used_ios, used_android)
+                    VALUES
+                    ({userId}, '{date:yyyy-MM-dd}', 1, 0, 1, 0, 0, 0, 1, 0)");
+            }
+        }
+
+        private async Task CleanupUsageTestData(AnalyticsEntitiesContext db, DateTime monday)
+        {
+            var sunday = monday.AddDays(6);
+            var userIdList = string.Join(",", new[] { TEST_USER_ID, TEST_USER_ID + 1, TEST_USER_ID + 2, TEST_USER_ID + 3 });
+
+            await ExecuteSql(db, $@"
+                DELETE FROM dbo.teams_user_device_usage_log
+                WHERE user_id IN ({userIdList}) AND date >= '{monday:yyyy-MM-dd}' AND date <= '{sunday:yyyy-MM-dd}'");
+            await ExecuteSql(db, $@"
+                DELETE FROM dbo.platform_user_activity_log
+                WHERE user_id IN ({userIdList}) AND date >= '{monday:yyyy-MM-dd}' AND date <= '{sunday:yyyy-MM-dd}'");
+            await ExecuteSql(db, $@"
+                DELETE FROM dbo.yammer_device_activity_log
+                WHERE user_id IN ({userIdList}) AND date >= '{monday:yyyy-MM-dd}' AND date <= '{sunday:yyyy-MM-dd}'");
+            await ExecuteSql(db, $@"
+                DELETE FROM profiling.UsageWeekly
+                WHERE date = '{monday:yyyy-MM-dd}' AND user_id IN ({userIdList})");
+        }
+
+        /// <summary>Monday (on or before) of the given date's week - mirrors profiling.udf_GetMonday.</summary>
+        private static DateTime MondayOf(DateTime d)
+        {
+            var daysSinceMonday = ((int)d.DayOfWeek + 6) % 7;
+            return d.Date.AddDays(-daysSinceMonday);
+        }
+
+        /// <summary>Seeds one row per weekly table (Activities long + columns + Usage) for a given week.</summary>
+        private async Task SeedWeeklyRows(AnalyticsEntitiesContext db, int userId, DateTime monday)
+        {
+            await ExecuteSql(db, $@"
+                INSERT INTO profiling.ActivitiesWeekly (user_id, MetricDate, Metric, [Sum])
+                VALUES ({userId}, '{monday:yyyy-MM-dd}', 'Teams Calls', 1)");
+            await ExecuteSql(db, $@"
+                INSERT INTO profiling.ActivitiesWeeklyColumns (user_id, date)
+                VALUES ({userId}, '{monday:yyyy-MM-dd}')");
+            await ExecuteSql(db, $@"
+                INSERT INTO profiling.UsageWeekly (user_id, date)
+                VALUES ({userId}, '{monday:yyyy-MM-dd}')");
+        }
+
+        /// <summary>Total rows for a user/week across the three weekly tables.</summary>
+        private async Task<int> CountWeeklyRows(AnalyticsEntitiesContext db, int userId, DateTime monday)
+        {
+            return await ExecuteScalar<int>(db, $@"
+                SELECT
+                    (SELECT COUNT(*) FROM profiling.ActivitiesWeekly WHERE user_id = {userId} AND MetricDate = '{monday:yyyy-MM-dd}')
+                  + (SELECT COUNT(*) FROM profiling.ActivitiesWeeklyColumns WHERE user_id = {userId} AND date = '{monday:yyyy-MM-dd}')
+                  + (SELECT COUNT(*) FROM profiling.UsageWeekly WHERE user_id = {userId} AND date = '{monday:yyyy-MM-dd}')");
+        }
+
+        private async Task CleanupWeeklyRows(AnalyticsEntitiesContext db, int userId)
+        {
+            await ExecuteSql(db, $@"
+                DELETE FROM profiling.ActivitiesWeekly WHERE user_id = {userId};
+                DELETE FROM profiling.ActivitiesWeeklyColumns WHERE user_id = {userId};
+                DELETE FROM profiling.UsageWeekly WHERE user_id = {userId};");
         }
 
         #endregion


### PR DESCRIPTION
## Description

Adds an internal contributor guide for the SQL `profiling` subsystem and materially expands its automated test coverage.

- **`PROFILING.md`** (next to the SQL): install path, Azure Automation runbook orchestration, data-flow diagram, full object reference, key behaviours and change gotchas.
- **`ProfilingStoredProcedureTests.cs`**: the existing tests asserted only that rows exist / a metric *name* is present — but `usp_CompileWeekActivityRows` UNPIVOTs every column including zeros, so every metric name is always present regardless of data (the numbers were never checked). New tests:
  - exact weekly **value** assertions in both `ActivitiesWeekly` (long) and `ActivitiesWeeklyColumns` (wide)
  - Mon–Sun **date-boundary** exclusion
  - Copilot **app-host mapping + folding** (`bizchat+M365App`, `appchat+Office`)
  - first coverage of **`usp_CompileUsageWeek` / `UsageWeekly`**
  - `usp_CompileWeekly` **retention**

Test-only + docs; no product/schema changes. 16/16 profiling tests pass against LocalDB.

## Type of Change
- [x] Documentation update
- [x] Tests