### PR TITLE
Fix Power Platform flow, sharing, connector and Copilot Studio audit ingestion

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Entities/AuditLog/PowerPlatformEvents.cs
+++ b/src/AnalyticsEngine/Common/Entities/Entities/AuditLog/PowerPlatformEvents.cs
@@ -166,7 +166,7 @@ namespace Common.Entities.Entities.AuditLog
     public class PowerAutomateFlow : AbstractEFEntity
     {
         /// <summary>
-        /// FlowId from the audit-event payload.
+        /// Flow identifier derived from FlowDetailsUrl (or the legacy FlowId field).
         /// </summary>
         [Column("flow_id")]
         [MaxLength(200)]
@@ -189,7 +189,7 @@ namespace Common.Entities.Entities.AuditLog
     }
 
     /// <summary>
-    /// Per-event metadata for an audit_events row of workload 'MicrosoftFlow'.
+    /// Per-event metadata for a Power Automate lifecycle or permission audit event.
     /// </summary>
     [Table("event_meta_power_automate_flow")]
     public class PowerAutomateFlowEventMetadata : BaseOfficeEvent
@@ -200,7 +200,8 @@ namespace Common.Entities.Entities.AuditLog
         public PowerAutomateFlow Flow { get; set; }
 
         /// <summary>
-        /// Per-execution correlation id from the flow run.
+        /// Legacy optional flow-run correlation id. Current Purview lifecycle and permission
+        /// records don't represent individual executions, so this is normally null.
         /// </summary>
         [Column("run_id")]
         [MaxLength(200)]
@@ -234,7 +235,7 @@ namespace Common.Entities.Entities.AuditLog
     }
 
     /// <summary>
-    /// Junction: which connectors a Power Automate flow currently uses.
+    /// Junction: connector names observed on Power Automate create/edit audit events.
     /// </summary>
     [Table("power_automate_flow_connectors")]
     public class PowerAutomateFlowConnector : AbstractEFEntity

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
@@ -31,7 +31,7 @@ namespace Tests.FakeDataGen.StressTests
         private static readonly string[] ReportTypes = { "PowerBIReport", "PaginatedReport" };
 
         private static readonly string[] AppOperations = { "LaunchPowerApp", "EditPowerApp", "PublishPowerApp", "CreatePowerApp" };
-        private static readonly string[] FlowOperations = { "FlowRunStarted", "FlowRunCompleted", "EditFlow", "CreateFlow" };
+        private static readonly string[] FlowOperations = { "CreateFlow", "EditFlow", "PutPermissions", "DeletePermissions" };
 
         protected override StressTestResult Execute()
         {
@@ -315,38 +315,30 @@ namespace Tests.FakeDataGen.StressTests
             var flowId = flows[random.Next(flows.Count)];
             var operation = FlowOperations[random.Next(FlowOperations.Length)];
             common.Operation = new EventOperation { Name = operation };
+            var environmentId = EnvironmentIds[random.Next(EnvironmentIds.Length)];
 
             var content = new PowerAutomateAuditLogContent
             {
-                FlowId = flowId,
-                FlowDisplayName = $"Display-{flowId}",
-                EnvironmentName = EnvironmentIds[random.Next(EnvironmentIds.Length)],
-                RunId = Guid.NewGuid().ToString("N"),
+                Operation = operation,
+                FlowDetailsUrl = $"https://admin.powerplatform.microsoft.com/environments/{environmentId}/flows/{flowId}/flowDetails",
             };
 
             if (operation == "CreateFlow" || operation == "EditFlow")
             {
-                content.ConnectionReferences = new List<PowerPlatformConnectionRef>();
+                var connectorNames = new List<string>();
                 int connectorCount = random.Next(1, 4);
                 for (int c = 0; c < connectorCount; c++)
                 {
-                    content.ConnectionReferences.Add(new PowerPlatformConnectionRef { ConnectorName = Connectors[random.Next(Connectors.Length)] });
+                    connectorNames.Add(Connectors[random.Next(Connectors.Length)]);
                 }
+                content.FlowConnectorNames = string.Join(", ", connectorNames);
             }
 
-            if (random.Next(100) < sharePercent)
+            if (operation == "PutPermissions" || operation == "DeletePermissions" || random.Next(100) < sharePercent)
             {
-                content.Permissions = new List<PowerPlatformPermissionEntry>();
-                int recipients = random.Next(1, 3);
-                for (int r = 0; r < recipients; r++)
-                {
-                    var recipient = users[random.Next(users.Count)];
-                    content.Permissions.Add(new PowerPlatformPermissionEntry
-                    {
-                        PrincipalName = recipient.Upn,
-                        RoleName = ShareRoles[random.Next(ShareRoles.Length)]
-                    });
-                }
+                var recipient = users[random.Next(users.Count)];
+                content.RecipientUpn = recipient.Upn;
+                content.SharingPermission = random.Next(0, 2) == 0 ? "2" : "3";
             }
 
             manager.SaveSinglePowerAutomateEventToSqlStaging(content, common).GetAwaiter().GetResult();
@@ -377,10 +369,13 @@ namespace Tests.FakeDataGen.StressTests
             var content = new CopilotStudioAuditLogContent
             {
                 BotId = botId,
-                BotName = $"Bot-{botId}",
-                EnvironmentName = EnvironmentIds[random.Next(EnvironmentIds.Length)],
+                BotSchemaName = $"contoso_agent_{botId}",
+                EnvironmentId = EnvironmentIds[random.Next(EnvironmentIds.Length)],
             };
-            common.Operation = new EventOperation { Name = random.Next(0, 10) < 7 ? "MessageSent" : "BotPublished" };
+            common.Operation = new EventOperation
+            {
+                Name = random.Next(0, 10) < 7 ? "BotUpdateOperation-BotPublish" : "BotUpdateOperation-BotNameUpdate"
+            };
             manager.SaveSingleCopilotStudioEventToSqlStaging(content, common).GetAwaiter().GetResult();
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/PowerPlatformAuditEventManagerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/PowerPlatformAuditEventManagerTests.cs
@@ -218,37 +218,95 @@ namespace Tests.UnitTests
         // -- Power Automate -------------------------------------------------------------------
 
         /// <summary>
-        /// A FlowRunStarted event should create the flow lookup and the per-event metadata.
+        /// A documented lifecycle event should derive the flow/environment ids from
+        /// FlowDetailsUrl and populate connector relationships.
         /// </summary>
         [TestMethod]
-        public async Task PowerAutomate_FlowEvent_PersistsFlowAndMetadata()
+        public async Task PowerAutomate_LifecycleEvent_PersistsFlowMetadataAndConnectors()
         {
             using (var db = new AnalyticsEntitiesContext())
             {
-                var commonEvent = BuildCommonEvent("FlowRunStarted", "flow-run");
+                var commonEvent = BuildCommonEvent("EditFlow", "flow-edit");
                 await PersistAuditEventAsync(db, commonEvent);
 
                 var flowId = "flow-" + Guid.NewGuid().ToString("N");
+                var environmentId = "env-" + Guid.NewGuid().ToString("N");
+                var connectorA = "connector-a-" + Guid.NewGuid().ToString("N");
+                var connectorB = "connector-b-" + Guid.NewGuid().ToString("N");
 
                 var manager = NewManager();
                 await manager.SaveSinglePowerAutomateEventToSqlStaging(new PowerAutomateAuditLogContent
                 {
-                    FlowId = flowId,
-                    FlowDisplayName = "Nightly Sync",
-                    EnvironmentName = "env-test",
-                    RunId = Guid.NewGuid().ToString("N")
+                    Operation = "EditFlow",
+                    FlowDetailsUrl = $"https://admin.powerplatform.microsoft.com/environments/{environmentId}/flows/{flowId}/flowDetails",
+                    FlowConnectorNames = $"{connectorA}, {connectorB}"
                 }, commonEvent);
 
                 await manager.CommitAllChanges();
 
                 var flowRow = await db.power_automate_flows.SingleOrDefaultAsync(f => f.FlowId == flowId);
                 Assert.IsNotNull(flowRow, "power_automate_flows row must be created for a brand-new flow_id.");
-                Assert.AreEqual("Nightly Sync", flowRow.Name);
+                Assert.AreEqual(flowId, flowRow.Name, "The audit schema has no flow display name, so the id is the stable fallback.");
                 Assert.IsTrue(flowRow.FirstSeenAt.HasValue, "first_seen_at should be populated on first sighting.");
 
                 var meta = await db.power_automate_flow_events.SingleOrDefaultAsync(m => m.EventID == commonEvent.Id);
                 Assert.IsNotNull(meta, "event_meta_power_automate_flow must exist for the staged event.");
                 Assert.AreEqual(flowRow.ID, meta.FlowId);
+                Assert.IsNull(meta.RunId, "Purview lifecycle records do not represent individual flow runs.");
+
+                var environment = await db.power_app_environments.SingleOrDefaultAsync(e => e.EnvironmentId == environmentId);
+                Assert.IsNotNull(environment);
+                Assert.AreEqual(environment.ID, flowRow.EnvironmentId);
+
+                var bindings = await db.power_automate_flow_connectors
+                    .Where(j => j.FlowId == flowRow.ID)
+                    .ToListAsync();
+                Assert.AreEqual(2, bindings.Count);
+                var connectorIds = bindings.Select(b => b.ConnectorId).ToArray();
+                var connectorNames = await db.power_platform_connectors
+                    .Where(c => connectorIds.Contains(c.ID))
+                    .Select(c => c.Name)
+                    .ToListAsync();
+                CollectionAssert.AreEquivalent(new[] { connectorA, connectorB }, connectorNames);
+            }
+        }
+
+        /// <summary>
+        /// Documented permission fields should emit one share row for the affected recipient.
+        /// </summary>
+        [TestMethod]
+        public async Task PowerAutomate_PermissionEvent_PersistsRecipientAndRole()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var commonEvent = BuildCommonEvent("PutPermissions", "flow-share");
+                await PersistAuditEventAsync(db, commonEvent);
+
+                var flowId = "flow-" + Guid.NewGuid().ToString("N");
+                var environmentId = "env-" + Guid.NewGuid().ToString("N");
+                var recipient = $"recipient-{Guid.NewGuid():N}@unit.test";
+
+                var manager = NewManager();
+                await manager.SaveSinglePowerAutomateEventToSqlStaging(new PowerAutomateAuditLogContent
+                {
+                    Operation = "PutPermissions",
+                    FlowDetailsUrl = $"https://admin.powerplatform.microsoft.com/environments/{environmentId}/flows/{flowId}/flowDetails",
+                    RecipientUpn = recipient,
+                    SharingPermission = "2"
+                }, commonEvent);
+
+                await manager.CommitAllChanges();
+
+                var flowRow = await db.power_automate_flows.SingleAsync(f => f.FlowId == flowId);
+                var shareRow = await db.power_automate_flow_share_events
+                    .SingleOrDefaultAsync(s => s.EventId == commonEvent.Id);
+                Assert.IsNotNull(shareRow);
+                Assert.AreEqual(flowRow.ID, shareRow.FlowId);
+                Assert.AreEqual("Run-only user", shareRow.RoleName);
+
+                var recipientUser = await db.users.SingleOrDefaultAsync(u => u.UserPrincipalName == recipient);
+                Assert.IsNotNull(recipientUser);
+                Assert.AreEqual(recipientUser.ID, shareRow.SharedWithUserId);
             }
         }
 
@@ -394,29 +452,34 @@ namespace Tests.UnitTests
         {
             using (var db = new AnalyticsEntitiesContext())
             {
-                var commonEvent = BuildCommonEvent("BotPublished", "bot-pub");
+                var commonEvent = BuildCommonEvent("BotUpdateOperation-BotPublish", "bot-pub");
                 await PersistAuditEventAsync(db, commonEvent);
 
                 var botId = "bot-" + Guid.NewGuid().ToString("N");
+                var environmentId = "env-" + Guid.NewGuid().ToString("N");
 
                 var manager = NewManager();
                 await manager.SaveSingleCopilotStudioEventToSqlStaging(new CopilotStudioAuditLogContent
                 {
                     BotId = botId,
-                    BotName = "HR Bot",
-                    EnvironmentName = "env-test"
+                    BotSchemaName = "contoso_hr_agent",
+                    EnvironmentId = environmentId
                 }, commonEvent);
 
                 await manager.CommitAllChanges();
 
                 var botRow = await db.copilot_studio_bots.SingleOrDefaultAsync(b => b.BotId == botId);
                 Assert.IsNotNull(botRow);
-                Assert.AreEqual("HR Bot", botRow.Name);
+                Assert.AreEqual("contoso_hr_agent", botRow.Name);
                 Assert.IsTrue(botRow.FirstSeenAt.HasValue);
 
                 var meta = await db.copilot_studio_events.SingleOrDefaultAsync(m => m.EventID == commonEvent.Id);
                 Assert.IsNotNull(meta);
                 Assert.AreEqual(botRow.ID, meta.BotId);
+
+                var environment = await db.power_app_environments.SingleOrDefaultAsync(e => e.EnvironmentId == environmentId);
+                Assert.IsNotNull(environment);
+                Assert.AreEqual(environment.ID, botRow.EnvironmentId);
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/WorkloadToggleTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/WorkloadToggleTests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
@@ -54,6 +55,90 @@ namespace Tests.UnitTests
             Assert.IsNotNull(
                 AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: true),
                 "Power Platform events must be imported when the workload is enabled.");
+        }
+
+        [TestMethod]
+        public void Dispatch_PowerAutomateLifecycleEvent_MapsDocumentedFields()
+        {
+            const string environmentId = "00000000-0000-0000-0000-000000000001";
+            const string flowId = "00000000-0000-0000-0000-000000000002";
+            var json = JToken.Parse($@"{{
+                ""Workload"": ""MicrosoftFlow"",
+                ""Operation"": ""EditFlow"",
+                ""FlowDetailsUrl"": ""https://admin.powerplatform.microsoft.com/environments/{environmentId}/flows/{flowId}/flowDetails"",
+                ""FlowConnectorNames"": ""Request, OpenApiConnection""
+            }}");
+            var logBase = json.ToObject<WorkloadOnlyAuditLogContent>();
+
+            var mapped = AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: true)
+                as PowerAutomateAuditLogContent;
+
+            Assert.IsNotNull(mapped);
+            Assert.AreEqual(flowId, mapped.FlowId);
+            Assert.AreEqual(environmentId, mapped.EnvironmentName);
+            CollectionAssert.AreEquivalent(
+                new[] { "Request", "OpenApiConnection" },
+                mapped.ConnectionReferences.Select(r => r.ConnectorName).ToArray());
+        }
+
+        [TestMethod]
+        public void Dispatch_PowerAutomatePermissionEvent_MapsRecipientAndRole()
+        {
+            const string flowId = "00000000-0000-0000-0000-000000000003";
+            var json = JToken.Parse($@"{{
+                ""Workload"": ""MicrosoftFlow"",
+                ""Operation"": ""PutPermissions"",
+                ""FlowDetailsUrl"": ""https://admin.powerplatform.microsoft.com/environments/00000000-0000-0000-0000-000000000004/flows/{flowId}/flowDetails"",
+                ""RecipientUPN"": ""recipient@contoso.example"",
+                ""SharingPermission"": ""3""
+            }}");
+            var logBase = json.ToObject<WorkloadOnlyAuditLogContent>();
+
+            var mapped = AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: true)
+                as PowerAutomateAuditLogContent;
+
+            Assert.IsNotNull(mapped);
+            Assert.AreEqual(flowId, mapped.FlowId);
+            Assert.AreEqual(1, mapped.Permissions.Count);
+            Assert.AreEqual("recipient@contoso.example", mapped.Permissions[0].PrincipalName);
+            Assert.AreEqual("Owner", mapped.Permissions[0].RoleName);
+        }
+
+        [TestMethod]
+        public void Dispatch_PowerAutomateEventWithoutFlowIdentity_IsDropped()
+        {
+            var json = JToken.Parse(@"{
+                ""Workload"": ""MicrosoftFlow"",
+                ""Operation"": ""StartAPaidTrial""
+            }");
+            var logBase = json.ToObject<WorkloadOnlyAuditLogContent>();
+
+            Assert.IsNull(
+                AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: true),
+                "Non-flow Power Automate audit events must not create NULL flow metadata rows.");
+        }
+
+        [TestMethod]
+        public void Dispatch_CopilotStudioAuthoringEvent_RoutesByBotIdShape()
+        {
+            const string botId = "00000000-0000-0000-0000-000000000005";
+            var json = JToken.Parse($@"{{
+                ""Workload"": ""PowerPlatform"",
+                ""RecordType"": 256,
+                ""Operation"": ""BotCreate"",
+                ""BotId"": ""{botId}"",
+                ""BotSchemaName"": ""contoso_support_agent"",
+                ""EnvironmentId"": ""00000000-0000-0000-0000-000000000006""
+            }}");
+            var logBase = json.ToObject<WorkloadOnlyAuditLogContent>();
+
+            var mapped = AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: true)
+                as CopilotStudioAuditLogContent;
+
+            Assert.IsNotNull(mapped);
+            Assert.AreEqual(botId, mapped.BotId);
+            Assert.AreEqual("contoso_support_agent", mapped.BotSchemaName);
+            Assert.AreEqual("00000000-0000-0000-0000-000000000006", mapped.EnvironmentId);
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Web/Controllers/UserDataLookupAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/UserDataLookupAPIController.cs
@@ -150,7 +150,7 @@ namespace Web.AnalyticsWeb.Controllers
                 Description = "Power Apps launch / usage events (Audit.General feed)." },
             new CategoryMeta { Key = CatFlowEvents, Label = "Power Automate events", SupportsDetail = true,
                 Table = "event_meta_power_automate_flow", ViaAuditEvent = true, WorkloadFlags = new[] { Wf.Copilot },
-                Description = "Power Automate flow run events (Audit.General feed)." },
+                Description = "Power Automate lifecycle and permission events (Audit.General feed)." },
             new CategoryMeta { Key = CatPowerBiEvents, Label = "Power BI events", SupportsDetail = true,
                 Table = "event_meta_power_bi", ViaAuditEvent = true, WorkloadFlags = new[] { Wf.Copilot },
                 Description = "Power BI audit events (Audit.General feed)." },

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ARCHITECTURE.md
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ARCHITECTURE.md
@@ -67,11 +67,12 @@ Each supported workload (`Constants.cs → ActivityImportConstants.WORKLOAD_*`) 
 | `AzureActiveDirectory` | `AzureADAuditLogContent` | None |
 | `MicrosoftStream` | `StreamAuditLogContent` | None |
 | `Copilot` | `CopilotAuditLogContent` | None (custom parser from JSON string) |
-| `PowerPlatform` (RecordType 256) | → `PowerPlatformAdminActivityRecordContent.ToWorkloadSpecificContent()` | Power Automate: FlowRunStarted only |
+| `PowerPlatform` (RecordType 256) | → `PowerPlatformAdminActivityRecordContent.ToWorkloadSpecificContent()` | Requires a supported resource identity |
 | `PowerApps` (legacy) | `PowerAppsAuditLogContent` | None |
-| `MicrosoftFlow` (legacy) | `PowerAutomateAuditLogContent` | FlowRunStarted only |
+| `MicrosoftFlow` | `PowerAutomateAuditLogContent` | Requires FlowId or usable FlowDetailsUrl |
 | `PowerBI` | `PowerBIAuditLogContent` | ViewReport only |
-| `MicrosoftCopilotStudio` | `CopilotStudioAuditLogContent` | None |
+| Copilot Studio authoring record (`BotId` present) | `CopilotStudioAuditLogContent` | Requires BotId |
+| `MicrosoftCopilotStudio` (legacy workload route) | `CopilotStudioAuditLogContent` | None |
 
 ---
 
@@ -103,8 +104,8 @@ PowerPlatformAdminActivityRecordContent (raw record)
 
 ### What's NOT in the Unified Schema
 - **AppType** (Canvas/Model-Driven/etc.) – not present in `LaunchPowerApp` events.
-- **RecurrenceType** – not present in `FlowRunStarted` events.
-- **ConnectionReferences** – only on publish/save events (which we don't persist).
+- **RecurrenceType** – not present in the current lifecycle/permission schema.
+- **Per-run metadata** – Purview does not emit individual flow runs.
 
 These were removed in migration `202605201510051_RemovePowerAppTypesAndFlowRecurrenceTypes`.
 
@@ -112,9 +113,9 @@ These were removed in migration `202605201510051_RemovePowerAppTypesAndFlowRecur
 
 ## Filtering Layers
 
-### 1. Workload Operation Filters (Dispatcher level)
+### 1. Workload Validation / Operation Filters (Dispatcher level)
 Applied **before** any staging. Defined in:
-- `PowerPlatformAuditLogFilter.ShouldPersistPowerAutomateOperation()` → FlowRunStarted only
+- `PowerPlatformAuditLogFilter.ShouldPersistPowerAutomateRecord()` → normalises documented fields and requires a flow identity
 - `ActivityImportConstants.PowerBIOps.IsSupported()` → ViewReport only
 - `PowerPlatformOps.IsPowerAppShareOp()` → recognises share operation names
 
@@ -184,7 +185,7 @@ payloads to verify property names.
 |---------|-------------|
 | "0 imported" but events exist | `SharePointOrgUrlsFilterConfig.InScope` returning false – check `org_urls` table has matching prefixes. Non-SP events must NOT be filtered by this. |
 | "skipping record with unsupported resource type ''" | Unified PowerPlatform event with an unknown `powerplatform.analytics.resource.type` value. Add handling to `ToWorkloadSpecificContent`. |
-| "skipping Power Automate event with non-run operation 'X'" | Expected – only `FlowRunStarted` is persisted. If a new run-like operation appears, add it to `PowerPlatformOps.FlowRunOps`. |
+| "Power Automate ... has no flow identity" | The record has neither legacy `FlowId` nor a `FlowDetailsUrl` containing `/flows/{id}`. Non-resource events such as trial licensing are intentionally skipped. |
 | Power BI events not saving | Only `ViewReport` is persisted. Other operations (Login, PublishReport, etc.) are intentionally dropped. |
 | Duplicate key violations in merge SQL | Typically a staging batch that includes the same natural key with different attribute values. Fix: `GROUP BY natural_key` + `MAX(other_cols)` in the upsert SELECT. |
 
@@ -227,9 +228,9 @@ Located in `Common/Entities/Migrations/`. Key points:
 8. Add unit tests mirroring `PowerPlatformAuditEventManagerTests` style.
 
 ### Adding a New Operation to an Existing Workload
-1. Add it to the relevant filter whitelist (e.g. `PowerPlatformOps.FlowRunOps`).
-2. Verify the operation carries the required fields (capture a real JSON sample first).
-3. Update the staging class if new columns are needed.
+1. Verify the operation carries the required resource identity and metadata fields.
+2. Capture and sanitise a JSON sample before adding schema-specific handling.
+3. Update the dispatcher validation and staging class if new columns are needed.
 4. Update the merge SQL.
 
 ---

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/AuditLogContentDispatcher.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/AuditLogContentDispatcher.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
+using System;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
@@ -8,8 +9,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
 {
     /// <summary>
     /// Routes a raw audit-log JSON object to the workload-specific <see cref="AbstractAuditLogContent"/>
-    /// subclass and applies the per-workload operation filters (e.g. PowerBI ViewReport-only,
-    /// Power Automate flow-run-only).
+    /// subclass and applies per-workload validation/filtering (for example, PowerBI ViewReport-only
+    /// and Power Automate records that identify a concrete flow).
     ///
     /// The activity report loader cares about IO, retries and batching; this class owns the
     /// "what deserialisation does this workload need" decision so the two concerns stay separate
@@ -33,12 +34,19 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                 return null;
             }
 
+            // Copilot Studio authoring records publish a top-level BotId. Route by that documented
+            // record shape rather than relying exclusively on a workload string that Microsoft does
+            // not publish in the Copilot Studio schema.
+            var isCopilotStudioRecord = reportItem.Type == JTokenType.Object
+                && !string.IsNullOrEmpty((string)reportItem["BotId"]);
+
             // Power Platform (the unified PowerPlatform record + the legacy per-product PowerApps / Power
             // Automate / Power BI schemas + Copilot Studio) all arrive via the Audit.General subscription.
             // When the workload is turned off, drop these events here so they are neither imported (no base
             // audit_events row) nor staged (no Power Platform merges) - the whole workload's cost is skipped.
             if (!importPowerPlatform
-                && (logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_PLATFORM
+                && (isCopilotStudioRecord
+                    || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_PLATFORM
                     || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_APPS
                     || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_AUTOMATE
                     || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_BI
@@ -93,6 +101,11 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                 return CopilotAuditLogContent.FromJson(reportItem.ToString());
             }
 
+            if (isCopilotStudioRecord)
+            {
+                return reportItem.ToObject<CopilotStudioAuditLogContent>();
+            }
+
             // Workload "PowerPlatform" -> AuditLogRecordType 256 PowerPlatformAdministratorActivity.
             // Unified Power Platform admin activity record where data lives in a
             // PropertyCollection (OpenTelemetry-style key/value pairs) rather than top-level
@@ -109,10 +122,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
 
                 var mapped = ppRecord.ToWorkloadSpecificContent(logger);
 
-                // Power Automate: only persist flow-run events; lifecycle events are filtered
-                // out by PowerPlatformAuditLogFilter.
                 if (mapped is PowerAutomateAuditLogContent
-                    && !PowerPlatformAuditLogFilter.ShouldPersistPowerAutomateOperation(logBase.Operation, logger))
+                    && !PowerPlatformAuditLogFilter.ShouldPersistPowerAutomateRecord((PowerAutomateAuditLogContent)mapped, logger))
                 {
                     return null;
                 }
@@ -130,16 +141,15 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
             }
 
             // Workload "MicrosoftFlow" (Power Automate) -> AuditLogRecordType 30 MicrosoftFlow.
-            // Same flow-run-only gate as the unified PowerPlatform schema above; filtered here
-            // so nothing reaches the staging tables.
+            // Current records expose lifecycle, connector, and permission metadata through
+            // FlowDetailsUrl / FlowConnectorNames / RecipientUPN / SharingPermission.
             // https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-schema#auditlogrecordtype
             if (logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_AUTOMATE)
             {
-                if (!PowerPlatformAuditLogFilter.ShouldPersistPowerAutomateOperation(logBase.Operation, logger))
-                {
-                    return null;
-                }
-                return reportItem.ToObject<PowerAutomateAuditLogContent>();
+                var flowRecord = reportItem.ToObject<PowerAutomateAuditLogContent>();
+                return PowerPlatformAuditLogFilter.ShouldPersistPowerAutomateRecord(flowRecord, logger)
+                    ? flowRecord
+                    : null;
             }
 
             // Workload "PowerBI" -> AuditLogRecordType 20 PowerBIAudit. We only persist ViewReport:
@@ -158,9 +168,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                 return reportItem.ToObject<PowerBIAuditLogContent>();
             }
 
-            // Workload "MicrosoftCopilotStudio" (formerly Power Virtual Agents) - admin and user
-            // activity for Copilot Studio agents, surfaced in Purview as workload
-            // "MicrosoftCopilotStudio".
+            // Retain the legacy workload route for records that identify the product by workload.
+            // Current records with BotId are routed by shape above.
             // https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-logging-copilot-studio
             if (logBase.Workload == ActivityImportConstants.WORKLOAD_COPILOT_STUDIO)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/PowerPlatformAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/PowerPlatformAuditEventManager.cs
@@ -103,6 +103,14 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 return Task.CompletedTask;
             }
 
+            auditRecord.NormaliseDocumentedFields();
+            if (string.IsNullOrEmpty(auditRecord.FlowId))
+            {
+                _logger.LogWarning(
+                    $"PowerPlatformAuditEventManager: Power Automate {auditRecord.Operation} event '{auditRecord.Id}' has no flow identity - skipping staging row.");
+                return Task.CompletedTask;
+            }
+
             _flowInserts.Rows.Add(new PowerAutomateFlowLogTempEntity
             {
                 EventId = baseOfficeEvent.Id,
@@ -177,12 +185,19 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 return Task.CompletedTask;
             }
 
+            if (string.IsNullOrEmpty(auditRecord.BotId))
+            {
+                _logger.LogWarning(
+                    $"PowerPlatformAuditEventManager: Copilot Studio {auditRecord.Operation} event '{auditRecord.Id}' has no BotId - skipping staging row.");
+                return Task.CompletedTask;
+            }
+
             _copilotStudioInserts.Rows.Add(new CopilotStudioLogTempEntity
             {
                 EventId = baseOfficeEvent.Id,
                 BotId = auditRecord.BotId,
-                BotName = auditRecord.BotName,
-                EnvironmentId = auditRecord.EnvironmentName,
+                BotName = string.IsNullOrEmpty(auditRecord.BotName) ? auditRecord.BotSchemaName : auditRecord.BotName,
+                EnvironmentId = string.IsNullOrEmpty(auditRecord.EnvironmentId) ? auditRecord.EnvironmentName : auditRecord.EnvironmentId,
                 EventTime = baseOfficeEvent.TimeStamp,
             });
             _totalCopilotStudioCount++;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/PowerPlatformAuditLogFilter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/PowerPlatformAuditLogFilter.cs
@@ -1,36 +1,38 @@
 ﻿using Microsoft.Extensions.Logging;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 
 namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
 {
     /// <summary>
-    /// Routing-stage filters for Power Platform / Power Automate audit events.
+    /// Routing-stage validation for Power Platform / Power Automate audit events.
     ///
     /// The activity report loader sees every audit event across every workload; this class
-    /// owns the rules that decide which Power Automate operations are worth persisting,
-    /// so the loader stays a thin dispatcher and the rules + their log messages live in
-    /// one place.
+    /// owns the rules that decide whether a Power Automate record identifies a flow that can
+    /// be persisted, so the loader stays a thin dispatcher.
     /// </summary>
     public static class PowerPlatformAuditLogFilter
     {
         /// <summary>
-        /// Returns true when an audit event with this <paramref name="operation"/> should be
-        /// persisted as a Power Automate flow event. Only flow-run operations (see
-        /// <see cref="ActivityImportConstants.PowerPlatformOps.FlowRunOps"/>) are kept;
-        /// lifecycle operations (CreateFlow, EditFlow, DeleteFlow, SharedFlow, ...) are
-        /// dropped here, before any staging or merge work happens.
-        ///
-        /// When the operation is rejected, an informational log line is written naming the
-        /// operation so unexpected/unknown names can be discovered from real audit data and
-        /// added to <see cref="ActivityImportConstants.PowerPlatformOps.FlowRunOps"/>.
+        /// Normalises Microsoft's documented Power Automate fields and returns true when the
+        /// record identifies a flow. Purview provides lifecycle and permission events rather
+        /// than individual flow runs, so filtering by a guessed run-operation name would drop
+        /// the records that carry flow, connector, and sharing metadata.
         /// </summary>
-        public static bool ShouldPersistPowerAutomateOperation(string operation, ILogger logger)
+        public static bool ShouldPersistPowerAutomateRecord(PowerAutomateAuditLogContent auditRecord, ILogger logger)
         {
-            if (ActivityImportConstants.PowerPlatformOps.IsFlowRunOp(operation))
+            if (auditRecord == null)
+            {
+                return false;
+            }
+
+            auditRecord.NormaliseDocumentedFields();
+            if (!string.IsNullOrEmpty(auditRecord.FlowId))
             {
                 return true;
             }
 
-            logger?.LogDebug($"PowerPlatform: skipping Power Automate event with non-run operation '{operation}'. Only flow-run operations are persisted - extend ActivityImportConstants.PowerPlatformOps.FlowRunOps if this should be tracked.");
+            logger?.LogDebug(
+                $"PowerPlatform: skipping Power Automate event '{auditRecord.Operation}' because it has neither a FlowId nor a usable FlowDetailsUrl.");
             return false;
         }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/SQL/insert_power_automate_events_from_staging_table.sql
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/SQL/insert_power_automate_events_from_staging_table.sql
@@ -63,7 +63,7 @@ LEFT JOIN power_automate_flows pf ON pf.flow_id = i.flow_id
 WHERE NOT EXISTS (SELECT 1 FROM event_meta_power_automate_flow m WHERE m.event_id = i.event_id);
 
 
--- 5. Refresh connector bindings (pipe-delimited connectors_csv from save / publish events).
+-- 5. Add connector bindings observed on create/edit events.
 WITH split_connectors AS (
     SELECT DISTINCT
         i.flow_id,

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Constants.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Constants.cs
@@ -118,33 +118,6 @@
                 return false;
             }
 
-            /// <summary>
-            /// Power Automate operation names we treat as "a flow was run". Only these are
-            /// persisted into <c>power_automate_flow_events</c> - lifecycle operations like
-            /// CreateFlow / EditFlow / DeleteFlow / SharedFlow / PublishFlow are intentionally
-            /// dropped because they don't represent a flow execution.
-            ///
-            /// This list is best-effort: Microsoft does not publish a guaranteed-canonical
-            /// set of operation names for the legacy <c>MicrosoftFlow</c> workload or the
-            /// new unified PowerPlatform schema. The downstream skip log in
-            /// <see cref="PowerAutomateAuditLogContent.ProcessExtendedProperties"/> writes
-            /// the operation name of every dropped event, so any real "flow run" operation
-            /// name we are missing will surface in the logs and can be added here.
-            /// </summary>
-            public static readonly string[] FlowRunOps = new[]
-            {
-                "FlowRunStarted",
-            };
-
-            public static bool IsFlowRunOp(string operation)
-            {
-                if (string.IsNullOrEmpty(operation)) return false;
-                foreach (var op in FlowRunOps)
-                {
-                    if (string.Equals(operation, op, System.StringComparison.OrdinalIgnoreCase)) return true;
-                }
-                return false;
-            }
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/PowerPlatformAuditLogContent.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/PowerPlatformAuditLogContent.cs
@@ -93,11 +93,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
     }
 
     /// <summary>
-    /// Audit-log payload for the 'MicrosoftFlow' workload (create, edit, run, share, delete).
-    /// Schema: https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-schema#microsoft-flow-schema
+    /// Audit-log payload for the 'MicrosoftFlow' workload (create, edit, share, delete).
+    /// Schema: https://learn.microsoft.com/en-us/power-platform/admin/activity-logging-auditing/activity-logs-power-automate
     /// </summary>
     public class PowerAutomateAuditLogContent : AbstractAuditLogContent
     {
+        /// <summary>
+        /// Legacy field retained for backward compatibility. Current Purview records identify
+        /// the flow inside <see cref="FlowDetailsUrl"/>.
+        /// </summary>
         [JsonProperty("FlowId")]
         public string FlowId { get; set; }
 
@@ -122,13 +126,106 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
         [JsonProperty("RunId")]
         public string RunId { get; set; }
 
-        /// <summary>Connectors used by this flow (populated on save / publish events).</summary>
+        /// <summary>Link to the flow's details page in the Power Platform admin center.</summary>
+        [JsonProperty("FlowDetailsUrl")]
+        public string FlowDetailsUrl { get; set; }
+
+        /// <summary>Comma-delimited connector names listed in the flow definition.</summary>
+        [JsonProperty("FlowConnectorNames")]
+        public string FlowConnectorNames { get; set; }
+
+        /// <summary>Permission code: 3 = owner/read-write, 2 = run-only/read.</summary>
+        [JsonProperty("SharingPermission")]
+        public string SharingPermission { get; set; }
+
+        /// <summary>UPN of the recipient affected by a permission-change event.</summary>
+        [JsonProperty("RecipientUPN")]
+        public string RecipientUpn { get; set; }
+
+        /// <summary>Legacy connector shape retained for backward compatibility.</summary>
         [JsonProperty("ConnectionReferences")]
         public List<PowerPlatformConnectionRef> ConnectionReferences { get; set; }
 
-        /// <summary>Recipients on share / permission-grant events.</summary>
+        /// <summary>Legacy permission shape retained for backward compatibility.</summary>
         [JsonProperty("Permissions")]
         public List<PowerPlatformPermissionEntry> Permissions { get; set; }
+
+        /// <summary>
+        /// Maps the current documented Purview schema into the legacy fields consumed by the
+        /// existing staging pipeline.
+        /// </summary>
+        internal void NormaliseDocumentedFields()
+        {
+            if (string.IsNullOrEmpty(FlowId))
+            {
+                FlowId = GetDetailsUrlSegment("flows");
+            }
+
+            if (string.IsNullOrEmpty(EnvironmentName))
+            {
+                EnvironmentName = GetDetailsUrlSegment("environments");
+            }
+
+            if ((ConnectionReferences == null || ConnectionReferences.Count == 0)
+                && !string.IsNullOrWhiteSpace(FlowConnectorNames))
+            {
+                ConnectionReferences = new List<PowerPlatformConnectionRef>();
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var connectorName in FlowConnectorNames.Split(new[] { ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var trimmedName = connectorName.Trim();
+                    if (trimmedName.Length > 0 && seen.Add(trimmedName))
+                    {
+                        ConnectionReferences.Add(new PowerPlatformConnectionRef { ConnectorName = trimmedName });
+                    }
+                }
+            }
+
+            if ((Permissions == null || Permissions.Count == 0)
+                && !string.IsNullOrWhiteSpace(RecipientUpn))
+            {
+                Permissions = new List<PowerPlatformPermissionEntry>
+                {
+                    new PowerPlatformPermissionEntry
+                    {
+                        PrincipalName = RecipientUpn.Trim(),
+                        RoleName = NormaliseSharingPermission(SharingPermission),
+                    }
+                };
+            }
+        }
+
+        private string GetDetailsUrlSegment(string segmentName)
+        {
+            if (!Uri.TryCreate(FlowDetailsUrl, UriKind.Absolute, out var detailsUri))
+            {
+                return null;
+            }
+
+            var segments = detailsUri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                if (string.Equals(segments[i], segmentName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Uri.UnescapeDataString(segments[i + 1]);
+                }
+            }
+
+            return null;
+        }
+
+        private static string NormaliseSharingPermission(string permission)
+        {
+            switch (permission?.Trim())
+            {
+                case "3":
+                    return "Owner";
+                case "2":
+                    return "Run-only user";
+                default:
+                    return permission;
+            }
+        }
 
         public override async Task<bool> ProcessExtendedProperties(SaveSession saveBatch, CommonAuditEvent relatedAuditEvent, ILogger logger)
         {
@@ -173,18 +270,29 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
     }
 
     /// <summary>
-    /// Audit-log payload for the 'MicrosoftCopilotStudio' workload (bot created, published, message sent).
+    /// Audit-log payload for Copilot Studio authoring events (bot created, updated, published, or shared).
     /// </summary>
     public class CopilotStudioAuditLogContent : AbstractAuditLogContent
     {
         [JsonProperty("BotId")]
         public string BotId { get; set; }
 
+        /// <summary>
+        /// Legacy display-name field. The current published audit schema exposes
+        /// <see cref="BotSchemaName"/> rather than a friendly bot name.
+        /// </summary>
         [JsonProperty("BotName")]
         public string BotName { get; set; }
 
+        [JsonProperty("BotSchemaName")]
+        public string BotSchemaName { get; set; }
+
+        /// <summary>Legacy environment field retained for backward compatibility.</summary>
         [JsonProperty("EnvironmentName")]
         public string EnvironmentName { get; set; }
+
+        [JsonProperty("EnvironmentId")]
+        public string EnvironmentId { get; set; }
 
         public override async Task<bool> ProcessExtendedProperties(SaveSession saveBatch, CommonAuditEvent relatedAuditEvent, ILogger logger)
         {


### PR DESCRIPTION
Addresses #243

## Problem

Power Platform analytics tables stay **completely empty** — `power_automate_flows`, `power_automate_flow_connectors`, `event_meta_power_automate_flow`, `event_meta_power_automate_flow_share`, `event_meta_power_app_share`, `event_meta_copilot_studio` — while Power Apps launches and Power BI report views import perfectly.

That combination is a misleading symptom: the `Audit.General` subscription is healthy, the Power Platform workload toggle is on, and other Power Platform data flows, so the fault looks like a permissions or subscription problem when it is actually payload filtering and deserialisation.

Root causes, all verified against Microsoft's current published schemas:

- **Power Automate routing accepted only `FlowRunStarted`.** Purview publishes flow *lifecycle and permission* events, not individual flow runs, so every usable record was rejected at the dispatcher before it could reach staging.
- **Power Automate parsing read the wrong fields** — `FlowId`, `RunId`, `ConnectionReferences`, `Permissions` — where the documented schema publishes `FlowDetailsUrl`, `FlowConnectorNames`, `RecipientUPN`, `SharingPermission`.
- **Copilot Studio was routed by an undocumented workload string** and mapped `BotName`/`EnvironmentName` rather than the documented `BotId`/`BotSchemaName`.

## What changed

- `PowerPlatformAuditLogFilter` replaces the operation-name allow-list (`ShouldPersistPowerAutomateOperation`) with `ShouldPersistPowerAutomateRecord`, which normalises the documented fields and keeps any record that identifies a concrete flow. Rejections now log *why* (neither a `FlowId` nor a usable `FlowDetailsUrl`) instead of naming an operation.
- `PowerPlatformAuditLogContent` gains `NormaliseDocumentedFields()` to derive `FlowId` from `FlowDetailsUrl` and map `FlowConnectorNames`, `RecipientUPN` and `SharingPermission` onto the existing connector/share model.
- `AuditLogContentDispatcher` routes Copilot Studio records by the documented **record shape** (presence of a top-level `BotId`) rather than relying solely on an unpublished workload string. The legacy workload route is retained for records that identify the product that way.
- The Power Platform workload toggle now also suppresses `BotId`-shaped records, so turning the workload off still skips the whole workload's cost (no base `audit_events` row, no staging, no merges).
- Removed the now-dead `FlowRunOps` constants.

## Scope — what this does *not* do

`#243` lists more than the ingestion fix. This PR deliberately covers **only the audit-log ingestion/parsing half**:

- ❌ **Not** the Power Platform **Inventory API** work (full app/flow/agent/connector inventory) — that is #245.
- ❌ **Not** the "runtime flow executions from a supported source" item (Dataverse flow-run records or Application Insights). Purview is no longer claimed as a source of flow runs, but no replacement source is added here.

So **#243 stays open** after this merges.

## Database impact

**None.** The only SQL file touched is a one-line **comment** change in `insert_power_automate_events_from_staging_table.sql`. No migration, no table/column/index change, no `CONFIG_VERSION` bump.

## Admin action required

**None.** No configuration change and no upgrade step beyond the normal deployment. Deployments with the Power Platform import already enabled will simply start populating the affected tables on the next import cycle. Historic audit data is not backfilled — only events imported after the upgrade are parsed with the corrected mappings.

## Tests

- `PowerPlatformAuditEventManagerTests` expanded to cover the documented lifecycle, connector and permission field mappings.
- New `WorkloadToggleTests` covering the workload on/off behaviour, including the `BotId`-shaped Copilot Studio records.
- All test payloads are **synthetic** — no customer or tenant data.
