### PR TITLE
Emit Application Insights telemetry (nothing was being sent at all)

### DIFF
--- a/infra/TelemetryService/azuredeploy.json
+++ b/infra/TelemetryService/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "2784755309735525658"
+      "version": "0.46.1.21595",
+      "templateHash": "15389986286903050903"
     }
   },
   "parameters": {
@@ -139,8 +139,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "13856034097467170917"
+              "version": "0.46.1.21595",
+              "templateHash": "8994386093001141853"
             }
           },
           "parameters": {
@@ -754,8 +754,7 @@
                 "AZURE_TENANT_ID": "[parameters('azureAdTenantId')]",
                 "DashboardCacheSeconds": "60",
                 "MaxDashboardItems": "5000",
-                "APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(resourceId('Microsoft.Insights/components', variables('appInsightsName')), '2020-02-02').ConnectionString]",
-                "ApplicationInsightsAgent_EXTENSION_VERSION": "~3"
+                "APPLICATIONINSIGHTS_CONNECTION_STRING": "[reference(resourceId('Microsoft.Insights/components', variables('appInsightsName')), '2020-02-02').ConnectionString]"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Insights/components', variables('appInsightsName'))]",

--- a/infra/TelemetryService/resources.bicep
+++ b/infra/TelemetryService/resources.bicep
@@ -515,8 +515,11 @@ resource webAppSettings 'Microsoft.Web/sites/config@2024-04-01' = {
     AZURE_TENANT_ID: azureAdTenantId
     DashboardCacheSeconds: '60'
     MaxDashboardItems: '5000'
+    // Telemetry is emitted in-process by Azure.Monitor.OpenTelemetry.AspNetCore (see
+    // Web.Server/Program.cs). Deliberately no ApplicationInsightsAgent_EXTENSION_VERSION:
+    // that codeless-attach setting only applies to Windows App Service, so on this Linux
+    // .NET site it silently does nothing while making the app look instrumented.
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsights.properties.ConnectionString
-    ApplicationInsightsAgent_EXTENSION_VERSION: '~3'
   }
   dependsOn: [
     cosmosDataRoleAssignment

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -53,6 +53,22 @@ installations (the AnalyticsEngine importer in
   role checks, while anonymous health, configuration and signed-upload
   requests continue to reach the application.
 
+### Application Insights
+
+Telemetry is emitted **in-process** by
+[`Azure.Monitor.OpenTelemetry.AspNetCore`](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore),
+wired up in `Program.cs` via `AddOpenTelemetry().UseAzureMonitor()`. It reads
+`APPLICATIONINSIGHTS_CONNECTION_STRING` and no-ops when that is unset, so local
+development sends nothing.
+
+Do **not** rely on the `ApplicationInsightsAgent_EXTENSION_VERSION` codeless
+attach setting. It applies only to **Windows** App Service, and this service
+runs on **Linux** (`DOTNETCORE|10.0`), so setting it there is silently
+ineffective for .NET while making the site look instrumented: the connection
+string is present and the ingestion endpoint is reachable, yet nothing is ever
+sent. If the Application Insights resource is empty, check that this package is
+actually referenced before investigating networking.
+
 ## Configuration
 
 | Key | Required | Description |

--- a/src/TelemetryService/Web.Server/Program.cs
+++ b/src/TelemetryService/Web.Server/Program.cs
@@ -1,4 +1,5 @@
 using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Identity.Web;
@@ -13,6 +14,16 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+// Application Insights. This MUST be wired up in-process: the service runs on Linux App
+// Service, where the ApplicationInsightsAgent_EXTENSION_VERSION codeless attach used on
+// Windows does nothing for .NET, so without this the connection string is configured but
+// no telemetry is ever emitted. Reads APPLICATIONINSIGHTS_CONNECTION_STRING and silently
+// no-ops when it is unset (e.g. local development).
+if (!string.IsNullOrWhiteSpace(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+{
+    builder.Services.AddOpenTelemetry().UseAzureMonitor();
+}
 
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/src/TelemetryService/Web.Server/Web.Server.csproj
+++ b/src/TelemetryService/Web.Server/Web.Server.csproj
@@ -17,6 +17,7 @@
       surfaces as CS0433 (DefaultAzureCredential exists in both Azure.Core and Azure.Identity).
     -->
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy">
       <Version>10.*-*</Version>


### PR DESCRIPTION
## Symptom

The Application Insights resource for the telemetry service (`appi-m365ai-telemetry-shcbyr`) had received **nothing since the service was first deployed on 13 August** — no requests, traces, dependencies or exceptions. The only three records in it are the pre-deployment placeholder hits (`hostingstart.html`, `robots933456.txt`).

Critically, this was **not** merely a side-effect of the EasyAuth 403 issue (#264): requests that demonstrably reach Kestrel and return **200** (e.g. `GET /health`) were also absent. The service has been running blind.

## Root cause

The connection string was configured correctly, and the ingestion endpoint is reachable from inside the container — a `GET` to `https://westeurope-5.in.applicationinsights.azure.com/v2/track` returns **405 Method Not Allowed**, i.e. the network path is fine and outbound VNet routing is not to blame.

Nothing was reading either. Two gaps:

1. **No telemetry SDK at all.** `Web.Server.csproj` referenced neither `Microsoft.ApplicationInsights.AspNetCore` nor any OpenTelemetry package, and `Program.cs` never wired one up. A repo-wide grep for `ApplicationInsights|OpenTelemetry|UseAzureMonitor` across `src/TelemetryService` returned no matches.
2. **A Windows-only setting on a Linux site.** The infrastructure set `ApplicationInsightsAgent_EXTENSION_VERSION: '~3'`, which is the **Windows** App Service codeless-attach switch. This site is Linux (`kind: app,linux`, `DOTNETCORE|10.0`), where that setting is silently ineffective for .NET — and .NET 10 is well outside codeless-attach support in any case.

Together these made the service *look* instrumented — connection string present, agent variable set, network healthy — while guaranteeing silence.

## Fix

| File | Change |
| --- | --- |
| `Web.Server/Web.Server.csproj` | Adds `Azure.Monitor.OpenTelemetry.AspNetCore` 1.6.0 |
| `Web.Server/Program.cs` | `builder.Services.AddOpenTelemetry().UseAzureMonitor();`, guarded on `APPLICATIONINSIGHTS_CONNECTION_STRING` being present so local development stays quiet |
| `infra/TelemetryService/resources.bicep` | Removes the misleading `ApplicationInsightsAgent_EXTENSION_VERSION`, with a comment explaining why it must not return |
| `infra/TelemetryService/azuredeploy.json` | Recompiled from the bicep |
| `src/TelemetryService/README.md` | Documents the in-process approach and the Windows/Linux trap, with the diagnostic hint to check the package reference before investigating networking |

`Azure.Monitor.OpenTelemetry.AspNetCore` is the supported route for .NET on Linux App Service and picks up `APPLICATIONINSIGHTS_CONNECTION_STRING` automatically, so no new configuration keys are introduced.

## Admin action

- **An application redeploy is required.** Unlike the EasyAuth fix in #264, correcting app settings alone will not start telemetry flowing — the SDK has to ship in the build.
- No database migration, no config-schema change, no `CONFIG_VERSION` bump.
- After redeploying, requests/traces should appear within a couple of minutes; confirm with `requests | where timestamp > ago(15m)`.

## Related

- #264 — EasyAuth returning 403 for every authenticated request (separate root cause; that one is fixed in the live config already).
- Noted separately: the live site has `alwaysOn: false` despite the bicep specifying `alwaysOn: true`, so the app cold-starts after idle. That is configuration drift on the deployed resource rather than a template defect, and is being corrected directly.
