### PR TITLE
Trace audit-import save hot-paths (expose the Copilot merge cost per cycle)

### DIFF
--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
@@ -195,11 +195,16 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 $"dedup+scope {(allStats.SaveDedupMs / 1000.0).ToString("n1")}s, staging+merge {(allStats.SaveMergeMs / 1000.0).ToString("n1")}s, " +
                 $"metadata {(allStats.SaveMetadataMs / 1000.0).ToString("n1")}s.");
 
-            // Optional-workload save costs this cycle (aggregate across batches). Both are zero when the
-            // workload / resolution is disabled - this is how we tell whether Copilot resource resolution or
-            // Power Platform is meaningfully extending the import, rather than guessing.
-            _logger.LogInformation($"Audit events import: optional-workload save cost - Copilot resource resolution " +
-                $"{(allStats.SaveCopilotResolveMs / 1000.0).ToString("n1")}s, Power Platform {(allStats.SavePowerPlatformMs / 1000.0).ToString("n1")}s.");
+            // Break the metadata phase into its hot-paths so the dominant cost is attributable rather than a
+            // single opaque number. On Copilot-heavy tenants the Copilot SQL commit (the shared accessed-resource
+            // / agents merge) typically dominates; Copilot resolution and Power Platform are zero when disabled.
+            // Costs are summed across batches; in concurrent-save mode these steps are serialised by the shared
+            // write lock, so the sums approximate the real wall-time.
+            _logger.LogInformation($"Audit events import: metadata breakdown - EF-load {(allStats.SaveMetadataLoadMs / 1000.0).ToString("n1")}s, " +
+                $"Copilot resource resolution {(allStats.SaveCopilotResolveMs / 1000.0).ToString("n1")}s, " +
+                $"Copilot SQL commit {(allStats.SaveCopilotCommitMs / 1000.0).ToString("n1")}s, " +
+                $"Power Platform {(allStats.SavePowerPlatformMs / 1000.0).ToString("n1")}s, " +
+                $"EF save-changes {(allStats.SaveEfChangesMs / 1000.0).ToString("n1")}s.");
 
             timer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -461,6 +461,9 @@ namespace WebJob.Office365ActivityImporter.Engine
 #endif
             if (listOfActivitiesSavedToSQL.Count > 0)
             {
+                // Time the metadata read-back (EF load of the just-saved audit + SharePoint events) on its own
+                // so it appears in the per-cycle metadata breakdown instead of being folded into the total.
+                var swMetaLoad = System.Diagnostics.Stopwatch.StartNew();
                 var ids = listOfActivitiesSavedToSQL.Select(l => l.Id).ToList();
                 var eventsJustSaved = db.AuditEventsCommon
                     .Include(e => e.User)
@@ -478,6 +481,8 @@ namespace WebJob.Office365ActivityImporter.Engine
                 {
                     saveSession.CachedSpEvents.Add(e.EventID, e);
                 }
+                swMetaLoad.Stop();
+                stats.SaveMetadataLoadMs = swMetaLoad.Elapsed.TotalMilliseconds;
 
                 foreach (var log in listOfActivitiesSavedToSQL)
                 {
@@ -518,7 +523,9 @@ namespace WebJob.Office365ActivityImporter.Engine
             // Surface the per-workload sub-costs (summed across batches in the cycle summary): the Copilot
             // per-event resolution measured above, and the Power Platform staging-merge cost.
             stats.SaveCopilotResolveMs = copilotResolveMs;
+            stats.SaveCopilotCommitMs = saveSession.LastCopilotCommitMs;
             stats.SavePowerPlatformMs = saveSession.LastPowerPlatformCommitMs;
+            stats.SaveEfChangesMs = saveSession.LastEfSaveChangesMs;
         }
     }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -396,9 +396,29 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
 
             _logger.LogDebug($"Committing batch: {_totalFilesCount} file(s), {_totalMeetingsCount} meeting(s), {_totalChatOnlyCount} chat-only event(s) to SQL.");
 
+            // Per-staging-table timing. Each of the three Copilot staging tables runs the shared
+            // accessed-resource / agents merge (common_upsert_copilot_agents.sql), which on Copilot-heavy
+            // tenants is the dominant save cost - so time each separately to see which workload's merge is
+            // expensive (the chat-only path carries accessed resources too, so it is often the largest).
+            var swSp = System.Diagnostics.Stopwatch.StartNew();
             await _copilotInsertsSP.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, docsMergeSql);
+            swSp.Stop();
+            var swTeams = System.Diagnostics.Stopwatch.StartNew();
             await _copilotInsertsTeams.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, teamsMergeSql);
+            swTeams.Stop();
+            var swChat = System.Diagnostics.Stopwatch.StartNew();
             await _copilotInsertsChatsNoContext.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, chatOnlyMergeSql);
+            swChat.Stop();
+
+            var copilotTimingMsg = $"Copilot commit timing: SP-docs {(swSp.Elapsed.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalFilesCount.ToString("n0")} file event(s)), " +
+                $"Teams {(swTeams.Elapsed.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalMeetingsCount.ToString("n0")} meeting event(s)), " +
+                $"chat-only {(swChat.Elapsed.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalChatOnlyCount.ToString("n0")} chat-only event(s)).";
+            // Surface a slow Copilot merge (the usual bottleneck) at Information so it stands out in the traces;
+            // keep routine fast batches at Debug to avoid per-batch noise.
+            if (swSp.Elapsed.TotalMilliseconds + swTeams.Elapsed.TotalMilliseconds + swChat.Elapsed.TotalMilliseconds >= 5000)
+                _logger.LogInformation(copilotTimingMsg);
+            else
+                _logger.LogDebug(copilotTimingMsg);
 
             // Clear lists & counters for next batch
             _copilotInsertsSP.Rows.Clear();

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/SaveSession.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/SaveSession.cs
@@ -79,9 +79,25 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
         /// <see cref="CommitAllChanges"/> call, so the save path can report the Power Platform workload's cost.</summary>
         public double LastPowerPlatformCommitMs { get; private set; }
 
+        /// <summary>Time (ms) spent in the Copilot commit (its staging-table load + the shared
+        /// accessed-resource / agents merge SQL) during the last <see cref="CommitAllChanges"/> call. This
+        /// merge runs for every batch that carries Copilot events - including chat-only events, and regardless
+        /// of <c>ResolveCopilotResourceMetadata</c> - so on Copilot-heavy tenants it is often the dominant save
+        /// cost. Surfaced separately so the per-cycle summary can attribute it instead of hiding it in metadata.</summary>
+        public double LastCopilotCommitMs { get; private set; }
+
+        /// <summary>Time (ms) spent in the final EF <c>SaveChangesAsync</c> (the metadata write) during the
+        /// last <see cref="CommitAllChanges"/> call.</summary>
+        public double LastEfSaveChangesMs { get; private set; }
+
         public async Task CommitAllChanges()
         {
+            // Copilot commit = staging-table load + the shared accessed-resource/agents merge SQL. Timed on its
+            // own because it is the usual save bottleneck on Copilot-heavy tenants.
+            var swCopilot = System.Diagnostics.Stopwatch.StartNew();
             await _copilotEventResolver.CommitAllChanges();
+            swCopilot.Stop();
+            LastCopilotCommitMs = swCopilot.Elapsed.TotalMilliseconds;
 
             // Power Platform commit (6 staging-table merges). Skipped when the workload is disabled - no PP
             // events are staged in that case, so this just avoids running the merges against empty tables.
@@ -95,7 +111,10 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
             }
 
             Database.ChangeTracker.DetectChanges();
+            var swEf = System.Diagnostics.Stopwatch.StartNew();
             await this.Database.SaveChangesAsync();
+            swEf.Stop();
+            LastEfSaveChangesMs = swEf.Elapsed.TotalMilliseconds;
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
@@ -59,14 +59,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
         public double SaveMetadataMs { get; set; }
 
         /// <summary>
-        /// Per-workload save sub-costs (milliseconds, summed across batches this cycle), so the per-cycle
-        /// summary can show what the optional workloads cost:
-        ///   <see cref="SaveCopilotResolveMs"/>  - the Copilot per-event Graph resolution (file + meeting).
-        ///   <see cref="SavePowerPlatformMs"/>    - the Power Platform staging-table merges.
-        /// Both are zero when the corresponding workload / resolution is disabled.
+        /// Sub-breakdown of the metadata phase (<see cref="SaveMetadataMs"/>), in milliseconds, summed across
+        /// batches this cycle, so the per-cycle summary can show where the metadata time actually goes:
+        ///   <see cref="SaveMetadataLoadMs"/>   - EF read-back of the just-saved audit + SharePoint events.
+        ///   <see cref="SaveCopilotResolveMs"/> - Copilot per-event Graph resolution (file + meeting lookups).
+        ///   <see cref="SaveCopilotCommitMs"/>  - the shared Copilot staging load + accessed-resource / agents
+        ///                                        merge SQL. Runs for any batch with Copilot events (even
+        ///                                        chat-only, and regardless of ResolveCopilotResourceMetadata),
+        ///                                        so it is typically the dominant cost on Copilot-heavy tenants.
+        ///   <see cref="SavePowerPlatformMs"/>  - the Power Platform staging-table merges (zero when disabled).
+        ///   <see cref="SaveEfChangesMs"/>      - the final EF SaveChangesAsync (metadata write).
+        /// In concurrent-save mode the merge + metadata are serialised by a shared lock, so these summed times
+        /// approximate the real serialised wall-time.
         /// </summary>
+        public double SaveMetadataLoadMs { get; set; }
         public double SaveCopilotResolveMs { get; set; }
+        public double SaveCopilotCommitMs { get; set; }
         public double SavePowerPlatformMs { get; set; }
+        public double SaveEfChangesMs { get; set; }
 
         public List<TimePeriod> ForTimeSlots { get; set; }
 
@@ -88,8 +98,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
             this.SaveDedupMs += statsToAdd.SaveDedupMs;
             this.SaveMergeMs += statsToAdd.SaveMergeMs;
             this.SaveMetadataMs += statsToAdd.SaveMetadataMs;
+            this.SaveMetadataLoadMs += statsToAdd.SaveMetadataLoadMs;
             this.SaveCopilotResolveMs += statsToAdd.SaveCopilotResolveMs;
+            this.SaveCopilotCommitMs += statsToAdd.SaveCopilotCommitMs;
             this.SavePowerPlatformMs += statsToAdd.SavePowerPlatformMs;
+            this.SaveEfChangesMs += statsToAdd.SaveEfChangesMs;
             this.Total += statsToAdd.Total;
         }
 


### PR DESCRIPTION
## What this does
Adds per-stage timing to the Office 365 audit-import save path so the dominant cost is attributable from the traces alone. The per-cycle summary previously reported one opaque `metadata` number that hid the shared **Copilot merge** (staging load + accessed-resource / agents merge SQL) - which on Copilot-heavy tenants is typically the biggest save cost (observed as multi-minute stalls per batch).

## New trace output (per cycle)
```
save-phase timing (aggregate across N events): dedup+scope Xs, staging+merge Xs, metadata Xs.
metadata breakdown - EF-load Xs, Copilot resource resolution Xs, Copilot SQL commit Xs,
                     Power Platform Xs, EF save-changes Xs.
```
Plus, for any slow batch, a pinpoint line showing which Copilot workload is expensive:
```
Copilot commit timing: SP-docs Xs (N file events), Teams Xs (N meeting events), chat-only Xs (N chat-only events).
```

## Changes (5 files, additive instrumentation only - no logic change)
- **SaveSession** - times the Copilot commit (`LastCopilotCommitMs`) and the final EF `SaveChangesAsync` (`LastEfSaveChangesMs`) separately.
- **ImportStat** - new aggregated fields `SaveMetadataLoadMs`, `SaveCopilotCommitMs`, `SaveEfChangesMs` (summed across batches in `AddStats`).
- **ActivityReportSqlPersistenceManager** - times the metadata EF read-back; captures the new sub-costs.
- **ActivityImporter** - new per-cycle "metadata breakdown" log line.
- **CopilotAuditEventManager** - per-staging-table timing (SP / Teams / chat-only), logged at Information only when the combined merge is slow (>=5s), else Debug, to avoid per-batch noise.

Complements the SQL-level `copilot_merge_step_timings` profiler: the C# trace says *the Copilot commit is the bottleneck*; the SQL profiler drills into *which of its steps*.

## Validation
Engine builds clean; **79/79** Copilot save-path tests pass. No schema/config change.
