### PR TITLE
Fix EasyAuth denying every authenticated dashboard request with 403

### DIFF
--- a/infra/TelemetryService/azuredeploy.json
+++ b/infra/TelemetryService/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "2784755309735525658"
+      "version": "0.46.1.21595",
+      "templateHash": "6166559255900457287"
     }
   },
   "parameters": {
@@ -139,8 +139,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "13856034097467170917"
+              "version": "0.46.1.21595",
+              "templateHash": "13555545860752310829"
             }
           },
           "parameters": {
@@ -662,7 +662,12 @@
                       "allowedAudiences": [
                         "[parameters('azureAdClientId')]",
                         "[format('api://{0}', parameters('azureAdClientId'))]"
-                      ]
+                      ],
+                      "defaultAuthorizationPolicy": {
+                        "allowedApplications": [
+                          "[parameters('azureAdClientId')]"
+                        ]
+                      }
                     }
                   }
                 },

--- a/infra/TelemetryService/resources.bicep
+++ b/infra/TelemetryService/resources.bicep
@@ -442,6 +442,19 @@ resource easyAuthSettings 'Microsoft.Web/sites/config@2024-04-01' = {
             azureAdClientId
             'api://${azureAdClientId}'
           ]
+          // MUST be set explicitly. With no defaultAuthorizationPolicy the platform
+          // materialises allowed_client_applications as an EMPTY array, and EasyAuth reads
+          // an empty allow-list as "permit nothing" - so it authenticates the caller and
+          // then rejects it with a bare 403 before the request ever reaches the app.
+          // The symptom is baffling: anonymous requests succeed (AllowAnonymous) and a
+          // token with a bad signature also succeeds (it fails validation, so it is treated
+          // as anonymous), while a perfectly valid token is the only thing that gets a 403.
+          // The SPA client is this same registration, so allow it explicitly.
+          defaultAuthorizationPolicy: {
+            allowedApplications: [
+              azureAdClientId
+            ]
+          }
         }
       }
     }

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -62,6 +62,11 @@ installations (the AnalyticsEngine importer in
   token is the only thing that gets rejected. Verify with
   `az webapp auth show` that `aadClaimsAuthorization` lists the SPA client ID
   rather than `"allowed_client_applications":[]`.
+- **Restart the App Service after changing `authsettingsV2`.** The EasyAuth /
+  MISE runtime caches the auth configuration, so a corrected
+  `allowedApplications` is not honoured until the site restarts. Until then the
+  config APIs report the new value while requests are still rejected using the
+  old one, which makes the fix look like it did not work.
 
 ## Configuration
 

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -52,6 +52,16 @@ installations (the AnalyticsEngine importer in
   authorization boundary. The ASP.NET Core API still performs the scope and
   role checks, while anonymous health, configuration and signed-upload
   requests continue to reach the application.
+- **EasyAuth `allowedApplications` must be set explicitly.** If
+  `defaultAuthorizationPolicy` is omitted, the platform stores
+  `allowed_client_applications` as an *empty array*, which EasyAuth reads as
+  "permit nothing": it authenticates the caller and then returns a bare `403`
+  before the request reaches the application. The symptom is deeply misleading —
+  anonymous requests still succeed, and a token with an invalid signature also
+  succeeds (it fails validation, so it is treated as anonymous), so a **valid**
+  token is the only thing that gets rejected. Verify with
+  `az webapp auth show` that `aadClaimsAuthorization` lists the SPA client ID
+  rather than `"allowed_client_applications":[]`.
 
 ## Configuration
 


### PR DESCRIPTION
## Symptom

The telemetry dashboard failed for every user with:

```
Could not load dashboard data: stats: HTTP 403
```

…while holding a **completely valid** token: correct `aud`, correct v2 issuer, correct tenant, not expired, and carrying **both** required claims — `roles: Telemetry.Dashboard.Read` and `scp: Telemetry.Read`.

## Root cause

The 403 came from **App Service Authentication (EasyAuth)**, not from the application. The request never reached Kestrel.

`authsettingsV2` set `validation.allowedAudiences` but no `defaultAuthorizationPolicy`, so the platform stored the client allow-list as an **empty array**:

```json
"aadClaimsAuthorization": "{\"allowed_groups\":null,\"allowed_client_applications\":[]}"
```

EasyAuth reads an empty allow-list as **"permit nothing"** — it authenticates the caller, then rejects it with a bare 403 before the app is invoked.

## Why this was so hard to diagnose

The symptom is the exact inverse of what you would expect:

| Request | EasyAuth behaviour | Result |
| --- | --- | --- |
| **No token** | No principal → `AllowAnonymous` | ✅ reaches app (`/health` → 200) |
| **Invalid-signature token** | Fails validation → treated as anonymous → `AllowAnonymous` | ✅ reaches app → app's own 401 |
| **Valid token** | Authenticates → checks allow-list → matches nothing | ❌ **403, before the app** |

So a *corrupted* token got further than a valid one, and endpoints marked `[AllowAnonymous]` in the app (`/health`, `/api/auth/config`) returned **200 without a token but 403 with one** — proving nothing in application code could be responsible.

Every conventional suspect checked out clean, because all of them were genuinely correct: app-role assignment, admin consent, audience, issuer, tenant, expiry, `allowedAudiences`, and the `[Authorize(Roles)]` / `[RequiredScope]` attributes. An isolated reproduction of the exact production auth pipeline — same .NET 10, same `Microsoft.Identity.Web` 4.14.2, same `AzureAd` configuration, same attributes — returned **200** for the very token production rejected with 403.

Diagnostic tell: the 403 carried `x-ms-middleware-request-id` and **no `Server: Kestrel`** header, whereas the app's own 401 carried `Server: Kestrel` and a `WWW-Authenticate` challenge.

## Fix

Name the SPA client explicitly in `defaultAuthorizationPolicy.allowedApplications`. The SPA and the API are the same registration, so this is a single entry — and it is **tighter** than leaving the policy `null`, which would admit any client application able to obtain a token for this audience.

## Compliance — EasyAuth stays enabled

EasyAuth here is not decorative: it is the remediation for **SFI ID2.1.1 / ID2.1.2** (MISE token-validation compliance), which mandate validating inbound tokens with a supported MISE version rather than `Microsoft.Identity.Web` / `JwtBearer`. The app registration was flagged in the S360 MISE Compliance KPI and is **scheduled for deletion** if it stops emitting compliant MISE key-discovery telemetry, with no exemptions offered.

This change therefore **keeps EasyAuth enabled and non-enforcing** — MISE key-discovery telemetry continues to flow and compliance is preserved. Disabling EasyAuth would have restored the dashboard while putting the registration back on the deletion list.

## Changes

| File | Change |
| --- | --- |
| `infra/TelemetryService/resources.bicep` | Adds `defaultAuthorizationPolicy.allowedApplications`, with a comment recording the misleading symptom so this is not re-diagnosed from scratch |
| `infra/TelemetryService/azuredeploy.json` | Recompiled from the bicep |
| `src/TelemetryService/README.md` | Documents the footgun and how to verify with `az webapp auth show` |

> **Note on the recompile:** the local Bicep CLI was upgraded 0.36.1 → 0.46.1 first. Building with the older version silently downgraded the nested-deployment `apiVersion` from `2025-04-01` to `2022-09-01` and rewrote a `resourceId()` scope into `format()`; that build was discarded. The only functional change in `azuredeploy.json` is the new `defaultAuthorizationPolicy` block.

## Admin action

No migration, no config-schema change, no `CONFIG_VERSION` bump. Existing deployments need the live setting corrected (or a redeploy of this template); until then the dashboard returns 403 for all users. After the fix, users must **sign out and back in** — MSAL caches tokens in `sessionStorage`.
