### PR TITLE
Fix new Application Insights resource deployment

### DIFF
--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Resources/AppInsightsArmTemplate.json
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Resources/AppInsightsArmTemplate.json
@@ -34,9 +34,7 @@
         "Application_Type": "[parameters('type')]",
         "Flow_Type": "Redfield",
         "Request_Source": "[parameters('requestSource')]",
-        "WorkspaceResourceId": "[parameters('workspaceResourceId')]",
-        "publicNetworkAccessForIngestion": "[parameters('publicNetworkAccessForIngestion')]",
-        "publicNetworkAccessForQuery": "[parameters('publicNetworkAccessForQuery')]"
+        "WorkspaceResourceId": "[parameters('workspaceResourceId')]"
       }
     }
   ]

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/AppInsightsArmTemplateTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/AppInsightsArmTemplateTests.cs
@@ -1,0 +1,39 @@
+using CloudInstallEngine.Azure.InstallTasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Tests.UnitTests.InstallTests
+{
+    [TestClass]
+    public class AppInsightsArmTemplateTests
+    {
+        [TestMethod]
+        public void TemplateReferencesOnlyDeclaredParameters()
+        {
+            var resourcesType = typeof(AppInsightsInstallTask).Assembly.GetType(
+                "CloudInstallEngine.Properties.Resources",
+                throwOnError: true);
+            var templateProperty = resourcesType.GetProperty(
+                "AppInsightsArmTemplate",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            var template = (string)templateProperty.GetValue(null);
+            var templateJson = JObject.Parse(template);
+            var declaredParameters = templateJson["parameters"]
+                .Children<JProperty>()
+                .Select(parameter => parameter.Name)
+                .ToHashSet();
+            var referencedParameters = Regex.Matches(template, @"parameters\('([^']+)'\)")
+                .Cast<Match>()
+                .Select(match => match.Groups[1].Value)
+                .Distinct();
+
+            CollectionAssert.IsSubsetOf(
+                referencedParameters.ToList(),
+                declaredParameters.ToList(),
+                "The ARM template references a parameter that is not declared.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="SentEmailImporterPipelineTests.cs" />
     <Compile Include="SentEmailImportTests.cs" />
     <Compile Include="InstallTests\VNetIntegrationTests.cs" />
+    <Compile Include="InstallTests\AppInsightsArmTemplateTests.cs" />
     <Compile Include="UserImportCaseSensitivityTests.cs" />
     <Compile Include="UserMetadataUpdaterBasicTests.cs" />
     <Compile Include="UserMetadataUpdaterInsertTests.cs" />


### PR DESCRIPTION
## Summary

- remove stale Application Insights ARM expressions for parameters that are no longer declared or supplied
- restore creation of new workspace-based Application Insights resources
- add regression coverage that verifies every ARM parameter reference is declared

## Operator impact

New installations and upgrades that need to create the Application Insights component no longer fail with `InvalidTemplate` for `publicNetworkAccessForIngestion` or `publicNetworkAccessForQuery`.

No configuration-schema or database migration changes.