### PR TITLE
Throttling: default to maximum speed so upgrades are behaviour-neutral

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -170,17 +170,21 @@ namespace Common.Entities.Config
             }
 
             // One-off start offset (minutes) applied before the first import cycle, used to stagger the
-            // two WebJobs so they don't peak on the shared App Service plan at the same time. 0 disables.
-            // Default = half the cycle pause. Invalid/empty falls back to that default.
+            // two WebJobs so they don't peak on the shared App Service plan at the same time. 0 disables,
+            // which is the default so an upgrade doesn't silently delay the first cycle. Opt in by setting
+            // ImportStartStaggerMinutes (a good starting point is half the cycle pause).
             this.ImportStartStaggerMinutes = int.TryParse(ConfigurationManager.AppSettings.Get("ImportStartStaggerMinutes"), out var importStartStaggerMinutes)
                 && importStartStaggerMinutes >= 0
                 ? importStartStaggerMinutes
-                : Math.Max(0, this.ImportCyclePauseMinutes / 2);
+                : 0;
         }
 
         /// <summary>
         /// Parses the <c>ImportAggressiveness</c> AppSetting, defaulting to
-        /// <see cref="ImportAggressivenessLevel.Balanced"/> when missing or invalid.
+        /// <see cref="ImportAggressivenessLevel.High"/> when missing or invalid.
+        ///
+        /// High is the default deliberately: it reproduces the legacy (pre-throttling) behaviour exactly,
+        /// so upgrading does not silently slow anyone's import down. Easing CPU is opt-in.
         /// </summary>
         private static ImportAggressivenessLevel ParseAggressiveness(string raw)
         {
@@ -188,7 +192,7 @@ namespace Common.Entities.Config
             {
                 return level;
             }
-            return ImportAggressivenessLevel.Balanced;
+            return ImportAggressivenessLevel.High;
         }
 
         /// <summary>
@@ -354,17 +358,18 @@ namespace Common.Entities.Config
 
         /// <summary>
         /// Import "aggressiveness" preset that supplies the default burst/cadence knobs below.
-        /// Default <see cref="ImportAggressivenessLevel.Balanced"/>. Set via the
+        /// Default <see cref="ImportAggressivenessLevel.High"/>, which reproduces the legacy
+        /// (pre-throttling) behaviour so an upgrade changes nothing until an admin opts in. Set via the
         /// <c>ImportAggressiveness</c> AppSetting (High | Balanced | Gentle).
         /// </summary>
-        public ImportAggressivenessLevel ImportAggressiveness { get; set; } = ImportAggressivenessLevel.Balanced;
+        public ImportAggressivenessLevel ImportAggressiveness { get; set; } = ImportAggressivenessLevel.High;
 
         /// <summary>
         /// Maximum simultaneous threads used to full-load audit reports from the Office 365 Management
         /// Activity API. Lower values reduce peak CPU. Preset-derived (High=20, Balanced=8, Gentle=3)
         /// unless the <c>MaxAuditReportLoadConcurrency</c> AppSetting is set &amp; &gt; 0.
         /// </summary>
-        public int MaxAuditReportLoadConcurrency { get; set; } = 8;
+        public int MaxAuditReportLoadConcurrency { get; set; } = 20;
 
         /// <summary>
         /// Maximum simultaneous threads <see cref="DataUtils.Sql.Inserts.InsertBatch{T}"/> uses to commit
@@ -375,7 +380,7 @@ namespace Common.Entities.Config
         /// AppSetting is set &amp; &gt; 0. Applied at WebJob startup via
         /// <c>InsertBatchConcurrency.MaxConcurrentThreads</c>.
         /// </summary>
-        public int MaxSqlCommitConcurrency { get; set; } = 8;
+        public int MaxSqlCommitConcurrency { get; set; } = 20;
 
         /// <summary>
         /// Minutes the WebJob waits between import cycles. Preset-derived (High/Balanced=10, Gentle=20)
@@ -388,7 +393,7 @@ namespace Common.Entities.Config
         /// Preset-derived (High=0 i.e. every cycle/legacy, Balanced/Gentle=24) unless the
         /// <c>GraphMetadataImportIntervalHours</c> AppSetting is set &gt;= 0. 0 disables the gate.
         /// </summary>
-        public int GraphMetadataImportIntervalHours { get; set; } = 24;
+        public int GraphMetadataImportIntervalHours { get; set; } = 0;
 
         /// <summary>
         /// Minimum hours between Teams crawls (channel messages/reactions, etc). Separate from
@@ -396,7 +401,7 @@ namespace Common.Entities.Config
         /// incrementally. Preset-derived (High=0, Balanced/Gentle=24) unless the
         /// <c>GraphTeamsImportIntervalHours</c> AppSetting is set &gt;= 0. 0 disables the gate.
         /// </summary>
-        public int GraphTeamsImportIntervalHours { get; set; } = 24;
+        public int GraphTeamsImportIntervalHours { get; set; } = 0;
 
         /// <summary>
         /// When true, bypasses the cadence gate for the non-fresh Graph imports (user metadata, user
@@ -410,7 +415,7 @@ namespace Common.Entities.Config
         /// two WebJobs so they don't peak on the shared App Service plan simultaneously. Default = half
         /// the cycle pause. 0 disables.
         /// </summary>
-        public int ImportStartStaggerMinutes { get; set; } = 5;
+        public int ImportStartStaggerMinutes { get; set; } = 0;
     }
 
     /// <summary>
@@ -420,10 +425,10 @@ namespace Common.Entities.Config
     /// </summary>
     public enum ImportAggressivenessLevel
     {
-        /// <summary>Fastest, highest peak CPU. Full legacy behaviour: 20 audit-load threads, 10-min pause, and the non-fresh Graph imports run every cycle (interval 0).</summary>
+        /// <summary>Default. Fastest, highest peak CPU. Full legacy behaviour: 20 audit-load threads, 20 SQL-commit threads, 10-min pause, and the non-fresh Graph imports run every cycle (interval 0). Chosen as the default so upgrading never slows an existing deployment down.</summary>
         High,
 
-        /// <summary>Default. Modestly eased: 8 audit-load threads, 10-min pause, non-fresh Graph imports daily-gated (24h).</summary>
+        /// <summary>Modestly eased: 8 audit-load threads, 8 SQL-commit threads, 10-min pause, non-fresh Graph imports daily-gated (24h).</summary>
         Balanced,
 
         /// <summary>Lowest CPU: 3 audit-load threads, 20-min pause, non-fresh Graph imports daily-gated (24h).</summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/AppConfigDefaultsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppConfigDefaultsTests.cs
@@ -226,17 +226,18 @@ namespace Tests.UnitTests
         // ----- Import aggressiveness preset & cadence knobs (issue #161) -----
 
         [TestMethod]
-        public void ImportAggressiveness_EmptyAppSetting_DefaultsToBalanced()
+        public void ImportAggressiveness_EmptyAppSetting_DefaultsToHigh()
         {
             ConfigurationManager.AppSettings.Set(ImportAggressiveness, string.Empty);
-            Assert.AreEqual(ImportAggressivenessLevel.Balanced, new AppConfig().ImportAggressiveness);
+            Assert.AreEqual(ImportAggressivenessLevel.High, new AppConfig().ImportAggressiveness,
+                "Default must be High so upgrading never silently slows an existing deployment down.");
         }
 
         [TestMethod]
-        public void ImportAggressiveness_InvalidAppSetting_DefaultsToBalanced()
+        public void ImportAggressiveness_InvalidAppSetting_DefaultsToHigh()
         {
             ConfigurationManager.AppSettings.Set(ImportAggressiveness, "turbo");
-            Assert.AreEqual(ImportAggressivenessLevel.Balanced, new AppConfig().ImportAggressiveness);
+            Assert.AreEqual(ImportAggressivenessLevel.High, new AppConfig().ImportAggressiveness);
         }
 
         [TestMethod]
@@ -323,6 +324,29 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public void NoAppSettingsAtAll_ReproducesLegacyStableBehaviour()
+        {
+            // Upgrade-parity guard. An existing deployment upgrading to this build has none of the new
+            // AppSettings, so every knob must land on the pre-throttling ("stable") value. If any of these
+            // change, the upgrade silently slows customers' imports down - which is exactly what the
+            // throttling work must NOT do by default.
+            foreach (var key in _trackedKeys)
+            {
+                ConfigurationManager.AppSettings.Set(key, string.Empty);
+            }
+
+            var cfg = new AppConfig();
+
+            Assert.AreEqual(ImportAggressivenessLevel.High, cfg.ImportAggressiveness, "Preset must default to High.");
+            Assert.AreEqual(20, cfg.MaxAuditReportLoadConcurrency, "Legacy audit-load concurrency was a hardcoded 20.");
+            Assert.AreEqual(20, cfg.MaxSqlCommitConcurrency, "Legacy SQL-commit concurrency was a hardcoded 20.");
+            Assert.AreEqual(10, cfg.ImportCyclePauseMinutes, "Legacy cycle pause was a hardcoded 10 minutes.");
+            Assert.AreEqual(0, cfg.GraphMetadataImportIntervalHours, "Legacy ran the static Graph imports every cycle.");
+            Assert.AreEqual(0, cfg.GraphTeamsImportIntervalHours, "Legacy ran the Teams crawl every cycle.");
+            Assert.AreEqual(0, cfg.ImportStartStaggerMinutes, "Legacy had no start stagger.");
+        }
+
+        [TestMethod]
         public void ExplicitImportCyclePauseMinutes_OverridesPreset()
         {
             ConfigurationManager.AppSettings.Set(ImportAggressiveness, "High");
@@ -331,13 +355,16 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void GraphMetadataImportIntervalHours_EmptyOrInvalid_DefaultsTo24()
+        public void GraphMetadataImportIntervalHours_EmptyOrInvalid_DefaultsToZero()
         {
+            // Default preset is High, whose non-fresh Graph interval is 0 (every cycle = legacy behaviour).
+            ConfigurationManager.AppSettings.Set(ImportAggressiveness, string.Empty);
             ConfigurationManager.AppSettings.Set(GraphMetadataImportIntervalHours, string.Empty);
-            Assert.AreEqual(24, new AppConfig().GraphMetadataImportIntervalHours);
+            Assert.AreEqual(0, new AppConfig().GraphMetadataImportIntervalHours,
+                "With the default High preset the gate is off, matching pre-throttling behaviour.");
 
             ConfigurationManager.AppSettings.Set(GraphMetadataImportIntervalHours, "nope");
-            Assert.AreEqual(24, new AppConfig().GraphMetadataImportIntervalHours);
+            Assert.AreEqual(0, new AppConfig().GraphMetadataImportIntervalHours);
         }
 
         [TestMethod]
@@ -356,14 +383,14 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void ImportStartStaggerMinutes_EmptyOrInvalid_DefaultsToHalfCyclePause()
+        public void ImportStartStaggerMinutes_EmptyOrInvalid_DefaultsToZero()
         {
-            // Gentle => pause 20 => default stagger 10
+            // Staggering delays the first cycle, so it is opt-in: an upgrade must not silently add a delay.
             ConfigurationManager.AppSettings.Set(ImportAggressiveness, "Gentle");
             ConfigurationManager.AppSettings.Set(ImportCyclePauseMinutes, string.Empty);
             ConfigurationManager.AppSettings.Set(ImportStartStaggerMinutes, string.Empty);
-            Assert.AreEqual(10, new AppConfig().ImportStartStaggerMinutes,
-                "Default stagger should be half the (Gentle=20) cycle pause.");
+            Assert.AreEqual(0, new AppConfig().ImportStartStaggerMinutes,
+                "Default stagger must be 0 (no added start delay) regardless of preset.");
         }
 
         [TestMethod]


### PR DESCRIPTION
Follow-up to #162.

## Problem

The import-aggressiveness presets shipped defaulting to **Balanced**. An existing deployment upgrading to this build has none of the new AppSettings, so it would silently get:

| Knob | Stable (today) | Balanced default | Effect |
|---|---|---|---|
| Audit-load concurrency | 20 | **8** | slower audit import |
| SQL-commit concurrency | 20 | **8** | slower commits |
| Non-fresh Graph imports | every cycle | **every 24h** | staler user/Teams metadata |
| Start stagger | none | **half the cycle pause** | first cycle delayed |

Throttling should be something an admin **opts into**, not something an upgrade does to them.

## Change

Default is now **High**, which reproduces the legacy pre-throttling behaviour exactly:

\\\
audit-load concurrency        20
SQL-commit concurrency        20
cycle pause                   10 min
non-fresh Graph interval       0 (every cycle)
start stagger                  0 (none)
\\\

\Balanced\ and \Gentle\ are unchanged and still available via \ImportAggressiveness\, as are all the individual knobs. The start stagger now defaults to 0 at **every** preset, because it delays the first cycle.

## Test

New \NoAppSettingsAtAll_ReproducesLegacyStableBehaviour\ pins all seven knobs to their pre-throttling values with no AppSettings present, so this cannot regress silently.

## Database impact

**None.** No migration, no schema change, no \CONFIG_VERSION\ bump (these are App Service application settings, not installer config schema).

## Admin action

**None.** Upgrading changes nothing. To reduce CPU, set \ImportAggressiveness=Balanced\ (or \Gentle\).

## Verification

Full **Release** build of the solution is clean, and 45 config/cadence tests pass.

Related: #161