### PR TITLE
Stable Release: cumulative features, installer reliability, and Copilot agent totals

### DIFF
--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -260,11 +260,17 @@ namespace Web.AnalyticsWeb.Controllers
                 "ORDER BY SeriesName, WeekStart\r\n" +
                 "OPTION (RECOMPILE);";
 
+            var displaySql = DisplaySql(agents, from, agentName);
+            var rowsTask = QueryNamedWeeksAsync(agents, from, agentName, 60);
+
             return new List<Task<ReportChart>>
             {
+                RunGroupedCategoryAsync("copilot-agent-totals", "Top Copilot agents by total executions",
+                    "Total executions for each selected agent across the reporting period.",
+                    "Executions", rowsTask, displaySql),
                 RunGroupedTimeSeriesAsync("copilot-agent-interactions", "Copilot agent interactions per week",
                     "Weekly interactions for the most-used Copilot agents matching the current filters.",
-                    "Interactions", agents, from, weekSpine, agentName, 60),
+                    "Interactions", rowsTask, displaySql, weekSpine),
             };
         }
 
@@ -471,7 +477,7 @@ namespace Web.AnalyticsWeb.Controllers
 
         /// <summary>Runs one query that returns multiple named weekly series.</summary>
         private static async Task<ReportChart> RunGroupedTimeSeriesAsync(string key, string title, string description,
-            string valueLabel, string body, DateTime from, List<DateTime> weekSpine, string agentName, int queryTimeoutSecs)
+            string valueLabel, Task<List<NamedWeekValueRow>> rowsTask, string sql, List<DateTime> weekSpine)
         {
             var chart = new ReportChart
             {
@@ -480,36 +486,23 @@ namespace Web.AnalyticsWeb.Controllers
                 Description = description,
                 Type = "timeseries",
                 ValueLabel = valueLabel,
-                Sql = DisplaySql(body, from, agentName),
+                Sql = sql,
             };
 
             try
             {
-                using (var db = new AnalyticsEntitiesContext())
-                {
-                    db.Database.CommandTimeout = queryTimeoutSecs;
-                    var rows = await db.Database
-                        .SqlQuery<NamedWeekValueRow>(
-                            body,
-                            new SqlParameter("@from", from),
-                            new SqlParameter("@agentName", System.Data.SqlDbType.NVarChar, 100)
-                            {
-                                Value = (object)agentName ?? DBNull.Value,
-                            })
-                        .ToListAsync();
-
-                    chart.Series = rows
-                        .GroupBy(r => new { r.SeriesKey, r.SeriesName })
-                        .OrderByDescending(g => g.Sum(r => r.Value))
-                        .Select(g => new ReportSeries
-                        {
-                            Name = g.Key.SeriesName,
-                            Points = FillWeeks(
-                                weekSpine,
-                                g.Select(r => new WeekValueRow { WeekStart = r.WeekStart, Value = r.Value }).ToList()),
-                        })
-                        .ToList();
-                }
+                var rows = await rowsTask;
+                chart.Series = rows
+                    .GroupBy(r => new { r.SeriesKey, r.SeriesName })
+                    .OrderByDescending(g => g.Sum(r => r.Value))
+                    .Select(g => new ReportSeries
+                    {
+                        Name = g.Key.SeriesName,
+                        Points = FillWeeks(
+                            weekSpine,
+                            g.Select(r => new WeekValueRow { WeekStart = r.WeekStart, Value = r.Value }).ToList()),
+                    })
+                    .ToList();
             }
             catch (Exception ex)
             {
@@ -517,6 +510,62 @@ namespace Web.AnalyticsWeb.Controllers
             }
 
             return chart;
+        }
+
+        /// <summary>Builds a categorical totals chart from the same shared weekly query result.</summary>
+        private static async Task<ReportChart> RunGroupedCategoryAsync(string key, string title, string description,
+            string valueLabel, Task<List<NamedWeekValueRow>> rowsTask, string sql)
+        {
+            var chart = new ReportChart
+            {
+                Key = key,
+                Title = title,
+                Description = description,
+                Type = "bar",
+                ValueLabel = valueLabel,
+                Sql = sql,
+            };
+
+            try
+            {
+                var rows = await rowsTask;
+                chart.Categories = rows
+                    .GroupBy(r => new { r.SeriesKey, r.SeriesName })
+                    .Select(g => new ReportCategory
+                    {
+                        Label = g.Key.SeriesName,
+                        Value = g.Sum(r => r.Value),
+                    })
+                    .OrderByDescending(category => category.Value)
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                chart.Error = InnermostMessage(ex);
+            }
+
+            return chart;
+        }
+
+        private static async Task<List<NamedWeekValueRow>> QueryNamedWeeksAsync(
+            string body,
+            DateTime from,
+            string agentName,
+            int queryTimeoutSecs)
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                db.Database.CommandTimeout = queryTimeoutSecs;
+                return await db.Database
+                    .SqlQuery<NamedWeekValueRow>(
+                        body,
+                        new SqlParameter("@from", from),
+                        new SqlParameter("@agentName", System.Data.SqlDbType.NVarChar, 100)
+                        {
+                            Value = (object)agentName ?? DBNull.Value,
+                        })
+                    .ToListAsync();
+            }
         }
 
         /// <summary>Runs a categorical (bar) query - label + value rows, already ordered by the query.</summary>


### PR DESCRIPTION
## Stable build 1732 — cumulative feature and installer-reliability release

**This release rolls up everything since the last published stable release, build 1716.** It adds built-in Copilot agent reporting—including ranked totals and weekly trends—and post-deployment WebJob verification, together with cumulative installer, private-networking, import-diagnostics, and telemetry fixes. There are **no database migrations**, **no `Create DB.sql` changes**, and **no installer configuration-schema change**.

### Should you upgrade?

| | |
|-|-|
| **Upgrade urgency** | **Recommended for everyone. High priority for private-endpoint App Service deployments:** the previous installer could leave public network access enabled and could fail SCM deployment with the misleading error `403 Ip Forbidden`. Also prioritise this release if you want built-in Copilot agent reporting with ranked totals and weekly trends, an installation can appear successful while a continuous WebJob is missing or stopped, you use Teams calls in a private/VNet deployment, or Application Insights creation has failed during an install. |
| **Database migrations** | **None.** `Migrations/` and `Create DB.sql` are unchanged. No database maintenance window is required, and the importer does not need to be stopped for schema work. |
| **Configuration changes** | **None.** The installer config schema remains **1.9.0**. Existing solution configuration files load unchanged and do not need to be re-saved. Existing encrypted proxy preferences also continue to load. |
| **Breaking changes** | No data-model, API, or saved-config breaking changes. **Operational change:** the installer no longer uses FTP/FTPS and disables FTP basic publishing credentials on the product App Service. Any separate automation that publishes to that App Service over FTP must move to SCM/Kudu or another supported deployment method. |
| **How to upgrade** | Download the new `ControlPanelApp.zip`, open the existing configuration in `AnalyticsInstaller.exe`, select the latest stable release, and run the installation again. Manual deployments can continue to use `Deploy-AppServiceContent.ps1`. |
| **Downtime** | No maintenance window. The installer downloads packages before stopping the App Service, stops it only while the database upgrade/check runs, and restarts it before SCM content deployment. Expect a brief App Service/WebJob interruption and warm-up. |

---

## Private-endpoint App Service installation no longer fails with a misleading SCM 403

**Who this affects:** new installations and upgrades where the product App Service uses a private endpoint or is configured with public network access disabled. Existing running workloads are not interrupted until an installation or upgrade is run.

**Symptom:** package download and Azure authentication could succeed, but website/WebJob deployment through Kudu/SCM then failed with:

```text
403 Ip Forbidden
```

This looked like a private DNS, access-restriction, publishing-credential, or firewall problem. Admins could spend time reopening public access or changing SCM rules even when the installer machine had the correct private network path.

A separate but related symptom was that an App Service selected for private-only access could still show public network access enabled after installation.

**Root cause:** there were two installer defects:

- Azure App Service stores `publicNetworkAccess` on the top-level site resource. The installer read and wrote a nested `siteConfig.publicNetworkAccess` value that Azure ignored.
- The installer stopped the App Service before downloading and deploying the release. Kudu/SCM rejects HTTPS content deployment while the site resource is stopped and returns `403 Ip Forbidden`, even when private endpoint routing and DNS are correct.

**What's changed:**

- The installer now reads and writes the supported top-level `WebSiteData.PublicNetworkAccess` property, so the requested public/private access state is actually applied.
- Release packages are downloaded and extracted while the App Service remains available.
- The App Service is stopped only for the database upgrade/check, preventing the existing website and WebJobs from using a partially upgraded schema.
- The App Service is restarted before Kudu/SCM HTTPS deployment, keeping the SCM endpoint available for content upload and the subsequent WebJob health check.
- Download-only preparation no longer deploys automation runbooks; runbooks are deployed once during the installation phase rather than duplicated during preparation.

**Action for admins:** upgrade and rerun any installation that failed with `403 Ip Forbidden`. Do **not** relax App Service access restrictions solely to work around that error. For private-only deployments, confirm the installer machine can resolve and reach the private SCM endpoint, then verify in the App Service **Networking** blade that public network access is disabled as intended. Everyone else has no additional action.

See **[Private Endpoints](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Private-Endpoints)**, **[Deployment Guidance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Deployment-Guidance)**, **[Troubleshooting](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Troubleshooting)**, and **[Updating the solution](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Updating-the-solution)**.

---

## Built-in Copilot agent report now shows totals and weekly trends

**Who this affects:** administrators with Copilot imports enabled who need to understand which Copilot agents are being used, their total execution volume, and how usage changes over time.

**Symptom:** the built-in Reports page showed overall Copilot interactions, active users, and app hosts, but it did not provide a ranked agent total or an agent-by-agent weekly view. Administrators had to use a separate reporting model or write SQL to compare standard and custom agent usage.

**Root cause:** the web application had no report endpoint or visualizations that grouped imported `copilot_chats` records by agent for the selected period.

**What's changed:**

- A **Copilot agents** sub-tab now appears under **Reports** whenever Copilot importing is enabled.
- A **Top Copilot agents by total executions** bar chart appears at the top. It shows each selected agent by name and totals its executions across the selected one-, three-, or six-month period.
- The weekly trend chart remains directly below it, showing interaction counts per agent and week for the same selection.
- Both visualizations honour the same Top 5, 8, 10, 15, or 20 selection and name-contains filter. Apply, Enter, Clear, period, and Top-N changes refresh both charts together.
- Both charts await the exact same shared SQL result. Loading them therefore performs one database query for the agent data—not one query per chart—and the totals are aggregated in memory over at most Top-N × weekly rows. No second scan of `audit_events` or `copilot_chats` is added.
- In a synthetic 10,000,000-interaction benchmark, the optimized shared query completed in about **15.8 seconds unfiltered** and **1.7 seconds with the name filter applied**. The plan scanned `audit_events` and `copilot_chats` once each and used only eight reads against `copilot_agents`. This is a scale reference rather than a performance SLA; actual time depends on SQL tier, cache state, date range, and data distribution.
- **SQL behind this chart** exposes the generated query so a DBA can inspect or reproduce it. Results are cached for 60 seconds per period, Top-N, and name filter.
- The query aggregates matching interactions before ranking the weekly result set. It has a 60-second SQL timeout and displays chart-level warnings instead of failing the whole Reports page.

**Action for admins:** none beyond the normal upgrade. Ensure Copilot importing is enabled, then open **Reports → Copilot agents** to use the totals and weekly views. Allow for the normal Microsoft 365 audit-data delay before expecting recent executions to appear. If the charts report a timeout on an unusually large database, use the disclosed SQL and normal SQL performance monitoring to investigate.

See **[Copilot Analytics](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Copilot)** and **[Monitoring System Performance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Monitoring-System-Performance)**.

---

## Installer now verifies that both continuous WebJobs actually started

**Who this affects:** everyone installing or upgrading through `AnalyticsInstaller.exe`.

**Symptom:** App Service content deployment and website warm-up could succeed while one continuous WebJob was missing or stopped. The installer could therefore appear to finish normally even though Microsoft 365 or Application Insights data would not continue importing.

**Root cause:** a successful Kudu ZIP deployment confirms that the package was accepted, but it does not prove that both continuous WebJobs were discovered and reached the `Running` state.

**What's changed:** after App Service warm-up, the installer queries Kudu's continuous-WebJob status API through the configured SCM proxy path. It requires both:

```text
Office365ActivityImporter=Running
AppInsightsImporter=Running
```

If either job is absent or not running, the installer records an ERROR with the exact status, for example:

```text
WebJob health check failed after App Service warm-up: Office365ActivityImporter=missing; AppInsightsImporter=Stopped. Both continuous WebJobs must report 'Running' in the App Service WebJobs blade.
```

If Kudu status itself cannot be queried, the installer records:

```text
Could not verify continuous WebJob health after App Service warm-up: ...
```

These errors are included in the end-of-install summary. A healthy deployment records a pass line naming both jobs as `Running`.

**Action for admins:** treat either error as a failed post-deployment verification even if the website opens. In the Azure portal, open the App Service **WebJobs** blade, confirm both jobs exist and show **Running**, then inspect each job's logs for startup, configuration, SQL, storage, or identity failures. Rerun the installer after correcting the cause.

See **[Verify — Verify Import Jobs are Running](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Verify#verify-import-jobs-are-running)** and **[Troubleshooting](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Troubleshooting)**.

---

## App Service deployment now uses HTTPS/443 instead of FTPS

**Who this affects:** anyone installing or upgrading through `AnalyticsInstaller.exe`; especially environments with restricted outbound rules, an HTTP proxy, App Service access restrictions, or private endpoints.

**Symptom:** the older installer could fail while uploading the website or continuous WebJobs even when Azure authentication and SQL tests succeeded. Searchable log messages included:

```text
Couldn't connect to <app-service FTPS endpoint> ... ensure app-service has 'FTP state' configured to 'FTPS only'.
FTP upload to '...' on <app-service FTPS endpoint> failed: An error occurred uploading file(s)...
```

The FTPS connectivity test could also fail because the control connection worked but the passive data channel was blocked. This often looked like bad publishing credentials or an App Service setting problem when the real cause was firewall or proxy handling of FTPS data ports.

**Root cause:** the installer uploaded three directory trees over FTPS. That required FTP control and passive data channels that are commonly blocked by enterprise egress controls and are not handled by a normal HTTP proxy.

**What's changed:**

- The installer builds one package containing the website at the root and the two continuous WebJobs under `app_data/jobs/continuous`, then sends it to the App Service SCM/Kudu endpoint over HTTPS/443.
- Obsolete FTPS connectivity tests, publishing-profile autodetection, passive-mode settings, UI fields, and the FTP client dependency have been removed.
- The App Service is set to **FTP/FTPS disabled** and **FTP basic publishing credentials disabled**. SCM basic publishing credentials remain enabled because Kudu ZIP deployment requires them.
- The proxy screen now describes an HTTP proxy for the SCM endpoint. Existing `proxyconfig.dat` preferences continue to load through their legacy saved-property names.
- Remaining connectivity failures now identify the actual path:

```text
App Service HTTPS deployment could not reach 'https://<app-name>.scm.azurewebsites.net'. Check installer proxy and SCM access settings.
```

**Action for admins:** if the installer machine already has HTTPS/443 access to `https://<app-name>.scm.azurewebsites.net`, none beyond the normal upgrade. Otherwise, allow that endpoint through outbound firewall/proxy controls. For a private-only App Service, run the installer from a VNet-connected machine with working private DNS for the SCM endpoint. If you have separate FTP-based deployment automation for this App Service, migrate it before upgrading; legacy FTP/passive-port allow rules can then be retired after your normal change review.

See **[Deployment Guidance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Deployment-Guidance)**, **[Troubleshooting](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Troubleshooting#network-restrictions-for-app-service-https-deployment-and-sql)**, and **[Updating the solution](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Updating-the-solution)**.

---

## New Application Insights resources deploy successfully again

**Who this affects:** new installations, or upgrades where the configured workspace-based Application Insights component does not yet exist and must be created. Deployments that reuse an existing component are unaffected.

**Symptom:** Azure resource deployment stops with `InvalidTemplate`, mentioning either:

```text
publicNetworkAccessForIngestion
publicNetworkAccessForQuery
```

Because those names describe network-access settings, the failure could be mistaken for an Azure Policy, private-link, or regional API compatibility problem.

**Root cause:** the embedded ARM template still referenced two parameters that were no longer declared or supplied. ARM validates all parameter references before resource creation, so the Application Insights component could not be created.

**What's changed:** the stale references have been removed while retaining the workspace link and the existing Application Insights settings. Automated coverage now verifies that every parameter referenced by the template is declared.

This does not change the product's Application Insights network model: the installer does not configure Azure Monitor Private Link Scope (AMPLS). Environments that require private Application Insights access should continue to configure AMPLS separately.

**Action for admins:** if you encountered this `InvalidTemplate` error, update the installer and rerun the failed installation. Do **not** add undocumented ARM parameters or relax Azure Policy/network controls to work around it. If Application Insights already exists, no action.

See **[Deployment Guidance](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Deployment-Guidance)**, **[Manual Azure resource installation](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Manual-Install-Azure-Resources#Create--Configure-Application-Insights)**, and **[Private Endpoints](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Private-Endpoints#application-insights)**.

---

## Private deployments no longer silently break the Teams calls import

**Who this affects:** deployments with VNet integration and public network access disabled where the Teams calls import is enabled.

**Symptom:** Teams call records stop importing, while the importer reports a 401 that looks like an authentication or RBAC failure:

```text
Put token failed. status-code: 401, status-description: Ip has been prevented to connect to the endpoint.
   ... Virtual Network service endpoints / IP Filters ...
```

**Root cause:** private endpoints on Service Bus require the Premium SKU, and Azure does not support an in-place Standard-to-Premium upgrade. The older installer could disable public access on a Standard namespace without creating a usable private endpoint, leaving Service Bus unreachable. This is a network-layer rejection before Entra token validation, so changing permissions does not fix it.

**What's changed:**

- If Service Bus cannot be made private, the installer leaves public access enabled on that namespace and displays a clear warning rather than silently creating an unreachable service.
- A pre-install warning explains the available choices: migrate Service Bus to Premium, retain public access on that namespace, or disable Teams calls import.
- The installer skips unusable Service Bus private-endpoint and private-DNS resources that could otherwise also break public hostname resolution.
- The warning is repeated in the installation summary.
- The Health page now identifies likely IP/VNet blocking and the Premium requirement instead of presenting the raw Azure error as an authentication problem.

**Action for admins:** private deployments using Teams calls should check the Service Bus SKU. If it is Standard, either [migrate it to Premium](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-migrate-standard-premium), retain public access on that one namespace, or disable the Teams calls import. Everyone else has no additional action.

See **[Private Endpoints](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Private-Endpoints)**.

---

## Copilot meeting enrichment reports one actionable warning instead of thousands of errors

**Who this affects:** tenants importing Copilot activity where meeting-context events occur.

**Symptom:** Application Insights can fill with repeated `403 Forbidden` exceptions from meeting lookups, while Copilot meeting name and creation date remain blank.

**Root cause:** `OnlineMeetings.Read.All` is not sufficient by itself. Microsoft Graph also requires a Teams application access policy for the importing application. Without that tenant-side policy, every meeting lookup is rejected even though the rest of the Copilot event imports normally.

**What's changed:**

- The importer emits one clear warning per run, naming `New-CsApplicationAccessPolicy` and `Grant-CsApplicationAccessPolicy`, rather than an exception for every affected event.
- It stops repeating meeting lookups for users already known not to be covered by the policy.
- Genuine permission errors remain fully reported; only this specific expected condition is quietened.

**Action for admins:** if you want Copilot meeting names and dates captured, have a Teams administrator grant the application access policy described on the **[Copilot](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Copilot)** and **[Prerequisites](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Prerequisites)** pages. If you do not use Copilot meeting reporting, no action.

---

## Anonymous usage-report uploads retry correctly and report more accurate statistics

**Who this affects:** deployments where optional anonymous usage reporting remains enabled. The existing `AllowTelemetry` opt-out is unchanged; nothing is sent when it is disabled.

**Symptom:** there was no visible local symptom. A rejected upload was recorded as successful, so the next retry could be delayed for a day and that report was lost.

**Root cause:** the uploader logged the receiving endpoint's rejection but still stamped the last-upload time. Table-size queries could also count a table more than once for some index layouts, and timestamps used local time.

**What's changed:**

- Rejected uploads are treated as failures and retried on the next import cycle.
- Upload failures are logged as errors so they are visible in Application Insights.
- Report timestamps use UTC.
- Each table is counted once and its database schema is recorded.

**Action for admins:** none.

---

## Code maintenance

Release-process guidance and focused regression coverage were improved; there is no separate operator action.

---

## Upgrade checklist

1. Private App Service deployments: confirm the installer machine can resolve and reach the private SCM endpoint over HTTPS/443. Do not open public access solely to work around `403 Ip Forbidden`.
2. Private deployments using Teams calls: confirm whether Service Bus is Premium; decide whether to migrate it, retain public access on that namespace, or disable the import.
3. If any out-of-band automation publishes to the product App Service over FTP/FTPS, migrate it to SCM/Kudu or another supported deployment path.
4. Download the stable `ControlPanelApp.zip`, start `AnalyticsInstaller.exe`, open the existing configuration, and select the latest stable release.
5. Run the installation. No database script or config re-save is required. The installer downloads first, briefly stops the App Service for the database upgrade/check, restarts it, and then deploys content through SCM.
6. For private-only deployments, verify in the App Service **Networking** blade that public network access is disabled as intended.
7. Review the end-of-install summary. Do not treat the upgrade as healthy if WebJob verification reports either job as missing, stopped, or unverifiable.
8. In the App Service **WebJobs** blade, confirm `Office365ActivityImporter` and `AppInsightsImporter` both show **Running**. If Application Insights creation previously failed, also confirm that the workspace-based component now exists.
9. Sign in to the web application. If Copilot importing is enabled, open **Reports → Copilot agents**, choose a period, Top-N value, and optional name filter, then confirm both the totals bar chart and weekly trend return data appropriate for the imported audit-data window.
10. Optional: grant the Teams application access policy if Copilot meeting names and dates are required.

---

_Issues resolved since the previous published stable release: #215, #228, and #235. Issue #206 is partially addressed and remains open for its client/server telemetry-contract work. The App Service private-endpoint installer reliability fix was delivered directly in commit `865c407`; the Copilot agent totals visualization was delivered directly in commit `c8b70fd`. Previous published stable release: build 1716._

**Full changelog:** https://github.com/pnp/Microsoft365-Analytics-Insights/compare/1716...1732
