### PR TITLE
Add test projects and CI/CD for the telemetry service

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,3 +13,13 @@
 
 * Run tests on pushes to `main`, `dev` and PRs ready for review.
 * Only runs if code under `src` has changed (can by bypassed manually).
+
+## telemetry-service
+
+* Builds, tests and deploys the maintainer-side telemetry dashboard (`src/TelemetryService`).
+* Separate from the workflows above because it is a .NET 10 Linux web app deployed straight to
+  App Service, not a .NET Framework build published as a GitHub release.
+* Only runs when `src/TelemetryService/**` (or the shared `UsageReporting` project) changes.
+* Deploys on pushes to `main` and `dev`; never from a pull request or a fork.
+* Requires the repository secrets/variables listed in
+  [`src/TelemetryService/README.md`](../../src/TelemetryService/README.md#continuous-delivery).

--- a/.github/workflows/telemetry-service.yml
+++ b/.github/workflows/telemetry-service.yml
@@ -1,0 +1,174 @@
+name: Telemetry Service
+
+# Build, test and deploy the maintainer-side telemetry dashboard (src/TelemetryService).
+#
+# Deliberately separate from ci.yml / pr.yml / tests.yml: those build the .NET Framework
+# AnalyticsEngine solution on Windows and publish GitHub releases, whereas this is a .NET 10
+# Linux web app that deploys straight to App Service.
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - src/TelemetryService/**
+      - src/AnalyticsEngine/Common/UsageReporting/**
+      - .github/workflows/telemetry-service.yml
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - src/TelemetryService/**
+      - src/AnalyticsEngine/Common/UsageReporting/**
+      - .github/workflows/telemetry-service.yml
+  workflow_dispatch:
+
+# Least privilege by default. id-token is needed by azure/login for OIDC (no stored credentials).
+permissions:
+  contents: read
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  NODE_VERSION: '22.x'
+  SERVICE_DIR: src/TelemetryService
+  CLIENT_DIR: src/TelemetryService/web.client
+
+# A newer push supersedes an in-flight run for the same branch, but never cancel a deploy
+# that is already under way.
+concurrency:
+  group: telemetry-service-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build_and_test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
+
+      # ---- Client -------------------------------------------------------------------
+      - name: Install client dependencies
+        working-directory: ${{ env.CLIENT_DIR }}
+        run: npm ci
+
+      - name: Lint client
+        working-directory: ${{ env.CLIENT_DIR }}
+        run: npm run lint
+
+      - name: Test client
+        working-directory: ${{ env.CLIENT_DIR }}
+        run: npm test -- --coverage
+
+      # ---- Server -------------------------------------------------------------------
+      - name: Restore server
+        run: dotnet restore ${{ env.SERVICE_DIR }}/Web.Server/Web.Server.csproj
+
+      - name: Test server
+        run: >
+          dotnet test ${{ env.SERVICE_DIR }}/Tests.Unit/Tests.Unit.csproj
+          --configuration Release
+          --logger "trx;LogFileName=telemetry-tests.trx"
+          --results-directory ${{ runner.temp }}/test-results
+
+      - name: Upload test results
+        # Results are most useful precisely when the tests failed.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: telemetry-test-results
+          path: ${{ runner.temp }}/test-results
+          if-no-files-found: ignore
+
+      # ---- Package ------------------------------------------------------------------
+      # `dotnet publish` also builds the Vite client via the esproj reference and drops it into
+      # wwwroot, so this single artifact is the whole deployable site.
+      - name: Publish
+        run: >
+          dotnet publish ${{ env.SERVICE_DIR }}/Web.Server/Web.Server.csproj
+          --configuration Release
+          --output ${{ runner.temp }}/publish
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: telemetry-site
+          path: ${{ runner.temp }}/publish
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy to App Service
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    # Never deploy from a fork or from a pull request - only from pushes to this repository, and
+    # only from the branches that represent a deployable state.
+    if: >
+      github.event_name != 'pull_request'
+      && github.repository == 'pnp/Microsoft365-Analytics-Insights'
+      && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    permissions:
+      contents: read
+      id-token: write # OIDC federated credential for azure/login
+    environment:
+      name: telemetry-service
+      url: ${{ steps.deploy.outputs.webapp-url }}
+    steps:
+      - name: Download site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: telemetry-site
+          path: publish
+
+      # Federated (OIDC) sign-in: no client secret is stored anywhere. The app registration used
+      # here needs a federated credential for this repository and environment, plus Contributor
+      # (or Website Contributor) on the target App Service.
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy
+        id: deploy
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.TELEMETRY_APP_NAME }}
+          resource-group-name: ${{ vars.TELEMETRY_RESOURCE_GROUP }}
+          package: publish
+
+      # The site is anonymous-friendly on /health, so this is a genuine end-to-end check that the
+      # deployed build actually starts - not just that the deployment API returned success.
+      - name: Verify health
+        run: |
+          url="${{ steps.deploy.outputs.webapp-url }}/health"
+          echo "Checking $url"
+          for attempt in $(seq 1 10); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$url" || true)
+            if [ "$code" = "200" ]; then
+              echo "Healthy after $attempt attempt(s)."
+              exit 0
+            fi
+            echo "Attempt $attempt: HTTP $code - retrying in 15s"
+            sleep 15
+          done
+          echo "::error::Site did not report healthy after deployment."
+          exit 1
+
+      - name: Azure logout
+        if: always()
+        run: az logout || true

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -81,6 +81,46 @@ populate them. Two derived values are worth knowing about:
   clients — otherwise a newly added import would look widely disabled simply
   because older builds do not mention it.
 
+## Tests
+
+| Project | Runner | Command |
+| --- | --- | --- |
+| `Tests.Unit` | MSTest (net10.0) | `dotnet test src/TelemetryService/Tests.Unit/Tests.Unit.csproj` |
+| `web.client` | Vitest + Testing Library | `npm test` (from `src/TelemetryService/web.client`) |
+
+The server tests cover the dashboard aggregation (freshness bucketing, build and feature
+adoption, schema/table keying, medians), the settings-string parser, the upload endpoint's
+signature checks, the save/merge behaviour and configuration binding. `Aggregate` takes an
+injectable `nowUtc` so the freshness buckets are deterministic rather than dependent on when
+the suite runs, and the internal helpers are exposed to the test project via `InternalsVisibleTo`.
+
+The client tests cover the formatting helpers and the sortable table component. Fluent UI is
+inlined in `vitest.config.ts` (`server.deps.inline`) because `@fluentui/react-icons` ships
+extensionless ESM chunk imports that Vite's node resolver cannot follow.
+
+## Continuous delivery
+
+[`.github/workflows/telemetry-service.yml`](../../.github/workflows/telemetry-service.yml)
+builds, lints and tests both halves on every pull request, and deploys on pushes to `main` and
+`dev`. `dotnet publish` also builds the Vite client into `wwwroot`, so a single artifact is the
+whole deployable site. After deploying, the workflow polls `/health` so a build that deploys but
+fails to start is reported as a failed deployment rather than a successful one.
+
+Azure sign-in uses **OIDC federated credentials**, so no client secret is stored. Configure the
+app registration with a federated credential for this repository and the `telemetry-service`
+environment, and grant it Website Contributor (or Contributor) on the target App Service.
+
+| Kind | Name | Purpose |
+| --- | --- | --- |
+| Secret | `AZURE_CLIENT_ID` | App registration used for the federated deployment credential. |
+| Secret | `AZURE_TENANT_ID` | Tenant of that app registration. |
+| Secret | `AZURE_SUBSCRIPTION_ID` | Subscription containing the App Service. |
+| Variable | `TELEMETRY_APP_NAME` | App Service name to deploy to. |
+| Variable | `TELEMETRY_RESOURCE_GROUP` | Resource group containing that App Service. |
+
+The deploy job is guarded so it can only ever run from this repository on a push — never from a
+pull request and never from a fork.
+
 ## Configuration
 
 | Key | Required | Description |

--- a/src/TelemetryService/TelemetryService.slnx
+++ b/src/TelemetryService/TelemetryService.slnx
@@ -5,4 +5,5 @@
     <Deploy />
   </Project>
   <Project Path="Web.Server/Web.Server.csproj" />
+  <Project Path="Tests.Unit/Tests.Unit.csproj" />
 </Solution>

--- a/src/TelemetryService/Tests.Unit/DashboardServiceTests.cs
+++ b/src/TelemetryService/Tests.Unit/DashboardServiceTests.cs
@@ -1,0 +1,490 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using UsageReporting;
+using Web.Dashboard;
+
+namespace Tests.Unit;
+
+[TestClass]
+public class DashboardServiceAggregateTests
+{
+    // Fixed "now" so the freshness buckets are deterministic regardless of when the suite runs.
+    private static readonly DateTime Now = new(2026, 08, 19, 12, 00, 00, DateTimeKind.Utc);
+
+    [TestMethod]
+    public void Aggregate_NoClients_ReturnsEmptyStatsNotNulls()
+    {
+        var stats = DashboardService.Aggregate(new List<AnonUsageStatsModel>(), Now);
+
+        Assert.AreEqual(0, stats.ClientCount);
+        Assert.AreEqual(0, stats.TotalRows);
+        Assert.IsEmpty(stats.TableTotals);
+        // The React side renders unconditionally, so these must never be null.
+        Assert.IsNotNull(stats.Freshness);
+        Assert.IsNotNull(stats.SizeDistribution);
+        Assert.IsNotNull(stats.Versions);
+        Assert.IsNotNull(stats.ImportFeatures);
+        Assert.IsNotNull(stats.SchemaTotals);
+    }
+
+    [TestMethod]
+    public void Aggregate_NullList_DoesNotThrow()
+    {
+        var stats = DashboardService.Aggregate(null!, Now);
+        Assert.AreEqual(0, stats.ClientCount);
+    }
+
+    [TestMethod]
+    public void Aggregate_SkipsNullClientsAndNullTables()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            null!,
+            TestData.Client("a", Now).WithTables(("dbo", "t1", 10, 1m)),
+            new AnonUsageStatsModel { AnonClientId = "b", Generated = Now, TableStats = null },
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual(2, stats.ClientCount, "Null entries must not be counted as clients.");
+        Assert.AreEqual(10, stats.TotalRows);
+    }
+
+    [TestMethod]
+    public void Aggregate_SumsRowsAndSizeAcrossClients()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now).WithTables(("dbo", "t1", 100, 10m), ("dbo", "t2", 50, 5m)),
+            TestData.Client("b", Now).WithTables(("dbo", "t1", 200, 20m)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual(350, stats.TotalRows);
+        Assert.AreEqual(35m, stats.TotalSpaceMB);
+        Assert.AreEqual(2, stats.DistinctTableCount);
+
+        var t1 = stats.TableTotals.Single(t => t.TableName == "t1");
+        Assert.AreEqual(300, t1.Rows);
+        Assert.AreEqual(2, t1.ClientCount, "t1 is reported by both clients.");
+    }
+
+    [TestMethod]
+    public void Aggregate_KeepsSameTableNameInDifferentSchemasSeparate()
+    {
+        // The whole point of SchemaName: an app table and a profiling table can share a name, and
+        // merging them would silently overstate both.
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now).WithTables(("dbo", "shared", 100, 10m), ("profiling", "shared", 7, 1m)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.HasCount(2, stats.TableTotals);
+        Assert.AreEqual(100, stats.TableTotals.Single(t => t.DisplayName == "dbo.shared").Rows);
+        Assert.AreEqual(7, stats.TableTotals.Single(t => t.DisplayName == "profiling.shared").Rows);
+    }
+
+    [TestMethod]
+    public void Aggregate_TableWithoutSchema_UsesBareNameAndUnknownSchemaBucket()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now).WithTables((null, "legacy", 5, 1m)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        var table = stats.TableTotals.Single();
+        Assert.AreEqual("legacy", table.DisplayName);
+        Assert.IsNull(table.SchemaName);
+        Assert.AreEqual("(unknown)", stats.SchemaTotals.Single().SchemaName);
+    }
+
+    [TestMethod]
+    public void Aggregate_SchemaTotals_RollUpPerSchema()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now).WithTables(("dbo", "t1", 100, 10m), ("dbo", "t2", 50, 5m), ("profiling", "p1", 9, 1m)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        var dbo = stats.SchemaTotals.Single(s => s.SchemaName == "dbo");
+        Assert.AreEqual(150, dbo.Rows);
+        Assert.AreEqual(15m, dbo.TotalSpaceMB);
+        Assert.AreEqual(2, dbo.TableCount);
+    }
+
+    [TestMethod]
+    public void Aggregate_TableTotals_AreSortedByRowsDescending()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now).WithTables(("dbo", "small", 1, 1m), ("dbo", "big", 999, 1m)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual("big", stats.TableTotals.First().TableName);
+    }
+
+    [TestMethod]
+    public void Aggregate_LastUpdated_IsTheMostRecentReport()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now.AddDays(-3)),
+            TestData.Client("b", Now.AddHours(-1)),
+            TestData.Client("c", Now.AddDays(-10)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual(Now.AddHours(-1), stats.LastUpdated);
+    }
+
+    #region Freshness
+
+    [TestMethod]
+    public void Aggregate_Freshness_BucketsByReportAge()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("fresh", Now.AddHours(-2)),
+            TestData.Client("recent", Now.AddDays(-3)),
+            TestData.Client("older", Now.AddDays(-20)),
+            TestData.Client("stale", Now.AddDays(-90)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual(1, stats.Freshness.Last24Hours);
+        Assert.AreEqual(1, stats.Freshness.Last7Days);
+        Assert.AreEqual(1, stats.Freshness.Last30Days);
+        Assert.AreEqual(1, stats.Freshness.Stale);
+    }
+
+    [TestMethod]
+    public void Aggregate_Freshness_TreatsMissingTimestampAsStale()
+    {
+        var client = TestData.Client("a", Now);
+        client.Generated = null;
+
+        var stats = DashboardService.Aggregate(new List<AnonUsageStatsModel> { client }, Now);
+
+        Assert.AreEqual(1, stats.Freshness.Stale);
+    }
+
+    [TestMethod]
+    public void Aggregate_Freshness_BucketsAlwaysTotalTheClientCount()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now.AddMinutes(-5)),
+            TestData.Client("b", Now.AddDays(-8)),
+            TestData.Client("c", Now.AddDays(-31)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+        var f = stats.Freshness;
+
+        Assert.AreEqual(stats.ClientCount, f.Last24Hours + f.Last7Days + f.Last30Days + f.Stale);
+    }
+
+    #endregion
+
+    #region Version adoption
+
+    [TestMethod]
+    public void Aggregate_Versions_CountsClientsPerBuildAndKeepsUnknowns()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now, build: "1756"),
+            TestData.Client("b", Now, build: "1756"),
+            TestData.Client("c", Now, build: "1732"),
+            TestData.Client("d", Now, build: null),
+            TestData.Client("e", Now, build: "   "),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual("1756", stats.Versions.First().BuildVersionLabel, "Most common build first.");
+        Assert.AreEqual(2, stats.Versions.First().ClientCount);
+        Assert.AreEqual(2, stats.Versions.Single(v => v.BuildVersionLabel == "(unknown)").ClientCount,
+            "Null and whitespace labels both fall into (unknown).");
+        Assert.AreEqual(stats.ClientCount, stats.Versions.Sum(v => v.ClientCount),
+            "Version counts must reconcile against the client total.");
+    }
+
+    [TestMethod]
+    public void Aggregate_Versions_TracksLastSeen()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now.AddDays(-5), build: "1756"),
+            TestData.Client("b", Now.AddDays(-1), build: "1756"),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual(Now.AddDays(-1), stats.Versions.Single().LastSeen);
+    }
+
+    #endregion
+
+    #region Import feature adoption
+
+    [TestMethod]
+    public void Aggregate_ImportFeatures_CountsEnabledAndDisabledPerToggle()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now, imports: "GraphUsersMetadata=True;GraphUserApps=False"),
+            TestData.Client("b", Now, imports: "GraphUsersMetadata=True;GraphUserApps=True"),
+            TestData.Client("c", Now, imports: "GraphUsersMetadata=False"),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        var meta = stats.ImportFeatures.Single(f => f.Name == "GraphUsersMetadata");
+        Assert.AreEqual(2, meta.EnabledCount);
+        Assert.AreEqual(1, meta.DisabledCount);
+        Assert.AreEqual(3, meta.ReportingClients);
+
+        var apps = stats.ImportFeatures.Single(f => f.Name == "GraphUserApps");
+        Assert.AreEqual(1, apps.EnabledCount);
+        Assert.AreEqual(2, apps.ReportingClients,
+            "Only the clients that mentioned the toggle count towards its denominator.");
+    }
+
+    [TestMethod]
+    public void Aggregate_ImportFeatures_IgnoresClientsThatReportNothing()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now, imports: "GraphUsersMetadata=True"),
+            TestData.Client("b", Now, imports: null),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual(1, stats.ImportFeatures.Single().ReportingClients,
+            "A client that never reported the toggle must not be counted as having it off.");
+    }
+
+    #endregion
+
+    #region Size distribution
+
+    [TestMethod]
+    public void Aggregate_SizeDistribution_ComputesMedianAverageAndMax()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now).WithTables(("dbo", "t", 10, 1m)),
+            TestData.Client("b", Now).WithTables(("dbo", "t", 20, 2m)),
+            TestData.Client("c", Now).WithTables(("dbo", "t", 300, 30m)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+        var sd = stats.SizeDistribution;
+
+        Assert.AreEqual(20, sd.MedianRowsPerClient, "Median of 10/20/300 is 20.");
+        Assert.AreEqual(110, sd.AvgRowsPerClient, "Average of 10/20/300 is 110.");
+        Assert.AreEqual(300, sd.MaxRowsPerClient);
+        Assert.AreEqual(30m, sd.MaxSpaceMBPerClient);
+        Assert.AreEqual(1, sd.AvgTablesPerClient);
+    }
+
+    [TestMethod]
+    public void Aggregate_SizeDistribution_MedianOfEvenCountAveragesTheMiddleTwo()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now).WithTables(("dbo", "t", 10, 1m)),
+            TestData.Client("b", Now).WithTables(("dbo", "t", 20, 2m)),
+            TestData.Client("c", Now).WithTables(("dbo", "t", 30, 3m)),
+            TestData.Client("d", Now).WithTables(("dbo", "t", 40, 4m)),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual(25, stats.SizeDistribution.MedianRowsPerClient);
+        Assert.AreEqual(2.5m, stats.SizeDistribution.MedianSpaceMBPerClient);
+    }
+
+    #endregion
+
+    #region Azure AI totals
+
+    [TestMethod]
+    public void Aggregate_AiTotals_OnlyCountClientsThatReportThem()
+    {
+        var clients = new List<AnonUsageStatsModel>
+        {
+            TestData.Client("a", Now, aiDataPoints: 100),
+            TestData.Client("b", Now, aiDataPoints: 50),
+            TestData.Client("c", Now, aiDataPoints: null),
+        };
+
+        var stats = DashboardService.Aggregate(clients, Now);
+
+        Assert.AreEqual(150, stats.AiDataPointsTotal);
+        Assert.AreEqual(2, stats.ClientsReportingAi);
+        Assert.AreEqual(3, stats.ClientCount);
+    }
+
+    #endregion
+}
+
+[TestClass]
+public class ParseSettingsTests
+{
+    [TestMethod]
+    public void ParsesStandardSettingsString()
+    {
+        var parsed = DashboardService.ParseSettings("GraphUsersMetadata=True;GraphUserApps=False");
+
+        Assert.HasCount(2, parsed);
+        Assert.IsTrue(parsed["GraphUsersMetadata"]);
+        Assert.IsFalse(parsed["GraphUserApps"]);
+    }
+
+    [TestMethod]
+    public void IsCaseInsensitiveOnNameAndValue()
+    {
+        var parsed = DashboardService.ParseSettings("graphusersmetadata=TRUE");
+        Assert.IsTrue(parsed["GraphUsersMetadata"]);
+    }
+
+    [TestMethod]
+    public void ToleratesTrailingSeparatorsAndWhitespace()
+    {
+        var parsed = DashboardService.ParseSettings(" A=True ; B=False ;;");
+
+        Assert.HasCount(2, parsed);
+        Assert.IsTrue(parsed["A"]);
+        Assert.IsFalse(parsed["B"]);
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void ReturnsEmptyForMissingInput(string? input)
+    {
+        Assert.IsEmpty(DashboardService.ParseSettings(input));
+    }
+
+    [TestMethod]
+    public void SkipsMalformedEntriesInsteadOfThrowing()
+    {
+        // The string is produced by whatever build the client happens to be running, so it must
+        // never be able to take the dashboard down.
+        var parsed = DashboardService.ParseSettings("Good=True;NoEquals;=True;Bad=NotABool;Another=False");
+
+        Assert.HasCount(2, parsed);
+        Assert.IsTrue(parsed["Good"]);
+        Assert.IsFalse(parsed["Another"]);
+    }
+
+    [TestMethod]
+    public void HandlesValueContainingEquals()
+    {
+        // Split on the first '=' only, so an odd value doesn't shift the name.
+        var parsed = DashboardService.ParseSettings("Weird=True=False");
+        Assert.IsEmpty(parsed, "'True=False' is not a bool, so the entry is skipped, not misread.");
+    }
+}
+
+[TestClass]
+public class DashboardServiceCachingTests
+{
+    private static DashboardService Build(FakeTelemetryStore store, TimeSpan cache, int maxItems = 5000) =>
+        new(store, NullLogger<DashboardService>.Instance, new MemoryCache(new MemoryCacheOptions()), maxItems, cache);
+
+    [TestMethod]
+    public async Task StatsAndClients_ShareASingleStoreRead_WhenCachingEnabled()
+    {
+        var store = new FakeTelemetryStore();
+        store.Seed(TestData.Client("a", DateTime.UtcNow).WithTables(("dbo", "t", 1, 1m)));
+        var service = Build(store, TimeSpan.FromMinutes(1));
+
+        await service.GetStatsAsync();
+        await service.GetClientsAsync();
+
+        Assert.AreEqual(1, store.LoadAllCallCount, "The second call must be served from cache.");
+    }
+
+    [TestMethod]
+    public async Task CachingDisabled_HitsTheStoreEveryTime()
+    {
+        var store = new FakeTelemetryStore();
+        store.Seed(TestData.Client("a", DateTime.UtcNow));
+        var service = Build(store, TimeSpan.Zero);
+
+        await service.GetStatsAsync();
+        await service.GetStatsAsync();
+
+        Assert.AreEqual(2, store.LoadAllCallCount);
+    }
+
+    [TestMethod]
+    public async Task PassesTheConfiguredMaxItemsToTheStore()
+    {
+        var store = new FakeTelemetryStore();
+        var service = Build(store, TimeSpan.Zero, maxItems: 42);
+
+        await service.GetStatsAsync();
+
+        Assert.AreEqual(42, store.LastMaxItems);
+    }
+
+    [TestMethod]
+    public async Task GetClients_ReturnsMostRecentlyReportedFirst()
+    {
+        var now = DateTime.UtcNow;
+        var store = new FakeTelemetryStore();
+        store.Seed(
+            TestData.Client("old", now.AddDays(-5)),
+            TestData.Client("new", now),
+            TestData.Client("mid", now.AddDays(-1)));
+        var service = Build(store, TimeSpan.Zero);
+
+        var clients = await service.GetClientsAsync();
+
+        CollectionAssert.AreEqual(new[] { "new", "mid", "old" }, clients.Select(c => c.AnonClientId).ToArray());
+    }
+
+    [TestMethod]
+    public async Task GetClients_ExposesEnabledImportsParsedFromTheSettingsString()
+    {
+        var store = new FakeTelemetryStore();
+        store.Seed(TestData.Client("a", DateTime.UtcNow, imports: "Zebra=True;Alpha=True;Off=False"));
+        var service = Build(store, TimeSpan.Zero);
+
+        var client = (await service.GetClientsAsync()).Single();
+
+        CollectionAssert.AreEqual(new[] { "Alpha", "Zebra" }, client.EnabledImports.ToArray(),
+            "Only enabled toggles, sorted for stable display.");
+    }
+
+    [TestMethod]
+    public async Task GetClients_SummarisesRowsSizeAndTableCount()
+    {
+        var store = new FakeTelemetryStore();
+        store.Seed(TestData.Client("a", DateTime.UtcNow).WithTables(("dbo", "t1", 10, 1m), ("dbo", "t2", 5, 0.5m)));
+        var service = Build(store, TimeSpan.Zero);
+
+        var client = (await service.GetClientsAsync()).Single();
+
+        Assert.AreEqual(15, client.Rows);
+        Assert.AreEqual(1.5m, client.TotalSpaceMB);
+        Assert.AreEqual(2, client.TableCount);
+    }
+}

--- a/src/TelemetryService/Tests.Unit/Fakes.cs
+++ b/src/TelemetryService/Tests.Unit/Fakes.cs
@@ -1,0 +1,76 @@
+using UsageReporting;
+
+namespace Tests.Unit;
+
+/// <summary>
+/// In-memory stand-ins for the Cosmos-backed telemetry store, so the services under test can be
+/// exercised without Azure. Deliberately hand-rolled rather than mocked: the interfaces are tiny
+/// and the fakes double as assertion helpers (SavedModels, LoadCallCount).
+/// </summary>
+internal sealed class FakeTelemetryStore : ITelemetrySaveAdaptor, ITelemetryQueryAdaptor
+{
+    private readonly List<AnonUsageStatsModel> _current = new();
+
+    public List<AnonUsageStatsModel> SavedModels { get; } = new();
+    public int LoadAllCallCount { get; private set; }
+    public int? LastMaxItems { get; private set; }
+
+    public void Seed(params AnonUsageStatsModel[] models) => _current.AddRange(models);
+
+    public Task<AnonUsageStatsModel> LoadCurrentRecordByClientId(AnonUsageStatsModel model)
+    {
+        var match = _current.FirstOrDefault(m =>
+            string.Equals(m.AnonClientId, model.AnonClientId, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(match!);
+    }
+
+    public Task SaveOrUpdate(AnonUsageStatsModel newVersion)
+    {
+        SavedModels.Add(newVersion);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<AnonUsageStatsModel>> LoadAllCurrentAsync(int? maxItems = null)
+    {
+        LoadAllCallCount++;
+        LastMaxItems = maxItems;
+        return Task.FromResult<IReadOnlyList<AnonUsageStatsModel>>(_current.ToList());
+    }
+}
+
+internal static class TestData
+{
+    /// <summary>Builds a client report. Chain <see cref="WithTables"/> to attach table stats.</summary>
+    public static AnonUsageStatsModel Client(
+        string id,
+        DateTime? generated = null,
+        string? build = null,
+        string? imports = null,
+        int? aiDataPoints = null)
+    {
+        return new AnonUsageStatsModel
+        {
+            AnonClientId = id,
+            Generated = generated ?? DateTime.UtcNow,
+            BuildVersionLabel = build,
+            ConfiguredImportsEnabledDescription = imports,
+            DataPointsFromAITotal = aiDataPoints,
+            TableStats = new List<AnonUsageStatsModel.TableStat>()
+        };
+    }
+
+    /// <summary>Attaches table stats given as (schema, table, rows, sizeMB).</summary>
+    public static AnonUsageStatsModel WithTables(
+        this AnonUsageStatsModel model,
+        params (string? Schema, string Table, long Rows, decimal SizeMB)[] tables)
+    {
+        model.TableStats = tables.Select(t => new AnonUsageStatsModel.TableStat
+        {
+            SchemaName = t.Schema,
+            TableName = t.Table,
+            Rows = t.Rows,
+            TotalSpaceMB = t.SizeMB
+        }).ToList();
+        return model;
+    }
+}

--- a/src/TelemetryService/Tests.Unit/MSTestSettings.cs
+++ b/src/TelemetryService/Tests.Unit/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/src/TelemetryService/Tests.Unit/ServiceAndControllerTests.cs
+++ b/src/TelemetryService/Tests.Unit/ServiceAndControllerTests.cs
@@ -1,0 +1,281 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using UsageReporting;
+using Web;
+using Web.Config;
+using Web.Dashboard;
+
+namespace Tests.Unit;
+
+[TestClass]
+public class StatsSaveServiceTests
+{
+    [TestMethod]
+    public async Task UnseenClient_IsSavedAsIs()
+    {
+        var store = new FakeTelemetryStore();
+        var service = new StatsSaveService(store, NullLogger<StatsSaveService>.Instance);
+        var incoming = TestData.Client("new-client", DateTime.UtcNow, build: "1756");
+
+        await service.SaveOrUpdate(incoming);
+
+        Assert.HasCount(1, store.SavedModels);
+        Assert.AreEqual("new-client", store.SavedModels[0].AnonClientId);
+        Assert.AreEqual("1756", store.SavedModels[0].BuildVersionLabel);
+    }
+
+    [TestMethod]
+    public async Task KnownClient_IsMergedRatherThanReplaced()
+    {
+        var existing = TestData.Client("known", DateTime.UtcNow.AddDays(-1), build: "1732", imports: "A=True");
+        var store = new FakeTelemetryStore();
+        store.Seed(existing);
+        var service = new StatsSaveService(store, NullLogger<StatsSaveService>.Instance);
+
+        // The new report carries a build but no imports; the previous imports must survive.
+        var incoming = TestData.Client("known", DateTime.UtcNow, build: "1756");
+
+        await service.SaveOrUpdate(incoming);
+
+        var saved = store.SavedModels.Single();
+        Assert.AreEqual("1756", saved.BuildVersionLabel, "Newer value wins.");
+        Assert.AreEqual("A=True", saved.ConfiguredImportsEnabledDescription,
+            "A field absent from the new report must not wipe the stored value.");
+    }
+
+    [TestMethod]
+    public async Task NullModel_Throws()
+    {
+        var service = new StatsSaveService(new FakeTelemetryStore(), NullLogger<StatsSaveService>.Instance);
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.SaveOrUpdate(null!));
+    }
+}
+
+[TestClass]
+public class TelemetryControllerTests
+{
+    private const string Secret = "unit-test-shared-secret";
+
+    private static TelemetryController BuildController(FakeTelemetryStore store, string? overrideSecret = null)
+    {
+        var config = BuildConfig(Secret);
+        if (overrideSecret != null)
+        {
+            // TelemetrySecret is a *required* config value, so WebAppConfig refuses to construct
+            // without it (covered in WebAppConfigTests). Blanking it afterwards is the only way to
+            // reach the controller's own defence-in-depth guard.
+            config.TelemetrySecret = overrideSecret;
+        }
+
+        var dashboard = new DashboardService(
+            store, NullLogger<DashboardService>.Instance, new MemoryCache(new MemoryCacheOptions()), 5000, TimeSpan.Zero);
+
+        return new TelemetryController(
+            new StatsSaveService(store, NullLogger<StatsSaveService>.Instance),
+            dashboard,
+            config,
+            NullLogger<TelemetryController>.Instance);
+    }
+
+    private static WebAppConfig BuildConfig(string? secret) =>
+        new(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TelemetrySecret"] = secret ?? string.Empty,
+                ["CosmosDb:AccountEndpoint"] = "https://example.documents.azure.com:443/",
+                ["CosmosDb:DatabaseName"] = "Telemetry",
+                ["CosmosDb:ContainerNameCurrent"] = "Current",
+                ["CosmosDb:ContainerNameHistory"] = "History",
+                ["AzureAd:Instance"] = "https://login.microsoftonline.com/",
+                ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000000",
+                ["AzureAd:ClientId"] = "00000000-0000-0000-0000-000000000000",
+                ["AzureAd:Scopes"] = "Telemetry.Read",
+            })
+            .Build());
+
+    private static TelemetryPayload ValidPayload(string clientId = "client-1")
+    {
+        var model = TestData.Client(clientId, DateTime.UtcNow).WithTables(("dbo", "t", 1, 1m));
+        return new TelemetryPayload(model, Secret);
+    }
+
+    [TestMethod]
+    public async Task Post_ValidSignedPayload_IsAccceptedAndStored()
+    {
+        var store = new FakeTelemetryStore();
+        var controller = BuildController(store);
+
+        var result = await controller.Post(ValidPayload());
+
+        Assert.IsInstanceOfType(result, typeof(OkResult));
+        Assert.HasCount(1, store.SavedModels);
+    }
+
+    [TestMethod]
+    public async Task Post_WrongSignature_IsRejectedAndNothingIsStored()
+    {
+        var store = new FakeTelemetryStore();
+        var controller = BuildController(store);
+
+        var payload = ValidPayload();
+        payload.Secret = new TelemetryPayload(TestData.Client("x", DateTime.UtcNow), "a-different-secret").Secret;
+
+        var result = await controller.Post(payload);
+
+        Assert.IsInstanceOfType(result, typeof(UnauthorizedResult));
+        Assert.IsEmpty(store.SavedModels, "An unauthorised payload must never reach the store.");
+    }
+
+    [TestMethod]
+    public async Task Post_NullPayload_IsBadRequest()
+    {
+        var store = new FakeTelemetryStore();
+        var controller = BuildController(store);
+
+        var result = await controller.Post(null!);
+
+        Assert.IsInstanceOfType(result, typeof(BadRequestResult));
+        Assert.IsEmpty(store.SavedModels);
+    }
+
+    [TestMethod]
+    public async Task Post_InvalidModel_IsBadRequest()
+    {
+        var store = new FakeTelemetryStore();
+        var controller = BuildController(store);
+
+        // No AnonClientId / Generated => IsValid is false.
+        var payload = new TelemetryPayload { StatsModel = new AnonUsageStatsModel(), Secret = "whatever" };
+
+        var result = await controller.Post(payload);
+
+        Assert.IsInstanceOfType(result, typeof(BadRequestResult));
+    }
+
+    [TestMethod]
+    public async Task Post_ServerWithNoConfiguredSecret_FailsLoudlyRatherThanAcceptingAnything()
+    {
+        var store = new FakeTelemetryStore();
+        var controller = BuildController(store, overrideSecret: string.Empty);
+
+        await Assert.ThrowsAsync<Exception>(() => controller.Post(ValidPayload()));
+        Assert.IsEmpty(store.SavedModels);
+    }
+
+    [TestMethod]
+    public async Task GetStats_ReturnsAggregatedFigures()
+    {
+        var store = new FakeTelemetryStore();
+        store.Seed(TestData.Client("a", DateTime.UtcNow).WithTables(("dbo", "t", 42, 4m)));
+        var controller = BuildController(store);
+
+        var result = await controller.GetStats();
+
+        var ok = (OkObjectResult)result.Result!;
+        var stats = (DashboardStats)ok.Value!;
+        Assert.AreEqual(1, stats.ClientCount);
+        Assert.AreEqual(42, stats.TotalRows);
+    }
+
+    [TestMethod]
+    public async Task GetClients_ReturnsPerClientRows()
+    {
+        var store = new FakeTelemetryStore();
+        store.Seed(TestData.Client("a", DateTime.UtcNow), TestData.Client("b", DateTime.UtcNow));
+        var controller = BuildController(store);
+
+        var result = await controller.GetClients();
+
+        var ok = (OkObjectResult)result.Result!;
+        var clients = (IReadOnlyList<ClientSummary>)ok.Value!;
+        Assert.HasCount(2, clients);
+    }
+}
+
+[TestClass]
+public class WebAppConfigTests
+{
+    private static IConfiguration Config(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private static Dictionary<string, string?> Minimum() => new()
+    {
+        ["TelemetrySecret"] = "secret",
+        ["CosmosDb:AccountEndpoint"] = "https://example.documents.azure.com:443/",
+        ["CosmosDb:DatabaseName"] = "Telemetry",
+        ["CosmosDb:ContainerNameCurrent"] = "Current",
+        ["CosmosDb:ContainerNameHistory"] = "History",
+        ["AzureAd:Instance"] = "https://login.microsoftonline.com/",
+        ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000000",
+        ["AzureAd:ClientId"] = "11111111-1111-1111-1111-111111111111",
+        ["AzureAd:Scopes"] = "Telemetry.Read",
+    };
+
+    [TestMethod]
+    public void BindsValuesAndSections()
+    {
+        var config = new WebAppConfig(Config(Minimum()));
+
+        Assert.AreEqual("secret", config.TelemetrySecret);
+        Assert.AreEqual("Telemetry", config.CosmosDb.DatabaseName);
+        Assert.AreEqual("11111111-1111-1111-1111-111111111111", config.AzureAd.ClientId);
+    }
+
+    [TestMethod]
+    public void MissingRequiredValue_ThrowsWithThePropertyName()
+    {
+        var values = Minimum();
+        values.Remove("TelemetrySecret");
+
+        var ex = Assert.Throws<ConfigurationMissingException>(() => new WebAppConfig(Config(values)));
+        StringAssert.Contains(ex.Message, nameof(WebAppConfig.TelemetrySecret));
+    }
+
+    [TestMethod]
+    public void AuthorityAndApiScope_AreDerivedFromInstanceAndClientId()
+    {
+        var config = new WebAppConfig(Config(Minimum()));
+
+        Assert.AreEqual(
+            "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000",
+            config.AzureAd.Authority,
+            "The trailing slash on Instance must not be doubled up.");
+        Assert.AreEqual(
+            "api://11111111-1111-1111-1111-111111111111/Telemetry.Read",
+            config.AzureAd.ApiScope);
+    }
+
+    [TestMethod]
+    [DataRow(null, 5000)]
+    [DataRow("", 5000)]
+    [DataRow("not-a-number", 5000)]
+    [DataRow("0", 5000)]
+    [DataRow("-1", 5000)]
+    [DataRow("250", 250)]
+    public void MaxDashboardItems_FallsBackToTheDefaultForUnusableValues(string? configured, int expected)
+    {
+        var values = Minimum();
+        if (configured != null) values["MaxDashboardItems"] = configured;
+
+        Assert.AreEqual(expected, new WebAppConfig(Config(values)).GetMaxDashboardItems());
+    }
+
+    [TestMethod]
+    [DataRow(null, 60)]
+    [DataRow("", 60)]
+    [DataRow("rubbish", 60)]
+    [DataRow("-5", 60)]
+    [DataRow("0", 0)]
+    [DataRow("120", 120)]
+    public void DashboardCacheSeconds_SupportsDisablingWithZeroButRejectsNegatives(string? configured, int expectedSeconds)
+    {
+        var values = Minimum();
+        if (configured != null) values["DashboardCacheSeconds"] = configured;
+
+        Assert.AreEqual(
+            TimeSpan.FromSeconds(expectedSeconds),
+            new WebAppConfig(Config(values)).GetDashboardCacheDuration());
+    }
+}

--- a/src/TelemetryService/Tests.Unit/Tests.Unit.csproj
+++ b/src/TelemetryService/Tests.Unit/Tests.Unit.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="MSTest" Version="4.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Web.Server\Web.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/TelemetryService/Web.Server/Dashboard/DashboardService.cs
+++ b/src/TelemetryService/Web.Server/Dashboard/DashboardService.cs
@@ -250,6 +250,9 @@ namespace Web.Dashboard
 
             stats.Versions = versionAccumulators.Values
                 .OrderByDescending(v => v.ClientCount)
+                // "(unknown)" is a real bucket but not a real version, so keep it last on ties -
+                // otherwise it can sort ahead of an actual build and read as the most common one.
+                .ThenBy(v => v.BuildVersionLabel == UnknownLabel ? 1 : 0)
                 .ThenBy(v => v.BuildVersionLabel, System.StringComparer.OrdinalIgnoreCase)
                 .ToList();
 

--- a/src/TelemetryService/Web.Server/Program.cs
+++ b/src/TelemetryService/Web.Server/Program.cs
@@ -1,14 +1,8 @@
-using Azure.Identity;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.Azure.Cosmos;
 using Microsoft.Identity.Web;
-using UsageReporting;
-using Web.Config;
-using Web.Dashboard;
+using Web.Startup;
 
 var builder = WebApplication.CreateBuilder(args);
-
-// Add services to the container.
 
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
@@ -19,60 +13,8 @@ builder.Services
     .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
 builder.Services.AddAuthorization();
 
-// Backing store for the dashboard read cache (see DashboardService).
-builder.Services.AddMemoryCache();
-
-
-var config = new WebAppConfig(builder.Configuration);
-builder.Services.AddSingleton(config);
-
-// Use Microsoft Entra ID (AAD) authentication for Cosmos DB.
-// The account has local (key) authorization disabled, so DefaultAzureCredential is used to
-// pick up the developer's Visual Studio / Azure CLI credentials locally and the Managed Identity
-// when running in Azure.
-if (string.IsNullOrWhiteSpace(config.CosmosDb.AccountEndpoint))
-{
-    throw new InvalidOperationException(
-        "CosmosDb:AccountEndpoint is not configured. Set it to the Cosmos account URL, e.g. https://<account>.documents.azure.com:443/");
-}
-
-// The Cosmos account only trusts tokens issued by its home tenant. If your default Azure
-// tenant differs (e.g. you're signed into the Microsoft corp tenant but the account lives
-// in a customer / lab tenant), set AZURE_TENANT_ID in configuration / env vars.
-var tenantId = builder.Configuration["AZURE_TENANT_ID"];
-var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
-{
-    TenantId = tenantId,
-    // Allow the chained credentials (VS, Azure CLI, etc.) to silently re-auth against
-    // the tenant required by the resource, instead of failing with an authority mismatch.
-    AdditionallyAllowedTenants = { "*" }
-});
-
-var cosmosClient = new CosmosClient(config.CosmosDb.AccountEndpoint, credential);
-builder.Services.AddSingleton(s => cosmosClient);
-
-
-// One Cosmos adaptor instance serves both the writer interface (called by the importer-side
-// POST handler) and the reader interface (called by the dashboard). Registered as the concrete
-// type first, then bound to each interface via a factory so we get a single singleton, not two.
-var adapter = new CosmosTelemetrySaveAdaptor(cosmosClient, config.CosmosDb);
-builder.Services.AddSingleton(adapter);
-builder.Services.AddSingleton<ITelemetrySaveAdaptor>(sp => sp.GetRequiredService<CosmosTelemetrySaveAdaptor>());
-builder.Services.AddSingleton<ITelemetryQueryAdaptor>(sp => sp.GetRequiredService<CosmosTelemetrySaveAdaptor>());
-
-builder.Services.AddSingleton(sp => new StatsSaveService(
-    sp.GetRequiredService<ITelemetrySaveAdaptor>(),
-    sp.GetRequiredService<ILogger<StatsSaveService>>()));
-
-builder.Services.AddSingleton(sp => new DashboardService(
-    sp.GetRequiredService<ITelemetryQueryAdaptor>(),
-    sp.GetRequiredService<ILogger<DashboardService>>(),
-    sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>(),
-    config.GetMaxDashboardItems(),
-    config.GetDashboardCacheDuration()));
-
-await adapter.Init();
-
+// Config, Cosmos, telemetry store and dashboard services (see TelemetryServiceCollectionExtensions).
+builder.Services.AddTelemetryServices(builder.Configuration);
 
 var app = builder.Build();
 
@@ -98,3 +40,8 @@ app.MapControllers();
 app.MapFallbackToFile("/index.html");
 
 app.Run();
+
+/// <summary>
+/// Exposed so integration tests can host the real application with <c>WebApplicationFactory</c>.
+/// </summary>
+public partial class Program;

--- a/src/TelemetryService/Web.Server/Startup/CosmosSchemaInitializer.cs
+++ b/src/TelemetryService/Web.Server/Startup/CosmosSchemaInitializer.cs
@@ -1,0 +1,43 @@
+using UsageReporting;
+
+namespace Web.Startup
+{
+    /// <summary>
+    /// Creates the Cosmos database and containers if they don't already exist.
+    ///
+    /// Runs as a hosted service rather than inline during startup: previously a Cosmos outage (or a
+    /// misconfigured endpoint) threw before the host was built, so the whole site failed to start and
+    /// even the anonymous <c>/health</c> endpoint was unreachable — which makes an outage look like a
+    /// deployment failure. Failures here are logged and swallowed, because the containers almost always
+    /// already exist and the per-request code paths surface their own errors.
+    /// </summary>
+    public class CosmosSchemaInitializer : IHostedService
+    {
+        private readonly CosmosTelemetrySaveAdaptor _adaptor;
+        private readonly ILogger<CosmosSchemaInitializer> _logger;
+
+        public CosmosSchemaInitializer(CosmosTelemetrySaveAdaptor adaptor, ILogger<CosmosSchemaInitializer> logger)
+        {
+            _adaptor = adaptor;
+            _logger = logger;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _adaptor.Init();
+                _logger.LogInformation("Cosmos database and containers verified.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Could not verify the Cosmos database/containers on startup ({Message}). The site will " +
+                    "still start; telemetry reads and writes will report their own errors until Cosmos is " +
+                    "reachable.", ex.Message);
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/TelemetryService/Web.Server/Startup/TelemetryServiceCollectionExtensions.cs
+++ b/src/TelemetryService/Web.Server/Startup/TelemetryServiceCollectionExtensions.cs
@@ -1,0 +1,93 @@
+using Azure.Identity;
+using Microsoft.Azure.Cosmos;
+using UsageReporting;
+using Web.Config;
+using Web.Dashboard;
+
+namespace Web.Startup
+{
+    /// <summary>
+    /// Composition root for the telemetry service. Extracted from <c>Program.cs</c> so the exact
+    /// production object graph can be built inside tests without duplicating the wiring.
+    /// </summary>
+    public static class TelemetryServiceCollectionExtensions
+    {
+        public static IServiceCollection AddTelemetryServices(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            var config = new WebAppConfig(configuration);
+            services.AddSingleton(config);
+
+            // Backing store for the dashboard read cache (see DashboardService).
+            services.AddMemoryCache();
+
+            if (string.IsNullOrWhiteSpace(config.CosmosDb.AccountEndpoint))
+            {
+                throw new InvalidOperationException(
+                    "CosmosDb:AccountEndpoint is not configured. Set it to the Cosmos account URL, " +
+                    "e.g. https://<account>.documents.azure.com:443/");
+            }
+
+            services.AddSingleton(_ => CreateCosmosClient(configuration, config));
+
+            // One Cosmos adaptor instance serves both the writer interface (called by the importer-side
+            // POST handler) and the reader interface (called by the dashboard). Registered as the concrete
+            // type first, then bound to each interface via a factory so we get a single singleton, not two.
+            services.AddSingleton(sp => new CosmosTelemetrySaveAdaptor(
+                sp.GetRequiredService<CosmosClient>(), config.CosmosDb));
+            services.AddSingleton<ITelemetrySaveAdaptor>(sp => sp.GetRequiredService<CosmosTelemetrySaveAdaptor>());
+            services.AddSingleton<ITelemetryQueryAdaptor>(sp => sp.GetRequiredService<CosmosTelemetrySaveAdaptor>());
+
+            services.AddTelemetryDomainServices(config);
+
+            // Container creation used to run inline before the host was built, which meant a Cosmos
+            // blip stopped the app booting outright - including the anonymous health endpoint. It now
+            // runs as a hosted service so startup is never blocked by it.
+            services.AddHostedService<CosmosSchemaInitializer>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Registers the parts that have no Azure dependency. Split out so tests can register fake
+        /// adaptors and still exercise the real services.
+        /// </summary>
+        public static IServiceCollection AddTelemetryDomainServices(this IServiceCollection services, WebAppConfig config)
+        {
+            services.AddSingleton(sp => new StatsSaveService(
+                sp.GetRequiredService<ITelemetrySaveAdaptor>(),
+                sp.GetRequiredService<ILogger<StatsSaveService>>()));
+
+            services.AddSingleton(sp => new DashboardService(
+                sp.GetRequiredService<ITelemetryQueryAdaptor>(),
+                sp.GetRequiredService<ILogger<DashboardService>>(),
+                sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>(),
+                config.GetMaxDashboardItems(),
+                config.GetDashboardCacheDuration()));
+
+            return services;
+        }
+
+        private static CosmosClient CreateCosmosClient(IConfiguration configuration, WebAppConfig config)
+        {
+            // Microsoft Entra ID (AAD) authentication for Cosmos DB. The account has local (key)
+            // authorization disabled, so DefaultAzureCredential picks up the developer's Visual Studio /
+            // Azure CLI credentials locally and the managed identity when running in Azure.
+            //
+            // The Cosmos account only trusts tokens issued by its home tenant. If the default Azure
+            // tenant differs (e.g. signed into a corp tenant while the account lives in a lab tenant),
+            // set AZURE_TENANT_ID in configuration / environment variables.
+            var tenantId = configuration["AZURE_TENANT_ID"];
+            var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+            {
+                TenantId = tenantId,
+                // Allow the chained credentials (VS, Azure CLI, etc.) to silently re-auth against
+                // the tenant required by the resource, instead of failing with an authority mismatch.
+                AdditionallyAllowedTenants = { "*" }
+            });
+
+            return new CosmosClient(config.CosmosDb.AccountEndpoint, credential);
+        }
+    }
+}

--- a/src/TelemetryService/Web.Server/Web.Server.csproj
+++ b/src/TelemetryService/Web.Server/Web.Server.csproj
@@ -11,6 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Aggregation helpers are internal so they stay off the public surface, but they hold the
+         logic most worth testing (medians, settings parsing, freshness bucketing). -->
+    <InternalsVisibleTo Include="Tests.Unit" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!--
       Must be >= the transitive version pulled in via UsageReporting -> DataUtils (currently 1.21.0),
       otherwise NuGet raises NU1605 (package downgrade) and the resulting binding redirect mess

--- a/src/TelemetryService/web.client/package-lock.json
+++ b/src/TelemetryService/web.client/package-lock.json
@@ -16,18 +16,96 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.4",
         "@types/node": "^24.12.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^3.2.7",
         "eslint": "^10.3.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "jsdom": "^29.1.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.59.2",
-        "vite": "^8.0.12"
+        "vite": "^8.0.12",
+        "vitest": "^3.2.7"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha1-tbcaJaTRavokglkt36YvzMYLx9E=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha1-7UQbb6YAByUgzhi0PSyMyMrsx/Q=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha1-KKCqyCIKTMGQRaw72agT1AYL03U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha1-AYgAhrskkAmPFnvrWFVdoabJrb0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha1-PQv2vk/AWYUTkKcHByDGAHr3k+w=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha1-rVVJMi3+nRU9S03W9/8q4jSwbiQ=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@azure/msal-browser": {
       "version": "5.18.0",
@@ -299,11 +377,616 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha1-u+EtyltO+YOg0K9LB7m8kOoKuro=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha1-qo246xc/3ucyT4IoSDMQat7sxkg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha1-GJAySNsdooKF6EWHk7A49g1zjPE=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha1-M8xL26uO3xtuOrjB66hJxBoyTxo=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha1-VvP1u+1mPXYxYWqKi/NPI7T5ync=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha1-4cZdwJN4tC8moRH8p/cHX8LCYWQ=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha1-Z6ZfSyZ2bDFd39K9uJrExT/dUec=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha1-eYozlQ0RImoOu2rK+mD1WUQkln8=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emotion/hash/-/hash-0.9.2.tgz",
       "integrity": "sha1-/5IhufWLTf5h5hmneIc0vWP2iYs=",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha1-grdPkqp41yC3FBYpOfskjJCt31M=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha1-WT4QoUULv8rGyzIfYfRoRTusIJ0=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha1-94y4oxIfwgWlMoWtskly2zhdGF0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha1-RTFD0HMyYDPS0iyvnkjeS64nSwc=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha1-byMAD7m0C34Et9BgbAaTvQYy8yI=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha1-Jzk90YuxJjxmOXnF8VduAMLQJL4=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha1-IuRjj6UC0cACcHcyTJdkDjrfOmI=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha1-kiS45P6pJM4hlOPvw+muv4IhktY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha1-uenQcMjBwESc8Ssg6sN9cKRZWSE=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha1-T10cJ1J9gXs1aEriFBnlfCvaCWY=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha1-P4D7aWqpYFGpQEfzXIWwiyHDb54=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha1-m+HywoIQsT67QVYiG7o1b+FnUgU=",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha1-SrXuZ6Pfy8tej9eIPa5uc1sRY7g=",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha1-2seMaJ9kmUWcQyHlwVAywSMH5+o=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha1-BQ99OzVcOpgwjpNbxNYyXakbACc=",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha1-1h9xXOYdQ/5YRK0Nj0Y/iMvk/vY=",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha1-yo4apHj8ggkle/Osj3nE3CmC8yo=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha1-FlDywblI3us++Ujy/DBhRyPAlpA=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha1-ZXcqs0LEszGb8HBaIRBQqsG24yA=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha1-N+18+mZUnXlVhS/ON9DD3k5xXqE=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha1-Ab89OFhV71DLM9t8S1L5V8NM0Xk=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha1-bB+Us0CGWZqr2k6sj2OClLmHdBA=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha1-Sw3ReuCmlB0tD9NakGOSUXBxqQ0=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha1-NBk6tVZdb/aMqSisBL51ECzLLnc=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha1-62fw5EglFdjBiU7eYxwyek2p/E0=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha1-j+MLMIi4m0hzw6bMh1l645IMCos=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
@@ -431,6 +1114,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha1-sTvEZMoWLBer8IN/s6Ea6reeRdE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2114,6 +2815,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha1-jcmvoqwVBssaWPiZQPHBJERsjfM=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2164,6 +2893,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha1-5X1DBpZgeGYgOAlPs465FG3Drqk=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.143.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oxc-project/types/-/types-0.143.0.tgz",
@@ -2172,6 +2918,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2419,6 +3176,356 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha1-K4bI//E6BlhF3bZfZNgUSZrOAg8=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha1-ryFzV+zAauXk9U7zTucrHjf428M=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha1-6dCtugbjm2MvyOiAEA/wZUftqAs=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha1-7/mDop232Op/cz8c5DD8ZOFZpeY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha1-q+E5mnDoGQNPSS0F28yXlkMQu1c=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha1-suD4wko2KscRK+PVVJxpQFl+AWg=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha1-pfKn5+txklSmgA2xjp82nTxiNDk=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha1-OQyGx5dpWvh8ONbwBSItkgtb+iI=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha1-H+p4YJoVgTzamNk/6NmHyHAX9XI=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha1-O1ADHJkWUXV2CY9uEbOKExR9xGM=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha1-tAMlVUYJmkMAsX2XbuF3YiTAkOU=",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha1-WQBhDlnGbuWUU5xlkFZtv9pwgrE=",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha1-qJLMi4QUvIrgsmeBa144Tl0yH/I=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha1-2eYNVot9tN8hlvskEbDGkYsjYMw=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha1-WzFBq0OvvZ5Q9jnlYulO0lbSAc8=",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha1-sP51EBW8OCL5AEiE6rpeXN/eeqY=",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha1-DLMj6FBQnhub9tJBMoqYsOEuKRY=",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha1-HnRwEj56i6jBYKegQ0R0ctVUlUI=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha1-Gd+aF9IP88F72OnMJVNWOuCqBYA=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha1-McPKG9AOgPMJodDLjaS99Zyy36M=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha1-hFYaFDgcrst2UuFY0QVRpe3Apvw=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha1-vFMu2yDNOcC1Pu4t+uQ7UsLjvh4=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha1-pvUUkpdsn8GYAb4pjfL3ajy+v3o=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha1-rmBxCwhosv5zHZ98NB+knL+Ohik=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha1-w6Jl/g+a9PtjuthtOCk4a8XaACY=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/helpers/-/helpers-0.5.23.tgz",
@@ -2427,6 +3534,131 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha1-1ET4qInppG6aO087iOD8s++2z5U=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha1-ZJqaiyA58o0p+fekbrqai3J/gR4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha1-mT6SXMHXPyxmLn113VpURSWaj9g=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha1-ZyiDt6y453X8BJLZ6dJeBuiXhtA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@testing-library/user-event/-/user-event-14.6.4.tgz",
+      "integrity": "sha1-Xl6jeL11AOZvYKSaJWCtHYdi3bM=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha1-GjHD03iFDSd42rtjdNA23LpLpwg=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha1-jpzZ4cNYH6azQaWu1ViOsoW+C0o=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha1-M0MRlx06BxIefrkbaEpgXn7qnL0=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -2746,6 +3978,128 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha1-LpzhEDRFwjeqpCCn8AWBJf5KeFQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha1-cKNBWDg9AIw79dgC4mQzF/Cd9tg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha1-KntZP44Afp2O9+c0OqMOxz/eryk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha1-wMCAIoGJ8fps2kD1m+CddGsKylE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha1-o6fhlQzpnsTPAjleIN3KQDtsgY4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha1-yn++5EAZUjykUDldmiKEzp7OHzE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha1-MCyBJiEaxN/qh7O1CFwJjW0i6J4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
@@ -2786,6 +4140,69 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha1-ZQxWnkGtkLUbPX315e7Rx1ScED4=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha1-9kGhlrM1aQsQcL8AtudZP+wZC/c=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha1-jrG3yG74SZhZvnYbF//ZFAbAw28=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha1-3/51mbSou3/jCv+NAjUjTf+3mDE=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2807,6 +4224,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha1-b4vPPId8TZIg3fSbm7aTDIj4d9I=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2856,6 +4283,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha1-gE4eb1Bu42PLDjzLsJytXdmHCVk=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001807",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001807.tgz",
@@ -2876,6 +4313,53 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha1-3T2pVeJwkWpL0/Yl9LkZmWrafgY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha1-JCc2ERe3DMqNyJaA6tMrFXAZyvU=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2899,11 +4383,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha1-hsrHARVhJysw5rHgQrps4EeqdRg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha1-7EjA8+mT5QZIyG2lWeJhCZXPmJo=",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha1-bc6LYyJqHs/dkHzhiozPse7lBtM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2923,12 +4442,39 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha1-5kmkPjq5U6chkv9Zg4ZeUJ837Zo=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha1-S3VtjXcKklcwCCXVKiws/5nDo0E=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha1-JkQhTxmX057Q7g7OcjNUkKesZ74=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2939,6 +4485,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha1-WnQp5gZus2ZNkR4z+w5F3o6whFM=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.402",
@@ -2969,6 +4530,75 @@
       "license": "MIT",
       "peerDependencies": {
         "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha1-wd9f42AkKXR/ojPQ3SbxQvDOR0M=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha1-kVlgFWGICoXyc0VgqQmbLDHlNyo=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha1-vK3OIrLz/XbyV+OmT4OmSYb+oR8=",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -3169,6 +4799,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha1-Z8PlSexAKkh7T8GT0ZU6UkdSNA0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esutils/-/esutils-2.0.3.tgz",
@@ -3177,6 +4817,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha1-JO338MxppE0AhWe6RZSrlvPDo9Y=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3269,6 +4919,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
@@ -3293,6 +4960,28 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3306,6 +4995,39 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
       "version": "17.9.0",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-17.9.0.tgz",
@@ -3317,6 +5039,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hermes-estree": {
@@ -3335,6 +5067,26 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha1-+Nk5Czs0i1DU9hwW3S71wFmAqII=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3356,6 +5108,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3364,6 +5126,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3379,6 +5151,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
@@ -3386,12 +5165,133 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha1-LRZsSwZE1Do58Ev2wu3R5YXzF1Y=",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha1-kIMFusmlvRdaxqdEier9D8JEWn0=",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha1-rK75SN93R8jrX78SZcuYD2NTpEE=",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha1-y0U1FitXhKpiPO4hpyUs8sgHrJM=",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha1-W5cEkG881RDDSqlBri+Pf4F53wE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha1-AOFmZckMYg+6FKPDaHMql2ST92A=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3747,6 +5647,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha1-AJXPVtxbepp8CP9bGoeW7IrRfnY=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3755,6 +5662,85 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha1-watQ93iHtxJiEgG6n9Tjpu0JmUE=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha1-VnY+wJoPqAkd8nh5/ZTRkHjADZE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha1-gwHDx9ZnBKB3HrG610J08OwDZzk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha1-w8IwencSd82WODBfkVwprnQbYU4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha1-43ucUIgLdTZsTUCsY9m7ys22Hw4=",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3771,6 +5757,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -3866,6 +5862,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha1-9DvNLNaD7+CEB1Mz6c4Np9Btox4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
@@ -3884,6 +5900,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha1-PsvsVUIWhbcKnahyss/z4cvtFxY=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha1-iFXFooma8HLWrAXRHkYEWtDcYF0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3945,6 +6002,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha1-IYGHn96lGnpYUfs52SD6pj8B2I4=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
@@ -3974,6 +6047,38 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha1-5Ve3mYMWu1PJ8fVvpiY1LGljBZ8=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -4009,6 +6114,52 @@
         "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha1-ltLmIHDwsKxjQk7dDJOn+4ZO8Gk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rtl-css-js": {
       "version": "1.16.1",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
@@ -4016,6 +6167,19 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha1-/ltKR2jfTxSiAbG6amXB89mYjMU=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4057,6 +6221,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha1-MudscLeXJOO7Vny51UPrhYzPrzA=",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4067,10 +6251,174 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha1-Gsig2Ug4SNFpXkGLbQMaPDzmjjs=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha1-2BCyfjoHMEeyteQANIgfXqb5yDs=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha1-wy4c7pQLazQyx3G8LFS8znPNMAE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha1-IiskPdLUnAvNDeiQatvYQXcZYDI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha1-LsQ5ZGWENSlvZ2GzThBnHC2VJ/Q=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stylis": {
       "version": "4.4.0",
       "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha1-xYRsk0X0v8Ub0MvXyjWgdE9IWl0=",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tabster": {
@@ -4082,6 +6430,35 @@
         "keyborg": "^2.14.0",
         "tslib": "^2.8.1"
       }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha1-SCOSB3YwvFfVYwwTq+kIu5EN/GU=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha1-EDyfi6bXI3pHq23R3P93JRhjQms=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha1-lBeU5leoXklld5lcbu9m9T9Cs9I=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -4098,6 +6475,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha1-BZ8tBCvTdWf7wBfT1Ca90qJhJZE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha1-lQmyFiQ2MV6A4+7g/M5EdNJEQpQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha1-13oAL7U6iKoUKbQZwckkkuDIH3g=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha1-wfKAS7AoBirlNFywrbEpzVD5RHE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha1-M7MYObw36Cg/l9i1dBqmZWkXAfA=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha1-ex8i/PLa8GxP+dU+wYRfRMZicGI=",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha1-9aGuVGoK2zKid6InjQ0X+i+Qk+Y=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4168,6 +6621,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha1-rg9vYuBuBXqcu3srX94rt095G48=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4305,6 +6768,327 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha1-82dtlMSvHnaJjBYsknKLymX3uwc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha1-kMLQt7lKIk5+fc8i0pEv8LUpEWU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha1-GUS27QE6Jf0mpz0Y4a+SwQpXr2w=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha1-MxvpRMt4PGQt1CvXQ0EayiTqBGY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha1-kMLQt7lKIk5+fc8i0pEv8LUpEWU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha1-+SW6JoVRWFlNkHMTzt0UdsWWf2w=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha1-Blflcf5vBvyxXKUO0f28tJXNFoY=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha1-2CMoldvVJ86u5079QWIAj7ioz0g=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha1-BH9/S9Nu92txmMFy0bHOvGb3ZN0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
@@ -4321,6 +7105,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha1-o/aalxB/SUs83Dvd3Yg6fWXOvwQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4330,6 +7131,124 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha1-gr6blX96/az5YeWYDxvyJ8C/dnM=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/src/TelemetryService/web.client/package.json
+++ b/src/TelemetryService/web.client/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
     "@azure/msal-browser": "^5.18.0",
@@ -18,16 +20,22 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.4",
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^3.2.7",
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "jsdom": "^29.1.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
-    "vite": "^8.0.12"
+    "vite": "^8.0.12",
+    "vitest": "^3.2.7"
   }
 }

--- a/src/TelemetryService/web.client/src/components/SortableTable.test.tsx
+++ b/src/TelemetryService/web.client/src/components/SortableTable.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+import type { ReactElement } from 'react';
+import { SortableTable, type Column } from './SortableTable';
+
+interface Row {
+    name: string;
+    rows: number;
+}
+
+const data: Row[] = [
+    { name: 'beta', rows: 20 },
+    { name: 'alpha', rows: 300 },
+    { name: 'gamma', rows: 1 },
+];
+
+const columns: Column<Row>[] = [
+    { key: 'name', header: 'Table', render: r => r.name, sortValue: r => r.name },
+    { key: 'rows', header: 'Rows', numeric: true, render: r => String(r.rows), sortValue: r => r.rows },
+    { key: 'static', header: 'Static', render: () => 'x' },
+];
+
+function renderWithProvider(ui: ReactElement) {
+    return render(<FluentProvider theme={webLightTheme}>{ui}</FluentProvider>);
+}
+
+function rowOrder(): string[] {
+    // First row group is the header, so read the body rows only.
+    const rows = screen.getAllByRole('row').slice(1);
+    return rows.map(r => within(r).getAllByRole('cell')[0].textContent ?? '');
+}
+
+describe('SortableTable', () => {
+    it('shows the empty message instead of an empty table', () => {
+        renderWithProvider(
+            <SortableTable items={[]} columns={columns} rowKey={r => r.name} emptyMessage="Nothing here." />);
+
+        expect(screen.getByText('Nothing here.')).toBeInTheDocument();
+        expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+
+    it('applies the initial sort descending', () => {
+        renderWithProvider(
+            <SortableTable items={data} columns={columns} rowKey={r => r.name} initialSortKey="rows" />);
+
+        expect(rowOrder()).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('honours an ascending initial sort', () => {
+        renderWithProvider(
+            <SortableTable
+                items={data}
+                columns={columns}
+                rowKey={r => r.name}
+                initialSortKey="rows"
+                initialDescending={false}
+            />);
+
+        expect(rowOrder()).toEqual(['gamma', 'beta', 'alpha']);
+    });
+
+    it('toggles direction when the same column header is clicked again', async () => {
+        const user = userEvent.setup();
+        renderWithProvider(
+            <SortableTable items={data} columns={columns} rowKey={r => r.name} initialSortKey="rows" />);
+
+        await user.click(screen.getByText('Rows'));
+
+        expect(rowOrder()).toEqual(['gamma', 'beta', 'alpha']);
+    });
+
+    it('sorts strings case-insensitively when a different column is picked', async () => {
+        const user = userEvent.setup();
+        renderWithProvider(
+            <SortableTable items={data} columns={columns} rowKey={r => r.name} initialSortKey="rows" />);
+
+        await user.click(screen.getByText('Table'));
+
+        // Switching column starts descending.
+        expect(rowOrder()).toEqual(['gamma', 'beta', 'alpha']);
+    });
+
+    it('ignores clicks on columns that have no sort value', async () => {
+        const user = userEvent.setup();
+        renderWithProvider(
+            <SortableTable items={data} columns={columns} rowKey={r => r.name} initialSortKey="rows" />);
+
+        const before = rowOrder();
+        await user.click(screen.getByText('Static'));
+
+        expect(rowOrder()).toEqual(before);
+    });
+
+    it('renders every row when unsorted', () => {
+        renderWithProvider(<SortableTable items={data} columns={columns} rowKey={r => r.name} />);
+
+        expect(screen.getAllByRole('row')).toHaveLength(data.length + 1);
+    });
+});

--- a/src/TelemetryService/web.client/src/format.test.ts
+++ b/src/TelemetryService/web.client/src/format.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import { formatMB, formatNumber, formatPercent, formatRelative } from './format';
+
+describe('formatNumber', () => {
+    it('renders an em dash for missing values rather than "null"', () => {
+        expect(formatNumber(null)).toBe('—');
+        expect(formatNumber(undefined)).toBe('—');
+    });
+
+    it('renders zero as a number, not as missing', () => {
+        expect(formatNumber(0)).toBe('0');
+    });
+
+    it('groups thousands', () => {
+        // Locale-dependent separator, so assert on the digits rather than the exact string.
+        expect(formatNumber(1234567).replace(/\D/g, '')).toBe('1234567');
+        expect(formatNumber(1234567)).not.toBe('1234567');
+    });
+});
+
+describe('formatMB', () => {
+    it('renders missing values as an em dash', () => {
+        expect(formatMB(null)).toBe('—');
+        expect(formatMB(undefined)).toBe('—');
+    });
+
+    it('keeps small values in MB', () => {
+        expect(formatMB(0)).toBe('0.00 MB');
+        expect(formatMB(512)).toBe('512.00 MB');
+        expect(formatMB(1023.99)).toBe('1023.99 MB');
+    });
+
+    it('scales to GB at 1024 MB', () => {
+        expect(formatMB(1024)).toBe('1.00 GB');
+        expect(formatMB(391000)).toBe('381.84 GB');
+    });
+
+    it('scales to TB so a large install base stays readable', () => {
+        expect(formatMB(1024 * 1024)).toBe('1.00 TB');
+        expect(formatMB(5 * 1024 * 1024)).toBe('5.00 TB');
+    });
+});
+
+describe('formatPercent', () => {
+    it('avoids dividing by zero', () => {
+        expect(formatPercent(5, 0)).toBe('0%');
+    });
+
+    it('rounds to whole percentages', () => {
+        expect(formatPercent(1, 3)).toBe('33%');
+        expect(formatPercent(2, 3)).toBe('67%');
+        expect(formatPercent(3, 3)).toBe('100%');
+    });
+});
+
+describe('formatRelative', () => {
+    const now = new Date('2026-08-19T12:00:00Z');
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(now);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('describes a missing timestamp as never', () => {
+        expect(formatRelative(null)).toBe('never');
+        expect(formatRelative(undefined)).toBe('never');
+    });
+
+    it('returns the raw value when it is not a date', () => {
+        expect(formatRelative('not-a-date')).toBe('not-a-date');
+    });
+
+    it('collapses very recent times', () => {
+        expect(formatRelative('2026-08-19T11:59:30Z')).toBe('just now');
+    });
+
+    it('singularises correctly', () => {
+        expect(formatRelative('2026-08-19T11:00:00Z')).toBe('1 hour ago');
+        expect(formatRelative('2026-08-19T10:00:00Z')).toBe('2 hours ago');
+    });
+
+    it('steps up through minutes, hours and days', () => {
+        expect(formatRelative('2026-08-19T11:55:00Z')).toBe('5 minutes ago');
+        expect(formatRelative('2026-08-17T12:00:00Z')).toBe('2 days ago');
+    });
+
+    it('describes long-stale clients in months', () => {
+        expect(formatRelative('2026-06-19T12:00:00Z')).toBe('2 months ago');
+    });
+});

--- a/src/TelemetryService/web.client/src/test/setup.ts
+++ b/src/TelemetryService/web.client/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/TelemetryService/web.client/vite.config.ts
+++ b/src/TelemetryService/web.client/vite.config.ts
@@ -7,38 +7,53 @@ import path from 'path';
 import child_process from 'child_process';
 import { env } from 'process';
 
-const baseFolder =
-    env.APPDATA !== undefined && env.APPDATA !== ''
-        ? `${env.APPDATA}/ASP.NET/https`
-        : `${env.HOME}/.aspnet/https`;
+/**
+ * Creates (if needed) and loads the ASP.NET Core dev certificate used by the Vite dev server.
+ *
+ * Only called when actually serving. It used to run at module scope, which meant every `vite build`
+ * — including in CI, where there is no dev certificate and no need for one — shelled out to
+ * `dotnet dev-certs`, making the production build depend on the .NET SDK being present and on
+ * certificate state that has nothing to do with the build output.
+ */
+function devServerHttps() {
+    const baseFolder =
+        env.APPDATA !== undefined && env.APPDATA !== ''
+            ? `${env.APPDATA}/ASP.NET/https`
+            : `${env.HOME}/.aspnet/https`;
 
-const certificateName = "web.client";
-const certFilePath = path.join(baseFolder, `${certificateName}.pem`);
-const keyFilePath = path.join(baseFolder, `${certificateName}.key`);
+    const certificateName = 'web.client';
+    const certFilePath = path.join(baseFolder, `${certificateName}.pem`);
+    const keyFilePath = path.join(baseFolder, `${certificateName}.key`);
 
-if (!fs.existsSync(baseFolder)) {
-    fs.mkdirSync(baseFolder, { recursive: true });
-}
-
-if (!fs.existsSync(certFilePath) || !fs.existsSync(keyFilePath)) {
-    if (0 !== child_process.spawnSync('dotnet', [
-        'dev-certs',
-        'https',
-        '--export-path',
-        certFilePath,
-        '--format',
-        'Pem',
-        '--no-password',
-    ], { stdio: 'inherit', }).status) {
-        throw new Error("Could not create certificate.");
+    if (!fs.existsSync(baseFolder)) {
+        fs.mkdirSync(baseFolder, { recursive: true });
     }
+
+    if (!fs.existsSync(certFilePath) || !fs.existsSync(keyFilePath)) {
+        if (0 !== child_process.spawnSync('dotnet', [
+            'dev-certs',
+            'https',
+            '--export-path',
+            certFilePath,
+            '--format',
+            'Pem',
+            '--no-password',
+        ], { stdio: 'inherit' }).status) {
+            throw new Error('Could not create certificate.');
+        }
+    }
+
+    return {
+        key: fs.readFileSync(keyFilePath),
+        cert: fs.readFileSync(certFilePath),
+    };
 }
 
 const target = env.ASPNETCORE_HTTPS_PORT ? `https://localhost:${env.ASPNETCORE_HTTPS_PORT}` :
     env.ASPNETCORE_URLS ? env.ASPNETCORE_URLS.split(';')[0] : 'https://localhost:7167';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
     plugins: [plugin()],
     resolve: {
         alias: {
@@ -53,9 +68,6 @@ export default defineConfig({
             }
         },
         port: parseInt(env.DEV_SERVER_PORT || '57674'),
-        https: {
-            key: fs.readFileSync(keyFilePath),
-            cert: fs.readFileSync(certFilePath),
-        }
+        https: command === 'serve' ? devServerHttps() : undefined,
     }
-})
+}));

--- a/src/TelemetryService/web.client/vitest.config.ts
+++ b/src/TelemetryService/web.client/vitest.config.ts
@@ -1,0 +1,28 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Test-only Vite config. Kept separate from vite.config.ts so the dev-server settings there
+// (HTTPS certs, SPA proxy) are not needed just to run unit tests in CI.
+export default defineConfig({
+    plugins: [react()],
+    test: {
+        environment: 'jsdom',
+        globals: true,
+        setupFiles: ['./src/test/setup.ts'],
+        include: ['src/**/*.{test,spec}.{ts,tsx}'],
+        server: {
+            deps: {
+                // @fluentui/react-icons ships extensionless ESM chunk imports that Vite's node
+                // resolver cannot follow, so it has to be transformed rather than externalised.
+                inline: [/@fluentui/],
+            },
+        },
+        coverage: {
+            provider: 'v8',
+            reporter: ['text-summary', 'cobertura'],
+            include: ['src/**/*.{ts,tsx}'],
+            exclude: ['src/**/*.{test,spec}.{ts,tsx}', 'src/test/**', 'src/main.tsx', 'src/vite-env.d.ts'],
+        },
+    },
+});


### PR DESCRIPTION
> **Stacked on #266.** This branches off `sambetts/telemetry-dashboard-ui`, because the tests cover the aggregation added there. GitHub will show #266's commits in this PR until that one merges — **please merge #266 first**.

## Why

The telemetry service had **no tests and no pipeline**. It was built and deployed by hand, and the dashboard aggregation — medians, settings parsing, freshness bucketing — was entirely unverified. As you said, the project is green, so this is the moment to fix that.

## Tests

| Suite | Framework | Count | Command |
| --- | --- | --- | --- |
| `Tests.Unit` | MSTest (net10.0) | **58** | `dotnet test src/TelemetryService/Tests.Unit/Tests.Unit.csproj` |
| `web.client` | Vitest + Testing Library | **22** | `npm test` |

Server-side coverage: dashboard aggregation (freshness bucketing, build/feature adoption, schema+table keying, medians, AI totals), the settings-string parser, the upload endpoint's signature checks, save-vs-merge behaviour, and configuration binding.

MSTest was chosen to match the repo's existing `Tests.UnitTests`, so contributors only have one testing idiom to learn — easy to swap for xUnit if you'd rather the new solution diverge.

## Two real defects the tests found

**1. `(unknown)` could present as the most common build.** On a tie, version adoption sorted `(unknown)` ahead of a real build label, so a bucket that isn't a version could top the list. Unknown is now deliberately ordered last. (The Adoption tab already compensated for this client-side; now the data is correct at source.)

**2. Unreachable defensive code.** `TelemetryController` guards against an empty `TelemetrySecret`, but that value is a *required* config binding — `WebAppConfig` already refuses to construct without it, so the guard can never fire through normal startup. The test now documents it honestly as defence-in-depth rather than pretending it's a live path.

## Refactoring

- **`Program.cs` is now just an entry point.** DI composition moved to `TelemetryServiceCollectionExtensions`, so tests build the *real* object graph rather than a duplicate of it. `Program` is `partial` so integration tests can host it with `WebApplicationFactory`.
- **Cosmos container creation moved off the startup path** into a hosted service. It previously ran *before the host was built*, so an unreachable or misconfigured Cosmos account stopped the site starting at all — including the anonymous `/health` endpoint. That turns a dependency outage into something that looks like a failed deployment.
- **`vite.config.ts` generated ASP.NET dev certificates at module scope**, so every production build — including CI, where there is no dev certificate and no need for one — shelled out to `dotnet dev-certs`. Certificate handling now only happens when actually serving. Without this the pipeline would have been coupled to local certificate state.

## CI/CD

New [`telemetry-service.yml`](.github/workflows/telemetry-service.yml), kept separate from `ci.yml` / `pr.yml` / `tests.yml` because those build the .NET Framework solution on Windows and publish GitHub releases, whereas this is a .NET 10 **Linux** web app deployed straight to App Service.

- Lints and tests **both halves** on every PR touching `src/TelemetryService/**` (or the shared `UsageReporting` project).
- Deploys on pushes to `main` and `dev`.
- `dotnet publish` also builds the Vite client into `wwwroot` (verified: 51 files including precompressed assets), so **one artifact is the whole site**.
- After deploying it **polls `/health`**, so a build that deploys but fails to start is reported as a failed deployment rather than a success.
- Test results are uploaded even on failure, which is exactly when they matter.

### Security posture

- **OIDC federated credentials** — no client secret is stored anywhere.
- **No environment identifiers are committed.** App name, resource group, tenant and subscription all come from repository secrets/variables, which matters because this repository is public and part of a fork network.
- The deploy job **cannot run from a pull request or from a fork** (`github.repository` guard plus an event guard), so an untrusted fork can never reach the App Service.

### Setup required before the deploy job can run

| Kind | Name |
| --- | --- |
| Secret | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` |
| Variable | `TELEMETRY_APP_NAME`, `TELEMETRY_RESOURCE_GROUP` |

Plus a federated credential on the app registration for this repo + the `telemetry-service` environment, and Website Contributor on the App Service. Documented in `src/TelemetryService/README.md`.

## Verification

`dotnet test` 58/58, `npm test` 22/22, `npm run lint` clean, `npm run build` clean, `dotnet publish` produces a complete site, and the workflow YAML parses.

## Worth a decision

`ci.yml` / `pr.yml` / `tests.yml` filter on `src/**`, so they still trigger on TelemetryService-only changes and pointlessly build the AnalyticsEngine solution. Narrowing those to `src/AnalyticsEngine/**` would save a lot of CI time, but it touches your release path so I've left it alone — happy to do it separately if you want.
