### PR TITLE
Installer: never leave Service Bus unreachable in a private deployment (#228)

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -124,6 +124,7 @@
     <Compile Include="SPO\SharePointModelBuilder\ValueLookups\JsonObjectToStringLookup.cs" />
     <Compile Include="SPO\SharePointModelBuilder\ValueLookups\ThumbnailImageProvisionAndLookup.cs" />
     <Compile Include="InstallSummary.cs" />
+    <Compile Include="PreInstallAdvisor.cs" />
     <Compile Include="SolutionInstaller.cs" />
     <Compile Include="Models\AzureSubscription.cs" />
     <Compile Include="Models\DatabasePaaSInfo.cs" />

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallSummary.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallSummary.cs
@@ -207,6 +207,10 @@ namespace App.ControlPanel.Engine
                 {
                     yield return "If warmup failed, browse to the admin site URL manually to confirm the App Service is responding.";
                 }
+                if (msg.Contains("service bus") && msg.Contains("premium"))
+                {
+                    yield return "Service Bus cannot be made private on the Standard SKU. Either migrate the namespace to Premium and re-run the installer, keep public network access enabled on Service Bus, or disable the Teams calls import — otherwise Teams calls will not import.";
+                }
             }
         }
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -369,13 +369,24 @@ namespace App.ControlPanel.Engine.InstallerTasks
                     "vault", subnetId, logger, tagDic);
                 if (deployDns) AddPrivateDnsZoneTask("privatelink.vaultcore.azure.net", vnetId, kvPeName, logger, tagDic);
 
-                // Service Bus
+                // Service Bus. Private endpoints require the Premium SKU: the wrappers skip (with a clear
+                // warning) rather than fail when a pre-existing Standard namespace can't be made private.
                 if (config.ServiceBusEnabled)
                 {
                     var sbPeName = peNames.GetNameOrDefault(peNames.ServiceBus, $"pe-{config.ServiceBusName}-sb");
-                    AddPrivateEndpointTask(sbPeName, $"/subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.ServiceBus/namespaces/{config.ServiceBusName}",
-                        "namespace", subnetId, logger, tagDic);
-                    if (deployDns) AddPrivateDnsZoneTask("privatelink.servicebus.windows.net", vnetId, sbPeName, logger, tagDic);
+                    var sbPeConfig = TaskConfig.GetConfigForName(sbPeName)
+                        .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_TARGET_RESOURCE_ID, $"/subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.ServiceBus/namespaces/{config.ServiceBusName}")
+                        .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_GROUP_ID, "namespace")
+                        .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_SUBNET_ID, subnetId);
+                    this.AddTask(new ServiceBusPrivateEndpointInstallTask(sbPeConfig, logger, Location, tagDic, _serviceBusNamespaceInstallTask));
+
+                    if (deployDns)
+                    {
+                        var sbDnsConfig = TaskConfig.GetConfigForName("privatelink.servicebus.windows.net")
+                            .AddSetting(PrivateDnsZoneInstallTask.CONFIG_KEY_VNET_ID, vnetId)
+                            .AddSetting(PrivateDnsZoneInstallTask.CONFIG_KEY_PE_NAME, sbPeName);
+                        this.AddTask(new ServiceBusPrivateDnsZoneInstallTask(sbDnsConfig, logger, Location, tagDic, _serviceBusNamespaceInstallTask));
+                    }
                 }
 
                 // Cognitive Services (Language/Text Analytics)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/PreInstallAdvisor.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/PreInstallAdvisor.cs
@@ -1,0 +1,47 @@
+using Common.Entities.Installer;
+
+namespace App.ControlPanel.Engine
+{
+    /// <summary>
+    /// Pre-install checks that warn about configurations which would install "successfully" but leave part of
+    /// the solution silently broken. Kept out of the UI so the rules can be unit tested.
+    /// </summary>
+    public static class PreInstallAdvisor
+    {
+        /// <summary>
+        /// Private deployments disable public network access on every PaaS resource, but Service Bus can only be
+        /// reached privately on the Premium SKU. If the namespace can't be Premium the Teams calls import fails at
+        /// runtime with an opaque "Ip has been prevented to connect to the endpoint" 401, so the operator needs to
+        /// know up front. See issue #228.
+        ///
+        /// Returns null when there is nothing to warn about.
+        /// </summary>
+        public static string GetServiceBusPrivateDeploymentWarning(BaseSolutionInstallConfig config)
+        {
+            if (config == null) return null;
+
+            var vnetEnabled = config.NetworkConfig != null && config.NetworkConfig.Enabled;
+            if (!vnetEnabled) return null;
+
+            // Public access still allowed = the namespace stays reachable whatever its SKU.
+            if (config.NetworkConfig.AllowPublicAccess) return null;
+
+            // Service Bus is only used by the Teams calls import.
+            if (!config.ServiceBusEnabled) return null;
+
+            return "Private deployment + Teams calls import: Service Bus must be on the PREMIUM SKU."
+                + "\r\n\r\nPublic network access will be disabled, and a Service Bus namespace can only be reached privately "
+                + "through a private endpoint, which requires Premium. Azure cannot upgrade an existing Standard namespace "
+                + "to Premium in place."
+                + "\r\n\r\nIf the namespace '" + config.ServiceBusName + "' is not Premium, the Teams calls import will fail at "
+                + "runtime with 'Put token failed. status-code: 401 ... Ip has been prevented to connect to the endpoint'."
+                + "\r\n\r\nOptions:"
+                + "\r\n  (a) Migrate the namespace to Premium and re-run the installer."
+                + "\r\n  (b) Keep public network access enabled on Service Bus."
+                + "\r\n  (c) Disable the Teams calls import (untick Service Bus on the Azure Storage page)."
+                + "\r\n\r\nThe installer will NOT disable public access on a namespace that cannot be made private - it stays "
+                + "reachable and this warning is repeated in the install summary."
+                + "\r\n\r\nContinue with the install?";
+        }
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
@@ -497,6 +497,19 @@ namespace App.ControlPanel.Frames
                 return;
             }
 
+            // A private deployment can leave Service Bus (and therefore the Teams calls import) unreachable if the
+            // namespace isn't Premium. Make that impossible to miss before a real deployment starts - see issue #228.
+            var serviceBusWarning = PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(GetConfigFromGUI());
+            if (serviceBusWarning != null)
+            {
+                var proceed = MessageBox.Show(this, serviceBusWarning, "Service Bus cannot be private on Standard SKU",
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
+                if (proceed != DialogResult.Yes)
+                {
+                    return;
+                }
+            }
+
             // Save settings
             (this.ParentForm as MainForm).SaveLastSettings();
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
@@ -14,6 +14,18 @@ namespace CloudInstallEngine.Azure.InstallTasks
         private readonly bool _requirePremiumSku;
         private readonly bool _allowPublicAccess;
 
+        /// <summary>
+        /// Standard warning text used when a private deployment can't make Service Bus private. Public so the
+        /// installer UI can show the same wording before an install starts.
+        /// </summary>
+        public const string NOT_PRIVATE_CAPABLE_WARNING =
+            "Service Bus is on the Standard SKU and cannot be made private (private endpoints require Premium). "
+            + "With public network access disabled the namespace would be unreachable from the VNet and the TEAMS CALLS IMPORT WOULD NOT WORK "
+            + "(the importer fails with 'Put token failed. status-code: 401 ... Ip has been prevented to connect to the endpoint'). "
+            + "Options: (a) migrate the namespace to Premium and re-run the installer "
+            + "(https://learn.microsoft.com/azure/service-bus-messaging/service-bus-migrate-standard-premium), "
+            + "(b) keep public network access enabled on Service Bus, or (c) disable the Teams calls import.";
+
         public ServiceBusNamespaceInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool requirePremiumSku = false, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
             _requirePremiumSku = requirePremiumSku;
@@ -21,6 +33,19 @@ namespace CloudInstallEngine.Azure.InstallTasks
         }
 
         public override string TaskName => "get/create Service-bus namespace";
+
+        /// <summary>
+        /// True when the namespace this task produced can host a private endpoint (i.e. it is Premium). False
+        /// means a private deployment cannot make Service Bus private, so we deliberately leave public access on.
+        /// Null until the task has run.
+        /// </summary>
+        public bool? IsPrivateEndpointCapable { get; private set; }
+
+        /// <summary>
+        /// True when a private deployment asked for public access to be disabled but we kept it enabled because
+        /// the namespace can't have a private endpoint - disabling it would silently break the Teams calls import.
+        /// </summary>
+        public bool PublicAccessKeptOpenForReachability { get; private set; }
 
         public async override Task<ServiceBusNamespaceResource> ExecuteTaskReturnResult(object contextArg)
         {
@@ -47,6 +72,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
                 sbNS = operation.Value;
 
+                // A namespace we just created at the SKU we asked for is private-capable whenever we asked for Premium.
+                IsPrivateEndpointCapable = IsPremium(sbNS) || _requirePremiumSku;
 
                 _logger.LogInformation($"Created service-bus namespace '{sbNS.Data.Name}'.");
             }
@@ -54,6 +81,29 @@ namespace CloudInstallEngine.Azure.InstallTasks
             {
                 _logger.LogInformation($"Found existing service-bus namespace '{sbNS.Data.Name}'.");
                 await base.EnsureTagsOnExisting(sbNS.Data.Tags, sbNS.GetTagResource());
+
+                // Azure has no in-place upgrade to Premium, so an existing non-Premium namespace in a private
+                // deployment can never get a private endpoint. Work that out BEFORE touching public access:
+                // disabling public access on a namespace that can't be reached privately makes it unreachable
+                // altogether, which silently kills the Teams calls import. See issue #228.
+                IsPrivateEndpointCapable = !_requirePremiumSku || IsPremium(sbNS);
+
+                var effectiveDesiredAccess = desiredAccess;
+                if (_requirePremiumSku && !IsPremium(sbNS))
+                {
+                    _logger.LogError($"Service Bus namespace '{sbNS.Data.Name}' is on the {sbNS.Data.Sku?.Name} SKU but private endpoints require Premium. "
+                        + "Azure does not support in-place SKU upgrades to Premium. " + NOT_PRIVATE_CAPABLE_WARNING);
+
+                    if (desiredAccess == ServiceBusPublicNetworkAccess.Disabled)
+                    {
+                        // Prefer "reachable and warned about" over "private and silently broken".
+                        effectiveDesiredAccess = ServiceBusPublicNetworkAccess.Enabled;
+                        PublicAccessKeptOpenForReachability = true;
+                        _logger.LogWarning($"Service Bus: leaving public network access ENABLED on '{sbNS.Data.Name}' even though this is a private deployment, "
+                            + "because the namespace cannot have a private endpoint and disabling public access would make the Teams calls import fail silently. "
+                            + "Migrate the namespace to Premium and re-run the installer to make it private, or disable the Teams calls import if it isn't needed.");
+                    }
+                }
 
                 bool needsUpdate = false;
                 var updateData = new ServiceBusNamespaceData(sbNS.Data.Location);
@@ -70,10 +120,10 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     needsUpdate = true;
                 }
 
-                if (sbNS.Data.PublicNetworkAccess == null || sbNS.Data.PublicNetworkAccess != desiredAccess)
+                if (sbNS.Data.PublicNetworkAccess == null || sbNS.Data.PublicNetworkAccess != effectiveDesiredAccess)
                 {
-                    _logger.LogInformation($"Updating service-bus namespace '{sbNS.Data.Name}' public network access to '{desiredAccess}'...");
-                    updateData.PublicNetworkAccess = desiredAccess;
+                    _logger.LogInformation($"Updating service-bus namespace '{sbNS.Data.Name}' public network access to '{effectiveDesiredAccess}'...");
+                    updateData.PublicNetworkAccess = effectiveDesiredAccess;
                     needsUpdate = true;
                 }
 
@@ -82,18 +132,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     var operation = await allNSs.CreateOrUpdateAsync(WaitUntil.Completed, name, updateData);
                     sbNS = operation.Value;
                 }
-
-                // Upgrade to Premium if required for private endpoints and not already Premium
-                if (_requirePremiumSku && sbNS.Data.Sku.Name != ServiceBusSkuName.Premium)
-                {
-                    _logger.LogError($"Service Bus namespace '{sbNS.Data.Name}' is on {sbNS.Data.Sku.Name} SKU but private endpoints require Premium. " +
-                        $"Azure does not support in-place SKU upgrades to Premium. Please manually migrate to a Premium namespace " +
-                        $"(see https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-migrate-standard-premium) " +
-                        $"and re-run the installer. Continuing installation...");
-                }
             }
 
             return sbNS;
         }
+
+        private static bool IsPremium(ServiceBusNamespaceResource ns)
+            => ns?.Data?.Sku != null && ns.Data.Sku.Name == ServiceBusSkuName.Premium;
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusPrivateNetworkingTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusPrivateNetworkingTasks.cs
@@ -1,0 +1,79 @@
+using Azure.Core;
+using Azure.ResourceManager.Network;
+using Azure.ResourceManager.PrivateDns;
+using CloudInstallEngine.Models;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure.InstallTasks
+{
+    /// <summary>
+    /// Service Bus-aware wrapper around <see cref="PrivateEndpointInstallTask"/>.
+    /// Private endpoints for Service Bus require the Premium SKU, and Azure has no in-place upgrade to Premium,
+    /// so a pre-existing Standard namespace can never get one. Attempting it fails the task with an opaque Azure
+    /// error; instead we skip it and explain the consequence for the Teams calls import. See issue #228.
+    /// </summary>
+    public class ServiceBusPrivateEndpointInstallTask : InstallTaskInAzResourceGroup<PrivateEndpointResource>
+    {
+        private readonly ServiceBusNamespaceInstallTask _namespaceTask;
+
+        public ServiceBusPrivateEndpointInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, ServiceBusNamespaceInstallTask namespaceTask)
+            : base(config, logger, azureLocation, tags)
+        {
+            _namespaceTask = namespaceTask;
+        }
+
+        public override string TaskName => "get/create Service Bus private endpoint";
+
+        public override async Task<PrivateEndpointResource> ExecuteTaskReturnResult(object contextArg)
+        {
+            if (_namespaceTask?.IsPrivateEndpointCapable == false)
+            {
+                _logger.LogWarning("Skipping Service Bus private endpoint creation: " + ServiceBusNamespaceInstallTask.NOT_PRIVATE_CAPABLE_WARNING);
+                return null;
+            }
+
+            var innerTask = new PrivateEndpointInstallTask(_config, _logger, AzureLocation, Tags)
+            {
+                Container = base.Container,
+            };
+            return await innerTask.ExecuteTaskReturnResult(contextArg);
+        }
+    }
+
+    /// <summary>
+    /// Service Bus-aware wrapper around <see cref="PrivateDnsZoneInstallTask"/>.
+    /// Skips the zone when the namespace can't have a private endpoint. Creating a VNet-linked
+    /// <c>privatelink.servicebus.windows.net</c> zone with no endpoint behind it is worse than doing nothing: it
+    /// can hijack resolution of the public hostname and leave a confusing orphan behind. See issues #228 / #229.
+    /// </summary>
+    public class ServiceBusPrivateDnsZoneInstallTask : InstallTaskInAzResourceGroup<PrivateDnsZoneResource>
+    {
+        private readonly ServiceBusNamespaceInstallTask _namespaceTask;
+
+        public ServiceBusPrivateDnsZoneInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, ServiceBusNamespaceInstallTask namespaceTask)
+            : base(config, logger, azureLocation, tags)
+        {
+            _namespaceTask = namespaceTask;
+        }
+
+        public override string TaskName => "get/create Service Bus private DNS zone";
+
+        public override async Task<PrivateDnsZoneResource> ExecuteTaskReturnResult(object contextArg)
+        {
+            if (_namespaceTask?.IsPrivateEndpointCapable == false)
+            {
+                _logger.LogInformation("Skipping Service Bus private DNS zone creation: the namespace has no private endpoint (Premium SKU required), "
+                    + "so the zone would not resolve to anything and could break access to the public endpoint.");
+                return null;
+            }
+
+            var innerTask = new PrivateDnsZoneInstallTask(_config, _logger, AzureLocation, Tags)
+            {
+                Container = base.Container,
+            };
+            return await innerTask.ExecuteTaskReturnResult(contextArg);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/PreInstallAdvisorTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/PreInstallAdvisorTests.cs
@@ -1,0 +1,104 @@
+using App.ControlPanel.Engine;
+using Common.Entities.Installer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Issue #228: a private (VNet, public access disabled) deployment leaves a non-Premium Service Bus namespace
+    /// unreachable, which silently kills the Teams calls import. The installer must warn before it happens.
+    /// </summary>
+    [TestClass]
+    public class PreInstallAdvisorTests
+    {
+        private static BaseSolutionInstallConfig PrivateConfigWithServiceBus()
+        {
+            return new BaseSolutionInstallConfig
+            {
+                ServiceBusEnabled = true,
+                ServiceBusName = "sb-contoso-analytics",
+                NetworkConfig = new VNetConfig { Enabled = true, AllowPublicAccess = false }
+            };
+        }
+
+        [TestMethod]
+        public void Warns_WhenPrivateDeploymentUsesServiceBus()
+        {
+            var warning = PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(PrivateConfigWithServiceBus());
+
+            Assert.IsNotNull(warning, "A private deployment with the Teams calls import on must warn about the Premium requirement.");
+            StringAssert.Contains(warning, "PREMIUM");
+            StringAssert.Contains(warning, "sb-contoso-analytics");
+        }
+
+        [TestMethod]
+        public void NoWarning_WhenPublicAccessStaysEnabled()
+        {
+            var config = PrivateConfigWithServiceBus();
+            config.NetworkConfig.AllowPublicAccess = true;
+
+            Assert.IsNull(PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(config),
+                "With public access still allowed the namespace stays reachable whatever its SKU.");
+        }
+
+        [TestMethod]
+        public void NoWarning_WhenVNetDisabled()
+        {
+            var config = PrivateConfigWithServiceBus();
+            config.NetworkConfig.Enabled = false;
+
+            Assert.IsNull(PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(config));
+        }
+
+        [TestMethod]
+        public void NoWarning_WhenServiceBusDisabled()
+        {
+            var config = PrivateConfigWithServiceBus();
+            config.ServiceBusEnabled = false;
+
+            Assert.IsNull(PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(config),
+                "Service Bus is only used by the Teams calls import - nothing to warn about when it's off.");
+        }
+
+        [TestMethod]
+        public void NoWarning_ForNullConfig()
+        {
+            Assert.IsNull(PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(null));
+        }
+
+        /// <summary>
+        /// The install summary must turn the warning into an actionable next step, so it survives to the end of
+        /// a long install log.
+        /// </summary>
+        [TestMethod]
+        public void InstallSummary_SurfacesServiceBusNextStep()
+        {
+            var summary = new InstallSummary();
+            summary.AddError("ServiceBus", "Service Bus namespace 'sb-contoso-analytics' is on the Standard SKU but private endpoints require Premium.");
+
+            var logger = new CollectingLogger();
+            summary.Print(logger);
+
+            var text = string.Join("\n", logger.Messages);
+            StringAssert.Contains(text, "Next steps:");
+            StringAssert.Contains(text, "migrate the namespace to Premium");
+        }
+
+        private class CollectingLogger : Microsoft.Extensions.Logging.ILogger
+        {
+            public readonly System.Collections.Generic.List<string> Messages = new System.Collections.Generic.List<string>();
+            public System.IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+            public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+            public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+
+            private class NullScope : System.IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <Compile Remove="Generated\**" />
     <Compile Include="AppConfigDefaultsTests.cs" />
+    <Compile Include="PreInstallAdvisorTests.cs" />
     <Compile Include="AppInsightsAuthTests.cs" />
     <Compile Include="CopilotAuditLogContentSchemaTests.cs" />
     <Compile Include="CopilotEventManagerAccessedResourcesTests.cs" />

--- a/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
+++ b/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
@@ -590,14 +590,39 @@ namespace Web.AnalyticsWeb.Models.Health
             }
             catch (Exception ex)
             {
+                var detail = InnermostMessage(ex);
+
+                // A network-layer rejection (rather than an auth failure) in a private deployment almost always
+                // means the namespace has public access disabled but no private endpoint - which needs Premium.
+                // See issue #228; without this hint the 401 reads like an RBAC problem.
+                if (LooksLikeNetworkRejection(detail))
+                {
+                    detail += " This looks like a network-level block rather than a permissions problem: in a private (VNet) deployment "
+                        + "Service Bus must be on the Premium SKU with a private endpoint, otherwise the namespace is unreachable and "
+                        + "Teams calls will not import. Either migrate the namespace to Premium, or re-enable public network access on it.";
+                }
+
                 UpsertComponent(section, new ComponentHealthRow
                 {
                     Component = "ServiceBus",
                     Status = HealthStatusNames.Degraded,
-                    Detail = "Couldn't read the Teams calls queue depth: " + InnermostMessage(ex),
+                    Detail = "Couldn't read the Teams calls queue depth: " + detail,
                     LastSeenUtc = DateTime.UtcNow
                 });
             }
+        }
+
+        /// <summary>
+        /// Service Bus rejects a blocked IP before the token is even validated, so the message mentions IP
+        /// filtering / VNet service endpoints rather than authorisation.
+        /// </summary>
+        private static bool LooksLikeNetworkRejection(string message)
+        {
+            if (string.IsNullOrEmpty(message)) return false;
+            return message.IndexOf("Ip has been prevented", StringComparison.OrdinalIgnoreCase) >= 0
+                || message.IndexOf("IP Filter", StringComparison.OrdinalIgnoreCase) >= 0
+                || message.IndexOf("Virtual Network", StringComparison.OrdinalIgnoreCase) >= 0
+                || message.IndexOf("prevented to connect to the endpoint", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         /// <summary>Adds or replaces a component row by name (runtime checks take precedence over any older telemetry row).</summary>


### PR DESCRIPTION
Addresses #228 — closable once this reaches `main`.

## What operators will notice

In a **private (VNet) deployment with public network access disabled**, the **Teams calls import** could stop working with no obvious cause. The importer failed to reach the `graphcalls` queue with:

```
Put token failed. status-code: 401, status-description: Ip has been prevented to connect to the endpoint.
```

That reads like a permissions problem, but it's a **network** block. The cause: a Service Bus namespace can only be reached privately through a **private endpoint, which requires the Premium SKU** — and Azure can't upgrade an existing Standard namespace to Premium in place. The installer disabled public access anyway, so a Standard namespace ended up reachable **neither publicly nor privately**. The error scrolled past in the install log and nobody noticed until Teams call data was missing.

Now the installer **refuses to create that broken state**, and tells you about it three times over: before the install starts, during it, and in the install summary.

## Changes

**1. Don't create the silently-broken state** (`ServiceBusNamespaceInstallTask`)
The task now determines whether the namespace can host a private endpoint **before** it touches public access. If a private deployment would disable public access on a namespace that can't be made private, it **leaves public access enabled** and says so loudly. Reachable-and-warned-about beats private-and-silently-broken. Two new properties (`IsPrivateEndpointCapable`, `PublicAccessKeptOpenForReachability`) expose the decision.

**2. Don't leave orphan private-networking artifacts**
New `ServiceBusPrivateEndpointInstallTask` / `ServiceBusPrivateDnsZoneInstallTask` wrappers (mirroring the existing Redis ones) skip the private endpoint and its `privatelink.servicebus.windows.net` DNS zone when the namespace isn't Premium. This matters beyond tidiness: a VNet-linked private DNS zone with **no** endpoint behind it hijacks resolution of the public hostname, so it would break the public endpoint too — the same trap described in #229.

**3. Warn before a real deployment starts (wizard UI)**
`PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning` (in the engine, so it's unit-testable) returns a warning whenever VNet is on, public access is off and Service Bus is enabled. The installer shows it as a **Yes/No confirmation dialog** — defaulting to **No** — before starting the (irreversible) deployment, spelling out the three options: migrate to Premium, keep public access on Service Bus, or disable the Teams calls import.

**4. Warn in the install summary**
`InstallSummary` derives a matching **next step**, so the warning survives to the end of a long install log rather than scrolling past.

**5. Health page (the optional item in the issue)**
When the Health page can't read the Teams calls queue and the error looks like an IP/VNet-level block, it now explains the Premium requirement instead of showing the raw Azure error.

## Docs

Wiki (sibling repo) — **Private Endpoints** gains a "Teams calls import needs Service Bus on Premium in a private deployment" section: the exact runtime error, why it isn't an auth problem, a table of the three valid options, and what the installer now does automatically.

## Validation

Build clean. 6 new `PreInstallAdvisorTests` pass, covering each warn/no-warn branch (private+SB on → warn; public access allowed → silent; VNet off → silent; Service Bus off → silent; null config → silent) plus the install-summary next step.

No config-schema change (no new persisted properties, so no `CONFIG_VERSION` bump), no SQL migration.
