### PR TITLE
Add private Azure infrastructure for Telemetry Service

### DIFF
--- a/.azure/plan.md
+++ b/.azure/plan.md
@@ -1,0 +1,275 @@
+# Azure Deployment Plan
+
+> **Status:** Deployed
+
+Generated: 2026-08-13T15:24:00+02:00
+
+---
+
+## 1. Project Overview
+
+**Goal:** Deploy the Telemetry Service to a new, isolated Azure resource group and publish the ASP.NET Core/React application. Keep the public HTTPS receiver reachable by external analytics-engine installations while making Cosmos DB and secret storage private-only.
+
+**Path:** Add Azure infrastructure and deployment automation to the existing Telemetry Service.
+
+**Public-repository rule:** Real subscription, tenant, user, resource, URL, secret, and environment parameter values are confirmed and used only out-of-band. They must not be committed to this repository.
+
+---
+
+## 2. Requirements
+
+| Attribute | Value |
+|-----------|-------|
+| Classification | Proof of concept |
+| Scale | Small: fewer than 1,000 reporting installations |
+| Budget | Cost-optimized |
+| Subscription | Confirmed out-of-band; deliberately omitted from this public repository |
+| Tenant | Confirmed out-of-band; deliberately omitted from this public repository |
+| Location | West Europe |
+| Ingress | Public HTTPS App Service for signed uploads and Entra-authenticated dashboard access |
+| Endpoint compatibility | Preserve the exact App Service hostname embedded in the latest release; the real name is supplied out-of-band |
+| Data access | Cosmos DB and Key Vault public network access disabled |
+| Parameters | No environment-specific parameter file committed |
+| Dashboard access | Current deployer receives the initial `Telemetry.Dashboard.Read` assignment |
+| Compliance | West Europe residency; no additional CMK or firewall requirement |
+
+---
+
+## 3. Components Detected
+
+| Component | Type | Technology | Path |
+|-----------|------|------------|------|
+| Telemetry API | API | ASP.NET Core 10 | `src/TelemetryService/Web.Server/` |
+| Telemetry dashboard | Frontend | React 19, Vite, MSAL Browser | `src/TelemetryService/web.client/` |
+| Telemetry contracts/store adaptor | Library | .NET Standard 2.0, Cosmos DB SDK | `src/AnalyticsEngine/Common/UsageReporting/` |
+| Existing deployment | None | No TelemetryService deployment workflow or IaC | N/A |
+
+The service already:
+
+- validates signed anonymous uploads at `POST /api/Telemetry`;
+- requires Entra scope and role authorization for dashboard reads;
+- uses `DefaultAzureCredential` for Cosmos DB;
+- creates/verifies its Cosmos database and containers on startup.
+
+---
+
+## 4. Recipe Selection
+
+**Selected:** Direct Bicep/ARM deployment with an idempotent PowerShell orchestrator.
+
+**Rationale:**
+
+- The user explicitly requested ARM infrastructure in the repository.
+- Bicep is the maintainable source; a compiled `azuredeploy.json` ARM template will also be committed.
+- Azure CLI/PowerShell is required for the Microsoft Graph app registration, initial app-role assignment, secure runtime parameters, and ZIP application publication.
+- No AZD environment or environment parameter values will be committed.
+
+---
+
+## 5. Architecture
+
+**Stack:** Azure App Service
+
+### Service Mapping
+
+| Component | Azure Service | SKU / Configuration |
+|-----------|---------------|---------------------|
+| API + dashboard | Linux App Service | Basic B1, one instance, .NET 10, Always On |
+| Hosting plan | App Service plan | Linux Basic B1 |
+| Telemetry store | Azure Cosmos DB for NoSQL | Serverless, selected after the subscription rejected free tier |
+| Secret storage | Azure Key Vault | Standard, RBAC, purge protection, private-only access |
+| Network | Virtual Network | Dedicated App Service integration and private-endpoint subnets |
+| Private access | Private endpoints | Cosmos DB SQL endpoint and Key Vault vault endpoint |
+| Private DNS | Azure Private DNS | Cosmos DB and Key Vault private-link zones linked to the VNet |
+| Authentication | Microsoft Entra ID | Single-tenant SPA/API app, `Telemetry.Read` scope, `Telemetry.Dashboard.Read` role |
+| Monitoring | Application Insights | Workspace-based, low-volume POC configuration |
+| Logs | Log Analytics workspace | 30-day retention |
+
+### Identity and Access
+
+- Enable a system-assigned managed identity on the App Service.
+- Grant the identity Cosmos DB Built-in Data Contributor at the Cosmos account scope.
+- Grant the identity Key Vault Secrets User at the vault scope.
+- Disable Cosmos DB local/key authentication.
+- Configure the SPA/API app registration without a client secret.
+- Assign the current deployer to the dashboard-reader app role.
+- Keep `POST /api/Telemetry` anonymous at the Entra layer; its BCrypt payload signature remains mandatory.
+
+### Network Design
+
+- App Service public network access remains enabled because external importers must reach the receiver.
+- The App Service name is a required deployment parameter and must match the currently released telemetry hostname exactly.
+- Azure global name availability was confirmed during planning; it must be checked again immediately before deployment.
+- HTTPS-only, TLS 1.2+, FTPS disabled, HTTP/2 enabled.
+- App Service regional VNet integration routes outbound Cosmos and Key Vault traffic through the VNet.
+- Cosmos DB and Key Vault public network access are disabled.
+- Private endpoint network policies are disabled only on the dedicated private-endpoint subnet.
+- CIDRs and concrete resource names are deployment parameters supplied out-of-band.
+
+### Data Design
+
+- Cosmos API: NoSQL.
+- Consistency: Session.
+- Capacity mode: serverless, with no provisioned RU/s.
+- Containers: current and history.
+- Partition key: `/AnonClientId`.
+- Azure rejected free tier because it is unsupported for this internal subscription.
+- The user selected serverless Cosmos DB as the cost-optimized fallback.
+
+### Secret Handling
+
+- Generate or supply `TelemetrySecret` at deployment time only.
+- Pass it as a secure deployment parameter and store it as a Key Vault secret.
+- Configure App Service with a Key Vault reference.
+- Never print, commit, or place the secret in a repository parameter file.
+- Updating GitHub `STATSAPIURL` or `STATSAPISECRET` is outside this deployment unless separately approved.
+
+### Cost/Availability Trade-offs
+
+- B1 is the lowest App Service tier that supports the required VNet integration.
+- Serverless Cosmos minimizes idle data-store cost for this low-volume POC.
+- Private endpoints and the B1 plan still incur monthly charges.
+- This POC is single-region, single-instance, and has no zone redundancy or deployment slot.
+
+### Research Findings
+
+- Official App Service guidance confirms Basic B1 supports regional VNet integration.
+- Linux App Service must set `vnetRouteAllEnabled` for private Key Vault references.
+- Cosmos DB free tier is unavailable for serverless accounts.
+- The target internal subscription also rejects Cosmos free tier, so the approved fallback is serverless.
+- Cosmos DB NoSQL private endpoints use group ID `Sql` and private DNS zone `privatelink.documents.azure.com`.
+- Key Vault references use the App Service managed identity and the built-in Key Vault Secrets User role.
+- Cosmos data access uses the Cosmos DB Built-in Data Contributor data-plane role.
+- The Key Vault resource provider is not currently registered and must be registered before deployment.
+- The exact App Service hostname embedded in the latest release is currently globally available.
+
+---
+
+## 6. Execution Checklist
+
+### Phase 1: Planning
+
+- [x] Analyze workspace
+- [x] Gather requirements
+- [x] Confirm subscription and location with user
+- [x] Scan codebase
+- [x] Select recipe
+- [x] Plan architecture
+- [x] **User approved this plan**
+
+### Phase 2: Execution
+
+- [x] Research exact App Service, Cosmos DB, Key Vault, private endpoint, DNS, monitoring, and Graph resource APIs
+- [x] Update Bicep modules from free-tier provisioned throughput to serverless
+- [x] Recompile `azuredeploy.json`
+- [x] Update the deployment/publish script for serverless
+- [x] Add an anonymous liveness endpoint for App Service health checks
+- [x] Add ignore rules for local parameter/output/artifact files
+- [x] Build the application publication package
+- [x] Update plan status to `Ready for Validation`
+
+### Phase 3: Validation
+
+- [x] Reinvoke azure-validate after the serverless template change
+- [x] Revalidate Bicep and compiled ARM
+- [x] Rerun subscription-scope what-if with out-of-band parameters
+- [x] Rebuild and lint the Telemetry Service
+- [x] Reconfirm no secrets or real environment values are present in the diff
+- [x] Restore plan status to `Validated`
+- [x] Append updated validation proof below
+
+### Phase 4: Deployment
+
+- [x] Invoke azure-deploy skill
+- [x] Register any missing resource providers
+- [x] Reconfirm availability of the released App Service hostname
+- [x] Create/configure the Entra app and service principal
+- [x] Deploy the new resource group and Azure resources
+- [x] Assign the initial dashboard reader
+- [x] Publish the application package
+- [x] Verify public health/auth endpoints and private Cosmos/Key Vault network state
+- [x] Update plan status to `Deployed`
+
+---
+
+## 7. Validation Proof
+
+> **Required:** The azure-validate skill must populate this section before setting status to `Validated`.
+
+| Check | Command Run | Result | Timestamp |
+|-------|-------------|--------|-----------|
+| Bicep compilation | `az bicep build --file infra/TelemetryService/main.bicep` | Pass; no Bicep diagnostics | 2026-08-13T15:44:34+02:00 |
+| Compiled ARM parity | Rebuilt ARM to a temporary file and compared SHA-256 with `azuredeploy.json` | Pass; hashes match and JSON is valid | 2026-08-13T15:44:34+02:00 |
+| Subscription deployment validation | `az deployment sub validate ... --template-file azuredeploy.json --parameters @<temporary-parameters>` | Pass; provisioning state `Succeeded` | 2026-08-13T15:44:34+02:00 |
+| Subscription what-if | `deploy.ps1 ... -WhatIf` with out-of-band environment values | Pass; 28 creates, no policy or template errors | 2026-08-13T15:44:34+02:00 |
+| Application build | `dotnet build src/TelemetryService/TelemetryService.slnx --configuration Release --no-restore` | Pass; 0 warnings, 0 errors | 2026-08-13T15:44:34+02:00 |
+| Frontend lint and dependency audit | `npm run lint` and `npm audit` | Pass; 0 vulnerabilities | 2026-08-13T15:44:34+02:00 |
+| NuGet dependency audit | `dotnet list ... package --vulnerable --include-transitive` | Pass; no vulnerable packages | 2026-08-13T15:44:34+02:00 |
+| Deployment script syntax | PowerShell parser over `infra/TelemetryService/deploy.ps1` | Pass; no parser errors | 2026-08-13T15:44:34+02:00 |
+| Repository safety scan | Zero-context diff scan for real environment identifiers and secret assignments | Pass; 0 findings | 2026-08-13T15:44:34+02:00 |
+| Azure preflight | Provider, policy, free-tier, hostname, runtime, RBAC, and Entra app-creation checks | Pass | 2026-08-13T15:44:34+02:00 |
+| Serverless ARM validation | `az deployment sub validate ... --template-file azuredeploy.json --parameters @<temporary-parameters>` | Pass; provisioning state `Succeeded` | 2026-08-13T17:02:02+02:00 |
+| Serverless what-if | `deploy.ps1 ... -WhatIf` against the partial resource group | Pass; 13 creates, 15 convergent deployments, no policy errors | 2026-08-13T17:02:02+02:00 |
+| Serverless application build | `dotnet build ... --configuration Release --no-restore` | Pass; 0 warnings, 0 errors | 2026-08-13T17:02:02+02:00 |
+| Serverless frontend and repository checks | `npm run lint`, `npm audit`, PowerShell parse, `git diff --check`, environment-data scan | Pass; 0 vulnerabilities or findings | 2026-08-13T17:02:02+02:00 |
+
+**Validated by:** azure-validate skill
+
+**Validation timestamp:** 2026-08-13T17:02:02+02:00
+
+The original provisioned-throughput validation is retained for history; the later serverless validation is authoritative.
+
+---
+
+## Deployment Pause
+
+- The resource group and some supporting resources were created before the ARM deployment failed.
+- Cosmos DB was not created because free tier is unsupported for the target internal subscription.
+- The App Service plan was not created because West Europe temporarily reported no B1 Linux capacity.
+- The Entra application and service principal were created; automatic admin consent was unavailable.
+- No application package was published.
+- The user selected serverless Cosmos DB and requested a pause before retrying.
+- After resume, the serverless changes were revalidated and the deployment completed successfully.
+
+---
+
+## Deployment Result
+
+Deployment completed: 2026-08-13T17:21:46+02:00
+
+- The released App Service hostname was preserved.
+- The public health endpoint returns HTTP 200.
+- The public MSAL configuration endpoint returns HTTP 200.
+- The dashboard data endpoint returns HTTP 401 without an Entra token.
+- An invalid telemetry upload returns HTTP 400.
+- App Service is running on Linux B1 with HTTPS-only ingress and VNet integration.
+- Cosmos DB uses serverless capacity, public access is disabled, and local/key authentication is disabled.
+- One Cosmos database and two containers exist with a managed-identity data-role assignment.
+- Key Vault public access is disabled and the App Service secret reference is resolved.
+- Two private endpoints are approved.
+- The Entra application, service principal, required assignment policy, and current-user role assignment exist.
+- Tenant admin consent could not be granted automatically; the assigned user might receive a delegated-consent prompt on first dashboard sign-in.
+
+---
+
+## 8. Files to Generate
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `.azure/plan.md` | Deployment source of truth | Complete |
+| `infra/TelemetryService/main.bicep` | Subscription-scope entry point and resource-group creation | Complete |
+| `infra/TelemetryService/resources.bicep` | Resource-group infrastructure | Complete |
+| `infra/TelemetryService/azuredeploy.json` | Compiled ARM template | Complete |
+| `infra/TelemetryService/deploy.ps1` | Generic Entra, ARM, RBAC, build, publish, and verification orchestrator | Complete |
+| `src/TelemetryService/Web.Server/Program.cs` | Anonymous health endpoint | Complete |
+| `.gitignore` | Exclude environment parameters, deployment outputs, and publish artifacts | Complete |
+
+No environment-specific parameter file will be generated inside the repository.
+
+---
+
+## 9. Next Steps
+
+> Current: Deployed and verified.
+
+1. Persist the parameterized IaC and deployment automation through a pull request to `dev`.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ src/TelemetryService/web.client/.vscode/*
 # VSTest output (vstest.console.exe writes TRX logs + per-run subfolders here)
 **/TestResults/
 *.trx
+# Telemetry Service Azure deployment values and artifacts
+/.azure/*.parameters.json
+/infra/TelemetryService/*.parameters.json
+/infra/TelemetryService/.deploy/
+/artifacts/TelemetryService/

--- a/infra/TelemetryService/azuredeploy.json
+++ b/infra/TelemetryService/azuredeploy.json
@@ -1,0 +1,801 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.43.8.12551",
+      "templateHash": "7526898000566360666"
+    }
+  },
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 90,
+      "metadata": {
+        "description": "Name of the new resource group."
+      }
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure region for all regional resources."
+      }
+    },
+    "webAppName": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 60,
+      "metadata": {
+        "description": "Existing release-compatible App Service name. Supply this out-of-band."
+      }
+    },
+    "namePrefix": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 18,
+      "metadata": {
+        "description": "Short product prefix used for generated Azure resource names."
+      }
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address prefix for the dedicated virtual network."
+      }
+    },
+    "appIntegrationSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address prefix for the delegated App Service integration subnet."
+      }
+    },
+    "privateEndpointSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address prefix for the private endpoint subnet."
+      }
+    },
+    "azureAdClientId": {
+      "type": "string",
+      "metadata": {
+        "description": "Application (client) ID of the single-tenant Entra SPA/API registration."
+      }
+    },
+    "telemetrySecret": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Signed-upload shared secret. This value is stored in Key Vault."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Optional additional resource tags."
+      }
+    }
+  },
+  "variables": {
+    "defaultTags": {
+      "Workload": "Microsoft365AnalyticsTelemetry",
+      "ManagedBy": "Bicep"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2024-03-01",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('location')]",
+      "tags": "[union(variables('defaultTags'), parameters('tags'))]"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "telemetry-resources",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "webAppName": {
+            "value": "[parameters('webAppName')]"
+          },
+          "namePrefix": {
+            "value": "[parameters('namePrefix')]"
+          },
+          "vnetAddressPrefix": {
+            "value": "[parameters('vnetAddressPrefix')]"
+          },
+          "appIntegrationSubnetPrefix": {
+            "value": "[parameters('appIntegrationSubnetPrefix')]"
+          },
+          "privateEndpointSubnetPrefix": {
+            "value": "[parameters('privateEndpointSubnetPrefix')]"
+          },
+          "azureAdTenantId": {
+            "value": "[tenant().tenantId]"
+          },
+          "azureAdClientId": {
+            "value": "[parameters('azureAdClientId')]"
+          },
+          "telemetrySecret": {
+            "value": "[parameters('telemetrySecret')]"
+          },
+          "tags": {
+            "value": "[union(variables('defaultTags'), parameters('tags'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.43.8.12551",
+              "templateHash": "4033566444911330528"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string"
+            },
+            "webAppName": {
+              "type": "string"
+            },
+            "namePrefix": {
+              "type": "string"
+            },
+            "vnetAddressPrefix": {
+              "type": "string"
+            },
+            "appIntegrationSubnetPrefix": {
+              "type": "string"
+            },
+            "privateEndpointSubnetPrefix": {
+              "type": "string"
+            },
+            "azureAdTenantId": {
+              "type": "string"
+            },
+            "azureAdClientId": {
+              "type": "string"
+            },
+            "telemetrySecret": {
+              "type": "securestring"
+            },
+            "tags": {
+              "type": "object"
+            }
+          },
+          "variables": {
+            "suffix": "[take(uniqueString(subscription().id, resourceGroup().id), 6)]",
+            "compactPrefix": "[toLower(replace(parameters('namePrefix'), '-', ''))]",
+            "appServicePlanName": "[take(format('asp-{0}-{1}', parameters('namePrefix'), variables('suffix')), 40)]",
+            "vnetName": "[take(format('vnet-{0}-{1}', parameters('namePrefix'), variables('suffix')), 64)]",
+            "appIntegrationSubnetName": "snet-app-integration",
+            "privateEndpointSubnetName": "snet-private-endpoints",
+            "appIntegrationNsgName": "[take(format('nsg-{0}-app-{1}', parameters('namePrefix'), variables('suffix')), 80)]",
+            "cosmosAccountName": "[take(format('cosmos{0}{1}', variables('compactPrefix'), variables('suffix')), 44)]",
+            "cosmosDatabaseName": "Telemetry",
+            "currentContainerName": "Current",
+            "historyContainerName": "History",
+            "keyVaultName": "[take(format('kv{0}{1}', variables('compactPrefix'), variables('suffix')), 24)]",
+            "telemetrySecretName": "telemetry-upload-signing-key",
+            "logAnalyticsName": "[take(format('log-{0}-{1}', parameters('namePrefix'), variables('suffix')), 63)]",
+            "appInsightsName": "[take(format('appi-{0}-{1}', parameters('namePrefix'), variables('suffix')), 260)]",
+            "cosmosPrivateDnsZoneName": "privatelink.documents.azure.com",
+            "keyVaultPrivateDnsZoneName": "privatelink.vaultcore.azure.net",
+            "keyVaultSecretsUserRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+            "cosmosDataContributorRoleId": "00000000-0000-0000-0000-000000000002"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2024-05-01",
+              "name": "[variables('appIntegrationNsgName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "securityRules": []
+              }
+            },
+            {
+              "type": "Microsoft.Network/virtualNetworks",
+              "apiVersion": "2024-05-01",
+              "name": "[variables('vnetName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[parameters('vnetAddressPrefix')]"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Network/virtualNetworks/subnets",
+              "apiVersion": "2024-05-01",
+              "name": "[format('{0}/{1}', variables('vnetName'), variables('appIntegrationSubnetName'))]",
+              "properties": {
+                "addressPrefix": "[parameters('appIntegrationSubnetPrefix')]",
+                "networkSecurityGroup": {
+                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('appIntegrationNsgName'))]"
+                },
+                "delegations": [
+                  {
+                    "name": "app-service-delegation",
+                    "properties": {
+                      "serviceName": "Microsoft.Web/serverFarms"
+                    }
+                  }
+                ],
+                "privateEndpointNetworkPolicies": "Enabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('appIntegrationNsgName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/virtualNetworks/subnets",
+              "apiVersion": "2024-05-01",
+              "name": "[format('{0}/{1}', variables('vnetName'), variables('privateEndpointSubnetName'))]",
+              "properties": {
+                "addressPrefix": "[parameters('privateEndpointSubnetPrefix')]",
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.OperationalInsights/workspaces",
+              "apiVersion": "2023-09-01",
+              "name": "[variables('logAnalyticsName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "retentionInDays": 30,
+                "sku": {
+                  "name": "PerGB2018"
+                },
+                "features": {
+                  "enableLogAccessUsingOnlyResourcePermissions": true
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Insights/components",
+              "apiVersion": "2020-02-02",
+              "name": "[variables('appInsightsName')]",
+              "location": "[parameters('location')]",
+              "kind": "web",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "Application_Type": "web",
+                "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]",
+                "publicNetworkAccessForIngestion": "Enabled",
+                "publicNetworkAccessForQuery": "Enabled"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2023-07-01",
+              "name": "[variables('keyVaultName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "tenantId": "[parameters('azureAdTenantId')]",
+                "sku": {
+                  "family": "A",
+                  "name": "standard"
+                },
+                "enableRbacAuthorization": true,
+                "enablePurgeProtection": true,
+                "enableSoftDelete": true,
+                "softDeleteRetentionInDays": 7,
+                "publicNetworkAccess": "Disabled",
+                "networkAcls": {
+                  "bypass": "None",
+                  "defaultAction": "Deny"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', variables('keyVaultName'), variables('telemetrySecretName'))]",
+              "properties": {
+                "value": "[parameters('telemetrySecret')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts",
+              "apiVersion": "2024-11-15",
+              "name": "[variables('cosmosAccountName')]",
+              "location": "[parameters('location')]",
+              "kind": "GlobalDocumentDB",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "databaseAccountOfferType": "Standard",
+                "consistencyPolicy": {
+                  "defaultConsistencyLevel": "Session"
+                },
+                "locations": [
+                  {
+                    "locationName": "[parameters('location')]",
+                    "failoverPriority": 0,
+                    "isZoneRedundant": false
+                  }
+                ],
+                "capabilities": [
+                  {
+                    "name": "EnableServerless"
+                  }
+                ],
+                "enableFreeTier": false,
+                "enableAutomaticFailover": false,
+                "enableMultipleWriteLocations": false,
+                "publicNetworkAccess": "Disabled",
+                "disableLocalAuth": true,
+                "disableKeyBasedMetadataWriteAccess": true,
+                "minimalTlsVersion": "Tls12",
+                "networkAclBypass": "None",
+                "networkAclBypassResourceIds": [],
+                "isVirtualNetworkFilterEnabled": false,
+                "virtualNetworkRules": [],
+                "ipRules": []
+              }
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+              "apiVersion": "2024-11-15",
+              "name": "[format('{0}/{1}', variables('cosmosAccountName'), variables('cosmosDatabaseName'))]",
+              "properties": {
+                "resource": {
+                  "id": "[variables('cosmosDatabaseName')]"
+                },
+                "options": {}
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+              "apiVersion": "2024-11-15",
+              "name": "[format('{0}/{1}/{2}', variables('cosmosAccountName'), variables('cosmosDatabaseName'), variables('currentContainerName'))]",
+              "properties": {
+                "resource": {
+                  "id": "[variables('currentContainerName')]",
+                  "partitionKey": {
+                    "paths": [
+                      "/AnonClientId"
+                    ],
+                    "kind": "Hash",
+                    "version": 2
+                  },
+                  "indexingPolicy": {
+                    "indexingMode": "consistent",
+                    "automatic": true,
+                    "includedPaths": [
+                      {
+                        "path": "/*"
+                      }
+                    ],
+                    "excludedPaths": [
+                      {
+                        "path": "/\"_etag\"/?"
+                      }
+                    ]
+                  }
+                },
+                "options": {}
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('cosmosAccountName'), variables('cosmosDatabaseName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+              "apiVersion": "2024-11-15",
+              "name": "[format('{0}/{1}/{2}', variables('cosmosAccountName'), variables('cosmosDatabaseName'), variables('historyContainerName'))]",
+              "properties": {
+                "resource": {
+                  "id": "[variables('historyContainerName')]",
+                  "partitionKey": {
+                    "paths": [
+                      "/AnonClientId"
+                    ],
+                    "kind": "Hash",
+                    "version": 2
+                  },
+                  "indexingPolicy": {
+                    "indexingMode": "consistent",
+                    "automatic": true,
+                    "includedPaths": [
+                      {
+                        "path": "/*"
+                      }
+                    ],
+                    "excludedPaths": [
+                      {
+                        "path": "/\"_etag\"/?"
+                      }
+                    ]
+                  }
+                },
+                "options": {}
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('cosmosAccountName'), variables('cosmosDatabaseName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2024-06-01",
+              "name": "[variables('cosmosPrivateDnsZoneName')]",
+              "location": "global",
+              "tags": "[parameters('tags')]"
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2024-06-01",
+              "name": "[format('{0}/{1}', variables('cosmosPrivateDnsZoneName'), 'cosmos-vnet-link')]",
+              "location": "global",
+              "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('cosmosPrivateDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2024-05-01",
+              "name": "[format('pep-{0}', variables('cosmosAccountName'))]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "subnet": {
+                  "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('privateEndpointSubnetName'))]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "cosmos-sql",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]",
+                      "groupIds": [
+                        "Sql"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('privateEndpointSubnetName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+              "apiVersion": "2024-05-01",
+              "name": "[format('{0}/{1}', format('pep-{0}', variables('cosmosAccountName')), 'default')]",
+              "properties": {
+                "privateDnsZoneConfigs": [
+                  {
+                    "name": "cosmos",
+                    "properties": {
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('cosmosPrivateDnsZoneName'))]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('cosmosPrivateDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/privateEndpoints', format('pep-{0}', variables('cosmosAccountName')))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2024-06-01",
+              "name": "[variables('keyVaultPrivateDnsZoneName')]",
+              "location": "global",
+              "tags": "[parameters('tags')]"
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2024-06-01",
+              "name": "[format('{0}/{1}', variables('keyVaultPrivateDnsZoneName'), 'key-vault-vnet-link')]",
+              "location": "global",
+              "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('keyVaultPrivateDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2024-05-01",
+              "name": "[format('pep-{0}', variables('keyVaultName'))]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "subnet": {
+                  "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('privateEndpointSubnetName'))]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "key-vault",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                      "groupIds": [
+                        "vault"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('privateEndpointSubnetName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+              "apiVersion": "2024-05-01",
+              "name": "[format('{0}/{1}', format('pep-{0}', variables('keyVaultName')), 'default')]",
+              "properties": {
+                "privateDnsZoneConfigs": [
+                  {
+                    "name": "key-vault",
+                    "properties": {
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('keyVaultPrivateDnsZoneName'))]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('keyVaultPrivateDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/privateEndpoints', format('pep-{0}', variables('keyVaultName')))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Web/serverfarms",
+              "apiVersion": "2024-04-01",
+              "name": "[variables('appServicePlanName')]",
+              "location": "[parameters('location')]",
+              "kind": "linux",
+              "tags": "[parameters('tags')]",
+              "sku": {
+                "name": "B1",
+                "tier": "Basic",
+                "capacity": 1
+              },
+              "properties": {
+                "reserved": true,
+                "zoneRedundant": false
+              }
+            },
+            {
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2024-04-01",
+              "name": "[parameters('webAppName')]",
+              "location": "[parameters('location')]",
+              "kind": "app,linux",
+              "tags": "[parameters('tags')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
+                "httpsOnly": true,
+                "publicNetworkAccess": "Enabled",
+                "clientAffinityEnabled": false,
+                "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('appIntegrationSubnetName'))]",
+                "vnetRouteAllEnabled": true,
+                "siteConfig": {
+                  "linuxFxVersion": "DOTNETCORE|10.0",
+                  "alwaysOn": true,
+                  "ftpsState": "Disabled",
+                  "minTlsVersion": "1.2",
+                  "scmMinTlsVersion": "1.2",
+                  "http20Enabled": true,
+                  "healthCheckPath": "/health",
+                  "remoteDebuggingEnabled": false,
+                  "webSocketsEnabled": false
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('appIntegrationSubnetName'))]",
+                "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+              "apiVersion": "2024-04-01",
+              "name": "[format('{0}/{1}', parameters('webAppName'), 'ftp')]",
+              "properties": {
+                "allow": false
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('webAppName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+              "apiVersion": "2024-04-01",
+              "name": "[format('{0}/{1}', parameters('webAppName'), 'scm')]",
+              "properties": {
+                "allow": false
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('webAppName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+              "name": "[guid(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), resourceId('Microsoft.Web/sites', parameters('webAppName')), variables('keyVaultSecretsUserRoleDefinitionId'))]",
+              "properties": {
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('webAppName')), '2024-04-01', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('keyVaultSecretsUserRoleDefinitionId')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                "[resourceId('Microsoft.Web/sites', parameters('webAppName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+              "apiVersion": "2024-11-15",
+              "name": "[format('{0}/{1}', variables('cosmosAccountName'), guid(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), resourceId('Microsoft.Web/sites', parameters('webAppName')), variables('cosmosDataContributorRoleId')))]",
+              "properties": {
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('webAppName')), '2024-04-01', 'full').identity.principalId]",
+                "roleDefinitionId": "[format('{0}/sqlRoleDefinitions/{1}', resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), variables('cosmosDataContributorRoleId'))]",
+                "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]",
+                "[resourceId('Microsoft.Web/sites', parameters('webAppName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Web/sites/config",
+              "apiVersion": "2024-04-01",
+              "name": "[format('{0}/{1}', parameters('webAppName'), 'appsettings')]",
+              "properties": {
+                "ASPNETCORE_ENVIRONMENT": "Production",
+                "WEBSITE_RUN_FROM_PACKAGE": "1",
+                "WEBSITE_VNET_ROUTE_ALL": "1",
+                "WEBSITE_HEALTHCHECK_MAXPINGFAILURES": "5",
+                "SCM_DO_BUILD_DURING_DEPLOYMENT": "false",
+                "ENABLE_ORYX_BUILD": "false",
+                "TelemetrySecret": "[format('@Microsoft.KeyVault(VaultName={0};SecretName={1})', variables('keyVaultName'), variables('telemetrySecretName'))]",
+                "CosmosDb__AccountEndpoint": "[reference(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), '2024-11-15').documentEndpoint]",
+                "CosmosDb__DatabaseName": "[variables('cosmosDatabaseName')]",
+                "CosmosDb__ContainerNameCurrent": "[variables('currentContainerName')]",
+                "CosmosDb__ContainerNameHistory": "[variables('historyContainerName')]",
+                "AzureAd__Instance": "[environment().authentication.loginEndpoint]",
+                "AzureAd__TenantId": "[parameters('azureAdTenantId')]",
+                "AzureAd__ClientId": "[parameters('azureAdClientId')]",
+                "AzureAd__Scopes": "Telemetry.Read",
+                "AZURE_TENANT_ID": "[parameters('azureAdTenantId')]",
+                "DashboardCacheSeconds": "60",
+                "MaxDashboardItems": "5000",
+                "APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(resourceId('Microsoft.Insights/components', variables('appInsightsName')), '2020-02-02').ConnectionString]",
+                "ApplicationInsightsAgent_EXTENSION_VERSION": "~3"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Insights/components', variables('appInsightsName'))]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments', variables('cosmosAccountName'), guid(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), resourceId('Microsoft.Web/sites', parameters('webAppName')), variables('cosmosDataContributorRoleId')))]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', format('pep-{0}', variables('cosmosAccountName')), 'default')]",
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', format('pep-{0}', variables('keyVaultName')), 'default')]",
+                "[extensionResourceId(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), resourceId('Microsoft.Web/sites', parameters('webAppName')), variables('keyVaultSecretsUserRoleDefinitionId')))]",
+                "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), variables('telemetrySecretName'))]",
+                "[resourceId('Microsoft.Web/sites', parameters('webAppName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "webAppName": {
+              "type": "string",
+              "value": "[parameters('webAppName')]"
+            },
+            "webAppUrl": {
+              "type": "string",
+              "value": "[format('https://{0}', reference(resourceId('Microsoft.Web/sites', parameters('webAppName')), '2024-04-01').defaultHostName)]"
+            },
+            "statsApiUrl": {
+              "type": "string",
+              "value": "[format('https://{0}/api/Telemetry', reference(resourceId('Microsoft.Web/sites', parameters('webAppName')), '2024-04-01').defaultHostName)]"
+            },
+            "authConfigUrl": {
+              "type": "string",
+              "value": "[format('https://{0}/api/auth/config', reference(resourceId('Microsoft.Web/sites', parameters('webAppName')), '2024-04-01').defaultHostName)]"
+            },
+            "cosmosAccountName": {
+              "type": "string",
+              "value": "[variables('cosmosAccountName')]"
+            },
+            "keyVaultName": {
+              "type": "string",
+              "value": "[variables('keyVaultName')]"
+            },
+            "appServicePrincipalId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Web/sites', parameters('webAppName')), '2024-04-01', 'full').identity.principalId]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[parameters('resourceGroupName')]"
+    },
+    "webAppName": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.webAppName.value]"
+    },
+    "webAppUrl": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.webAppUrl.value]"
+    },
+    "statsApiUrl": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.statsApiUrl.value]"
+    },
+    "authConfigUrl": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.authConfigUrl.value]"
+    },
+    "cosmosAccountName": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.cosmosAccountName.value]"
+    },
+    "keyVaultName": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.keyVaultName.value]"
+    },
+    "appServicePrincipalId": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.appServicePrincipalId.value]"
+    }
+  }
+}

--- a/infra/TelemetryService/deploy.ps1
+++ b/infra/TelemetryService/deploy.ps1
@@ -1,0 +1,610 @@
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $SubscriptionId,
+
+    [Parameter(Mandatory)]
+    [string] $Tenant,
+
+    [Parameter(Mandatory)]
+    [string] $Location,
+
+    [Parameter(Mandatory)]
+    [string] $ResourceGroupName,
+
+    [Parameter(Mandatory)]
+    [string] $WebAppName,
+
+    [Parameter(Mandatory)]
+    [string] $NamePrefix,
+
+    [Parameter(Mandatory)]
+    [string] $VnetAddressPrefix,
+
+    [Parameter(Mandatory)]
+    [string] $AppIntegrationSubnetPrefix,
+
+    [Parameter(Mandatory)]
+    [string] $PrivateEndpointSubnetPrefix,
+
+    [string] $EnvironmentName = 'poc',
+
+    [string] $EntraAppDisplayName = 'Microsoft 365 Analytics Telemetry Dashboard',
+
+    [string] $TelemetrySecretEnvironmentVariableName = 'TELEMETRY_SERVICE_SECRET',
+
+    [string] $AzureAdClientId,
+
+    [switch] $SkipApplicationPublish,
+
+    [switch] $WhatIf
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:ScopeName = 'Telemetry.Read'
+$script:RoleName = 'Telemetry.Dashboard.Read'
+
+function Invoke-AzCli {
+    param(
+        [Parameter(Mandatory)]
+        [string[]] $Arguments,
+
+        [switch] $AsJson
+    )
+
+    $allArguments = @($Arguments) + @('--only-show-errors')
+    $errorFile = Join-Path ([IO.Path]::GetTempPath()) "telemetry-az-$([guid]::NewGuid().ToString('N')).log"
+    try {
+        $output = & az @allArguments 2> $errorFile
+        if ($LASTEXITCODE -ne 0) {
+            $errorText = if (Test-Path -LiteralPath $errorFile) {
+                Get-Content -LiteralPath $errorFile -Raw
+            }
+            else {
+                ''
+            }
+            throw "Azure CLI failed: az $($Arguments -join ' ')`n$errorText"
+        }
+
+        $text = $output -join [Environment]::NewLine
+        if ($AsJson) {
+            if ([string]::IsNullOrWhiteSpace($text)) {
+                return $null
+            }
+            return $text | ConvertFrom-Json
+        }
+
+        return $text.Trim()
+    }
+    finally {
+        if (Test-Path -LiteralPath $errorFile) {
+            Remove-Item -LiteralPath $errorFile -Force
+        }
+    }
+}
+
+function Invoke-AzRestJson {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('get', 'post', 'patch', 'put', 'delete')]
+        [string] $Method,
+
+        [Parameter(Mandatory)]
+        [string] $Uri,
+
+        [object] $Body
+    )
+
+    $arguments = @('rest', '--method', $Method, '--url', $Uri, '--output', 'json')
+    $bodyFile = $null
+    try {
+        if ($null -ne $Body) {
+            $bodyFile = Join-Path ([IO.Path]::GetTempPath()) "telemetry-rest-$([guid]::NewGuid().ToString('N')).json"
+            $Body | ConvertTo-Json -Depth 30 | Set-Content -LiteralPath $bodyFile -Encoding utf8NoBOM
+            $arguments += @('--headers', 'Content-Type=application/json', '--body', "@$bodyFile")
+        }
+
+        return Invoke-AzCli -Arguments $arguments -AsJson
+    }
+    finally {
+        if ($bodyFile -and (Test-Path -LiteralPath $bodyFile)) {
+            Remove-Item -LiteralPath $bodyFile -Force
+        }
+    }
+}
+
+function Assert-AzureContext {
+    $account = Invoke-AzCli -Arguments @(
+        'account', 'show',
+        '--subscription', $SubscriptionId,
+        '--output', 'json'
+    ) -AsJson
+
+    $tokenTenant = Invoke-AzCli -Arguments @(
+        'account', 'get-access-token',
+        '--tenant', $Tenant,
+        '--scope', 'https://management.azure.com/.default',
+        '--query', 'tenant',
+        '--output', 'tsv'
+    )
+    if ([string]::IsNullOrWhiteSpace($tokenTenant)) {
+        throw "Azure CLI could not acquire a management token for tenant '$Tenant'."
+    }
+
+    if ($Tenant -match '^[0-9a-fA-F-]{36}$' -and $account.tenantId -ne $Tenant) {
+        throw "Subscription '$SubscriptionId' belongs to a different tenant."
+    }
+
+    Invoke-AzCli -Arguments @('account', 'set', '--subscription', $SubscriptionId) | Out-Null
+}
+
+function Register-ResourceProviders {
+    $providers = @(
+        'Microsoft.DocumentDB',
+        'Microsoft.Insights',
+        'Microsoft.KeyVault',
+        'Microsoft.Network',
+        'Microsoft.OperationalInsights',
+        'Microsoft.Web'
+    )
+
+    foreach ($provider in $providers) {
+        $state = Invoke-AzCli -Arguments @(
+            'provider', 'show',
+            '--namespace', $provider,
+            '--query', 'registrationState',
+            '--output', 'tsv'
+        )
+        if ($state -ne 'Registered') {
+            Write-Host "Registering resource provider $provider..."
+            Invoke-AzCli -Arguments @('provider', 'register', '--namespace', $provider, '--wait') | Out-Null
+        }
+    }
+}
+
+function Assert-WebAppNameAvailable {
+    $existingApps = @(Invoke-AzCli -Arguments @(
+        'webapp', 'list',
+        '--subscription', $SubscriptionId,
+        '--query', "[?name=='$WebAppName'].{name:name,resourceGroup:resourceGroup}",
+        '--output', 'json'
+    ) -AsJson)
+
+    if ($existingApps.Count -gt 0) {
+        $matchingApp = $existingApps | Where-Object { $_.resourceGroup -eq $ResourceGroupName }
+        if (-not $matchingApp) {
+            throw "App Service name '$WebAppName' is already used in a different accessible resource group."
+        }
+        return
+    }
+
+    $availability = Invoke-AzRestJson -Method post `
+        -Uri "https://management.azure.com/subscriptions/$SubscriptionId/providers/Microsoft.Web/checknameavailability?api-version=2024-04-01" `
+        -Body @{
+            name = $WebAppName
+            type = 'Microsoft.Web/sites'
+            isFqdn = $false
+        }
+
+    if (-not $availability.nameAvailable) {
+        throw "App Service name '$WebAppName' is unavailable: $($availability.message)"
+    }
+}
+
+function Get-OrCreateEntraApplication {
+    param(
+        [Parameter(Mandatory)]
+        [string] $RedirectUri
+    )
+
+    $applications = @(Invoke-AzCli -Arguments @(
+        'ad', 'app', 'list',
+        '--display-name', $EntraAppDisplayName,
+        '--output', 'json'
+    ) -AsJson | Where-Object { $_.displayName -eq $EntraAppDisplayName })
+
+    if ($applications.Count -gt 1) {
+        throw "More than one Entra application has display name '$EntraAppDisplayName'."
+    }
+
+    if ($applications.Count -eq 0) {
+        Write-Host 'Creating the single-tenant Entra SPA/API registration...'
+        $application = Invoke-AzCli -Arguments @(
+            'ad', 'app', 'create',
+            '--display-name', $EntraAppDisplayName,
+            '--sign-in-audience', 'AzureADMyOrg',
+            '--output', 'json'
+        ) -AsJson
+    }
+    else {
+        $application = $applications[0]
+    }
+
+    $applicationObject = Invoke-AzRestJson -Method get `
+        -Uri "https://graph.microsoft.com/v1.0/applications/$($application.id)"
+
+    $scope = @($applicationObject.api.oauth2PermissionScopes) |
+        Where-Object { $_.value -eq $script:ScopeName } |
+        Select-Object -First 1
+    $scopeId = if ($scope) { $scope.id } else { [guid]::NewGuid().ToString() }
+
+    $role = @($applicationObject.appRoles) |
+        Where-Object { $_.value -eq $script:RoleName } |
+        Select-Object -First 1
+    $roleId = if ($role) { $role.id } else { [guid]::NewGuid().ToString() }
+
+    $otherScopes = @($applicationObject.api.oauth2PermissionScopes) |
+        Where-Object { $_.value -ne $script:ScopeName }
+    $otherRoles = @($applicationObject.appRoles) |
+        Where-Object { $_.value -ne $script:RoleName }
+    $otherRequiredAccess = @($applicationObject.requiredResourceAccess) |
+        Where-Object { $_.resourceAppId -ne $application.appId }
+
+    $scopeDefinition = @{
+        id = $scopeId
+        value = $script:ScopeName
+        type = 'User'
+        isEnabled = $true
+        adminConsentDisplayName = 'Read telemetry dashboard data'
+        adminConsentDescription = 'Allows assigned users to read the Microsoft 365 Analytics telemetry dashboard.'
+        userConsentDisplayName = 'Read telemetry dashboard data'
+        userConsentDescription = 'Allows you to read the Microsoft 365 Analytics telemetry dashboard.'
+    }
+    $roleDefinition = @{
+        id = $roleId
+        value = $script:RoleName
+        displayName = 'Telemetry dashboard reader'
+        description = 'Can view aggregate telemetry dashboard data.'
+        allowedMemberTypes = @('User')
+        isEnabled = $true
+    }
+
+    Invoke-AzRestJson -Method patch `
+        -Uri "https://graph.microsoft.com/v1.0/applications/$($application.id)" `
+        -Body @{
+            identifierUris = @("api://$($application.appId)")
+            spa = @{
+                redirectUris = @($RedirectUri)
+            }
+            api = @{
+                requestedAccessTokenVersion = 2
+                oauth2PermissionScopes = @($otherScopes) + @($scopeDefinition)
+            }
+            appRoles = @($otherRoles) + @($roleDefinition)
+            requiredResourceAccess = @($otherRequiredAccess) + @(
+                @{
+                    resourceAppId = $application.appId
+                    resourceAccess = @(
+                        @{
+                            id = $scopeId
+                            type = 'Scope'
+                        }
+                    )
+                }
+            )
+        } | Out-Null
+
+    $servicePrincipals = @(Invoke-AzCli -Arguments @(
+        'ad', 'sp', 'list',
+        '--filter', "appId eq '$($application.appId)'",
+        '--output', 'json'
+    ) -AsJson)
+
+    if ($servicePrincipals.Count -eq 0) {
+        $servicePrincipal = Invoke-AzCli -Arguments @(
+            'ad', 'sp', 'create',
+            '--id', $application.appId,
+            '--output', 'json'
+        ) -AsJson
+    }
+    else {
+        $servicePrincipal = $servicePrincipals[0]
+    }
+
+    Invoke-AzRestJson -Method patch `
+        -Uri "https://graph.microsoft.com/v1.0/servicePrincipals/$($servicePrincipal.id)" `
+        -Body @{
+            appRoleAssignmentRequired = $true
+        } | Out-Null
+
+    return [pscustomobject]@{
+        AppId = $application.appId
+        ApplicationObjectId = $application.id
+        ServicePrincipalId = $servicePrincipal.id
+        ScopeId = $scopeId
+        RoleId = $roleId
+    }
+}
+
+function Grant-CurrentUserDashboardAccess {
+    param(
+        [Parameter(Mandatory)]
+        [pscustomobject] $EntraApplication
+    )
+
+    $user = Invoke-AzCli -Arguments @('ad', 'signed-in-user', 'show', '--output', 'json') -AsJson
+    $assignmentResponse = Invoke-AzRestJson -Method get `
+        -Uri "https://graph.microsoft.com/v1.0/users/$($user.id)/appRoleAssignments"
+    $assignments = if ($assignmentResponse.PSObject.Properties.Name -contains 'value') {
+        @($assignmentResponse.value)
+    }
+    else {
+        @($assignmentResponse)
+    }
+
+    $existingAssignment = $assignments | Where-Object {
+        $_.PSObject.Properties.Name -contains 'resourceId' -and
+        $_.PSObject.Properties.Name -contains 'appRoleId' -and
+        $_.resourceId -eq $EntraApplication.ServicePrincipalId -and
+        $_.appRoleId -eq $EntraApplication.RoleId
+    }
+
+    if (-not $existingAssignment) {
+        Invoke-AzRestJson -Method post `
+            -Uri "https://graph.microsoft.com/v1.0/users/$($user.id)/appRoleAssignments" `
+            -Body @{
+                principalId = $user.id
+                resourceId = $EntraApplication.ServicePrincipalId
+                appRoleId = $EntraApplication.RoleId
+            } | Out-Null
+    }
+
+    try {
+        Invoke-AzCli -Arguments @(
+            'ad', 'app', 'permission', 'admin-consent',
+            '--id', $EntraApplication.AppId
+        ) | Out-Null
+    }
+    catch {
+        Write-Warning 'Admin consent could not be granted automatically. The assigned user might be prompted for delegated consent on first sign-in.'
+    }
+}
+
+function New-DeploymentParameterFile {
+    param(
+        [Parameter(Mandatory)]
+        [string] $TelemetrySecret,
+
+        [Parameter(Mandatory)]
+        [string] $ClientId
+    )
+
+    $parameterFile = Join-Path ([IO.Path]::GetTempPath()) "telemetry-parameters-$([guid]::NewGuid().ToString('N')).json"
+    @{
+        '$schema' = 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
+        contentVersion = '1.0.0.0'
+        parameters = @{
+            resourceGroupName = @{ value = $ResourceGroupName }
+            location = @{ value = $Location }
+            webAppName = @{ value = $WebAppName }
+            namePrefix = @{ value = $NamePrefix }
+            vnetAddressPrefix = @{ value = $VnetAddressPrefix }
+            appIntegrationSubnetPrefix = @{ value = $AppIntegrationSubnetPrefix }
+            privateEndpointSubnetPrefix = @{ value = $PrivateEndpointSubnetPrefix }
+            azureAdClientId = @{ value = $ClientId }
+            telemetrySecret = @{ value = $TelemetrySecret }
+            tags = @{
+                value = @{
+                    Environment = $EnvironmentName
+                }
+            }
+        }
+    } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $parameterFile -Encoding utf8NoBOM
+
+    return $parameterFile
+}
+
+function Publish-TelemetryApplication {
+    param(
+        [Parameter(Mandatory)]
+        [string] $WebAppResourceId
+    )
+
+    $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    $artifactRoot = Join-Path $repositoryRoot 'artifacts\TelemetryService'
+    $publishDirectory = Join-Path $artifactRoot 'publish'
+    $zipPath = Join-Path $artifactRoot 'TelemetryService.zip'
+
+    if (Test-Path -LiteralPath $artifactRoot) {
+        Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $publishDirectory -Force | Out-Null
+
+    dotnet publish (Join-Path $repositoryRoot 'src\TelemetryService\Web.Server\Web.Server.csproj') `
+        --configuration Release `
+        --output $publishDirectory
+    if ($LASTEXITCODE -ne 0) {
+        throw 'dotnet publish failed.'
+    }
+
+    Compress-Archive -Path (Join-Path $publishDirectory '*') -DestinationPath $zipPath -Force
+
+    Invoke-AzCli -Arguments @(
+        'webapp', 'deploy',
+        '--resource-group', $ResourceGroupName,
+        '--name', $WebAppName,
+        '--src-path', $zipPath,
+        '--type', 'zip',
+        '--clean', 'true',
+        '--restart', 'true',
+        '--async', 'false'
+    ) | Out-Null
+
+    Invoke-AzRestJson -Method post `
+        -Uri "https://management.azure.com$WebAppResourceId/config/configreferences/appsettings/refresh?api-version=2022-03-01" | Out-Null
+}
+
+function Test-TelemetryDeployment {
+    param(
+        [Parameter(Mandatory)]
+        [pscustomobject] $Outputs
+    )
+
+    $healthUrl = "$($Outputs.webAppUrl.value)/health"
+    $healthSucceeded = $false
+    for ($attempt = 1; $attempt -le 30; $attempt++) {
+        try {
+            $health = Invoke-WebRequest -Uri $healthUrl -TimeoutSec 20 -SkipHttpErrorCheck
+            if ($health.StatusCode -eq 200) {
+                $healthSucceeded = $true
+                break
+            }
+        }
+        catch {
+            # App Service can take several minutes to restart after ZIP deployment and role propagation.
+        }
+        Start-Sleep -Seconds 10
+    }
+    if (-not $healthSucceeded) {
+        throw "Health endpoint did not become ready: $healthUrl"
+    }
+
+    $authConfig = Invoke-WebRequest -Uri $Outputs.authConfigUrl.value -TimeoutSec 20 -SkipHttpErrorCheck
+    if ($authConfig.StatusCode -ne 200) {
+        throw "Authentication configuration endpoint returned HTTP $($authConfig.StatusCode)."
+    }
+
+    $protectedEndpoint = Invoke-WebRequest `
+        -Uri "$($Outputs.webAppUrl.value)/api/Telemetry/stats" `
+        -TimeoutSec 20 `
+        -SkipHttpErrorCheck
+    if ($protectedEndpoint.StatusCode -ne 401) {
+        throw "Protected dashboard endpoint returned HTTP $($protectedEndpoint.StatusCode) without a token; expected 401."
+    }
+
+    $cosmosPublicAccess = Invoke-AzCli -Arguments @(
+        'cosmosdb', 'show',
+        '--resource-group', $ResourceGroupName,
+        '--name', $Outputs.cosmosAccountName.value,
+        '--query', 'publicNetworkAccess',
+        '--output', 'tsv'
+    )
+    if ($cosmosPublicAccess -ne 'Disabled') {
+        throw 'Cosmos DB public network access is not disabled.'
+    }
+
+    $keyVaultPublicAccess = Invoke-AzCli -Arguments @(
+        'keyvault', 'show',
+        '--resource-group', $ResourceGroupName,
+        '--name', $Outputs.keyVaultName.value,
+        '--query', 'properties.publicNetworkAccess',
+        '--output', 'tsv'
+    )
+    if ($keyVaultPublicAccess -ne 'Disabled') {
+        throw 'Key Vault public network access is not disabled.'
+    }
+
+    $webAppResourceId = Invoke-AzCli -Arguments @(
+        'webapp', 'show',
+        '--resource-group', $ResourceGroupName,
+        '--name', $WebAppName,
+        '--query', 'id',
+        '--output', 'tsv'
+    )
+    $configReferences = Invoke-AzRestJson -Method get `
+        -Uri "https://management.azure.com$webAppResourceId/config/configreferences/appsettings?api-version=2026-07-15"
+    $telemetrySecretReference = @($configReferences.value) |
+        Where-Object { $_.name -eq 'TelemetrySecret' -or $_.id -match '/TelemetrySecret$' } |
+        Select-Object -First 1
+    $referenceStatus = if ($telemetrySecretReference.properties.status -is [string]) {
+        $telemetrySecretReference.properties.status
+    }
+    else {
+        $telemetrySecretReference.properties.status.name
+    }
+    if ($referenceStatus -ne 'Resolved') {
+        throw "TelemetrySecret Key Vault reference status is '$referenceStatus'; expected 'Resolved'."
+    }
+
+    $privateEndpoints = @(Invoke-AzCli -Arguments @(
+        'network', 'private-endpoint', 'list',
+        '--resource-group', $ResourceGroupName,
+        '--output', 'json'
+    ) -AsJson)
+    $privateEndpointCount = $privateEndpoints.Count
+    if ($privateEndpointCount -lt 2) {
+        throw "Expected at least two private endpoints; found $privateEndpointCount."
+    }
+}
+
+Assert-AzureContext
+Register-ResourceProviders
+Assert-WebAppNameAvailable
+
+$redirectUri = "https://$WebAppName.azurewebsites.net"
+
+if ($WhatIf) {
+    $clientId = if ($AzureAdClientId) { $AzureAdClientId } else { '00000000-0000-0000-0000-000000000000' }
+}
+else {
+    $entraApplication = Get-OrCreateEntraApplication -RedirectUri $redirectUri
+    Grant-CurrentUserDashboardAccess -EntraApplication $entraApplication
+    $clientId = $entraApplication.AppId
+}
+
+$telemetrySecret = [Environment]::GetEnvironmentVariable($TelemetrySecretEnvironmentVariableName)
+if ([string]::IsNullOrWhiteSpace($telemetrySecret)) {
+    if ($WhatIf) {
+        $telemetrySecret = 'synthetic-validation-secret'
+    }
+    else {
+        throw "Environment variable '$TelemetrySecretEnvironmentVariableName' must contain the telemetry signing secret."
+    }
+}
+
+$templateFile = Join-Path $PSScriptRoot 'azuredeploy.json'
+$parameterFile = New-DeploymentParameterFile `
+    -TelemetrySecret $telemetrySecret `
+    -ClientId $clientId
+
+try {
+    $deploymentName = "telemetry-$([DateTime]::UtcNow.ToString('yyyyMMddHHmmss'))"
+    if ($WhatIf) {
+        Invoke-AzCli -Arguments @(
+            'deployment', 'sub', 'what-if',
+            '--name', $deploymentName,
+            '--location', $Location,
+            '--template-file', $templateFile,
+            '--parameters', "@$parameterFile",
+            '--result-format', 'ResourceIdOnly',
+            '--output', 'json'
+        ) | Write-Output
+        return
+    }
+
+    $deployment = Invoke-AzCli -Arguments @(
+        'deployment', 'sub', 'create',
+        '--name', $deploymentName,
+        '--location', $Location,
+        '--template-file', $templateFile,
+        '--parameters', "@$parameterFile",
+        '--output', 'json'
+    ) -AsJson
+
+    $outputs = $deployment.properties.outputs
+    $webAppResourceId = Invoke-AzCli -Arguments @(
+        'webapp', 'show',
+        '--resource-group', $ResourceGroupName,
+        '--name', $WebAppName,
+        '--query', 'id',
+        '--output', 'tsv'
+    )
+
+    if (-not $SkipApplicationPublish) {
+        Publish-TelemetryApplication -WebAppResourceId $webAppResourceId
+    }
+
+    Test-TelemetryDeployment -Outputs $outputs
+
+    Write-Host "Telemetry Service deployed successfully: $($outputs.statsApiUrl.value)"
+}
+finally {
+    if (Test-Path -LiteralPath $parameterFile) {
+        Remove-Item -LiteralPath $parameterFile -Force
+    }
+    Remove-Variable telemetrySecret -ErrorAction SilentlyContinue
+}

--- a/infra/TelemetryService/main.bicep
+++ b/infra/TelemetryService/main.bicep
@@ -1,0 +1,75 @@
+targetScope = 'subscription'
+
+@description('Name of the new resource group.')
+@minLength(1)
+@maxLength(90)
+param resourceGroupName string
+
+@description('Azure region for all regional resources.')
+param location string
+
+@description('Existing release-compatible App Service name. Supply this out-of-band.')
+@minLength(2)
+@maxLength(60)
+param webAppName string
+
+@description('Short product prefix used for generated Azure resource names.')
+@minLength(3)
+@maxLength(18)
+param namePrefix string
+
+@description('Address prefix for the dedicated virtual network.')
+param vnetAddressPrefix string
+
+@description('Address prefix for the delegated App Service integration subnet.')
+param appIntegrationSubnetPrefix string
+
+@description('Address prefix for the private endpoint subnet.')
+param privateEndpointSubnetPrefix string
+
+@description('Application (client) ID of the single-tenant Entra SPA/API registration.')
+param azureAdClientId string
+
+@description('Signed-upload shared secret. This value is stored in Key Vault.')
+@secure()
+param telemetrySecret string
+
+@description('Optional additional resource tags.')
+param tags object = {}
+
+var defaultTags = {
+  Workload: 'Microsoft365AnalyticsTelemetry'
+  ManagedBy: 'Bicep'
+}
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: resourceGroupName
+  location: location
+  tags: union(defaultTags, tags)
+}
+
+module telemetryResources './resources.bicep' = {
+  name: 'telemetry-resources'
+  scope: resourceGroup
+  params: {
+    location: location
+    webAppName: webAppName
+    namePrefix: namePrefix
+    vnetAddressPrefix: vnetAddressPrefix
+    appIntegrationSubnetPrefix: appIntegrationSubnetPrefix
+    privateEndpointSubnetPrefix: privateEndpointSubnetPrefix
+    azureAdTenantId: tenant().tenantId
+    azureAdClientId: azureAdClientId
+    telemetrySecret: telemetrySecret
+    tags: union(defaultTags, tags)
+  }
+}
+
+output resourceGroupName string = resourceGroup.name
+output webAppName string = telemetryResources.outputs.webAppName
+output webAppUrl string = telemetryResources.outputs.webAppUrl
+output statsApiUrl string = telemetryResources.outputs.statsApiUrl
+output authConfigUrl string = telemetryResources.outputs.authConfigUrl
+output cosmosAccountName string = telemetryResources.outputs.cosmosAccountName
+output keyVaultName string = telemetryResources.outputs.keyVaultName
+output appServicePrincipalId string = telemetryResources.outputs.appServicePrincipalId

--- a/infra/TelemetryService/resources.bicep
+++ b/infra/TelemetryService/resources.bicep
@@ -1,0 +1,494 @@
+targetScope = 'resourceGroup'
+
+param location string
+param webAppName string
+param namePrefix string
+param vnetAddressPrefix string
+param appIntegrationSubnetPrefix string
+param privateEndpointSubnetPrefix string
+param azureAdTenantId string
+param azureAdClientId string
+
+@secure()
+param telemetrySecret string
+
+param tags object
+
+var suffix = take(uniqueString(subscription().id, resourceGroup().id), 6)
+var compactPrefix = toLower(replace(namePrefix, '-', ''))
+var appServicePlanName = take('asp-${namePrefix}-${suffix}', 40)
+var vnetName = take('vnet-${namePrefix}-${suffix}', 64)
+var appIntegrationSubnetName = 'snet-app-integration'
+var privateEndpointSubnetName = 'snet-private-endpoints'
+var appIntegrationNsgName = take('nsg-${namePrefix}-app-${suffix}', 80)
+var cosmosAccountName = take('cosmos${compactPrefix}${suffix}', 44)
+var cosmosDatabaseName = 'Telemetry'
+var currentContainerName = 'Current'
+var historyContainerName = 'History'
+var keyVaultName = take('kv${compactPrefix}${suffix}', 24)
+var telemetrySecretName = 'telemetry-upload-signing-key'
+var logAnalyticsName = take('log-${namePrefix}-${suffix}', 63)
+var appInsightsName = take('appi-${namePrefix}-${suffix}', 260)
+var cosmosPrivateDnsZoneName = 'privatelink.documents.azure.com'
+var keyVaultPrivateDnsZoneName = 'privatelink.vaultcore.azure.net'
+var keyVaultSecretsUserRoleDefinitionId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '4633458b-17de-408a-b874-0445c86b69e6'
+)
+var cosmosDataContributorRoleId = '00000000-0000-0000-0000-000000000002'
+
+resource appIntegrationNsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: appIntegrationNsgName
+  location: location
+  tags: tags
+  properties: {
+    securityRules: []
+  }
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+  name: vnetName
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+  }
+}
+
+resource appIntegrationSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
+  parent: vnet
+  name: appIntegrationSubnetName
+  properties: {
+    addressPrefix: appIntegrationSubnetPrefix
+    networkSecurityGroup: {
+      id: appIntegrationNsg.id
+    }
+    delegations: [
+      {
+        name: 'app-service-delegation'
+        properties: {
+          serviceName: 'Microsoft.Web/serverFarms'
+        }
+      }
+    ]
+    privateEndpointNetworkPolicies: 'Enabled'
+    privateLinkServiceNetworkPolicies: 'Enabled'
+  }
+}
+
+resource privateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
+  parent: vnet
+  name: privateEndpointSubnetName
+  properties: {
+    addressPrefix: privateEndpointSubnetPrefix
+    privateEndpointNetworkPolicies: 'Disabled'
+    privateLinkServiceNetworkPolicies: 'Enabled'
+  }
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: logAnalyticsName
+  location: location
+  tags: tags
+  properties: {
+    retentionInDays: 30
+    sku: {
+      name: 'PerGB2018'
+    }
+    features: {
+      enableLogAccessUsingOnlyResourcePermissions: true
+    }
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  tags: tags
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalytics.id
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+  }
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: location
+  tags: tags
+  properties: {
+    tenantId: azureAdTenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    enableRbacAuthorization: true
+    enablePurgeProtection: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 7
+    publicNetworkAccess: 'Disabled'
+    networkAcls: {
+      bypass: 'None'
+      defaultAction: 'Deny'
+    }
+  }
+}
+
+resource telemetrySigningSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: telemetrySecretName
+  properties: {
+    value: telemetrySecret
+  }
+}
+
+resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
+  name: cosmosAccountName
+  location: location
+  kind: 'GlobalDocumentDB'
+  tags: tags
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+        isZoneRedundant: false
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
+      }
+    ]
+    enableFreeTier: false
+    enableAutomaticFailover: false
+    enableMultipleWriteLocations: false
+    publicNetworkAccess: 'Disabled'
+    disableLocalAuth: true
+    disableKeyBasedMetadataWriteAccess: true
+    minimalTlsVersion: 'Tls12'
+    networkAclBypass: 'None'
+    networkAclBypassResourceIds: []
+    isVirtualNetworkFilterEnabled: false
+    virtualNetworkRules: []
+    ipRules: []
+  }
+}
+
+resource cosmosDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-11-15' = {
+  parent: cosmosAccount
+  name: cosmosDatabaseName
+  properties: {
+    resource: {
+      id: cosmosDatabaseName
+    }
+    options: {}
+  }
+}
+
+resource currentContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-11-15' = {
+  parent: cosmosDatabase
+  name: currentContainerName
+  properties: {
+    resource: {
+      id: currentContainerName
+      partitionKey: {
+        paths: [
+          '/AnonClientId'
+        ]
+        kind: 'Hash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          {
+            path: '/*'
+          }
+        ]
+        excludedPaths: [
+          {
+            path: '/"_etag"/?'
+          }
+        ]
+      }
+    }
+    options: {}
+  }
+}
+
+resource historyContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-11-15' = {
+  parent: cosmosDatabase
+  name: historyContainerName
+  properties: {
+    resource: {
+      id: historyContainerName
+      partitionKey: {
+        paths: [
+          '/AnonClientId'
+        ]
+        kind: 'Hash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          {
+            path: '/*'
+          }
+        ]
+        excludedPaths: [
+          {
+            path: '/"_etag"/?'
+          }
+        ]
+      }
+    }
+    options: {}
+  }
+}
+
+resource cosmosPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+  name: cosmosPrivateDnsZoneName
+  location: 'global'
+  tags: tags
+}
+
+resource cosmosPrivateDnsVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+  parent: cosmosPrivateDnsZone
+  name: 'cosmos-vnet-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}
+
+resource cosmosPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
+  name: 'pep-${cosmosAccountName}'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: privateEndpointSubnet.id
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'cosmos-sql'
+        properties: {
+          privateLinkServiceId: cosmosAccount.id
+          groupIds: [
+            'Sql'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource cosmosPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01' = {
+  parent: cosmosPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'cosmos'
+        properties: {
+          privateDnsZoneId: cosmosPrivateDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+resource keyVaultPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+  name: keyVaultPrivateDnsZoneName
+  location: 'global'
+  tags: tags
+}
+
+resource keyVaultPrivateDnsVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+  parent: keyVaultPrivateDnsZone
+  name: 'key-vault-vnet-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnet.id
+    }
+  }
+}
+
+resource keyVaultPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
+  name: 'pep-${keyVaultName}'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: privateEndpointSubnet.id
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'key-vault'
+        properties: {
+          privateLinkServiceId: keyVault.id
+          groupIds: [
+            'vault'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource keyVaultPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01' = {
+  parent: keyVaultPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'key-vault'
+        properties: {
+          privateDnsZoneId: keyVaultPrivateDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2024-04-01' = {
+  name: appServicePlanName
+  location: location
+  kind: 'linux'
+  tags: tags
+  sku: {
+    name: 'B1'
+    tier: 'Basic'
+    capacity: 1
+  }
+  properties: {
+    reserved: true
+    zoneRedundant: false
+  }
+}
+
+resource webApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: webAppName
+  location: location
+  kind: 'app,linux'
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    publicNetworkAccess: 'Enabled'
+    clientAffinityEnabled: false
+    virtualNetworkSubnetId: appIntegrationSubnet.id
+    vnetRouteAllEnabled: true
+    siteConfig: {
+      linuxFxVersion: 'DOTNETCORE|10.0'
+      alwaysOn: true
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      scmMinTlsVersion: '1.2'
+      http20Enabled: true
+      healthCheckPath: '/health'
+      remoteDebuggingEnabled: false
+      webSocketsEnabled: false
+    }
+  }
+}
+
+resource ftpPublishingPolicy 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2024-04-01' = {
+  parent: webApp
+  name: 'ftp'
+  properties: {
+    allow: false
+  }
+}
+
+resource scmPublishingPolicy 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2024-04-01' = {
+  parent: webApp
+  name: 'scm'
+  properties: {
+    allow: false
+  }
+}
+
+resource keyVaultRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, webApp.id, keyVaultSecretsUserRoleDefinitionId)
+  scope: keyVault
+  properties: {
+    principalId: webApp.identity.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: keyVaultSecretsUserRoleDefinitionId
+  }
+}
+
+resource cosmosDataRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-11-15' = {
+  parent: cosmosAccount
+  name: guid(cosmosAccount.id, webApp.id, cosmosDataContributorRoleId)
+  properties: {
+    principalId: webApp.identity.principalId
+    roleDefinitionId: '${cosmosAccount.id}/sqlRoleDefinitions/${cosmosDataContributorRoleId}'
+    scope: cosmosAccount.id
+  }
+}
+
+resource webAppSettings 'Microsoft.Web/sites/config@2024-04-01' = {
+  parent: webApp
+  name: 'appsettings'
+  properties: {
+    ASPNETCORE_ENVIRONMENT: 'Production'
+    WEBSITE_RUN_FROM_PACKAGE: '1'
+    WEBSITE_VNET_ROUTE_ALL: '1'
+    WEBSITE_HEALTHCHECK_MAXPINGFAILURES: '5'
+    SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
+    ENABLE_ORYX_BUILD: 'false'
+    TelemetrySecret: '@Microsoft.KeyVault(VaultName=${keyVault.name};SecretName=${telemetrySecretName})'
+    CosmosDb__AccountEndpoint: cosmosAccount.properties.documentEndpoint
+    CosmosDb__DatabaseName: cosmosDatabaseName
+    CosmosDb__ContainerNameCurrent: currentContainerName
+    CosmosDb__ContainerNameHistory: historyContainerName
+    AzureAd__Instance: environment().authentication.loginEndpoint
+    AzureAd__TenantId: azureAdTenantId
+    AzureAd__ClientId: azureAdClientId
+    AzureAd__Scopes: 'Telemetry.Read'
+    AZURE_TENANT_ID: azureAdTenantId
+    DashboardCacheSeconds: '60'
+    MaxDashboardItems: '5000'
+    APPLICATIONINSIGHTS_CONNECTION_STRING: appInsights.properties.ConnectionString
+    ApplicationInsightsAgent_EXTENSION_VERSION: '~3'
+  }
+  dependsOn: [
+    cosmosDataRoleAssignment
+    cosmosPrivateDnsZoneGroup
+    keyVaultPrivateDnsZoneGroup
+    keyVaultRoleAssignment
+    telemetrySigningSecret
+  ]
+}
+
+output webAppName string = webApp.name
+output webAppUrl string = 'https://${webApp.properties.defaultHostName}'
+output statsApiUrl string = 'https://${webApp.properties.defaultHostName}/api/Telemetry'
+output authConfigUrl string = 'https://${webApp.properties.defaultHostName}/api/auth/config'
+output cosmosAccountName string = cosmosAccount.name
+output keyVaultName string = keyVault.name
+output appServicePrincipalId string = webApp.identity.principalId

--- a/src/TelemetryService/Web.Server/Program.cs
+++ b/src/TelemetryService/Web.Server/Program.cs
@@ -90,6 +90,9 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.MapGet("/health", () => Results.Ok(new { status = "Healthy" }))
+    .AllowAnonymous();
+
 app.MapControllers();
 
 app.MapFallbackToFile("/index.html");


### PR DESCRIPTION
## Summary
- add subscription-scope Bicep plus a compiled ARM template for the Telemetry Service
- deploy Linux App Service with VNet integration, serverless Cosmos DB, private endpoints/DNS, private Key Vault, managed-identity RBAC, Log Analytics, and Application Insights
- add an idempotent PowerShell orchestrator for Entra setup, secure parameters, ARM deployment, ZIP publication, and live verification
- add an anonymous `/health` liveness endpoint

## Security and configuration
- Cosmos DB and Key Vault public access are disabled
- Cosmos key authentication is disabled; App Service uses managed identity
- upload signing secrets are supplied out-of-band and stored in Key Vault
- the released App Service hostname is supplied as a parameter rather than committed
- no subscription, tenant, user, resource, URL, secret, CIDR, or environment parameter values are included

## Validation
- Bicep compilation and compiled ARM parity
- subscription-scope ARM validate and what-if
- TelemetryService Release build and frontend lint/audit
- PowerShell parser and public-repository data scan
- deployed POC health, authorization, private networking, Cosmos schema/RBAC, and Key Vault-reference checks