### PR TITLE
Fail the build when a migration snapshot predates the target branch

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/MigrationSnapshotTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/MigrationSnapshotTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Entity.Migrations.Design;
+using System.IO;
+using System.Linq;
+using Common.Entities.Migrations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Guards against the class of breakage described in issue #271: two pull requests each add an EF6
+    /// migration that is valid in isolation, and merging both silently breaks the target branch.
+    ///
+    /// Every migration's <c>.resx</c> carries a gzipped EDMX snapshot of the entity model as it stood
+    /// when the migration was scaffolded. If PR B is scaffolded before PR A merges, and B's migration id
+    /// sorts AFTER A's, then once both land the newest snapshot in the chain knows nothing about A's
+    /// entities. <c>Migrations/Configuration.cs</c> sets <c>AutomaticMigrationsEnabled = true</c>, so EF
+    /// reconciles the difference with an on-the-fly automatic migration - which re-creates A's objects
+    /// ("There is already an object named 'x' in the database") or, for removals, throws
+    /// <see cref="System.Data.Entity.Migrations.Infrastructure.AutomaticDataLossException"/>.
+    ///
+    /// Neither branch fails on its own, so nothing catches it until the merge reaches the target branch.
+    ///
+    /// This test asks EF the question directly: scaffold against the current entity model and assert
+    /// that nothing is pending. That is exactly the condition that triggers the automatic migration, so
+    /// it needs no heuristics about snapshot sizes or table names, and it fails on the PULL REQUEST
+    /// because CI builds the merge of the PR into its target branch.
+    ///
+    /// REPAIRING A STALE SNAPSHOT
+    /// The canonical fix is <c>Add-Migration -Force &lt;Name&gt;</c> in the Visual Studio Package Manager
+    /// Console. When that is not available, set the environment variable
+    /// <c>MIGRATION_SNAPSHOT_DUMP_PATH</c> to a file path and run this test: it writes the correct
+    /// base64 <c>Target</c> for the current model to that file, which can be pasted over the
+    /// <c>&lt;data name="Target"&gt;</c> value in the newest migration's <c>.resx</c>.
+    /// </summary>
+    [TestClass]
+    public class MigrationSnapshotTests
+    {
+        /// <summary>
+        /// Calls EF generates into a migration's Up() when it has real work to do. If the model and the
+        /// newest snapshot agree, Scaffold() produces an empty Up() and none of these appear.
+        /// </summary>
+        private static readonly string[] MigrationOperations =
+        {
+            "CreateTable(", "DropTable(", "AddColumn(", "DropColumn(", "AlterColumn(",
+            "CreateIndex(", "DropIndex(", "AddForeignKey(", "DropForeignKey(",
+            "AddPrimaryKey(", "DropPrimaryKey(", "RenameTable(", "RenameColumn(",
+            "RenameIndex(", "MoveTable(", "CreateStoredProcedure(", "AlterStoredProcedure(",
+            "DropStoredProcedure("
+        };
+
+        [TestMethod]
+        public void LatestMigrationSnapshot_IsUpToDateWithTheEntityModel()
+        {
+            var scaffolded = new MigrationScaffolder(new Configuration()).Scaffold("PendingModelChangeProbe");
+
+            DumpTargetSnapshotIfRequested(scaffolded);
+
+            var userCode = scaffolded.UserCode ?? string.Empty;
+            var pending = FindPendingOperations(userCode);
+            if (pending.Count == 0)
+            {
+                return;
+            }
+
+            Assert.Fail(
+                "The newest EF migration's model snapshot does not match the current entity model, so EF " +
+                "would generate an automatic migration at runtime (see issue #271).\r\n\r\n" +
+                "This normally means a migration was scaffolded before another migration - one that sorts " +
+                "EARLIER but was merged LATER - reached this branch. The snapshot in the newest .resx " +
+                "therefore predates it.\r\n\r\n" +
+                "Pending operations EF wants to apply:\r\n" +
+                string.Join("\r\n", pending.Select(p => "    " + p)) +
+                "\r\n\r\nFix: re-scaffold the newest migration's snapshot with `Add-Migration -Force " +
+                "<Name>` (Package Manager Console, project Entities, startup project " +
+                "WebJob.Office365ActivityImporter), keeping its existing Up()/Down() DDL. Headless " +
+                "alternative: set MIGRATION_SNAPSHOT_DUMP_PATH and re-run this test to emit the correct " +
+                "Target value.");
+        }
+
+        /// <summary>
+        /// Returns the trimmed source lines of the scaffolded Up() that represent real schema operations.
+        ///
+        /// Only Up() is considered. Down() is the inverse of Up(), so a scaffolded CreateTable in Up()
+        /// always has a matching DropTable in Down() - scanning the whole file would report every change
+        /// twice and in both directions, which reads as though the model wanted to drop the very tables
+        /// it is actually missing.
+        ///
+        /// Deliberately line-based rather than a full parse: the point is a readable diagnostic, and any
+        /// operation at all is a failure regardless of its arguments.
+        /// </summary>
+        private static List<string> FindPendingOperations(string userCode)
+        {
+            var found = new List<string>();
+
+            foreach (var rawLine in ExtractUpBody(userCode).Split(new[] { "\r\n", "\n" }, StringSplitOptions.None))
+            {
+                var line = rawLine.Trim();
+                if (line.Length == 0 || line.StartsWith("//"))
+                {
+                    continue;
+                }
+
+                if (MigrationOperations.Any(op => line.IndexOf(op, StringComparison.Ordinal) >= 0))
+                {
+                    // Long CreateTable() calls span many lines; the first is enough to identify it.
+                    found.Add(line.Length > 200 ? line.Substring(0, 200) + " ..." : line);
+                }
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        /// Text between the scaffolded Up() and Down() methods. EF always emits Up() first, so this is a
+        /// stable split without needing to brace-match.
+        /// </summary>
+        private static string ExtractUpBody(string userCode)
+        {
+            const string upMarker = "public override void Up()";
+            const string downMarker = "public override void Down()";
+
+            var start = userCode.IndexOf(upMarker, StringComparison.Ordinal);
+            if (start < 0)
+            {
+                return userCode;
+            }
+
+            start += upMarker.Length;
+
+            var end = userCode.IndexOf(downMarker, start, StringComparison.Ordinal);
+            return end < 0 ? userCode.Substring(start) : userCode.Substring(start, end - start);
+        }
+
+        private static void DumpTargetSnapshotIfRequested(ScaffoldedMigration scaffolded)
+        {
+            var path = Environment.GetEnvironmentVariable("MIGRATION_SNAPSHOT_DUMP_PATH");
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            object target;
+            if (scaffolded.Resources.TryGetValue("Target", out target) && target is string)
+            {
+                File.WriteAllText(path, (string)target);
+                Console.WriteLine("Wrote current-model Target snapshot to " + path);
+            }
+
+            File.WriteAllText(path + ".usercode.txt", scaffolded.UserCode ?? string.Empty);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -165,6 +165,7 @@
     <Compile Include="UrlFullUrlMigrationPipelineTests.cs" />
     <Compile Include="IndexUsageReportSnapshotsMigrationTests.cs" />
     <Compile Include="IndexReportDateQueriesMigrationTests.cs" />
+    <Compile Include="MigrationSnapshotTests.cs" />
     <Compile Include="ScratchDatabase.cs" />
     <Compile Include="StressHarness\ActivityApiDbStressRunner.cs" />
     <Compile Include="StressHarness\ActivityApiDbStressTests.cs" />


### PR DESCRIPTION
Addresses #271.

## Problem

Two pull requests can each add an EF6 migration that is valid **in isolation** and still break `dev` the moment both are merged, with nothing in CI to catch it.

Every migration's `.resx` carries a gzipped EDMX snapshot of the entity model as it stood when the migration was scaffolded. If PR B is scaffolded before PR A merges, and B's migration id sorts **after** A's, then once both land the newest snapshot in the chain knows nothing about A's entities. `Migrations/Configuration.cs` sets `AutomaticMigrationsEnabled = true`, so EF reconciles the difference with an on-the-fly automatic migration — which re-creates A's objects, or for removals throws `AutomaticDataLossException`.

Neither branch fails on its own, so nothing catches it until it is already on the target branch.

## Change

One test: `Tests.UnitTests/MigrationSnapshotTests.cs`.

It asks EF the question directly — scaffold against the current entity model with `MigrationScaffolder` and assert nothing is pending:

```csharp
var scaffolded = new MigrationScaffolder(new Configuration()).Scaffold("PendingModelChangeProbe");
var pending = FindPendingOperations(scaffolded.UserCode);   // Up() only
```

A non-empty `Up()` **is** the condition that makes EF generate the automatic migration at runtime, so this needs no heuristics about snapshot sizes or table names, and it fails on the **pull request** because CI builds the merge of the PR into its target branch.

The failure message lists the operations EF wants to apply and explains the fix, rather than surfacing a bare SQL error.

### Deviation from the acceptance criteria

The issue asks for a job gated on `Migrations/` being touched, and suggests a cheap "newest snapshot is not smaller than its predecessor" pre-check. This implements a unit test in the existing suite instead:

- It runs in **~9 seconds** inside the existing `test_dotnet` job, so it needs no new job, no new runner and no path gate — a migrations change is by definition a `src/AnalyticsEngine/**` change, which already gates that job.
- It is **exact rather than heuristic**. The snapshot-size check is a proxy; this is the actual condition.
- The size heuristic would have produced a **false positive on #279**, which legitimately shrinks the model by deprecating the Teams add-on tables. My first design — "allow a removal if the migration's `Up()` calls `DropTable`" — would *also* have failed on #279, because it drops its tables in raw SQL inside `Up_Sql` rather than via the `DropTable` API. Asking EF removes that whole class of false positive.

### Repairing a stale snapshot without Visual Studio

The canonical fix is `Add-Migration -Force <Name>` in the Package Manager Console. That needs the VS host, which CI and headless environments do not have. Setting `MIGRATION_SNAPSHOT_DUMP_PATH` and running this test writes the correct base64 `Target` for the current model to that path, ready to paste over the `<data name="Target">` value in the newest migration's `.resx`. This is how #260's snapshot was repaired.

## Verification

Measured on a real reproduction: a scratch merge of `dev` and #260, each run after dropping the LocalDB test database and rebuilding.

| Tree | Migration tests |
| --- | --- |
| `dev` alone | **27 passed**, 0 failed |
| `dev` + #260 (as it stands on the PR) | **18 failed**, 8 passed, 26 total |
| `dev` + #260 with the snapshot repaired | **27 passed**, 0 failed |

The 18/8/26 line reproduces issue #271's reported numbers exactly, with the same error:

```
CREATE TABLE [dbo].[copilot_event_accessed_resource_actions] ...
-- Failed in 1 ms with error: There is already an object named
   'copilot_event_accessed_resource_actions' in the database.
```

On the failing tree the new test reports, before any SQL runs:

```
The newest EF migration's model snapshot does not match the current entity model, so EF
would generate an automatic migration at runtime (see issue #271).
...
Pending operations EF wants to apply:
    CreateTable(
    CreateTable(
    ...
```

Snapshot sizes across the chain, for the record:

| Migration | Branch | `Target` bytes | Entity sets |
| --- | --- | --- | --- |
| `202608190622001_CopilotDroppedAuditFields` | dev (#262) | 53,852 | 130 |
| `202608190725064_AddCopilotUsageReports` | #260, before | 53,548 | 128 |
| `202608190725064_AddCopilotUsageReports` | #260, repaired | 55,764 | 133 |

Later migration, smaller snapshot, five missing entity sets — including `copilot_event_accessed_resource_actions`, the exact table in the runtime error.

## Reviewer notes

- The test costs ~9s and makes no schema changes; it only scaffolds in memory.
- `Up()` only is scanned. `Down()` is the inverse, so scanning the whole generated file reports every change twice and in the wrong direction — it reads as though the model wants to drop the very tables it is missing. That mistake is called out in a comment so it is not reintroduced.
- This does not replace review of the migration itself, only the snapshot chain.
