### PR TITLE
Stable Release: asynchronous App Service deployment

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/InstallAppServiceContentsTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/InstallAppServiceContentsTask.cs
@@ -29,6 +29,12 @@ namespace App.ControlPanel.Engine.InstallerTasks
         private readonly InstallerProxyConfig _proxyConfig;
         private readonly VNetConfig _networkConfig;
 
+        /// <summary>How long to keep polling Kudu for the deployment outcome after the upload is accepted.</summary>
+        internal static readonly TimeSpan DeploymentCompletionTimeout = TimeSpan.FromMinutes(30);
+
+        /// <summary>Gap between deployment-status polls.</summary>
+        internal static readonly TimeSpan DeploymentPollInterval = TimeSpan.FromSeconds(5);
+
         public InstallAppServiceContentsTask(InstallerProxyConfig proxyConfig, TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, VNetConfig networkConfig)
             : base(config, logger, azureLocation, tags)
         {
@@ -151,7 +157,151 @@ namespace App.ControlPanel.Engine.InstallerTasks
                         throw new InstallException(
                             $"App Service HTTPS deployment failed with HTTP {(int)response.StatusCode} ({response.ReasonPhrase}): {detail}");
                     }
+
+                    // The upload is only accepted at this point, not finished. Azure's App Service front end
+                    // aborts ANY single request at ~230 seconds, so a synchronous publish of a package this
+                    // size fails with an HTML "500 - The request timed out" even when the deployment itself
+                    // is progressing fine server-side. We therefore publish with async=true and poll Kudu for
+                    // the real outcome.
+                    var statusUri = ResolveDeploymentStatusUri(response.Headers.Location, publishInfo.RootUrl);
+                    await WaitForDeploymentAsync(client, statusUri);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Where to poll for the outcome of an async publish. Kudu returns the deployment's own status URL in
+        /// the Location header; fall back to the "latest deployment" endpoint when it is absent or relative.
+        /// </summary>
+        internal static Uri ResolveDeploymentStatusUri(Uri locationHeader, string publishUrl)
+        {
+            if (locationHeader != null && locationHeader.IsAbsoluteUri)
+            {
+                return locationHeader;
+            }
+
+            var absoluteUrl = publishUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? publishUrl
+                : "https://" + publishUrl;
+            return new Uri(new Uri(absoluteUrl).GetLeftPart(UriPartial.Authority) + "/api/deployments/latest");
+        }
+
+        /// <summary>
+        /// Polls Kudu until the deployment completes, fails, or we give up. Transient read failures are
+        /// tolerated (the SCM site can briefly drop requests while the site restarts mid-deploy) - only the
+        /// overall deadline is fatal.
+        /// </summary>
+        private async Task WaitForDeploymentAsync(HttpClient client, Uri statusUri)
+        {
+            var deadline = DateTime.UtcNow.Add(DeploymentCompletionTimeout);
+            string lastProgressLogged = null;
+            string lastTransientError = null;
+
+            while (true)
+            {
+                KuduDeploymentStatus status = null;
+                try
+                {
+                    var statusResponse = await client.GetAsync(statusUri);
+                    using (statusResponse)
+                    {
+                        var body = await statusResponse.Content.ReadAsStringAsync();
+                        if (statusResponse.IsSuccessStatusCode)
+                        {
+                            status = ParseDeploymentStatus(body);
+                        }
+                        else
+                        {
+                            lastTransientError = $"HTTP {(int)statusResponse.StatusCode} ({statusResponse.ReasonPhrase})";
+                        }
+                    }
+                }
+                catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
+                {
+                    lastTransientError = CloudInstallEngine.ExceptionMessages.Format(ex);
+                }
+
+                if (status != null)
+                {
+                    if (status.IsFailed)
+                    {
+                        var detail = string.IsNullOrWhiteSpace(status.StatusText) ? status.Message : status.StatusText;
+                        throw new InstallException(
+                            $"App Service deployment failed on the server after the package uploaded successfully. " +
+                            $"Kudu reported status {status.Status} ({detail}). " +
+                            $"Deployment log: {status.LogUrl ?? statusUri.ToString()}");
+                    }
+
+                    if (status.IsSuccess)
+                    {
+                        _logger.LogInformation("App Service deployment completed successfully.");
+                        return;
+                    }
+
+                    var progress = status.DescribeProgress();
+                    if (progress != lastProgressLogged)
+                    {
+                        _logger.LogInformation($"App Service deployment in progress: {progress}");
+                        lastProgressLogged = progress;
+                    }
+                }
+
+                if (DateTime.UtcNow >= deadline)
+                {
+                    var trailing = status == null && lastTransientError != null
+                        ? $" Last error reading deployment status: {lastTransientError}."
+                        : string.Empty;
+                    throw new InstallException(
+                        $"App Service deployment did not report completion within {DeploymentCompletionTimeout.TotalMinutes:N0} minutes. " +
+                        $"The package uploaded successfully, so the deployment may still finish on its own - check {statusUri}.{trailing}");
+                }
+
+                await Task.Delay(DeploymentPollInterval);
+            }
+        }
+
+        internal static KuduDeploymentStatus ParseDeploymentStatus(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return null;
+            return Newtonsoft.Json.JsonConvert.DeserializeObject<KuduDeploymentStatus>(json);
+        }
+
+        /// <summary>Kudu's deployment status document, as returned by /api/deployments/latest.</summary>
+        internal class KuduDeploymentStatus
+        {
+            internal const int StatusFailed = 3;
+
+            [Newtonsoft.Json.JsonProperty("id")]
+            public string Id { get; set; }
+
+            [Newtonsoft.Json.JsonProperty("status")]
+            public int? Status { get; set; }
+
+            [Newtonsoft.Json.JsonProperty("status_text")]
+            public string StatusText { get; set; }
+
+            [Newtonsoft.Json.JsonProperty("progress")]
+            public string Progress { get; set; }
+
+            [Newtonsoft.Json.JsonProperty("complete")]
+            public bool Complete { get; set; }
+
+            [Newtonsoft.Json.JsonProperty("log_url")]
+            public string LogUrl { get; set; }
+
+            [Newtonsoft.Json.JsonProperty("message")]
+            public string Message { get; set; }
+
+            internal bool IsFailed => Complete && Status == StatusFailed;
+
+            /// <summary>Complete and not explicitly failed. Kudu uses 4 for success.</summary>
+            internal bool IsSuccess => Complete && Status != StatusFailed;
+
+            internal string DescribeProgress()
+            {
+                if (!string.IsNullOrWhiteSpace(Progress)) return Progress;
+                if (!string.IsNullOrWhiteSpace(StatusText)) return StatusText;
+                return $"status {Status?.ToString() ?? "unknown"}";
             }
         }
 
@@ -179,7 +329,10 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 ? publishUrl
                 : "https://" + publishUrl;
             var profileUri = new Uri(absoluteUrl);
-            return new Uri(profileUri.GetLeftPart(UriPartial.Authority) + "/api/publish?type=zip");
+            // async=true is required: Azure's front end kills any single request at ~230s, so a large
+            // package cannot be published synchronously. Kudu accepts the upload and reports progress
+            // separately - see WaitForDeploymentAsync.
+            return new Uri(profileUri.GetLeftPart(UriPartial.Authority) + "/api/publish?type=zip&async=true");
         }
 
         private static void ResetDirectory(string path)

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -153,8 +153,56 @@ namespace Tests.UnitTests
             var publishInfo = publishData.FromXml(publishXml).GetKuduPublishInfo();
             var publishUri = InstallAppServiceContentsTask.BuildKuduPublishUri(publishInfo.RootUrl);
 
-            Assert.AreEqual("https://contoso.scm.azurewebsites.net/api/publish?type=zip", publishUri.ToString());
+            // async=true is not cosmetic: Azure's front end aborts any single request at ~230 seconds, so a
+            // synchronous publish of a large package fails with "500 - The request timed out" even when the
+            // deployment is fine. Losing this parameter silently reintroduces that failure.
+            Assert.AreEqual("https://contoso.scm.azurewebsites.net/api/publish?type=zip&async=true", publishUri.ToString());
             Assert.AreEqual("$contoso", publishInfo.Username);
+        }
+
+        [TestMethod]
+        public void DeploymentStatusUriPrefersKuduLocationHeader()
+        {
+            var fromHeader = InstallAppServiceContentsTask.ResolveDeploymentStatusUri(
+                new Uri("https://contoso.scm.azurewebsites.net/api/deployments/abc123"),
+                "contoso.scm.azurewebsites.net:443");
+
+            Assert.AreEqual("https://contoso.scm.azurewebsites.net/api/deployments/abc123", fromHeader.ToString());
+        }
+
+        [TestMethod]
+        public void DeploymentStatusUriFallsBackToLatestWhenNoLocationHeader()
+        {
+            var noHeader = InstallAppServiceContentsTask.ResolveDeploymentStatusUri(
+                null, "contoso.scm.azurewebsites.net:443");
+            Assert.AreEqual("https://contoso.scm.azurewebsites.net/api/deployments/latest", noHeader.ToString());
+
+            // A relative Location can't be polled directly, so it must fall back too.
+            var relativeHeader = InstallAppServiceContentsTask.ResolveDeploymentStatusUri(
+                new Uri("/api/deployments/abc123", UriKind.Relative), "contoso.scm.azurewebsites.net:443");
+            Assert.AreEqual("https://contoso.scm.azurewebsites.net/api/deployments/latest", relativeHeader.ToString());
+        }
+
+        [TestMethod]
+        public void KuduDeploymentStatusDistinguishesSuccessFailureAndInProgress()
+        {
+            // Kudu: 3 = Failed, 4 = Success. "complete" gates both.
+            var success = InstallAppServiceContentsTask.ParseDeploymentStatus(
+                @"{""id"":""abc"",""status"":4,""status_text"":"""",""complete"":true,""progress"":""""}");
+            Assert.IsTrue(success.IsSuccess, "status 4 + complete must be treated as a successful deployment.");
+            Assert.IsFalse(success.IsFailed);
+
+            var failed = InstallAppServiceContentsTask.ParseDeploymentStatus(
+                @"{""id"":""abc"",""status"":3,""status_text"":""Deployment failed"",""complete"":true,""log_url"":""https://contoso.scm.azurewebsites.net/api/deployments/abc/log""}");
+            Assert.IsTrue(failed.IsFailed, "status 3 + complete must be surfaced as a failure, not a success.");
+            Assert.IsFalse(failed.IsSuccess);
+
+            // Still running: must NOT be reported as either outcome, or we'd stop polling early.
+            var running = InstallAppServiceContentsTask.ParseDeploymentStatus(
+                @"{""id"":""abc"",""status"":2,""status_text"":""Deploying"",""complete"":false,""progress"":""Copying files""}");
+            Assert.IsFalse(running.IsSuccess);
+            Assert.IsFalse(running.IsFailed);
+            Assert.AreEqual("Copying files", running.DescribeProgress());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Release diff and implementation summary

`main` `0c1d9f768bab144bee972aa9695064fb77e0a2d9` → `dev` `2ada302` (2 files). A single installer fix on top of Stable build 1754: App Service content deployment now publishes asynchronously and polls Kudu for the outcome.

No database migrations, no schema change, no configuration-schema change, no runtime/importer change.

## Problem

`InstallAppServiceContentsTask.PublishZipAsync` published the combined website + web-jobs package with one synchronous `POST /api/publish?type=zip`. Azure's App Service front end aborts **any** single request at ~230 seconds, so once the package became large enough the request was killed and Kudu returned an HTML error page:

```
[InstallException] App Service HTTPS deployment failed with HTTP 500 (Internal Server Error):
<html><head><title>500 - The request timed out.</title></head>...
```

Observed on a real deployment: upload started `17:48:49`, failed `17:53:03` — **254 s**, i.e. the 230 s front-end limit plus connection overhead. The current package is ~125 MB across the five component zips, so the margin is already thin and shrinks as the packages grow.

Two aggravating details:

- The `HttpClient.Timeout = TimeSpan.FromMinutes(30)` on the publish client was never reached, because Azure returns a real HTTP 500 long before the client gives up. The `TaskCanceledException` branch (which carries the useful proxy/SCM guidance) was therefore unreachable for this failure mode.
- Kudu frequently **continues and completes the deployment** after the front end has already returned 500, so the installer reported a hard failure for a deployment that actually succeeded — and the operator's natural response (re-run the installer) redid the whole upload.

## Change

- `BuildKuduPublishUri` now emits `/api/publish?type=zip&async=true`. Kudu acknowledges the upload and performs the deployment out of band, so the request itself is short and never approaches the 230 s ceiling.
- `PublishZipAsync` treats a successful POST as *upload accepted*, not *deployment finished*. It resolves the status endpoint and polls until Kudu reports completion.
- `ResolveDeploymentStatusUri` prefers Kudu's `Location` response header, falling back to `/api/deployments/latest` when the header is absent or relative (a relative URI cannot be polled directly).
- `WaitForDeploymentAsync` polls every 5 s up to a 30-minute deadline. Transient read failures (`HttpRequestException` / `TaskCanceledException`, or a non-success status) are tolerated rather than fatal, because the SCM site can briefly drop requests while the site restarts mid-deployment; only the overall deadline is fatal. Progress is logged when it changes, so a long deployment is visibly alive rather than apparently hung.
- A server-side failure (`status == 3`) is surfaced as an `InstallException` including Kudu's `status_text`/`message` and the deployment `log_url`. Previously a post-upload failure could not be distinguished from success at all.
- On timeout the message states explicitly that the package uploaded successfully and the deployment may still complete, with the status URL to check — so the operator does not blindly repeat a 125 MB upload.

`KuduDeploymentStatus` models Kudu's status document. `IsFailed` is `complete && status == 3`; `IsSuccess` is `complete && status != 3` (Kudu uses 4 for success, and the tolerant form avoids treating an unexpected terminal code as "still running" forever).

## Tests

`InstallEngineTests` (40/40 pass locally, Debug):

- `KuduPublishingProfileBuildsHttpsPublishUri` — updated to assert `&async=true`, with a comment recording that dropping it silently reintroduces the 230 s failure.
- `DeploymentStatusUriPrefersKuduLocationHeader` — absolute `Location` is used as-is.
- `DeploymentStatusUriFallsBackToLatestWhenNoLocationHeader` — covers both the missing header and the relative-URI case.
- `KuduDeploymentStatusDistinguishesSuccessFailureAndInProgress` — success (4), failure (3) and in-progress (2, `complete:false`) are each classified correctly; in-progress must report neither outcome or polling would stop early.

## Risk and scope

- Confined to the installer's App Service publish path; nothing else calls these methods.
- The polling loop is the only meaningful risk: it is bounded by an explicit deadline, cannot loop forever on repeated read errors, and distinguishes "in progress" from "failed" via `complete` rather than inferring from the status code alone.
- `CONFIG_VERSION` unchanged (1.9.0); no `Migrations/`, `Create DB.sql` or `Profiling-03-CreateSchema.sql` change; no installer UI or persisted-config change.

## Reviewer hotspots

- Confirm the async publish contract: 202 + `Location`, and that a non-success POST still throws before any polling begins.
- Confirm the transient-tolerance window cannot mask a genuine early failure — a completed-and-failed status is acted on immediately; only unreadable status is retried.
- The 30-minute deadline and 5-second interval are `internal static readonly` so they are visible to tests and easy to tune.
