### PR TITLE
Run required PR checks on every non-draft pull request

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,10 +2,19 @@ name: PR build
 
 on:
   pull_request:
+    # See issue #270: `ready_for_review` on its own never fires for a PR opened directly as
+    # non-draft (that emits `opened`), so this build simply never ran for most pull requests.
+    # `synchronize` also gets the artifacts rebuilt when new commits are pushed.
     types:
+      - opened
+      - synchronize
+      - reopened
       - ready_for_review
+    # Unlike tests.yml this workflow is NOT a required status check, so keeping the path filter
+    # is safe - a PR that never triggers it is not blocked by its absence.
     paths:
       - src/AnalyticsEngine/**
+      - src/SPO/AITracker/**
       - reports/**
       - .github/workflows/pr.yml
   workflow_dispatch:
@@ -44,6 +53,8 @@ jobs:
     #   - Zip files
     #   - Publish artifacts
     runs-on: windows-latest
+    # Drafts are still work in progress - do not spend four Windows runners on them.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
         configuration: [Release] # [Debug, Release]
@@ -143,6 +154,7 @@ jobs:
     #   - Zip files
     #   - Publish artifacts
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout source
         uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,9 @@ on:
     # `test_dotnet (Release)` and `test_aitracker` are REQUIRED status checks on dev and main. A
     # workflow that never starts reports nothing at all, so a PR touching only (say)
     # src/TelemetryService/** would sit at BLOCKED for ever with zero statuses and again need an
-    # admin bypass. Every PR must therefore start this workflow; the actual per-path gating lives
-    # in `setup_tests` below, and a job skipped by its `if:` still reports - as a success - so the
-    # required checks are satisfied without burning a Windows runner on an unrelated change.
+    # admin bypass. Every PR must therefore start this workflow; the actual per-path gating is
+    # applied per step inside the jobs below, so both required checks always report a real
+    # success without running a build for an unrelated change.
   workflow_dispatch:
     inputs:
       force_run:
@@ -61,11 +61,12 @@ jobs:
     #
     # Also the single place the draft-PR guard lives: `test_aitracker` and `test_dotnet` both
     # `needs:` this job, so skipping it here skips them too and a draft PR costs no CI minutes.
+    # A draft cannot be merged, so it does not matter that its required checks go unreported.
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     outputs:
-      code_changed: ${{ steps.changes.outputs.code == 'true' }}
-      aitracker_changed: ${{ steps.changes.outputs.aitracker == 'true' }}
+      run_dotnet: ${{ inputs.force_run || steps.changes.outputs.code == 'true' }}
+      run_aitracker: ${{ inputs.force_run || steps.changes.outputs.aitracker == 'true' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -82,14 +83,16 @@ jobs:
   test_aitracker:
     runs-on: ubuntu-latest
     needs: setup_tests
-    # Gated on the AI tracker's own sources. It used to be gated on src/AnalyticsEngine/**, which
-    # is the wrong tree entirely: the tracker's tests never ran when the tracker changed, and always
-    # ran when it had not. See issue #270.
-    if: inputs.force_run || needs.setup_tests.outputs.aitracker_changed == 'true'
+    # Gated per step rather than with a job-level `if:` - see the note on test_dotnet below.
+    # The gate is the AI tracker's own sources: this used to key off src/AnalyticsEngine/**,
+    # the wrong tree entirely, so the tracker's tests never ran when the tracker changed and
+    # always ran when it had not. See issue #270.
     steps:
       - name: Checkout source
+        if: needs.setup_tests.outputs.run_aitracker == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - name: Run AI Tracker tests
+        if: needs.setup_tests.outputs.run_aitracker == 'true'
         run: |
           cd src/SPO/AITracker/TypeScript
           npm ci
@@ -110,14 +113,24 @@ jobs:
     # runs. windows-2022 ships VS2022 Enterprise at that exact path. See PR #123 / issue #122.
     runs-on: windows-2022
     needs: setup_tests
-    if: inputs.force_run || needs.setup_tests.outputs.code_changed == 'true'
+    # NOTE: the per-path gate is applied to every step below rather than as a job-level `if:`,
+    # and that is deliberate. `test_dotnet (Release)` is a REQUIRED status check, and the
+    # "(Release)" suffix comes from the matrix. GitHub evaluates a job-level `if:` BEFORE it
+    # expands the matrix, so a job skipped that way reports a single check named plain
+    # "test_dotnet" - the required "test_dotnet (Release)" context never appears at all and the
+    # PR stays BLOCKED exactly as it did before. Measured on PR #280: with a job-level `if:` the
+    # check runs were `test_dotnet => completed/skipped`, with no `(Release)` variant.
+    # Gating each step instead keeps the matrix, so the correctly-named check always reports and
+    # simply does no work when nothing under src/AnalyticsEngine/** changed.
     strategy:
       matrix:
         configuration: [Release] # [Debug, Release]
     steps:
       - name: Checkout source
+        if: needs.setup_tests.outputs.run_dotnet == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - name: Setup MSBuild
+        if: needs.setup_tests.outputs.run_dotnet == 'true'
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
       - name: Cache NuGet Packages
         id: nuget-packages
@@ -129,10 +142,12 @@ jobs:
           path: ~\.nuget\packages
           key: ${{ runner.os }}-${{ env.cache-name }}
       - name: Config substitution - Unit tests
+        if: needs.setup_tests.outputs.run_dotnet == 'true'
         uses: devops-actions/variable-substitution@452ffbbfb1c26fd5d9aaf24faffb59c5084257e9 # v2.0.0
         with:
           files: '${{ env.Solution_Directory }}\App.Release.config'
       - name: Start Redis
+        if: needs.setup_tests.outputs.run_dotnet == 'true'
         shell: pwsh
         run: |
           $ProgressPreference = 'SilentlyContinue'
@@ -142,6 +157,7 @@ jobs:
           Start-Sleep -Seconds 3
           & "$env:RUNNER_TEMP\redis\redis-cli.exe" ping
       - name: Restore the application
+        if: needs.setup_tests.outputs.run_dotnet == 'true'
         run: msbuild ${{ env.Solution_Directory }} -t:Restore `
           -p:Configuration=${{ env.Configuration }} `
           -p:Platform=${{ env.Build_Platform }} `
@@ -149,6 +165,7 @@ jobs:
         env:
           Configuration: ${{ matrix.configuration }}
       - name: Build solution
+        if: needs.setup_tests.outputs.run_dotnet == 'true'
         run: msbuild ${{ env.Solution_Directory }} `
           -p:Configuration=${{ env.Configuration }} `
           -p:Platform=${{ env.Build_Platform }} `
@@ -156,6 +173,7 @@ jobs:
         env:
           Configuration: ${{ matrix.configuration }}
       - name: Execute unit tests
+        if: needs.setup_tests.outputs.run_dotnet == 'true'
         uses: jesusfer/vstest-action@f5ec12ddb71f6e151b738fa4740f8fea61e9214b
         with:
           testAssembly: Tests.UnitTests.dll

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,15 +7,28 @@ on:
       - dev
     paths:
       - src/AnalyticsEngine/**
+      - src/SPO/AITracker/**
       - reports/**
       - .github/workflows/tests.yml
   pull_request:
+    # `ready_for_review` alone is NOT enough. A pull request opened directly as non-draft emits
+    # `opened`, never `ready_for_review`, so this workflow never started and the required checks
+    # were never reported - leaving the PR permanently at mergeStateStatus BLOCKED and mergeable
+    # only by an admin bypass, which skips the test suite outright. `synchronize` additionally
+    # means pushing new commits to an open PR re-runs the tests. See issue #270.
     types:
+      - opened
+      - synchronize
+      - reopened
       - ready_for_review
-    paths:
-      - src/AnalyticsEngine/**
-      - reports/**
-      - .github/workflows/tests.yml
+    # Deliberately NO `paths:` filter here, unlike the `push` trigger above.
+    #
+    # `test_dotnet (Release)` and `test_aitracker` are REQUIRED status checks on dev and main. A
+    # workflow that never starts reports nothing at all, so a PR touching only (say)
+    # src/TelemetryService/** would sit at BLOCKED for ever with zero statuses and again need an
+    # admin bypass. Every PR must therefore start this workflow; the actual per-path gating lives
+    # in `setup_tests` below, and a job skipped by its `if:` still reports - as a success - so the
+    # required checks are satisfied without burning a Windows runner on an unrelated change.
   workflow_dispatch:
     inputs:
       force_run:
@@ -45,9 +58,14 @@ env:
 jobs:
   setup_tests:
     # Will check that the interesting folders have been updated.
+    #
+    # Also the single place the draft-PR guard lives: `test_aitracker` and `test_dotnet` both
+    # `needs:` this job, so skipping it here skips them too and a draft PR costs no CI minutes.
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     outputs:
       code_changed: ${{ steps.changes.outputs.code == 'true' }}
+      aitracker_changed: ${{ steps.changes.outputs.aitracker == 'true' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -58,11 +76,16 @@ jobs:
           filters: |
             code:
               - 'src/AnalyticsEngine/**'
+            aitracker:
+              - 'src/SPO/AITracker/**'
 
   test_aitracker:
     runs-on: ubuntu-latest
     needs: setup_tests
-    if: inputs.force_run || needs.setup_tests.outputs.code_changed == 'true'
+    # Gated on the AI tracker's own sources. It used to be gated on src/AnalyticsEngine/**, which
+    # is the wrong tree entirely: the tracker's tests never ran when the tracker changed, and always
+    # ran when it had not. See issue #270.
+    if: inputs.force_run || needs.setup_tests.outputs.aitracker_changed == 'true'
     steps:
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2


### PR DESCRIPTION
Addresses #270.

## Problem

Two independent defects in `tests.yml` meant the required status checks on `dev` and `main` (`test_dotnet (Release)`, `test_aitracker`) were frequently never reported at all, leaving PRs at `mergeStateStatus: BLOCKED` with zero statuses and mergeable only by an admin bypass — which skips the test suite entirely.

### 1. Wrong `pull_request` event types

```yaml
pull_request:
  types:
    - ready_for_review
```

A PR opened directly as non-draft emits `opened`, not `ready_for_review`, so the workflow never started. Pushing further commits to an open PR emits `synchronize`, which was also not listened for, so the checks never re-ran either.

### 2. Workflow-level `paths:` filter on the `pull_request` trigger

This is the half not covered by the issue text, and on its own it keeps the bug alive. The `pull_request` trigger was filtered to `src/AnalyticsEngine/**`, `reports/**` and `.github/workflows/tests.yml`. A PR touching only `src/TelemetryService/**` or `infra/**` therefore never starts the workflow, and **a workflow that never starts reports nothing** — so those PRs sit at `BLOCKED` for ever regardless of the event-type fix. This is not hypothetical: it blocks the telemetry-service work in #272 and #276.

## Changes

### `.github/workflows/tests.yml`

- `pull_request` types are now `opened`, `synchronize`, `reopened`, `ready_for_review`.
- The `pull_request` `paths:` filter is removed, so every PR starts the workflow and the required checks always report. Per-path gating moves to a step-level `if:` inside `test_dotnet` and `test_aitracker`, driven by the pre-existing `setup_tests` / `dorny/paths-filter` job. The `push` trigger keeps its `paths:` filter, where the same reasoning does not apply.
- **The gate is per step, not a job-level `if:`, and that distinction is load-bearing** — see Verification 3 below.
- Draft PRs are guarded by a single `if:` on `setup_tests`. Both test jobs `needs:` it, so skipping it skips them, and drafts cost no CI minutes. A draft cannot be merged, so unreported required checks do not matter there.
- `test_aitracker` was gated on a filter derived from `src/AnalyticsEngine/**` — the wrong tree. The AI tracker lives in `src/SPO/AITracker/**`, so its tests never ran when it changed and always ran when it had not. A second `aitracker` paths-filter output now gates it, and `src/SPO/AITracker/**` is added to the `push` paths so tracker changes on `dev`/`main` are tested too.

### `.github/workflows/pr.yml`

Same event-type fix and draft guard. This workflow is **not** a required check, so its `paths:` filter is deliberately retained — a PR that never triggers it is not blocked by its absence. `src/SPO/AITracker/**` added there too, since `build_aitracker` produces `AITrackerInstaller.zip`.

## Verification

`pull_request` workflows are read from the merge ref, so this PR exercises its own fix.

### 1. A PR opened directly as non-draft reports both required checks

This PR was opened non-draft and the `Tests` workflow started on the `opened` event, which never happened before.

### 2. Pushing a commit re-runs them

The second commit produced a second `Tests | pull_request` run; both are `completed/success`.

### 3. The first attempt failed, and that failure is why there is a second commit

The initial version used a job-level `if:` on `test_dotnet`. Check runs on the first commit were:

```
test_aitracker => completed/skipped
test_dotnet    => completed/skipped      <-- note: no "(Release)"
gitleaks       => completed/success
setup_tests    => completed/success
```

GitHub evaluates a job-level `if:` **before** expanding the matrix, so a job skipped that way reports a single check named plain `test_dotnet`. The required context is `test_dotnet (Release)`, which was therefore still absent and the PR still `BLOCKED` — the original bug, in a new disguise. Moving the gate to each step preserves matrix expansion, and the second commit produced:

```
test_dotnet (Release) => completed/success
test_aitracker        => completed/success
```

### 4. Drafts still do not burn CI minutes, and non-AnalyticsEngine PRs are unblocked

Throwaway PR #281 was branched off this one, changed only a file under `src/TelemetryService/**`, and was opened as a draft. While a draft:

```
setup_tests    => completed/skipped
test_dotnet    => completed/skipped
test_aitracker => completed/skipped
```

No Windows runner was used. Marked ready for review, the same PR reported:

```
test_dotnet (Release) => pass (10s)
test_aitracker        => pass (4s)
gitleaks              => pass
```

10s and 4s because the gated steps correctly did no work. **This is the case that was impossible before**: under the old `paths:` filter a telemetry-service-only PR never started the workflow, so those two contexts never appeared and the PR could only be merged by an admin bypass. #281 has since been closed and its branch deleted.

### 5. No admin bypass needed

With all three required contexts green, the only outstanding item is `required_approving_review_count: 1` with `require_code_owner_reviews: true` — an ordinary human review, which is the intended gate.

## Reviewer notes

- No branch-protection change is required: the contexts `test_dotnet (Release)` and `test_aitracker` are unchanged.
- Cost of the new always-run behaviour is one Windows runner per PR doing nothing for ~10s when `src/AnalyticsEngine/**` is untouched. Actions minutes are free on public repositories, and the alternative is the status quo of unenforceable required checks.
- `ci.yml` (the release build, `push` only) still omits `src/SPO/AITracker/**` from its `paths:`, so a tracker-only change merged to `main` produces no release build. Left out to keep this PR to PR-triggered CI; worth a follow-up issue.
