### PR TITLE
Fix flaky SPSiteIdToUrlCacheTests (unique fake URLs via GUID)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
@@ -33,8 +33,11 @@ namespace Tests.UnitTests
             using (var db = new AnalyticsEntitiesContext())
             {
                 // Test the cache with new site URL & ID
-                var fakeId = $"fake id {DateTime.Now.Ticks}";
-                var fakeUrlNew = $"fake URL {DateTime.Now.Ticks}";
+                // Use GUIDs (not DateTime.Now.Ticks) so the two URLs are guaranteed distinct:
+                // Ticks resolution is coarse, so fakeUrlNew and fakeUrlExisting could collide and
+                // hit the unique IX_url_base index when the second site is inserted below.
+                var fakeId = $"fake id {Guid.NewGuid()}";
+                var fakeUrlNew = $"fake URL {Guid.NewGuid()}";
                 var siteUrlCache = new FakeSPSiteIdToUrlCache(db, logger, fakeUrlNew);
                 var site1 = await siteUrlCache.Load(fakeId);
 
@@ -44,13 +47,13 @@ namespace Tests.UnitTests
                 Assert.AreEqual(fakeId, site1.SiteId);
 
                 // Pre-add a site with just the URL
-                var fakeUrlExisting = $"fake URL {DateTime.Now.Ticks}";
+                var fakeUrlExisting = $"fake URL {Guid.NewGuid()}";
                 db.sites.Add(new Site { SiteId = null, UrlBase = fakeUrlExisting });
                 await db.SaveChangesAsync();
 
                 // Load the site with a new fake ID. Currently in the DB it doesn't have an ID
                 var siteUrlCache2 = new FakeSPSiteIdToUrlCache(db, logger, fakeUrlExisting);
-                var site2 = await siteUrlCache2.Load($"fake id2 {DateTime.Now.Ticks}");
+                var site2 = await siteUrlCache2.Load($"fake id2 {Guid.NewGuid()}");
                 Assert.IsNotNull(site2);
                 Assert.AreEqual(fakeUrlExisting, site2.SiteUrl);
 


### PR DESCRIPTION
## What

Fixes a **flaky unit test**, GraphUsageReportImportTests.SPSiteIdToUrlCacheTests, that intermittently failed CI (seen on the dev->main release PR #212) with:

> `System.Data.SqlClient.SqlException: Cannot insert duplicate key row in object 'dbo.sites' with unique index 'IX_url_base'`

## Why

The test built **two** fake site URLs from `DateTime.Now.Ticks` (`fakeUrlNew` and `fakeUrlExisting`) and assumed they'd differ. `DateTime.Now` resolution is coarse (~1-15 ms), so when the intervening work runs inside one timer tick the two strings are identical — and inserting the second site then violates the unique `IX_url_base` index. It is purely a test-data issue (no product code involved) and unrelated to the release changes.

## Fix

Generate the fake ids/URLs with `Guid.NewGuid()` instead of `DateTime.Now.Ticks` so they are always distinct.

## Validation

Built Debug and ran the test via vstest against localdb **4x — all pass**. The change is test-only.