### PR TITLE
Stop mailbox-less users flooding App Insights with 404 exceptions

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -160,6 +160,16 @@ namespace Common.Entities.Config
                 ? graphTeamsImportIntervalHours
                 : preset.NonFreshGraphIntervalHours;
 
+            // How long a user found to have no Exchange mailbox is skipped before being re-checked.
+            // Mailbox-less users (unlicensed, on-premises, inactive, or guest accounts) return HTTP 404
+            // from Graph on every sent-email call, forever, so re-checking them each 10-minute cycle is
+            // pure waste and noise. The whole directory is re-swept on this interval so newly-licensed
+            // users get picked up. 0 disables the skip list (re-checks everyone every cycle).
+            this.SentEmailNoMailboxRetryHours = int.TryParse(ConfigurationManager.AppSettings.Get("SentEmailNoMailboxRetryHours"), out var sentEmailNoMailboxRetryHours)
+                && sentEmailNoMailboxRetryHours >= 0
+                ? sentEmailNoMailboxRetryHours
+                : 24;
+
             // One-off force flag: bypass the cadence gate for the non-fresh Graph imports (user metadata,
             // user apps, Teams) for this run. Mirrors ForceUsageReportsImport. Default false.
             var forceGraphMetadataImport = ConfigurationManager.AppSettings.Get("ForceGraphMetadataImport");
@@ -409,6 +419,14 @@ namespace Common.Entities.Config
         /// for those imports. Default false.
         /// </summary>
         public bool ForceGraphMetadataImport { get; set; } = false;
+
+        /// <summary>
+        /// Hours a user found to have no Exchange mailbox is skipped by the sent-emails import before
+        /// being re-checked. Such users (unlicensed, on-premises, inactive, or guests) return HTTP 404
+        /// from Graph on every call, permanently. Default 24; 0 disables the skip list entirely.
+        /// Overridable with the <c>SentEmailNoMailboxRetryHours</c> AppSetting.
+        /// </summary>
+        public int SentEmailNoMailboxRetryHours { get; set; } = 24;
 
         /// <summary>
         /// One-off start offset (minutes) applied before the first import cycle, used to stagger the

--- a/src/AnalyticsEngine/Tests.UnitTests/SentEmailMailboxSkipListTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SentEmailMailboxSkipListTests.cs
@@ -1,0 +1,304 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+using WebJob.Office365ActivityImporter.Engine.Graph.Email;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Covers the handling of Graph 404s in the sent-email import path.
+    ///
+    /// Background: users with no Exchange Online mailbox (unlicensed, on-premises, inactive, or guest
+    /// accounts) return HTTP 404 from Graph forever. Previously each such user produced three
+    /// Application Insights exception records on every 10-minute import cycle, and was re-checked
+    /// indefinitely. These tests pin the fix: a 404 is a typed, non-error outcome, it is logged once,
+    /// and the user is negatively cached until the next full sweep.
+    /// </summary>
+    [TestClass]
+    public class SentEmailMailboxSkipListTests
+    {
+        private const string MailboxNotEnabled =
+            "{\"error\":{\"code\":\"MailboxNotEnabledForRESTAPI\",\"message\":\"The mailbox is either inactive, soft-deleted, or is hosted on-premise.\"}}";
+        private const string ResourceNotFound =
+            "{\"error\":{\"code\":\"Request_ResourceNotFound\",\"message\":\"Resource 'guest_contoso.com' does not exist.\"}}";
+
+        #region Fake HTTP handler
+
+        /// <summary>Returns a canned status code + body for every request.</summary>
+        private class StubHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _status;
+            private readonly string _body;
+            public int CallCount { get; private set; }
+
+            public StubHandler(HttpStatusCode status, string body)
+            {
+                _status = status;
+                _body = body;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                CallCount++;
+                return Task.FromResult(new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_body ?? string.Empty),
+                    RequestMessage = request,
+                });
+            }
+        }
+
+        private static ManualGraphCallClient ClientReturning(HttpStatusCode status, string body, out StubHandler handler)
+        {
+            handler = new StubHandler(status, body);
+            return new ManualGraphCallClient(handler, NullLogger.Instance);
+        }
+
+        #endregion
+
+        #region 404 classification
+
+        [TestMethod]
+        public async Task Get404_ThrowsTypedNotFoundException_WithGraphErrorCode()
+        {
+            using (var client = ClientReturning(HttpStatusCode.NotFound, MailboxNotEnabled, out _))
+            {
+                try
+                {
+                    await client.GetAsyncWithThrottleRetries<object>("https://graph.microsoft.com/v1.0/users/nobody/mailFolders/sentitems/messages/delta");
+                    Assert.Fail("Expected a GraphResourceNotFoundException.");
+                }
+                catch (GraphResourceNotFoundException ex)
+                {
+                    Assert.AreEqual("MailboxNotEnabledForRESTAPI", ex.GraphErrorCode);
+                    StringAssert.Contains(ex.Message, "404");
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task Get404_TypedExceptionIsStillAnHttpRequestException()
+        {
+            // Existing callers catch HttpRequestException - that must keep working.
+            using (var client = ClientReturning(HttpStatusCode.NotFound, ResourceNotFound, out _))
+            {
+                try
+                {
+                    await client.GetAsyncWithThrottleRetries<object>("https://graph.microsoft.com/v1.0/users/guest/messages");
+                    Assert.Fail("Expected an exception.");
+                }
+                catch (HttpRequestException ex)
+                {
+                    Assert.IsInstanceOfType(ex, typeof(GraphResourceNotFoundException));
+                    Assert.AreEqual("Request_ResourceNotFound", ((GraphResourceNotFoundException)ex).GraphErrorCode);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task NonNotFoundStatus_StillThrowsPlainHttpRequestException()
+        {
+            using (var client = ClientReturning(HttpStatusCode.InternalServerError, "boom", out _))
+            {
+                try
+                {
+                    await client.GetAsyncWithThrottleRetries<object>("https://graph.microsoft.com/v1.0/users/someone/messages");
+                    Assert.Fail("Expected an exception.");
+                }
+                catch (HttpRequestException ex)
+                {
+                    Assert.IsNotInstanceOfType(ex, typeof(GraphResourceNotFoundException),
+                        "Only a 404 should be classified as 'resource not found'.");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ExtractGraphErrorCode_HandlesJunkWithoutThrowing()
+        {
+            Assert.IsNull(GraphResourceNotFoundException.ExtractGraphErrorCode(null));
+            Assert.IsNull(GraphResourceNotFoundException.ExtractGraphErrorCode(""));
+            Assert.IsNull(GraphResourceNotFoundException.ExtractGraphErrorCode("   "));
+            Assert.IsNull(GraphResourceNotFoundException.ExtractGraphErrorCode("<html>404</html>"));
+            Assert.IsNull(GraphResourceNotFoundException.ExtractGraphErrorCode("{\"unexpected\":true}"));
+            Assert.AreEqual("MailboxNotEnabledForRESTAPI", GraphResourceNotFoundException.ExtractGraphErrorCode(MailboxNotEnabled));
+        }
+
+        #endregion
+
+        #region Pageable loader opt-in
+
+        [TestMethod]
+        public async Task PageableLoader_ByDefault_Swallows404AndReturnsPartialResults()
+        {
+            // Every pre-existing caller (usage reports, user loaders) relies on this behaviour.
+            using (var client = ClientReturning(HttpStatusCode.NotFound, MailboxNotEnabled, out var handler))
+            {
+                var results = await client.LoadAllPagesWithThrottleRetries<object>("https://graph.microsoft.com/v1.0/anything", NullLogger.Instance);
+
+                Assert.IsNotNull(results);
+                Assert.AreEqual(0, results.Count);
+                Assert.AreEqual(1, handler.CallCount, "A 404 is terminal - it must never be retried.");
+            }
+        }
+
+        [TestMethod]
+        public async Task PageableLoader_WithThrowOnNotFound_PropagatesToCaller()
+        {
+            using (var client = ClientReturning(HttpStatusCode.NotFound, MailboxNotEnabled, out var handler))
+            {
+                await Assert.ThrowsExceptionAsync<GraphResourceNotFoundException>(() =>
+                    client.LoadAllPagesWithThrottleRetries<object>("https://graph.microsoft.com/v1.0/anything", NullLogger.Instance, throwOnNotFound: true));
+
+                Assert.AreEqual(1, handler.CallCount);
+            }
+        }
+
+        #endregion
+
+        #region Skip list store
+
+        [TestMethod]
+        public async Task InMemorySkipList_RoundTrips()
+        {
+            var store = new InMemorySentEmailMailboxSkipList();
+
+            var initial = await store.LoadAsync();
+            Assert.IsNull(initial.GeneratedUtc);
+            Assert.AreEqual(0, initial.Upns.Count);
+
+            var when = new DateTime(2026, 08, 19, 09, 00, 00, DateTimeKind.Utc);
+            await store.SaveAsync(new MailboxSkipList { GeneratedUtc = when, Upns = new List<string> { "a@contoso.com", "b@contoso.com" } });
+
+            var loaded = await store.LoadAsync();
+            Assert.AreEqual(when, loaded.GeneratedUtc);
+            CollectionAssert.AreEquivalent(new[] { "a@contoso.com", "b@contoso.com" }, loaded.Upns);
+        }
+
+        [TestMethod]
+        public async Task InMemorySkipList_ReturnsDefensiveCopy()
+        {
+            var store = new InMemorySentEmailMailboxSkipList();
+            await store.SaveAsync(new MailboxSkipList { GeneratedUtc = DateTime.UtcNow, Upns = new List<string> { "a@contoso.com" } });
+
+            var first = await store.LoadAsync();
+            first.Upns.Add("mutated@contoso.com");
+
+            var second = await store.LoadAsync();
+            Assert.AreEqual(1, second.Upns.Count, "Mutating a loaded copy must not corrupt the stored set.");
+        }
+
+        [TestMethod]
+        public void UpnSet_IsCaseInsensitive()
+        {
+            var list = new MailboxSkipList { Upns = new List<string> { "Person@Contoso.com" } };
+            Assert.IsTrue(list.UpnSet.Contains("person@contoso.com"),
+                "UPN casing varies between Graph and the DB, so matching must be case-insensitive.");
+        }
+
+        #endregion
+
+        #region Skip list update semantics
+
+        private static readonly DateTime Now = new DateTime(2026, 08, 19, 12, 00, 00, DateTimeKind.Utc);
+
+        [TestMethod]
+        public void BuildUpdatedSkipList_FullSweep_ReplacesSetAndStampsTime()
+        {
+            var previous = new MailboxSkipList
+            {
+                GeneratedUtc = Now.AddDays(-1),
+                Upns = new List<string> { "stale@contoso.com" },
+            };
+
+            var updated = SentEmailImporter.BuildUpdatedSkipList(
+                previous,
+                discoveredNoMailbox: new[] { "nomailbox@contoso.com" },
+                skippedThisRun: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                fullSweepDue: true,
+                nowUtc: Now);
+
+            Assert.AreEqual(Now, updated.GeneratedUtc, "A full sweep must move the timestamp on.");
+            CollectionAssert.AreEquivalent(new[] { "nomailbox@contoso.com" }, updated.Upns);
+            CollectionAssert.DoesNotContain(updated.Upns, "stale@contoso.com",
+                "A user who has since been licensed must drop out of the skip list after a full sweep.");
+        }
+
+        [TestMethod]
+        public void BuildUpdatedSkipList_Incremental_CarriesSkippedForwardAndKeepsTimestamp()
+        {
+            var swept = Now.AddHours(-3);
+            var previous = new MailboxSkipList { GeneratedUtc = swept, Upns = new List<string> { "known@contoso.com" } };
+
+            var updated = SentEmailImporter.BuildUpdatedSkipList(
+                previous,
+                discoveredNoMailbox: new[] { "newlyfound@contoso.com" },
+                skippedThisRun: new HashSet<string>(new[] { "known@contoso.com" }, StringComparer.OrdinalIgnoreCase),
+                fullSweepDue: false,
+                nowUtc: Now);
+
+            Assert.AreEqual(swept, updated.GeneratedUtc,
+                "An incremental run must not push the next full sweep out, or users would never be re-checked.");
+            CollectionAssert.AreEquivalent(new[] { "known@contoso.com", "newlyfound@contoso.com" }, updated.Upns);
+        }
+
+        [TestMethod]
+        public void BuildUpdatedSkipList_DeduplicatesCaseInsensitively()
+        {
+            var updated = SentEmailImporter.BuildUpdatedSkipList(
+                new MailboxSkipList { GeneratedUtc = Now.AddHours(-1) },
+                discoveredNoMailbox: new[] { "Person@Contoso.com" },
+                skippedThisRun: new HashSet<string>(new[] { "person@contoso.com" }, StringComparer.OrdinalIgnoreCase),
+                fullSweepDue: false,
+                nowUtc: Now);
+
+            Assert.AreEqual(1, updated.Upns.Count);
+        }
+
+        [TestMethod]
+        public void BuildUpdatedSkipList_NeverSweptBefore_StampsNow()
+        {
+            var updated = SentEmailImporter.BuildUpdatedSkipList(
+                MailboxSkipList.Empty(),
+                discoveredNoMailbox: Enumerable.Empty<string>(),
+                skippedThisRun: null,
+                fullSweepDue: false,
+                nowUtc: Now);
+
+            Assert.AreEqual(Now, updated.GeneratedUtc);
+            Assert.AreEqual(0, updated.Upns.Count);
+        }
+
+        #endregion
+
+        #region Re-check cadence
+
+        [TestMethod]
+        public void SkipList_IsBypassedEntirely_WhenRetryHoursIsZero()
+        {
+            // 0 = disabled, so every cycle is a "full sweep" and nobody is skipped.
+            Assert.IsTrue(ImportCadenceGate.ShouldRun(Now.AddMinutes(-1), 0, force: false, nowUtc: Now));
+        }
+
+        [TestMethod]
+        public void SkipList_ReSweepsOnlyAfterTheRetryInterval()
+        {
+            Assert.IsFalse(ImportCadenceGate.ShouldRun(Now.AddHours(-1), 24, force: false, nowUtc: Now),
+                "Within the interval, mailbox-less users stay skipped.");
+            Assert.IsTrue(ImportCadenceGate.ShouldRun(Now.AddHours(-25), 24, force: false, nowUtc: Now),
+                "After the interval, every mailbox is re-checked so newly-licensed users are picked up.");
+            Assert.IsTrue(ImportCadenceGate.ShouldRun(null, 24, force: false, nowUtc: Now),
+                "Never swept - must check everyone.");
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="PerfRegressionTests.cs" />
     <Compile Include="SentEmailImporterPipelineTests.cs" />
     <Compile Include="SentEmailImportTests.cs" />
+    <Compile Include="SentEmailMailboxSkipListTests.cs" />
     <Compile Include="InstallTests\VNetIntegrationTests.cs" />
     <Compile Include="InstallTests\AppInsightsArmTemplateTests.cs" />
     <Compile Include="UserImportCaseSensitivityTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/GraphSentEmailSourceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/GraphSentEmailSourceLoader.cs
@@ -83,7 +83,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                     var thisPageDelta = StringUtils.ExtractCodeFromGraphUrl(deltaLink);
                     await _deltaTokenStore.SetDeltaToken(deltaKey, thisPageDelta);
                     writes++;
-                });
+                },
+                // A mailbox-less user 404s here. Surface it instead of silently returning an empty list,
+                // so the importer can tell "no mailbox" apart from "mailbox with no sent mail" and stop
+                // re-checking the user every cycle.
+                throwOnNotFound: true);
 
             return new SentEmailLoadResult
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailImporter.cs
@@ -40,10 +40,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
         private readonly Func<AnalyticsEntitiesContext> _dbContextFactory;
         private readonly int _userChunkSize;
         private readonly int _graphLoadParallelism;
+        private readonly ISentEmailMailboxSkipList _mailboxSkipList;
+        private readonly int _noMailboxRetryHours;
+
+        // UPNs discovered during this run to have no mailbox at all (Graph 404). Concurrent because the
+        // Graph load phase populates it from parallel worker threads.
+        private readonly ConcurrentDictionary<string, byte> _noMailboxUpns =
+            new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
 
         // Stats collected across the whole run. All updated via Interlocked from worker threads.
         private int _mailboxesScanned;
         private int _mailboxesFailed;
+        private int _mailboxesNotFound;
+        private int _mailboxesSkipped;
         private int _messagesSeen;
         private int _messagesInserted;
         private int _recipientsInserted;
@@ -57,7 +66,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
             ISentEmailSentimentScorer sentimentScorer,
             Func<AnalyticsEntitiesContext> dbContextFactory = null,
             int userChunkSize = DefaultUserChunkSize,
-            int graphLoadParallelism = DefaultGraphLoadParallelism)
+            int graphLoadParallelism = DefaultGraphLoadParallelism,
+            ISentEmailMailboxSkipList mailboxSkipList = null,
+            int noMailboxRetryHours = 0)
             : base(logger, settings)
         {
             _sourceLoader = sourceLoader ?? throw new ArgumentNullException(nameof(sourceLoader));
@@ -65,6 +76,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
             _dbContextFactory = dbContextFactory ?? (() => new AnalyticsEntitiesContext());
             _userChunkSize = userChunkSize > 0 ? userChunkSize : DefaultUserChunkSize;
             _graphLoadParallelism = graphLoadParallelism > 0 ? graphLoadParallelism : DefaultGraphLoadParallelism;
+            _mailboxSkipList = mailboxSkipList;
+            _noMailboxRetryHours = noMailboxRetryHours;
         }
 
         /// <summary>
@@ -76,12 +89,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
             AppConfig settings,
             ManualGraphCallClient httpClient,
             IDeltaTokenStore deltaTokenStore,
-            DataUtils.Http.ImportAppIndentityOAuthContext appIdentity)
+            DataUtils.Http.ImportAppIndentityOAuthContext appIdentity,
+            ISentEmailMailboxSkipList mailboxSkipList = null)
             : this(
                 logger,
                 settings,
                 new GraphSentEmailSourceLoader(httpClient, deltaTokenStore, appIdentity, logger),
-                SentEmailSentimentScorerFactory.Create(settings, logger))
+                SentEmailSentimentScorerFactory.Create(settings, logger),
+                mailboxSkipList: mailboxSkipList,
+                noMailboxRetryHours: settings?.SentEmailNoMailboxRetryHours ?? 0)
         {
         }
 
@@ -105,26 +121,106 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                 return;
             }
 
+            // Users with no Exchange mailbox (unlicensed, on-premises, inactive, or guest accounts) 404 on
+            // every call, forever. Skip the ones we already know about, and re-sweep the whole directory
+            // periodically so a newly-licensed user is picked up. A retry interval of 0 disables the cache.
+            var skipList = _mailboxSkipList != null ? await _mailboxSkipList.LoadAsync() : MailboxSkipList.Empty();
+            var fullSweepDue = ImportCadenceGate.ShouldRun(skipList.GeneratedUtc, _noMailboxRetryHours, force: false, nowUtc: DateTime.UtcNow);
+
+            var knownNoMailbox = fullSweepDue ? new HashSet<string>(StringComparer.OrdinalIgnoreCase) : skipList.UpnSet;
+            if (fullSweepDue && _mailboxSkipList != null && _noMailboxRetryHours > 0)
+            {
+                _logger.LogInformation(
+                    $"Sent emails: re-checking every mailbox (last full sweep {skipList.GeneratedUtc?.ToString("u") ?? "never"}, " +
+                    $"interval {_noMailboxRetryHours}h).");
+            }
+
+            var usersToScan = knownNoMailbox.Count == 0
+                ? users
+                : users.Where(u => string.IsNullOrEmpty(u.UserPrincipalName) || !knownNoMailbox.Contains(u.UserPrincipalName)).ToList();
+
+            _mailboxesSkipped = users.Count - usersToScan.Count;
+            if (_mailboxesSkipped > 0)
+            {
+                _logger.LogInformation(
+                    $"Sent emails: skipping {_mailboxesSkipped} of {users.Count} users already known to have no mailbox. " +
+                    $"They'll be re-checked after {skipList.GeneratedUtc?.AddHours(_noMailboxRetryHours):u} UTC.");
+            }
+
+            if (usersToScan.Count == 0)
+            {
+                _logger.LogInformation("No users left to scan for sent items once mailbox-less users are excluded.");
+                return;
+            }
+
             _logger.LogInformation(
-                $"Found {users.Count} users with email addresses to scan for sent items. " +
+                $"Found {usersToScan.Count} users with email addresses to scan for sent items. " +
                 $"Processing in chunks of {_userChunkSize} (Graph load parallelism: {_graphLoadParallelism}; " +
                 $"persistence uses single-connection multi-row SQL inserts to avoid unique-index deadlocks).");
 
-            for (int i = 0; i < users.Count; i += _userChunkSize)
+            for (int i = 0; i < usersToScan.Count; i += _userChunkSize)
             {
                 // GetRange instead of Skip().Take() - Skip() on a List walks past every
                 // prior element, so chunking N users in slices of K costs O(N^2/K). At
                 // 200k users with K=25 that's ~800M wasted iterations just for slicing.
-                var chunk = users.GetRange(i, Math.Min(_userChunkSize, users.Count - i));
+                var chunk = usersToScan.GetRange(i, Math.Min(_userChunkSize, usersToScan.Count - i));
                 _logger.LogInformation(
                     $"Processing user chunk {(i / _userChunkSize) + 1} of " +
-                    $"{(users.Count + _userChunkSize - 1) / _userChunkSize} ({chunk.Count} users).");
+                    $"{(usersToScan.Count + _userChunkSize - 1) / _userChunkSize} ({chunk.Count} users).");
 
                 await ProcessUserChunkAsync(chunk);
             }
 
+            await PersistMailboxSkipListAsync(skipList, knownNoMailbox, fullSweepDue);
+
             swTotal.Stop();
             LogRunSummary(swTotal.Elapsed);
+        }
+
+        /// <summary>
+        /// Writes back the no-mailbox negative cache. A full sweep replaces the set outright (so users who
+        /// have since been licensed drop out of it); an incremental run only adds newly-discovered entries
+        /// and keeps the original sweep timestamp, so the next full sweep still happens on schedule.
+        /// </summary>
+        private async Task PersistMailboxSkipListAsync(MailboxSkipList previous, HashSet<string> skippedThisRun, bool fullSweepDue)
+        {
+            if (_mailboxSkipList == null || _noMailboxRetryHours <= 0)
+                return;
+
+            var updated = BuildUpdatedSkipList(previous, _noMailboxUpns.Keys, skippedThisRun, fullSweepDue, DateTime.UtcNow);
+            await _mailboxSkipList.SaveAsync(updated);
+        }
+
+        /// <summary>
+        /// Pure decision logic for the no-mailbox negative cache, factored out so it can be unit tested
+        /// without Redis or a database (mirrors <see cref="ImportCadenceGate"/>).
+        /// </summary>
+        /// <param name="previous">The skip list as loaded at the start of the run.</param>
+        /// <param name="discoveredNoMailbox">UPNs that returned a Graph 404 during this run.</param>
+        /// <param name="skippedThisRun">UPNs that weren't checked because they were already in the list.</param>
+        /// <param name="fullSweepDue">True when every user was checked, so the set can be rebuilt outright.</param>
+        internal static MailboxSkipList BuildUpdatedSkipList(
+            MailboxSkipList previous,
+            IEnumerable<string> discoveredNoMailbox,
+            HashSet<string> skippedThisRun,
+            bool fullSweepDue,
+            DateTime nowUtc)
+        {
+            var updated = new HashSet<string>(discoveredNoMailbox ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+
+            if (!fullSweepDue && skippedThisRun != null)
+            {
+                // Incremental run: the users we skipped weren't re-checked, so carry them forward.
+                updated.UnionWith(skippedThisRun);
+            }
+
+            return new MailboxSkipList
+            {
+                // Only a full sweep moves the timestamp - otherwise an incremental run every 10 minutes
+                // would keep pushing the next sweep out and users would never get re-checked.
+                GeneratedUtc = fullSweepDue ? nowUtc : previous?.GeneratedUtc ?? nowUtc,
+                Upns = updated.ToList(),
+            };
         }
 
         /// <summary>
@@ -265,6 +361,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
                         Interlocked.Add(ref _deltaTokenReads, load.DeltaTokenReads);
                         Interlocked.Add(ref _deltaTokenWrites, load.DeltaTokenWrites);
                         loaded.Add(new LoadedUser { User = user, Messages = load.Messages });
+                    }
+                    catch (GraphResourceNotFoundException ex)
+                    {
+                        // The mailbox genuinely doesn't exist - the user is unlicensed, on-premises,
+                        // inactive, or an external/guest account. Permanent, so record it and stop
+                        // re-checking every cycle. Not an error: nothing is wrong and nothing is lost.
+                        Interlocked.Increment(ref _mailboxesNotFound);
+                        if (!string.IsNullOrEmpty(user.UserPrincipalName))
+                            _noMailboxUpns[user.UserPrincipalName] = 0;
+
+                        _logger.LogDebug(
+                            $"User '{user.UserPrincipalName}' has no mailbox ({ex.GraphErrorCode ?? "unknown"}); " +
+                            "skipping and adding to the no-mailbox list.");
                     }
                     catch (System.Net.Http.HttpRequestException ex)
                     {
@@ -578,7 +687,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
         {
             _logger.LogInformation(
                 $"Finished sent emails import in {elapsed:hh\\:mm\\:ss}. " +
-                $"Mailboxes scanned: {_mailboxesScanned} (failed: {_mailboxesFailed}). " +
+                $"Mailboxes scanned: {_mailboxesScanned} (failed: {_mailboxesFailed}, " +
+                $"no mailbox: {_mailboxesNotFound}, skipped as already known to have no mailbox: {_mailboxesSkipped}). " +
                 $"Messages seen: {_messagesSeen}. Messages inserted: {_messagesInserted} " +
                 $"(recipient rows: {_recipientsInserted}). " +
                 $"Delta tokens read: {_deltaTokenReads}, written: {_deltaTokenWrites}.");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailMailboxSkipList.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Email/SentEmailMailboxSkipList.cs
@@ -1,0 +1,129 @@
+using Common.Entities.Redis;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Email
+{
+    /// <summary>
+    /// The set of user principal names known to have no Exchange Online mailbox, plus when that set was
+    /// last rebuilt from a full sweep of every user.
+    /// </summary>
+    public class MailboxSkipList
+    {
+        /// <summary>When the set was last rebuilt by checking every user. Null = never swept.</summary>
+        [JsonProperty("generatedUtc")]
+        public DateTime? GeneratedUtc { get; set; }
+
+        [JsonProperty("upns")]
+        public List<string> Upns { get; set; } = new List<string>();
+
+        [JsonIgnore]
+        public HashSet<string> UpnSet => new HashSet<string>(Upns ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+
+        public static MailboxSkipList Empty() => new MailboxSkipList();
+    }
+
+    /// <summary>
+    /// Stores the "these users have no mailbox" negative cache for the sent-email importer.
+    ///
+    /// Deliberately a <b>single</b> key holding the whole set rather than one key per user: the importer
+    /// runs every cycle against every user, so per-user lookups would be one round trip per user per
+    /// cycle (200,000 round trips at the tenant scale this solution targets). One read at the start of a
+    /// run and one write at the end is O(1) regardless of tenant size.
+    /// </summary>
+    public interface ISentEmailMailboxSkipList
+    {
+        Task<MailboxSkipList> LoadAsync();
+        Task SaveAsync(MailboxSkipList skipList);
+    }
+
+    /// <summary>
+    /// In-memory skip list, used when Redis isn't configured. The cache still works for the lifetime of
+    /// the WebJob process (which runs many import cycles), and resets on restart - so a restart is itself
+    /// a way to force an immediate re-check of every mailbox.
+    /// </summary>
+    public class InMemorySentEmailMailboxSkipList : ISentEmailMailboxSkipList
+    {
+        private MailboxSkipList _current = MailboxSkipList.Empty();
+        private readonly object _lock = new object();
+
+        public Task<MailboxSkipList> LoadAsync()
+        {
+            lock (_lock)
+            {
+                return Task.FromResult(new MailboxSkipList
+                {
+                    GeneratedUtc = _current.GeneratedUtc,
+                    Upns = _current.Upns.ToList(),
+                });
+            }
+        }
+
+        public Task SaveAsync(MailboxSkipList skipList)
+        {
+            lock (_lock)
+            {
+                _current = new MailboxSkipList
+                {
+                    GeneratedUtc = skipList.GeneratedUtc,
+                    Upns = (skipList.Upns ?? new List<string>()).ToList(),
+                };
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Redis-backed skip list, so the negative cache survives WebJob restarts and is shared between the
+    /// importer instances. Reads and writes are <b>fail-open</b>: a Redis outage yields an empty skip list
+    /// (so every mailbox is checked, exactly like the legacy behaviour) rather than failing the import.
+    /// </summary>
+    public class RedisSentEmailMailboxSkipList : ISentEmailMailboxSkipList
+    {
+        internal const string CacheKey = "SentEmailNoMailboxUsers";
+
+        private readonly CacheConnectionManager _cacheConnectionManager;
+        private readonly ILogger _logger;
+
+        public RedisSentEmailMailboxSkipList(string redisConnectionString, ILogger logger, string tenantId = null, string clientId = null, string clientSecret = null)
+        {
+            _cacheConnectionManager = CacheConnectionManager.GetConnectionManager(redisConnectionString, tenantId: tenantId, clientId: clientId, clientSecret: clientSecret);
+            _logger = logger;
+        }
+
+        public async Task<MailboxSkipList> LoadAsync()
+        {
+            try
+            {
+                var raw = await _cacheConnectionManager.GetString(CacheKey);
+                if (string.IsNullOrEmpty(raw))
+                    return MailboxSkipList.Empty();
+
+                return JsonConvert.DeserializeObject<MailboxSkipList>(raw) ?? MailboxSkipList.Empty();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning($"Sent emails: could not read the no-mailbox skip list from Redis ({ex.Message}); " +
+                    "every mailbox will be checked this cycle.");
+                return MailboxSkipList.Empty();
+            }
+        }
+
+        public async Task SaveAsync(MailboxSkipList skipList)
+        {
+            try
+            {
+                await _cacheConnectionManager.SetString(CacheKey, JsonConvert.SerializeObject(skipList));
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning($"Sent emails: could not save the no-mailbox skip list to Redis ({ex.Message}); " +
+                    "mailbox-less users will be re-checked next cycle.");
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -30,8 +30,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         // skipped safely), the other gates how often the non-fresh Graph sections re-run.
         private readonly ISingleDateStore _activityReportsLastImportedStore;
         private readonly IImportLastRunStore _lastRunStore;
+        // Negative cache of users with no Exchange mailbox, so the sent-email import stops re-checking
+        // them (and logging a 404) on every cycle. Must be process-lifetime, hence injected.
+        private readonly ISentEmailMailboxSkipList _sentEmailMailboxSkipList;
 
-        public GraphImporter(AnalyticsLogger logger, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null, IImportLastRunStore lastRunStore = null)
+        public GraphImporter(AnalyticsLogger logger, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null, IImportLastRunStore lastRunStore = null, ISentEmailMailboxSkipList sentEmailMailboxSkipList = null)
             : base(logger, settings)
         {
             _userGroupsCache = userGroupsCache;
@@ -42,6 +45,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             // Defensive: a per-instance in-memory store still works (just doesn't persist the gate
             // across cycles). Production passes the process-lifetime store hoisted in Program.cs.
             _lastRunStore = lastRunStore ?? new InMemoryImportLastRunStore();
+            _sentEmailMailboxSkipList = sentEmailMailboxSkipList ?? new InMemorySentEmailMailboxSkipList();
         }
 
         // Keys for the per-section "last run" timestamps used to daily-gate the non-fresh Graph imports.
@@ -175,7 +179,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                         deltaTokenStore = new InMemoryDeltaTokenStore();
                     }
 
-                    var sentEmailImporter = new SentEmailImporter(_logger, _settings, httpClient, deltaTokenStore, _graphAppIndentityOAuthContext);
+                    var sentEmailImporter = new SentEmailImporter(_logger, _settings, httpClient, deltaTokenStore, _graphAppIndentityOAuthContext, _sentEmailMailboxSkipList);
                     await sentEmailImporter.ImportSentEmails();
 
                     sentEmailsTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphResourceNotFoundException.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphResourceNotFoundException.cs
@@ -1,0 +1,72 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Net.Http;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Thrown when a Graph call returns HTTP 404.
+    ///
+    /// A 404 is a <b>terminal, expected outcome</b> rather than an application error: the resource
+    /// genuinely does not exist. The common cases are a user with no Exchange Online mailbox
+    /// (unlicensed, on-premises or inactive - Graph error <c>MailboxNotEnabledForRESTAPI</c>) and a
+    /// guest / external account that has no mailbox in this tenant (<c>Request_ResourceNotFound</c>).
+    ///
+    /// Neither condition ever resolves by retrying, so callers must treat it as "nothing to import for
+    /// this resource" and must <b>not</b> log it via <c>LogError</c> - doing so records an Application
+    /// Insights exception on every import cycle, forever, for a perfectly normal tenant state.
+    /// </summary>
+    /// <remarks>
+    /// Derives from <see cref="HttpRequestException"/> so pre-existing <c>catch (HttpRequestException)</c>
+    /// handlers keep working unchanged; callers that want to special-case a 404 catch this type first.
+    /// </remarks>
+    public class GraphResourceNotFoundException : HttpRequestException
+    {
+        public GraphResourceNotFoundException(string url, string responseBody, Exception innerException)
+            : base(BuildMessage(url, responseBody), innerException)
+        {
+            Url = url;
+            ResponseBody = responseBody;
+            GraphErrorCode = ExtractGraphErrorCode(responseBody);
+        }
+
+        /// <summary>The URL that returned the 404.</summary>
+        public string Url { get; }
+
+        /// <summary>The raw response body, kept for diagnostics.</summary>
+        public string ResponseBody { get; }
+
+        /// <summary>
+        /// Graph's machine-readable error code (e.g. <c>MailboxNotEnabledForRESTAPI</c> or
+        /// <c>Request_ResourceNotFound</c>), or null when the body isn't a parseable Graph error.
+        /// </summary>
+        public string GraphErrorCode { get; }
+
+        private static string BuildMessage(string url, string responseBody)
+        {
+            var code = ExtractGraphErrorCode(responseBody);
+            return string.IsNullOrEmpty(code)
+                ? $"Graph returned 404 (Not Found) for {url}."
+                : $"Graph returned 404 (Not Found) for {url} with error code '{code}'.";
+        }
+
+        /// <summary>
+        /// Pulls <c>error.code</c> out of a standard Graph error payload. Never throws - a malformed or
+        /// non-JSON body simply yields null, because this is only used for logging and diagnostics.
+        /// </summary>
+        internal static string ExtractGraphErrorCode(string responseBody)
+        {
+            if (string.IsNullOrWhiteSpace(responseBody))
+                return null;
+
+            try
+            {
+                return JObject.Parse(responseBody)["error"]?["code"]?.ToString();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/ManualGraphCallClient.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/ManualGraphCallClient.cs
@@ -2,6 +2,7 @@ using DataUtils.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -39,6 +40,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 }
                 catch (HttpRequestException ex)
                 {
+                    // A 404 means the resource simply isn't there (typically a user with no Exchange
+                    // mailbox, or a guest account). That's a permanent, expected tenant state - not an
+                    // application error - so log it at debug and surface a dedicated type that callers
+                    // can skip on. Logging it as an error would push an exception to Application
+                    // Insights on every single import cycle for a condition that never clears.
+                    if (callResponse.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        var notFound = new GraphResourceNotFoundException(url, callResponseBody, ex);
+                        _logger.LogDebug($"Got HTTP 404 calling {url} (Graph error code " +
+                            $"'{notFound.GraphErrorCode ?? "unknown"}'). Response body: {callResponseBody}");
+                        throw notFound;
+                    }
+
                     _logger.LogError(ex, $"Got HTTP exception calling {url}: {ex.Message}. Response body: {callResponseBody}");
                     throw;
                 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/PageableGraphLoaderExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/PageableGraphLoaderExtensions.cs
@@ -7,21 +7,27 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
     public static class PageableGraphLoaderExtensions
     {
-        public static async Task<List<T>> LoadAllPagesWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger logger)
+        public static async Task<List<T>> LoadAllPagesWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger logger, bool throwOnNotFound = false)
         {
-            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, logger, null);
+            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, logger, null, throwOnNotFound);
 
             return results;
         }
 
-        public static async Task<List<T>> LoadAllPagesPlusDeltaWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger logger, Func<string, Task> deltaTokenFunc)
+        public static async Task<List<T>> LoadAllPagesPlusDeltaWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger logger, Func<string, Task> deltaTokenFunc, bool throwOnNotFound = false)
         {
-            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, logger, deltaTokenFunc);
+            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, logger, deltaTokenFunc, throwOnNotFound);
 
             return results;
         }
 
-        static async Task<List<T>> LoadPageableGraphResponseAllWithOptionalDelta<T>(ManualGraphCallClient client, string url, ILogger logger, Func<string, Task> deltaTokenFunc)
+        /// <param name="throwOnNotFound">
+        /// When true, a 404 is rethrown as <see cref="GraphResourceNotFoundException"/> so the caller can
+        /// tell "this resource does not exist" apart from "this resource exists but is empty". Defaults to
+        /// false, which preserves the long-standing behaviour of returning the pages loaded so far - most
+        /// callers (usage reports, user loaders) genuinely want the partial result.
+        /// </param>
+        static async Task<List<T>> LoadPageableGraphResponseAllWithOptionalDelta<T>(ManualGraphCallClient client, string url, ILogger logger, Func<string, Task> deltaTokenFunc, bool throwOnNotFound = false)
         {
             var allResults = new List<T>();
 
@@ -38,20 +44,35 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     queryResult = await client.GetAsyncWithThrottleRetries<PageableGraphResponseWithDelta<T>>(nextUrl);
                     pageSuccess = true;
                 }
+                catch (GraphResourceNotFoundException ex)
+                {
+                    // 404 - the resource doesn't exist. Always terminal, never worth a retry.
+                    if (throwOnNotFound)
+                        throw;
+
+                    pageSuccess = false;
+                    logger.LogDebug($"Got 404 loading {typeof(T).Name} page {pageCount} ({ex.GraphErrorCode ?? "unknown"}). " +
+                        "Returning results up to current page.");
+                    nextUrl = null;
+                }
                 catch (System.Net.Http.HttpRequestException ex)
                 {
                     pageSuccess = false;
-                    logger.LogError(ex, $"Got unexpected HTTP exception on page {pageCount}: {ex.Message}.");
 
                     // Transient error?
                     if (ex.Message != null && ex.Message.ToLower().Contains("gateway timeout"))
                     {
-                        logger.LogInformation($"Got gateway timeout. Will retry page.");
+                        logger.LogInformation($"Got gateway timeout on page {pageCount}. Will retry page.");
                         await Task.Delay(1000);
                     }
                     else
                     {
-                        logger.LogError(ex, $"Unexpected HTTP error. Will not retry page & returning results upto current page.");
+                        // ManualGraphCallClient has already logged this at error level, with the URL and the
+                        // response body - which is strictly more useful than anything we can add here. Log
+                        // only the paging consequence, at warning, so a single failed call produces a single
+                        // Application Insights exception record instead of three.
+                        logger.LogWarning($"Unexpected HTTP error on page {pageCount}: {ex.Message}. " +
+                            "Will not retry page & returning results upto current page.");
                         nextUrl = null;
                     }
                 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -129,7 +129,9 @@
     <Compile Include="Graph\Email\ISentEmailSentimentScorer.cs" />
     <Compile Include="Graph\Email\ISentEmailSourceLoader.cs" />
     <Compile Include="Graph\Email\SentEmailImporter.cs" />
+    <Compile Include="Graph\Email\SentEmailMailboxSkipList.cs" />
     <Compile Include="Graph\Email\SentEmailSentimentScorer.cs" />
+    <Compile Include="Graph\GraphResourceNotFoundException.cs" />
     <Compile Include="Graph\PageableGraphLoaderExtensions.cs" />
     <Compile Include="Graph\PageableGraphResponse.cs" />
     <Compile Include="Graph\OfficeLicenseNameResolver.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI; // for AuditTraceConfig
+using WebJob.Office365ActivityImporter.Engine.Graph.Email;
 using WebJob.Office365ActivityImporter.Engine.StatsUploader;
 #endregion
 
@@ -226,12 +227,30 @@ namespace WebJob.Office365ActivityImporter
                 graphLastRunStore = new InMemoryImportLastRunStore();
             }
 
+            // Negative cache of users with no Exchange mailbox, for the sent-emails import. Also created
+            // ONCE here so the in-memory fallback survives across cycles - a per-cycle instance would
+            // always start empty and re-check (and 404 on) every mailbox-less user every 10 minutes.
+            ISentEmailMailboxSkipList sentEmailMailboxSkipList;
+            if (!string.IsNullOrEmpty(configuredSettings.ConnectionStrings.RedisConnectionString))
+            {
+                sentEmailMailboxSkipList = new RedisSentEmailMailboxSkipList(
+                    configuredSettings.ConnectionStrings.RedisConnectionString,
+                    logger,
+                    tenantId: configuredSettings.TenantGUID.ToString(),
+                    clientId: configuredSettings.ClientID,
+                    clientSecret: configuredSettings.ClientSecret);
+            }
+            else
+            {
+                sentEmailMailboxSkipList = new InMemorySentEmailMailboxSkipList();
+            }
+
             // Run app
             while (runAgain)
             {
                 var importCycleTimer = new JobTimer(logger, Process.GetCurrentProcess().ProcessName);
                 importCycleTimer.Start();
-                var tasks = new ProgramTasks(logger, configuredSettings, activityReportsLastImportedStore, graphLastRunStore);
+                var tasks = new ProgramTasks(logger, configuredSettings, activityReportsLastImportedStore, graphLastRunStore, sentEmailMailboxSkipList);
 
                 // Start listening for SB messages & register notifications web-hook with Graph 
                 if (webHookUrl != null && configuredSettings.ImportJobSettings.Calls)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -12,6 +12,7 @@ using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders;
 using WebJob.Office365ActivityImporter.Engine.Graph;
 using WebJob.Office365ActivityImporter.Engine.Graph.Calls;
+using WebJob.Office365ActivityImporter.Engine.Graph.Email;
 using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter
@@ -30,14 +31,16 @@ namespace WebJob.Office365ActivityImporter
         private GraphUserGroupsCache _graphUserGroupsCache = null;
         private readonly ISingleDateStore _activityReportsLastImportedStore;
         private readonly IImportLastRunStore _graphLastRunStore;
+        private readonly ISentEmailMailboxSkipList _sentEmailMailboxSkipList;
 
-        public ProgramTasks(AnalyticsLogger logger, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null, IImportLastRunStore graphLastRunStore = null)
+        public ProgramTasks(AnalyticsLogger logger, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null, IImportLastRunStore graphLastRunStore = null, ISentEmailMailboxSkipList sentEmailMailboxSkipList = null)
         {
             _graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(logger, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
             _logger = logger;
             _settings = settings;
             _activityReportsLastImportedStore = activityReportsLastImportedStore;
             _graphLastRunStore = graphLastRunStore;
+            _sentEmailMailboxSkipList = sentEmailMailboxSkipList;
         }
 
         internal async Task ProcessCallQueueAndWebhook(Uri webHookUrl)
@@ -62,7 +65,7 @@ namespace WebJob.Office365ActivityImporter
 
             await InitAuth();
 
-            var graphReader = new GraphImporter(_logger, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings, _activityReportsLastImportedStore, _graphLastRunStore);
+            var graphReader = new GraphImporter(_logger, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings, _activityReportsLastImportedStore, _graphLastRunStore, _sentEmailMailboxSkipList);
 
             try
             {


### PR DESCRIPTION
## Problem

Analysis of the `exceptions` table in App Insights showed **882 exceptions in 7 days (89% of all exceptions)** from a single source: the sent-email importer getting HTTP 404 from Graph.

It was not transitory and not a process-start artefact — the **same 2 users failed on every 10-minute cycle, continuously**, with two permanent Graph error codes:

| Graph error code | Cause |
|---|---|
| `MailboxNotEnabledForRESTAPI` | User has no Exchange Online mailbox (unlicensed / on-premises / inactive) |
| `Request_ResourceNotFound` | Guest (`#EXT#`) account — guests never have a mailbox in the tenant |

Neither ever resolves by retrying.

**Correctness was never at risk** — `SentEmailImporter` already tolerated the failure and those users genuinely have no sent mail. The problems were noise, cost and a hidden ambiguity:

1. **One failed call produced three exception records.** `ManualGraphCallClient` logged it, then `PageableGraphLoaderExtensions` logged the *same* exception twice more (`Got unexpected HTTP exception on page` + `Unexpected HTTP error. Will not retry page`). 2 users x 3 records x 6 cycles/hr = 36/hr, exactly matching the observed rate.
2. **Mailbox-less users were retried forever.** Sent-email import is *not* behind the `ImportCadenceGate` added in #161/#162 (user metadata, Teams apps, Teams and usage reports all are), and `LoadUsersWithMailAsync` has no exclusion or negative cache.
3. **"No mailbox" and "no sent mail" were indistinguishable.** The pageable loader swallowed the 404 and returned an empty list, so `_mailboxesFailed` was never incremented and the run summary silently under-reported.

At the 200k-user scale this solution targets, with even 5% of users lacking a mailbox, that is ~10,000 users x 3 records x 144 cycles/day = **~4.3M exception records/day** — a real App Insights bill, and enough noise to bury genuine errors.

## Changes

**1. A 404 is a typed, non-error outcome**
New `GraphResourceNotFoundException`, thrown by `ManualGraphCallClient` on 404 and logged at `Debug` instead of `Error`. It derives from `HttpRequestException` so every existing `catch (HttpRequestException)` is unaffected, and exposes Graph's machine-readable `GraphErrorCode` for diagnostics.

**2. No more double-logging**
`PageableGraphLoaderExtensions` now logs only the paging consequence, at `Warning`, since `ManualGraphCallClient` has already logged the exception with the URL and response body. One failed call -> one exception record instead of three. It also gains an opt-in `throwOnNotFound` flag (**default `false`**, so usage reports, user loaders and every other existing caller keep their partial-result behaviour); the sent-email loader opts in.

**3. Negative cache for mailbox-less users**
`SentEmailImporter` records users that 404 and skips them on subsequent cycles, re-sweeping the entire directory every `SentEmailNoMailboxRetryHours` so newly-licensed users are picked up. Backed by Redis when configured, otherwise in-memory, and hoisted to process lifetime in `Program.cs` next to the existing cadence stores (a per-cycle instance would always start empty and defeat the point). The run summary now reports `no mailbox` and `skipped` counts separately from `failed`.

Deliberately **a single key holding the whole set**, not one key per user — the importer runs against every user every cycle, so per-user lookups would be 200k round trips per cycle at target scale. One read at the start and one write at the end is O(1) regardless of tenant size.

## Config

| AppSetting | Default | Meaning |
|---|---|---|
| `SentEmailNoMailboxRetryHours` | `24` | Hours before a mailbox-less user is re-checked. `0` disables the skip list entirely (legacy behaviour). |

## Admin impact

- **No database migration.** No schema change, no `Create DB.sql` change.
- **No `CONFIG_VERSION` bump.** `AppConfig` is runtime app settings, not the installer's saved config schema (consistent with #161, which added `GraphMetadataImportIntervalHours` the same way).
- **No breaking change.** Every new parameter is optional and defaults to existing behaviour.
- Admins who were seeing `Response status code does not indicate success: 404 (Not Found).` in App Insights will simply stop seeing it. Nothing was being lost before and nothing is lost now — the affected users have no mailbox to import from.
- To force an immediate re-check of every mailbox, restart the WebJob (in-memory mode) or delete the `SentEmailNoMailboxUsers` Redis key.

## Testing

New `SentEmailMailboxSkipListTests` (15 tests, all passing) covering:
- 404 -> `GraphResourceNotFoundException` with the Graph error code parsed; still catchable as `HttpRequestException`
- non-404 errors still throw a plain `HttpRequestException`
- error-code extraction never throws on junk/HTML/empty bodies
- **the pageable loader's default behaviour is unchanged** (swallows the 404, returns partial results, never retries) — the regression guard for all other callers
- `throwOnNotFound: true` propagates
- skip-list store round-trip, defensive copies, case-insensitive UPN matching
- full sweep replaces the set and stamps the time; incremental runs carry entries forward and **do not** push the next sweep out
- re-check cadence, including `0` disabling the cache

Also verified: 131 related existing tests (`SentEmail*`, `ImportCadence*`, `AppConfigDefaults*`, `WorkloadToggle*`) pass, and the full `O365 Advanced Analytics Engine.sln` builds clean.
