### PR TITLE
Opt-in Power Platform + Copilot resource-resolution workload toggles

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/TargetSolutionConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/TargetSolutionConfigControl.Designer.cs
@@ -47,6 +47,7 @@
             this.lblGUITargetsHeader = new System.Windows.Forms.Label();
             this.chkCopilot = new System.Windows.Forms.CheckBox();
             this.chkSentEmails = new System.Windows.Forms.CheckBox();
+            this.chkPowerPlatform = new System.Windows.Forms.CheckBox();
             this.pnlSolutionSelectionContainer.SuspendLayout();
             this.grpProductCfgInsights.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
@@ -74,6 +75,7 @@
             this.grpProductCfgInsights.Controls.Add(this.chkUserMetadata);
             this.grpProductCfgInsights.Controls.Add(this.chkCopilot);
             this.grpProductCfgInsights.Controls.Add(this.chkSentEmails);
+            this.grpProductCfgInsights.Controls.Add(this.chkPowerPlatform);
             this.grpProductCfgInsights.Controls.Add(this.chkUserApps);
             this.grpProductCfgInsights.Controls.Add(this.chkWeb);
             this.grpProductCfgInsights.Controls.Add(this.chkCalls);
@@ -261,6 +263,17 @@
             this.chkSentEmails.Text = "Sent emails";
             this.chkSentEmails.UseVisualStyleBackColor = true;
             // 
+            // chkPowerPlatform
+            // 
+            this.chkPowerPlatform.AutoSize = true;
+            this.chkPowerPlatform.Location = new System.Drawing.Point(4, 287);
+            this.chkPowerPlatform.Margin = new System.Windows.Forms.Padding(2);
+            this.chkPowerPlatform.Name = "chkPowerPlatform";
+            this.chkPowerPlatform.Size = new System.Drawing.Size(140, 17);
+            this.chkPowerPlatform.TabIndex = 25;
+            this.chkPowerPlatform.Text = "Power Platform";
+            this.chkPowerPlatform.UseVisualStyleBackColor = true;
+            // 
             // lblGUITargetsHeader
             // 
             this.lblGUITargetsHeader.AutoSize = true;
@@ -311,5 +324,6 @@
         private System.Windows.Forms.Label lblGUITargetsHeader;
         private System.Windows.Forms.CheckBox chkCopilot;
         private System.Windows.Forms.CheckBox chkSentEmails;
+        private System.Windows.Forms.CheckBox chkPowerPlatform;
     }
 }

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/TargetSolutionConfigControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/TargetSolutionConfigControl.cs
@@ -31,7 +31,8 @@ namespace App.ControlPanel.Controls
                         Calls = chkCalls.Checked,
                         WebTraffic = chkWeb.Checked,
                         Copilot = chkCopilot.Checked,
-                        SentEmails = chkSentEmails.Checked
+                        SentEmails = chkSentEmails.Checked,
+                        ImportPowerPlatform = chkPowerPlatform.Checked
                     }
                 };
             }
@@ -54,6 +55,7 @@ namespace App.ControlPanel.Controls
             chkWeb.Checked = value.ImportTaskSettings.WebTraffic;
             chkCopilot.Checked = value.ImportTaskSettings.Copilot;
             chkSentEmails.Checked = value.ImportTaskSettings.SentEmails;
+            chkPowerPlatform.Checked = value.ImportTaskSettings.ImportPowerPlatform;
         }
 
 

--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -53,6 +53,12 @@ namespace Common.Entities.Config
                 ? daysBeforeNowToDownload
                 : 6;
 
+            // Resolve Copilot file/meeting metadata from Graph. Default true so behaviour is unchanged unless
+            // a tenant opts out. (The Power Platform workload is toggled separately on ImportJobSettings.)
+            this.ResolveCopilotResourceMetadata = bool.TryParse(ConfigurationManager.AppSettings.Get("ResolveCopilotResourceMetadata"), out var resolveCopilotResourceMetadata)
+                ? resolveCopilotResourceMetadata
+                : true;
+
             // Optional: how many days before today to start reading hits from App Insights.
             // Can be overridden via the -readHitsDaysBeforeToday command line argument.
             var readHitsDaysBeforeTodayString = ConfigurationManager.AppSettings.Get("ReadHitsDaysBeforeToday");
@@ -153,6 +159,15 @@ namespace Common.Entities.Config
         public string ContentTypesString { get; set; }
 
         public int DaysBeforeNowToDownload { get; set; }
+
+        /// <summary>
+        /// Resolve Copilot file + meeting resource metadata from the Graph (file name/site, meeting
+        /// name/date). Default true. When false, Copilot interactions are still imported with their agent
+        /// metadata (agent id/name/type, cost, messages, accessed resources) but the per-event Graph
+        /// resolution is skipped - removing serial, network-bound calls from the save path. Set false when
+        /// only Copilot agent-level reporting is needed.
+        /// </summary>
+        public bool ResolveCopilotResourceMetadata { get; set; }
 
         /// <summary>
         /// Optional: how many days before today to start reading hits from App Insights.

--- a/src/AnalyticsEngine/Common/Entities/ImportTaskSettings.cs
+++ b/src/AnalyticsEngine/Common/Entities/ImportTaskSettings.cs
@@ -99,6 +99,14 @@ namespace Common.Entities
         [ImportProp]
         public bool Copilot { get; set; } = false;
 
+        /// <summary>
+        /// Import the Power Platform workload - PowerApps / Power Automate / Power BI / Copilot Studio
+        /// (also delivered via the Audit.General activity feed). Opt-in (default false) as it is a newer
+        /// workload; when off, these events are dropped at dispatch (not imported, and no staging merges run).
+        /// </summary>
+        [ImportProp]
+        public bool ImportPowerPlatform { get; set; } = false;
+
         IEnumerable<PropertyInfo> GetImportProps()
         {
             return this.GetType().GetProperties().Where(p => Attribute.IsDefined(p, typeof(ImportPropAttribute)));
@@ -135,7 +143,8 @@ namespace Common.Entities
         public string ToActivityApiContentTypesString()
         {
             var types = new List<string>();
-            if (Copilot) types.Add(CONTENT_TYPE_AUDIT_GENERAL);
+            // Copilot and Power Platform are both delivered via the Audit.General feed.
+            if (Copilot || ImportPowerPlatform) types.Add(CONTENT_TYPE_AUDIT_GENERAL);
             if (ActivityLog) types.Add(CONTENT_TYPE_AUDIT_SHAREPOINT);
             return types.Count > 0 ? string.Join(SEP, types) : CONTENT_TYPE_AUDIT_SHAREPOINT;
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeCopilotEventAdaptor.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeCopilotEventAdaptor.cs
@@ -70,4 +70,31 @@ namespace UnitTests.FakeLoaderClasses
             throw new InvalidOperationException("Simulated user lookup failure");
         }
     }
+
+    /// <summary>
+    /// Metadata loader that counts how many times each Graph resolution method is called, so a test can
+    /// assert that disabling Copilot resource resolution makes NO Graph calls at all.
+    /// </summary>
+    public class RecordingCopilotMetadataLoader : ICopilotMetadataLoader
+    {
+        public int MeetingCalls;
+        public int FileCalls;
+        public int UserIdCalls;
+
+        public Task<MeetingMetadata> GetMeetingInfo(string meetingId, string userGuid)
+        {
+            System.Threading.Interlocked.Increment(ref MeetingCalls);
+            return Task.FromResult<MeetingMetadata>(null);
+        }
+        public Task<SpoDocumentFileInfo> GetSpoFileInfo(string copilotId, string eventUpn)
+        {
+            System.Threading.Interlocked.Increment(ref FileCalls);
+            return Task.FromResult<SpoDocumentFileInfo>(null);
+        }
+        public Task<string> GetUserIdFromUpn(string userPrincipalName)
+        {
+            System.Threading.Interlocked.Increment(ref UserIdCalls);
+            return Task.FromResult("testId");
+        }
+    }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="CopilotPrewarmExtractionTests.cs" />
     <Compile Include="CopilotEventManagerSaveTests.cs" />
     <Compile Include="CopilotTestBase.cs" />
+    <Compile Include="WorkloadToggleTests.cs" />
     <Compile Include="PageUpdateManagerPerfTests.cs" />
     <Compile Include="PerfRegressionTests.cs" />
     <Compile Include="SentEmailImporterPipelineTests.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/WorkloadToggleTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/WorkloadToggleTests.cs
@@ -1,0 +1,133 @@
+using Common.Entities;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine;
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests for the optional-workload toggles:
+    ///   - ImportPowerPlatform (ImportJobSettings): when off, Power Platform events are dropped at dispatch.
+    ///   - ResolveCopilotResourceMetadata (AppConfig): when off, Copilot events are still imported with their
+    ///     agent metadata but no file/meeting Graph resolution happens (no network calls on the save path).
+    /// </summary>
+    [TestClass]
+    public class WorkloadToggleTests
+    {
+        private static ILogger Logger => new LoggerFactory().CreateLogger("WorkloadToggleTests");
+
+        [TestMethod]
+        public void Dispatch_PowerPlatformDisabled_DropsPowerPlatformWorkloads()
+        {
+            var json = JToken.Parse("{}");
+
+            foreach (var workload in new[]
+            {
+                ActivityImportConstants.WORKLOAD_POWER_PLATFORM,
+                ActivityImportConstants.WORKLOAD_POWER_APPS,
+                ActivityImportConstants.WORKLOAD_POWER_AUTOMATE,
+                ActivityImportConstants.WORKLOAD_POWER_BI,
+                ActivityImportConstants.WORKLOAD_COPILOT_STUDIO
+            })
+            {
+                var logBase = new WorkloadOnlyAuditLogContent { Workload = workload };
+                Assert.IsNull(
+                    AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: false),
+                    $"'{workload}' must be dropped when Power Platform import is disabled.");
+            }
+        }
+
+        [TestMethod]
+        public void Dispatch_PowerPlatformEnabled_KeepsPowerAppsEvent()
+        {
+            var json = JToken.Parse("{}");
+            var logBase = new WorkloadOnlyAuditLogContent { Workload = ActivityImportConstants.WORKLOAD_POWER_APPS };
+
+            Assert.IsNotNull(
+                AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: true),
+                "Power Platform events must be imported when the workload is enabled.");
+        }
+
+        [TestMethod]
+        public void Dispatch_PowerPlatformDisabled_DoesNotAffectSharePoint()
+        {
+            var json = JToken.Parse("{}");
+            var logBase = new WorkloadOnlyAuditLogContent { Workload = ActivityImportConstants.WORKLOAD_SP };
+
+            Assert.IsNotNull(
+                AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: false),
+                "SharePoint events must never be affected by the Power Platform toggle.");
+        }
+
+        [TestMethod]
+        public async Task CopilotResolutionDisabled_MakesNoGraphCalls()
+        {
+            var loader = new RecordingCopilotMetadataLoader();
+            // A dummy (non-empty) connection string is fine: staging only builds in-memory rows; no DB is
+            // touched until CommitAllChanges (which this test deliberately does not call).
+            var manager = new CopilotAuditEventManager(
+                "Data Source=(localdb)\\unused;Initial Catalog=unused;Integrated Security=true",
+                loader, Logger, resolveResourceMetadata: false);
+
+            var baseEvent = new CommonAuditEvent
+            {
+                Id = Guid.NewGuid(),
+                TimeStamp = DateTime.UtcNow,
+                Operation = new EventOperation { Name = "op" },
+                User = new User { UserPrincipalName = "user@contoso.onmicrosoft.com" }
+            };
+
+            // Meeting-context event: would normally call GetUserIdFromUpn + GetMeetingInfo.
+            await manager.SaveSingleCopilotEventToSqlStaging(new CopilotAuditLogContent
+            {
+                AgentId = "agent-1",
+                AgentName = "Test Agent",
+                IsCustomAgent = true,
+                CopilotEventData = new CopilotEventData
+                {
+                    AppHost = "Teams",
+                    Contexts = new List<Context>
+                    {
+                        new Context
+                        {
+                            Id = "https://microsoft.teams.com/threads/19:meeting_abc@thread.v2",
+                            Type = ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING
+                        }
+                    }
+                }
+            }, baseEvent);
+
+            // File-context event: would normally call GetSpoFileInfo.
+            await manager.SaveSingleCopilotEventToSqlStaging(new CopilotAuditLogContent
+            {
+                AgentId = "agent-1",
+                AgentName = "Test Agent",
+                IsCustomAgent = true,
+                CopilotEventData = new CopilotEventData
+                {
+                    AppHost = "Word",
+                    Contexts = new List<Context>
+                    {
+                        new Context
+                        {
+                            Id = "https://contoso.sharepoint.com/sites/x/Shared Documents/doc.docx",
+                            Type = "SharePoint"
+                        }
+                    }
+                }
+            }, baseEvent);
+
+            Assert.AreEqual(0, loader.MeetingCalls, "No meeting Graph call when Copilot resource resolution is disabled.");
+            Assert.AreEqual(0, loader.FileCalls, "No file Graph call when Copilot resource resolution is disabled.");
+            Assert.AreEqual(0, loader.UserIdCalls, "No user-id Graph call when Copilot resource resolution is disabled.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
+++ b/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
@@ -401,6 +401,7 @@ namespace Web.AnalyticsWeb.Models.Health
                 {
                     if (config.ImportJobSettings.ActivityLog) section.EnabledImports.Add("Activity/audit");
                     if (config.ImportJobSettings.Copilot) section.EnabledImports.Add("Copilot");
+                    if (config.ImportJobSettings.ImportPowerPlatform) section.EnabledImports.Add("Power Platform");
                     if (config.ImportJobSettings.GraphUsersMetadata) section.EnabledImports.Add("User metadata");
                     if (config.ImportJobSettings.GraphUserApps) section.EnabledImports.Add("User apps");
                     if (config.ImportJobSettings.GraphUsageReports) section.EnabledImports.Add("Usage reports");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
@@ -189,6 +189,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 _logger.LogInformation("Audit events import: all save batches committed successfully this cycle.");
             }
 
+            // Optional-workload save costs this cycle (aggregate across batches). Both are zero when the
+            // workload / resolution is disabled - this is how we tell whether Copilot resource resolution or
+            // Power Platform is meaningfully extending the import, rather than guessing.
+            _logger.LogInformation($"Audit events import: optional-workload save cost - Copilot resource resolution " +
+                $"{(allStats.SaveCopilotResolveMs / 1000.0).ToString("n1")}s, Power Platform {(allStats.SavePowerPlatformMs / 1000.0).ToString("n1")}s.");
+
             timer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
 
             return allStats;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -117,8 +117,11 @@ namespace WebJob.Office365ActivityImporter.Engine
             // Copilot file events it calls Graph (network). Resolving those ahead of time - overlapping across
             // batches and within a batch - turns the in-lock calls into cache hits, so the lock is held only for
             // SQL work, not network round-trips.
+            // Skip the prewarm entirely when Copilot resource resolution is disabled - the save path makes no
+            // Graph resource calls in that mode (every Copilot event is staged agent-metadata-only), so there
+            // is nothing to warm.
             var sharedLoader = await GetSharedCopilotLoaderAsync();
-            if (sharedLoader != null)
+            if (sharedLoader != null && _appConfig.ResolveCopilotResourceMetadata)
             {
                 await PrewarmCopilotFileMetadataAsync(activities, sharedLoader);
             }
@@ -350,7 +353,7 @@ namespace WebJob.Office365ActivityImporter.Engine
             if (mergeLock != null) await mergeLock.WaitAsync();
             try
             {
-                await SaveMetadataAsync(db, listOfActivitiesSavedToSQL, sharedCopilotLoader);
+                await SaveMetadataAsync(db, listOfActivitiesSavedToSQL, sharedCopilotLoader, stats);
             }
             finally
             {
@@ -366,7 +369,7 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// The EF metadata pass (webs/sites + workload-specific resolvers). Extracted so the concurrent-save
         /// path can wrap it in the shared-write lock. Writes shared tables, so callers serialise it.
         /// </summary>
-        private async Task SaveMetadataAsync(AnalyticsEntitiesContext db, ConcurrentBag<AbstractAuditLogContent> listOfActivitiesSavedToSQL, ICopilotMetadataLoader sharedCopilotLoader)
+        private async Task SaveMetadataAsync(AnalyticsEntitiesContext db, ConcurrentBag<AbstractAuditLogContent> listOfActivitiesSavedToSQL, ICopilotMetadataLoader sharedCopilotLoader, ImportStat stats)
         {
             // Add metadata the traditional way with EF. By now should have all the sites saved.
             // Pass the run-scoped Copilot loader so per-event Graph resolution hits the cache warmed above.
@@ -374,6 +377,7 @@ namespace WebJob.Office365ActivityImporter.Engine
             await saveSession.Init();
 
             int metaSaveIdx = 0, changesMadeCount = 0;
+            double copilotResolveMs = 0;   // per-event Copilot resolution time (the Graph file/meeting calls)
 #if DEBUG
             Console.WriteLine($"\nDEBUG: Updating metadata for {listOfActivitiesSavedToSQL.Count.ToString("n0")} saved events...");
 #endif
@@ -415,7 +419,11 @@ namespace WebJob.Office365ActivityImporter.Engine
                         metaSaveIdx++;
                         continue;
                     }
+                    // Time the Copilot per-event work separately - this is where the Graph file/meeting
+                    // resolution happens - so its cost shows up in the per-cycle summary.
+                    var copilotSw = log is CopilotAuditLogContent ? System.Diagnostics.Stopwatch.StartNew() : null;
                     var changesMade = await log.ProcessExtendedProperties(saveSession, savedEvent, _logger);
+                    if (copilotSw != null) { copilotSw.Stop(); copilotResolveMs += copilotSw.Elapsed.TotalMilliseconds; }
                     if (changesMade)
                         changesMadeCount++;
 
@@ -428,6 +436,11 @@ namespace WebJob.Office365ActivityImporter.Engine
 
             // Save metadata updates
             await saveSession.CommitAllChanges();
+
+            // Surface the per-workload sub-costs (summed across batches in the cycle summary): the Copilot
+            // per-event resolution measured above, and the Power Platform staging-merge cost.
+            stats.SaveCopilotResolveMs = copilotResolveMs;
+            stats.SavePowerPlatformMs = saveSession.LastPowerPlatformCommitMs;
         }
     }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -32,6 +32,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
 
         private readonly ICopilotMetadataLoader _copilotEventAdaptor;
         private readonly ILogger _logger;
+        private readonly bool _resolveResourceMetadata;
         private readonly InsertBatch<SPCopilotLogTempEntity> _copilotInsertsSP;
         private readonly InsertBatch<TeamsCopilotLogTempEntity> _copilotInsertsTeams;
         private readonly InsertBatch<ChatOnlyCopilotLogTempEntity> _copilotInsertsChatsNoContext;
@@ -42,11 +43,12 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         private int _totalFilesCount;
         private int _totalChatOnlyCount;
 
-        public CopilotAuditEventManager(string connectionString, ICopilotMetadataLoader copilotEventAdaptor, ILogger logger)
+        public CopilotAuditEventManager(string connectionString, ICopilotMetadataLoader copilotEventAdaptor, ILogger logger, bool resolveResourceMetadata = true)
         {
             if (string.IsNullOrEmpty(connectionString)) throw new ArgumentException($"'{nameof(connectionString)}' cannot be null or empty.", nameof(connectionString));
             _copilotEventAdaptor = copilotEventAdaptor ?? throw new ArgumentNullException(nameof(copilotEventAdaptor));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _resolveResourceMetadata = resolveResourceMetadata;
             _rr = new ProjectResourceReader(System.Reflection.Assembly.GetExecutingAssembly());
             _copilotInsertsSP = new InsertBatch<SPCopilotLogTempEntity>(connectionString, logger);
             _copilotInsertsTeams = new InsertBatch<TeamsCopilotLogTempEntity>(connectionString, logger);
@@ -61,6 +63,18 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             if (auditRecord == null || baseOfficeEvent == null)
             {
                 _logger.LogWarning("CopilotAuditEventManager received null auditRecord or baseOfficeEvent.");
+                return;
+            }
+
+            // Agent-metadata-only mode: when resource resolution is disabled, stage every interaction as a
+            // chat-only record - which still carries the agent id/name/type, cost, messages and accessed
+            // resources - and skip all file/meeting Graph resolution. This removes the serial, network-bound
+            // Graph calls from the save path for tenants that only want Copilot agent-level reporting.
+            if (!_resolveResourceMetadata)
+            {
+                AddChatOnly(auditRecord, baseOfficeEvent);
+                _totalChatOnlyCount++;
+                _logger.LogTrace($"Event {baseOfficeEvent.Id}: staged agent metadata only (Copilot resource resolution disabled).");
                 return;
             }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
@@ -22,13 +22,15 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         private AutoThrottleHttpClient _httpClient;
         private readonly ILogger _logger;
         private readonly string _tenantId;
+        private readonly bool _importPowerPlatform;
         private int _reportDownloadErrors = 0;
 
-        public ActivityReportWebLoader(AutoThrottleHttpClient httpClient, ILogger logger, string tenantId)
+        public ActivityReportWebLoader(AutoThrottleHttpClient httpClient, ILogger logger, string tenantId, bool importPowerPlatform = true)
         {
             _httpClient = httpClient;
             _logger = logger;
             _tenantId = tenantId;
+            _importPowerPlatform = importPowerPlatform;
         }
 
         /// <summary>
@@ -191,7 +193,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
             // thin IO + batching layer.
             try
             {
-                thisAuditLogReport = AuditLogContentDispatcher.Dispatch(reportItem, logBase, _logger);
+                thisAuditLogReport = AuditLogContentDispatcher.Dispatch(reportItem, logBase, _logger, _importPowerPlatform);
             }
             catch (JsonReaderException ex)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityWebImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityWebImporter.cs
@@ -20,7 +20,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         {
             var auth = new ActivityAPIAppIndentityOAuthContext(logger, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
             var httpClient = new ConfidentialClientApplicationThrottledHttpClient(auth, false, logger);
-            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, logger, settings.TenantGUID.ToString());
+            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, logger, settings.TenantGUID.ToString(), settings.ImportJobSettings?.ImportPowerPlatform ?? false);
             _contentMetaDataLoader = new WebContentMetaDataLoader(logger, httpClient, settings);
             _activitySubscriptionManager = new ActivitySubscriptionManager(settings, logger, httpClient);
         }
@@ -31,7 +31,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         /// </summary>
         public ActivityWebImporter(ConfidentialClientApplicationThrottledHttpClient httpClient, AppConfig settings, AnalyticsLogger logger, int maxSavesPerBatch) : base(settings, logger, maxSavesPerBatch)
         {
-            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, logger, settings.TenantGUID.ToString());
+            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, logger, settings.TenantGUID.ToString(), settings.ImportJobSettings?.ImportPowerPlatform ?? false);
             _contentMetaDataLoader = new WebContentMetaDataLoader(logger, httpClient, settings);
             _activitySubscriptionManager = new ActivitySubscriptionManager(settings, logger, httpClient);
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/AuditLogContentDispatcher.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/AuditLogContentDispatcher.cs
@@ -26,9 +26,23 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         /// JSON deserialisation exceptions are intentionally not caught here - the caller already
         /// logs them with the originating workload name and continues to the next record.
         /// </summary>
-        public static AbstractAuditLogContent Dispatch(JToken reportItem, WorkloadOnlyAuditLogContent logBase, ILogger logger)
+        public static AbstractAuditLogContent Dispatch(JToken reportItem, WorkloadOnlyAuditLogContent logBase, ILogger logger, bool importPowerPlatform = true)
         {
             if (reportItem == null || logBase == null)
+            {
+                return null;
+            }
+
+            // Power Platform (the unified PowerPlatform record + the legacy per-product PowerApps / Power
+            // Automate / Power BI schemas + Copilot Studio) all arrive via the Audit.General subscription.
+            // When the workload is turned off, drop these events here so they are neither imported (no base
+            // audit_events row) nor staged (no Power Platform merges) - the whole workload's cost is skipped.
+            if (!importPowerPlatform
+                && (logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_PLATFORM
+                    || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_APPS
+                    || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_AUTOMATE
+                    || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_BI
+                    || logBase.Workload == ActivityImportConstants.WORKLOAD_COPILOT_STUDIO))
             {
                 return null;
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/SaveSession.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/SaveSession.cs
@@ -57,7 +57,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 await _authContext.InitClientCredential();
                 loader = new GraphFileMetadataLoader(new GraphServiceClient(_authContext.Creds), _logger);
             }
-            _copilotEventResolver = new CopilotAuditEventManager(_appConfig.ConnectionStrings.DatabaseConnectionString, loader, _logger);
+            _copilotEventResolver = new CopilotAuditEventManager(_appConfig.ConnectionStrings.DatabaseConnectionString, loader, _logger, _appConfig.ResolveCopilotResourceMetadata);
             _powerPlatformEventResolver = new PowerPlatformAuditEventManager(_appConfig.ConnectionStrings.DatabaseConnectionString, _logger);
         }
 
@@ -75,10 +75,25 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
             this.Database.Dispose();
         }
 
+        /// <summary>Time (ms) spent in the Power Platform commit (its staging-table merges) during the last
+        /// <see cref="CommitAllChanges"/> call, so the save path can report the Power Platform workload's cost.</summary>
+        public double LastPowerPlatformCommitMs { get; private set; }
+
         public async Task CommitAllChanges()
         {
             await _copilotEventResolver.CommitAllChanges();
-            await _powerPlatformEventResolver.CommitAllChanges();
+
+            // Power Platform commit (6 staging-table merges). Skipped when the workload is disabled - no PP
+            // events are staged in that case, so this just avoids running the merges against empty tables.
+            LastPowerPlatformCommitMs = 0;
+            if (_appConfig.ImportJobSettings?.ImportPowerPlatform ?? false)
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                await _powerPlatformEventResolver.CommitAllChanges();
+                sw.Stop();
+                LastPowerPlatformCommitMs = sw.Elapsed.TotalMilliseconds;
+            }
+
             Database.ChangeTracker.DetectChanges();
             await this.Database.SaveChangesAsync();
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
@@ -45,6 +45,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
         /// </summary>
         public int FailedBatchEvents { get; set; }
 
+        /// <summary>
+        /// Per-workload save sub-costs (milliseconds, summed across batches this cycle), so the per-cycle
+        /// summary can show what the optional workloads cost:
+        ///   <see cref="SaveCopilotResolveMs"/>  - the Copilot per-event Graph resolution (file + meeting).
+        ///   <see cref="SavePowerPlatformMs"/>    - the Power Platform staging-table merges.
+        /// Both are zero when the corresponding workload / resolution is disabled.
+        /// </summary>
+        public double SaveCopilotResolveMs { get; set; }
+        public double SavePowerPlatformMs { get; set; }
+
         public List<TimePeriod> ForTimeSlots { get; set; }
 
         public void AddStats(ImportStat statsToAdd)
@@ -62,6 +72,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
             this.BlobsSkipped += statsToAdd.BlobsSkipped;
             this.FailedBatches += statsToAdd.FailedBatches;
             this.FailedBatchEvents += statsToAdd.FailedBatchEvents;
+            this.SaveCopilotResolveMs += statsToAdd.SaveCopilotResolveMs;
+            this.SavePowerPlatformMs += statsToAdd.SavePowerPlatformMs;
             this.Total += statsToAdd.Total;
         }
 


### PR DESCRIPTION
## What & why
Lets a tenant turn off workloads / enrichment it doesn't need, to cut save-path cost — and adds tracing so we can see what each costs. Builds on the per-cycle dedup-cache PR.

## New config
- **Power Platform import** — a **Power Platform** checkbox on the installer's Import Targets page (`ImportJobSettings.ImportPowerPlatform`). **Default OFF** (opt-in; it is a newer workload). When off, PowerApps / Power Automate / Power BI / Copilot Studio events are dropped at ingest and their staging merges do not run. Enabling it also subscribes to the `Audit.General` feed. Shows on the Health page when enabled.
- **Copilot resource resolution** — app setting `ResolveCopilotResourceMetadata`. **Default ON** (unchanged behaviour). When **off**, Copilot interactions are still imported with their **agent metadata** (which agent, which type, cost, messages, accessed resources), but the per-event file/meeting **Graph resolution is skipped** — removing serial, network-bound calls from the save path. Use when only Copilot agent-level reporting is needed.

## Tracing
The per-cycle summary now logs the per-workload save cost: `Copilot resource resolution Xs, Power Platform Ys` (both 0 when disabled), so we can tell from real traces whether either meaningfully extends the import.

## Tests
`WorkloadToggleTests` — Power Platform dispatch gate (off drops the PP workloads, on keeps them, SharePoint unaffected) and Copilot-off makes zero Graph calls. Existing Copilot / import / config-serialisation tests still pass.

Refs #217
