### PR TITLE
Stable Release: cumulative bug fixes and deployment hardening

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/NetworkingConfigControl.Designer.cs
@@ -467,7 +467,7 @@ namespace App.ControlPanel.Frames.InstallWizard
             // lblHybridWorkerVm
             // 
             this.lblHybridWorkerVm.AutoSize = true;
-            this.lblHybridWorkerVm.Location = new System.Drawing.Point(15, 444);
+            this.lblHybridWorkerVm.Location = new System.Drawing.Point(15, 394);
             this.lblHybridWorkerVm.Name = "lblHybridWorkerVm";
             this.lblHybridWorkerVm.Size = new System.Drawing.Size(140, 13);
             this.lblHybridWorkerVm.TabIndex = 17;


### PR DESCRIPTION
## Stable release — cumulative bug-fix and deployment-hardening release

**This release rolls up everything since the last published stable release, build 1716.** It contains the cumulative installer, private-networking, import-diagnostics, and telemetry fixes described below. There are **no database migrations**, **no `Create DB.sql` changes**, and **no installer configuration-schema change**.

### Should you upgrade?

| | |
|-|-|
| **Upgrade urgency** | **Recommended for everyone.** Treat it as high priority if you use Teams calls in a private/VNet deployment, are planning an installation or upgrade where FTPS is restricted, or Application Insights creation fails with `InvalidTemplate`. Already-running website and WebJob content is unaffected until you upgrade. |
| **Database migrations** | **None.** `Migrations/` and `Create DB.sql` are unchanged. No database maintenance window is required, and the importer does not need to be stopped for schema work. |
| **Configuration changes** | **None.** The installer config schema remains **1.9.0**. Existing solution configuration files load unchanged and do not need to be re-saved. Existing encrypted proxy preferences also continue to load. |
| **Breaking changes** | No data-model, API, or saved-config breaking changes. **Operational change:** the installer no longer uses FTP/FTPS and disables FTP basic publishing credentials on the product App Service. Any separate automation that publishes to that App Service over FTP must move to SCM/Kudu or another supported deployment method. |
| **How to upgrade** | Download the new `ControlPanelApp.zip`, open the existing configuration in `AnalyticsInstaller.exe`, select the latest stable release, and run the installation again. Manual deployments can continue to use `Deploy-AppServiceContent.ps1`. |
| **Downtime** | No maintenance window. Expect only the normal brief App Service/WebJob restart while content is replaced. |

---

## App Service deployment now uses HTTPS/443 instead of FTPS

**Who this affects:** anyone installing or upgrading through `AnalyticsInstaller.exe`; especially environments with restricted outbound rules, an HTTP proxy, App Service access restrictions, or private endpoints.

**Symptom:** the older installer could fail while uploading the website or continuous WebJobs even when Azure authentication and SQL tests succeeded. Searchable log messages included:

```text
Couldn't connect to <app-service FTPS endpoint> ... ensure app-service has 'FTP state' configured to 'FTPS only'.
FTP upload to '...' on <app-service FTPS endpoint> failed: An error occurred uploading file(s)...
```

The FTPS connectivity test could also fail because the control connection worked but the passive data channel was blocked. This often looked like bad publishing credentials or an App Service setting problem when the real cause was firewall or proxy handling of FTPS data ports.

**Root cause:** the installer uploaded three directory trees over FTPS. That required FTP control and passive data channels that are commonly blocked by enterprise egress controls and are not handled by a normal HTTP proxy.

**What's changed:**

- The installer builds one package containing the website at the root and the two continuous WebJobs under `app_data/jobs/continuous`, then sends it to the App Service SCM/Kudu endpoint over HTTPS/443.
- Obsolete FTPS connectivity tests, publishing-profile autodetection, passive-mode settings, UI fields, and the FTP client dependency have been removed.
- The App Service is set to **FTP/FTPS disabled** and **FTP basic publishing credentials disabled**. SCM basic publishing credentials remain enabled because Kudu ZIP deployment requires them.
- The proxy screen now describes an HTTP proxy for the SCM endpoint. Existing `proxyconfig.dat` preferences continue to load through their legacy saved-property names.
- Remaining connectivity failures now identify the actual path:

```text
App Service HTTPS deployment could not reach 'https://<app-name>.scm.azurewebsites.net'. Check installer proxy and SCM access settings.
```

**Action for admins:** if the installer machine already has HTTPS/443 access to `https://<app-name>.scm.azurewebsites.net`, none beyond the normal upgrade. Otherwise, allow that endpoint through outbound firewall/proxy controls. For a private-only App Service, run the installer from a VNet-connected machine with working private DNS for the SCM endpoint. If you have separate FTP-based deployment automation for this App Service, migrate it before upgrading; legacy FTP/passive-port allow rules can then be retired after your normal change review.

See **[Deployment Guidance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Deployment-Guidance)**, **[Troubleshooting](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Troubleshooting#network-restrictions-for-app-service-https-deployment-and-sql)**, and **[Updating the solution](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Updating-the-solution)**.

---

## New Application Insights resources deploy successfully again

**Who this affects:** new installations, or upgrades where the configured workspace-based Application Insights component does not yet exist and must be created. Deployments that reuse an existing component are unaffected.

**Symptom:** Azure resource deployment stops with `InvalidTemplate`, mentioning either:

```text
publicNetworkAccessForIngestion
publicNetworkAccessForQuery
```

Because those names describe network-access settings, the failure could be mistaken for an Azure Policy, private-link, or regional API compatibility problem.

**Root cause:** the embedded ARM template still referenced two parameters that were no longer declared or supplied. ARM validates all parameter references before resource creation, so the Application Insights component could not be created.

**What's changed:** the stale references have been removed while retaining the workspace link and the existing Application Insights settings. Automated coverage now verifies that every parameter referenced by the template is declared.

This does not change the product's Application Insights network model: the installer does not configure Azure Monitor Private Link Scope (AMPLS). Environments that require private Application Insights access should continue to configure AMPLS separately.

**Action for admins:** if you encountered this `InvalidTemplate` error, update the installer and rerun the failed installation. Do **not** add undocumented ARM parameters or relax Azure Policy/network controls to work around it. If Application Insights already exists, no action.

See **[Deployment Guidance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Deployment-Guidance)**, **[Manual Azure resource installation](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Manual-Install-Azure-Resources#Create--Configure-Application-Insights)**, and **[Private Endpoints](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Private-Endpoints#application-insights)**.

---

## Private deployments no longer silently break the Teams calls import

**Who this affects:** deployments with VNet integration and public network access disabled where the Teams calls import is enabled.

**Symptom:** Teams call records stop importing, while the importer reports a 401 that looks like an authentication or RBAC failure:

```text
Put token failed. status-code: 401, status-description: Ip has been prevented to connect to the endpoint.
   ... Virtual Network service endpoints / IP Filters ...
```

**Root cause:** private endpoints on Service Bus require the Premium SKU, and Azure does not support an in-place Standard-to-Premium upgrade. The older installer could disable public access on a Standard namespace without creating a usable private endpoint, leaving Service Bus unreachable. This is a network-layer rejection before Entra token validation, so changing permissions does not fix it.

**What's changed:**

- If Service Bus cannot be made private, the installer leaves public access enabled on that namespace and displays a clear warning rather than silently creating an unreachable service.
- A pre-install warning explains the available choices: migrate Service Bus to Premium, retain public access on that namespace, or disable Teams calls import.
- The installer skips unusable Service Bus private-endpoint and private-DNS resources that could otherwise also break public hostname resolution.
- The warning is repeated in the installation summary.
- The Health page now identifies likely IP/VNet blocking and the Premium requirement instead of presenting the raw Azure error as an authentication problem.

**Action for admins:** private deployments using Teams calls should check the Service Bus SKU. If it is Standard, either [migrate it to Premium](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-migrate-standard-premium), retain public access on that one namespace, or disable the Teams calls import. Everyone else has no additional action.

See **[Private Endpoints](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Private-Endpoints)**.

---

## Copilot meeting enrichment reports one actionable warning instead of thousands of errors

**Who this affects:** tenants importing Copilot activity where meeting-context events occur.

**Symptom:** Application Insights can fill with repeated `403 Forbidden` exceptions from meeting lookups, while Copilot meeting name and creation date remain blank.

**Root cause:** `OnlineMeetings.Read.All` is not sufficient by itself. Microsoft Graph also requires a Teams application access policy for the importing application. Without that tenant-side policy, every meeting lookup is rejected even though the rest of the Copilot event imports normally.

**What's changed:**

- The importer emits one clear warning per run, naming `New-CsApplicationAccessPolicy` and `Grant-CsApplicationAccessPolicy`, rather than an exception for every affected event.
- It stops repeating meeting lookups for users already known not to be covered by the policy.
- Genuine permission errors remain fully reported; only this specific expected condition is quietened.

**Action for admins:** if you want Copilot meeting names and dates captured, have a Teams administrator grant the application access policy described on the **[Copilot](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Copilot)** and **[Prerequisites](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Prerequisites)** pages. If you do not use Copilot meeting reporting, no action.

---

## Anonymous usage-report uploads retry correctly and report more accurate statistics

**Who this affects:** deployments where optional anonymous usage reporting remains enabled. The existing `AllowTelemetry` opt-out is unchanged; nothing is sent when it is disabled.

**Symptom:** there was no visible local symptom. A rejected upload was recorded as successful, so the next retry could be delayed for a day and that report was lost.

**Root cause:** the uploader logged the receiving endpoint's rejection but still stamped the last-upload time. Table-size queries could also count a table more than once for some index layouts, and timestamps used local time.

**What's changed:**

- Rejected uploads are treated as failures and retried on the next import cycle.
- Upload failures are logged as errors so they are visible in Application Insights.
- Report timestamps use UTC.
- Each table is counted once and its database schema is recorded.

**Action for admins:** none.

---

## Code maintenance

Internal release-process guidance and focused regression coverage were improved; there is no separate operator action.

---

## Upgrade checklist

1. Private deployments using Teams calls: confirm whether Service Bus is Premium; decide whether to migrate it, retain public access on that namespace, or disable the import.
2. Confirm the installer machine can reach `https://<app-name>.scm.azurewebsites.net` over HTTPS/443; for private-only App Services, also confirm VNet connectivity and private DNS resolution.
3. If any out-of-band automation publishes to the product App Service over FTP/FTPS, migrate it to SCM/Kudu or another supported deployment path.
4. Download the stable `ControlPanelApp.zip`, start `AnalyticsInstaller.exe`, open the existing configuration, and select the latest stable release.
5. Run the installation. No database script or config re-save is required; expect only a brief App Service/WebJob restart.
6. Verify that the website responds and both continuous WebJobs are running. If Application Insights creation previously failed, also confirm that the workspace-based component now exists. See **[Verify](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Verify#verify-import-jobs-are-running)**.
7. Optional: grant the Teams application access policy if Copilot meeting names and dates are required.

---

_Issues resolved: #215, #228, and #235. Additional telemetry work under #206. Included implementation PRs: #236 and #237. Changes since the last published stable release, build 1716._
