### PR TITLE
Move azure/login off deprecated Node 20

### DIFF
--- a/.github/workflows/telemetry-service.yml
+++ b/.github/workflows/telemetry-service.yml
@@ -137,7 +137,7 @@ jobs:
       # here needs a federated credential for this repository and environment, plus Contributor
       # (or Website Contributor) on the target App Service.
       - name: Azure login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
The previous pipeline run annotated:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `azure/login@v2`

Azure publishes **v3** specifically for Node 24 support, with the same inputs (`client-id` / `tenant-id` / `subscription-id`), so this is a straight major bump.

`azure/webapps-deploy@v3` was **not** flagged and is already current, so it is left alone.

This is the last of the Node 20 warnings — #268 already moved `checkout`, `setup-dotnet`, `setup-node`, `upload-artifact` and `download-artifact` to their current majors.
