### PR TITLE
Fix first-workload timeout blanking the whole chart; correct stale config comment

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -112,7 +112,7 @@ namespace Common.Entities.Config
                 ? maxSummaryFetchConcurrency
                 : 8;
 
-            // Import "aggressiveness" preset (High | Balanced | Gentle, default Balanced). It provides
+            // Import "aggressiveness" preset (High | Balanced | Gentle, default High). It provides
             // the default values for the burst/cadence knobs below so an admin can ease up CPU usage
             // with a single setting. Any explicit per-knob AppSetting still overrides the preset.
             this.ImportAggressiveness = ParseAggressiveness(ConfigurationManager.AppSettings.Get("ImportAggressiveness"));

--- a/src/AnalyticsEngine/Tests.UnitTests/ReportsAPIControllerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ReportsAPIControllerTests.cs
@@ -12,6 +12,63 @@ namespace Tests.UnitTests
     public class ReportsAPIControllerTests
     {
         [TestMethod]
+        public void FirstWorkloadTimeout_DoesNotAbandonTheRemainingWorkloads()
+        {
+            // The workloads run in a fixed order and the first one is not special. Bailing out on the
+            // first timeout left rowsBySeries empty, so the chart errored anyway - defeating the whole
+            // point of partial rendering. Keep going until something has actually been retrieved.
+            var noRowsYet = new List<KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>>();
+
+            Assert.IsFalse(
+                ReportsAPIController.ShouldStopAfterSeriesFailure(TimeoutException(), noRowsYet),
+                "A timeout on the first workload must not stop the others - that would blank the chart.");
+
+            // A workload that returned zero rows is not data to draw either.
+            var emptySeries = new List<KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>>
+            {
+                new KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>(
+                    "Teams", new List<ReportsAPIController.WeekValueRow>()),
+            };
+            Assert.IsFalse(
+                ReportsAPIController.ShouldStopAfterSeriesFailure(TimeoutException(), emptySeries),
+                "An empty series is nothing to render, so keep trying the remaining workloads.");
+        }
+
+        [TestMethod]
+        public void TimeoutStopsRemainingWorkloads_OnceSomethingCanBeDrawn()
+        {
+            var week = new DateTime(2026, 8, 10);
+            var populated = new List<KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>>
+            {
+                Series("Teams", week),
+            };
+
+            Assert.IsTrue(
+                ReportsAPIController.ShouldStopAfterSeriesFailure(TimeoutException(), populated),
+                "With data already retrieved, stop rather than waiting on more timeouts.");
+        }
+
+        [TestMethod]
+        public void NonTimeoutFailure_NeverStopsTheRemainingWorkloads()
+        {
+            var week = new DateTime(2026, 8, 10);
+            var populated = new List<KeyValuePair<string, List<ReportsAPIController.WeekValueRow>>>
+            {
+                Series("Teams", week),
+            };
+
+            Assert.IsFalse(
+                ReportsAPIController.ShouldStopAfterSeriesFailure(
+                    new InvalidOperationException("bad column"), populated),
+                "A workload-specific error says nothing about the other workloads.");
+        }
+
+        private static Exception TimeoutException()
+        {
+            return new Exception("outer", new TimeoutException("The wait operation timed out"));
+        }
+
+        [TestMethod]
         public void CompleteMultiTimeSeries_QueryFailureKeepsSuccessfulWorkloads()
         {
             var week = new DateTime(2026, 8, 10);

--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -584,7 +584,14 @@ namespace Web.AnalyticsWeb.Controllers
                 catch (Exception ex)
                 {
                     warnings.Add($"{sq.Name}: {InnermostMessage(ex)}");
-                    if (IsQueryTimeout(ex))
+
+                    // Give up on the rest only once we already have something to draw. Bailing out on
+                    // the very first timeout would blank the whole chart - the exact failure this
+                    // partial-rendering behaviour exists to prevent - because the workloads are queried
+                    // in a fixed order and the first one is not special. Once at least one series has
+                    // data we stop, so a struggling database costs one extra timeout, not one per
+                    // remaining workload.
+                    if (ShouldStopAfterSeriesFailure(ex, rowsBySeries))
                     {
                         warnings.Add("Remaining workloads were not attempted after the database timeout");
                         break;
@@ -595,8 +602,25 @@ namespace Web.AnalyticsWeb.Controllers
             return CompleteMultiTimeSeries(chart, rowsBySeries, warnings, weekSpine);
         }
 
-        internal static ReportChart CompleteMultiTimeSeries(
-            ReportChart chart,
+        /// <summary>
+        /// Whether to abandon the remaining workloads after one has failed.
+        ///
+        /// Only a database timeout is worth giving up for (a workload-specific error says nothing about
+        /// the others), and only once at least one series already has data. Stopping on the very first
+        /// timeout would blank the entire chart - the exact failure partial rendering exists to prevent -
+        /// because the workloads run in a fixed order and the first is not special. This way a struggling
+        /// database costs one extra timeout rather than one per remaining workload.
+        /// </summary>
+        internal static bool ShouldStopAfterSeriesFailure(
+            Exception ex,
+            List<KeyValuePair<string, List<WeekValueRow>>> rowsSoFar)
+        {
+            return IsQueryTimeout(ex)
+                && rowsSoFar != null
+                && rowsSoFar.Any(s => s.Value != null && s.Value.Count > 0);
+        }
+
+        internal static ReportChart CompleteMultiTimeSeries(            ReportChart chart,
             List<KeyValuePair<string, List<WeekValueRow>>> rowsBySeries,
             List<string> warnings,
             List<DateTime> weekSpine)


### PR DESCRIPTION
Found by independent adversarial review of release PR #254.

## The partial-rendering fix did not work in its most likely case

#250 claimed *"one slow workload no longer blanks the whole chart"*. That was **false when the first workload timed out**.

Workloads are queried in a fixed order and **Teams goes first**. Any timeout broke out of the loop immediately, so a first-workload timeout left `rowsBySeries` empty and the chart fell through to an error — precisely the blank chart the change existed to prevent. It only helped when a *later* workload failed, which is exactly the case the existing test covered.

## Fix

Give up on the remaining workloads only once **at least one series has data to draw**, and only for a **timeout** (a workload-specific error says nothing about the others).

A struggling database therefore costs one extra timeout rather than one per remaining workload, and a first-workload timeout no longer hides every other workload.

The decision is extracted as `ShouldStopAfterSeriesFailure` so it is directly testable.

## Tests

Regression tests covering the gap the old test missed:

- first-workload timeout must **not** stop the others
- a series that returned **zero rows** is not "data to draw" either
- a **non-timeout** failure never stops the others
- once something *is* drawable, a timeout **does** stop the rest

## Also

Corrects a stale comment in `AppConfig.cs` still describing the preset default as `Balanced` after #251 changed it to `High`.

## Database impact

**None.** No migration, no schema change, no `CONFIG_VERSION` bump.

## Verification

Full **Release** build clean; 46 tests pass.
