### PR TITLE
Stable Release (build 1720): bug-fix release - private-deployment Service Bus safety, quieter Copilot meeting warnings, reliable usage reporting

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -124,6 +124,7 @@
     <Compile Include="SPO\SharePointModelBuilder\ValueLookups\JsonObjectToStringLookup.cs" />
     <Compile Include="SPO\SharePointModelBuilder\ValueLookups\ThumbnailImageProvisionAndLookup.cs" />
     <Compile Include="InstallSummary.cs" />
+    <Compile Include="PreInstallAdvisor.cs" />
     <Compile Include="SolutionInstaller.cs" />
     <Compile Include="Models\AzureSubscription.cs" />
     <Compile Include="Models\DatabasePaaSInfo.cs" />

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallSummary.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallSummary.cs
@@ -207,6 +207,10 @@ namespace App.ControlPanel.Engine
                 {
                     yield return "If warmup failed, browse to the admin site URL manually to confirm the App Service is responding.";
                 }
+                if (msg.Contains("service bus") && msg.Contains("premium"))
+                {
+                    yield return "Service Bus cannot be made private on the Standard SKU. Either migrate the namespace to Premium and re-run the installer, keep public network access enabled on Service Bus, or disable the Teams calls import — otherwise Teams calls will not import.";
+                }
             }
         }
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -369,13 +369,24 @@ namespace App.ControlPanel.Engine.InstallerTasks
                     "vault", subnetId, logger, tagDic);
                 if (deployDns) AddPrivateDnsZoneTask("privatelink.vaultcore.azure.net", vnetId, kvPeName, logger, tagDic);
 
-                // Service Bus
+                // Service Bus. Private endpoints require the Premium SKU: the wrappers skip (with a clear
+                // warning) rather than fail when a pre-existing Standard namespace can't be made private.
                 if (config.ServiceBusEnabled)
                 {
                     var sbPeName = peNames.GetNameOrDefault(peNames.ServiceBus, $"pe-{config.ServiceBusName}-sb");
-                    AddPrivateEndpointTask(sbPeName, $"/subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.ServiceBus/namespaces/{config.ServiceBusName}",
-                        "namespace", subnetId, logger, tagDic);
-                    if (deployDns) AddPrivateDnsZoneTask("privatelink.servicebus.windows.net", vnetId, sbPeName, logger, tagDic);
+                    var sbPeConfig = TaskConfig.GetConfigForName(sbPeName)
+                        .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_TARGET_RESOURCE_ID, $"/subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.ServiceBus/namespaces/{config.ServiceBusName}")
+                        .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_GROUP_ID, "namespace")
+                        .AddSetting(PrivateEndpointInstallTask.CONFIG_KEY_SUBNET_ID, subnetId);
+                    this.AddTask(new ServiceBusPrivateEndpointInstallTask(sbPeConfig, logger, Location, tagDic, _serviceBusNamespaceInstallTask));
+
+                    if (deployDns)
+                    {
+                        var sbDnsConfig = TaskConfig.GetConfigForName("privatelink.servicebus.windows.net")
+                            .AddSetting(PrivateDnsZoneInstallTask.CONFIG_KEY_VNET_ID, vnetId)
+                            .AddSetting(PrivateDnsZoneInstallTask.CONFIG_KEY_PE_NAME, sbPeName);
+                        this.AddTask(new ServiceBusPrivateDnsZoneInstallTask(sbDnsConfig, logger, Location, tagDic, _serviceBusNamespaceInstallTask));
+                    }
                 }
 
                 // Cognitive Services (Language/Text Analytics)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/PreInstallAdvisor.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/PreInstallAdvisor.cs
@@ -1,0 +1,47 @@
+using Common.Entities.Installer;
+
+namespace App.ControlPanel.Engine
+{
+    /// <summary>
+    /// Pre-install checks that warn about configurations which would install "successfully" but leave part of
+    /// the solution silently broken. Kept out of the UI so the rules can be unit tested.
+    /// </summary>
+    public static class PreInstallAdvisor
+    {
+        /// <summary>
+        /// Private deployments disable public network access on every PaaS resource, but Service Bus can only be
+        /// reached privately on the Premium SKU. If the namespace can't be Premium the Teams calls import fails at
+        /// runtime with an opaque "Ip has been prevented to connect to the endpoint" 401, so the operator needs to
+        /// know up front. See issue #228.
+        ///
+        /// Returns null when there is nothing to warn about.
+        /// </summary>
+        public static string GetServiceBusPrivateDeploymentWarning(BaseSolutionInstallConfig config)
+        {
+            if (config == null) return null;
+
+            var vnetEnabled = config.NetworkConfig != null && config.NetworkConfig.Enabled;
+            if (!vnetEnabled) return null;
+
+            // Public access still allowed = the namespace stays reachable whatever its SKU.
+            if (config.NetworkConfig.AllowPublicAccess) return null;
+
+            // Service Bus is only used by the Teams calls import.
+            if (!config.ServiceBusEnabled) return null;
+
+            return "Private deployment + Teams calls import: Service Bus must be on the PREMIUM SKU."
+                + "\r\n\r\nPublic network access will be disabled, and a Service Bus namespace can only be reached privately "
+                + "through a private endpoint, which requires Premium. Azure cannot upgrade an existing Standard namespace "
+                + "to Premium in place."
+                + "\r\n\r\nIf the namespace '" + config.ServiceBusName + "' is not Premium, the Teams calls import will fail at "
+                + "runtime with 'Put token failed. status-code: 401 ... Ip has been prevented to connect to the endpoint'."
+                + "\r\n\r\nOptions:"
+                + "\r\n  (a) Migrate the namespace to Premium and re-run the installer."
+                + "\r\n  (b) Keep public network access enabled on Service Bus."
+                + "\r\n  (c) Disable the Teams calls import (untick Service Bus on the Azure Storage page)."
+                + "\r\n\r\nThe installer will NOT disable public access on a namespace that cannot be made private - it stays "
+                + "reachable and this warning is repeated in the install summary."
+                + "\r\n\r\nContinue with the install?";
+        }
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
@@ -497,6 +497,19 @@ namespace App.ControlPanel.Frames
                 return;
             }
 
+            // A private deployment can leave Service Bus (and therefore the Teams calls import) unreachable if the
+            // namespace isn't Premium. Make that impossible to miss before a real deployment starts - see issue #228.
+            var serviceBusWarning = PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(GetConfigFromGUI());
+            if (serviceBusWarning != null)
+            {
+                var proceed = MessageBox.Show(this, serviceBusWarning, "Service Bus cannot be private on Standard SKU",
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
+                if (proceed != DialogResult.Yes)
+                {
+                    return;
+                }
+            }
+
             // Save settings
             (this.ParentForm as MainForm).SaveLastSettings();
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
@@ -14,6 +14,18 @@ namespace CloudInstallEngine.Azure.InstallTasks
         private readonly bool _requirePremiumSku;
         private readonly bool _allowPublicAccess;
 
+        /// <summary>
+        /// Standard warning text used when a private deployment can't make Service Bus private. Public so the
+        /// installer UI can show the same wording before an install starts.
+        /// </summary>
+        public const string NOT_PRIVATE_CAPABLE_WARNING =
+            "Service Bus is on the Standard SKU and cannot be made private (private endpoints require Premium). "
+            + "With public network access disabled the namespace would be unreachable from the VNet and the TEAMS CALLS IMPORT WOULD NOT WORK "
+            + "(the importer fails with 'Put token failed. status-code: 401 ... Ip has been prevented to connect to the endpoint'). "
+            + "Options: (a) migrate the namespace to Premium and re-run the installer "
+            + "(https://learn.microsoft.com/azure/service-bus-messaging/service-bus-migrate-standard-premium), "
+            + "(b) keep public network access enabled on Service Bus, or (c) disable the Teams calls import.";
+
         public ServiceBusNamespaceInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool requirePremiumSku = false, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
             _requirePremiumSku = requirePremiumSku;
@@ -21,6 +33,19 @@ namespace CloudInstallEngine.Azure.InstallTasks
         }
 
         public override string TaskName => "get/create Service-bus namespace";
+
+        /// <summary>
+        /// True when the namespace this task produced can host a private endpoint (i.e. it is Premium). False
+        /// means a private deployment cannot make Service Bus private, so we deliberately leave public access on.
+        /// Null until the task has run.
+        /// </summary>
+        public bool? IsPrivateEndpointCapable { get; private set; }
+
+        /// <summary>
+        /// True when a private deployment asked for public access to be disabled but we kept it enabled because
+        /// the namespace can't have a private endpoint - disabling it would silently break the Teams calls import.
+        /// </summary>
+        public bool PublicAccessKeptOpenForReachability { get; private set; }
 
         public async override Task<ServiceBusNamespaceResource> ExecuteTaskReturnResult(object contextArg)
         {
@@ -47,6 +72,8 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
                 sbNS = operation.Value;
 
+                // A namespace we just created at the SKU we asked for is private-capable whenever we asked for Premium.
+                IsPrivateEndpointCapable = IsPremium(sbNS) || _requirePremiumSku;
 
                 _logger.LogInformation($"Created service-bus namespace '{sbNS.Data.Name}'.");
             }
@@ -54,6 +81,29 @@ namespace CloudInstallEngine.Azure.InstallTasks
             {
                 _logger.LogInformation($"Found existing service-bus namespace '{sbNS.Data.Name}'.");
                 await base.EnsureTagsOnExisting(sbNS.Data.Tags, sbNS.GetTagResource());
+
+                // Azure has no in-place upgrade to Premium, so an existing non-Premium namespace in a private
+                // deployment can never get a private endpoint. Work that out BEFORE touching public access:
+                // disabling public access on a namespace that can't be reached privately makes it unreachable
+                // altogether, which silently kills the Teams calls import. See issue #228.
+                IsPrivateEndpointCapable = !_requirePremiumSku || IsPremium(sbNS);
+
+                var effectiveDesiredAccess = desiredAccess;
+                if (_requirePremiumSku && !IsPremium(sbNS))
+                {
+                    _logger.LogError($"Service Bus namespace '{sbNS.Data.Name}' is on the {sbNS.Data.Sku?.Name} SKU but private endpoints require Premium. "
+                        + "Azure does not support in-place SKU upgrades to Premium. " + NOT_PRIVATE_CAPABLE_WARNING);
+
+                    if (desiredAccess == ServiceBusPublicNetworkAccess.Disabled)
+                    {
+                        // Prefer "reachable and warned about" over "private and silently broken".
+                        effectiveDesiredAccess = ServiceBusPublicNetworkAccess.Enabled;
+                        PublicAccessKeptOpenForReachability = true;
+                        _logger.LogWarning($"Service Bus: leaving public network access ENABLED on '{sbNS.Data.Name}' even though this is a private deployment, "
+                            + "because the namespace cannot have a private endpoint and disabling public access would make the Teams calls import fail silently. "
+                            + "Migrate the namespace to Premium and re-run the installer to make it private, or disable the Teams calls import if it isn't needed.");
+                    }
+                }
 
                 bool needsUpdate = false;
                 var updateData = new ServiceBusNamespaceData(sbNS.Data.Location);
@@ -70,10 +120,10 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     needsUpdate = true;
                 }
 
-                if (sbNS.Data.PublicNetworkAccess == null || sbNS.Data.PublicNetworkAccess != desiredAccess)
+                if (sbNS.Data.PublicNetworkAccess == null || sbNS.Data.PublicNetworkAccess != effectiveDesiredAccess)
                 {
-                    _logger.LogInformation($"Updating service-bus namespace '{sbNS.Data.Name}' public network access to '{desiredAccess}'...");
-                    updateData.PublicNetworkAccess = desiredAccess;
+                    _logger.LogInformation($"Updating service-bus namespace '{sbNS.Data.Name}' public network access to '{effectiveDesiredAccess}'...");
+                    updateData.PublicNetworkAccess = effectiveDesiredAccess;
                     needsUpdate = true;
                 }
 
@@ -82,18 +132,12 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     var operation = await allNSs.CreateOrUpdateAsync(WaitUntil.Completed, name, updateData);
                     sbNS = operation.Value;
                 }
-
-                // Upgrade to Premium if required for private endpoints and not already Premium
-                if (_requirePremiumSku && sbNS.Data.Sku.Name != ServiceBusSkuName.Premium)
-                {
-                    _logger.LogError($"Service Bus namespace '{sbNS.Data.Name}' is on {sbNS.Data.Sku.Name} SKU but private endpoints require Premium. " +
-                        $"Azure does not support in-place SKU upgrades to Premium. Please manually migrate to a Premium namespace " +
-                        $"(see https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-migrate-standard-premium) " +
-                        $"and re-run the installer. Continuing installation...");
-                }
             }
 
             return sbNS;
         }
+
+        private static bool IsPremium(ServiceBusNamespaceResource ns)
+            => ns?.Data?.Sku != null && ns.Data.Sku.Name == ServiceBusSkuName.Premium;
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusPrivateNetworkingTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusPrivateNetworkingTasks.cs
@@ -1,0 +1,79 @@
+using Azure.Core;
+using Azure.ResourceManager.Network;
+using Azure.ResourceManager.PrivateDns;
+using CloudInstallEngine.Models;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure.InstallTasks
+{
+    /// <summary>
+    /// Service Bus-aware wrapper around <see cref="PrivateEndpointInstallTask"/>.
+    /// Private endpoints for Service Bus require the Premium SKU, and Azure has no in-place upgrade to Premium,
+    /// so a pre-existing Standard namespace can never get one. Attempting it fails the task with an opaque Azure
+    /// error; instead we skip it and explain the consequence for the Teams calls import. See issue #228.
+    /// </summary>
+    public class ServiceBusPrivateEndpointInstallTask : InstallTaskInAzResourceGroup<PrivateEndpointResource>
+    {
+        private readonly ServiceBusNamespaceInstallTask _namespaceTask;
+
+        public ServiceBusPrivateEndpointInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, ServiceBusNamespaceInstallTask namespaceTask)
+            : base(config, logger, azureLocation, tags)
+        {
+            _namespaceTask = namespaceTask;
+        }
+
+        public override string TaskName => "get/create Service Bus private endpoint";
+
+        public override async Task<PrivateEndpointResource> ExecuteTaskReturnResult(object contextArg)
+        {
+            if (_namespaceTask?.IsPrivateEndpointCapable == false)
+            {
+                _logger.LogWarning("Skipping Service Bus private endpoint creation: " + ServiceBusNamespaceInstallTask.NOT_PRIVATE_CAPABLE_WARNING);
+                return null;
+            }
+
+            var innerTask = new PrivateEndpointInstallTask(_config, _logger, AzureLocation, Tags)
+            {
+                Container = base.Container,
+            };
+            return await innerTask.ExecuteTaskReturnResult(contextArg);
+        }
+    }
+
+    /// <summary>
+    /// Service Bus-aware wrapper around <see cref="PrivateDnsZoneInstallTask"/>.
+    /// Skips the zone when the namespace can't have a private endpoint. Creating a VNet-linked
+    /// <c>privatelink.servicebus.windows.net</c> zone with no endpoint behind it is worse than doing nothing: it
+    /// can hijack resolution of the public hostname and leave a confusing orphan behind. See issues #228 / #229.
+    /// </summary>
+    public class ServiceBusPrivateDnsZoneInstallTask : InstallTaskInAzResourceGroup<PrivateDnsZoneResource>
+    {
+        private readonly ServiceBusNamespaceInstallTask _namespaceTask;
+
+        public ServiceBusPrivateDnsZoneInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, ServiceBusNamespaceInstallTask namespaceTask)
+            : base(config, logger, azureLocation, tags)
+        {
+            _namespaceTask = namespaceTask;
+        }
+
+        public override string TaskName => "get/create Service Bus private DNS zone";
+
+        public override async Task<PrivateDnsZoneResource> ExecuteTaskReturnResult(object contextArg)
+        {
+            if (_namespaceTask?.IsPrivateEndpointCapable == false)
+            {
+                _logger.LogInformation("Skipping Service Bus private DNS zone creation: the namespace has no private endpoint (Premium SKU required), "
+                    + "so the zone would not resolve to anything and could break access to the public endpoint.");
+                return null;
+            }
+
+            var innerTask = new PrivateDnsZoneInstallTask(_config, _logger, AzureLocation, Tags)
+            {
+                Container = base.Container,
+            };
+            return await innerTask.ExecuteTaskReturnResult(contextArg);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/UsageReporting/AnonUsageStatsModel.cs
+++ b/src/AnalyticsEngine/Common/UsageReporting/AnonUsageStatsModel.cs
@@ -41,12 +41,20 @@ namespace UsageReporting
         public class TableStat
         {
             public string TableName { get; set; }
+
+            /// <summary>
+            /// Owning SQL schema, so app tables (dbo) can be told apart from profiling ones - and from a
+            /// same-named table in another schema. Null on reports from clients older than this field.
+            /// </summary>
+            public string SchemaName { get; set; }
+
             public decimal TotalSpaceMB { get; set; }
             public long Rows { get; set; }
 
             public override string ToString()
             {
-                return $"{TableName}: {Rows} rows, {TotalSpaceMB}mb";
+                var name = string.IsNullOrEmpty(SchemaName) ? TableName : $"{SchemaName}.{TableName}";
+                return $"{name}: {Rows} rows, {TotalSpaceMB}mb";
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphFileMetadataLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphFileMetadataLoaderTests.cs
@@ -1,7 +1,12 @@
 using ActivityImporter.Engine.ActivityAPI.Copilot;
 using DataUtils;
+using Microsoft.Extensions.Logging;
 using Microsoft.Graph.Models;
+using Microsoft.Graph.Models.ODataErrors;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
 
@@ -166,6 +171,110 @@ namespace Tests.UnitTests
             Assert.IsNotNull(result);
             Assert.AreEqual("unit test meeting", result.Subject);
             Assert.AreEqual(1, fake.GetOnlineMeetingCalls);
+        }
+
+        /// <summary>
+        /// Issue #215: a tenant without a Teams application access policy gets a 403 on *every* meeting-context
+        /// Copilot event. That's a tenant-configuration prerequisite, not a product fault, so it must be logged
+        /// once per run with actionable guidance (and without an exception object) instead of flooding telemetry.
+        /// </summary>
+        [TestMethod]
+        public async Task GetMeetingInfo_NoApplicationAccessPolicy_LogsOnceWithoutExceptionAndSkipsRepeatGraphCalls()
+        {
+            var fake = new FakeSpoGraphClient
+            {
+                OnGetOnlineMeeting = (userId, meetingId) => throw NoApplicationAccessPolicyError()
+            };
+            var log = new CapturingLogger();
+            var loader = new GraphFileMetadataLoader(fake, log);
+
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_a@thread.v2", "user-guid"));
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_b@thread.v2", "user-guid"));
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_c@thread.v2", "USER-GUID"));
+
+            Assert.AreEqual(1, fake.GetOnlineMeetingCalls, "Graph must not be re-called for a user we know has no access policy");
+
+            var warnings = log.Entries.FindAll(e => e.Level == LogLevel.Warning);
+            Assert.AreEqual(1, warnings.Count, "The missing-policy condition must be logged exactly once per run");
+            StringAssert.Contains(warnings[0].Message, "New-CsApplicationAccessPolicy");
+            Assert.IsNull(warnings[0].Exception, "The warning must not carry the exception, so it isn't counted as exception telemetry");
+        }
+
+        [TestMethod]
+        public async Task GetMeetingInfo_OtherGraphError_StillLoggedWithException()
+        {
+            var otherError = new ODataError
+            {
+                ResponseStatusCode = (int)HttpStatusCode.NotFound,
+                Error = new MainError { Code = "NotFound", Message = "Meeting not found" }
+            };
+            var fake = new FakeSpoGraphClient { OnGetOnlineMeeting = (userId, meetingId) => throw otherError };
+            var log = new CapturingLogger();
+            var loader = new GraphFileMetadataLoader(fake, log);
+
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_abc@thread.v2", "user-guid"));
+            Assert.IsNull(await loader.GetMeetingInfo("19:meeting_abc@thread.v2", "user-guid"));
+
+            Assert.AreEqual(2, fake.GetOnlineMeetingCalls, "Unrelated errors must not disable meeting lookups for the user");
+            var warnings = log.Entries.FindAll(e => e.Level == LogLevel.Warning);
+            Assert.AreEqual(2, warnings.Count);
+            Assert.IsNotNull(warnings[0].Exception);
+        }
+
+        [TestMethod]
+        public void IsMissingApplicationAccessPolicy_OnlyMatchesTheAccessPolicyForbidden()
+        {
+            Assert.IsTrue(GraphFileMetadataLoader.IsMissingApplicationAccessPolicy(NoApplicationAccessPolicyError()));
+
+            Assert.IsFalse(GraphFileMetadataLoader.IsMissingApplicationAccessPolicy(new ODataError
+            {
+                ResponseStatusCode = (int)HttpStatusCode.Forbidden,
+                Error = new MainError { Code = "Forbidden", Message = "Insufficient privileges to complete the operation." }
+            }), "A generic 403 is still a real permissions problem and must keep its exception logging");
+
+            Assert.IsFalse(GraphFileMetadataLoader.IsMissingApplicationAccessPolicy(new ODataError
+            {
+                ResponseStatusCode = (int)HttpStatusCode.InternalServerError,
+                Error = new MainError { Code = "ServiceError", Message = "No application access policy found for this app" }
+            }), "Only forbidden (or status-less) errors count");
+
+            Assert.IsFalse(GraphFileMetadataLoader.IsMissingApplicationAccessPolicy(null));
+        }
+
+        private static ODataError NoApplicationAccessPolicyError() => new ODataError
+        {
+            ResponseStatusCode = (int)HttpStatusCode.Forbidden,
+            Error = new MainError
+            {
+                Code = "Forbidden",
+                Message = "No application access policy found for this app 00000000-0000-0000-0000-000000000000 on the user."
+            }
+        };
+
+        /// <summary>Minimal <see cref="ILogger"/> that records level, message and exception for assertions.</summary>
+        private class CapturingLogger : ILogger
+        {
+            public class Entry
+            {
+                public LogLevel Level;
+                public string Message;
+                public Exception Exception;
+            }
+
+            public readonly List<Entry> Entries = new List<Entry>();
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Entries.Add(new Entry { Level = logLevel, Message = formatter(state, exception), Exception = exception });
+            }
+
+            private class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/PreInstallAdvisorTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/PreInstallAdvisorTests.cs
@@ -1,0 +1,104 @@
+using App.ControlPanel.Engine;
+using Common.Entities.Installer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Issue #228: a private (VNet, public access disabled) deployment leaves a non-Premium Service Bus namespace
+    /// unreachable, which silently kills the Teams calls import. The installer must warn before it happens.
+    /// </summary>
+    [TestClass]
+    public class PreInstallAdvisorTests
+    {
+        private static BaseSolutionInstallConfig PrivateConfigWithServiceBus()
+        {
+            return new BaseSolutionInstallConfig
+            {
+                ServiceBusEnabled = true,
+                ServiceBusName = "sb-contoso-analytics",
+                NetworkConfig = new VNetConfig { Enabled = true, AllowPublicAccess = false }
+            };
+        }
+
+        [TestMethod]
+        public void Warns_WhenPrivateDeploymentUsesServiceBus()
+        {
+            var warning = PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(PrivateConfigWithServiceBus());
+
+            Assert.IsNotNull(warning, "A private deployment with the Teams calls import on must warn about the Premium requirement.");
+            StringAssert.Contains(warning, "PREMIUM");
+            StringAssert.Contains(warning, "sb-contoso-analytics");
+        }
+
+        [TestMethod]
+        public void NoWarning_WhenPublicAccessStaysEnabled()
+        {
+            var config = PrivateConfigWithServiceBus();
+            config.NetworkConfig.AllowPublicAccess = true;
+
+            Assert.IsNull(PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(config),
+                "With public access still allowed the namespace stays reachable whatever its SKU.");
+        }
+
+        [TestMethod]
+        public void NoWarning_WhenVNetDisabled()
+        {
+            var config = PrivateConfigWithServiceBus();
+            config.NetworkConfig.Enabled = false;
+
+            Assert.IsNull(PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(config));
+        }
+
+        [TestMethod]
+        public void NoWarning_WhenServiceBusDisabled()
+        {
+            var config = PrivateConfigWithServiceBus();
+            config.ServiceBusEnabled = false;
+
+            Assert.IsNull(PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(config),
+                "Service Bus is only used by the Teams calls import - nothing to warn about when it's off.");
+        }
+
+        [TestMethod]
+        public void NoWarning_ForNullConfig()
+        {
+            Assert.IsNull(PreInstallAdvisor.GetServiceBusPrivateDeploymentWarning(null));
+        }
+
+        /// <summary>
+        /// The install summary must turn the warning into an actionable next step, so it survives to the end of
+        /// a long install log.
+        /// </summary>
+        [TestMethod]
+        public void InstallSummary_SurfacesServiceBusNextStep()
+        {
+            var summary = new InstallSummary();
+            summary.AddError("ServiceBus", "Service Bus namespace 'sb-contoso-analytics' is on the Standard SKU but private endpoints require Premium.");
+
+            var logger = new CollectingLogger();
+            summary.Print(logger);
+
+            var text = string.Join("\n", logger.Messages);
+            StringAssert.Contains(text, "Next steps:");
+            StringAssert.Contains(text, "migrate the namespace to Premium");
+        }
+
+        private class CollectingLogger : Microsoft.Extensions.Logging.ILogger
+        {
+            public readonly System.Collections.Generic.List<string> Messages = new System.Collections.Generic.List<string>();
+            public System.IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+            public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+            public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+
+            private class NullScope : System.IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <Compile Remove="Generated\**" />
     <Compile Include="AppConfigDefaultsTests.cs" />
+    <Compile Include="PreInstallAdvisorTests.cs" />
     <Compile Include="AppInsightsAuthTests.cs" />
     <Compile Include="CopilotAuditLogContentSchemaTests.cs" />
     <Compile Include="CopilotEventManagerAccessedResourcesTests.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/UsageStatsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UsageStatsTests.cs
@@ -8,7 +8,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;
 using System.Configuration;
+using System.Data.Entity;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using UsageReporting;
@@ -150,13 +153,22 @@ namespace Tests.UnitTests
                 result = await r.ProcessAndUploadStats();
                 Assert.IsTrue(result);
 
-                // Verify result saved in DB
-                var latestReport = await sqlStatsAdaptor.GetLatestSavedDbStats();
+                // Verify result saved in DB (read the saved report back directly - the builder no longer
+                // exposes a read-back method, it only ever writes).
+                var latestReportJson = await db.TelemetryReports.OrderByDescending(s => s.ReportSubmitted).Select(s => s.Report).FirstOrDefaultAsync();
+                Assert.IsFalse(string.IsNullOrEmpty(latestReportJson));
+                var latestReport = JsonConvert.DeserializeObject<AnonUsageStatsModel>(latestReportJson);
                 Assert.IsNotNull(latestReport);
                 Assert.IsTrue(latestReport.TableStats.Count > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(latestReport.TableStats[0].TableName));
+                Assert.IsFalse(string.IsNullOrEmpty(latestReport.TableStats[0].SchemaName), "Table stats must record the owning schema so dbo tables can be told apart from other schemas");
                 Assert.IsTrue(latestReport.TableStats.Where(s => s.TotalSpaceMB > 0).Any());
                 Assert.IsTrue(latestReport.TableStats.Where(s => s.Rows > 0).Any());
+
+                // One row per table: a table with several indexes must not be reported multiple times
+                var duplicated = latestReport.TableStats.GroupBy(s => $"{s.SchemaName}.{s.TableName}").Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+                Assert.AreEqual(0, duplicated.Count, $"Each table must appear exactly once. Duplicated: {string.Join(", ", duplicated)}");
+
                 Assert.IsNull(latestReport.ConfiguredSolutionsEnabledDescription);
                 Assert.IsTrue(latestReport.ConfiguredImportsEnabledDescription == cfg.SolutionConfig.ImportTaskSettings.ToSettingsString());
             }
@@ -343,6 +355,78 @@ namespace Tests.UnitTests
                 var result = await mgr.ProcessAndFailSilently();
                 Assert.IsFalse(result, "ProcessAndFailSilently must report failure but not throw when the uploader is misconfigured.");
             }
+        }
+
+        /// <summary>
+        /// Issue #206 (1): a rejected upload used to be logged and then treated as a success, so the
+        /// "last uploaded" date advanced and the report wasn't retried for a whole day - telemetry silently lost.
+        /// </summary>
+        [TestMethod]
+        public async Task WebApiStatsUploader_ServerRejectsUpload_Throws()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var model = AnonUsageStatsModelLoader.Load(Guid.NewGuid(), null);
+
+            using (var client = new HttpClient(new StubHandler(HttpStatusCode.InternalServerError)))
+            using (var uploader = new WebApiStatsUploader("https://stats.example/", "shared-secret", logger, client))
+            {
+                await Assert.ThrowsExceptionAsync<HttpRequestException>(
+                    async () => await uploader.UploadToServer(model),
+                    "A non-2xx response must throw so the caller does not register a successful upload.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WebApiStatsUploader_ServerAcceptsUpload_DoesNotThrow()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var model = AnonUsageStatsModelLoader.Load(Guid.NewGuid(), null);
+
+            using (var client = new HttpClient(new StubHandler(HttpStatusCode.OK)))
+            using (var uploader = new WebApiStatsUploader("https://stats.example/", "shared-secret", logger, client))
+            {
+                await uploader.UploadToServer(model);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageStatsManager_FailedUpload_DoesNotAdvanceTheOnceADayThrottle()
+        {
+            // The MIN_WAIT throttle must only advance on a genuinely successful upload, otherwise a
+            // server-side outage costs a full day of telemetry per failure.
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var tenantId = Guid.NewGuid();
+            var loader = new InMemoryStatsDatesLoader();
+
+            using (var client = new HttpClient(new StubHandler(HttpStatusCode.InternalServerError)))
+            using (var uploader = new WebApiStatsUploader("https://stats.example/", "shared-secret", logger, client))
+            {
+                var mgr = new UsageStatsManager(new AlwaysWorksUsageStatsBuilder(logger, tenantId), loader, uploader, logger);
+
+                Assert.IsFalse(await mgr.ProcessAndFailSilently(), "A rejected upload must be reported as a failure.");
+                Assert.IsNull(await loader.GetLastUploadDt(), "A rejected upload must not register a last-upload date, so the next cycle retries.");
+            }
+        }
+
+        /// <summary>Issue #206 (4): timestamps that feed the payload signature / document id must be UTC.</summary>
+        [TestMethod]
+        public void AnonUsageStatsModelLoader_GeneratedIsUtc()
+        {
+            var model = AnonUsageStatsModelLoader.Load(Guid.NewGuid(), null);
+
+            Assert.IsTrue(model.Generated.HasValue);
+            Assert.AreEqual(DateTimeKind.Utc, model.Generated.Value.Kind, "Generated must be UTC - it feeds the payload signature and the server-side document id.");
+            Assert.IsTrue(Math.Abs((DateTime.UtcNow - model.Generated.Value).TotalMinutes) < 5);
+        }
+
+        /// <summary>Always returns the configured status code, so upload handling can be tested offline.</summary>
+        private class StubHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _status;
+            public StubHandler(HttpStatusCode status) { _status = status; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(_status) { RequestMessage = request });
         }
     }
 

--- a/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
+++ b/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
@@ -590,14 +590,39 @@ namespace Web.AnalyticsWeb.Models.Health
             }
             catch (Exception ex)
             {
+                var detail = InnermostMessage(ex);
+
+                // A network-layer rejection (rather than an auth failure) in a private deployment almost always
+                // means the namespace has public access disabled but no private endpoint - which needs Premium.
+                // See issue #228; without this hint the 401 reads like an RBAC problem.
+                if (LooksLikeNetworkRejection(detail))
+                {
+                    detail += " This looks like a network-level block rather than a permissions problem: in a private (VNet) deployment "
+                        + "Service Bus must be on the Premium SKU with a private endpoint, otherwise the namespace is unreachable and "
+                        + "Teams calls will not import. Either migrate the namespace to Premium, or re-enable public network access on it.";
+                }
+
                 UpsertComponent(section, new ComponentHealthRow
                 {
                     Component = "ServiceBus",
                     Status = HealthStatusNames.Degraded,
-                    Detail = "Couldn't read the Teams calls queue depth: " + InnermostMessage(ex),
+                    Detail = "Couldn't read the Teams calls queue depth: " + detail,
                     LastSeenUtc = DateTime.UtcNow
                 });
             }
+        }
+
+        /// <summary>
+        /// Service Bus rejects a blocked IP before the token is even validated, so the message mentions IP
+        /// filtering / VNet service endpoints rather than authorisation.
+        /// </summary>
+        private static bool LooksLikeNetworkRejection(string message)
+        {
+            if (string.IsNullOrEmpty(message)) return false;
+            return message.IndexOf("Ip has been prevented", StringComparison.OrdinalIgnoreCase) >= 0
+                || message.IndexOf("IP Filter", StringComparison.OrdinalIgnoreCase) >= 0
+                || message.IndexOf("Virtual Network", StringComparison.OrdinalIgnoreCase) >= 0
+                || message.IndexOf("prevented to connect to the endpoint", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         /// <summary>Adds or replaces a component row by name (runtime checks take precedence over any older telemetry row).</summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/GraphFileMetadataLoader.cs
@@ -5,6 +5,8 @@ using Microsoft.Graph.Models;
 using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Collections.Concurrent;
+using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
 
@@ -31,6 +33,14 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         private readonly ConcurrentDictionary<string, SpoDocumentFileInfo> _fileInfoByContext =
             new ConcurrentDictionary<string, SpoDocumentFileInfo>(StringComparer.OrdinalIgnoreCase);
 
+        // Users for whom Graph has told us there's no Teams application access policy for this app. The grant is
+        // per-user (or global), so this is cached per user rather than tenant-wide, and only for this run.
+        private readonly ConcurrentDictionary<string, byte> _usersWithoutMeetingAccessPolicy =
+            new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+
+        // 1 once we've logged the "no application access policy" explanation for this run.
+        private int _meetingAccessPolicyWarningLogged;
+
         public GraphFileMetadataLoader(GraphServiceClient graphServiceClient, ILogger logger)
             : this(new GraphSpoClient(graphServiceClient), logger)
         {
@@ -47,17 +57,68 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         public async Task<MeetingMetadata> GetMeetingInfo(string meetingId, string userGuid)
         {
             // Requires OnlineMeetings.Read.All and https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy#configure-application-access-policy
+
+            // A tenant that hasn't granted the application access policy rejects *every* online-meeting read for
+            // that user, so once we've seen it don't keep calling Graph for the same user this run.
+            if (userGuid != null && _usersWithoutMeetingAccessPolicy.ContainsKey(userGuid))
+            {
+                _logger.LogDebug("Skipping meeting lookup for meetingId {meetingId}: no Teams application access policy for this app on the user", meetingId);
+                return null;
+            }
+
             try
             {
                 var meeting = await _spoGraphClient.GetOnlineMeetingAsync(userGuid, meetingId);
 
                 return new MeetingMetadata(meeting);
             }
+            catch (ODataError ex) when (IsMissingApplicationAccessPolicy(ex))
+            {
+                // Expected tenant-configuration condition rather than a product fault, and it hits every
+                // meeting-context Copilot event. Log the actionable explanation once per import run (without the
+                // exception object, so it doesn't dominate exception telemetry) and skip enrichment quietly.
+                if (userGuid != null)
+                {
+                    _usersWithoutMeetingAccessPolicy.TryAdd(userGuid, 0);
+                }
+
+                if (Interlocked.Exchange(ref _meetingAccessPolicyWarningLogged, 1) == 0)
+                {
+                    _logger.LogWarning("Copilot meeting enrichment is unavailable in this tenant: Microsoft Graph reports no Teams application "
+                        + "access policy for this application, so online-meeting details can't be read and meeting metadata will be skipped. "
+                        + "To enable it, grant the importer application an access policy with the Teams PowerShell cmdlets "
+                        + "New-CsApplicationAccessPolicy / Grant-CsApplicationAccessPolicy - see "
+                        + "https://learn.microsoft.com/graph/cloud-communication-online-meeting-application-access-policy. "
+                        + "Further occurrences this import run are logged at debug level only.");
+                }
+                else
+                {
+                    _logger.LogDebug("Skipping meeting info for meetingId {meetingId}: no Teams application access policy for this app on the user", meetingId);
+                }
+
+                return null;
+            }
             catch (ODataError ex)
             {
                 _logger.LogWarning(ex, "Error getting meeting info for meetingId {meetingId}", meetingId);
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Is this the "No application access policy found for this app ... on the user" 403 that Graph returns when
+        /// the tenant hasn't run New-CsApplicationAccessPolicy / Grant-CsApplicationAccessPolicy for the importer app?
+        /// </summary>
+        internal static bool IsMissingApplicationAccessPolicy(ODataError ex)
+        {
+            if (ex == null) return false;
+
+            // Some Graph/Kiota paths leave the status code unset (0), so don't require it to be exactly 403 - the
+            // message text is the reliable discriminator; just make sure we never swallow a non-forbidden error.
+            if (ex.ResponseStatusCode != (int)HttpStatusCode.Forbidden && ex.ResponseStatusCode != 0) return false;
+
+            var message = ex.Error?.Message ?? ex.Message ?? string.Empty;
+            return message.IndexOf("application access policy", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         public async Task<SpoDocumentFileInfo> GetSpoFileInfo(string copilotDocContextId, string eventUpn)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/AnonUsageStatsModelLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/AnonUsageStatsModelLoader.cs
@@ -9,7 +9,10 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
     {
         public static AnonUsageStatsModel Load(Guid tenantId, BaseSolutionInstallConfig lastSettings)
         {
-            var model = new AnonUsageStatsModel() { Generated = DateTime.Now };
+            // UTC: Generated.Ticks feeds both the payload signature and the server-side document id, so a
+            // local-time value would make those inconsistent across servers in different timezones (and shift
+            // by an hour at DST boundaries).
+            var model = new AnonUsageStatsModel() { Generated = DateTime.UtcNow };
             model.AnonClientId = StringUtils.GetHashedStringSimple(tenantId.ToString());
             if (lastSettings != null && lastSettings.SolutionConfig != null)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/SqlUsageStatsBuilder.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/SqlUsageStatsBuilder.cs
@@ -22,23 +22,6 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
             _db = db;
         }
 
-        public async Task<AnonUsageStatsModel> GetLatestSavedDbStats()
-        {
-            var latestReports = await _db.TelemetryReports.OrderByDescending(s => s.ReportSubmitted).Take(1).ToListAsync();
-            if (latestReports.Count == 1 && !string.IsNullOrEmpty(latestReports[0].Report))
-            {
-                try
-                {
-                    return JsonConvert.DeserializeObject<AnonUsageStatsModel>(latestReports[0].Report);
-                }
-                catch (JsonReaderException)
-                {
-                    // Ignore
-                }
-            }
-            return null;
-        }
-
         public override async Task<BaseSolutionInstallConfig> GetLastAppliedSolutionConfig()
         {
             var latestConfig = await _db.ConfigStates.OrderByDescending(s => s.DateApplied).Take(1).ToListAsync();
@@ -68,34 +51,39 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
             return stats;
         }
 
-        private Task<List<AnonUsageStatsModel.TableStat>> GetStatsFromSql()
+        private async Task<List<AnonUsageStatsModel.TableStat>> GetStatsFromSql()
         {
+            // Metadata-only (sys.*) so this stays cheap on a large tenant - no scan of customer data.
+            // Row counts come from the heap/clustered index only (index_id 0 or 1) via the CROSS APPLY, while
+            // size sums every allocation unit. Grouping on schema+table alone means a table can never be split
+            // into several output rows just because it gained an extra (e.g. filtered) index.
             var sql = @"
 SELECT 
-    t.NAME as TableName,
-    p.rows as [Rows],
+    s.name AS SchemaName,
+    t.name AS TableName,
+    MAX(tableRows.[Rows]) AS [Rows],
     CAST(ROUND(((SUM(a.total_pages) * 8) / 1024.00), 2) AS NUMERIC(36, 2)) AS TotalSpaceMB
 FROM 
     sys.tables t
 INNER JOIN      
-    sys.indexes i ON t.OBJECT_ID = i.object_id
+    sys.indexes i ON t.object_id = i.object_id
 INNER JOIN 
-    sys.partitions p ON i.object_id = p.OBJECT_ID AND i.index_id = p.index_id
+    sys.partitions p ON i.object_id = p.object_id AND i.index_id = p.index_id
 INNER JOIN 
     sys.allocation_units a ON p.partition_id = a.container_id
-LEFT OUTER JOIN 
+INNER JOIN 
     sys.schemas s ON t.schema_id = s.schema_id
+CROSS APPLY 
+    (SELECT SUM(pRows.rows) FROM sys.partitions pRows WHERE pRows.object_id = t.object_id AND pRows.index_id IN (0, 1)) AS tableRows([Rows])
 WHERE 
     t.is_ms_shipped = 0
 GROUP BY 
-    t.Name, s.Name, p.Rows
+    s.name, t.name
 ORDER BY 
-    TotalSpaceMB DESC, t.Name
+    TotalSpaceMB DESC, t.name
 ";
 
-            var resuls = _db.Database.SqlQuery<AnonUsageStatsModel.TableStat>(sql);
-
-            return Task.FromResult(resuls.ToList());
+            return await _db.Database.SqlQuery<AnonUsageStatsModel.TableStat>(sql).ToListAsync();
         }
 
         public override async Task SaveUsageStatsModelToDatabase(AnonUsageStatsModel latestStats)
@@ -103,7 +91,7 @@ ORDER BY
             _db.TelemetryReports.Add(new Common.Entities.Entities.TelemetryReport
             {
                 Report = JsonConvert.SerializeObject(latestStats),
-                ReportSubmitted = DateTime.Now
+                ReportSubmitted = DateTime.UtcNow
             });
             await _db.SaveChangesAsync();
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/UsageStatsManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/UsageStatsManager.cs
@@ -35,7 +35,9 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"{LOG_PREFIX}error uploading anonymised runtime stats - {ex.Message}");
+                // Logged as an error (not a warning): telemetry silently never uploading is exactly the
+                // failure mode this subsystem is blind to, so it needs to be visible in App Insights.
+                _logger.LogError(ex, $"{LOG_PREFIX}error uploading anonymised runtime stats - {ex.Message}");
                 return false;
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/WebApiStatsUploader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/StatsUploader/WebApiStatsUploader.cs
@@ -18,12 +18,22 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
         private readonly string _url;
         private readonly string _statsApiSecret;
         private readonly ILogger _logger;
+        private readonly HttpClient _client;
 
-        public WebApiStatsUploader(string url, string statsApiSecret, ILogger logger)
+        public WebApiStatsUploader(string url, string statsApiSecret, ILogger logger) : this(url, statsApiSecret, logger, _httpClient)
+        {
+        }
+
+        /// <summary>
+        /// Test seam: lets unit tests supply a client with a stub handler so the non-2xx behaviour can be
+        /// verified without a live endpoint. Production always uses the shared static client.
+        /// </summary>
+        internal WebApiStatsUploader(string url, string statsApiSecret, ILogger logger, HttpClient client)
         {
             _url = url;
             _statsApiSecret = statsApiSecret;
             _logger = logger;
+            _client = client;
         }
 
         public void Dispose()
@@ -38,14 +48,18 @@ namespace WebJob.Office365ActivityImporter.Engine.StatsUploader
                 var body = new TelemetryPayload(stats, _statsApiSecret);
                 var content = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
 
-                var response = await _httpClient.PostAsync(_url, content);
+                var response = await _client.PostAsync(_url, content);
                 if (response.IsSuccessStatusCode)
                 {
                     _logger.LogInformation($"Uploaded stats to {_url}");
                 }
                 else
                 {
-                    _logger.LogError($"Can't upload stats to API - server returned unexpected response {response.StatusCode}");
+                    // Must throw: the caller only registers the "last uploaded" date - which gates the next
+                    // upload for a whole day - when this method completes without error. Returning normally on a
+                    // rejected upload would silently drop the report and not retry until the next day.
+                    _logger.LogError($"Can't upload stats to API - server returned unexpected response {(int)response.StatusCode} ({response.StatusCode})");
+                    response.EnsureSuccessStatusCode();
                 }
             }
             else


### PR DESCRIPTION
## Stable Release (PR `dev` -> `main`)

This PR promoted `dev` to `main` and produced the draft **Stable build 1720** release. The published release notes are reproduced below.

---

## Stable build 1720 — bug-fix release

**This is mainly a bug-fix release.** There are **no new features**, no database changes and no configuration changes. It fixes three problems that all shared the same characteristic: *something was failing quietly, or an error was telling you the wrong story*.

### Should you upgrade?

| | |
|-|-|
| **Upgrade urgency** | **Recommended for everyone.** High priority if you run a **private (VNet) deployment** and import **Teams calls** — see the first fix. |
| **Database migrations** | **None.** No schema change, nothing to run, no maintenance window. |
| **Configuration changes** | **None.** Config schema stays at **1.9.0** — existing config files load and work unchanged; no need to re-save your installer configuration. |
| **Breaking changes** | **None.** No behaviour changes to imports, reporting or the data model. |
| **How to upgrade** | Deploy the new binaries — re-run `AnalyticsInstaller.exe`, or use `Deploy-AppServiceContent.ps1`. Nothing else. |
| **Downtime** | None beyond the normal App Service restart when web-job content is replaced. |

---

## Fix 1 — Private deployments no longer silently break the Teams calls import

**Who this affects:** deployments with **VNet enabled and public network access disabled**, where the **Teams calls import** is on. Everyone else is unaffected.

**Symptom:** Teams call records stop importing. The importer logs a 401 that looks like an authentication or RBAC problem, but isn't:

```
Put token failed. status-code: 401, status-description: Ip has been prevented to connect to the endpoint.
   ... Virtual Network service endpoints / IP Filters ...
```

**Root cause:** Service Bus can only be reached privately via a **private endpoint**, and private endpoints on Service Bus require the **Premium** SKU. Azure does not support an in-place Standard → Premium upgrade. Previously the installer disabled public network access on the namespace regardless of SKU, so a **Standard** namespace ended up reachable **neither publicly nor privately**. The install log recorded an error, but it scrolled past and the failure only surfaced later as missing call data.

Note this is a **network-layer rejection** — the connection is refused before the Entra token is validated — so no amount of RBAC or permission work fixes it. That's exactly why it was so easy to misdiagnose.

**What's changed:**

- **The installer will no longer create that state.** If the namespace can't be made private, it **leaves public network access enabled on Service Bus** and warns clearly. Every other resource is still locked down as normal. A reachable namespace you've been told about beats a private one that silently drops your data.
- **You're warned before anything happens.** Choosing a private deployment with the Teams calls import enabled now shows a confirmation dialog listing your three options — (a) migrate the namespace to Premium and re-run, (b) keep public access on Service Bus only, (c) turn the Teams calls import off. It defaults to "No".
- **No more misleading leftovers.** The unusable Service Bus private endpoint and its `privatelink.servicebus.windows.net` private DNS zone are skipped. This matters: a VNet-linked private DNS zone with no endpoint behind it hijacks resolution of the public hostname, so it breaks public access too.
- **The warning survives the install.** It's repeated in the end-of-install summary as an actionable next step.
- **The Health page diagnoses it.** If the Teams calls queue can't be read and the error looks like an IP/VNet block, the Service Bus component now names the Premium requirement instead of showing a raw Azure error.

**Action for admins:** if you're on a private deployment with Teams calls enabled, check your Service Bus SKU. If it's Standard, either [migrate it to Premium](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-migrate-standard-premium), keep public access on that one namespace, or disable the Teams calls import. See **[Private Endpoints](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Private-Endpoints)** in the wiki.

---

## Fix 2 — Copilot meeting details: one actionable warning instead of thousands of errors

**Who this affects:** tenants importing **Copilot** activity where meeting-context events occur — which is most of them.

**Symptom:** Application Insights fills with thousands of identical `403 Forbidden` exceptions from meeting look-ups, burying real problems. Copilot **meeting name** and **meeting created date** are always blank.

**Root cause:** reading Teams meeting details needs more than the `OnlineMeetings.Read.All` Graph permission — Microsoft Graph *also* requires the tenant to grant the application a **Teams application access policy**. Without it, Graph rejects **every** meeting look-up. This is a **tenant configuration prerequisite**, not a product fault, and nothing else was ever broken by it: Copilot events imported normally, only the meeting fields were empty.

**What's changed:**

- The importer logs **one clear warning per import run** — naming the exact fix (`New-CsApplicationAccessPolicy` / `Grant-CsApplicationAccessPolicy`) and linking the Microsoft documentation — instead of an exception per event. Your exception telemetry becomes usable again.
- It stops re-querying Graph for users it already knows aren't covered, removing those wasted calls from every cycle.
- **Genuine permission errors are still reported in full** — only this specific, expected condition is quietened.

**Action for admins:** if you want Copilot meeting names captured, have a Teams administrator grant the policy (PowerShell provided on the **[Copilot](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Copilot)** wiki page; also cross-referenced from **[Prerequisites](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Prerequisites)**). If you don't use Copilot meeting reporting, no action — the noise simply stops.

---

## Fix 3 — Anonymous usage reporting no longer silently lost

**Who this affects:** deployments with the optional anonymous usage reporting left enabled. It remains fully controlled by the existing **AllowTelemetry** opt-out, and nothing is collected or sent when that's off.

**Symptom:** none visible locally — that's the point. A rejected upload was recorded as a success.

**Root cause:** if the receiving endpoint rejected an upload, the error was logged but the code carried on as though it had worked: it stamped the "last uploaded" time, which gates the next attempt for a day. That day's report was lost and never retried.

**What's changed:**

- A rejected upload is now treated as a failure and **retried on the next import cycle**.
- The failure is logged as a **proper error**, so it's visible in Application Insights instead of hidden as a warning.
- Report timestamps are now **UTC**, so reports stay consistent across servers in different time zones and across daylight-saving changes.
- Table-size figures are more accurate: each table is counted **exactly once** (a table with certain index types could previously be counted several times) and now records which database schema it belongs to.

**Action for admins:** none.

---

## Code maintenance

Internal-only changes with no user-visible effect: a test seam on the stats uploader, removal of an unused read-back helper, and new automated test coverage for all three fixes above.

---

## Upgrade checklist

1. Deploy the new build (`AnalyticsInstaller.exe`, or `Deploy-AppServiceContent.ps1`).
2. No database migration, no config-schema change, no re-save of the installer configuration.
3. *Optional* — grant the Teams application access policy if you want Copilot meeting names.
4. *Optional* — private/VNet deployments using Teams calls: confirm Service Bus is Premium.

---

_Issues resolved: #215, #228, and part of #206. Changes since the last stable release (build 1716)._
