### PR TITLE
Copilot meeting enrichment: stop the Graph 403 exception flood when no Teams application access policy exists (#215)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/GraphFileMetadataLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphFileMetadataLoaderTests.cs
@@ -1,7 +1,12 @@
 using ActivityImporter.Engine.ActivityAPI.Copilot;
 using DataUtils;
+using Microsoft.Extensions.Logging;
 using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
 
@@ -166,6 +171,110 @@ namespace Tests.UnitTests
             Assert.IsNotNull(result);
             Assert.AreEqual("unit test meeting", result.Subject);
             Assert.AreEqual(1, fake.GetOnlineMeetingCalls);
+        }
+
+        /// <summary>
+        /// Issue #215: a tenant without a Teams application access policy gets a 403 on *every* meeting-context
+        /// Copilot event. That's a tenant-configuration prerequisite, not a product fault, so it must be logged
+        /// once per run with actionable guidance (and without an exception object) instead of flooding telemetry.
+        /// </summary>
+        [TestMethod]
+        public async Task GetMeetingInfo_NoApplicationAccessPolicy_LogsOnceWithoutExceptionAndSkipsRepeatGraphCalls()
+        {
+            var fake = new FakeSpoGraphClient
+            {
+                OnGetOnlineMeeting = (userId, meetingId) => throw NoApplicationAccessPolicyError()
+            };
+            var log = new CapturingLogger();
+            var loader = new GraphFileMetadataLoader(fake, log);
+
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_a@thread.v2", "user-guid"));
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_b@thread.v2", "user-guid"));
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_c@thread.v2", "USER-GUID"));
+
+            Assert.AreEqual(1, fake.GetOnlineMeetingCalls, "Graph must not be re-called for a user we know has no access policy");
+
+            var warnings = log.Entries.FindAll(e => e.Level == LogLevel.Warning);
+            Assert.AreEqual(1, warnings.Count, "The missing-policy condition must be logged exactly once per run");
+            StringAssert.Contains(warnings[0].Message, "New-CsApplicationAccessPolicy");
+            Assert.IsNull(warnings[0].Exception, "The warning must not carry the exception, so it isn't counted as exception telemetry");
+        }
+
+        [TestMethod]
+        public async Task GetMeetingInfo_OtherGraphError_StillLoggedWithException()
+        {
+            var otherError = new ODataError
+            {
+                ResponseStatusCode = (int)HttpStatusCode.NotFound,
+                Error = new MainError { Code = "NotFound", Message = "Meeting not found" }
+            };
+            var fake = new FakeSpoGraphClient { OnGetOnlineMeeting = (userId, meetingId) => throw otherError };
+            var log = new CapturingLogger();
+            var loader = new GraphFileMetadataLoader(fake, log);
+
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_abc@thread.v2", "user-guid"));
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_abc@thread.v2", "user-guid"));
+
+            Assert.AreEqual(2, fake.GetOnlineMeetingCalls, "Unrelated errors must not disable meeting lookups for the user");
+            var warnings = log.Entries.FindAll(e => e.Level == LogLevel.Warning);
+            Assert.AreEqual(2, warnings.Count);
+            Assert.IsNotNull(warnings[0].Exception);
+        }
+
+        [TestMethod]
+        public void IsMissingApplicationAccessPolicy_OnlyMatchesTheAccessPolicyForbidden()
+        {
+            Assert.IsTrue(GraphFileMetadataLoader.IsMissingApplicationAccessPolicy(NoApplicationAccessPolicyError()));
+
+            Assert.IsFalse(GraphFileMetadataLoader.IsMissingApplicationAccessPolicy(new ODataError
+            {
+                ResponseStatusCode = (int)HttpStatusCode.Forbidden,
+                Error = new MainError { Code = "Forbidden", Message = "Insufficient privileges to complete the operation." }
+            }), "A generic 403 is still a real permissions problem and must keep its exception logging");
+
+            Assert.IsFalse(GraphFileMetadataLoader.IsMissingApplicationAccessPolicy(new ODataError
+            {
+                ResponseStatusCode = (int)HttpStatusCode.InternalServerError,
+                Error = new MainError { Code = "ServiceError", Message = "No application access policy found for this app" }
+            }), "Only forbidden (or status-less) errors count");
+
+            Assert.IsFalse(GraphFileMetadataLoader.IsMissingApplicationAccessPolicy(null));
+        }
+
+        private static ODataError NoApplicationAccessPolicyError() => new ODataError
+        {
+            ResponseStatusCode = (int)HttpStatusCode.Forbidden,
+            Error = new MainError
+            {
+                Code = "Forbidden",
+                Message = "No application access policy found for this app 00000000-0000-0000-0000-000000000000 on the user."
+            }
+        };
+
+        /// <summary>Minimal <see cref="ILogger"/> that records level, message and exception for assertions.</summary>
+        private class CapturingLogger : ILogger
+        {
+            public class Entry
+            {
+                public LogLevel Level;
+                public string Message;
+                public Exception Exception;
+            }
+
+            public readonly List<Entry> Entries = new List<Entry>();
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Entries.Add(new Entry { Level = logLevel, Message = formatter(state, exception), Exception = exception });
+            }
+
+            private class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
@@ -5,6 +5,8 @@ using Microsoft.Graph.Models;
 using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Collections.Concurrent;
+using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
 
@@ -31,6 +33,14 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         private readonly ConcurrentDictionary<string, SpoDocumentFileInfo> _fileInfoByContext =
             new ConcurrentDictionary<string, SpoDocumentFileInfo>(StringComparer.OrdinalIgnoreCase);
 
+        // Users for whom Graph has told us there's no Teams application access policy for this app. The grant is
+        // per-user (or global), so this is cached per user rather than tenant-wide, and only for this run.
+        private readonly ConcurrentDictionary<string, byte> _usersWithoutMeetingAccessPolicy =
+            new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+
+        // 1 once we've logged the "no application access policy" explanation for this run.
+        private int _meetingAccessPolicyWarningLogged;
+
         public GraphFileMetadataLoader(GraphServiceClient graphServiceClient, ILogger logger)
             : this(new GraphSpoClient(graphServiceClient), logger)
         {
@@ -47,17 +57,68 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         public async Task<MeetingMetadata> GetMeetingInfo(string meetingId, string userGuid)
         {
             // Requires OnlineMeetings.Read.All and https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy#configure-application-access-policy
+
+            // A tenant that hasn't granted the application access policy rejects *every* online-meeting read for
+            // that user, so once we've seen it don't keep calling Graph for the same user this run.
+            if (userGuid != null && _usersWithoutMeetingAccessPolicy.ContainsKey(userGuid))
+            {
+                _logger.LogDebug("Skipping meeting lookup for meetingId {meetingId}: no Teams application access policy for this app on the user", meetingId);
+                return null;
+            }
+
             try
             {
                 var meeting = await _spoGraphClient.GetOnlineMeetingAsync(userGuid, meetingId);
 
                 return new MeetingMetadata(meeting);
             }
+            catch (ODataError ex) when (IsMissingApplicationAccessPolicy(ex))
+            {
+                // Expected tenant-configuration condition rather than a product fault, and it hits every
+                // meeting-context Copilot event. Log the actionable explanation once per import run (without the
+                // exception object, so it doesn't dominate exception telemetry) and skip enrichment quietly.
+                if (userGuid != null)
+                {
+                    _usersWithoutMeetingAccessPolicy.TryAdd(userGuid, 0);
+                }
+
+                if (Interlocked.Exchange(ref _meetingAccessPolicyWarningLogged, 1) == 0)
+                {
+                    _logger.LogWarning("Copilot meeting enrichment is unavailable in this tenant: Microsoft Graph reports no Teams application "
+                        + "access policy for this application, so online-meeting details can't be read and meeting metadata will be skipped. "
+                        + "To enable it, grant the importer application an access policy with the Teams PowerShell cmdlets "
+                        + "New-CsApplicationAccessPolicy / Grant-CsApplicationAccessPolicy - see "
+                        + "https://learn.microsoft.com/graph/cloud-communication-online-meeting-application-access-policy. "
+                        + "Further occurrences this import run are logged at debug level only.");
+                }
+                else
+                {
+                    _logger.LogDebug("Skipping meeting info for meetingId {meetingId}: no Teams application access policy for this app on the user", meetingId);
+                }
+
+                return null;
+            }
             catch (ODataError ex)
             {
                 _logger.LogWarning(ex, "Error getting meeting info for meetingId {meetingId}", meetingId);
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Is this the "No application access policy found for this app ... on the user" 403 that Graph returns when
+        /// the tenant hasn't run New-CsApplicationAccessPolicy / Grant-CsApplicationAccessPolicy for the importer app?
+        /// </summary>
+        internal static bool IsMissingApplicationAccessPolicy(ODataError ex)
+        {
+            if (ex == null) return false;
+
+            // Some Graph/Kiota paths leave the status code unset (0), so don't require it to be exactly 403 - the
+            // message text is the reliable discriminator; just make sure we never swallow a non-forbidden error.
+            if (ex.ResponseStatusCode != (int)HttpStatusCode.Forbidden && ex.ResponseStatusCode != 0) return false;
+
+            var message = ex.Error?.Message ?? ex.Message ?? string.Empty;
+            return message.IndexOf("application access policy", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         public async Task<SpoDocumentFileInfo> GetSpoFileInfo(string copilotDocContextId, string eventUpn)


### PR DESCRIPTION
Addresses #215 — closable once this reaches `main`.

## What operators will notice

Tenants that haven't configured a **Teams application access policy** for the importer application can't have their Copilot **meeting** details read by Microsoft Graph — every meeting-context Copilot event comes back `403 No application access policy found for this app <app-id> on the user`.

Copilot events still imported fine (only the meeting name / created date were blank), but the importer logged the exception **for every single event**, so Application Insights filled up with thousands of identical failures and real problems got buried.

After this change the importer logs **one clear, actionable warning per import run** telling the admin exactly how to fix it, and stops re-asking Graph for users it already knows aren't covered.

## Changes

- `GraphFileMetadataLoader.GetMeetingInfo` now recognises the "no application access policy" 403 as an expected tenant-configuration condition and logs it **once per run**, at warning level, **without** the exception object (so it isn't counted as exception telemetry). Subsequent occurrences drop to debug.
- The warning text names the fix — `New-CsApplicationAccessPolicy` / `Grant-CsApplicationAccessPolicy` — and links to the Microsoft Learn article.
- Users known to be uncovered are cached for the run, so we stop making Graph calls that can only fail. Cached **per user**, not tenant-wide, because the policy grant can be per-user.
- Every other Graph error keeps its existing warning-with-exception behaviour — a generic 403 is still a real permissions problem and must stay visible.

## Docs

Wiki updates (in the sibling wiki repo) documenting the prerequisite:
- **Copilot** — new "Meeting enrichment also needs a Teams application access policy" section with the PowerShell to grant it.
- **Prerequisites** — `OnlineMeetings.Read.All` row now points at that section.

## Validation

Build clean. `GraphFileMetadataLoaderTests` 12/12 pass, including 3 new tests covering: logged once per run without an exception + no repeat Graph calls; unrelated Graph errors still logged with the exception and not suppressed; and the discriminator only matching the access-policy 403.

No config-schema change, no SQL migration.
