### PR TITLE
Fix hand-run manual upgrade script to stamp __MigrationHistory even when already clean

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Migrations/202607130900001_DedupCopilotAccessedResourceSiteUrls.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202607130900001_DedupCopilotAccessedResourceSiteUrls.manual.sql
@@ -87,7 +87,7 @@ BEGIN
     SET @msg = @migration + N': already clean, nothing to do.';
     RAISERROR(@msg, 0, 1) WITH NOWAIT;
     DROP TABLE #norm; DROP TABLE #map;
-    RETURN;
+    GOTO StampHistory;   -- nothing to change, but still record the migration as applied (idempotent no-op)
 END
 
 -- Materialise each phase's exact work-set ONCE, keyed so the loops below batch by a seek instead of
@@ -219,7 +219,10 @@ RAISERROR(@msg, 0, 1) WITH NOWAIT;
 -- Record the migration so EF (DatabaseUpgrader / MigrateDatabaseToLatestVersion) and the web app Health
 -- page treat it as applied. No model change here, so the EF snapshot is byte-identical to the previous
 -- migration's - copy that row's Model / ContextKey / ProductVersion. Guarded so re-running is safe.
+-- Reached both after the clean-up runs AND (via GOTO above) when there was nothing to clean, so a hand-run
+-- always stamps the migration - even on an already-clean database.
 -- =====================================================================================================
+StampHistory:
 IF NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202607130900001_DedupCopilotAccessedResourceSiteUrls')
 BEGIN
     IF EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202607101200001_IndexCopilotAccessedResourceLookups')


### PR DESCRIPTION
## Problem
The standalone **manual SQL upgrade script** for migration `202607130900001_DedupCopilotAccessedResourceSiteUrls` `RETURN`ed on its "already clean, nothing to do" path **before** the `__MigrationHistory` stamp. So a DBA running it by hand against a database whose `site_url` data was already clean would run the (no-op) clean-up but **not** record the migration as applied — leaving it "pending" until the installer / EF reconciled it. (Observed while applying migrations by hand.)

## Fix
The already-clean path now `GOTO`s a `StampHistory:` label placed just before the stamp, so the migration is **always recorded** even when there's nothing to clean. The genuine "prerequisite table missing" guard still `RETURN`s without stamping (correct — the migration can't apply there).

Only the **hand-run script** is affected — the compiled EF migration is unchanged (EF stamps automatically after `Up()` succeeds).

## Audit of the other manual scripts (all correct)
- `IndexCopilotAccessedResourceLookups`, `IndexAuditEventsTimeStamp` — loop structure, no early return; always reach the stamp.
- `IndexSitesSiteId`, `CoverCopilotAccessedResourceDedup` — the "index already exists" path uses `IF/ELSE` and **falls through** to the stamp; their `RETURN`s are table/column-missing prerequisite guards (correctly skip the stamp).

## Validation
Ran the fixed script against a migrated DB: it parses (`GOTO`/label valid) and reaches the stamp section on the already-clean path (previously it returned before it).
