### PR TITLE
Enable EasyAuth MISE validation for telemetry dashboard

### DIFF
--- a/.azure/plan.md
+++ b/.azure/plan.md
@@ -3,6 +3,12 @@
 > **Status:** Deployed
 
 Generated: 2026-08-13T15:24:00+02:00
+Updated: 2026-08-18T14:28:15+02:00
+
+**Current change:** Enable the App Service MISE authentication runtime in
+allow-anonymous mode so bearer-token validation emits compliant key-discovery
+telemetry while the ASP.NET Core application continues enforcing dashboard
+scope and role authorization.
 
 ---
 
@@ -190,6 +196,21 @@ The service already:
 - [x] Verify public health/auth endpoints and private Cosmos/Key Vault network state
 - [x] Update plan status to `Deployed`
 
+### Phase 5: MISE Remediation
+
+- [x] Add non-enforcing App Service Authentication for the existing Entra SPA/API
+- [x] Enable the App Service MISE runtime
+- [x] Preserve anonymous signed uploads, health checks and MSAL configuration
+- [x] Add deployment checks for EasyAuth configuration, client ID, scope and runtime version
+- [x] Recompile the ARM template and build the Telemetry Service
+- [x] Reconfirm the production resource and Entra application out-of-band
+- [x] Confirm the production Azure CLI context with the user
+- [x] Reinvoke azure-validate after the Linux EasyAuth verification adjustment
+- [x] Run a production subscription what-if
+- [x] Deploy the infrastructure update
+- [ ] Generate authenticated dashboard traffic
+- [ ] Verify compliant MISE key-discovery telemetry after the reporting window
+
 ---
 
 ## 7. Validation Proof
@@ -218,6 +239,49 @@ The service already:
 **Validation timestamp:** 2026-08-13T17:02:02+02:00
 
 The original provisioned-throughput validation is retained for history; the later serverless validation is authoritative.
+
+### Current MISE remediation validation proof
+
+| Check | Sanitized command shape | Result | Timestamp |
+|-------|-------------------------|--------|-----------|
+| Production Azure context | `az account set/show` against retained out-of-band values | Pass; subscription and tenant confirmed by the user | 2026-08-18T14:47:03+02:00 |
+| Bicep compilation and ARM parity | `az bicep build --file infra/TelemetryService/main.bicep` plus SHA-256 comparison | Pass; checked-in ARM exactly matches Bicep output | 2026-08-18T14:47:03+02:00 |
+| Production ARM validation | `az deployment sub validate ... --parameters @<temporary-parameters>` | Pass; provisioning state `Succeeded` | 2026-08-18T14:47:03+02:00 |
+| Production what-if | `deploy.ps1 ... -AzureAdClientId <out-of-band> -WhatIf` | Pass; 29 convergent deployments, 5 ignored platform resources, no deletions | 2026-08-18T14:47:03+02:00 |
+| Application build | `dotnet build src/TelemetryService/Web.Server/Web.Server.csproj --configuration Release` | Pass; build succeeded | 2026-08-18T14:47:03+02:00 |
+| Frontend lint and production dependency audit | `npm run lint` and `npm audit --omit=dev` | Pass; lint clean and no production vulnerabilities | 2026-08-18T14:47:03+02:00 |
+| NuGet dependency audit | `dotnet list ... package --vulnerable --include-transitive` | Pass; no vulnerable packages | 2026-08-18T14:47:03+02:00 |
+| Deployment script and repository safety | PowerShell parser, `git diff --check`, and exact production-identifier scan | Pass; no parser errors, whitespace errors, secrets, or environment identifiers in the diff | 2026-08-18T14:47:03+02:00 |
+| Linux EasyAuth behavior | ARM authsettings query plus anonymous health, platform-route, protected-API and public-config probes | Pass; EasyAuth enabled with `~1`, platform route intercepted, health/config public and dashboard API protected | 2026-08-18T15:05:37+02:00 |
+| Linux verification adjustment | Bicep/ARM parity, PowerShell parser, repository safety scan and Release build | Pass; all current artifacts and checks succeeded | 2026-08-18T15:05:37+02:00 |
+
+**Validated by:** azure-validate skill
+
+**Validation timestamp:** 2026-08-18T15:05:37+02:00
+
+All production identifiers and parameters remain out-of-band and are
+intentionally omitted from this public repository.
+
+The first deployment applied the ARM changes successfully, but the post-deploy
+check assumed anonymous access to `/.auth/version`. Linux App Service protects
+that platform route with HTTP 401. The verification now accepts that
+interception behavior while retaining the `~1` runtime-selector check.
+
+### Current MISE remediation deployment result
+
+Deployment completed: 2026-08-18T15:11:50+02:00
+
+- App Service Authentication is enabled in allow-anonymous mode.
+- The App Service MISE runtime setting is enabled.
+- The configured authentication runtime selector is `~1`.
+- The platform authentication route is intercepted by EasyAuth.
+- The public health and MSAL-configuration endpoints return HTTP 200.
+- The dashboard API returns HTTP 401 without an access token.
+- An anonymous invalid telemetry upload reaches the application and returns HTTP 400.
+- Automatic tenant admin consent remains unavailable; an assigned dashboard
+  user might receive a delegated-consent prompt on first sign-in.
+- No subscription, tenant, resource, application, user, URL, network or secret
+  values are recorded in this plan.
 
 ---
 
@@ -270,6 +334,7 @@ No environment-specific parameter file will be generated inside the repository.
 
 ## 9. Next Steps
 
-> Current: Deployed and verified.
+> Current: EasyAuth/MISE remediation deployed; authenticated traffic and KPI confirmation remain.
 
-1. Persist the parameterized IaC and deployment automation through a pull request to `dev`.
+1. Exercise the authenticated dashboard with an assigned user.
+2. Confirm the MISE compliance KPI after its reporting delay.

--- a/infra/TelemetryService/azuredeploy.json
+++ b/infra/TelemetryService/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "7526898000566360666"
+      "templateHash": "2784755309735525658"
     }
   },
   "parameters": {
@@ -140,7 +140,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.43.8.12551",
-              "templateHash": "4033566444911330528"
+              "templateHash": "13856034097467170917"
             }
           },
           "parameters": {
@@ -194,7 +194,8 @@
             "cosmosPrivateDnsZoneName": "privatelink.documents.azure.com",
             "keyVaultPrivateDnsZoneName": "privatelink.vaultcore.azure.net",
             "keyVaultSecretsUserRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
-            "cosmosDataContributorRoleId": "00000000-0000-0000-0000-000000000002"
+            "cosmosDataContributorRoleId": "00000000-0000-0000-0000-000000000002",
+            "easyAuthIssuer": "[format('{0}{1}/v2.0', environment().authentication.loginEndpoint, parameters('azureAdTenantId'))]"
           },
           "resources": [
             {
@@ -638,6 +639,47 @@
               ]
             },
             {
+              "type": "Microsoft.Web/sites/config",
+              "apiVersion": "2024-04-01",
+              "name": "[format('{0}/{1}', parameters('webAppName'), 'authsettingsV2')]",
+              "properties": {
+                "platform": {
+                  "enabled": true,
+                  "runtimeVersion": "~1"
+                },
+                "globalValidation": {
+                  "requireAuthentication": false,
+                  "unauthenticatedClientAction": "AllowAnonymous"
+                },
+                "identityProviders": {
+                  "azureActiveDirectory": {
+                    "enabled": true,
+                    "registration": {
+                      "clientId": "[parameters('azureAdClientId')]",
+                      "openIdIssuer": "[variables('easyAuthIssuer')]"
+                    },
+                    "validation": {
+                      "allowedAudiences": [
+                        "[parameters('azureAdClientId')]",
+                        "[format('api://{0}', parameters('azureAdClientId'))]"
+                      ]
+                    }
+                  }
+                },
+                "login": {
+                  "tokenStore": {
+                    "enabled": false
+                  }
+                },
+                "httpSettings": {
+                  "requireHttps": true
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('webAppName'))]"
+              ]
+            },
+            {
               "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
               "apiVersion": "2024-04-01",
               "name": "[format('{0}/{1}', parameters('webAppName'), 'ftp')]",
@@ -699,6 +741,7 @@
                 "WEBSITE_HEALTHCHECK_MAXPINGFAILURES": "5",
                 "SCM_DO_BUILD_DURING_DEPLOYMENT": "false",
                 "ENABLE_ORYX_BUILD": "false",
+                "WEBSITE_AAD_ENABLE_MISE": "true",
                 "TelemetrySecret": "[format('@Microsoft.KeyVault(VaultName={0};SecretName={1})', variables('keyVaultName'), variables('telemetrySecretName'))]",
                 "CosmosDb__AccountEndpoint": "[reference(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), '2024-11-15').documentEndpoint]",
                 "CosmosDb__DatabaseName": "[variables('cosmosDatabaseName')]",
@@ -744,6 +787,10 @@
               "type": "string",
               "value": "[format('https://{0}/api/auth/config', reference(resourceId('Microsoft.Web/sites', parameters('webAppName')), '2024-04-01').defaultHostName)]"
             },
+            "easyAuthIssuer": {
+              "type": "string",
+              "value": "[variables('easyAuthIssuer')]"
+            },
             "cosmosAccountName": {
               "type": "string",
               "value": "[variables('cosmosAccountName')]"
@@ -784,6 +831,10 @@
     "authConfigUrl": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.authConfigUrl.value]"
+    },
+    "easyAuthIssuer": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'telemetry-resources'), '2025-04-01').outputs.easyAuthIssuer.value]"
     },
     "cosmosAccountName": {
       "type": "string",

--- a/infra/TelemetryService/deploy.ps1
+++ b/infra/TelemetryService/deploy.ps1
@@ -441,7 +441,10 @@ function Publish-TelemetryApplication {
 function Test-TelemetryDeployment {
     param(
         [Parameter(Mandatory)]
-        [pscustomobject] $Outputs
+        [pscustomobject] $Outputs,
+
+        [Parameter(Mandatory)]
+        [string] $ClientId
     )
 
     $healthUrl = "$($Outputs.webAppUrl.value)/health"
@@ -463,9 +466,119 @@ function Test-TelemetryDeployment {
         throw "Health endpoint did not become ready: $healthUrl"
     }
 
+    $webAppResourceId = Invoke-AzCli -Arguments @(
+        'webapp', 'show',
+        '--resource-group', $ResourceGroupName,
+        '--name', $WebAppName,
+        '--query', 'id',
+        '--output', 'tsv'
+    )
+
+    $authSettings = Invoke-AzRestJson -Method get `
+        -Uri "https://management.azure.com$webAppResourceId/config/authsettingsV2/list?api-version=2024-04-01"
+    if (-not $authSettings -or -not $authSettings.properties) {
+        throw 'App Service Authentication settings were not returned.'
+    }
+
+    $authProperties = $authSettings.properties
+    if ($authProperties.platform.enabled -ne $true) {
+        throw 'App Service Authentication is not enabled.'
+    }
+    if ($authProperties.platform.runtimeVersion -ne '~1') {
+        throw "App Service Authentication runtime is '$($authProperties.platform.runtimeVersion)'; expected '~1'."
+    }
+    if ($authProperties.globalValidation.requireAuthentication -ne $false) {
+        throw 'EasyAuth must allow anonymous requests so signed telemetry uploads can reach the application.'
+    }
+    if ($authProperties.globalValidation.unauthenticatedClientAction -ne 'AllowAnonymous') {
+        throw "EasyAuth unauthenticated action is '$($authProperties.globalValidation.unauthenticatedClientAction)'; expected 'AllowAnonymous'."
+    }
+
+    $azureAdProvider = $authProperties.identityProviders.azureActiveDirectory
+    if ($azureAdProvider.enabled -ne $true) {
+        throw 'The EasyAuth Microsoft Entra provider is not enabled.'
+    }
+    if ($azureAdProvider.registration.clientId -ne $ClientId) {
+        throw 'The EasyAuth client ID does not match the telemetry dashboard app registration.'
+    }
+    if ($azureAdProvider.registration.openIdIssuer -ne $Outputs.easyAuthIssuer.value) {
+        throw "EasyAuth issuer is '$($azureAdProvider.registration.openIdIssuer)'; expected '$($Outputs.easyAuthIssuer.value)'."
+    }
+
+    $allowedAudiences = @($azureAdProvider.validation.allowedAudiences)
+    foreach ($expectedAudience in @($ClientId, "api://$ClientId")) {
+        if ($allowedAudiences -notcontains $expectedAudience) {
+            throw "EasyAuth allowed audiences do not include '$expectedAudience'."
+        }
+    }
+    if ($authProperties.login.tokenStore.enabled -ne $false) {
+        throw 'The EasyAuth token store should remain disabled because the SPA manages its own tokens.'
+    }
+
+    $miseSetting = Invoke-AzCli -Arguments @(
+        'webapp', 'config', 'appsettings', 'list',
+        '--resource-group', $ResourceGroupName,
+        '--name', $WebAppName,
+        '--query', "[?name=='WEBSITE_AAD_ENABLE_MISE'].value | [0]",
+        '--output', 'tsv'
+    )
+    if ($miseSetting -ne 'true') {
+        throw "WEBSITE_AAD_ENABLE_MISE is '$miseSetting'; expected 'true'."
+    }
+
+    $easyAuthReady = $false
+    for ($attempt = 1; $attempt -le 30; $attempt++) {
+        $easyAuthVersionResponse = $null
+        try {
+            $easyAuthVersionResponse = Invoke-WebRequest `
+                -Uri "$($Outputs.webAppUrl.value)/.auth/version" `
+                -TimeoutSec 20 `
+                -SkipHttpErrorCheck
+        }
+        catch {
+            # App Service Authentication can recycle after authsettings or app settings change.
+        }
+
+        if ($null -eq $easyAuthVersionResponse) {
+            Start-Sleep -Seconds 10
+            continue
+        }
+
+        if ($easyAuthVersionResponse.StatusCode -eq 401) {
+            # Linux EasyAuth can require an authenticated session for this endpoint.
+            # A 401 proves the platform route is active instead of falling through to the SPA.
+            $easyAuthReady = $true
+            break
+        }
+
+        if ($easyAuthVersionResponse.StatusCode -eq 200) {
+            $versionMatch = [regex]::Match($easyAuthVersionResponse.Content, '\d+(?:\.\d+){2,3}')
+            if ($versionMatch.Success) {
+                $easyAuthVersion = [version] $versionMatch.Value
+                if ($easyAuthVersion -le [version] '1.7.0') {
+                    throw "EasyAuth runtime version is $easyAuthVersion; a version newer than 1.7.0 is required."
+                }
+                $easyAuthReady = $true
+                break
+            }
+        }
+
+        Start-Sleep -Seconds 10
+    }
+    if (-not $easyAuthReady) {
+        throw 'EasyAuth did not begin intercepting platform authentication routes.'
+    }
+
     $authConfig = Invoke-WebRequest -Uri $Outputs.authConfigUrl.value -TimeoutSec 20 -SkipHttpErrorCheck
     if ($authConfig.StatusCode -ne 200) {
         throw "Authentication configuration endpoint returned HTTP $($authConfig.StatusCode)."
+    }
+    $authClientConfig = $authConfig.Content | ConvertFrom-Json -ErrorAction Stop
+    if ($authClientConfig.clientId -ne $ClientId) {
+        throw 'The deployed dashboard authentication configuration has an unexpected client ID.'
+    }
+    if ($authClientConfig.scope -ne "api://$ClientId/$script:ScopeName") {
+        throw "The deployed dashboard scope is '$($authClientConfig.scope)'; expected 'api://$ClientId/$script:ScopeName'."
     }
 
     $protectedEndpoint = Invoke-WebRequest `
@@ -498,13 +611,6 @@ function Test-TelemetryDeployment {
         throw 'Key Vault public network access is not disabled.'
     }
 
-    $webAppResourceId = Invoke-AzCli -Arguments @(
-        'webapp', 'show',
-        '--resource-group', $ResourceGroupName,
-        '--name', $WebAppName,
-        '--query', 'id',
-        '--output', 'tsv'
-    )
     $configReferences = Invoke-AzRestJson -Method get `
         -Uri "https://management.azure.com$webAppResourceId/config/configreferences/appsettings?api-version=2026-07-15"
     $telemetrySecretReference = @($configReferences.value) |
@@ -598,7 +704,7 @@ try {
         Publish-TelemetryApplication -WebAppResourceId $webAppResourceId
     }
 
-    Test-TelemetryDeployment -Outputs $outputs
+    Test-TelemetryDeployment -Outputs $outputs -ClientId $clientId
 
     Write-Host "Telemetry Service deployed successfully: $($outputs.statsApiUrl.value)"
 }

--- a/infra/TelemetryService/main.bicep
+++ b/infra/TelemetryService/main.bicep
@@ -70,6 +70,7 @@ output webAppName string = telemetryResources.outputs.webAppName
 output webAppUrl string = telemetryResources.outputs.webAppUrl
 output statsApiUrl string = telemetryResources.outputs.statsApiUrl
 output authConfigUrl string = telemetryResources.outputs.authConfigUrl
+output easyAuthIssuer string = telemetryResources.outputs.easyAuthIssuer
 output cosmosAccountName string = telemetryResources.outputs.cosmosAccountName
 output keyVaultName string = telemetryResources.outputs.keyVaultName
 output appServicePrincipalId string = telemetryResources.outputs.appServicePrincipalId

--- a/infra/TelemetryService/resources.bicep
+++ b/infra/TelemetryService/resources.bicep
@@ -36,6 +36,7 @@ var keyVaultSecretsUserRoleDefinitionId = subscriptionResourceId(
   '4633458b-17de-408a-b874-0445c86b69e6'
 )
 var cosmosDataContributorRoleId = '00000000-0000-0000-0000-000000000002'
+var easyAuthIssuer = '${environment().authentication.loginEndpoint}${azureAdTenantId}/v2.0'
 
 resource appIntegrationNsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
   name: appIntegrationNsgName
@@ -415,6 +416,46 @@ resource webApp 'Microsoft.Web/sites@2024-04-01' = {
   }
 }
 
+// EasyAuth validates bearer tokens with the App Service MISE runtime, while the
+// application remains responsible for enforcing dashboard scopes and roles.
+resource easyAuthSettings 'Microsoft.Web/sites/config@2024-04-01' = {
+  parent: webApp
+  name: 'authsettingsV2'
+  properties: {
+    platform: {
+      enabled: true
+      runtimeVersion: '~1'
+    }
+    globalValidation: {
+      requireAuthentication: false
+      unauthenticatedClientAction: 'AllowAnonymous'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        registration: {
+          clientId: azureAdClientId
+          openIdIssuer: easyAuthIssuer
+        }
+        validation: {
+          allowedAudiences: [
+            azureAdClientId
+            'api://${azureAdClientId}'
+          ]
+        }
+      }
+    }
+    login: {
+      tokenStore: {
+        enabled: false
+      }
+    }
+    httpSettings: {
+      requireHttps: true
+    }
+  }
+}
+
 resource ftpPublishingPolicy 'Microsoft.Web/sites/basicPublishingCredentialsPolicies@2024-04-01' = {
   parent: webApp
   name: 'ftp'
@@ -461,6 +502,7 @@ resource webAppSettings 'Microsoft.Web/sites/config@2024-04-01' = {
     WEBSITE_HEALTHCHECK_MAXPINGFAILURES: '5'
     SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
     ENABLE_ORYX_BUILD: 'false'
+    WEBSITE_AAD_ENABLE_MISE: 'true'
     TelemetrySecret: '@Microsoft.KeyVault(VaultName=${keyVault.name};SecretName=${telemetrySecretName})'
     CosmosDb__AccountEndpoint: cosmosAccount.properties.documentEndpoint
     CosmosDb__DatabaseName: cosmosDatabaseName
@@ -489,6 +531,7 @@ output webAppName string = webApp.name
 output webAppUrl string = 'https://${webApp.properties.defaultHostName}'
 output statsApiUrl string = 'https://${webApp.properties.defaultHostName}/api/Telemetry'
 output authConfigUrl string = 'https://${webApp.properties.defaultHostName}/api/auth/config'
+output easyAuthIssuer string = easyAuthIssuer
 output cosmosAccountName string = cosmosAccount.name
 output keyVaultName string = keyVault.name
 output appServicePrincipalId string = webApp.identity.principalId

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -47,6 +47,11 @@ installations (the AnalyticsEngine importer in
   both the `Telemetry.Read` scope and the `Telemetry.Dashboard.Read` app role,
   so only explicitly assigned users or groups can view the reports. The SPA
   uses MSAL and stores tokens in session storage.
+- **App Service Authentication** runs in allow-anonymous mode so it validates
+  bearer tokens and emits MISE key-discovery telemetry without becoming the
+  authorization boundary. The ASP.NET Core API still performs the scope and
+  role checks, while anonymous health, configuration and signed-upload
+  requests continue to reach the application.
 
 ## Configuration
 
@@ -57,6 +62,7 @@ installations (the AnalyticsEngine importer in
 | `AzureAd:TenantId` | yes | Tenant containing the dashboard app registration. |
 | `AzureAd:ClientId` | yes | Client ID of the single-tenant SPA/API app registration. |
 | `AzureAd:Scopes` | yes | Delegated scope name exposed by the app registration. Must be `Telemetry.Read`. |
+| `WEBSITE_AAD_ENABLE_MISE` | Azure deployment | Enables the App Service MISE validation runtime. The Bicep deployment sets this to `true`. |
 | `CosmosDb:AccountEndpoint` | yes | Cosmos account URL, e.g. `https://myaccount.documents.azure.com:443/`. The account uses AAD (key auth disabled) — `DefaultAzureCredential` is used. |
 | `CosmosDb:DatabaseName` | yes | Cosmos database to use (created on startup if missing). |
 | `CosmosDb:ContainerNameCurrent` | yes | Container for the latest record per client. |
@@ -203,12 +209,14 @@ The script:
 2. registers required Azure resource providers;
 3. creates or updates the single-tenant Entra SPA/API and assigns the current
    user the `Telemetry.Dashboard.Read` role;
-4. deploys the ARM template using a temporary parameters file that is deleted
-   afterward;
+4. deploys the ARM template, including non-enforcing App Service
+   Authentication and the MISE runtime setting, using a temporary parameters
+   file that is deleted afterward;
 5. stores the signing secret in private Key Vault;
 6. builds and ZIP-deploys the application using Entra authentication;
-7. verifies health, authorization, Cosmos/Key Vault network isolation, private
-   endpoints and the Key Vault reference.
+7. verifies health, application authorization, EasyAuth configuration and
+   runtime version, Cosmos/Key Vault network isolation, private endpoints and
+   the Key Vault reference.
 
 Tenant admin consent might need to be granted manually after deployment. The
 assigned dashboard user can otherwise be prompted for delegated
@@ -217,6 +225,28 @@ assigned dashboard user can otherwise be prompted for delegated
 > Deploying `azuredeploy.json` directly provisions only Azure resources. Use
 > `deploy.ps1` for the complete Entra configuration, secure secret handling,
 > application publication and verification workflow.
+
+### MISE compliance verification
+
+The public repository intentionally keeps `Microsoft.Identity.Web` for its
+portable, public NuGet restore path. App Service Authentication supplies the
+MISE runtime and validates the same bearer tokens before the application
+performs its existing scope and role authorization.
+
+After deploying:
+
+1. Sign in to the dashboard and load both protected API endpoints so token
+   acquisition and key discovery occur together.
+2. Confirm the deployment script sees EasyAuth intercept `/.auth/version`.
+   Authenticated responses must report a runtime newer than `1.7.0`; Linux
+   App Service can return HTTP 401 to anonymous version requests, so the script
+   also verifies the ARM runtime selector is `~1`.
+3. Allow 3–5 days for the compliance pipeline to report the new key-discovery
+   telemetry.
+
+Do not change EasyAuth to require authentication globally without preserving
+the anonymous signed-upload, health and public authentication-configuration
+paths. Deployed importers do not send Entra tokens to the upload endpoint.
 
 ## Importer side — pointing an installation at this service
 

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -99,6 +99,125 @@ dotnet user-secrets set "CosmosDb:ContainerNameHistory" "History" --project Web.
 > on startup, so the configured database / containers are created automatically
 > the first time the app runs against a fresh Cosmos account.
 
+## Deploying to Azure
+
+The deployment assets are in [`infra/TelemetryService/`](../../infra/TelemetryService):
+
+| File | Purpose |
+| --- | --- |
+| `main.bicep` | Subscription-scope entry point; creates the resource group. |
+| `resources.bicep` | App Service, serverless Cosmos DB, Key Vault, VNet, private endpoints/DNS, RBAC and monitoring. |
+| `azuredeploy.json` | Compiled ARM template generated from the Bicep files. |
+| `deploy.ps1` | Recommended deployment and redeployment entry point. It also configures Entra, builds/publishes the app and verifies the result. |
+
+The script intentionally does **not** use or generate a committed environment
+parameter file. Supply environment-specific values at runtime and keep them in
+your approved secure backup system.
+
+### Prerequisites
+
+- PowerShell 7, Azure CLI, .NET 10 SDK and Node.js/npm.
+- Azure CLI signed into the target tenant and subscription.
+- Permission to create resources and role assignments in the subscription.
+- Permission to create an Entra app registration and assign its app role.
+- A globally unique App Service name.
+- The upload signing secret. It must match `StatsApiSecret` in every importer
+  that sends telemetry to this service.
+
+On a managed Microsoft device, configure npm to use the approved package feed:
+
+```pwsh
+npm config set registry "https://packagefeedproxy.microsoft.io/npm/" --location=user
+npm config set replace-registry-host npmjs --location=user
+```
+
+### Parameters to retain securely
+
+Back up these values outside the public repository so the deployment can be
+reproduced:
+
+- subscription ID and tenant/domain;
+- Azure region and resource-group name;
+- App Service name and resource-name prefix;
+- VNet and subnet CIDR prefixes;
+- Entra app display name, if changed from the default;
+- `TelemetrySecret` / importer `StatsApiSecret`.
+
+Azure resource configuration is reproducible from Bicep. The signing secret is
+stored in Key Vault after deployment, but the deployer still needs an approved
+copy when rebuilding an environment from scratch.
+
+### Preview the deployment
+
+From the repository root, set the secret for the current PowerShell process:
+
+```pwsh
+$env:TELEMETRY_SERVICE_SECRET = "<existing-importer-StatsApiSecret>"
+```
+
+Run an ARM what-if before provisioning:
+
+```pwsh
+.\infra\TelemetryService\deploy.ps1 `
+  -SubscriptionId "<subscription-id>" `
+  -Tenant "<tenant-domain-or-id>" `
+  -Location "<azure-region>" `
+  -ResourceGroupName "<resource-group-name>" `
+  -WebAppName "<globally-unique-app-service-name>" `
+  -NamePrefix "<short-resource-prefix>" `
+  -VnetAddressPrefix "<vnet-cidr>" `
+  -AppIntegrationSubnetPrefix "<app-service-subnet-cidr>" `
+  -PrivateEndpointSubnetPrefix "<private-endpoint-subnet-cidr>" `
+  -WhatIf
+```
+
+The preview does not create the Entra application; it uses a synthetic client
+ID only for ARM validation.
+
+### Deploy or redeploy
+
+Run the same command without `-WhatIf`:
+
+```pwsh
+.\infra\TelemetryService\deploy.ps1 `
+  -SubscriptionId "<subscription-id>" `
+  -Tenant "<tenant-domain-or-id>" `
+  -Location "<azure-region>" `
+  -ResourceGroupName "<resource-group-name>" `
+  -WebAppName "<globally-unique-app-service-name>" `
+  -NamePrefix "<short-resource-prefix>" `
+  -VnetAddressPrefix "<vnet-cidr>" `
+  -AppIntegrationSubnetPrefix "<app-service-subnet-cidr>" `
+  -PrivateEndpointSubnetPrefix "<private-endpoint-subnet-cidr>"
+
+Remove-Item Env:TELEMETRY_SERVICE_SECRET
+```
+
+The deployment is idempotent. Reusing the same values updates the existing
+resources and republishes the current application. Use
+`-SkipApplicationPublish` to update only infrastructure and Entra configuration.
+
+The script:
+
+1. checks the Azure context and App Service hostname;
+2. registers required Azure resource providers;
+3. creates or updates the single-tenant Entra SPA/API and assigns the current
+   user the `Telemetry.Dashboard.Read` role;
+4. deploys the ARM template using a temporary parameters file that is deleted
+   afterward;
+5. stores the signing secret in private Key Vault;
+6. builds and ZIP-deploys the application using Entra authentication;
+7. verifies health, authorization, Cosmos/Key Vault network isolation, private
+   endpoints and the Key Vault reference.
+
+Tenant admin consent might need to be granted manually after deployment. The
+assigned dashboard user can otherwise be prompted for delegated
+`Telemetry.Read` consent on first sign-in.
+
+> Deploying `azuredeploy.json` directly provisions only Azure resources. Use
+> `deploy.ps1` for the complete Entra configuration, secure secret handling,
+> application publication and verification workflow.
+
 ## Importer side — pointing an installation at this service
 
 The importer reads two values from its `App.config` / Azure app settings


### PR DESCRIPTION
## Summary

- Enable App Service Authentication (`authsettingsV2`) for the Telemetry Service using the existing single-tenant SPA/API registration.
- Run EasyAuth in allow-anonymous mode so signed telemetry uploads, health checks, static assets and public MSAL configuration continue to reach the application.
- Enable the App Service MISE runtime with `WEBSITE_AAD_ENABLE_MISE=true`.
- Retain `Microsoft.Identity.Web` as the application authorization boundary for the delegated scope and dashboard-reader role.
- Add production deployment verification for the EasyAuth ARM configuration, MISE setting, configured client ID/scope and Linux platform-route behavior.
- Regenerate the compiled ARM template and update the deployment/compliance documentation.

## Why

The dashboard SPA acquires delegated Entra tokens for the API, but the API currently validates them only with `Microsoft.Identity.Web`. The S360 MISE KPI therefore observes token acquisition without compliant MISE key-discovery telemetry.

A direct migration to `Microsoft.Identity.ServiceEssentials.AspNetCore` is not suitable for this public repository because the package is distributed through an internal feed. EasyAuth supplies the platform MISE runtime without making public builds depend on internal packages.

## Request path

```text
Dashboard SPA / MSAL bearer token
  -> App Service EasyAuth / MISE validation and telemetry (non-enforcing)
  -> ASP.NET Core Microsoft.Identity.Web validation
  -> Telemetry.Read scope + Telemetry.Dashboard.Read role authorization

Signed telemetry upload without Entra token
  -> EasyAuth pass-through
  -> BCrypt payload-signature validation
```

## Deployment behavior

- `platform.enabled = true`, runtime selector `~1`.
- A tenant-specific v2 issuer and both supported API audience formats are configured.
- `requireAuthentication = false` and `AllowAnonymous` preserve the mixed public/protected endpoint model.
- The EasyAuth token store remains disabled because the SPA manages its own tokens.
- Linux App Service can return HTTP 401 for anonymous `/.auth/version` requests; deployment verification treats that as proof that the platform route is intercepted while retaining the ARM runtime-selector check.

## Validation and rollout

- Bicep compiled cleanly and the checked-in ARM template matches its output.
- Production ARM validation and what-if completed without deletion operations.
- Release build, frontend lint, production npm dependency audit and NuGet vulnerability audit passed.
- The production update has been deployed successfully.
- Health and public auth configuration return HTTP 200.
- The dashboard API returns HTTP 401 without a token.
- An anonymous invalid upload reaches the application and returns HTTP 400.
- EasyAuth is enabled with the MISE app setting and runtime selector applied.

The compliance item remains telemetry-gated: an assigned user must exercise the authenticated dashboard, then the MISE/S360 reporting pipeline needs approximately 3-5 days to show compliant key discovery.

## Rollback

Remove the `authsettingsV2` resource and `WEBSITE_AAD_ENABLE_MISE` setting, regenerate the ARM template and redeploy. Application-level `Microsoft.Identity.Web` authorization remains unchanged, so rollback does not alter the dashboard's existing token-validation code.
