### PR TITLE
Fix blob-checkpoint data loss on failed downloads + duplicate-summary PK race

### DIFF
--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/ActivityApiDbStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/ActivityApiDbStressTest.cs
@@ -34,6 +34,7 @@ namespace Tests.FakeDataGen.StressTests
                 PreSeedHistoricalAuditEvents = GetIntegerInput("Pre-seed historical audit_events rows (models a large table)", 0, 0, 100000000, "STRESS_PRESEED_AUDIT_EVENTS"),
                 UseBlobCheckpoint = GetBooleanInput("Use blob-level checkpoint (opt B)", true, "STRESS_BLOB_CHECKPOINT"),
                 MaxConcurrentSaves = GetIntegerInput("Max concurrent SQL saves (opt C; 1 = serial)", 1, 1, 64, "STRESS_MAX_CONCURRENT_SAVES"),
+                FailedBlobPercent = GetIntegerInput("Percent of blob downloads to simulate as failed", 0, 0, 100, "STRESS_FAILED_BLOB_PERCENT"),
                 BaseTimeUtc = DateTime.UtcNow
             };
             int maxSavesPerBatch = GetIntegerInput("Max events per commit batch", 2000, 1, 100000, "STRESS_MAX_SAVES_PER_BATCH");

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeControllers/Office365FakeController.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeControllers/Office365FakeController.cs
@@ -9,6 +9,10 @@ namespace Tests.UnitTests.FakeControllers
 {
     public class Office365FakeController : ApiController
     {
+        // Process-wide counter so every fake content-summary gets a unique contentId across all pages /
+        // time-chunk requests (mirrors real, globally-unique Activity API content blob ids).
+        private static int _fakeContentCounter = 0;
+
         public Office365FakeController()
         {
         }
@@ -77,11 +81,15 @@ namespace Tests.UnitTests.FakeControllers
             string fakeActivity = string.Empty;
             Guid fakeDomain = default(Guid);
 
-            // Taken from a real request 30-5-2018.
+            // Taken from a real request 30-5-2018. Each summary gets a UNIQUE contentId/contentUri (via a
+            // process-wide counter) - real Activity API content blobs each have a distinct id, and the
+            // importer now de-duplicates summaries by contentId (a blob in the time-chunk overlap window is
+            // legitimately listed twice), so reusing one id here would collapse every summary into one blob.
             fakeActivity = "[";
             for (int i = 0; i < Constants.ACTIVITIES_PER_SUMMARY; i++)
             {
-                fakeActivity += "{\"contentUri\":\"https://manage.office.com/api/v1.0/34eb3720-3d40-4da8-9f80-f939e220821c/activity/feed/audit/20180530160628319079931$20180530160628319079931$audit_sharepoint$Audit_SharePoint\",\"contentId\":\"20180530160628319079931$20180530160628319079931$audit_sharepoint$Audit_SharePoint\",\"contentType\":\"Audit.SharePoint\",\"contentCreated\":\"2018-05-30T16:06:28.319Z\",\"contentExpiration\":\"2018-06-06T16:06:28.319Z\"}";
+                var uniqueContentId = "20180530160628319079931$" + System.Threading.Interlocked.Increment(ref _fakeContentCounter) + "$audit_sharepoint$Audit_SharePoint";
+                fakeActivity += "{\"contentUri\":\"https://manage.office.com/api/v1.0/34eb3720-3d40-4da8-9f80-f939e220821c/activity/feed/audit/" + uniqueContentId + "\",\"contentId\":\"" + uniqueContentId + "\",\"contentType\":\"Audit.SharePoint\",\"contentCreated\":\"2018-05-30T16:06:28.319Z\",\"contentExpiration\":\"2018-06-06T16:06:28.319Z\"}";
                 fakeActivity += ",";
             }
             fakeActivity = fakeActivity.TrimEnd(",".ToCharArray());

--- a/src/AnalyticsEngine/Tests.UnitTests/StressHarness/ActivityApiDbStressTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StressHarness/ActivityApiDbStressTests.cs
@@ -56,6 +56,7 @@ namespace Tests.UnitTests.StressHarness
                 PreSeedHistoricalAuditEvents = EnvInt("STRESS_PRESEED_AUDIT_EVENTS", 0),
                 UseBlobCheckpoint = IsTruthy(Env("STRESS_BLOB_CHECKPOINT") ?? "true"),
                 MaxConcurrentSaves = EnvInt("STRESS_MAX_CONCURRENT_SAVES", 1),
+                FailedBlobPercent = EnvInt("STRESS_FAILED_BLOB_PERCENT", 0),
                 BaseTimeUtc = DateTime.UtcNow
             };
             int maxSavesPerBatch = EnvInt("STRESS_MAX_SAVES_PER_BATCH", 2000);
@@ -95,11 +96,26 @@ namespace Tests.UnitTests.StressHarness
 
                 if (data.UseBlobCheckpoint)
                 {
-                    // Blob checkpoint (opt B): WARM re-runs the same window, so every blob COLD committed is
-                    // skipped - nothing is re-downloaded and the cycle is near-instant on the save side.
-                    Assert.AreEqual(result.Cold.BlobsLoaded, result.Warm.MergedStats.BlobsSkipped, "WARM should skip exactly the blobs COLD committed.");
-                    Assert.AreEqual(0, result.Warm.BlobsLoaded, "WARM should re-download no blobs when the checkpoint is enabled.");
-                    Assert.AreEqual(0, result.Warm.EventsGenerated, "WARM should generate no events when all blobs are checkpointed.");
+                    if (data.FailedBlobPercent > 0)
+                    {
+                        // Failed-download blobs must NOT be checkpointed - they must be re-downloaded next
+                        // cycle (data-loss regression guard). The successfully-committed blobs are skipped.
+                        int failedBlobs = 0;
+                        for (int i = 0; i < data.BlobCount; i++)
+                        {
+                            if (i % 100 < data.FailedBlobPercent) failedBlobs++;
+                        }
+                        Assert.AreEqual(failedBlobs, result.Warm.BlobsLoaded, "WARM should re-download exactly the failed-download blobs (a failed download must never be checkpointed).");
+                        Assert.AreEqual(result.Cold.BlobsLoaded - failedBlobs, result.Warm.MergedStats.BlobsSkipped, "WARM should skip only the successfully-committed blobs.");
+                    }
+                    else
+                    {
+                        // Blob checkpoint (opt B): WARM re-runs the same window, so every blob COLD committed is
+                        // skipped - nothing is re-downloaded and the cycle is near-instant on the save side.
+                        Assert.AreEqual(result.Cold.BlobsLoaded, result.Warm.MergedStats.BlobsSkipped, "WARM should skip exactly the blobs COLD committed.");
+                        Assert.AreEqual(0, result.Warm.BlobsLoaded, "WARM should re-download no blobs when the checkpoint is enabled.");
+                        Assert.AreEqual(0, result.Warm.EventsGenerated, "WARM should generate no events when all blobs are checkpointed.");
+                    }
                 }
                 else
                 {

--- a/src/AnalyticsEngine/Tests.UnitTests/StressHarness/DeterministicActivityReportLoaderForStress.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StressHarness/DeterministicActivityReportLoaderForStress.cs
@@ -34,9 +34,17 @@ namespace Tests.UnitTests.StressHarness
             }
 
             int blobIndex = StressBlobId.Parse(metadata.ContentId);
-            var set = StressAuditDataGenerator.GenerateBlobEvents(_cfg, blobIndex);
-
             Interlocked.Increment(ref _blobsLoaded);
+
+            // Simulate a failed/partial download for a deterministic subset: an empty set flagged
+            // DownloadComplete=false. The importer must NOT checkpoint these (they'd be permanently lost),
+            // so they must be re-downloaded next cycle.
+            if (_cfg.FailedBlobPercent > 0 && (blobIndex % 100) < _cfg.FailedBlobPercent)
+            {
+                return new WebActivityReportSet { DownloadComplete = false };
+            }
+
+            var set = StressAuditDataGenerator.GenerateBlobEvents(_cfg, blobIndex);
             Interlocked.Add(ref _eventsGenerated, set.Count);
             return set;
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/StressHarness/StressAuditDataGenerator.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StressHarness/StressAuditDataGenerator.cs
@@ -52,6 +52,10 @@ namespace Tests.UnitTests.StressHarness
         /// batches in parallel (shared-table writes still serialised).</summary>
         public int MaxConcurrentSaves { get; set; } = 1;
 
+        /// <summary>Percent of blobs whose download "fails" (loader returns an empty, DownloadComplete=false
+        /// set). Used to validate that failed downloads are NOT checkpointed and are re-processed next cycle.</summary>
+        public int FailedBlobPercent { get; set; } = 0;
+
         public string InScopePrefix { get; set; } = "https://contoso.sharepoint.com/sites/inscope";
         public string OutOfScopePrefix { get; set; } = "https://contoso.sharepoint.com/sites/other";
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
@@ -47,15 +47,44 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
 
             var allSummaries = await ContentMetaDataLoader.GetChangesSummary(active, timeChunks);
 
+            // De-duplicate summaries by content-blob id. TimeChunkOverlapMinutes (default 5) means a blob
+            // created in the overlap window is listed by two adjacent time-chunks, and GetChangesSummary
+            // concatenates per-(contentType x chunk) results without deduping - so the same blob would be
+            // downloaded twice and its events streamed in twice. In serial mode the per-batch import cache
+            // catches the second copy; under concurrent saves (opt C) two in-flight batches can both carry
+            // the same event id and collide on the audit_events primary key, failing the cycle. Deduping the
+            // summaries here removes the duplicate at the source (and avoids the redundant download).
+            if (allSummaries.Count > 1)
+            {
+                int beforeDedup = allSummaries.Count;
+                var seenBlobIds = new HashSet<string>();
+                allSummaries = allSummaries.Where(s => string.IsNullOrEmpty(s.BlobId) || seenBlobIds.Add(s.BlobId)).ToList();
+                int duplicateSummaries = beforeDedup - allSummaries.Count;
+                if (duplicateSummaries > 0)
+                {
+                    _logger.LogInformation($"Audit events import: de-duplicated {duplicateSummaries.ToString("n0")} overlapping content-blob summary link(s).");
+                }
+            }
+
             // Blob-level checkpoint: skip re-downloading content blobs already fully committed in a previous
             // cycle (consecutive cycles overlap almost entirely). A blob is only recorded as done once all
-            // its events are committed, so skipping it here can never drop un-saved data.
+            // its events are committed, so skipping it here can never drop un-saved data. The checkpoint is a
+            // best-effort OPTIMISATION: a store failure must never fail the import - we just process every
+            // blob this cycle (and marking is likewise best-effort in BlobCommitTracker).
             BlobCommitTracker blobTracker = null;
             if (_processedBlobStore != null)
             {
                 int beforeFilter = allSummaries.Count;
-                var alreadyProcessed = await _processedBlobStore.GetProcessedBlobIdsAsync();
-                if (alreadyProcessed.Count > 0)
+                ISet<string> alreadyProcessed = null;
+                try
+                {
+                    alreadyProcessed = await _processedBlobStore.GetProcessedBlobIdsAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning($"Audit events import: blob checkpoint read failed ({ex.Message}); processing all content blobs this cycle.");
+                }
+                if (alreadyProcessed != null && alreadyProcessed.Count > 0)
                 {
                     allSummaries = allSummaries
                         .Where(s => { var id = s.BlobId; return string.IsNullOrEmpty(id) || !alreadyProcessed.Contains(id); })
@@ -152,7 +181,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
 
                 // Tag each event with its source blob and register the blob's event count BEFORE queueing
                 // for save, so the checkpoint tracker can record the blob once all its events are committed.
-                if (blobTracker != null)
+                // ONLY track a blob whose download COMPLETED cleanly: a failed or partial download returns
+                // zero / a prefix of events, and registering it (a zero count marks a blob done immediately)
+                // would checkpoint it and skip it next cycle - permanently losing the un-downloaded events.
+                // Leaving an incomplete blob's events untagged means it is never checkpointed, so it is
+                // re-downloaded next cycle (any events it did commit dedup against audit_events).
+                if (blobTracker != null && metaReports.DownloadComplete)
                 {
                     var blobId = job.BlobId;
                     if (!string.IsNullOrEmpty(blobId))

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSet.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSet.cs
@@ -21,6 +21,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
         }
         #endregion
 
+        /// <summary>
+        /// False when the blob download did NOT complete cleanly (transient HTTP/timeout/OOM error, a
+        /// non-array response, or a mid-stream JSON parse abort). The importer must NOT checkpoint a blob
+        /// whose download was incomplete - the returned events are empty or a partial prefix, so marking it
+        /// "processed" would skip it next cycle and permanently lose the un-downloaded events.
+        /// </summary>
+        public bool DownloadComplete { get; set; } = true;
+
         #region Props
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/BlobCommitTracker.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/BlobCommitTracker.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -71,8 +72,17 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
 
         private async Task MarkAsync(IReadOnlyCollection<string> blobIds)
         {
-            await _store.MarkProcessedAsync(blobIds);
-            Interlocked.Add(ref _markedDone, blobIds.Count);
+            // Best-effort: a checkpoint write failure must not fail the import. If we fail to record a blob,
+            // it is simply re-processed next cycle (its events dedup against audit_events), which is safe.
+            try
+            {
+                await _store.MarkProcessedAsync(blobIds);
+                Interlocked.Add(ref _markedDone, blobIds.Count);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, $"Blob checkpoint: failed to record {blobIds.Count} processed blob(s); they will be re-processed next cycle.");
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
@@ -53,7 +53,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
             {
                 Interlocked.Increment(ref _reportDownloadErrors);
                 _logger.LogError(ex, $"Got error '{ex.Message}' downloading {metadata.ContentUri}. Will try again on next cycle.");
-                return new WebActivityReportSet();
+                return new WebActivityReportSet { DownloadComplete = false };
             }
             catch (TaskCanceledException ex)
             {
@@ -62,7 +62,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                 // hung request doesn't crash the whole audit-log import. The item is retried on the next cycle.
                 Interlocked.Increment(ref _reportDownloadErrors);
                 _logger.LogError(ex, $"Timed out downloading {metadata.ContentUri}: '{ex.Message}'. Will try again on next cycle.");
-                return new WebActivityReportSet();
+                return new WebActivityReportSet { DownloadComplete = false };
             }
 
             // Use 'using' to ensure response is disposed and memory is freed
@@ -88,7 +88,9 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                         if (jsonReader.TokenType != JsonToken.StartArray)
                         {
                             // Empty or non-array response - treat as no data, consistent with prior behaviour
-                            // when JArray.LoadAsync returned an empty/null result.
+                            // when JArray.LoadAsync returned an empty/null result. Mark incomplete so a
+                            // (malformed / unexpected) non-array response is NOT checkpointed and is retried.
+                            logs.DownloadComplete = false;
                             return logs;
                         }
 
@@ -107,9 +109,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                             catch (JsonReaderException ex)
                             {
                                 // A single malformed object will desync the reader; bail out of the stream
-                                // so we don't accidentally mis-parse subsequent siblings.
+                                // so we don't accidentally mis-parse subsequent siblings. This is a PARTIAL
+                                // result (some events parsed, tail dropped), so mark it incomplete - the blob
+                                // must be re-downloaded next cycle, not checkpointed on the partial prefix.
                                 Interlocked.Increment(ref _reportDownloadErrors);
                                 _logger.LogWarning($"Invalid JSON object in stream from URL '{newUri}': {ex.Message}. Aborting stream for this batch.");
+                                logs.DownloadComplete = false;
                                 break;
                             }
 
@@ -121,13 +126,13 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                 {
                     Interlocked.Increment(ref _reportDownloadErrors);
                     _logger.LogError($"Out of memory streaming response from {metadata.ContentUri}. Will try again on next cycle.");
-                    return new WebActivityReportSet();
+                    return new WebActivityReportSet { DownloadComplete = false };
                 }
                 catch (JsonReaderException ex)
                 {
                     Interlocked.Increment(ref _reportDownloadErrors);
                     _logger.LogWarning($"Invalid JSON response for URL '{newUri}': {ex.Message}. Ignoring");
-                    return new WebActivityReportSet();
+                    return new WebActivityReportSet { DownloadComplete = false };
                 }
 
                 logs.OriginalMetadata = metadata;


### PR DESCRIPTION
Follow-up to #207 (audit-importer scale), from a code-review pass — two real bugs + hardening.

**1. Critical (opt B, always-on): blob-checkpoint data loss on failed downloads.**
A failed/partial content-blob download returns 0/partial events; that was registered with the returned count, and a zero count marked the blob "processed" immediately → it was checkpointed and **skipped forever**, losing every event that failed to download. Now `ActivityReportSet.DownloadComplete` is set false on any failed/partial load, and the importer only checkpoints a blob whose download **completed** — an incomplete blob is re-downloaded next cycle. New harness scenario (`STRESS_FAILED_BLOB_PERCENT`) proves failed blobs are re-loaded on WARM.

**2. opt C: duplicate-summary PK race.** Overlap-window duplicate summaries (same contentId in two adjacent time-chunks) could collide on the `audit_events` PK under concurrent saves. Now summaries are **de-duplicated by contentId** before processing (also avoids the redundant download in serial mode).

**3. Hardening:** the checkpoint store reads/writes are now genuinely **best-effort** — a transient store error (e.g. Azure Table) logs a warning and the importer degrades gracefully instead of failing the cycle.

**4. Test fake:** `Office365FakeController` now emits a **unique contentId per summary** (real blobs are globally unique); the previous single reused id hid the dedup.

All 50 importer/datautils/insertbatch tests pass; the DB-backed load test passes the checkpoint, failed-download, and concurrent-save scenarios.