### PR TITLE
Throttle usage-report import to once a day without Redis

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/SingleDateStoreTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SingleDateStoreTests.cs
@@ -1,0 +1,91 @@
+using Common.Entities.Config;
+using DataUtils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests for the once-a-day throttle store that gates the whole activity/usage-report phase, and the
+    /// factory that picks Redis vs the in-memory fallback (used when no Redis connection string is configured).
+    /// </summary>
+    [TestClass]
+    public class SingleDateStoreTests
+    {
+        [TestMethod]
+        public async Task InMemorySingleDateStore_GetLastDT_IsNullUntilSaved()
+        {
+            var store = new InMemorySingleDateStore();
+            Assert.IsNull(await store.GetLastDT(),
+                "A fresh in-memory store must report no last date so the first cycle imports.");
+        }
+
+        [TestMethod]
+        public async Task InMemorySingleDateStore_SaveDT_ThenGetReturnsRecentDate()
+        {
+            var store = new InMemorySingleDateStore();
+
+            var before = DateTime.Now.AddSeconds(-1);
+            await store.SaveDT();
+            var after = DateTime.Now.AddSeconds(1);
+
+            var stored = await store.GetLastDT();
+            Assert.IsTrue(stored.HasValue, "SaveDT must persist a value for the life of the instance.");
+            Assert.IsTrue(stored.Value >= before && stored.Value <= after,
+                "SaveDT should store roughly the current time.");
+        }
+
+        [TestMethod]
+        public async Task InMemorySingleDateStore_DeleteDt_ClearsStoredDate()
+        {
+            var store = new InMemorySingleDateStore();
+            await store.SaveDT();
+
+            await store.DeleteDt();
+
+            Assert.IsNull(await store.GetLastDT(),
+                "DeleteDt must clear the stored date so an empty/wiped DB re-imports immediately.");
+        }
+
+        [TestMethod]
+        public async Task InMemorySingleDateStore_SurvivesRepeatedReads_SoThrottleHoldsAcrossCycles()
+        {
+            // A single instance is held for the process lifetime (constructed once, outside the cycle loop),
+            // so repeated GetLastDT calls across cycles keep seeing the saved timestamp and keep throttling.
+            var store = new InMemorySingleDateStore();
+            await store.SaveDT();
+
+            var first = await store.GetLastDT();
+            var second = await store.GetLastDT();
+
+            Assert.IsTrue(first.HasValue && second.HasValue);
+            Assert.AreEqual(first.Value, second.Value,
+                "The stored date must be stable across reads so the once-a-day gate stays closed within the window.");
+        }
+
+        [TestMethod]
+        public void Factory_NoRedis_ReturnsInMemoryStore()
+        {
+            var config = new AppConfig
+            {
+                ConnectionStrings = new AppConnectionStrings { RedisConnectionString = null }
+            };
+
+            var store = ActivityReportsLastImportedStoreFactory.Create(config, AnalyticsLogger.ConsoleOnlyTracer());
+
+            Assert.IsInstanceOfType(store, typeof(InMemorySingleDateStore),
+                "With no Redis configured the factory must fall back to the in-memory once-a-day throttle.");
+        }
+
+        [TestMethod]
+        public void Factory_NullConfig_ReturnsInMemoryStore()
+        {
+            // Defensive: a null config (or null ConnectionStrings) must not throw - just fall back to in-memory.
+            var store = ActivityReportsLastImportedStoreFactory.Create(null, AnalyticsLogger.ConsoleOnlyTracer());
+
+            Assert.IsInstanceOfType(store, typeof(InMemorySingleDateStore));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -175,6 +175,7 @@
     <Compile Include="FakeLoaderClasses\FakeActivitySubscriptionManager.cs" />
     <Compile Include="FakeLoaderClasses\FakeUserAppLoader.cs" />
     <Compile Include="GraphUsageReportImportTests.cs" />
+    <Compile Include="SingleDateStoreTests.cs" />
     <Compile Include="AutoThrottleHttpClientTests.cs" />
     <Compile Include="GraphImportTests.cs" />
     <Compile Include="InstallTests\FakeInstallClasses.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -26,13 +26,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         private readonly UserGroupsCache _userGroupsCache;
         private readonly GraphAppIndentityOAuthContext _graphAppIndentityOAuthContext;
         private readonly GraphServiceClient _graphClient;
+        private readonly ISingleDateStore _activityReportsLastImportedStore;
 
-        public GraphImporter(AnalyticsLogger logger, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings)
+        public GraphImporter(AnalyticsLogger logger, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null)
             : base(logger, settings)
         {
             _userGroupsCache = userGroupsCache;
             _graphAppIndentityOAuthContext = graphAppIndentityOAuthContext;
             _graphClient = graphClient;
+            _activityReportsLastImportedStore = activityReportsLastImportedStore;
         }
 
 
@@ -144,27 +146,31 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         {
             var MIN_WAIT = TimeSpan.FromDays(1);
 
+            // Throttle the whole activity/usage-report phase (all daily loaders + the weekly SharePoint sites
+            // loader) to run at most once a day. The store is injected so it survives across import cycles:
+            // Redis when configured, otherwise an in-memory fallback (see ActivityReportsLastImportedStoreFactory).
+            // When no store is supplied (e.g. unit tests) we don't throttle and always import.
             DateTime? lastImportedDate = null;
-            UserActivityLastImportedRedisSingleDateLoader lastImportedDateLoader = null;
-            if (!string.IsNullOrEmpty(_settings.ConnectionStrings.RedisConnectionString))
+            var lastImportedStore = _activityReportsLastImportedStore;
+            if (lastImportedStore != null)
             {
-                lastImportedDateLoader = new UserActivityLastImportedRedisSingleDateLoader(_settings.ConnectionStrings.RedisConnectionString, _settings.TenantGUID.ToString(), _settings.ClientID, _settings.ClientSecret);
-
-                // Clear "last imported" date in redis if no data in DB
+                // Clear the "last imported" date if there's no activity data in the DB at all, so a fresh or
+                // wiped database imports immediately instead of waiting out a stale timestamp. EXISTS (AnyAsync)
+                // is used rather than COUNT(*) because this only needs "is the table empty" and runs every cycle.
                 using (var db = new AnalyticsEntitiesContext())
                 {
-                    var teamsActivityCountAll = await db.TeamUserActivityLogs.CountAsync();
-                    if (teamsActivityCountAll == 0)
+                    var anyActivityData = await db.TeamUserActivityLogs.AnyAsync();
+                    if (!anyActivityData)
                     {
-                        await lastImportedDateLoader.DeleteDt();
+                        await lastImportedStore.DeleteDt();
                     }
                 }
 
-                lastImportedDate = await lastImportedDateLoader.GetLastDT();
+                lastImportedDate = await lastImportedStore.GetLastDT();
             }
             else
             {
-                _logger.LogWarning("No Redis connection string - cannot find last date for imported for activity reports.");
+                _logger.LogWarning("No activity-reports throttle store configured - cannot check last import date; will import this cycle.");
             }
 
             var runImport = (lastImportedDate == null || DateTime.Now.Subtract(lastImportedDate.Value) > MIN_WAIT);
@@ -232,10 +238,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     }
                 }
 
-                // Remember last import date
-                if (lastImportedDateLoader != null)
+                // Remember last import date so the next cycle within the throttle window is skipped.
+                if (lastImportedStore != null)
                 {
-                    await lastImportedDateLoader.SaveDT();
+                    await lastImportedStore.SaveDT();
                 }
 
                 _logger.LogInformation($"Activity reports imported. Will run again in {MIN_WAIT.TotalHours} hours");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/RedisSingleDateLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/RedisSingleDateLoader.cs
@@ -8,7 +8,7 @@ namespace WebJob.Office365ActivityImporter.Engine
     /// <summary>
     /// For loading and saving a single date value in Redis
     /// </summary>
-    public class RedisSingleDateLoader
+    public class RedisSingleDateLoader : ISingleDateStore
     {
         private readonly string _key;
         private CacheConnectionManager _cacheConnectionManager = null;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/SingleDateStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/SingleDateStore.cs
@@ -1,0 +1,82 @@
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace WebJob.Office365ActivityImporter.Engine
+{
+    /// <summary>
+    /// Stores a single "last run" timestamp so a periodic import can be throttled to run at most once per
+    /// window (e.g. once a day). Backed by Redis when configured, otherwise an in-memory fallback that lives
+    /// only for the life of the (long-running) WebJob process.
+    /// </summary>
+    public interface ISingleDateStore
+    {
+        Task<DateTime?> GetLastDT();
+        Task SaveDT();
+        Task DeleteDt();
+    }
+
+    /// <summary>
+    /// In-memory fallback for <see cref="ISingleDateStore"/>, used when Redis is not configured. The stored
+    /// date lives only for the lifetime of this instance.
+    ///
+    /// IMPORTANT: callers must hold a single instance for the lifetime of the WebJob process (construct it
+    /// ONCE, outside the per-cycle import loop). A fresh instance per cycle would always return null from
+    /// <see cref="GetLastDT"/> and defeat the throttle, re-running the multi-hour usage-report phase every
+    /// cycle. Mirrors <see cref="StatsUploader.InMemoryStatsDatesLoader"/>.
+    /// </summary>
+    public class InMemorySingleDateStore : ISingleDateStore
+    {
+        private readonly object _lock = new object();
+        private DateTime? _lastDt;
+
+        public Task<DateTime?> GetLastDT()
+        {
+            lock (_lock)
+            {
+                return Task.FromResult(_lastDt);
+            }
+        }
+
+        public Task SaveDT()
+        {
+            lock (_lock)
+            {
+                _lastDt = DateTime.Now;
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteDt()
+        {
+            lock (_lock)
+            {
+                _lastDt = null;
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Builds the <see cref="ISingleDateStore"/> used to throttle the activity/usage-report phase to at most
+    /// once a day: a Redis-backed store (durable across process restarts) when Redis is configured, otherwise
+    /// an in-memory store that persists only for the life of this process. Mirrors the stats-upload throttle so
+    /// the usage-report phase behaves the same as other once-a-day imports even without Redis configured.
+    /// </summary>
+    public static class ActivityReportsLastImportedStoreFactory
+    {
+        public static ISingleDateStore Create(AppConfig config, ILogger logger)
+        {
+            var redisConn = config?.ConnectionStrings?.RedisConnectionString;
+            if (!string.IsNullOrEmpty(redisConn))
+            {
+                return new UserActivityLastImportedRedisSingleDateLoader(redisConn, config.TenantGUID.ToString(), config.ClientID, config.ClientSecret);
+            }
+
+            logger?.LogInformation("No Redis connection string configured - using in-memory throttle for activity/usage reports (the once-a-day window resets each time the WebJob process restarts).");
+            return new InMemorySingleDateStore();
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -199,6 +199,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="RedisSingleDateLoader.cs" />
+    <Compile Include="SingleDateStore.cs" />
     <Compile Include="StatsUploader\AnonUsageStatsModelLoader.cs" />
     <Compile Include="StatsUploader\BaseClasses.cs" />
     <Compile Include="StatsUploader\InMemoryStatsDatesLoader.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -185,12 +185,18 @@ namespace WebJob.Office365ActivityImporter
                 statsDatesLoader = new InMemoryStatsDatesLoader();
             }
 
+            // Activity/usage reports also run at most once a day. Like the stats throttle above, this needs a
+            // store that survives across cycles - Redis when configured, otherwise an in-memory fallback built
+            // ONCE here (a fresh per-cycle instance would always look "never imported" and re-run the multi-hour
+            // usage-report phase every cycle, even without Redis).
+            ISingleDateStore activityReportsLastImportedStore = ActivityReportsLastImportedStoreFactory.Create(configuredSettings, logger);
+
             // Run app
             while (runAgain)
             {
                 var importCycleTimer = new JobTimer(logger, Process.GetCurrentProcess().ProcessName);
                 importCycleTimer.Start();
-                var tasks = new ProgramTasks(logger, configuredSettings);
+                var tasks = new ProgramTasks(logger, configuredSettings, activityReportsLastImportedStore);
 
                 // Start listening for SB messages & register notifications web-hook with Graph 
                 if (webHookUrl != null && configuredSettings.ImportJobSettings.Calls)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -28,12 +28,14 @@ namespace WebJob.Office365ActivityImporter
         private readonly AppConfig _settings;
         private ManualGraphCallClient _manualGraphCallClient = null;
         private GraphUserGroupsCache _graphUserGroupsCache = null;
+        private readonly ISingleDateStore _activityReportsLastImportedStore;
 
-        public ProgramTasks(AnalyticsLogger logger, AppConfig settings)
+        public ProgramTasks(AnalyticsLogger logger, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null)
         {
             _graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(logger, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
             _logger = logger;
             _settings = settings;
+            _activityReportsLastImportedStore = activityReportsLastImportedStore;
         }
 
         internal async Task ProcessCallQueueAndWebhook(Uri webHookUrl)
@@ -58,7 +60,7 @@ namespace WebJob.Office365ActivityImporter
 
             await InitAuth();
 
-            var graphReader = new GraphImporter(_logger, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings);
+            var graphReader = new GraphImporter(_logger, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings, _activityReportsLastImportedStore);
 
             try
             {


### PR DESCRIPTION
## What & why

The Graph **activity/usage-report** import phase (all daily loaders — Teams, Outlook, OneDrive, SharePoint-user, Yammer, Apps & platform — plus the weekly SharePoint sites report) is designed to run **at most once a day** (`MIN_WAIT = 1 day`). But the "last imported" throttle was only honoured **when Redis was configured**. With no Redis the tracker was `null`, so `runImport` was always `true` and the entire multi-hour phase **re-ran on every import cycle** — a large, repeated waste on tenants that don't run Redis, and directly relevant to keeping a big tenant's full cycle inside 24h.

This mirrors exactly what the **stats-upload** "other import" already does with `InMemoryStatsDatesLoader`.

## Change

- New `ISingleDateStore` abstraction (`SingleDateStore.cs`):
  - Redis-backed via the existing `RedisSingleDateLoader` / `UserActivityLastImportedRedisSingleDateLoader` (now implements the interface).
  - New `InMemorySingleDateStore` fallback for when Redis isn't configured.
  - `ActivityReportsLastImportedStoreFactory` picks the right one (mirrors `ProcessedBlobStoreFactory`).
- The store is constructed **once** in `Program.cs`, **outside** the per-cycle loop, so the in-memory timestamp **survives across cycles**, then plumbed through `ProgramTasks → GraphImporter`.
- Net effect: the whole activity-report phase is throttled to once/day **even without Redis** (resets on process restart, same documented trade-off as the stats fallback).
- When no store is injected (unit tests) the gate is skipped and it always imports — existing behaviour preserved.
- Empty-DB guard switched from `CountAsync() == 0` to `AnyAsync()` (EXISTS) — it now runs every cycle and only needs "is the table empty", which is cheaper than `COUNT(*)` on a large `team_user_activity_logs` table at 200k-user scale.

## Not in scope (deliberate)

The **save path itself is already batched/bounded on dev** — `AbstractDailyActivityLoader` (per-day, `SaveBatchSize=1000`, `AutoDetectChangesEnabled=false`, detach) covers *every* daily loader via the shared base, and `AbstractAggregateWeeklyUsageReportLoader` / `SharePointSitesWeeklyUsageReportLoader` bulk-preload in one query. So this PR intentionally adds **only** the once-a-day gate; intra-loader load/save pipelining was considered and skipped (small gain, higher risk).

## Testing

- New `SingleDateStoreTests` (DB-free): in-memory store null-until-saved / save / delete / stable-across-reads, and factory no-Redis + null-config fallback. **6/6 pass** via `vstest.console`.
- WebJob + Engine + Tests projects build clean (VS 2022 MSBuild).
- Existing `GraphUsageReportImportTests` unaffected (they construct `GraphImporter` without a store ⇒ always import, as before).

No customer data; synthetic/none throughout.

Part of the audit-importer scale epic (milestone #2).
