### PR TITLE
Audit importer: build dedup cache once per cycle (throughput + memory)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/StressHarness/ActivityApiDbStressRunner.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StressHarness/ActivityApiDbStressRunner.cs
@@ -76,6 +76,10 @@ namespace Tests.UnitTests.StressHarness
             {
                 PreSeedHistoricalAuditEvents(connectionString, data.PreSeedHistoricalAuditEvents, data.BaseTimeUtc, log);
             }
+            if (data.PreSeedInWindowAuditEvents > 0)
+            {
+                PreSeedInWindowAuditEvents(connectionString, data.PreSeedInWindowAuditEvents, data.BaseTimeUtc, data.WindowDays, log);
+            }
             // Start the blob checkpoint empty so COLD is a true cold start (the in-memory store is static,
             // so it would otherwise carry over from a previous run in the same process).
             if (data.UseBlobCheckpoint)
@@ -110,7 +114,7 @@ namespace Tests.UnitTests.StressHarness
             log($"===== {name} scenario =====");
 
             var logger = AnalyticsLogger.ConsoleOnlyTracer();
-            var appConfig = StressAppConfigFactory.Create(connectionString);
+            var appConfig = StressAppConfigFactory.Create(connectionString, data.WindowDays);
 
             SharePointOrgUrlsFilterConfig spFilter;
             using (var db = new AnalyticsEntitiesContext(connectionString, true, false))
@@ -120,8 +124,9 @@ namespace Tests.UnitTests.StressHarness
             log($"  Whitelist rules loaded: {spFilter.OrgUrlConfigs.Count}");
 
             var realManager = new ActivityReportSqlPersistenceManager(
-                spFilter, new NoUsersHaveGroupsUserGroupsCache(logger), logger, appConfig, data.MaxConcurrentSaves);
+                spFilter, new NoUsersHaveGroupsUserGroupsCache(logger), logger, appConfig, data.MaxConcurrentSaves, data.UsePerBatchDedupCache);
             var countingManager = new CountingActivityReportPersistenceManager(realManager);
+            log($"  Dedup cache mode: {(data.UsePerBatchDedupCache ? "PER-BATCH (legacy: rebuilt every save)" : "PER-CYCLE (built once, reused)")}");
 
             // Production-like: the checkpoint store is selected by the factory from config (empty storage
             // conn -> in-memory). The in-memory store is static, so COLD's marks are visible to WARM.
@@ -312,6 +317,64 @@ namespace Tests.UnitTests.StressHarness
         }
 
         /// <summary>
+        /// Bulk-inserts <paramref name="count"/> rows into audit_events with timestamps spread across the event
+        /// window ([baseTimeUtc - windowDays, baseTimeUtc]), modelling a large standing set of already-imported
+        /// IN-WINDOW events (the production condition). A save batch's dedup query covers [batch oldest, batch
+        /// newest] - almost the whole window - so these rows are what the per-batch cache re-materialises into
+        /// memory on EVERY save; the per-cycle cache loads them once. Random ids, so they never dedup against
+        /// the generated events (they just enlarge the cache the save path must build).
+        /// </summary>
+        private static void PreSeedInWindowAuditEvents(string connectionString, int count, DateTime baseTimeUtc, int windowDays, Action<string> log)
+        {
+            log($"[prep] Pre-seeding {count:N0} IN-WINDOW audit_events rows (models a large standing in-window backlog)...");
+            var sw = Stopwatch.StartNew();
+            int windowMinutes = Math.Max(1, windowDays * 24 * 60);
+            using (var c = new SqlConnection(connectionString))
+            {
+                c.Open();
+
+                const string dummyUpn = "preseed-inwindow@contoso.onmicrosoft.com";
+                using (var cmd = new SqlCommand("IF NOT EXISTS (SELECT 1 FROM users WHERE user_name=@u) INSERT INTO users(user_name) VALUES(@u);", c))
+                {
+                    cmd.Parameters.Add(new SqlParameter("@u", System.Data.SqlDbType.NVarChar, 400) { Value = dummyUpn });
+                    cmd.ExecuteNonQuery();
+                }
+                int userId;
+                using (var cmd = new SqlCommand("SELECT id FROM users WHERE user_name=@u", c))
+                {
+                    cmd.Parameters.Add(new SqlParameter("@u", System.Data.SqlDbType.NVarChar, 400) { Value = dummyUpn });
+                    userId = (int)cmd.ExecuteScalar();
+                }
+
+                const int chunkSize = 250000;
+                int done = 0;
+                while (done < count)
+                {
+                    int take = Math.Min(chunkSize, count - done);
+                    // Spread uniformly across the window: minute offset = ((rn + done) % windowMinutes) + 60, so
+                    // rows land in [baseTimeUtc - windowDays, baseTimeUtc - 60min] (matching the generated
+                    // events' distribution), guaranteeing the per-batch cache query captures them.
+                    using (var cmd = new SqlCommand(
+                        ";WITH n AS (SELECT TOP (@take) ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS rn " +
+                        "FROM sys.all_objects a CROSS JOIN sys.all_objects b) " +
+                        "INSERT INTO audit_events (id, user_id, time_stamp) " +
+                        "SELECT NEWID(), @user, DATEADD(minute, -(((rn + @offset) % @windowMinutes) + 60), @baseTime) FROM n;", c)
+                    { CommandTimeout = 0 })
+                    {
+                        cmd.Parameters.Add(new SqlParameter("@take", System.Data.SqlDbType.Int) { Value = take });
+                        cmd.Parameters.Add(new SqlParameter("@user", System.Data.SqlDbType.Int) { Value = userId });
+                        cmd.Parameters.Add(new SqlParameter("@offset", System.Data.SqlDbType.Int) { Value = done });
+                        cmd.Parameters.Add(new SqlParameter("@windowMinutes", System.Data.SqlDbType.Int) { Value = windowMinutes });
+                        cmd.Parameters.Add(new SqlParameter("@baseTime", System.Data.SqlDbType.DateTime) { Value = baseTimeUtc });
+                        cmd.ExecuteNonQuery();
+                    }
+                    done += take;
+                }
+            }
+            log($"[prep] In-window pre-seed done ({count:N0} rows) in {sw.Elapsed.TotalSeconds:F1}s");
+        }
+
+        /// <summary>
         /// Injects/overrides a runtime connection string in <see cref="ConfigurationManager"/> so
         /// <c>new AnalyticsEntitiesContext()</c> (name=SPOInsightsEntities) resolves to our target DB.
         /// </summary>
@@ -353,6 +416,9 @@ namespace Tests.UnitTests.StressHarness
             void Row(string label, string c, string w) => log($"{label,-26}{c,16}{w,16}");
             Row("Wall time (s)", (cold.WallMs / 1000.0).ToString("F1"), warm != null ? (warm.WallMs / 1000.0).ToString("F1") : "-");
             Row("Save phase (s)", (cold.TotalCommitMs / 1000.0).ToString("F1"), warm != null ? (warm.TotalCommitMs / 1000.0).ToString("F1") : "-");
+            Row("  - dedup+scope (s)", (cold.MergedStats.SaveDedupMs / 1000.0).ToString("F1"), warm != null ? (warm.MergedStats.SaveDedupMs / 1000.0).ToString("F1") : "-");
+            Row("  - staging+merge (s)", (cold.MergedStats.SaveMergeMs / 1000.0).ToString("F1"), warm != null ? (warm.MergedStats.SaveMergeMs / 1000.0).ToString("F1") : "-");
+            Row("  - metadata (s)", (cold.MergedStats.SaveMetadataMs / 1000.0).ToString("F1"), warm != null ? (warm.MergedStats.SaveMetadataMs / 1000.0).ToString("F1") : "-");
             Row("Commit batches", cold.CommitAllCalls.ToString("N0"), warm != null ? warm.CommitAllCalls.ToString("N0") : "-");
             Row("Blobs loaded", cold.BlobsLoaded.ToString("N0"), warm != null ? warm.BlobsLoaded.ToString("N0") : "-");
             Row("Blobs skipped (ckpt)", cold.MergedStats.BlobsSkipped.ToString("N0"), warm != null ? warm.MergedStats.BlobsSkipped.ToString("N0") : "-");
@@ -383,6 +449,7 @@ namespace Tests.UnitTests.StressHarness
         {
             log($"  {Name} wall time:      {WallMs / 1000.0:F1}s");
             log($"  {Name} save phase:     {TotalCommitMs / 1000.0:F1}s across {CommitAllCalls:N0} commit batch(es)");
+            log($"  {Name}   breakdown:    dedup+scope {MergedStats.SaveDedupMs / 1000.0:F1}s | staging+merge {MergedStats.SaveMergeMs / 1000.0:F1}s | metadata {MergedStats.SaveMetadataMs / 1000.0:F1}s");
             log($"  {Name} blobs loaded:   {BlobsLoaded:N0}");
             log($"  {Name} blobs skipped:  {MergedStats.BlobsSkipped:N0} (checkpoint)");
             log($"  {Name} events:         {EventsGenerated:N0} generated");

--- a/src/AnalyticsEngine/Tests.UnitTests/StressHarness/ActivityApiDbStressTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StressHarness/ActivityApiDbStressTests.cs
@@ -22,6 +22,9 @@ namespace Tests.UnitTests.StressHarness
     ///   STRESS_OUTOFSCOPE_SITES      (default 500)
     ///   STRESS_WINDOW_DAYS           (default 6)
     ///   STRESS_BLOB_LATENCY_MS       (default 0)
+    ///   STRESS_PRESEED_AUDIT_EVENTS  (default 0; historical rows OUT of window - bloats the table only)
+    ///   STRESS_PRESEED_INWINDOW_EVENTS (default 0; standing IN-window backlog - stresses the dedup cache)
+    ///   STRESS_PERBATCH_DEDUP_CACHE  (default false; true = legacy per-batch cache, for before/after runs)
     ///   STRESS_RUN_WARM              (default true)
     /// </summary>
     [TestClass]
@@ -54,6 +57,8 @@ namespace Tests.UnitTests.StressHarness
                 WindowDays = EnvInt("STRESS_WINDOW_DAYS", 6),
                 SimulatedBlobLatencyMs = EnvInt("STRESS_BLOB_LATENCY_MS", 0),
                 PreSeedHistoricalAuditEvents = EnvInt("STRESS_PRESEED_AUDIT_EVENTS", 0),
+                PreSeedInWindowAuditEvents = EnvInt("STRESS_PRESEED_INWINDOW_EVENTS", 0),
+                UsePerBatchDedupCache = IsTruthy(Env("STRESS_PERBATCH_DEDUP_CACHE")),
                 UseBlobCheckpoint = IsTruthy(Env("STRESS_BLOB_CHECKPOINT") ?? "true"),
                 MaxConcurrentSaves = EnvInt("STRESS_MAX_CONCURRENT_SAVES", 1),
                 FailedBlobPercent = EnvInt("STRESS_FAILED_BLOB_PERCENT", 0),

--- a/src/AnalyticsEngine/Tests.UnitTests/StressHarness/StressAppConfigFactory.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StressHarness/StressAppConfigFactory.cs
@@ -13,10 +13,9 @@ namespace Tests.UnitTests.StressHarness
     /// </summary>
     public static class StressAppConfigFactory
     {
-        public static AppConfig Create(string databaseConnectionString)
+        public static AppConfig Create(string databaseConnectionString, int windowDays = 6)
         {
             var config = (AppConfig)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(AppConfig));
-
             config.TenantGUID = Guid.Parse("00000000-0000-0000-0000-000000000001");
             config.ClientID = "fake-client-id-for-stress-testing";
             config.ClientSecret = "fake-client-secret";
@@ -25,8 +24,10 @@ namespace Tests.UnitTests.StressHarness
             config.AADInstance = "https://login.microsoftonline.com/";
             config.UseClientCertificate = false;
 
-            // Activity import window - must yield >= 1 time-chunk or the content loader is never called.
-            config.DaysBeforeNowToDownload = 7;
+            // Activity import window - must yield >= 1 time-chunk or the content loader is never called, and
+            // must be >= the data's WindowDays so the run-scoped dedup cache (sized by DaysBeforeNowToDownload)
+            // covers every generated event (else WARM would re-import events older than the cache window).
+            config.DaysBeforeNowToDownload = Math.Max(7, windowDays + 1);
             config.TimeChunkOverlapMinutes = 5;
             config.ChunkSize = TimeSpan.FromDays(1);
             config.ContentTypesString = "Audit.SharePoint";

--- a/src/AnalyticsEngine/Tests.UnitTests/StressHarness/StressAuditDataGenerator.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StressHarness/StressAuditDataGenerator.cs
@@ -41,6 +41,21 @@ namespace Tests.UnitTests.StressHarness
         /// </summary>
         public int PreSeedHistoricalAuditEvents { get; set; }
 
+        /// <summary>
+        /// Optional number of historical rows to pre-seed into audit_events WITHIN the event window (spread
+        /// across <see cref="WindowDays"/>), modelling the production condition: a large standing set of
+        /// already-imported in-window events that the per-batch dedup cache re-materialises into memory on
+        /// EVERY save. This is what makes the per-cycle-cache optimisation measurable - unlike
+        /// <see cref="PreSeedHistoricalAuditEvents"/>, which seeds OUT of window so it only bloats the table.
+        /// Random ids, so they never dedup against the generated events.
+        /// </summary>
+        public int PreSeedInWindowAuditEvents { get; set; }
+
+        /// <summary>When true, the persistence manager rebuilds the dedup cache per batch (the
+        /// pre-optimisation behaviour) instead of once per cycle - lets the harness measure the before/after
+        /// of the per-cycle-cache optimisation in a single build.</summary>
+        public bool UsePerBatchDedupCache { get; set; } = false;
+
         /// <summary>Captured ONCE by the runner; shared by COLD + WARM so timestamps are identical.</summary>
         public DateTime BaseTimeUtc { get; set; }
 
@@ -109,6 +124,13 @@ namespace Tests.UnitTests.StressHarness
             var set = new WebActivityReportSet();
             int startGlobal = blobIndex * cfg.EventsPerBlob;
             int windowMinutes = Math.Max(1, cfg.WindowDays * 24 * 60);
+            // Each blob is a small time-slice, and consecutive blob indices are scattered across the whole
+            // window by a coprime multiplier (a full-period step), so a SAVE BATCH of several blobs spans
+            // ~the entire window - faithfully modelling the real importer, where ~130 threads download blobs
+            // out of order so each 2000-event batch's [Min,Max] CreationTime covers almost the whole window
+            // (which is what makes the per-batch dedup-cache reload materialise ~the entire in-window set).
+            // Deterministic in blobIndex, so COLD and WARM still generate byte-identical timestamps.
+            int blobBaseMinute = (int)(((long)blobIndex * 2654435761L) % windowMinutes);
 
             for (int j = 0; j < cfg.EventsPerBlob; j++)
             {
@@ -147,9 +169,11 @@ namespace Tests.UnitTests.StressHarness
                     SiteUrl = siteUrl,
                     ObjectId = objectId,
                     EventData = "<Event><Id>" + g + "</Id></Event>",
-                    // Stable, in-window timestamp (>= 1h before BaseTimeUtc) so the per-batch cache window
-                    // [oldest-1min, newest+1min] captures COLD's rows on the WARM re-run.
-                    CreationTime = cfg.BaseTimeUtc.AddMinutes(-((g % windowMinutes) + 60)),
+                    // Stable, in-window timestamp: the blob's scattered base minute + a small within-blob
+                    // offset (events in one blob are close in time, blobs are spread across the window). >= 1h
+                    // before BaseTimeUtc so the per-batch cache window [oldest-1min, newest+1min] captures
+                    // COLD's rows on the WARM re-run.
+                    CreationTime = cfg.BaseTimeUtc.AddMinutes(-(((blobBaseMinute + j) % windowMinutes) + 60)),
                     OriginalImportFileContents = "stress"
                 };
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
@@ -189,6 +189,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 _logger.LogInformation("Audit events import: all save batches committed successfully this cycle.");
             }
 
+            // Where did the SQL save time go this cycle? Aggregate across all batches (see ImportStat timing
+            // fields). Makes the save bottleneck visible in the traces so we don't have to infer it.
+            _logger.LogInformation($"Audit events import: save-phase timing (aggregate across {allStats.Total.ToString("n0")} event(s)): " +
+                $"dedup+scope {(allStats.SaveDedupMs / 1000.0).ToString("n1")}s, staging+merge {(allStats.SaveMergeMs / 1000.0).ToString("n1")}s, " +
+                $"metadata {(allStats.SaveMetadataMs / 1000.0).ToString("n1")}s.");
+
             timer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
 
             return allStats;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -55,6 +55,23 @@ namespace WebJob.Office365ActivityImporter.Engine
         private readonly SemaphoreSlim _saveConcurrencyGate;
         private static readonly SemaphoreSlim _sharedWriteSemaphore = new SemaphoreSlim(1, 1);
 
+        // --- Run-scoped dedup cache (perf: build ONCE per cycle, not per batch) -------------------------
+        // The set of audit-event ids already imported/ignored within the download window. This manager is
+        // created once per import cycle, so the cache is built ONCE (lazily, for the whole window) and kept
+        // current in-memory as each batch saves - replacing the old behaviour of re-querying audit_events on
+        // every CommitAll. A 2000-event batch's [Min,Max] CreationTime spans almost the entire window (events
+        // download out-of-order across ~130 threads), so the per-batch query materialised ~the whole in-window
+        // audit_events set on EVERY batch: the dominant cost, and a large memory spike, at scale. Correctness
+        // is unchanged - the same ids are cached (full window, keyed by id) and the merge SQL's NOT EXISTS
+        // guards remain the authoritative cross-instance/cross-cycle dedup backstop. ActivityImportCache is
+        // internally thread-safe, so one instance is shared safely across concurrent saves.
+        //   _usePerBatchDedupCache is an ops safety-valve (app setting AUDIT_PERBATCH_DEDUP_CACHE=true) that
+        //   restores the old per-batch build without a redeploy; default false = new per-cycle behaviour.
+        private readonly bool _usePerBatchDedupCache;
+        private ActivityImportCache _runImportCache;
+        private bool _runImportCacheBuilt;
+        private readonly SemaphoreSlim _runImportCacheInitLock = new SemaphoreSlim(1, 1);
+
         // Run-scoped Copilot Graph metadata loader, shared across every batch so its Graph caches (resolved
         // files, users, sites, and unresolvable contexts) persist for the whole import instead of being rebuilt
         // per batch. Lazily built once; best-effort (null on failure -> each SaveSession falls back to its own).
@@ -65,7 +82,7 @@ namespace WebJob.Office365ActivityImporter.Engine
         // How many Copilot file contexts to resolve concurrently while pre-warming the cache (outside the SQL lock).
         private const int PrewarmConcurrency = 8;
 
-        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves = 1)
+        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves = 1, bool usePerBatchDedupCache = false)
         {
             _filterConfig = filterConfig;
             _userGroupsCache = userGroupsCache;
@@ -73,6 +90,7 @@ namespace WebJob.Office365ActivityImporter.Engine
             _appConfig = appConfig;
             _userGroupsFilter = new UserGroupsFilterModel(appConfig.UserGroupsFilter);
             _maxConcurrentSaves = Math.Max(1, maxConcurrentSaves);
+            _usePerBatchDedupCache = usePerBatchDedupCache;
             if (_maxConcurrentSaves > 1)
             {
                 _saveConcurrencyGate = new SemaphoreSlim(_maxConcurrentSaves, _maxConcurrentSaves);
@@ -86,7 +104,13 @@ namespace WebJob.Office365ActivityImporter.Engine
         {
             if (activities.Count > 0)
             {
-                var cache = ActivityImportCache.GetAndBuildNewCache(activities.OldestContent, activities.NewestContent);
+                // Build the dedup cache ONCE per cycle (shared, kept current in-memory) instead of
+                // re-querying audit_events for every batch. The per-batch reload materialised ~the whole
+                // in-window event set each time because a batch spans nearly the whole window. See the field
+                // comment on _runImportCache. The AUDIT_PERBATCH_DEDUP_CACHE safety-valve restores the old path.
+                var cache = _usePerBatchDedupCache
+                    ? ActivityImportCache.GetAndBuildNewCache(activities.OldestContent, activities.NewestContent)
+                    : await GetOrBuildRunImportCacheAsync();
 
                 // Read default connection-string
                 if (string.IsNullOrEmpty(_defaultConnectionString))
@@ -172,6 +196,47 @@ namespace WebJob.Office365ActivityImporter.Engine
             }
 
             return allStats;
+        }
+
+        /// <summary>
+        /// Lazily build the run-scoped dedup cache ONCE per import cycle (this manager is created per cycle),
+        /// covering the whole download window [now - DaysBeforeNowToDownload, now]. Every event processed this
+        /// cycle has a CreationTime inside that window (the API only serves it there) and the cache is keyed by
+        /// event id, so a single full-window load is equivalent to the old per-batch [Min,Max] loads - without
+        /// the massive redundancy. Kept current thereafter in-memory by RememberProcessedEvent /
+        /// RememberNewlyIgnoredEvent as batches save. Thread-safe (double-checked init + a thread-safe cache).
+        /// </summary>
+        private async Task<ActivityImportCache> GetOrBuildRunImportCacheAsync()
+        {
+            if (_runImportCacheBuilt) return _runImportCache;
+            await _runImportCacheInitLock.WaitAsync();
+            try
+            {
+                if (!_runImportCacheBuilt)
+                {
+                    // +1 day of lower margin so an event created just outside the exact window boundary (the
+                    // download window is computed slightly earlier, at cycle start) can never be missed.
+                    var daysBack = Math.Max(_appConfig.DaysBeforeNowToDownload, 1) + 1;
+                    var cacheFrom = DateTime.UtcNow.AddDays(-daysBack);
+                    var cacheTo = DateTime.UtcNow.AddMinutes(2);
+
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    var built = ActivityImportCache.GetAndBuildNewCache(cacheFrom, cacheTo);
+                    sw.Stop();
+
+                    _logger.LogInformation($"Audit events import: built run dedup cache from audit_events in " +
+                        $"{sw.Elapsed.TotalSeconds.ToString("n1")}s ({built.ProcessedIdCount.ToString("n0")} already-processed id(s), " +
+                        $"{daysBack}-day window) - reused across all save batches this cycle instead of reloading per batch.");
+
+                    _runImportCache = built;
+                    _runImportCacheBuilt = true;
+                }
+            }
+            finally
+            {
+                _runImportCacheInitLock.Release();
+            }
+            return _runImportCache;
         }
 
         /// <summary>
@@ -288,6 +353,11 @@ namespace WebJob.Office365ActivityImporter.Engine
             var processedIds = new HashSet<Guid>();
             var stats = new ImportStat() { Total = activities.Count };
 
+            // Phase timing, surfaced per cycle so operators can see where the save time actually goes: the
+            // in-memory dedup + scope check, the SQL staging-load + merge, and the EF metadata pass. Aggregated
+            // (summed) across batches in ImportStat.AddStats; in concurrent-save mode the merge/metadata are
+            // serialised by mergeLock so their summed times approximate the real serialised wall-time.
+            var swDedup = System.Diagnostics.Stopwatch.StartNew();
             foreach (var abtractLog in activities)
             {
                 // Don't insert duplicates in same set
@@ -331,6 +401,8 @@ namespace WebJob.Office365ActivityImporter.Engine
                     processedIds.Add(abtractLog.Id);
                 }
             }
+            swDedup.Stop();
+            stats.SaveDedupMs = swDedup.Elapsed.TotalMilliseconds;
 
             // Merge data
 #if DEBUG
@@ -341,12 +413,16 @@ namespace WebJob.Office365ActivityImporter.Engine
             // tables); the parallel staging LOAD inside SaveToStagingTable runs unlocked.
             var effectiveStagingTable = stagingTableName ?? ActivityImportConstants.STAGING_TABLE_ACTIVITY;
             var mergeSQL = Resources.Insert_Activity_from_Staging_Table.Replace("${STAGING_TABLE_ACTIVITY}", effectiveStagingTable);
+            var swMerge = System.Diagnostics.Stopwatch.StartNew();
             await logsToInsert.SaveToStagingTable(10000, mergeSQL, stagingTableName, mergeLock);
+            swMerge.Stop();
+            stats.SaveMergeMs = swMerge.Elapsed.TotalMilliseconds;
 
             #region Add Extra Metadata
 
             // The metadata pass writes SHARED tables (webs/sites via ProcessExtendedProperties, plus the
             // Copilot / Power Platform commits), so in concurrent mode it is serialised by the same lock.
+            var swMeta = System.Diagnostics.Stopwatch.StartNew();
             if (mergeLock != null) await mergeLock.WaitAsync();
             try
             {
@@ -356,6 +432,8 @@ namespace WebJob.Office365ActivityImporter.Engine
             {
                 if (mergeLock != null) mergeLock.Release();
             }
+            swMeta.Stop();
+            stats.SaveMetadataMs = swMeta.Elapsed.TotalMilliseconds;
 
             #endregion
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
@@ -143,7 +143,28 @@ namespace WebJob.Office365ActivityImporter.Engine
         {
             lock (_lock)
             {
-                this.GetCacheChunkForAuditLog(processedDate, CacheType.Processed).Add(id, processedDate);
+                // Indexer (not .Add) so a duplicate id is an idempotent overwrite rather than an
+                // ArgumentException - e.g. an id present in both ignored_audit_events and audit_events when
+                // the cache is loaded, or the same event remembered by two concurrent save batches that now
+                // share this single run-scoped cache.
+                this.GetCacheChunkForAuditLog(processedDate, CacheType.Processed)[id] = processedDate;
+            }
+        }
+
+        /// <summary>
+        /// Total number of processed (imported-or-ignored) event ids currently held, across all hourly
+        /// chunks. Used for telemetry when the run-scoped cache is built (how many ids were loaded).
+        /// </summary>
+        public int ProcessedIdCount
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    int total = 0;
+                    foreach (var chunk in ProcessedIDs.Values) total += chunk.Count;
+                    return total;
+                }
             }
         }
 
@@ -242,7 +263,9 @@ namespace WebJob.Office365ActivityImporter.Engine
             lock (_lock)
             {
                 Dictionary<Guid, DateTime> theCache = this.GetCacheChunkForAuditLog(auditLogContent, CacheType.Processed);
-                theCache.Add(auditLogContent.Id, auditLogContent.CreationTime);
+                // Indexer (not .Add): idempotent, so the shared run-scoped cache is safe when the same event
+                // id is remembered by two concurrent save batches (a duplicate .Add would throw).
+                theCache[auditLogContent.Id] = auditLogContent.CreationTime;
             }
         }
 
@@ -253,8 +276,9 @@ namespace WebJob.Office365ActivityImporter.Engine
         {
             lock (_lock)
             {
-                this.GetCacheChunkForAuditLog(auditLogContent, CacheType.NewlyIgnored).Add(auditLogContent.Id, auditLogContent.CreationTime);
-                this.GetCacheChunkForAuditLog(auditLogContent, CacheType.Processed).Add(auditLogContent.Id, auditLogContent.CreationTime);
+                // Indexer (not .Add): idempotent for the shared run-scoped cache (see RememberProcessedEvent).
+                this.GetCacheChunkForAuditLog(auditLogContent, CacheType.NewlyIgnored)[auditLogContent.Id] = auditLogContent.CreationTime;
+                this.GetCacheChunkForAuditLog(auditLogContent, CacheType.Processed)[auditLogContent.Id] = auditLogContent.CreationTime;
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
@@ -45,6 +45,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
         /// </summary>
         public int FailedBatchEvents { get; set; }
 
+        /// <summary>
+        /// Aggregate save-phase timings (milliseconds), summed across all save batches this cycle, so the
+        /// per-cycle summary can show where the SQL save time goes:
+        ///   <see cref="SaveDedupMs"/>    - in-memory dedup + scope check + staging-row build (CPU).
+        ///   <see cref="SaveMergeMs"/>     - SQL staging load + the merge into the normal tables.
+        ///   <see cref="SaveMetadataMs"/>  - the EF metadata pass (webs/sites, Copilot / Power Platform).
+        /// In concurrent-save mode the merge + metadata are serialised by a shared lock, so their summed
+        /// times approximate the real serialised wall-time; dedup runs in parallel so its sum is total CPU.
+        /// </summary>
+        public double SaveDedupMs { get; set; }
+        public double SaveMergeMs { get; set; }
+        public double SaveMetadataMs { get; set; }
+
         public List<TimePeriod> ForTimeSlots { get; set; }
 
         public void AddStats(ImportStat statsToAdd)
@@ -62,6 +75,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
             this.BlobsSkipped += statsToAdd.BlobsSkipped;
             this.FailedBatches += statsToAdd.FailedBatches;
             this.FailedBatchEvents += statsToAdd.FailedBatchEvents;
+            this.SaveDedupMs += statsToAdd.SaveDedupMs;
+            this.SaveMergeMs += statsToAdd.SaveMergeMs;
+            this.SaveMetadataMs += statsToAdd.SaveMetadataMs;
             this.Total += statsToAdd.Total;
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -148,7 +148,20 @@ namespace WebJob.Office365ActivityImporter
 
                 var importer = new ActivityWebImporter(_settings, _logger, MAX_IMPORTS_PER_BATCH, maxConcurrentSaves);
 
-                var sqlAdaptor = new ActivityReportSqlPersistenceManager(spFilterList, _graphUserGroupsCache, _logger, _settings, maxConcurrentSaves);
+                // Safety valve: the dedup cache is built ONCE per cycle by default (it used to be rebuilt from
+                // audit_events for every batch, which materialised ~the whole in-window event set each time -
+                // the dominant save cost at scale). Set AUDIT_PERBATCH_DEDUP_CACHE=true to restore the old
+                // per-batch build without a redeploy if the new path ever misbehaves.
+                bool usePerBatchDedupCache = false;
+                var perBatchCacheEnv = Environment.GetEnvironmentVariable("AUDIT_PERBATCH_DEDUP_CACHE");
+                if (!string.IsNullOrWhiteSpace(perBatchCacheEnv) &&
+                    (perBatchCacheEnv.Trim() == "1" || perBatchCacheEnv.Trim().Equals("true", StringComparison.OrdinalIgnoreCase)))
+                {
+                    usePerBatchDedupCache = true;
+                    _logger.LogWarning("Activity import: per-batch dedup cache ENABLED (AUDIT_PERBATCH_DEDUP_CACHE) - reverts the per-cycle cache optimisation; expect slower saves on large tables.");
+                }
+
+                var sqlAdaptor = new ActivityReportSqlPersistenceManager(spFilterList, _graphUserGroupsCache, _logger, _settings, maxConcurrentSaves, usePerBatchDedupCache);
                 try
                 {
                     var stats = await importer.LoadReportsAndSave(sqlAdaptor);


### PR DESCRIPTION
## What & why
The O365 audit importer was importing **slower than a large tenant produces audit data**, so it never caught up — and because the Management Activity API only serves content blobs for ~7 days, un-imported events age out of the window and are lost, not just delayed.

A major part of the cost: the "already-processed" dedup cache was rebuilt from `audit_events` on **every** save batch. A 2000-event batch spans almost the whole download window (blobs download out of order across ~130 threads), so each rebuild pulled ~the entire in-window event set into memory — the dominant save cost, and a large memory spike, at scale.

## Change
- Build the dedup cache **once per cycle** (shared, kept current in-memory) instead of per batch. Dedup semantics are unchanged — the same ids are cached and the merge `NOT EXISTS` guards remain the authoritative backstop, so **no event can be wrongly skipped (no data loss)**.
- Adds **per-phase save timing** to the per-cycle summary (dedup+scope / staging+merge / metadata) so the bottleneck is visible in traces instead of inferred.
- Extends the DB-backed load-sim harness to reproduce this exact condition (large in-window backlog + out-of-order batches) so throughput changes never need to be tested in a customer tenant.

## Config
- New optional app setting **`AUDIT_PERBATCH_DEDUP_CACHE`** (default off). Set to `true` only as a safety valve to revert to the old per-batch cache without a redeploy.

## Measured (harness: 600k in-window backlog / 60k events / 4 concurrent saves)
dedup-cache cost ~31.8s → ~3.0s, save phase 43.5s → 17.0s, **peak memory 406 MB → 156 MB**, import stats identical.

Refs #217
