### PR TITLE
Stable Release: Copilot agent reporting and deployment verification

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -73,6 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseInstallProcessClasses.cs" />
+    <Compile Include="AppServiceWebJobHealthVerifier.cs" />
     <Compile Include="InstallLogCapturingLogger.cs" />
     <Compile Include="InstallerLogs.cs" />
     <Compile Include="InstallerTasks\JobTasks\HybridWorkerGroupTask.cs" />

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/AppServiceWebJobHealthVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/AppServiceWebJobHealthVerifier.cs
@@ -1,0 +1,147 @@
+using App.ControlPanel.Engine.InstallerTasks;
+using App.ControlPanel.Engine.Entities;
+using App.ControlPanel.Engine.Models;
+using Azure.ResourceManager.AppService;
+using Azure.ResourceManager.AppService.Models;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace App.ControlPanel.Engine
+{
+    internal static class AppServiceWebJobHealthVerifier
+    {
+        internal const string ActivityImporterName = "Office365ActivityImporter";
+        internal const string AppInsightsImporterName = "AppInsightsImporter";
+
+        private static readonly string[] ExpectedWebJobs =
+        {
+            ActivityImporterName,
+            AppInsightsImporterName,
+        };
+
+        internal static async Task VerifyAndLogAsync(
+            WebSiteResource webApp,
+            InstallerProxyConfig proxyConfig,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var publishingProfile = webApp.GetPublishingProfileXmlWithSecrets(
+                    new CsmPublishingProfile { Format = PublishingProfileFormat.WebDeploy });
+                KuduPublishInfo publishInfo;
+                using (var reader = new StreamReader(publishingProfile.Value))
+                {
+                    publishInfo = publishData.FromXml(reader).GetKuduPublishInfo();
+                }
+
+                var statuses = await GetStatusesAsync(publishInfo, proxyConfig, cancellationToken);
+                var failures = FindFailures(statuses);
+
+                if (failures.Count > 0)
+                {
+                    logger.LogError(
+                        $"WebJob health check failed after App Service warm-up: {string.Join("; ", failures)}. " +
+                        "Both continuous WebJobs must report 'Running' in the App Service WebJobs blade.");
+                    return;
+                }
+
+                logger.LogInformation(
+                    $"WebJob health check passed: {ActivityImporterName}=Running; {AppInsightsImporterName}=Running.");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    "Could not verify continuous WebJob health after App Service warm-up: " +
+                    CloudInstallEngine.ExceptionMessages.Format(ex));
+            }
+        }
+
+        internal static List<string> FindFailures(IReadOnlyCollection<KuduContinuousWebJobStatus> statuses)
+        {
+            return ExpectedWebJobs
+                    .Select(name =>
+                    {
+                        var job = statuses.FirstOrDefault(
+                            status => string.Equals(status.Name, name, StringComparison.OrdinalIgnoreCase));
+                        return job == null
+                            ? $"{name}=missing"
+                            : string.Equals(job.Status, "Running", StringComparison.OrdinalIgnoreCase)
+                                ? null
+                                : $"{name}={job.Status ?? "unknown"}";
+                    })
+                    .Where(failure => failure != null)
+                    .ToList();
+        }
+
+        internal static async Task<List<KuduContinuousWebJobStatus>> GetStatusesAsync(
+            KuduPublishInfo publishInfo,
+            InstallerProxyConfig proxyConfig,
+            CancellationToken cancellationToken)
+        {
+            using (var handler = InstallAppServiceContentsTask.CreateHttpClientHandler(proxyConfig))
+            using (var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) })
+            {
+                var credentials = Convert.ToBase64String(
+                    Encoding.UTF8.GetBytes($"{publishInfo.Username}:{publishInfo.Password}"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+                var response = await client.GetAsync(
+                    BuildKuduContinuousWebJobsUri(publishInfo.RootUrl),
+                    cancellationToken);
+                using (response)
+                {
+                    var responseBody = await response.Content.ReadAsStringAsync();
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        throw new HttpRequestException(
+                            $"Kudu WebJob status request failed with HTTP {(int)response.StatusCode} " +
+                            $"({response.ReasonPhrase}).");
+                    }
+
+                    return ParseStatuses(responseBody);
+                }
+            }
+        }
+
+        internal static Uri BuildKuduContinuousWebJobsUri(string publishUrl)
+        {
+            if (string.IsNullOrWhiteSpace(publishUrl))
+                throw new ArgumentOutOfRangeException(nameof(publishUrl));
+
+            var absoluteUrl = publishUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? publishUrl
+                : "https://" + publishUrl;
+            var profileUri = new Uri(absoluteUrl);
+            return new Uri(profileUri.GetLeftPart(UriPartial.Authority) + "/api/continuouswebjobs");
+        }
+
+        internal static List<KuduContinuousWebJobStatus> ParseStatuses(string json)
+        {
+            return JsonConvert.DeserializeObject<List<KuduContinuousWebJobStatus>>(json)
+                ?? new List<KuduContinuousWebJobStatus>();
+        }
+    }
+
+    internal sealed class KuduContinuousWebJobStatus
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/InstallAppServiceContentsTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/InstallAppServiceContentsTask.cs
@@ -108,17 +108,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
         private async Task PublishZipAsync(KuduPublishInfo publishInfo, FileInfo deploymentPackage, InstallerProxyConfig proxyConfig)
         {
-            var handler = new HttpClientHandler();
-            if (proxyConfig.UseProxy)
-            {
-                var proxy = new WebProxy(proxyConfig.Host, proxyConfig.Port);
-                proxy.Credentials = proxyConfig.IntegratedAuth
-                    ? CredentialCache.DefaultCredentials
-                    : new NetworkCredential(proxyConfig.Username, proxyConfig.Password);
-                handler.Proxy = proxy;
-                handler.UseProxy = true;
-            }
-
+            var handler = CreateHttpClientHandler(proxyConfig);
             using (handler)
             using (var client = new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(30) })
             using (var packageStream = deploymentPackage.OpenRead())
@@ -163,6 +153,21 @@ namespace App.ControlPanel.Engine.InstallerTasks
                     }
                 }
             }
+        }
+
+        internal static HttpClientHandler CreateHttpClientHandler(InstallerProxyConfig proxyConfig)
+        {
+            var handler = new HttpClientHandler();
+            if (proxyConfig.UseProxy)
+            {
+                var proxy = new WebProxy(proxyConfig.Host, proxyConfig.Port);
+                proxy.Credentials = proxyConfig.IntegratedAuth
+                    ? CredentialCache.DefaultCredentials
+                    : new NetworkCredential(proxyConfig.Username, proxyConfig.Password);
+                handler.Proxy = proxy;
+                handler.UseProxy = true;
+            }
+            return handler;
         }
 
         internal static Uri BuildKuduPublishUri(string publishUrl)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
@@ -111,6 +111,12 @@ namespace App.ControlPanel.Engine
                     await WarmupCallRecordWebhook(log, adminSiteUrl, ct);
                 }
 
+                await AppServiceWebJobHealthVerifier.VerifyAndLogAsync(
+                    azureBackeEndCreationJob.CreatedWebSiteResource,
+                    _proxyConfig,
+                    log,
+                    ct);
+
                 log.LogInformation($"Reminder: Ensure Azure AD app registration for the runtime account has correct authentication configuration (see 'Configure Reply URLs' of deployment guide).");
 
                 // Open admin site?

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -158,6 +158,62 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public void KuduContinuousWebJobsUriUsesHttpsApiEndpoint()
+        {
+            var uri = AppServiceWebJobHealthVerifier.BuildKuduContinuousWebJobsUri(
+                "contoso.scm.azurewebsites.net:443");
+
+            Assert.AreEqual(
+                "https://contoso.scm.azurewebsites.net/api/continuouswebjobs",
+                uri.ToString());
+        }
+
+        [TestMethod]
+        public void WebJobHealthCheckRequiresBothJobsRunning()
+        {
+            const string statusesJson = @"[
+                { ""name"": ""Office365ActivityImporter"", ""status"": ""Running"" },
+                { ""name"": ""AppInsightsImporter"", ""status"": ""Stopped"" }
+            ]";
+
+            var failures = AppServiceWebJobHealthVerifier.FindFailures(
+                AppServiceWebJobHealthVerifier.ParseStatuses(statusesJson));
+
+            CollectionAssert.AreEqual(
+                new[] { "AppInsightsImporter=Stopped" },
+                failures);
+        }
+
+        [TestMethod]
+        public void WebJobHealthCheckReportsMissingJob()
+        {
+            const string statusesJson = @"[
+                { ""name"": ""Office365ActivityImporter"", ""status"": ""Running"" }
+            ]";
+
+            var failures = AppServiceWebJobHealthVerifier.FindFailures(
+                AppServiceWebJobHealthVerifier.ParseStatuses(statusesJson));
+
+            CollectionAssert.AreEqual(
+                new[] { "AppInsightsImporter=missing" },
+                failures);
+        }
+
+        [TestMethod]
+        public void WebJobHealthCheckPassesWhenBothJobsAreRunning()
+        {
+            const string statusesJson = @"[
+                { ""name"": ""AppInsightsImporter"", ""status"": ""Running"" },
+                { ""name"": ""Office365ActivityImporter"", ""status"": ""Running"" }
+            ]";
+
+            var failures = AppServiceWebJobHealthVerifier.FindFailures(
+                AppServiceWebJobHealthVerifier.ParseStatuses(statusesJson));
+
+            Assert.AreEqual(0, failures.Count);
+        }
+
+        [TestMethod]
         public void AppServiceDeploymentPackageContainsWebsiteAndWebJobs()
         {
             var testRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -72,6 +72,14 @@ namespace Web.AnalyticsWeb.Controllers
         [Route("copilot")]
         public Task<IHttpActionResult> Copilot(int months = DefaultMonths) => AreaAsync("copilot", months);
 
+        // GET: api/Reports/copilot-agents?months=3
+        [HttpGet]
+        [Route("copilot-agents")]
+        public Task<IHttpActionResult> CopilotAgents(
+            int months = DefaultMonths,
+            int top = 8,
+            string agentName = null) => AreaAsync("copilot-agents", months, top, agentName);
+
         // GET: api/Reports/usage?months=3
         [HttpGet]
         [Route("usage")]
@@ -100,12 +108,29 @@ namespace Web.AnalyticsWeb.Controllers
         /// <summary>
         /// Builds (or serves from cache) the charts for one area over the requested window.
         /// </summary>
-        private async Task<IHttpActionResult> AreaAsync(string area, int months)
+        private async Task<IHttpActionResult> AreaAsync(
+            string area,
+            int months,
+            int topAgents = 8,
+            string agentName = null)
         {
             if (months < 1) months = DefaultMonths;
             if (months > MaxMonths) months = MaxMonths;
 
+            if (topAgents < 1) topAgents = 1;
+            if (topAgents > 20) topAgents = 20;
+
+            var trimmedAgentName = agentName?.Trim();
+            var normalizedAgentName = string.IsNullOrEmpty(trimmedAgentName)
+                ? null
+                : trimmedAgentName.Substring(0, Math.Min(trimmedAgentName.Length, 100));
+
             var cacheKey = CacheKeyPrefix + area + "::" + months;
+            if (area == "copilot-agents")
+            {
+                cacheKey += $"::top={topAgents}::agent={normalizedAgentName ?? "(all)"}";
+            }
+
             if (MemoryCache.Default.Get(cacheKey) is ReportAreaData cached)
             {
                 return Ok(cached);
@@ -124,6 +149,9 @@ namespace Web.AnalyticsWeb.Controllers
             {
                 case "copilot":
                     chartTasks = CopilotCharts(firstMonday, weekSpine);
+                    break;
+                case "copilot-agents":
+                    chartTasks = CopilotAgentCharts(firstMonday, weekSpine, topAgents, normalizedAgentName);
                     break;
                 case "usage":
                     chartTasks = UsageCharts(firstMonday, weekSpine);
@@ -186,6 +214,57 @@ namespace Web.AnalyticsWeb.Controllers
                     "Distinct users with at least one Copilot interaction each week.", "Users", "Active users", users, from, weekSpine),
                 RunCategoryAsync("copilot-hosts", "Interactions by app",
                     "Where Copilot is being used across the window (top apps).", "Interactions", hosts, from),
+            };
+        }
+
+        private static List<Task<ReportChart>> CopilotAgentCharts(
+            DateTime from,
+            List<DateTime> weekSpine,
+            int topAgents,
+            string agentName)
+        {
+            var wb = WeekBucket("au.time_stamp");
+            var agents =
+                "WITH EligibleAgents AS (\r\n" +
+                "    SELECT id\r\n" +
+                "    FROM dbo.copilot_agents\r\n" +
+                "    WHERE @agentName IS NULL OR CHARINDEX(@agentName, ISNULL(name, '')) > 0\r\n" +
+                "),\r\n" +
+                "AgentWeeks AS (\r\n" +
+                "    SELECT c.agent_id AS AgentKey,\r\n" +
+                $"           {wb} AS WeekStart,\r\n" +
+                "           COUNT_BIG(*) AS InteractionCount\r\n" +
+                "    FROM dbo.copilot_chats AS c\r\n" +
+                "    JOIN dbo.audit_events AS au ON c.event_id = au.id\r\n" +
+                "    JOIN EligibleAgents AS eligible ON c.agent_id = eligible.id\r\n" +
+                "    WHERE au.time_stamp >= @from\r\n" +
+                $"    GROUP BY c.agent_id, {wb}\r\n" +
+                "),\r\n" +
+                "AgentWeeksWithTotals AS (\r\n" +
+                "    SELECT AgentKey, WeekStart, InteractionCount,\r\n" +
+                "           SUM(InteractionCount) OVER (PARTITION BY AgentKey) AS TotalInteractions\r\n" +
+                "    FROM AgentWeeks\r\n" +
+                "),\r\n" +
+                "RankedAgentWeeks AS (\r\n" +
+                "    SELECT AgentKey, WeekStart, InteractionCount,\r\n" +
+                "           DENSE_RANK() OVER (ORDER BY TotalInteractions DESC, AgentKey) AS PopularityRank\r\n" +
+                "    FROM AgentWeeksWithTotals\r\n" +
+                ")\r\n" +
+                "SELECT ranked.AgentKey AS SeriesKey,\r\n" +
+                "       COALESCE(NULLIF(LTRIM(RTRIM(agent.name)), ''), NULLIF(LTRIM(RTRIM(agent.agent_id)), ''), '(unnamed agent)') AS SeriesName,\r\n" +
+                "       ranked.WeekStart,\r\n" +
+                "       CAST(ranked.InteractionCount AS float) AS Value\r\n" +
+                "FROM RankedAgentWeeks AS ranked\r\n" +
+                "JOIN dbo.copilot_agents AS agent ON ranked.AgentKey = agent.id\r\n" +
+                $"WHERE ranked.PopularityRank <= {topAgents}\r\n" +
+                "ORDER BY SeriesName, WeekStart\r\n" +
+                "OPTION (RECOMPILE);";
+
+            return new List<Task<ReportChart>>
+            {
+                RunGroupedTimeSeriesAsync("copilot-agent-interactions", "Copilot agent interactions per week",
+                    "Weekly interactions for the most-used Copilot agents matching the current filters.",
+                    "Interactions", agents, from, weekSpine, agentName, 60),
             };
         }
 
@@ -390,6 +469,56 @@ namespace Web.AnalyticsWeb.Controllers
             return chart;
         }
 
+        /// <summary>Runs one query that returns multiple named weekly series.</summary>
+        private static async Task<ReportChart> RunGroupedTimeSeriesAsync(string key, string title, string description,
+            string valueLabel, string body, DateTime from, List<DateTime> weekSpine, string agentName, int queryTimeoutSecs)
+        {
+            var chart = new ReportChart
+            {
+                Key = key,
+                Title = title,
+                Description = description,
+                Type = "timeseries",
+                ValueLabel = valueLabel,
+                Sql = DisplaySql(body, from, agentName),
+            };
+
+            try
+            {
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    db.Database.CommandTimeout = queryTimeoutSecs;
+                    var rows = await db.Database
+                        .SqlQuery<NamedWeekValueRow>(
+                            body,
+                            new SqlParameter("@from", from),
+                            new SqlParameter("@agentName", System.Data.SqlDbType.NVarChar, 100)
+                            {
+                                Value = (object)agentName ?? DBNull.Value,
+                            })
+                        .ToListAsync();
+
+                    chart.Series = rows
+                        .GroupBy(r => new { r.SeriesKey, r.SeriesName })
+                        .OrderByDescending(g => g.Sum(r => r.Value))
+                        .Select(g => new ReportSeries
+                        {
+                            Name = g.Key.SeriesName,
+                            Points = FillWeeks(
+                                weekSpine,
+                                g.Select(r => new WeekValueRow { WeekStart = r.WeekStart, Value = r.Value }).ToList()),
+                        })
+                        .ToList();
+                }
+            }
+            catch (Exception ex)
+            {
+                chart.Error = InnermostMessage(ex);
+            }
+
+            return chart;
+        }
+
         /// <summary>Runs a categorical (bar) query - label + value rows, already ordered by the query.</summary>
         private static async Task<ReportChart> RunCategoryAsync(string key, string title, string description,
             string valueLabel, string body, DateTime from)
@@ -499,6 +628,16 @@ namespace Web.AnalyticsWeb.Controllers
             return $"DECLARE @from datetime = '{from:yyyy-MM-dd}';\r\n" + body;
         }
 
+        private static string DisplaySql(string body, DateTime from, string agentName)
+        {
+            var agentNameSql = agentName == null
+                ? "NULL"
+                : $"N'{agentName.Replace("'", "''")}'";
+            return $"DECLARE @from datetime = '{from:yyyy-MM-dd}';\r\n" +
+                   $"DECLARE @agentName nvarchar(100) = {agentNameSql};\r\n" +
+                   body;
+        }
+
         /// <summary>EF wraps SQL errors; the innermost message (the SqlException) is the useful one.</summary>
         private static string InnermostMessage(Exception ex)
         {
@@ -520,6 +659,15 @@ namespace Web.AnalyticsWeb.Controllers
         /// <summary>Shape for a weekly (WeekStart, Value) raw SQL result.</summary>
         private sealed class WeekValueRow
         {
+            public DateTime WeekStart { get; set; }
+            public double Value { get; set; }
+        }
+
+        /// <summary>Shape for a named weekly series raw SQL result.</summary>
+        private sealed class NamedWeekValueRow
+        {
+            public int SeriesKey { get; set; }
+            public string SeriesName { get; set; }
             public DateTime WeekStart { get; set; }
             public double Value { get; set; }
         }

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/api/reportsApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/api/reportsApi.ts
@@ -18,9 +18,22 @@ export async function fetchReportAreas(): Promise<ReportAreas> {
   return response.json() as Promise<ReportAreas>;
 }
 
+export type ReportAreaOptions = {
+  topAgents?: number;
+  agentName?: string;
+};
+
 /** Fetch the weekly charts for one report area over the given window (months). */
-export async function fetchReportArea(area: ReportAreaKey, months: number): Promise<ReportAreaData> {
-  const url = `${baseUrl()}/${area}?months=${encodeURIComponent(months)}`;
+export async function fetchReportArea(
+  area: ReportAreaKey,
+  months: number,
+  options?: ReportAreaOptions,
+): Promise<ReportAreaData> {
+  const params = new URLSearchParams({ months: String(months) });
+  if (options?.topAgents !== undefined) params.set('top', String(options.topAgents));
+  if (options?.agentName) params.set('agentName', options.agentName);
+
+  const url = `${baseUrl()}/${area}?${params.toString()}`;
   const response = await fetch(url, {
     method: 'GET',
     credentials: 'same-origin',

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
@@ -4,6 +4,7 @@ import {
   Body1,
   Text,
   Card,
+  Input,
   Select,
   Tab,
   TabList,
@@ -25,6 +26,7 @@ import CategoryBarChart from '../components/charts/CategoryBarChart';
 /** The report areas in display order, with the enabled-flag they map to and their friendly copy. */
 const AREA_DEFS: { flag: keyof ReportAreas; key: ReportAreaKey; label: string; blurb: string }[] = [
   { flag: 'copilot', key: 'copilot', label: 'Copilot', blurb: 'Microsoft 365 Copilot adoption and usage.' },
+  { flag: 'copilot', key: 'copilot-agents', label: 'Copilot agents', blurb: 'Copilot agent popularity and usage.' },
   { flag: 'usage', key: 'usage', label: 'Microsoft 365 usage', blurb: 'Weekly active users across Microsoft 365 workloads.' },
   { flag: 'spoAudit', key: 'spo-audit', label: 'SharePoint & OneDrive', blurb: 'File activity from the audit log.' },
   { flag: 'webTraffic', key: 'web-traffic', label: 'Website traffic', blurb: 'Page views and visitors from the page tracker.' },
@@ -96,6 +98,9 @@ export default function ReportsPage() {
 
   const [months, setMonths] = useState(3);
   const [selectedArea, setSelectedArea] = useState<ReportAreaKey | null>(null);
+  const [topAgents, setTopAgents] = useState(8);
+  const [agentNameDraft, setAgentNameDraft] = useState('');
+  const [agentNameFilter, setAgentNameFilter] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -197,11 +202,59 @@ export default function ReportsPage() {
             </div>
           )}
 
+          {selectedArea === 'copilot-agents' && (
+            <div className={styles.controls} style={{ marginTop: '16px', flexWrap: 'wrap' }}>
+              <Text size={200} className={styles.muted}>
+                Top agents
+              </Text>
+              <Select
+                value={String(topAgents)}
+                onChange={(_e, data) => setTopAgents(Number(data.value))}
+                aria-label="Number of top Copilot agents"
+              >
+                {[5, 8, 10, 15, 20].map((count) => (
+                  <option key={count} value={count}>
+                    {count}
+                  </option>
+                ))}
+              </Select>
+              <Input
+                value={agentNameDraft}
+                onChange={(_e, data) => setAgentNameDraft(data.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') setAgentNameFilter(agentNameDraft.trim());
+                }}
+                placeholder="Filter by agent name"
+                aria-label="Filter Copilot agents by name"
+              />
+              <Button
+                size="small"
+                onClick={() => setAgentNameFilter(agentNameDraft.trim())}
+              >
+                Apply
+              </Button>
+              {agentNameFilter && (
+                <Button
+                  appearance="subtle"
+                  size="small"
+                  onClick={() => {
+                    setAgentNameDraft('');
+                    setAgentNameFilter('');
+                  }}
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+          )}
+
           <ReportAreaView
             key={selectedArea}
             area={selectedArea}
             months={months}
             blurb={enabledAreas.find((a) => a.key === selectedArea)?.blurb ?? ''}
+            topAgents={topAgents}
+            agentName={agentNameFilter}
           />
         </>
       )}
@@ -210,7 +263,19 @@ export default function ReportsPage() {
 }
 
 /** Fetches and renders the charts for a single report area over the chosen window. */
-function ReportAreaView({ area, months, blurb }: { area: ReportAreaKey; months: number; blurb: string }) {
+function ReportAreaView({
+  area,
+  months,
+  blurb,
+  topAgents,
+  agentName,
+}: {
+  area: ReportAreaKey;
+  months: number;
+  blurb: string;
+  topAgents: number;
+  agentName: string;
+}) {
   const styles = useStyles();
 
   const [data, setData] = useState<ReportAreaData | null>(null);
@@ -222,7 +287,11 @@ function ReportAreaView({ area, months, blurb }: { area: ReportAreaKey; months: 
     let cancelled = false;
     setLoading(true);
     setError(null);
-    fetchReportArea(area, months)
+    fetchReportArea(
+      area,
+      months,
+      area === 'copilot-agents' ? { topAgents, agentName } : undefined,
+    )
       .then((d) => {
         if (!cancelled) setData(d);
       })
@@ -235,7 +304,7 @@ function ReportAreaView({ area, months, blurb }: { area: ReportAreaKey; months: 
     return () => {
       cancelled = true;
     };
-  }, [area, months, reloadKey]);
+  }, [area, months, topAgents, agentName, reloadKey]);
 
   if (loading) {
     return (

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
@@ -54,6 +54,7 @@ export interface ReportAreaData {
 /** A report area key, as used in the api/Reports/{area} route. */
 export type ReportAreaKey =
   | 'copilot'
+  | 'copilot-agents'
   | 'usage'
   | 'spo-audit'
   | 'web-traffic'


### PR DESCRIPTION
## Stable release — cumulative feature and deployment-hardening release

**This release rolls up everything since the last published stable release, build 1716.** It adds built-in Copilot agent reporting and post-deployment WebJob verification, together with the cumulative installer, private-networking, import-diagnostics, and telemetry fixes below. There are **no database migrations**, **no `Create DB.sql` changes**, and **no installer configuration-schema change**.

### Should you upgrade?

| | |
|-|-|
| **Upgrade urgency** | **Recommended for everyone.** Prioritise it if you want built-in Copilot agent usage reporting, if an installation can appear successful while a continuous WebJob is missing or stopped, if you use Teams calls in a private/VNet deployment, or if App Service deployment/Application Insights creation has failed during an install. |
| **Database migrations** | **None.** `Migrations/` and `Create DB.sql` are unchanged. No database maintenance window is required, and the importer does not need to be stopped for schema work. |
| **Configuration changes** | **None.** The installer config schema remains **1.9.0**. Existing solution configuration files load unchanged and do not need to be re-saved. Existing encrypted proxy preferences also continue to load. |
| **Breaking changes** | No data-model, API, or saved-config breaking changes. **Operational change:** the installer no longer uses FTP/FTPS and disables FTP basic publishing credentials on the product App Service. Any separate automation that publishes to that App Service over FTP must move to SCM/Kudu or another supported deployment method. |
| **How to upgrade** | Download the new `ControlPanelApp.zip`, open the existing configuration in `AnalyticsInstaller.exe`, select the latest stable release, and run the installation again. Manual deployments can continue to use `Deploy-AppServiceContent.ps1`. |
| **Downtime** | No maintenance window. Expect only the normal brief App Service/WebJob restart while content is replaced. |

---

## New built-in report shows weekly Copilot agent usage

**Who this affects:** administrators with Copilot imports enabled who need to understand which Copilot agents are being used and how interaction volume changes over time.

**Symptom:** the built-in Reports page showed overall Copilot interactions, active users, and app hosts, but it did not provide an agent-by-agent weekly view. Administrators had to use a separate reporting model or write SQL to compare standard and custom agent usage.

**Root cause:** the web application had no report endpoint or chart that grouped imported `copilot_chats` records by agent and week.

**What's changed:**

- A **Copilot agents** sub-tab now appears under **Reports** whenever Copilot importing is enabled.
- It charts weekly interaction counts for the most-used agents over the selected one-, three-, or six-month period.
- The UI offers Top 5, 8, 10, 15, or 20 agents. The API accepts and clamps Top-N values from 1 through 20.
- A name-contains filter narrows the chart to matching agent names; Apply, Enter, Clear, period, and Top-N changes all refresh the report.
- The chart exposes the generated SQL through **SQL behind this chart**, so a DBA can inspect or reproduce the query.
- Results are cached for 60 seconds per period, Top-N, and name filter.
- The query aggregates matching interactions in one pass before ranking the small weekly result set. A synthetic LocalDB test with 10 million interactions completed in about **15.8 seconds unfiltered** and **1.7 seconds with a specific agent-name filter**, with one scan each of the large `copilot_chats` and `audit_events` tables. The chart has a 60-second SQL timeout and displays a chart-level warning instead of failing the whole Reports page.

**Action for admins:** none beyond the normal upgrade. Ensure Copilot importing is enabled and allow for the normal Microsoft 365 audit-data delay before expecting recent interactions to appear. If the chart reports a timeout on an unusually large database, use the disclosed SQL and normal SQL performance monitoring to investigate.

See **[Copilot Analytics](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Copilot)** and **[Monitoring System Performance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Monitoring-System-Performance)**.

---

## Installer now verifies that both continuous WebJobs actually started

**Who this affects:** everyone installing or upgrading through `AnalyticsInstaller.exe`.

**Symptom:** App Service content deployment and website warm-up could succeed while one continuous WebJob was missing or stopped. The installer could therefore appear to finish normally even though Microsoft 365 or Application Insights data would not continue importing.

**Root cause:** a successful Kudu ZIP deployment confirms that the package was accepted, but it does not prove that both continuous WebJobs were discovered and reached the `Running` state.

**What's changed:** after App Service warm-up, the installer queries Kudu's continuous-WebJob status API through the configured SCM proxy path. It requires both:

```text
Office365ActivityImporter=Running
AppInsightsImporter=Running
```

If either job is absent or not running, the installer records an ERROR with the exact status, for example:

```text
WebJob health check failed after App Service warm-up: Office365ActivityImporter=missing; AppInsightsImporter=Stopped. Both continuous WebJobs must report 'Running' in the App Service WebJobs blade.
```

If Kudu status itself cannot be queried, the installer records:

```text
Could not verify continuous WebJob health after App Service warm-up: ...
```

These errors are included in the end-of-install summary. A healthy deployment records a pass line naming both jobs as `Running`.

**Action for admins:** treat either error as a failed post-deployment verification even if the website opens. In the Azure portal, open the App Service **WebJobs** blade, confirm both jobs exist and show **Running**, then inspect each job's logs for startup, configuration, SQL, storage, or identity failures. Rerun the installer after correcting the cause.

See **[Verify — Verify Import Jobs are Running](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Verify#verify-import-jobs-are-running)** and **[Troubleshooting](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Troubleshooting)**.

---

## App Service deployment now uses HTTPS/443 instead of FTPS

**Who this affects:** anyone installing or upgrading through `AnalyticsInstaller.exe`; especially environments with restricted outbound rules, an HTTP proxy, App Service access restrictions, or private endpoints.

**Symptom:** the older installer could fail while uploading the website or continuous WebJobs even when Azure authentication and SQL tests succeeded. Searchable log messages included:

```text
Couldn't connect to <app-service FTPS endpoint> ... ensure app-service has 'FTP state' configured to 'FTPS only'.
FTP upload to '...' on <app-service FTPS endpoint> failed: An error occurred uploading file(s)...
```

The FTPS connectivity test could also fail because the control connection worked but the passive data channel was blocked. This often looked like bad publishing credentials or an App Service setting problem when the real cause was firewall or proxy handling of FTPS data ports.

**Root cause:** the installer uploaded three directory trees over FTPS. That required FTP control and passive data channels that are commonly blocked by enterprise egress controls and are not handled by a normal HTTP proxy.

**What's changed:**

- The installer builds one package containing the website at the root and the two continuous WebJobs under `app_data/jobs/continuous`, then sends it to the App Service SCM/Kudu endpoint over HTTPS/443.
- Obsolete FTPS connectivity tests, publishing-profile autodetection, passive-mode settings, UI fields, and the FTP client dependency have been removed.
- The App Service is set to **FTP/FTPS disabled** and **FTP basic publishing credentials disabled**. SCM basic publishing credentials remain enabled because Kudu ZIP deployment requires them.
- The proxy screen now describes an HTTP proxy for the SCM endpoint. Existing `proxyconfig.dat` preferences continue to load through their legacy saved-property names.
- Remaining connectivity failures now identify the actual path:

```text
App Service HTTPS deployment could not reach 'https://<app-name>.scm.azurewebsites.net'. Check installer proxy and SCM access settings.
```

**Action for admins:** if the installer machine already has HTTPS/443 access to `https://<app-name>.scm.azurewebsites.net`, none beyond the normal upgrade. Otherwise, allow that endpoint through outbound firewall/proxy controls. For a private-only App Service, run the installer from a VNet-connected machine with working private DNS for the SCM endpoint. If you have separate FTP-based deployment automation for this App Service, migrate it before upgrading; legacy FTP/passive-port allow rules can then be retired after your normal change review.

See **[Deployment Guidance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Deployment-Guidance)**, **[Troubleshooting](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Troubleshooting#network-restrictions-for-app-service-https-deployment-and-sql)**, and **[Updating the solution](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Updating-the-solution)**.

---

## New Application Insights resources deploy successfully again

**Who this affects:** new installations, or upgrades where the configured workspace-based Application Insights component does not yet exist and must be created. Deployments that reuse an existing component are unaffected.

**Symptom:** Azure resource deployment stops with `InvalidTemplate`, mentioning either:

```text
publicNetworkAccessForIngestion
publicNetworkAccessForQuery
```

Because those names describe network-access settings, the failure could be mistaken for an Azure Policy, private-link, or regional API compatibility problem.

**Root cause:** the embedded ARM template still referenced two parameters that were no longer declared or supplied. ARM validates all parameter references before resource creation, so the Application Insights component could not be created.

**What's changed:** the stale references have been removed while retaining the workspace link and the existing Application Insights settings. Automated coverage now verifies that every parameter referenced by the template is declared.

This does not change the product's Application Insights network model: the installer does not configure Azure Monitor Private Link Scope (AMPLS). Environments that require private Application Insights access should continue to configure AMPLS separately.

**Action for admins:** if you encountered this `InvalidTemplate` error, update the installer and rerun the failed installation. Do **not** add undocumented ARM parameters or relax Azure Policy/network controls to work around it. If Application Insights already exists, no action.

See **[Deployment Guidance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Deployment-Guidance)**, **[Manual Azure resource installation](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Manual-Install-Azure-Resources#Create--Configure-Application-Insights)**, and **[Private Endpoints](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Private-Endpoints#application-insights)**.

---

## Private deployments no longer silently break the Teams calls import

**Who this affects:** deployments with VNet integration and public network access disabled where the Teams calls import is enabled.

**Symptom:** Teams call records stop importing, while the importer reports a 401 that looks like an authentication or RBAC failure:

```text
Put token failed. status-code: 401, status-description: Ip has been prevented to connect to the endpoint.
   ... Virtual Network service endpoints / IP Filters ...
```

**Root cause:** private endpoints on Service Bus require the Premium SKU, and Azure does not support an in-place Standard-to-Premium upgrade. The older installer could disable public access on a Standard namespace without creating a usable private endpoint, leaving Service Bus unreachable. This is a network-layer rejection before Entra token validation, so changing permissions does not fix it.

**What's changed:**

- If Service Bus cannot be made private, the installer leaves public access enabled on that namespace and displays a clear warning rather than silently creating an unreachable service.
- A pre-install warning explains the available choices: migrate Service Bus to Premium, retain public access on that namespace, or disable Teams calls import.
- The installer skips unusable Service Bus private-endpoint and private-DNS resources that could otherwise also break public hostname resolution.
- The warning is repeated in the installation summary.
- The Health page now identifies likely IP/VNet blocking and the Premium requirement instead of presenting the raw Azure error as an authentication problem.

**Action for admins:** private deployments using Teams calls should check the Service Bus SKU. If it is Standard, either [migrate it to Premium](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-migrate-standard-premium), retain public access on that one namespace, or disable the Teams calls import. Everyone else has no additional action.

See **[Private Endpoints](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Private-Endpoints)**.

---

## Copilot meeting enrichment reports one actionable warning instead of thousands of errors

**Who this affects:** tenants importing Copilot activity where meeting-context events occur.

**Symptom:** Application Insights can fill with repeated `403 Forbidden` exceptions from meeting lookups, while Copilot meeting name and creation date remain blank.

**Root cause:** `OnlineMeetings.Read.All` is not sufficient by itself. Microsoft Graph also requires a Teams application access policy for the importing application. Without that tenant-side policy, every meeting lookup is rejected even though the rest of the Copilot event imports normally.

**What's changed:**

- The importer emits one clear warning per run, naming `New-CsApplicationAccessPolicy` and `Grant-CsApplicationAccessPolicy`, rather than an exception for every affected event.
- It stops repeating meeting lookups for users already known not to be covered by the policy.
- Genuine permission errors remain fully reported; only this specific expected condition is quietened.

**Action for admins:** if you want Copilot meeting names and dates captured, have a Teams administrator grant the application access policy described on the **[Copilot](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Copilot)** and **[Prerequisites](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Prerequisites)** pages. If you do not use Copilot meeting reporting, no action.

---

## Anonymous usage-report uploads retry correctly and report more accurate statistics

**Who this affects:** deployments where optional anonymous usage reporting remains enabled. The existing `AllowTelemetry` opt-out is unchanged; nothing is sent when it is disabled.

**Symptom:** there was no visible local symptom. A rejected upload was recorded as successful, so the next retry could be delayed for a day and that report was lost.

**Root cause:** the uploader logged the receiving endpoint's rejection but still stamped the last-upload time. Table-size queries could also count a table more than once for some index layouts, and timestamps used local time.

**What's changed:**

- Rejected uploads are treated as failures and retried on the next import cycle.
- Upload failures are logged as errors so they are visible in Application Insights.
- Report timestamps use UTC.
- Each table is counted once and its database schema is recorded.

**Action for admins:** none.

---

## Code maintenance

Release-process guidance and focused regression coverage were improved; there is no separate operator action.

---

## Upgrade checklist

1. Private deployments using Teams calls: confirm whether Service Bus is Premium; decide whether to migrate it, retain public access on that namespace, or disable the import.
2. Confirm the installer machine can reach `https://<app-name>.scm.azurewebsites.net` over HTTPS/443; for private-only App Services, also confirm VNet connectivity and private DNS resolution.
3. If any out-of-band automation publishes to the product App Service over FTP/FTPS, migrate it to SCM/Kudu or another supported deployment path.
4. Download the stable `ControlPanelApp.zip`, start `AnalyticsInstaller.exe`, open the existing configuration, and select the latest stable release.
5. Run the installation. No database script or config re-save is required; expect only a brief App Service/WebJob restart.
6. Review the end-of-install summary. Do not treat the upgrade as healthy if the new WebJob verification reports either job as missing, stopped, or unverifiable.
7. In the App Service **WebJobs** blade, confirm `Office365ActivityImporter` and `AppInsightsImporter` both show **Running**. If Application Insights creation previously failed, also confirm that the workspace-based component now exists.
8. Sign in to the web application. If Copilot importing is enabled, open **Reports → Copilot agents**, choose a period and Top-N value, and confirm the chart returns data appropriate for the imported audit-data window.
9. Optional: grant the Teams application access policy if Copilot meeting names and dates are required.

---

_Issues resolved since the previous published stable release: #215, #228, and #235. Issue #206 is partially addressed and remains open for its client/server telemetry-contract work. Previous published stable release: build 1716._

**Full changelog:** https://github.com/pnp/Microsoft365-Analytics-Insights/compare/1716...dev
