### PR TITLE
Usage reporting: don't lose telemetry on a rejected upload; UTC timestamps + accurate table stats (#206)

### DIFF
--- a/src/AnalyticsEngine/Common/UsageReporting/AnonUsageStatsModel.cs
+++ b/src/AnalyticsEngine/Common/UsageReporting/AnonUsageStatsModel.cs
@@ -41,12 +41,20 @@ namespace UsageReporting
         public class TableStat
         {
             public string TableName { get; set; }
+
+            /// <summary>
+            /// Owning SQL schema, so app tables (dbo) can be told apart from profiling ones - and from a
+            /// same-named table in another schema. Null on reports from clients older than this field.
+            /// </summary>
+            public string SchemaName { get; set; }
+
             public decimal TotalSpaceMB { get; set; }
             public long Rows { get; set; }
 
             public override string ToString()
             {
-                return $"{TableName}: {Rows} rows, {TotalSpaceMB}mb";
+                var name = string.IsNullOrEmpty(SchemaName) ? TableName : $"{SchemaName}.{TableName}";
+                return $"{name}: {Rows} rows, {TotalSpaceMB}mb";
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/UsageStatsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UsageStatsTests.cs
@@ -8,7 +8,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;
 using System.Configuration;
+using System.Data.Entity;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using UsageReporting;
@@ -150,13 +153,22 @@ namespace Tests.UnitTests
                 result = await r.ProcessAndUploadStats();
                 Assert.IsTrue(result);
 
-                // Verify result saved in DB
-                var latestReport = await sqlStatsAdaptor.GetLatestSavedDbStats();
+                // Verify result saved in DB (read the saved report back directly - the builder no longer
+                // exposes a read-back method, it only ever writes).
+                var latestReportJson = await db.TelemetryReports.OrderByDescending(s => s.ReportSubmitted).Select(s => s.Report).FirstOrDefaultAsync();
+                Assert.IsFalse(string.IsNullOrEmpty(latestReportJson));
+                var latestReport = JsonConvert.DeserializeObject<AnonUsageStatsModel>(latestReportJson);
                 Assert.IsNotNull(latestReport);
                 Assert.IsTrue(latestReport.TableStats.Count > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(latestReport.TableStats[0].TableName));
+                Assert.IsFalse(string.IsNullOrEmpty(latestReport.TableStats[0].SchemaName), "Table stats must record the owning schema so dbo tables can be told apart from other schemas");
                 Assert.IsTrue(latestReport.TableStats.Where(s => s.TotalSpaceMB > 0).Any());
                 Assert.IsTrue(latestReport.TableStats.Where(s => s.Rows > 0).Any());
+
+                // One row per table: a table with several indexes must not be reported multiple times
+                var duplicated = latestReport.TableStats.GroupBy(s => $"{s.SchemaName}.{s.TableName}").Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+                Assert.AreEqual(0, duplicated.Count, $"Each table must appear exactly once. Duplicated: {string.Join(", ", duplicated)}");
+
                 Assert.IsNull(latestReport.ConfiguredSolutionsEnabledDescription);
                 Assert.IsTrue(latestReport.ConfiguredImportsEnabledDescription == cfg.SolutionConfig.ImportTaskSettings.ToSettingsString());
             }
@@ -343,6 +355,78 @@ namespace Tests.UnitTests
                 var result = await mgr.ProcessAndFailSilently();
                 Assert.IsFalse(result, "ProcessAndFailSilently must report failure but not throw when the uploader is misconfigured.");
             }
+        }
+
+        /// <summary>
+        /// Issue #206 (1): a rejected upload used to be logged and then treated as a success, so the
+        /// "last uploaded" date advanced and the report wasn't retried for a whole day - telemetry silently lost.
+        /// </summary>
+        [TestMethod]
+        public async Task WebApiStatsUploader_ServerRejectsUpload_Throws()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var model = AnonUsageStatsModelLoader.Load(Guid.NewGuid(), null);
+
+            using (var client = new HttpClient(new StubHandler(HttpStatusCode.InternalServerError)))
+            using (var uploader = new WebApiStatsUploader("https://stats.example/", "shared-secret", logger, client))
+            {
+                await Assert.ThrowsExceptionAsync<HttpRequestException>(
+                    async () => await uploader.UploadToServer(model),
+                    "A non-2xx response must throw so the caller does not register a successful upload.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WebApiStatsUploader_ServerAcceptsUpload_DoesNotThrow()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var model = AnonUsageStatsModelLoader.Load(Guid.NewGuid(), null);
+
+            using (var client = new HttpClient(new StubHandler(HttpStatusCode.OK)))
+            using (var uploader = new WebApiStatsUploader("https://stats.example/", "shared-secret", logger, client))
+            {
+                await uploader.UploadToServer(model);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageStatsManager_FailedUpload_DoesNotAdvanceTheOnceADayThrottle()
+        {
+            // The MIN_WAIT throttle must only advance on a genuinely successful upload, otherwise a
+            // server-side outage costs a full day of telemetry per failure.
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var tenantId = Guid.NewGuid();
+            var loader = new InMemoryStatsDatesLoader();
+
+            using (var client = new HttpClient(new StubHandler(HttpStatusCode.InternalServerError)))
+            using (var uploader = new WebApiStatsUploader("https://stats.example/", "shared-secret", logger, client))
+            {
+                var mgr = new UsageStatsManager(new AlwaysWorksUsageStatsBuilder(logger, tenantId), loader, uploader, logger);
+
+                Assert.IsFalse(await mgr.ProcessAndFailSilently(), "A rejected upload must be reported as a failure.");
+                Assert.IsNull(await loader.GetLastUploadDt(), "A rejected upload must not register a last-upload date, so the next cycle retries.");
+            }
+        }
+
+        /// <summary>Issue #206 (4): timestamps that feed the payload signature / document id must be UTC.</summary>
+        [TestMethod]
+        public void AnonUsageStatsModelLoader_GeneratedIsUtc()
+        {
+            var model = AnonUsageStatsModelLoader.Load(Guid.NewGuid(), null);
+
+            Assert.IsTrue(model.Generated.HasValue);
+            Assert.AreEqual(DateTimeKind.Utc, model.Generated.Value.Kind, "Generated must be UTC - it feeds the payload signature and the server-side document id.");
+            Assert.IsTrue(Math.Abs((DateTime.UtcNow - model.Generated.Value).TotalMinutes) < 5);
+        }
+
+        /// <summary>Always returns the configured status code, so upload handling can be tested offline.</summary>
+        private class StubHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _status;
+            public StubHandler(HttpStatusCode status) { _status = status; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(_status) { RequestMessage = request });
         }
     }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/AnonUsageStatsModelLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/AnonUsageStatsModelLoader.cs
@@ -9,7 +9,10 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
     {
         public static AnonUsageStatsModel Load(Guid tenantId, BaseSolutionInstallConfig lastSettings)
         {
-            var model = new AnonUsageStatsModel() { Generated = DateTime.Now };
+            // UTC: Generated.Ticks feeds both the payload signature and the server-side document id, so a
+            // local-time value would make those inconsistent across servers in different timezones (and shift
+            // by an hour at DST boundaries).
+            var model = new AnonUsageStatsModel() { Generated = DateTime.UtcNow };
             model.AnonClientId = StringUtils.GetHashedStringSimple(tenantId.ToString());
             if (lastSettings != null && lastSettings.SolutionConfig != null)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/SqlUsageStatsBuilder.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/SqlUsageStatsBuilder.cs
@@ -22,23 +22,6 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
             _db = db;
         }
 
-        public async Task<AnonUsageStatsModel> GetLatestSavedDbStats()
-        {
-            var latestReports = await _db.TelemetryReports.OrderByDescending(s => s.ReportSubmitted).Take(1).ToListAsync();
-            if (latestReports.Count == 1 && !string.IsNullOrEmpty(latestReports[0].Report))
-            {
-                try
-                {
-                    return JsonConvert.DeserializeObject<AnonUsageStatsModel>(latestReports[0].Report);
-                }
-                catch (JsonReaderException)
-                {
-                    // Ignore
-                }
-            }
-            return null;
-        }
-
         public override async Task<BaseSolutionInstallConfig> GetLastAppliedSolutionConfig()
         {
             var latestConfig = await _db.ConfigStates.OrderByDescending(s => s.DateApplied).Take(1).ToListAsync();
@@ -68,34 +51,39 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
             return stats;
         }
 
-        private Task<List<AnonUsageStatsModel.TableStat>> GetStatsFromSql()
+        private async Task<List<AnonUsageStatsModel.TableStat>> GetStatsFromSql()
         {
+            // Metadata-only (sys.*) so this stays cheap on a large tenant - no scan of customer data.
+            // Row counts come from the heap/clustered index only (index_id 0 or 1) via the CROSS APPLY, while
+            // size sums every allocation unit. Grouping on schema+table alone means a table can never be split
+            // into several output rows just because it gained an extra (e.g. filtered) index.
             var sql = @"
 SELECT 
-    t.NAME as TableName,
-    p.rows as [Rows],
+    s.name AS SchemaName,
+    t.name AS TableName,
+    MAX(tableRows.[Rows]) AS [Rows],
     CAST(ROUND(((SUM(a.total_pages) * 8) / 1024.00), 2) AS NUMERIC(36, 2)) AS TotalSpaceMB
 FROM 
     sys.tables t
 INNER JOIN      
-    sys.indexes i ON t.OBJECT_ID = i.object_id
+    sys.indexes i ON t.object_id = i.object_id
 INNER JOIN 
-    sys.partitions p ON i.object_id = p.OBJECT_ID AND i.index_id = p.index_id
+    sys.partitions p ON i.object_id = p.object_id AND i.index_id = p.index_id
 INNER JOIN 
     sys.allocation_units a ON p.partition_id = a.container_id
-LEFT OUTER JOIN 
+INNER JOIN 
     sys.schemas s ON t.schema_id = s.schema_id
+CROSS APPLY 
+    (SELECT SUM(pRows.rows) FROM sys.partitions pRows WHERE pRows.object_id = t.object_id AND pRows.index_id IN (0, 1)) AS tableRows([Rows])
 WHERE 
     t.is_ms_shipped = 0
 GROUP BY 
-    t.Name, s.Name, p.Rows
+    s.name, t.name
 ORDER BY 
-    TotalSpaceMB DESC, t.Name
+    TotalSpaceMB DESC, t.name
 ";
 
-            var resuls = _db.Database.SqlQuery<AnonUsageStatsModel.TableStat>(sql);
-
-            return Task.FromResult(resuls.ToList());
+            return await _db.Database.SqlQuery<AnonUsageStatsModel.TableStat>(sql).ToListAsync();
         }
 
         public override async Task SaveUsageStatsModelToDatabase(AnonUsageStatsModel latestStats)
@@ -103,7 +91,7 @@ ORDER BY
             _db.TelemetryReports.Add(new Common.Entities.Entities.TelemetryReport
             {
                 Report = JsonConvert.SerializeObject(latestStats),
-                ReportSubmitted = DateTime.Now
+                ReportSubmitted = DateTime.UtcNow
             });
             await _db.SaveChangesAsync();
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/UsageStatsManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/UsageStatsManager.cs
@@ -35,7 +35,9 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"{LOG_PREFIX}error uploading anonymised runtime stats - {ex.Message}");
+                // Logged as an error (not a warning): telemetry silently never uploading is exactly the
+                // failure mode this subsystem is blind to, so it needs to be visible in App Insights.
+                _logger.LogError(ex, $"{LOG_PREFIX}error uploading anonymised runtime stats - {ex.Message}");
                 return false;
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/WebApiStatsUploader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/WebApiStatsUploader.cs
@@ -18,12 +18,22 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
         private readonly string _url;
         private readonly string _statsApiSecret;
         private readonly ILogger _logger;
+        private readonly HttpClient _client;
 
-        public WebApiStatsUploader(string url, string statsApiSecret, ILogger logger)
+        public WebApiStatsUploader(string url, string statsApiSecret, ILogger logger) : this(url, statsApiSecret, logger, _httpClient)
+        {
+        }
+
+        /// <summary>
+        /// Test seam: lets unit tests supply a client with a stub handler so the non-2xx behaviour can be
+        /// verified without a live endpoint. Production always uses the shared static client.
+        /// </summary>
+        internal WebApiStatsUploader(string url, string statsApiSecret, ILogger logger, HttpClient client)
         {
             _url = url;
             _statsApiSecret = statsApiSecret;
             _logger = logger;
+            _client = client;
         }
 
         public void Dispose()
@@ -38,14 +48,18 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
                 var body = new TelemetryPayload(stats, _statsApiSecret);
                 var content = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
 
-                var response = await _httpClient.PostAsync(_url, content);
+                var response = await _client.PostAsync(_url, content);
                 if (response.IsSuccessStatusCode)
                 {
                     _logger.LogInformation($"Uploaded stats to {_url}");
                 }
                 else
                 {
-                    _logger.LogError($"Can't upload stats to API - server returned unexpected response {response.StatusCode}");
+                    // Must throw: the caller only registers the "last uploaded" date - which gates the next
+                    // upload for a whole day - when this method completes without error. Returning normally on a
+                    // rejected upload would silently drop the report and not retry until the next day.
+                    _logger.LogError($"Can't upload stats to API - server returned unexpected response {(int)response.StatusCode} ({response.StatusCode})");
+                    response.EnsureSuccessStatusCode();
                 }
             }
             else


### PR DESCRIPTION
Addresses #206 — the non-breaking subset. **Does not close the issue** (see "Deliberately not in scope"), and per our workflow it only becomes closable once it reaches `main`.

## What operators will notice

**Usage reports no longer go missing when the telemetry server has a bad day.** Previously, if the stats endpoint rejected an upload, the importer logged the error but then carried on as if it had succeeded — it saved the report, stamped the "last uploaded" date, and so didn't try again for a **full day**. That day's telemetry was simply lost. Now a rejected upload is treated as a failure and retried on the next import cycle, and the failure is logged as an **error** (with the exception) so it's actually visible in Application Insights instead of hiding in a warning.

The **table-size figures in the usage report are also more accurate**: each table now appears exactly once and records which SQL schema it belongs to, so app tables can be told apart from tables of the same name in another schema.

## Changes

| # (from the issue) | Change |
|-|-|
| 1 (bug) | `WebApiStatsUploader.UploadToServer` calls `EnsureSuccessStatusCode()` on a non-2xx response so the caller can't register a successful upload. The status code is logged first. |
| 4 (correctness) | `Generated` and `ReportSubmitted` use `DateTime.UtcNow`. `Generated.Ticks` feeds the payload signature and the server-side document id, so local time made those inconsistent across servers and shifted at DST boundaries. |
| 5 (correctness/quality) | Table-stats SQL: selects the schema into a new `TableStat.SchemaName`; groups by schema+table only (a table that gains a filtered/columnstore index can no longer be split across several rows); takes row counts from the heap/clustered index (`index_id IN (0,1)`) while still summing all allocation units for size; uses `ToListAsync()` instead of sync-over-async. Still metadata-only (`sys.*`), so it stays cheap at 200k-user scale. |
| 6 (cleanup) | Removed `GetLatestSavedDbStats` — production never called it; only a test did. That test now reads `sys_telemetry_reports` directly. |
| 7 (observability) | `ProcessAndFailSilently` logs a genuine failure as `LogError` **with** the exception rather than a bare warning. |

`WebApiStatsUploader` gained an `internal` constructor taking an `HttpClient` purely as a test seam; production still uses the shared static client.

## Deliberately not in scope

Items **2** (replace the unsalted-SHA256 tenant hash with a random per-install id / keyed HMAC) and **3** (sign the whole payload with HMAC-SHA256 instead of BCrypt over shared-secret+timestamp) both change the **client↔telemetry-service contract**. They can't ship from the client alone without breaking every existing deployment, so they need a coordinated server-side change and their own PR. The issue stays open for them.

## Validation

Build clean. Usage-stats tests 13/14 pass, with 4 new ones: rejected upload throws; accepted upload doesn't; a rejected upload leaves the once-a-day throttle unadvanced so the next cycle retries; and `Generated` is UTC. Existing table-stat assertions were extended to require a schema and exactly one row per table.

The 14th (`UsageStatsReporterRealTests`) fails in this environment only — it's a live-integration test that needs Azure Redis, and it throws in the `RedisStatsDatesLoader` constructor before reaching any changed code. The reworked stats SQL was instead validated directly against the LocalDB test database: 150 tables, 150 distinct `schema.table` rows (no duplicates), schema populated on every row.

No config-schema change, no SQL migration.
