### PR TITLE
Compile profiling weeks in bounded chunks: cap tempdb and limit failure blast radius

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql
@@ -2832,14 +2832,47 @@ BEGIN
     @Monday,
     @ThisWeeksMonday;
 
-  -- Compile every outstanding week in a single set-based pass: each source log is
-  -- scanned once for the whole [First..Last] range and bucketed to its week, instead
-  -- of being re-scanned once per week.
+  -- Compile outstanding weeks in BOUNDED CHUNKS rather than one pass covering the whole
+  -- outstanding range. Each chunk still scans each source log once for its own range (the
+  -- point of the range procs) instead of once per week.
+  --
+  -- Measured at 50,000 users x 52 weeks: a single 52-week pass peaks at ~25.5 GB tempdb with
+  -- ~19 GB spilled, and 81.6% of that spill is one step - usp_CompileWeekActivityRows, which
+  -- unpivots ~2.5m staging rows x 59 metrics into ~146m narrow rows. The memory grant is
+  -- effectively fixed regardless of range size (~508 MB observed for both a 10-week and a
+  -- 52-week pass), so anything past roughly a week spills, and the spill then grows about
+  -- linearly with the range. Capping the range per call therefore caps peak tempdb: ~4.1 GB
+  -- for a 10-week chunk versus ~25.5 GB for 52 weeks, for essentially the same total work.
+  --
+  -- Chunking also bounds the BLAST RADIUS. The range procs stage the entire range and write
+  -- to the permanent tables once at the very end, and their CATCH logs without re-throwing,
+  -- so a failure anywhere in the range silently discards every week in that call. Week-at-a-
+  -- time compiling only ever lost the failing week. With chunks, at most one chunk is lost.
   IF @ThisWeeksMonday > @Monday
   BEGIN
-    DECLARE @LastSunday DATE = DATEADD(DAY, -1, @ThisWeeksMonday);
-    EXECUTE profiling.usp_CompileActivityRange @Monday, @LastSunday;
-    EXECUTE profiling.usp_CompileUsageRange @Monday, @LastSunday;
+    DECLARE @ChunkWeeks INT = 10;
+    DECLARE @ChunkStart DATE = @Monday;
+    DECLARE @ChunkEnd DATE;
+    DECLARE @ChunkLastSunday DATE;
+
+    WHILE @ChunkStart < @ThisWeeksMonday
+    BEGIN
+      SET @ChunkEnd = DATEADD(WEEK, @ChunkWeeks, @ChunkStart);
+      IF @ChunkEnd > @ThisWeeksMonday
+        SET @ChunkEnd = @ThisWeeksMonday;
+
+      SET @ChunkLastSunday = DATEADD(DAY, -1, @ChunkEnd);
+
+      EXEC profiling.usp_Trace
+        N'Compiling weeks %s to %s.',
+        @ChunkStart,
+        @ChunkLastSunday;
+
+      EXECUTE profiling.usp_CompileActivityRange @ChunkStart, @ChunkLastSunday;
+      EXECUTE profiling.usp_CompileUsageRange @ChunkStart, @ChunkLastSunday;
+
+      SET @ChunkStart = @ChunkEnd;
+    END
   END
 
   -- Cleanup. Remove data in the tables before the retention date

--- a/src/AnalyticsEngine/Tests.UnitTests/ProfilingStoredProcedureTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ProfilingStoredProcedureTests.cs
@@ -834,6 +834,75 @@ namespace Tests.UnitTests
         /// this from a per-week loop to a single set-based range call; the multi-week tests use this
         /// so they validate whichever compile path is current.
         /// </summary>
+        // usp_CompileWeekly compiles outstanding weeks in bounded 10-week chunks (to cap tempdb
+        // and limit the blast radius of a mid-range failure). Weeks spanning MORE than one chunk
+        // must still each be compiled exactly once - no week skipped at a chunk boundary, and no
+        // week counted twice by overlapping chunks. 13 weeks forces a 10 + 3 split.
+        [TestMethod]
+        public async Task UspCompileWeekly_RangeSpanningChunkBoundary_CompilesEveryWeekExactlyOnce()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                const int weekCount = 13;
+                var firstMonday = TEST_MONDAY.AddDays(154);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+
+                var mondays = new System.Collections.Generic.List<DateTime>();
+                for (var i = 0; i < weekCount; i++)
+                {
+                    mondays.Add(firstMonday.AddDays(7 * i));
+                }
+
+                foreach (var m in mondays)
+                {
+                    await CleanupTestData(db, m);
+                }
+
+                // One day of activity per week = 5 private chats per week (5/day).
+                foreach (var m in mondays)
+                {
+                    await InsertTeamsActivityTestData(db, TEST_USER_ID, m, m);
+                }
+
+                await CompileWeeksInChunks(db, firstMonday, mondays[weekCount - 1]);
+
+                foreach (var m in mondays)
+                {
+                    Assert.AreEqual(5, await GetActivityMetricSum(db, m, TEST_USER_ID, "Teams Private Chats"),
+                        $"Week starting {m:yyyy-MM-dd} must be compiled exactly once across the chunk boundary.");
+                    Assert.AreEqual(5, await GetActivityColumnValue(db, m, TEST_USER_ID, "Teams Private Chats"),
+                        $"Wide table for week starting {m:yyyy-MM-dd} must agree.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Mirrors the chunked loop in profiling.usp_CompileWeekly (10-week chunks) so the chunk
+        /// boundary is exercised without depending on the current date.
+        /// </summary>
+        private async Task CompileWeeksInChunks(AnalyticsEntitiesContext db, DateTime firstMonday, DateTime lastMonday)
+        {
+            const int chunkWeeks = 10;
+            var endExclusive = lastMonday.AddDays(7);
+            var chunkStart = firstMonday;
+
+            while (chunkStart < endExclusive)
+            {
+                var chunkEnd = chunkStart.AddDays(7 * chunkWeeks);
+                if (chunkEnd > endExclusive)
+                {
+                    chunkEnd = endExclusive;
+                }
+
+                var chunkLastSunday = chunkEnd.AddDays(-1);
+                await ExecuteSql(db, $"EXEC profiling.usp_CompileActivityRange @StartDate = '{chunkStart:yyyy-MM-dd}', @EndDate = '{chunkLastSunday:yyyy-MM-dd}'");
+                await ExecuteSql(db, $"EXEC profiling.usp_CompileUsageRange @StartDate = '{chunkStart:yyyy-MM-dd}', @EndDate = '{chunkLastSunday:yyyy-MM-dd}'");
+
+                chunkStart = chunkEnd;
+            }
+        }
+
         private async Task CompileWeeks(AnalyticsEntitiesContext db, DateTime firstMonday, DateTime lastMonday)
         {
             var lastSunday = lastMonday.AddDays(6);


### PR DESCRIPTION
Benchmarks #209's range-wide profiling rewrite before it reaches stable, per the prove-it policy (#252) — and fixes what the measurement found.

## The measurement

**50,000 users × 52 weeks, ~40.3M source rows.** Medians where repeated, plan cache cleared.

| Scenario | OLD (week-by-week loop) | NEW (single range pass) |
|---|---|---|
| **1 week** (routine cadence) | 44.3 s, 1.25M reads, 119 MB tempdb | 47.8 s, 1.25M reads, 119 MB tempdb |
| **10 weeks** | 36.9 min, 107.2M reads, 1.18 GB tempdb | **11.7 min**, **8.4M reads**, 4.11 GB tempdb |
| **52 weeks** (catch-up) | *would not finish* (~10–15 h, extrapolated + partial run) | **58.2 min**, 35.0M reads, **25.5 GB tempdb** |

Two conclusions:

1. **The routine single-week compile — the one that actually runs weekly — is NEUTRAL.** #209 buys nothing for normal operation.
2. **The win is entirely in multi-week catch-up, and it is a big one** — 58 minutes versus a run that realistically never completes in a maintenance window.

## But it was not free

A 52-week pass peaks at **~25.5 GB tempdb with ~19 GB spilled — at only 50,000 users**. This product targets **200,000**, where a linear extrapolation is **~100 GB**. That risks the catch-up **failing outright on tempdb exhaustion**, which is a worse failure mode than the old slow-but-completing behaviour. This was never measured or disclosed in #209.

**Why it spills:** the memory grant is effectively fixed regardless of range size (~508 MB observed for *both* the 10-week and 52-week passes). Anything past roughly one week blows past it, and the spill then grows about linearly with the range. **81.6% of all spill is one step** — `usp_CompileWeekActivityRows`, which unpivots ~2.5M staging rows × 59 metrics into ~146M narrow rows.

Because the cost is linear beyond the threshold, capping the range per call directly caps the peak.

## The fix

`usp_CompileWeekly` now compiles in **10-week chunks** instead of one pass over every outstanding week. Each chunk keeps the single-scan-per-source benefit, so catch-up stays fast, while peak tempdb drops to roughly the 10-week figure (**~4.1 GB measured, vs ~25.5 GB**).

Indexing `#ActivitiesStaging` was considered and rejected — the dominant spill is in the step that *reads* staging and unpivots it, so an index there addresses the margins, not the hot spot.

## It also bounds a silent-failure blast radius

The range procs stage the entire range and write to the permanent tables **once at the very end**, and their `CATCH` logs without re-throwing. So a failure anywhere in the range **silently discards every week in that call** — a 52-week catch-up could produce *nothing* while `usp_CompileWeekly` and the Automation runbook still reported success.

Week-at-a-time compiling only ever lost the failing week. With chunks, at most one chunk is lost.

> The swallow-without-rethrow itself is **pre-existing** and identical on `main` (3 occurrences each side) — it is not a regression from #209. Only the blast radius changed, and this bounds it. Making those procs propagate failure is worth a follow-up issue.

## Tests

New regression test compiles **13 weeks — a 10 + 3 split** — and asserts every week is compiled exactly once, so no week is skipped at a chunk boundary and none is double-counted by overlapping chunks. The existing tests only spanned 2–3 weeks and never crossed a boundary.

**19 profiling tests pass** against LocalDB.

## Database impact

**No migration and no schema change.** `Profiling-03-CreateSchema.sql` is re-run by the installer on every upgrade; this alters the body of one stored procedure. No table, column, index or table type changes.

## Admin guidance for the release notes

Extrapolated tempdb for a **full-retention catch-up** (only the first run or a backfill; the routine weekly compile is unaffected). Azure SQL provides roughly 32 GB tempdb per vCore:

| Users | Before this fix | After this fix (10-week chunks) |
|---|---|---|
| 50,000 (measured) | ~25.5 GB | ~4–5 GB |
| 100,000 | ~50–55 GB *(extrapolated)* | ~8–10 GB |
| 200,000 | ~100–110 GB *(extrapolated)* | ~16–20 GB |

⚠️ The 100k/200k figures are **linear extrapolations from a single 50k measurement**, not direct tests.

Related: #209
