### PR TITLE
Optimise Graph usage-report import: skip finalized days and dirty-check upserts

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/OutlookUserActivityLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/OutlookUserActivityLoaderTests.cs
@@ -2,6 +2,7 @@ using Common.Entities;
 using Common.Entities.Config;
 using Common.Entities.LookupCaches;
 using DataUtils;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -155,6 +156,165 @@ namespace Tests.UnitTests
                 var logsAfter = await db.OutlookUsageActivityLogs.Where(l => userIds.Contains(l.UserID) && l.Date == testDate).ToListAsync();
                 Assert.AreEqual(5, logsAfter.Count, "Re-saving must update, not duplicate, across batches");
                 Assert.IsTrue(logsAfter.All(l => l.ReadCount == 99), "Existing rows should be updated to the new values");
+            }
+        }
+
+        /// <summary>
+        /// Optimisation A: the per-date upsert dirty-checks each existing row and only issues an UPDATE when a
+        /// mapped value actually changed. Re-saving identical data (what happens for the finalized days re-fetched
+        /// every run) must write nothing; changing a value must write and persist. No Graph involved.
+        /// </summary>
+        [TestMethod]
+        public async Task SaveLoadedReportsToSql_DirtyCheck_SkipsUnchangedRows()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                db.Configuration.LazyLoadingEnabled = false;
+
+                var groupsCache = new NoUsersHaveGroupsUserGroupsCache(logger);
+                var loader = new OutlookUserActivityLoader(null, groupsCache, new UserGroupsFilterModel("FakeGroup1;FakeGroup2"), logger);
+
+                var testDate = DateTime.UtcNow.Date.AddDays(-4);
+                var runId = DateTime.UtcNow.Ticks;
+                var upns = Enumerable.Range(0, 3).Select(n => $"dirtycheck{n}_{runId}@unit.test".ToLower()).ToList();
+
+                List<OutlookUserActivityUserDetail> BuildPage(int readCount) => upns.Select(u => new OutlookUserActivityUserDetail
+                {
+                    UserPrincipalName = u,
+                    LastActivityDateString = testDate.ToString("yyyy-MM-dd"),
+                    ReadCount = readCount,
+                    ReceiveCount = 7,
+                    SendCount = 3,
+                }).ToList();
+
+                var userIdCache = new ConcurrentLookupDbIdsCache();
+                var userCache = new UserCache(db);
+
+                // Insert three new rows -> three DB writes.
+                loader.LoadedReportPages.Clear();
+                loader.LoadedReportPages.Add(testDate, BuildPage(5));
+                await loader.SaveLoadedReportsToSql(userIdCache, userCache);
+                Assert.AreEqual(3, loader.LastSaveDbWriteCount, "Initial insert should write all three rows");
+
+                // Re-save identical data -> dirty-check should issue ZERO writes (this is the optimisation).
+                loader.LoadedReportPages.Clear();
+                loader.LoadedReportPages.Add(testDate, BuildPage(5));
+                await loader.SaveLoadedReportsToSql(userIdCache, userCache);
+                Assert.AreEqual(0, loader.LastSaveDbWriteCount, "Re-saving identical data must issue no UPDATEs");
+
+                // Change a value -> the changed rows are written and the DB reflects the new value.
+                loader.LoadedReportPages.Clear();
+                loader.LoadedReportPages.Add(testDate, BuildPage(99));
+                await loader.SaveLoadedReportsToSql(userIdCache, userCache);
+                Assert.AreEqual(3, loader.LastSaveDbWriteCount, "Changed rows must be written");
+
+                var userIds = await db.users.Where(u => upns.Contains(u.UserPrincipalName)).Select(u => u.ID).ToListAsync();
+                var logs = await db.OutlookUsageActivityLogs.Where(l => userIds.Contains(l.UserID) && l.Date == testDate).ToListAsync();
+                Assert.AreEqual(3, logs.Count, "Upsert must not duplicate rows");
+                Assert.IsTrue(logs.All(l => l.ReadCount == 99), "Existing rows should be updated to the new value");
+            }
+        }
+
+        /// <summary>
+        /// Optimisation B (SQL half): a stored date old enough to be finalized in Graph is returned as skippable,
+        /// but a recently-stored date (which can still change) is never returned. Pure DB, no Graph.
+        /// </summary>
+        [TestMethod]
+        public async Task GetFinalizedStoredDatesToSkipAsync_IncludesFinalizedStored_ExcludesRecent()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                db.Configuration.LazyLoadingEnabled = false;
+
+                var groupsCache = new NoUsersHaveGroupsUserGroupsCache(logger);
+                var loader = new OutlookUserActivityLoader(null, groupsCache, new UserGroupsFilterModel("FakeGroup1;FakeGroup2"), logger)
+                {
+                    RefreshableRecentDays = 3
+                };
+
+                var finalizedDate = DateTime.UtcNow.Date.AddDays(-6);   // stored + older than the recent window -> skippable
+                var recentDate = DateTime.UtcNow.Date.AddDays(-2);      // stored but within the recent window -> never skipped
+
+                var runId = DateTime.UtcNow.Ticks;
+                var upn = $"skipdates_{runId}@unit.test".ToLower();
+                var userIdCache = new ConcurrentLookupDbIdsCache();
+                var userCache = new UserCache(db);
+
+                loader.LoadedReportPages.Clear();
+                loader.LoadedReportPages.Add(finalizedDate, new List<OutlookUserActivityUserDetail>
+                {
+                    new OutlookUserActivityUserDetail { UserPrincipalName = upn, LastActivityDateString = finalizedDate.ToString("yyyy-MM-dd"), ReadCount = 1 }
+                });
+                loader.LoadedReportPages.Add(recentDate, new List<OutlookUserActivityUserDetail>
+                {
+                    new OutlookUserActivityUserDetail { UserPrincipalName = upn, LastActivityDateString = recentDate.ToString("yyyy-MM-dd"), ReadCount = 1 }
+                });
+                await loader.SaveLoadedReportsToSql(userIdCache, userCache);
+
+                var skip = await loader.GetFinalizedStoredDatesToSkipAsync(db, daysBackMax: 7);
+
+                Assert.IsTrue(skip.Contains(finalizedDate), "A stored, finalized date should be skippable");
+                Assert.IsFalse(skip.Contains(recentDate), "A date within the recent window must never be skipped, even if stored");
+            }
+        }
+
+        /// <summary>
+        /// Optimisation B (download half): PopulateLoadedReportPagesFromGraph must NOT fetch a date in the skip
+        /// set, but must still fetch every other date in the window. The Graph fetch is overridden so this runs
+        /// with no HTTP - proving the loaders are abstract enough to test the skip path without Graph.
+        /// </summary>
+        [TestMethod]
+        public async Task PopulateLoadedReportPagesFromGraph_SkipsFinalizedDates_WithoutCallingGraph()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var groupsCache = new NoUsersHaveGroupsUserGroupsCache(logger);
+
+            var loader = new RecordingOutlookLoader(groupsCache, new UserGroupsFilterModel("FakeGroup1;FakeGroup2"), logger,
+                date => new List<OutlookUserActivityUserDetail>
+                {
+                    new OutlookUserActivityUserDetail { UserPrincipalName = $"u_{date:yyyyMMdd}@unit.test", LastActivityDateString = date.ToString("yyyy-MM-dd") }
+                });
+
+            const int daysBackMax = 7;
+            var skippedDate = DateTime.UtcNow.Date.AddDays(-5);
+            var datesToSkip = new HashSet<DateTime> { skippedDate };
+
+            await loader.PopulateLoadedReportPagesFromGraph(daysBackMax, datesToSkip);
+
+            CollectionAssert.DoesNotContain(loader.RequestedDates, skippedDate, "Skipped finalized date must not be fetched from Graph");
+            Assert.IsFalse(loader.LoadedReportPages.Keys.Any(k => k.Date == skippedDate), "Skipped date must not be loaded");
+            Assert.AreEqual(daysBackMax - 1, loader.RequestedDates.Count, "Exactly one day should be skipped");
+
+            for (int d = 1; d <= daysBackMax; d++)
+            {
+                var expected = DateTime.UtcNow.Date.AddDays(-d);
+                if (expected == skippedDate) continue;
+                CollectionAssert.Contains(loader.RequestedDates, expected, $"Date {expected:yyyy-MM-dd} should have been fetched");
+            }
+        }
+
+        // Test double: overrides the Graph fetch so the date-skipping logic can be verified with no HTTP.
+        private class RecordingOutlookLoader : OutlookUserActivityLoader
+        {
+            public List<DateTime> RequestedDates { get; } = new List<DateTime>();
+            private readonly Func<DateTime, List<OutlookUserActivityUserDetail>> _dataForDate;
+
+            public RecordingOutlookLoader(UserGroupsCache groupsCache, UserGroupsFilterModel filter, ILogger logger,
+                Func<DateTime, List<OutlookUserActivityUserDetail>> dataForDate)
+                : base(null, groupsCache, filter, logger)
+            {
+                _dataForDate = dataForDate;
+            }
+
+            protected override Task<List<OutlookUserActivityUserDetail>> LoadReportPageForDateFromGraph(DateTime date)
+            {
+                RequestedDates.Add(date.Date);
+                var data = _dataForDate?.Invoke(date.Date) ?? new List<OutlookUserActivityUserDetail>();
+                return Task.FromResult(data);
             }
         }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -264,7 +264,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             where CACHETYPE : DBLookupCache<TLookupType>
         {
             logger.LogInformation($"Importing {thingWeAreImporting} reports...");
-            await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax);
+
+            // Graph usage data is stable once finalized (~2-3 day latency), so days we already hold and that can no
+            // longer change don't need re-downloading or re-writing. Skip them unless a forced full re-import is set.
+            ISet<DateTime> datesToSkip = null;
+            if (!_settings.ForceUsageReportsImport)
+            {
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    datesToSkip = await abstractActivityLoader.GetFinalizedStoredDatesToSkipAsync(db, daysBackMax);
+                }
+                if (datesToSkip.Count > 0)
+                {
+                    logger.LogInformation($"{thingWeAreImporting}: skipping {datesToSkip.Count} already-stored finalized day(s); " +
+                        $"only re-importing the most recent {abstractActivityLoader.RefreshableRecentDays} day(s) that can still change in Graph.");
+                }
+            }
+
+            await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax, datesToSkip);
 
             using (var db = new AnalyticsEntitiesContext())
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
@@ -40,11 +41,58 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         /// </summary>
         public int SaveBatchSize { get; set; } = 1000;
 
-        public async Task PopulateLoadedReportPagesFromGraph(int daysBackMax)
+        /// <summary>
+        /// Recent-day window (in days) during which Graph usage data can still change and therefore must be
+        /// re-imported every run. Graph usage reports have a ~2-3 day latency and are stable once finalized, so
+        /// dates older than this are treated as final: once stored they are skipped entirely (no re-download,
+        /// no re-write). 3 is a safe default; every date is still fully re-imported on its first ~3 daily runs
+        /// (as day-1, day-2, day-3) before it is ever skipped, so transient partial saves self-heal. Settable so
+        /// tests can exercise the boundary.
+        /// </summary>
+        public int RefreshableRecentDays { get; set; } = 3;
+
+        /// <summary>
+        /// Number of rows actually inserted/updated in SQL by the last <see cref="SaveLoadedReportsToSql"/> call.
+        /// Unchanged rows are dirty-checked and skipped, so this is 0 when nothing changed. Exposed for tests and
+        /// diagnostics.
+        /// </summary>
+        public int LastSaveDbWriteCount { get; private set; }
+
+        private const int MIN_DAYS_BACK = 3;    // Activity reports don't tend to refresh until a couple of days late; always collect something useful.
+        private const int MAX_DAYS_BACK = 28;   // Graph only retains ~28 days of daily detail.
+
+        private static int ClampDaysBack(int daysBackMax)
         {
-            // Activity reports don't tend to refresh until a couple of days late. Make sure we collect something useful. 
-            if (daysBackMax < 3) daysBackMax = 3;
-            else if (daysBackMax > 28) daysBackMax = 28;        // Also don't live for more than 28 days
+            if (daysBackMax < MIN_DAYS_BACK) return MIN_DAYS_BACK;
+            if (daysBackMax > MAX_DAYS_BACK) return MAX_DAYS_BACK;
+            return daysBackMax;
+        }
+
+        /// <summary>
+        /// The set of dates within the [now-daysBackMax, now) import window that are already stored in SQL AND old
+        /// enough that Graph will no longer change them (older than <see cref="RefreshableRecentDays"/>). These can
+        /// be skipped entirely on the next import - no re-download, no re-write. Dates within the recent window are
+        /// never returned because their data can still change.
+        /// </summary>
+        public async Task<HashSet<DateTime>> GetFinalizedStoredDatesToSkipAsync(AnalyticsEntitiesContext db, int daysBackMax)
+        {
+            daysBackMax = ClampDaysBack(daysBackMax);
+            var today = DateTime.UtcNow.Date;
+            var windowStart = today.AddDays(-daysBackMax);
+            var mutableCutoff = today.AddDays(-RefreshableRecentDays);   // dates >= this can still change; never skip them
+
+            var storedFinalizedDates = await GetTable(db)
+                .Where(t => t.Date >= windowStart && t.Date < mutableCutoff)
+                .Select(t => t.Date)
+                .Distinct()
+                .ToListAsync();
+
+            return new HashSet<DateTime>(storedFinalizedDates.Select(d => d.Date));
+        }
+
+        public async Task PopulateLoadedReportPagesFromGraph(int daysBackMax, ISet<DateTime> datesToSkip = null)
+        {
+            daysBackMax = ClampDaysBack(daysBackMax);
 
             LoadedReportPages.Clear();
 
@@ -57,10 +105,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 // produces the wrong date bucket near midnight.
                 var dt = DateTime.UtcNow.AddDays(daysBack);
 
+                // Finalized days we already hold don't change in Graph - skip the (often slow) paged download entirely.
+                if (datesToSkip != null && datesToSkip.Contains(dt.Date))
+                {
+                    Telemetry.LogInformation($"Skipping {this.GetType().Name} for date {dt.ToString("dd-MM-yyyy")} - already stored and finalized (no longer changes in Graph).");
+                    continue;
+                }
+
                 Telemetry.LogInformation($"Loading {this.GetType().Name} for date {dt.ToString("dd-MM-yyyy")}");
 
-                var requestUrl = $"{ReportGraphURL}(date={dt.ToString("yyyy-MM-dd")})?$format=application/json";
-                var dayReports = await _client.LoadAllPagesWithThrottleRetries<TUserActivityUserDetail>(requestUrl, Telemetry);
+                var dayReports = await LoadReportPageForDateFromGraph(dt);
 
                 if (LoadedReportPages.ContainsKey(dt))
                 {
@@ -75,11 +129,22 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         }
 
         /// <summary>
+        /// Fetch one day's report from Graph (all pages, with throttle retries). Virtual so tests can supply canned
+        /// data with no HTTP, and so the date-skipping in <see cref="PopulateLoadedReportPagesFromGraph"/> can be
+        /// verified without hitting Graph.
+        /// </summary>
+        protected virtual Task<List<TUserActivityUserDetail>> LoadReportPageForDateFromGraph(DateTime date)
+        {
+            var requestUrl = $"{ReportGraphURL}(date={date.ToString("yyyy-MM-dd")})?$format=application/json";
+            return _client.LoadAllPagesWithThrottleRetries<TUserActivityUserDetail>(requestUrl, Telemetry);
+        }
+
+        /// <summary>
         /// Save to SQL. Needs a shared ConcurrentLookupDbIdsCache if running in parallel with other imports.
         /// </summary>
         public async Task SaveLoadedReportsToSql(ConcurrentLookupDbIdsCache userEmailToDbIdCache, CACHETYPE lookupCache)
         {
-            int i = 0; var enUS = new System.Globalization.CultureInfo("en-US");
+            int i = 0; int dbWrites = 0; var enUS = new System.Globalization.CultureInfo("en-US");
             var db = lookupCache.DB;
 
             Telemetry.LogInformation($"Saving {this.GetType().Name} for {LoadedReportPages.Keys.Count} dates");
@@ -166,22 +231,35 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                         }
                         PopulateReportSpecificMetadata(dateRequestedLog, reportPage);
 
-                        // Auto-detect is off, so state the change explicitly.
+                        // Auto-detect is off, so state the change explicitly. Only write when something actually
+                        // changed: existing rows for finalized days re-fetched by the recent-window rule are almost
+                        // always identical to what's stored, so dirty-checking skips the vast majority of UPDATEs -
+                        // the dominant cost of this import at large-tenant scale.
+                        bool willWrite;
                         if (isNewLog)
                         {
                             GetTable(db).Add(dateRequestedLog);
+                            willWrite = true;
                         }
                         else
                         {
-                            db.Entry(dateRequestedLog).State = EntityState.Modified;
+                            willWrite = HasMappedValueChanged(db.Entry(dateRequestedLog));
+                            if (willWrite)
+                            {
+                                db.Entry(dateRequestedLog).State = EntityState.Modified;
+                            }
                         }
 
                         i++;
-                        pendingChanges++;
-                        if (pendingChanges >= SaveBatchSize)
+                        if (willWrite)
                         {
-                            await db.SaveChangesAsync();
-                            pendingChanges = 0;
+                            dbWrites++;
+                            pendingChanges++;
+                            if (pendingChanges >= SaveBatchSize)
+                            {
+                                await db.SaveChangesAsync();
+                                pendingChanges = 0;
+                            }
                         }
                     }
 
@@ -198,6 +276,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             {
                 db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
             }
+
+            LastSaveDbWriteCount = dbWrites;
         }
 
         // Resolve the DB id for a report row's user/group lookup, using the shared cross-thread id cache and
@@ -244,6 +324,25 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             {
                 entry.State = EntityState.Detached;
             }
+        }
+
+        // True if any mapped scalar value on the tracked entity differs from the value originally loaded from the
+        // DB. Compares the EF6 original/current value snapshots directly so it works with
+        // AutoDetectChangesEnabled = false (auto-detect is deliberately off to keep bulk saves O(n)). Navigation
+        // properties and [NotMapped] members (e.g. AssociatedLookupId) are not in these snapshots, so only real
+        // column changes trigger an UPDATE.
+        private static bool HasMappedValueChanged(DbEntityEntry entry)
+        {
+            var current = entry.CurrentValues;
+            var original = entry.OriginalValues;
+            foreach (var propertyName in current.PropertyNames)
+            {
+                if (!object.Equals(original[propertyName], current[propertyName]))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         protected virtual Task<bool> IdInScope(string lookupId)


### PR DESCRIPTION
## Problem

The Graph **usage-report** importer (the daily `getEmailActivityUserDetail` / `getSharePointSiteUsageDetail` etc. loaders) re-downloaded **and** re-wrote the full N-day window (`DaysBeforeNowToDownload`) every run. The per-date upsert unconditionally marked **every user x day row** `Modified`, issuing an UPDATE for the entire window even when older days had not changed.

Microsoft Graph usage data has a ~2-3 day latency and is **stable once finalized** - a given date's data does not change afterwards. So re-processing the finalized older days each night is redundant, and the SQL re-write phase (not the download) dominated the multi-hour nightly run at large-tenant scale (assume ~200k users).

## What changed

**A - Dirty-check upserts** (`AbstractDailyActivityLoader.SaveLoadedReportsToSql`)
Existing rows are only marked `Modified` when a mapped column actually changed, by comparing the EF6 `OriginalValues`/`CurrentValues` snapshots (works with `AutoDetectChangesEnabled = false`, which we keep off for O(n) bulk saves). Re-fetched finalized days are almost all identical, so the UPDATE storm disappears. Adds `LastSaveDbWriteCount` for verification/diagnostics.

**B - Skip finalized days** (`GetFinalizedStoredDatesToSkipAsync` + `GraphImporter` orchestration)
Dates already stored **and** older than `RefreshableRecentDays` (default **3**) are skipped entirely - no re-download, no re-write. The most recent days are always re-pulled because their data can still change, so every date is still fully imported on its first ~3 daily runs before it is ever skipped (transient partial saves self-heal). `ForceUsageReportsImport` bypasses the skip for a full re-import.

**Testability**
Extracted a `protected virtual LoadReportPageForDateFromGraph(date)` seam so the date-skipping can be unit-tested with **no Graph/HTTP**.

## Impact

- Save phase drops to near-zero work for finalized days; download skips the older, already-stored days. Expect the nightly usage-report run to fall substantially (roughly an hour or less, down from multiple hours), with lower SQL load.
- No schema change. No config-schema change (`RefreshableRecentDays` is an in-code default, settable for tests). Backward-compatible: the new `PopulateLoadedReportPagesFromGraph` parameter is optional, so existing callers (installer verifier, web-job) are unaffected.

## Testing

- Full solution builds clean (0 warnings, 0 errors).
- 13 tests pass, no regressions: 3 new (dirty-check writes 3/0/3; skip-set include/exclude; download-skip without Graph) + 2 existing Outlook upsert tests + 8 offline usage-report tests.
