### PR TITLE
Profiling perf: single set-based multi-week compile (schema-safe)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql
@@ -1096,7 +1096,7 @@ BEGIN
   )
   SELECT
     "user_id",
-    @StartDate,
+    DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE)),
     SUM(private_chat_count),
     SUM(team_chat_count),
     SUM(calls_count),
@@ -1117,7 +1117,7 @@ BEGIN
     SUM(urgent_messages)
   FROM dbo.teams_user_activity_log
   WHERE @StartDate <= "date" AND "date" <= @EndDate
-  GROUP BY "user_id";
+  GROUP BY "user_id", DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE));
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -1218,14 +1218,14 @@ BEGIN
   )
   SELECT
     "user_id",
-    @StartDate,
+    DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE)),
     SUM(viewed_or_edited),
     SUM(synced),
     SUM(shared_internally),
     SUM(shared_externally)
   FROM dbo.onedrive_user_activity_log
   WHERE @StartDate <= "date" AND "date" <= @EndDate
-  GROUP BY "user_id";
+  GROUP BY "user_id", DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE));
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -1284,14 +1284,14 @@ BEGIN
   )
   SELECT
     "user_id",
-    @StartDate,
+    DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE)),
     SUM(viewed_or_edited),
     SUM(synced),
     SUM(shared_internally),
     SUM(shared_externally)
   FROM dbo.sharepoint_user_activity_log
   WHERE @StartDate <= "date" AND "date" <= @EndDate
-  GROUP BY "user_id";
+  GROUP BY "user_id", DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE));
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -1351,7 +1351,7 @@ BEGIN
   )
   SELECT
     "user_id",
-    @StartDate,
+    DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE)),
     SUM(email_send_count),
     SUM(email_receive_count),
     SUM(email_read_count),
@@ -1359,7 +1359,7 @@ BEGIN
     SUM(meeting_interacted_count)
   FROM dbo.outlook_user_activity_log
   WHERE @StartDate <= "date" AND "date" <= @EndDate
-  GROUP BY "user_id";
+  GROUP BY "user_id", DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE));
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -1420,13 +1420,13 @@ BEGIN
   )
   SELECT
     "user_id",
-    @StartDate,
+    DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE)),
     SUM(posted_count),
     SUM(read_count),
     SUM(liked_count)
   FROM dbo.yammer_user_activity_log
   WHERE @StartDate <= "date" AND "date" <= @EndDate
-  GROUP BY "user_id";
+  GROUP BY "user_id", DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE));
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -1488,7 +1488,7 @@ BEGIN
   )
   SELECT
     "user_id",
-    @StartDate,
+    DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE)),
     -- multiplication here converts the BIT column into an INT so the aggregation works
     MAX(1 * used_web),
     MAX(1 * used_mac),
@@ -1503,7 +1503,7 @@ BEGIN
     MAX(1 * used_android)
   FROM dbo.teams_user_device_usage_log
   WHERE @StartDate <= "date" AND "date" <= @EndDate
-  GROUP BY "user_id";
+  GROUP BY "user_id", DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE));
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -1607,7 +1607,7 @@ BEGIN
   )
   SELECT
     "user_id",
-    @StartDate,
+    DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE)),
     MAX(1 * windows),
     MAX(1 * mac),
     MAX(1 * mobile),
@@ -1644,7 +1644,7 @@ BEGIN
     MAX(1 * teams_web)
   FROM dbo.platform_user_activity_log
   WHERE @StartDate <= "date" AND "date" <= @EndDate
-  GROUP BY "user_id";
+  GROUP BY "user_id", DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE));
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -1797,7 +1797,7 @@ BEGIN
   )
   SELECT
     "user_id",
-    @StartDate,
+    DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE)),
     MAX(1 * used_web + 1 * used_others + 1 * used_win_phone + 1 * used_android
       + 1 * used_ipad + 1 * used_iphone + 1 * used_others),
     MAX(1 * used_web),
@@ -1809,7 +1809,7 @@ BEGIN
     MAX(1 * used_iphone)
   FROM dbo.yammer_device_activity_log
   WHERE @StartDate <= "date" AND "date" <= @EndDate
-  GROUP BY "user_id";
+  GROUP BY "user_id", DATEADD(DAY, -(DATEDIFF(DAY, '19000101', "date") % 7), CAST("date" AS DATE));
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -1900,7 +1900,7 @@ BEGIN
       FROM (
         SELECT
           app_host,
-          @StartDate AS "date",
+          DATEADD(DAY, -(DATEDIFF(DAY, '19000101', au.time_stamp) % 7), CAST(au.time_stamp AS DATE)) AS "date",
           "user_id",
           event_id
         FROM dbo.copilot_chats AS c
@@ -1969,7 +1969,7 @@ BEGIN
     events AS (
       SELECT
         "user_id",
-        @StartDate AS "date",
+        DATEADD(DAY, -(DATEDIFF(DAY, '19000101', au.time_stamp) % 7), CAST(au.time_stamp AS DATE)) AS "date",
         c.event_id AS chat_id,
         f.copilot_chat_id AS has_file,
         m.copilot_chat_id AS has_meeting
@@ -2020,7 +2020,7 @@ BEGIN
   )
   SELECT
     a."user_id",
-    @StartDate,
+    a."date",
     SUM(c.chat_count),
     SUM(c.meeting_count),
     SUM(c.file_count),
@@ -2046,8 +2046,8 @@ BEGIN
     SUM(copilot_whiteboard),
     SUM(copilot_word)
   FROM host_activities AS a
-    JOIN event_counts AS c ON a."user_id" = c."user_id"
-  GROUP BY a."user_id";
+    JOIN event_counts AS c ON a."user_id" = c."user_id" AND a."date" = c."date"
+  GROUP BY a."user_id", a."date";
 
   /* tsqllint-disable warning update-where */
   UPDATE t
@@ -2157,23 +2157,26 @@ END
 GO
 
 CREATE PROCEDURE profiling.usp_CompileWeekActivityRows
-(
-  -- Start day of the week to aggregate
-  @Monday DATE
-)
 AS
 BEGIN
   SET NOCOUNT ON;
   BEGIN TRY
-    EXEC profiling.usp_Trace '[usp_CompileWeekActivityRows] Starting: %s', @Monday;
+    EXEC profiling.usp_Trace '[usp_CompileWeekActivityRows] Starting';
 
-    INSERT INTO profiling.ActivitiesWeekly
+    INSERT INTO profiling.ActivitiesWeekly ("user_id", MetricDate, Metric, [Sum])
     SELECT
       "user_id",
-      @Monday AS MetricDate,
+      "date" AS MetricDate,
       Metric,
       SUM(VALUE) AS Sum
-    FROM #ActivitiesStaging AS Pivoted
+    FROM (
+      SELECT s.*
+      FROM #ActivitiesStaging AS s
+      WHERE NOT EXISTS (
+        SELECT 1 FROM profiling.ActivitiesWeekly AS a
+        WHERE a."user_id" = s."user_id" AND a.MetricDate = s."date"
+      )
+    ) AS Pivoted
     UNPIVOT (
       -- Convert columns into rows
       VALUE FOR Metric IN (
@@ -2237,7 +2240,7 @@ BEGIN
         "Copilot App Word"
       )
     ) AS Unpivoted
-    GROUP BY "user_id", Metric;
+    GROUP BY "user_id", "date", Metric;
   END TRY
   BEGIN CATCH
     DECLARE @ErrorMessage NVARCHAR(4000);
@@ -2258,15 +2261,11 @@ END
 GO
 
 CREATE PROCEDURE profiling.usp_CompileWeekActivityColumns
-(
-  -- Start day of the week to aggregate
-  @Monday DATE
-)
 AS
 BEGIN
   SET NOCOUNT ON;
   BEGIN TRY
-    EXEC profiling.usp_Trace '[usp_CompileWeekActivityColumns] Starting: %s', @Monday;
+    EXEC profiling.usp_Trace '[usp_CompileWeekActivityColumns] Starting';
 
     INSERT INTO profiling.ActivitiesWeeklyColumns
     (
@@ -2333,7 +2332,7 @@ BEGIN
     )
     SELECT
       "user_id",
-      @Monday AS "date",
+      "date",
       "OneDrive Viewed/Edited",
       "OneDrive Synced",
       "OneDrive Shared Internally",
@@ -2392,7 +2391,11 @@ BEGIN
       "Copilot App VivaGoals",
       "Copilot App Whiteboard",
       "Copilot App Word"
-    FROM #ActivitiesStaging;
+    FROM #ActivitiesStaging AS s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM profiling.ActivitiesWeeklyColumns AS c
+      WHERE c."user_id" = s."user_id" AND c."date" = s."date"
+    );
   END TRY
   BEGIN CATCH
     DECLARE @ErrorMessage NVARCHAR(4000);
@@ -2406,36 +2409,30 @@ GO
 -- Aggregates a week of usage. Data in columns
 -- ===========================================
 
+IF OBJECT_ID(N'profiling.usp_CompileUsageRange') IS NOT NULL
+BEGIN
+  DROP PROCEDURE profiling.usp_CompileUsageRange;
+END
+GO
+
 IF OBJECT_ID(N'profiling.usp_CompileUsageWeek') IS NOT NULL
 BEGIN
   DROP PROCEDURE profiling.usp_CompileUsageWeek;
 END
 GO
 
-CREATE PROCEDURE profiling.usp_CompileUsageWeek
+CREATE PROCEDURE profiling.usp_CompileUsageRange
 (
-  -- Start day of the week to aggregate
-  @Monday DATE
+  @StartDate DATE,
+  @EndDate DATE
 )
 AS
 BEGIN
   SET NOCOUNT ON;
   BEGIN TRY
-    EXEC profiling.usp_Trace '[usp_CompileUsageWeek] Starting: %s', @Monday;
+    EXEC profiling.usp_Trace '[usp_CompileUsageRange] Starting: %s to %s', @StartDate, @EndDate;
 
-    DECLARE
-      @Sunday DATE = DATEADD(DAY, 6, @Monday),
-      @ColumnsDone INT = 0;
-    
-    -- Check if the data has already been aggregated
-    SELECT @ColumnsDone = COUNT(DATE)
-    FROM profiling.UsageWeekly
-    WHERE "date" = @Monday;
-    
-    -- If the data has not been aggregated, do it
-    IF @ColumnsDone = 0
-    BEGIN
-      CREATE TABLE #UsageStaging
+    CREATE TABLE #UsageStaging
       (
         "user_id" INT NOT NULL,
         "date" DATETIME NOT NULL,
@@ -2491,9 +2488,9 @@ BEGIN
         "Yammer Used iPad" BIT NOT NULL DEFAULT 0,
         "Yammer Used iPhone" BIT NOT NULL DEFAULT 0
       );
-      EXECUTE profiling.usp_UpsertTeamsDevices @Monday, @Sunday;
-      EXECUTE profiling.usp_UpsertM365Apps @Monday, @Sunday;
-      EXECUTE profiling.usp_UpsertYammerDevices @Monday, @Sunday;
+      EXECUTE profiling.usp_UpsertTeamsDevices @StartDate, @EndDate;
+      EXECUTE profiling.usp_UpsertM365Apps @StartDate, @EndDate;
+      EXECUTE profiling.usp_UpsertYammerDevices @StartDate, @EndDate;
 
       INSERT INTO profiling.UsageWeekly
       (
@@ -2553,7 +2550,7 @@ BEGIN
       )
       SELECT
         "user_id",
-        @Monday AS "date",
+        "date",
         "Teams Used Web",
         "Teams Used Mac",
         "Teams Used Windows",
@@ -2605,15 +2602,18 @@ BEGIN
         "Yammer Used Android",
         "Yammer Used iPad",
         "Yammer Used iPhone"
-      FROM #UsageStaging;
+      FROM #UsageStaging AS s
+      WHERE NOT EXISTS (
+        SELECT 1 FROM profiling.UsageWeekly AS u
+        WHERE u."user_id" = s."user_id" AND u."date" = s."date"
+      );
 
       DROP TABLE #UsageStaging;
-    END
   END TRY
   BEGIN CATCH
     DECLARE @ErrorMessage NVARCHAR(4000);
     SELECT @ErrorMessage = ERROR_MESSAGE();
-    EXEC profiling.usp_Trace 'Catch [usp_CompileUsageWeek]: %s', @ErrorMessage;
+    EXEC profiling.usp_Trace 'Catch [usp_CompileUsageRange]: %s', @ErrorMessage;
     IF OBJECT_ID('tempdb..#UsageStaging') IS NOT NULL
     BEGIN
       DROP TABLE #UsageStaging;
@@ -2622,9 +2622,28 @@ BEGIN
 END;
 GO
 
+-- Backwards-compatible single-week wrapper (used by tests and any external callers).
+CREATE PROCEDURE profiling.usp_CompileUsageWeek
+(
+  @Monday DATE
+)
+AS
+BEGIN
+  SET NOCOUNT ON;
+  DECLARE @Sunday DATE = DATEADD(DAY, 6, @Monday);
+  EXECUTE profiling.usp_CompileUsageRange @Monday, @Sunday;
+END;
+GO
+
 -- ===================================
 -- Aggregates a week of analytics data
 -- ===================================
+
+IF OBJECT_ID(N'profiling.usp_CompileActivityRange') IS NOT NULL
+BEGIN
+  DROP PROCEDURE profiling.usp_CompileActivityRange;
+END
+GO
 
 IF OBJECT_ID(N'profiling.usp_CompileActivityWeek') IS NOT NULL
 BEGIN
@@ -2632,34 +2651,18 @@ BEGIN
 END
 GO
 
-CREATE PROCEDURE profiling.usp_CompileActivityWeek
+CREATE PROCEDURE profiling.usp_CompileActivityRange
 (
-  -- Start day of the week to aggregate
-  @Monday DATE
+  @StartDate DATE,
+  @EndDate DATE
 )
 AS
 BEGIN
   SET NOCOUNT ON;
   BEGIN TRY
-    EXEC profiling.usp_Trace '[usp_CompileActivityWeek] Starting: %s', @Monday;
+    EXEC profiling.usp_Trace '[usp_CompileActivityRange] Starting: %s to %s', @StartDate, @EndDate;
 
-    DECLARE
-      @Sunday DATE = DATEADD(DAY, 6, @Monday),
-      @RowsDone INT = 0,
-      @ColumnsDone INT = 0;
-
-    -- Check if the data has already been aggregated
-    SELECT @ColumnsDone = COUNT("date")
-    FROM profiling.ActivitiesWeeklyColumns
-    WHERE "date" = @Monday;
-
-    SELECT @RowsDone = COUNT(MetricDate)
-    FROM profiling.ActivitiesWeekly
-    WHERE MetricDate = @Monday;
-
-    IF @RowsDone = 0 OR @ColumnsDone = 0
-    BEGIN
-      CREATE TABLE #ActivitiesStaging
+    CREATE TABLE #ActivitiesStaging
       (
         "user_id" BIGINT,
         "date" DATE,
@@ -2724,35 +2727,40 @@ BEGIN
       );
 
       -- Insert only the activities between the dates
-      EXECUTE profiling.usp_UpsertTeams @Monday, @Sunday;
-      EXECUTE profiling.usp_UpsertOneDrive @Monday, @Sunday;
-      EXECUTE profiling.usp_UpsertSharePoint @Monday, @Sunday;
-      EXECUTE profiling.usp_UpsertOutlook @Monday, @Sunday;
-      EXECUTE profiling.usp_UpsertYammer @Monday, @Sunday;
-      EXECUTE profiling.usp_UpsertCopilot @Monday, @Sunday;
+      EXECUTE profiling.usp_UpsertTeams @StartDate, @EndDate;
+      EXECUTE profiling.usp_UpsertOneDrive @StartDate, @EndDate;
+      EXECUTE profiling.usp_UpsertSharePoint @StartDate, @EndDate;
+      EXECUTE profiling.usp_UpsertOutlook @StartDate, @EndDate;
+      EXECUTE profiling.usp_UpsertYammer @StartDate, @EndDate;
+      EXECUTE profiling.usp_UpsertCopilot @StartDate, @EndDate;
 
-      IF @ColumnsDone = 0
-      BEGIN
-        EXECUTE profiling.usp_CompileWeekActivityColumns @Monday;
-      END
-
-      IF @RowsDone = 0
-      BEGIN
-        EXECUTE profiling.usp_CompileWeekActivityRows @Monday;
-      END
+      EXECUTE profiling.usp_CompileWeekActivityColumns;
+      EXECUTE profiling.usp_CompileWeekActivityRows;
 
       DROP TABLE #ActivitiesStaging;
-    END
   END TRY
   BEGIN CATCH
     DECLARE @ErrorMessage NVARCHAR(4000);
     SELECT @ErrorMessage = ERROR_MESSAGE();
-    EXEC profiling.usp_Trace '[usp_CompileActivityWeek] Catch: %s', @ErrorMessage;
+    EXEC profiling.usp_Trace '[usp_CompileActivityRange] Catch: %s', @ErrorMessage;
     IF OBJECT_ID('tempdb..#ActivitiesStaging') IS NOT NULL
     BEGIN
       DROP TABLE #ActivitiesStaging;
     END
   END CATCH;
+END;
+GO
+
+-- Backwards-compatible single-week wrapper (used by tests and any external callers).
+CREATE PROCEDURE profiling.usp_CompileActivityWeek
+(
+  @Monday DATE
+)
+AS
+BEGIN
+  SET NOCOUNT ON;
+  DECLARE @Sunday DATE = DATEADD(DAY, 6, @Monday);
+  EXECUTE profiling.usp_CompileActivityRange @Monday, @Sunday;
 END;
 GO
 
@@ -2809,16 +2817,14 @@ BEGIN
     @Monday,
     @ThisWeeksMonday;
 
-  WHILE @ThisWeeksMonday > @Monday
+  -- Compile every outstanding week in a single set-based pass: each source log is
+  -- scanned once for the whole [First..Last] range and bucketed to its week, instead
+  -- of being re-scanned once per week.
+  IF @ThisWeeksMonday > @Monday
   BEGIN
-    DECLARE @Sunday DATE = DATEADD(DAY, 6, @Monday);
-
-    EXEC profiling.usp_Trace 'Week from %s to %s', @Monday, @Sunday;
-
-    EXECUTE profiling.usp_CompileActivityWeek @Monday;
-    EXECUTE profiling.usp_CompileUsageWeek @Monday;
-
-    SELECT @Monday = DATEADD(DAY, 7, @Monday);
+    DECLARE @LastSunday DATE = DATEADD(DAY, -1, @ThisWeeksMonday);
+    EXECUTE profiling.usp_CompileActivityRange @Monday, @LastSunday;
+    EXECUTE profiling.usp_CompileUsageRange @Monday, @LastSunday;
   END
 
   -- Cleanup. Remove data in the tables before the retention date

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql
@@ -1120,7 +1120,7 @@ BEGIN
   GROUP BY "user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "Teams Private Chats" = tvp.private_chat_count,
     "Teams Team Chats" = tvp.team_chat_count,
@@ -1228,7 +1228,7 @@ BEGIN
   GROUP BY "user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "OneDrive Viewed/Edited" = tvp.viewed_or_edited,
     "OneDrive Synced" = tvp.synced,
@@ -1294,7 +1294,7 @@ BEGIN
   GROUP BY "user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "SPO Viewed/Edited" = tvp.viewed_or_edited,
     "SPO Synced" = tvp.synced,
@@ -1362,7 +1362,7 @@ BEGIN
   GROUP BY "user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "Emails Sent" = tvp.email_send_count,
     "Emails Received" = tvp.email_receive_count,
@@ -1429,7 +1429,7 @@ BEGIN
   GROUP BY "user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "Yammer Posted" = tvp.posted_count,
     "Yammer Read" = tvp.read_count,
@@ -1506,7 +1506,7 @@ BEGIN
   GROUP BY "user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "Teams Used Web" = staging.used_web,
     "Teams Used Mac" = staging.used_mac,
@@ -1647,7 +1647,7 @@ BEGIN
   GROUP BY "user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "Office Windows" = staging.windows,
     "Office Mac" = staging.mac,
@@ -1812,7 +1812,7 @@ BEGIN
   GROUP BY "user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "Yammer Platform Count" = staging.used_count,
     "Yammer Used Web" = staging.used_web,
@@ -2050,7 +2050,7 @@ BEGIN
   GROUP BY a."user_id";
 
   /* tsqllint-disable warning update-where */
-  UPDATE t WITH (UPDLOCK, SERIALIZABLE)
+  UPDATE t
   SET
     "Copilot Chats" = tvp.copilot_chats,
     "Copilot Meetings" = tvp.copilot_meetings,

--- a/src/AnalyticsEngine/Tests.UnitTests/ProfilingStoredProcedureTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ProfilingStoredProcedureTests.cs
@@ -563,6 +563,76 @@ namespace Tests.UnitTests
             }
         }
 
+        // ---- Multi-week aggregation: each week must bucket independently ----
+        // This guards the set-based multi-week compile: distinct data in three
+        // consecutive weeks must produce three distinct per-week totals, never
+        // merged. (Achieved here by seeding a different number of days per week.)
+
+        [TestMethod]
+        public async Task Profiling_MultipleWeeks_BucketEachWeekIndependently()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var week1 = TEST_MONDAY.AddDays(105);
+                var week2 = week1.AddDays(7);
+                var week3 = week2.AddDays(7);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                foreach (var m in new[] { week1, week2, week3 })
+                {
+                    await CleanupTestData(db, m);
+                }
+
+                // 7 days -> 35, 3 days -> 15, 1 day -> 5 private chats (5/day).
+                await InsertTeamsActivityTestData(db, TEST_USER_ID, week1, week1.AddDays(6));
+                await InsertTeamsActivityTestData(db, TEST_USER_ID, week2, week2.AddDays(2));
+                await InsertTeamsActivityTestData(db, TEST_USER_ID, week3, week3);
+
+                await CompileWeeks(db, week1, week3);
+
+                Assert.AreEqual(35, await GetActivityMetricSum(db, week1, TEST_USER_ID, "Teams Private Chats"), "Week 1 (7 days)");
+                Assert.AreEqual(15, await GetActivityMetricSum(db, week2, TEST_USER_ID, "Teams Private Chats"), "Week 2 (3 days)");
+                Assert.AreEqual(5, await GetActivityMetricSum(db, week3, TEST_USER_ID, "Teams Private Chats"), "Week 3 (1 day)");
+
+                // Wide table must agree, per week.
+                Assert.AreEqual(35, await GetActivityColumnValue(db, week1, TEST_USER_ID, "Teams Private Chats"));
+                Assert.AreEqual(15, await GetActivityColumnValue(db, week2, TEST_USER_ID, "Teams Private Chats"));
+                Assert.AreEqual(5, await GetActivityColumnValue(db, week3, TEST_USER_ID, "Teams Private Chats"));
+            }
+        }
+
+        // Copilot buckets by the joined audit event's timestamp and, in a multi-week pass,
+        // must not cross-join weeks (the range compile joins host counts to event counts on
+        // user_id AND week). Two weeks with different apps/counts must stay independent.
+        [TestMethod]
+        public async Task Profiling_Copilot_MultipleWeeks_DoNotCrossJoin()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var week1 = TEST_MONDAY.AddDays(126);
+                var week2 = week1.AddDays(7);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupTestData(db, week1);
+                await CleanupTestData(db, week2);
+
+                await InsertCopilotChat(db, TEST_USER_ID, week1, "Word");
+                await InsertCopilotChat(db, TEST_USER_ID, week1.AddDays(1), "Word");           // week1: 2 Word
+                await InsertCopilotChat(db, TEST_USER_ID, week2, "Excel");
+                await InsertCopilotChat(db, TEST_USER_ID, week2.AddDays(1), "Excel");
+                await InsertCopilotChat(db, TEST_USER_ID, week2.AddDays(2), "Excel");          // week2: 3 Excel
+
+                await CompileWeeks(db, week1, week2);
+
+                Assert.AreEqual(2, await GetActivityMetricSum(db, week1, TEST_USER_ID, "Copilot Chats"), "Week 1 total chats");
+                Assert.AreEqual(2, await GetActivityMetricSum(db, week1, TEST_USER_ID, "Copilot App Word"));
+                Assert.AreEqual(0, await GetActivityMetricSum(db, week1, TEST_USER_ID, "Copilot App Excel"), "Week 2 data must not leak into week 1");
+                Assert.AreEqual(3, await GetActivityMetricSum(db, week2, TEST_USER_ID, "Copilot Chats"), "Week 2 total chats");
+                Assert.AreEqual(3, await GetActivityMetricSum(db, week2, TEST_USER_ID, "Copilot App Excel"));
+                Assert.AreEqual(0, await GetActivityMetricSum(db, week2, TEST_USER_ID, "Copilot App Word"), "Week 1 data must not leak into week 2");
+            }
+        }
+
         #region Helper Methods
 
         private async Task EnsureTestUserExists(AnalyticsEntitiesContext db, int userId)
@@ -749,6 +819,18 @@ namespace Tests.UnitTests
         private async Task ExecuteStoredProcedure(AnalyticsEntitiesContext db, string procedureName, DateTime monday)
         {
             await ExecuteSql(db, $"EXEC {procedureName} @Monday = '{monday:yyyy-MM-dd}'");
+        }
+
+        /// <summary>
+        /// Compiles every week from firstMonday to lastMonday (inclusive). The perf rewrite changes
+        /// this from a per-week loop to a single set-based range call; the multi-week tests use this
+        /// so they validate whichever compile path is current.
+        /// </summary>
+        private async Task CompileWeeks(AnalyticsEntitiesContext db, DateTime firstMonday, DateTime lastMonday)
+        {
+            var lastSunday = lastMonday.AddDays(6);
+            await ExecuteSql(db, $"EXEC profiling.usp_CompileActivityRange @StartDate = '{firstMonday:yyyy-MM-dd}', @EndDate = '{lastSunday:yyyy-MM-dd}'");
+            await ExecuteSql(db, $"EXEC profiling.usp_CompileUsageRange @StartDate = '{firstMonday:yyyy-MM-dd}', @EndDate = '{lastSunday:yyyy-MM-dd}'");
         }
 
         private async Task<int> GetActivitiesWeeklyRowCount(AnalyticsEntitiesContext db, DateTime monday)


### PR DESCRIPTION
## Description

Performance rework of the SQL profiling weekly aggregation for large (~200k-user) tenants, **without changing the `profiling.*` output schema** that `reports/Usage Analytics/Analytics_DataModel.pbit` consumes. Part of milestone **Profiling performance**.

### 1. Single set-based multi-week compile (main win)
`usp_CompileWeekly` looped **week-by-week**, so each of the ~9 source activity/usage logs was re-scanned **once per week** (a 53-week backfill ≈ 53 scans of every log). Now each source is scanned **once for the whole outstanding range** and every row is bucketed to its week inline:
- The 9 `usp_Upsert*` procs group by `(user_id, week)` via an inline Monday-of-week expression (`DATEADD`/`DATEDIFF` from the 1900-01-01 Monday epoch) — verified over 400 days to be identical to `profiling.udf_GetMonday`.
- Copilot buckets by the joined audit-event timestamp and now joins host counts to event counts on **user_id AND week** (was user_id only — would cross-join weeks in a multi-week pass).
- `usp_CompileActivityWeek` / `usp_CompileUsageWeek` are now thin single-week wrappers over new `usp_CompileActivityRange` / `usp_CompileUsageRange` (build a multi-week staging table, compile all weeks at once). Idempotency moved from per-week `COUNT` guards to per-`(user, week)` `NOT EXISTS` inserts, preserving re-run safety and partial-week self-heal.
- `usp_CompileWeekly` issues a single `...Range` call for the whole span.

### 2. Dropped pointless temp-table lock hints
Removed `WITH (UPDLOCK, SERIALIZABLE)` from the nine staging updates — the `#…Staging` tables are session-private, so the hints only added SERIALIZABLE range-locking overhead.

### Schema safety (the important bit)
No `profiling.*` output-table or view DDL was touched — `ActivitiesWeekly`, `ActivitiesWeeklyColumns`, `UsageWeekly` and the `users` / `user_PostalCodes` views are unchanged, so the `.pbit` (bound to those columns via Power Query schema navigation) keeps working. Diff is proc bodies + tests only.

### Validation
18 profiling stored-procedure tests, all green on LocalDB:
- single-week value/mapping/usage/retention (existing + new exact-value assertions)
- multi-week bucketing (three weeks with distinct data stay independent)
- Copilot multi-week no-cross-join

> Note: absolute speedup should still be measured against a real ~200k-user dataset; this PR removes the per-week re-scan multiplier and is behaviour-preserving per the tests.

## Type of Change
- [x] Refactoring / performance