### PR TITLE
Release review fixes: manual-script prerequisite and O(N^2) row filter

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608190725064_AddCopilotUsageReports.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608190725064_AddCopilotUsageReports.manual.sql
@@ -22,14 +22,14 @@
 --   table is rewritten; the only lock taken on existing data is a brief schema lock on dbo.users to
 --   create the foreign key. The script is fully guarded and idempotent - re-running it is a no-op.
 --
--- Prerequisite: migration 202608131055001_IndexReportDateQueries must already be applied.
+-- Prerequisite: migration 202608190622001_CopilotDroppedAuditFields must already be applied.
 -- =====================================================================================================
 
 SET NOCOUNT ON;
 SET XACT_ABORT ON;
 
 DECLARE @migration nvarchar(100) = N'202608190725064_AddCopilotUsageReports';
-DECLARE @predecessor nvarchar(100) = N'202608131055001_IndexReportDateQueries';
+DECLARE @predecessor nvarchar(100) = N'202608190622001_CopilotDroppedAuditFields';
 DECLARE @msg nvarchar(2000);
 
 IF OBJECT_ID(N'dbo.__MigrationHistory', N'U') IS NULL

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageUserDetailLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageUserDetailLoader.cs
@@ -220,17 +220,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             // A row that states no period and a request that can't supply one (ALL) has no key, so it is
             // dropped rather than stored under the meaningless period 0. Filtered in place: at ~200k licensed
             // users a second full-size list is a pointless copy of the whole report.
+            //
+            // RemoveAll rather than a reverse loop calling RemoveAt: each RemoveAt shifts every surviving
+            // element after it, so dropping a scattered subset of a 200k-row report costs O(N^2) element
+            // moves (~5 billion when half the rows are unkeyable). RemoveAll is a single O(N) compaction.
             var requestedPeriodDays = request.PeriodDays;
-            var unkeyable = 0;
-            for (var i = rows.Count - 1; i >= 0; i--)
+            var unkeyable = rows.RemoveAll(row =>
             {
-                rows[i].ReportPeriodDays = rows[i].ReportPeriodDays ?? requestedPeriodDays;
-                if (!rows[i].ReportPeriodDays.HasValue)
-                {
-                    rows.RemoveAt(i);
-                    unkeyable++;
-                }
-            }
+                row.ReportPeriodDays = row.ReportPeriodDays ?? requestedPeriodDays;
+                return !row.ReportPeriodDays.HasValue;
+            });
 
             if (unkeyable > 0)
             {


### PR DESCRIPTION
Two findings from a multi-model rubber-duck review of the `dev` -> `main` release diff (#283). Both are small; neither changes behaviour on the installer path.

## 1. `AddCopilotUsageReports.manual.sql` gated on the wrong predecessor

It required `202608131055001_IndexReportDateQueries` instead of its immediate predecessor `202608190622001_CopilotDroppedAuditFields`.

The manual scripts exist for DBAs who upgrade by hand. A DBA could apply `IndexReportDateQueries` then `AddCopilotUsageReports`, **skip** `CopilotDroppedAuditFields`, and still pass the prerequisite check - leaving `copilot_chats.thread_id` / `client_region` / `copilot_log_version` and the new Copilot audit tables absent. The failure would surface later and somewhere else, as `Invalid column name 'thread_id'` on the next Copilot audit merge.

The installer / EF path applies migrations in id order and was never affected. The other two scripts already named their immediate predecessor correctly.

The `ContextKey` / `ProductVersion` copy is unaffected by this change - both are invariant across `__MigrationHistory` rows.

## 2. `CopilotUsageUserDetailLoader` dropped rows with an O(N^2) filter

Unkeyable rows were removed with a reverse loop calling `List<T>.RemoveAt`. Each `RemoveAt` shifts every surviving element after it, so removing a scattered subset of a 200,000-row report costs O(N^2) element moves - roughly 5 billion when half the rows are unkeyable.

`RemoveAll` does the same job as a single O(N) compaction, with identical semantics: the predicate still applies the `?? requestedPeriodDays` fallback to every row before deciding, and still returns the number dropped.

Worth being precise about severity: the pathological case needs `request.PeriodDays` to be null (period `ALL`) **and** a mix of keyable and unkeyable rows. When a period is requested, nothing is removed and the old loop was O(N). So this is a latent edge case, not a live incident - but the fix is free.

## Testing

Built and ran the migration, Copilot and upgrade suites locally: **186 passed**. The single failure is `SolutionInstallConfig_VNetEnabled_SkuUpgradeValidation`, which needs a local-only `InstallerTestConfig.json` that is not in the repo, and is unrelated to these changes.

## Not changed, and why

The same review flagged `.ToLowerInvariant()` calls in `SentEmailImporter` as redundant allocations against `OrdinalIgnoreCase` collections. That one is **wrong**: those values are assigned back and persisted (`FromAddress`, `recipientAddresses`), so they normalise stored email addresses rather than merely keying a set. Removing them would change what is written to the database.