### PR TITLE
Fix vulnerable NuGet packages (AngleSharp, System.Security.Cryptography.Xml)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -184,7 +184,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp">
-      <Version>0.17.1</Version>
+      <Version>1.5.2</Version>
     </PackageReference>
     <PackageReference Include="Azure.Core">
       <Version>1.57.0</Version>

--- a/src/AnalyticsEngine/App.ControlPanel/App.Template.config
+++ b/src/AnalyticsEngine/App.ControlPanel/App.Template.config
@@ -42,7 +42,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0" />
+				<bindingRedirect oldVersion="0.0.0.0-1.5.2.0" newVersion="1.5.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.ResourceManager" publicKeyToken="92742159e12e44c8" culture="neutral" />

--- a/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
+++ b/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
@@ -69,7 +69,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0" />
+				<bindingRedirect oldVersion="0.0.0.0-1.5.2.0" newVersion="1.5.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/AnalyticsEngine/Web/Web.Template.config
+++ b/src/AnalyticsEngine/Web/Web.Template.config
@@ -54,7 +54,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Hashing" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -74,7 +74,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0" />
+				<bindingRedirect oldVersion="0.0.0.0-1.5.2.0" newVersion="1.5.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -129,7 +129,7 @@
       <Version>4.3.2</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.Xml">
-      <Version>10.0.8</Version>
+      <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
       <Version>10.0.8</Version>


### PR DESCRIPTION
## What & why

Visual Studio / NuGet audit flagged two packages with known security vulnerabilities. This updates both to patched versions and refreshes the affected assembly binding redirects.

### Vulnerable packages fixed
| Package | From | To | Advisory |
|---|---|---|---|
| `System.Security.Cryptography.Xml` (Web) | 10.0.8 | **10.0.10** | 5 HIGH .NET advisories (CVE-2026-50648, -50525, -47302, -47304, -50527); affected `<= 10.0.9`, patched in 10.0.10 |
| `AngleSharp` (App.ControlPanel.Engine) | 0.17.1 | **1.5.2** | Moderate mXSS `GHSA-pgww-w46g-26qg`; affected `< 1.5.0`, patched in 1.5.0 (1.5.2 = latest stable) |

AngleSharp is a pinned dependency not referenced directly in any C# code, so the major-version bump is compile-safe (full solution builds clean).

### Binding redirects
The runnable projects' `App.config`/`Web.config` are generated at build from `*.Template.config` via `TransformXml` (and are gitignored), so the redirects are updated in the tracked **template** configs:

- **AngleSharp** `0.17.1.0` -> `1.5.2.0` in `App.ControlPanel`, `Tests.UnitTests` and `Web` template configs.
- **System.Formats.Asn1** `10.0.0.8` -> `10.0.0.10` in `Web` — Crypto.Xml 10.0.10 transitively unifies Asn1 to 10.0.10, which surfaced an `MSB3247` conflict; the redirect bump resolves it.
- `System.Security.Cryptography.Xml` keeps assembly version `10.0.0.0` across the patch, so no redirect was needed for it.

## Validation
- `dotnet restore /p:NuGetAuditMode=all` -> **no `NU190x` warnings** (was 6).
- Full solution build (VS MSBuild, Debug) succeeds; Web clean rebuild has **no `MSB3247`** conflict.