### PR TITLE
Reports performance: adaptive Copilot joins, partial-failure charts, safer usage-report skipping

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
+++ b/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
@@ -267,6 +267,10 @@
 				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+			</dependentAssembly>
 		</assemblyBinding>
 		
 	</runtime>

--- a/src/AnalyticsEngine/Tests.UnitTests/OutlookUserActivityLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/OutlookUserActivityLoaderTests.cs
@@ -236,7 +236,9 @@ namespace Tests.UnitTests
                     RefreshableRecentDays = 3
                 };
 
-                var finalizedDate = DateTime.UtcNow.Date.AddDays(-6);   // stored + older than the recent window -> skippable
+                var lastSuccessfulImport = DateTime.UtcNow.Date.AddDays(-10);
+                var finalizedDate = DateTime.UtcNow.Date.AddDays(-12); // stored by the completed run -> skippable
+                var partialAfterSuccess = DateTime.UtcNow.Date.AddDays(-6); // could be from a later failed run -> retry
                 var recentDate = DateTime.UtcNow.Date.AddDays(-2);      // stored but within the recent window -> never skipped
 
                 var runId = DateTime.UtcNow.Ticks;
@@ -253,12 +255,65 @@ namespace Tests.UnitTests
                 {
                     new OutlookUserActivityUserDetail { UserPrincipalName = upn, LastActivityDateString = recentDate.ToString("yyyy-MM-dd"), ReadCount = 1 }
                 });
+                loader.LoadedReportPages.Add(partialAfterSuccess, new List<OutlookUserActivityUserDetail>
+                {
+                    new OutlookUserActivityUserDetail { UserPrincipalName = upn, LastActivityDateString = partialAfterSuccess.ToString("yyyy-MM-dd"), ReadCount = 1 }
+                });
                 await loader.SaveLoadedReportsToSql(userIdCache, userCache);
 
-                var skip = await loader.GetFinalizedStoredDatesToSkipAsync(db, daysBackMax: 7);
+                var skip = await loader.GetFinalizedStoredDatesToSkipAsync(
+                    db,
+                    daysBackMax: 14,
+                    lastSuccessfulImport: lastSuccessfulImport);
 
                 Assert.IsTrue(skip.Contains(finalizedDate), "A stored, finalized date should be skippable");
+                Assert.IsFalse(
+                    skip.Contains(partialAfterSuccess),
+                    "A stored date newer than the last completed import may be partial and must be retried");
                 Assert.IsFalse(skip.Contains(recentDate), "A date within the recent window must never be skipped, even if stored");
+            }
+        }
+
+        [TestMethod]
+        public async Task FinalizedDateLookup_DetectsIndexedAndUnindexedTables()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var groupsCache = new NoUsersHaveGroupsUserGroupsCache(logger);
+            var filter = new UserGroupsFilterModel("FakeGroup1;FakeGroup2");
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var indexedLoader = new OutlookUserActivityLoader(null, groupsCache, filter, logger);
+                var unindexedLoader = new OneDriveUsageLoader(null, groupsCache, filter, logger);
+
+                Assert.IsTrue(
+                    await indexedLoader.HasLeadingDateIndexAsync(db),
+                    "The widened Outlook IX_date should use bounded date seeks.");
+                Assert.IsFalse(
+                    await unindexedLoader.HasLeadingDateIndexAsync(db),
+                    "OneDrive account usage has no date-leading index and must keep one range scan.");
+            }
+        }
+
+        [TestMethod]
+        public async Task GetFinalizedStoredDatesToSkipAsync_NoCompletedImportSkipsNothing()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var groupsCache = new NoUsersHaveGroupsUserGroupsCache(logger);
+            var loader = new OutlookUserActivityLoader(
+                null,
+                groupsCache,
+                new UserGroupsFilterModel("FakeGroup1;FakeGroup2"),
+                logger);
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var skip = await loader.GetFinalizedStoredDatesToSkipAsync(
+                    db,
+                    daysBackMax: 28,
+                    lastSuccessfulImport: null);
+
+                Assert.AreEqual(0, skip.Count, "Rows from an interrupted first import must be re-imported.");
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/ReportsAPIControllerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ReportsAPIControllerTests.cs
@@ -1,0 +1,146 @@
+extern alias AnalyticsWeb;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using ReportChart = AnalyticsWeb::Web.AnalyticsWeb.Models.ReportChart;
+using ReportsAPIController = AnalyticsWeb::Web.AnalyticsWeb.Controllers.ReportsAPIController;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class ReportsAPIControllerTests
+    {
+        [TestMethod]
+        public void CompleteMultiTimeSeries_QueryFailureKeepsSuccessfulWorkloads()
+        {
+            var week = new DateTime(2026, 8, 10);
+            var chart = Chart();
+            var rows = new List<KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>>
+            {
+                Series("Teams", week),
+            };
+
+            var result = ReportsAPIController.CompleteMultiTimeSeries(
+                chart,
+                rows,
+                new List<string> { "Outlook: query timed out" },
+                new List<DateTime> { week });
+
+            Assert.IsNull(result.Error);
+            Assert.AreEqual(1, result.Series.Count);
+            Assert.AreEqual("Teams", result.Series[0].Name);
+            StringAssert.Contains(result.Warning, "Outlook: query timed out");
+        }
+
+        [TestMethod]
+        public void CompleteMultiTimeSeries_EmptyWorkloadDoesNotBlockPopulatedWorkloads()
+        {
+            var week = new DateTime(2026, 8, 10);
+            var chart = Chart();
+            var rows = new List<KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>>
+            {
+                Series("Teams", week),
+                new KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>(
+                    "Viva Engage",
+                    new List<ReportsAPIController.WeekValueRow>()),
+            };
+
+            var result = ReportsAPIController.CompleteMultiTimeSeries(
+                chart,
+                rows,
+                new List<string>(),
+                new List<DateTime> { week });
+
+            Assert.IsNull(result.Error);
+            Assert.AreEqual(1, result.Series.Count);
+            Assert.AreEqual("Teams", result.Series[0].Name);
+            StringAssert.Contains(result.Warning, "Viva Engage: no settled usage data");
+        }
+
+        [TestMethod]
+        public void CompleteMultiTimeSeries_AllWorkloadsEmptyReturnsError()
+        {
+            var week = new DateTime(2026, 8, 10);
+            var chart = Chart();
+            var rows = new List<KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>>
+            {
+                new KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>(
+                    "Viva Engage",
+                    new List<ReportsAPIController.WeekValueRow>()),
+            };
+
+            var result = ReportsAPIController.CompleteMultiTimeSeries(
+                chart,
+                rows,
+                new List<string>(),
+                new List<DateTime> { week });
+
+            Assert.IsNotNull(result.Error);
+            Assert.IsNull(result.Series);
+        }
+
+        [TestMethod]
+        public void CopilotQueries_PinMeasuredMergePlans()
+        {
+            var today = new DateTime(2026, 8, 14);
+            var wideUsersSql = ReportsAPIController.BuildCopilotUsersQuery(
+                today.AddDays(-90),
+                today);
+
+            StringAssert.Contains(wideUsersSql, "INNER MERGE JOIN dbo.audit_events");
+            StringAssert.Contains(wideUsersSql, "OPTION (RECOMPILE)");
+        }
+
+        [TestMethod]
+        public void CopilotJoinSelection_UsesMeasuredWindowAndFilterRules()
+        {
+            var today = new DateTime(2026, 8, 14);
+
+            Assert.AreEqual(
+                ReportsAPIController.CopilotAuditNaturalJoin,
+                ReportsAPIController.SelectCopilotAuditJoin(
+                    today.AddDays(-30),
+                    hasAgentFilter: false,
+                    today));
+            StringAssert.Contains(
+                ReportsAPIController.SelectCopilotAuditJoin(
+                    today.AddDays(-90),
+                    hasAgentFilter: false,
+                    today),
+                "INNER MERGE JOIN");
+            Assert.AreEqual(
+                ReportsAPIController.CopilotAuditNaturalJoin,
+                ReportsAPIController.SelectCopilotAuditJoin(
+                    today.AddDays(-180),
+                    hasAgentFilter: true,
+                    today));
+        }
+
+        [TestMethod]
+        public void QueryTimeoutDetection_RecognizesNestedTimeout()
+        {
+            var error = new InvalidOperationException(
+                "EF wrapper",
+                new TimeoutException("Query timed out"));
+
+            Assert.IsTrue(ReportsAPIController.IsQueryTimeout(error));
+            Assert.IsFalse(ReportsAPIController.IsQueryTimeout(new InvalidOperationException("Other failure")));
+        }
+
+        private static ReportChart Chart() => new ReportChart
+        {
+            Description = "Distinct users active in each completed week.",
+        };
+
+        private static KeyValuePair<string, List<ReportsAPIController.WeekValueRow>> Series(
+            string name,
+            DateTime week) =>
+            new KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>(
+                name,
+                new List<ReportsAPIController.WeekValueRow>
+                {
+                    new ReportsAPIController.WeekValueRow { WeekStart = week, Value = 1 },
+                });
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="PowerPlatformAuditEventManagerTests.cs" />
     <Compile Include="PowerPlatformAdminActivityRecordParseTests.cs" />
     <Compile Include="ProfilingStoredProcedureTests.cs" />
+    <Compile Include="ReportsAPIControllerTests.cs" />
     <Compile Include="SimplePropsDicTests.cs" />
     <Compile Include="PageUpdateEventListParseTests.cs" />
     <Compile Include="UserGroupsCacheTtlTests.cs" />
@@ -272,6 +273,11 @@
     <ProjectReference Include="..\WebJob.Office365ActivityImporter.Engine\WebJob.Office365ActivityImporter.Engine.csproj">
       <Project>{1919bde6-c311-426d-adb3-a1487133e397}</Project>
       <Name>WebJob.Office365ActivityImporter.Engine</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Web\Web.csproj">
+      <Project>{944C6021-D995-4F92-8BF9-DC91FC514250}</Project>
+      <Name>Web</Name>
+      <Aliases>AnalyticsWeb</Aliases>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -54,6 +54,17 @@ namespace Web.AnalyticsWeb.Controllers
         // snapshot makes the most recent week look like a sudden collapse in activity.
         private const int UsageReportLagDays = 3;
 
+        internal const string CopilotAuditMergeJoin =
+            "INNER MERGE JOIN dbo.audit_events AS au ON c.event_id = au.id";
+
+        internal const string CopilotAuditNaturalJoin =
+            "INNER JOIN dbo.audit_events AS au ON c.event_id = au.id";
+
+        // Benchmarked at 5m audit rows with both dense (1m chats) and sparse (10k/50k chats)
+        // histories: natural joins win for the one-month UI window, while merge joins prevent
+        // severe hash-plan regressions for the wider windows. Agent-name filters always stay natural.
+        private const int CopilotMergeJoinThresholdDays = 45;
+
         // GET: api/Reports/areas
         // Which report areas are available, based on the enabled imports.
         [HttpGet]
@@ -199,24 +210,25 @@ namespace Web.AnalyticsWeb.Controllers
         // no date column of its own), mirroring the profiling compile.
         private static List<Task<ReportChart>> CopilotCharts(DateTime from, List<DateTime> weekSpine)
         {
-            const string join = "FROM dbo.copilot_chats AS c JOIN dbo.audit_events AS au ON c.event_id = au.id WHERE au.time_stamp >= @from";
+            var join = "FROM dbo.copilot_chats AS c "
+                + SelectCopilotAuditJoin(from, hasAgentFilter: false)
+                + " WHERE au.time_stamp >= @from";
 
             var wb = WeekBucket("au.time_stamp");
 
             var interactions =
                 $"SELECT {wb} AS WeekStart, CAST(COUNT(*) AS float) AS Value\r\n" +
                 join + "\r\n" +
-                $"GROUP BY {wb} ORDER BY WeekStart;";
+                $"GROUP BY {wb} ORDER BY WeekStart\r\n" +
+                "OPTION (RECOMPILE);";
 
-            var users =
-                $"SELECT {wb} AS WeekStart, CAST(COUNT(DISTINCT au.user_id) AS float) AS Value\r\n" +
-                join + "\r\n" +
-                $"GROUP BY {wb} ORDER BY WeekStart;";
+            var users = BuildCopilotUsersQuery(from);
 
             var hosts =
                 "SELECT TOP 8 ISNULL(c.app_host, '(unknown)') AS Label, CAST(COUNT(*) AS float) AS Value\r\n" +
                 join + "\r\n" +
-                "GROUP BY ISNULL(c.app_host, '(unknown)') ORDER BY Value DESC;";
+                "GROUP BY ISNULL(c.app_host, '(unknown)') ORDER BY Value DESC\r\n" +
+                "OPTION (RECOMPILE);";
 
             return new List<Task<ReportChart>>
             {
@@ -229,6 +241,29 @@ namespace Web.AnalyticsWeb.Controllers
             };
         }
 
+        internal static string BuildCopilotUsersQuery(DateTime from, DateTime? today = null)
+        {
+            var wb = WeekBucket("au.time_stamp");
+            return
+                $"SELECT {wb} AS WeekStart, CAST(COUNT(DISTINCT au.user_id) AS float) AS Value\r\n" +
+                "FROM dbo.copilot_chats AS c "
+                + SelectCopilotAuditJoin(from, hasAgentFilter: false, today)
+                + " WHERE au.time_stamp >= @from\r\n" +
+                $"GROUP BY {wb} ORDER BY WeekStart\r\n" +
+                "OPTION (RECOMPILE);";
+        }
+
+        internal static string SelectCopilotAuditJoin(
+            DateTime from,
+            bool hasAgentFilter,
+            DateTime? today = null)
+        {
+            var windowDays = ((today ?? DateTime.UtcNow.Date) - from.Date).TotalDays;
+            return !hasAgentFilter && windowDays >= CopilotMergeJoinThresholdDays
+                ? CopilotAuditMergeJoin
+                : CopilotAuditNaturalJoin;
+        }
+
         private static List<Task<ReportChart>> CopilotAgentCharts(
             DateTime from,
             List<DateTime> weekSpine,
@@ -236,6 +271,9 @@ namespace Web.AnalyticsWeb.Controllers
             string agentName)
         {
             var wb = WeekBucket("au.time_stamp");
+            var auditJoin = SelectCopilotAuditJoin(
+                from,
+                hasAgentFilter: !string.IsNullOrEmpty(agentName));
             var agents =
                 "WITH EligibleAgents AS (\r\n" +
                 "    SELECT id\r\n" +
@@ -247,7 +285,7 @@ namespace Web.AnalyticsWeb.Controllers
                 $"           {wb} AS WeekStart,\r\n" +
                 "           COUNT_BIG(*) AS InteractionCount\r\n" +
                 "    FROM dbo.copilot_chats AS c\r\n" +
-                "    JOIN dbo.audit_events AS au ON c.event_id = au.id\r\n" +
+                "    " + auditJoin + "\r\n" +
                 "    JOIN EligibleAgents AS eligible ON c.agent_id = eligible.id\r\n" +
                 "    WHERE au.time_stamp >= @from\r\n" +
                 $"    GROUP BY c.agent_id, {wb}\r\n" +
@@ -516,6 +554,7 @@ namespace Web.AnalyticsWeb.Controllers
                         DisplaySql(series.First().Body, from, lastWeek, settled);
 
             var rowsBySeries = new List<KeyValuePair<string, List<WeekValueRow>>>();
+            var warnings = new List<string>();
 
             // Sequentially per series keeps a bounded number of concurrent contexts (the area itself
             // already runs in parallel with other areas' charts); each performs indexed seeks into
@@ -529,20 +568,50 @@ namespace Web.AnalyticsWeb.Controllers
                 }
                 catch (Exception ex)
                 {
-                    chart.Error = $"{sq.Name}: {InnermostMessage(ex)}";
-                    return chart;
+                    warnings.Add($"{sq.Name}: {InnermostMessage(ex)}");
+                    if (IsQueryTimeout(ex))
+                    {
+                        warnings.Add("Remaining workloads were not attempted after the database timeout");
+                        break;
+                    }
                 }
             }
 
+            return CompleteMultiTimeSeries(chart, rowsBySeries, warnings, weekSpine);
+        }
+
+        internal static ReportChart CompleteMultiTimeSeries(
+            ReportChart chart,
+            List<KeyValuePair<string, List<WeekValueRow>>> rowsBySeries,
+            List<string> warnings,
+            List<DateTime> weekSpine)
+        {
+            var populatedSeries = rowsBySeries
+                .Where(seriesRows => seriesRows.Value.Count > 0)
+                .ToList();
+
+            warnings.AddRange(rowsBySeries
+                .Where(seriesRows => seriesRows.Value.Count == 0)
+                .Select(seriesRows => $"{seriesRows.Key}: no settled usage data"));
+
+            if (populatedSeries.Count == 0)
+            {
+                chart.Error = warnings.Count == 0
+                    ? "No completed usage-report weeks are available."
+                    : "No workload series could be loaded. " + string.Join("; ", warnings);
+                return chart;
+            }
+
             // Trailing weeks are trimmed once, across every workload, so the chart ends where the
-            // slowest report has caught up. Interior weeks are NOT trimmed: they keep their place on
-            // the spine and any workload missing that week gets a null (a gap in its line) rather
-            // than a zero, which would draw a false collapse in activity.
+            // slowest populated report has caught up. Workloads with no settled data are omitted
+            // rather than preventing every other workload from rendering. Interior weeks are NOT
+            // trimmed: they keep their place on the spine and any workload missing that week gets a
+            // null (a gap in its line) rather than a zero, which would draw a false collapse.
             var lastCompleteWeekIndex = weekSpine.Count - 1;
             while (lastCompleteWeekIndex >= 0)
             {
                 var week = weekSpine[lastCompleteWeekIndex];
-                if (rowsBySeries.All(s => s.Value.Any(r => r.WeekStart.Date == week)))
+                if (populatedSeries.All(s => s.Value.Any(r => r.WeekStart.Date == week)))
                 {
                     break;
                 }
@@ -551,18 +620,23 @@ namespace Web.AnalyticsWeb.Controllers
 
             if (lastCompleteWeekIndex < 0)
             {
-                chart.Error = "No completed usage-report weeks are available for every workload.";
+                chart.Error = "No completed usage-report weeks are available for workloads with data.";
                 return chart;
             }
 
             var completeWeekSpine = weekSpine.Take(lastCompleteWeekIndex + 1).ToList();
-            chart.Series = rowsBySeries
+            chart.Series = populatedSeries
                 .Select(s => new ReportSeries
                 {
                     Name = s.Key,
                     Points = FillWeeks(completeWeekSpine, s.Value, missingValue: null),
                 })
                 .ToList();
+
+            if (warnings.Count > 0)
+            {
+                chart.Warning = "Some workload series are unavailable: " + string.Join("; ", warnings) + ".";
+            }
 
             return chart;
         }
@@ -852,6 +926,22 @@ namespace Web.AnalyticsWeb.Controllers
             return e.Message;
         }
 
+        internal static bool IsQueryTimeout(Exception ex)
+        {
+            for (var current = ex; current != null; current = current.InnerException)
+            {
+                if (current is TimeoutException)
+                {
+                    return true;
+                }
+                if (current is SqlException sqlException && sqlException.Number == -2)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         /// <summary>A named series and the weekly query that produces it (used by the usage chart).</summary>
         private sealed class SeriesQuery
         {
@@ -860,7 +950,7 @@ namespace Web.AnalyticsWeb.Controllers
         }
 
         /// <summary>Shape for a weekly (WeekStart, Value) raw SQL result.</summary>
-        private sealed class WeekValueRow
+        internal sealed class WeekValueRow
         {
             public DateTime WeekStart { get; set; }
             public double Value { get; set; }

--- a/src/AnalyticsEngine/Web/Models/ReportsModels.cs
+++ b/src/AnalyticsEngine/Web/Models/ReportsModels.cs
@@ -116,6 +116,10 @@ namespace Web.AnalyticsWeb.Models
         /// <summary>Set when the query failed/timed out; the chart data is then empty.</summary>
         [JsonProperty("error")]
         public string Error { get; set; }
+
+        /// <summary>Set when part of a chart could not load but other series remain usable.</summary>
+        [JsonProperty("warning")]
+        public string Warning { get; set; }
     }
 
     /// <summary>The set of charts for one report area over the requested window.</summary>

--- a/src/AnalyticsEngine/Web/Properties/AssemblyInfo.cs
+++ b/src/AnalyticsEngine/Web/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: InternalsVisibleTo("Tests.UnitTests")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("944c6021-d995-4f92-8bf9-dc91fc514250")]

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
@@ -369,12 +369,21 @@ function ReportAreaView({
               <MessageBar intent="warning">
                 <MessageBarBody>Couldn't load this chart: {chart.error}</MessageBarBody>
               </MessageBar>
-            ) : chart.type === 'timeseries' && chart.series ? (
-              <TimeSeriesChart series={chart.series} valueLabel={chart.valueLabel} />
-            ) : chart.type === 'bar' && chart.categories ? (
-              <CategoryBarChart categories={chart.categories} valueLabel={chart.valueLabel} />
             ) : (
-              <Text className={styles.muted}>No data for this period.</Text>
+              <>
+                {chart.warning && (
+                  <MessageBar intent="warning">
+                    <MessageBarBody>{chart.warning}</MessageBarBody>
+                  </MessageBar>
+                )}
+                {chart.type === 'timeseries' && chart.series ? (
+                  <TimeSeriesChart series={chart.series} valueLabel={chart.valueLabel} />
+                ) : chart.type === 'bar' && chart.categories ? (
+                  <CategoryBarChart categories={chart.categories} valueLabel={chart.valueLabel} />
+                ) : (
+                  <Text className={styles.muted}>No data for this period.</Text>
+                )}
+              </>
             )}
           </div>
         </Card>

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
@@ -43,6 +43,7 @@ export interface ReportChart {
   categories: ReportCategory[] | null;
   sql: string;
   error: string | null;
+  warning: string | null;
 }
 
 /** The set of charts for one report area over the requested window. */

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -181,6 +181,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             if (runImport)
             {
+                // The timestamp is both the once-a-day throttle and the proof that every loader
+                // completed. Clear it before any batched writes: if this phase fails after a
+                // partial save, the next cycle must re-import rather than trusting the old marker.
+                // Keep lastImportedDate locally so rows covered by that prior successful phase can
+                // still be skipped safely during this run.
+                if (lastImportedStore != null)
+                {
+                    await lastImportedStore.DeleteDt();
+                }
+
                 _logger.LogInformation($"Reading all activity reports from {daysBackMax} days back...");
 
                 // Parallel-load all, each one with own DB context
@@ -190,34 +200,34 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
                 // Daily imports
                 var teamsUserUsageLoader = new TeamsUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserUsageLoader, daysBackMax, "Teams user activity", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserUsageLoader, daysBackMax, "Teams user activity", _logger, lookupIdCache, lastImportedDate));
 
                 var teamsUserDeviceLoader = new TeamsUserDeviceLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserDeviceLoader, daysBackMax, "Teams user device", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserDeviceLoader, daysBackMax, "Teams user device", _logger, lookupIdCache, lastImportedDate));
 
                 var outlookLoader = new OutlookUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(outlookLoader, daysBackMax, "Outlook activity", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(outlookLoader, daysBackMax, "Outlook activity", _logger, lookupIdCache, lastImportedDate));
 
                 var oneDriveUsageLoader = new OneDriveUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUsageLoader, daysBackMax, "OneDrive usage", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUsageLoader, daysBackMax, "OneDrive usage", _logger, lookupIdCache, lastImportedDate));
 
                 var oneDriveUserActivityLoader = new OneDriveUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUserActivityLoader, daysBackMax, "OneDrive activity", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUserActivityLoader, daysBackMax, "OneDrive activity", _logger, lookupIdCache, lastImportedDate));
 
                 var sharePointUserActivityLoader = new SharePointUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(sharePointUserActivityLoader, daysBackMax, "SharePoint user activity", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(sharePointUserActivityLoader, daysBackMax, "SharePoint user activity", _logger, lookupIdCache, lastImportedDate));
 
                 var yammerUserActivityLoader = new YammerUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerUserActivityLoader, daysBackMax, "Yammer user activity", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(yammerUserActivityLoader, daysBackMax, "Yammer user activity", _logger, lookupIdCache, lastImportedDate));
 
                 var yammerGroupsActivityLoader = new YammerGroupUsageLoader(client, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerGroupsActivityLoader, daysBackMax, "Yammer group activity", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(yammerGroupsActivityLoader, daysBackMax, "Yammer group activity", _logger, lookupIdCache, lastImportedDate));
 
                 var yammerDeviceActivityLoader = new YammerDeviceUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerDeviceActivityLoader, daysBackMax, "Yammer device activity", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(yammerDeviceActivityLoader, daysBackMax, "Yammer device activity", _logger, lookupIdCache, lastImportedDate));
 
                 var userPlatActivityLoader = new AppPlatformUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(userPlatActivityLoader, daysBackMax, "Apps & platform activity", _logger, lookupIdCache));
+                importTasks.Add(LoadAndSaveDailyImportReport(userPlatActivityLoader, daysBackMax, "Apps & platform activity", _logger, lookupIdCache, lastImportedDate));
 
                 // Weekly imports
                 using (var db = new AnalyticsEntitiesContext())
@@ -257,7 +267,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
         async Task<int> LoadAndSaveDailyImportReport<TReportDbType, TUserActivityUserDetail, TLookupType, CACHETYPE>
             (AbstractDailyActivityLoader<TReportDbType, TUserActivityUserDetail, TLookupType, CACHETYPE> abstractActivityLoader,
-            int daysBackMax, string thingWeAreImporting, ILogger logger, ConcurrentLookupDbIdsCache userEmailToDbIdCache)
+            int daysBackMax, string thingWeAreImporting, ILogger logger, ConcurrentLookupDbIdsCache userEmailToDbIdCache,
+            DateTime? lastSuccessfulImport)
             where TReportDbType : AbstractUsageActivityLog, new()
             where TUserActivityUserDetail : AbstractActivityRecord<TLookupType>
             where TLookupType : AbstractEFEntity
@@ -272,7 +283,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             {
                 using (var db = new AnalyticsEntitiesContext())
                 {
-                    datesToSkip = await abstractActivityLoader.GetFinalizedStoredDatesToSkipAsync(db, daysBackMax);
+                    datesToSkip = await abstractActivityLoader.GetFinalizedStoredDatesToSkipAsync(
+                        db,
+                        daysBackMax,
+                        lastSuccessfulImport);
                 }
                 if (datesToSkip.Count > 0)
                 {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -4,9 +4,12 @@ using DataUtils;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
+using System.Data.SqlClient;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
 
@@ -44,10 +47,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         /// <summary>
         /// Recent-day window (in days) during which Graph usage data can still change and therefore must be
         /// re-imported every run. Graph usage reports have a ~2-3 day latency and are stable once finalized, so
-        /// dates older than this are treated as final: once stored they are skipped entirely (no re-download,
-        /// no re-write). 3 is a safe default; every date is still fully re-imported on its first ~3 daily runs
-        /// (as day-1, day-2, day-3) before it is ever skipped, so transient partial saves self-heal. Settable so
-        /// tests can exercise the boundary.
+        /// dates older than this can be treated as final. A date is skipped only when it was already inside the
+        /// window of a previously completed import phase; rows newer than that completion marker may be from an
+        /// interrupted save and are retried. Settable so tests can exercise the boundary.
         /// </summary>
         public int RefreshableRecentDays { get; set; } = 3;
 
@@ -69,25 +71,88 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         }
 
         /// <summary>
-        /// The set of dates within the [now-daysBackMax, now) import window that are already stored in SQL AND old
-        /// enough that Graph will no longer change them (older than <see cref="RefreshableRecentDays"/>). These can
-        /// be skipped entirely on the next import - no re-download, no re-write. Dates within the recent window are
-        /// never returned because their data can still change.
+        /// The set of dates within the [now-daysBackMax, now) import window that are already stored in SQL, old
+        /// enough that Graph will no longer change them, and covered by a previously completed import phase. These
+        /// can be skipped entirely on the next import - no re-download, no re-write. Dates within the recent window
+        /// or newer than the completion marker are never returned because they can still change or be partial.
         /// </summary>
-        public async Task<HashSet<DateTime>> GetFinalizedStoredDatesToSkipAsync(AnalyticsEntitiesContext db, int daysBackMax)
+        public async Task<HashSet<DateTime>> GetFinalizedStoredDatesToSkipAsync(
+            AnalyticsEntitiesContext db,
+            int daysBackMax,
+            DateTime? lastSuccessfulImport)
         {
             daysBackMax = ClampDaysBack(daysBackMax);
+            if (!lastSuccessfulImport.HasValue)
+            {
+                // Existing rows could be from an interrupted import. Until a full usage-report
+                // phase completes, no stored date is proven complete enough to skip safely.
+                return new HashSet<DateTime>();
+            }
+
             var today = DateTime.UtcNow.Date;
             var windowStart = today.AddDays(-daysBackMax);
             var mutableCutoff = today.AddDays(-RefreshableRecentDays);   // dates >= this can still change; never skip them
+            var completedCutoff = lastSuccessfulImport.Value.ToUniversalTime().Date;
+            var safeCutoff = completedCutoff < mutableCutoff ? completedCutoff : mutableCutoff;
 
-            var storedFinalizedDates = await GetTable(db)
-                .Where(t => t.Date >= windowStart && t.Date < mutableCutoff)
-                .Select(t => t.Date)
+            var table = GetTable(db);
+            if (await HasLeadingDateIndexAsync(db))
+            {
+                // The window contains at most 25 finalized dates. DISTINCT over an indexed range
+                // still scans every user's row for every date (millions of rows at 200k users);
+                // bounded existence seeks touch one index entry per candidate date instead.
+                var storedFinalizedDates = new HashSet<DateTime>();
+                for (var date = windowStart; date < safeCutoff; date = date.AddDays(1))
+                {
+                    if (await table.AnyAsync(activity => activity.Date == date))
+                    {
+                        storedFinalizedDates.Add(date);
+                    }
+                }
+
+                return storedFinalizedDates;
+            }
+
+            // Some account/group report tables have no date-leading index. Repeated existence
+            // probes would each scan the table, so use one range scan until an index is available.
+            var scannedDates = await table
+                .Where(activity => activity.Date >= windowStart && activity.Date < safeCutoff)
+                .Select(activity => activity.Date)
                 .Distinct()
                 .ToListAsync();
 
-            return new HashSet<DateTime>(storedFinalizedDates.Select(d => d.Date));
+            return new HashSet<DateTime>(scannedDates.Select(date => date.Date));
+        }
+
+        internal async Task<bool> HasLeadingDateIndexAsync(AnalyticsEntitiesContext db)
+        {
+            var table = typeof(TReportDbType).GetCustomAttribute<TableAttribute>();
+            if (table == null)
+            {
+                throw new InvalidOperationException(
+                    $"{typeof(TReportDbType).Name} must declare TableAttribute to inspect its date index.");
+            }
+
+            var qualifiedTableName = $"{table.Schema ?? "dbo"}.{table.Name}";
+            const string sql = @"
+SELECT CAST(CASE WHEN EXISTS (
+    SELECT 1
+    FROM sys.indexes AS i
+    INNER JOIN sys.index_columns AS ic
+      ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+    INNER JOIN sys.columns AS c
+      ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+    WHERE i.object_id = OBJECT_ID(@tableName)
+      AND i.is_disabled = 0
+      AND i.is_hypothetical = 0
+      AND i.has_filter = 0
+      AND ic.key_ordinal = 1
+      AND c.name = N'date'
+) THEN 1 ELSE 0 END AS bit);";
+
+            return await db.Database
+                .SqlQuery<bool>(sql, new SqlParameter("@tableName", qualifiedTableName))
+                .SingleAsync();
         }
 
         public async Task PopulateLoadedReportPagesFromGraph(int daysBackMax, ISet<DateTime> datesToSkip = null)


### PR DESCRIPTION
## Title

Reports performance: adaptive Copilot joins, partial-failure charts, safer usage-report skipping

## Type of Change

- [x] Bug fix
- [x] Performance

## Description

Follow-up to #244 (report query timeouts) and #230 (usage-report import optimisation), both of which shipped in draft `Testing build 1736`. This tackles the remaining reports-performance issues and fixes a data-correctness risk introduced by #230's skip optimisation.

### 1. Adaptive join selection for the Copilot charts

The Copilot charts join `dbo.copilot_chats` to `dbo.audit_events`. A single fixed join shape doesn't hold up across window sizes: benchmarked at 5m audit rows with both dense (1m chats) and sparse (10k / 50k chats) histories, **natural joins win for the one-month UI window, while an `INNER MERGE JOIN` prevents severe hash-plan regressions on the wider windows**.

The join is now chosen per query (threshold: 45 days), and `OPTION (RECOMPILE)` lets the actual window drive the plan rather than a cached one. Agent-name filters always stay on the natural join, because the filter already restricts the row count.

The selection rule is pinned by tests so the measured behaviour can't be silently changed.

### 2. A slow workload no longer blanks the whole chart

Previously, one failing series aborted the entire multi-series chart and the user saw only an error. Now:

- surviving workloads still render;
- the reason is surfaced through a new `Warning` field on `ReportChart` (plumbed through `reports.ts` → `ReportsPage.tsx`) rather than being silently dropped;
- a **database timeout stops** the remaining workloads instead of serially waiting on more timeouts;
- workloads with no settled data are omitted rather than blocking every other workload from rendering.

### 3. 🐞 Fixes a data-loss risk in the #230 skip optimisation

**This is the most important change here.** #230 added "skip days Graph has already finalized". The completion marker was written such that **an interrupted save could leave dates both stored *and* treated as finalized — so they would never be re-imported**, leaving permanent gaps that no later cycle would repair.

- The marker is now **cleared before any batched writes**, so a failure mid-phase forces a re-import next cycle instead of trusting a stale marker.
- A date is skipped only when it falls inside a phase that **actually completed** (`lastSuccessfulImport`); when no completed phase exists, nothing is skipped.

### 4. Cheaper "what's already stored" check

The stored-date probe was a `DISTINCT` over the whole import window, which reads **every user's row for every date** — millions of rows at 200k users. The window holds at most 25 finalized dates, so this is now a bounded existence seek per candidate date (one index entry each), guarded by a leading-date-index check.

## Database impact

**None.** No migration, no schema change, no `CONFIG_VERSION` bump. This is query-shape and import-sequencing work only.

## Admin action required

**None.** Deployments that were showing partially-rendered or timing-out Copilot charts should improve immediately on deploy. Any usage-report dates previously skipped due to an interrupted save will be re-imported automatically on the next cycle.

## Tests

- New `ReportsAPIControllerTests` (6 tests) covering partial-failure rendering, the empty-workload case, all-workloads-empty, the measured join-selection rules, the pinned merge plans, and nested timeout detection.
- Extended `OutlookUserActivityLoaderTests` for the completion-marker/skip behaviour.
- `Web` now exposes internals to `Tests.UnitTests` via `InternalsVisibleTo` so the query builders can be tested directly.

Verified locally: solution builds clean; all new tests pass. `AllO365ActivityTests` and `SharePointSitesUsageLoaderTest` fail both with and without this change (they require real tenant credentials), so they are pre-existing environmental failures, not regressions.

## Related

- Follows #244, #230
