### PR TITLE
Telemetry service: WebApplicationFactory integration tests, and fix the unenforced dashboard scope

### DIFF
--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -47,6 +47,15 @@ installations (the AnalyticsEngine importer in
   both the `Telemetry.Read` scope and the `Telemetry.Dashboard.Read` app role,
   so only explicitly assigned users or groups can view the reports. The SPA
   uses MSAL and stores tokens in session storage.
+
+  Both checks live in a **single authorization policy**
+  (`DashboardAuthorization.PolicyName`), not in separate `[Authorize(Roles = …)]`
+  and `[RequiredScope(…)]` attributes. That attribute pair reads as if it
+  enforces both, but only the role is applied: `RequiredScopeAttribute` is
+  endpoint *metadata*, and the handler that evaluates it is reached only through
+  the default authorization policy — which `[Authorize(Roles = …)]` replaces
+  rather than extends. The integration tests assert the scope is genuinely
+  enforced.
 - **App Service Authentication** runs in allow-anonymous mode so it validates
   bearer tokens and emits MISE key-discovery telemetry without becoming the
   authorization boundary. The ASP.NET Core API still performs the scope and
@@ -128,6 +137,24 @@ the suite runs, and the internal helpers are exposed to the test project via `In
 The client tests cover the formatting helpers and the sortable table component. Fluent UI is
 inlined in `vitest.config.ts` (`server.deps.inline`) because `@fluentui/react-icons` ships
 extensionless ESM chunk imports that Vite's node resolver cannot follow.
+
+### Integration tests
+
+`IntegrationTests.cs` hosts the real application with `WebApplicationFactory` (see
+`TelemetryWebAppFactory.cs`), so routing, the authorisation pipeline, model binding and the DI
+graph are exercised as they run in Azure. The Cosmos adaptors are replaced with the in-memory
+`FakeTelemetryStore` and JWT bearer validation with a header-driven test scheme, so the tests need
+no Azure resources and no real tokens; they run in the ordinary `dotnet test` pass.
+
+They assert that `/health` and `/api/auth/config` stay anonymous, that the dashboard endpoints
+return `401` unauthenticated and `403` for a token missing either the role or the scope, and that
+the signed upload endpoint accepts a correct signature and rejects a wrong one.
+
+Configuration is supplied through **environment variables** rather than
+`ConfigureAppConfiguration`. `Program.cs` reads `builder.Configuration` while registering services,
+which happens inside `Main` — before `WebApplicationFactory` applies its configuration callbacks at
+`Build()`. Environment variables are read by `WebApplication.CreateBuilder` itself, so they are the
+only injection point early enough.
 
 ## Continuous delivery
 

--- a/src/TelemetryService/Tests.Unit/IntegrationTests.cs
+++ b/src/TelemetryService/Tests.Unit/IntegrationTests.cs
@@ -1,0 +1,310 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using UsageReporting;
+using Web.Auth;
+using Web.Config;
+using Web.Controllers;
+using Web.Dashboard;
+using Web.Startup;
+
+namespace Tests.Unit;
+
+/// <summary>
+/// End-to-end tests over the real HTTP pipeline (see <see cref="TelemetryWebAppFactory"/>).
+///
+/// These cover what the unit tests structurally cannot: that the endpoints are actually reachable at
+/// the routes the client calls, and that the authorisation attributes are wired to a pipeline that
+/// enforces them. #264 was an auth failure that every unit test passed straight through.
+///
+/// Each test builds its own host because the assembly parallelises at method level and the fake
+/// store is shared mutable state.
+/// </summary>
+[TestClass]
+public class AnonymousEndpointTests
+{
+    [TestMethod]
+    public async Task Health_RequiresNoToken()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var response = await client.GetAsync("/health");
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+            "/health is what the deployment workflow polls to decide a release is good. If it ever " +
+            "starts requiring auth, every deploy fails its verification step.");
+        StringAssert.Contains(await response.Content.ReadAsStringAsync(), "Healthy");
+    }
+
+    [TestMethod]
+    public async Task AuthConfig_RequiresNoToken()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var response = await client.GetAsync("/api/auth/config");
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+            "The SPA reads this before it can sign anyone in, so it cannot itself require a token.");
+    }
+
+    [TestMethod]
+    public async Task AuthConfig_ReturnsTheValuesTheSpaNeedsToSignIn()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var config = await client.GetFromJsonAsync<AuthClientConfig>("/api/auth/config");
+
+        Assert.IsNotNull(config);
+        Assert.AreEqual($"https://login.microsoftonline.com/{TelemetryWebAppFactory.TenantId}", config.Authority);
+        Assert.AreEqual(TelemetryWebAppFactory.ClientId, config.ClientId);
+        Assert.AreEqual($"api://{TelemetryWebAppFactory.ClientId}/{DashboardAuthorization.RequiredScope}", config.Scope,
+            "The scope the SPA requests must match the one the API demands, or every call 403s.");
+    }
+}
+
+[TestClass]
+public class DashboardAuthorizationTests
+{
+    private const string Role = DashboardAuthorization.RequiredRole;
+    private const string Scope = DashboardAuthorization.RequiredScope;
+
+    [TestMethod]
+    [DataRow("/api/Telemetry/stats")]
+    [DataRow("/api/Telemetry/clients")]
+    public async Task WithoutAToken_Returns401(string url)
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var response = await client.SendAsync(TestRequests.Get(url));
+
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode,
+            "An anonymous caller must be challenged, never quietly handed tenant telemetry.");
+    }
+
+    [TestMethod]
+    [DataRow("/api/Telemetry/stats")]
+    [DataRow("/api/Telemetry/clients")]
+    public async Task WithAValidTokenButNoRole_Returns403(string url)
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        // Authenticated, correct scope, but not granted the app role.
+        var response = await client.SendAsync(TestRequests.Get(url, scopes: Scope));
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode,
+            $"Authentication is not authorisation: without the {Role} role this must be refused.");
+    }
+
+    [TestMethod]
+    [DataRow("/api/Telemetry/stats")]
+    [DataRow("/api/Telemetry/clients")]
+    public async Task WithTheRoleButTheWrongScope_Returns403(string url)
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var response = await client.SendAsync(TestRequests.Get(url, roles: Role, scopes: "Some.Other.Scope"));
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode,
+            "RequiredScope must be enforced independently of the role, or a token issued for a " +
+            "different API would be accepted here.");
+    }
+
+    [TestMethod]
+    [DataRow("/api/Telemetry/stats")]
+    [DataRow("/api/Telemetry/clients")]
+    public async Task WithTheRoleButNoScopeClaimAtAll_Returns403(string url)
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        // An app-only (client credentials) token looks like this: app roles, but no delegated scope.
+        var response = await client.SendAsync(TestRequests.Get(url, roles: Role));
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode,
+            "A token carrying no scope claim must not satisfy a scope requirement.");
+    }
+
+    [TestMethod]
+    public async Task Stats_WithTheRoleAndScope_ReturnsDataFromTheStore()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        factory.Store.Seed(
+            TestData.Client("client-a", DateTime.UtcNow, build: "1801"),
+            TestData.Client("client-b", DateTime.UtcNow.AddDays(-3), build: "1756"));
+        using var client = factory.CreateApiClient();
+
+        var response = await client.SendAsync(TestRequests.Get("/api/Telemetry/stats", roles: Role, scopes: Scope));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.IsGreaterThanOrEqualTo(1, factory.Store.LoadAllCallCount,
+            "The real DashboardService should have queried the store rather than short-circuiting.");
+    }
+
+    [TestMethod]
+    public async Task Clients_WithTheRoleAndScope_ReturnsTheSeededClients()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        factory.Store.Seed(TestData.Client("client-a", DateTime.UtcNow, build: "1801"));
+        using var client = factory.CreateApiClient();
+
+        var response = await client.SendAsync(TestRequests.Get("/api/Telemetry/clients", roles: Role, scopes: Scope));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var clients = await response.Content.ReadFromJsonAsync<List<ClientSummary>>();
+        Assert.IsNotNull(clients);
+        Assert.HasCount(1, clients);
+    }
+
+    [TestMethod]
+    public async Task ExtraRolesAlongsideTheRequiredOne_AreStillAccepted()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var response = await client.SendAsync(
+            TestRequests.Get("/api/Telemetry/stats", roles: $"Some.Other.Role,{Role}", scopes: Scope));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+            "A principal holding additional app roles must not be locked out.");
+    }
+}
+
+[TestClass]
+public class TelemetryUploadEndpointTests
+{
+    /// <summary>Fixed and UTC: the signature is derived from Generated.Ticks, so it must round-trip exactly.</summary>
+    private static readonly DateTime Generated = new(2026, 8, 20, 9, 0, 0, DateTimeKind.Utc);
+
+    [TestMethod]
+    public async Task ValidSignature_IsAcceptedWithoutAToken_AndIsPersisted()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var stats = TestData.Client("integration-client", Generated, build: "1801");
+        var payload = new TelemetryPayload(stats, TelemetryWebAppFactory.SharedSecret);
+
+        var response = await client.PostAsJsonAsync("/api/Telemetry", payload);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+            "Importers have no Entra identity - they authenticate the payload, not themselves.");
+        var saved = factory.Store.SavedModels.Single();
+        Assert.AreEqual("integration-client", saved.AnonClientId);
+        Assert.AreEqual("1801", saved.BuildVersionLabel);
+    }
+
+    [TestMethod]
+    public async Task WrongSignature_Returns401_AndPersistsNothing()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var stats = TestData.Client("hostile-client", Generated, build: "1801");
+        var payload = new TelemetryPayload(stats, "not-the-shared-secret");
+
+        var response = await client.PostAsJsonAsync("/api/Telemetry", payload);
+
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.HasCount(0, factory.Store.SavedModels,
+            "A rejected upload must not reach the store.");
+    }
+
+    [TestMethod]
+    public async Task PayloadWithNoTimestamp_Returns400()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        // Built by hand rather than via TelemetryPayload: generating a signature requires Generated,
+        // so this shape can only arrive from a malformed or hand-rolled caller.
+        var json = """{"statsModel":{"anonClientId":"no-timestamp"},"secret":"irrelevant"}""";
+        var response = await client.PostAsync(
+            "/api/Telemetry", new StringContent(json, Encoding.UTF8, "application/json"));
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode,
+            "An invalid model must be refused before the signature check dereferences Generated.");
+        Assert.HasCount(0, factory.Store.SavedModels);
+    }
+
+    [TestMethod]
+    public async Task PayloadWithNoStatsModel_Returns400()
+    {
+        using var factory = new TelemetryWebAppFactory();
+        using var client = factory.CreateApiClient();
+
+        var response = await client.PostAsync(
+            "/api/Telemetry", new StringContent("""{"secret":"irrelevant"}""", Encoding.UTF8, "application/json"));
+
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.HasCount(0, factory.Store.SavedModels);
+    }
+}
+
+[TestClass]
+public class DependencyInjectionTests
+{
+    /// <summary>
+    /// The production registrations from <see cref="TelemetryServiceCollectionExtensions.AddTelemetryServices"/>,
+    /// validated with no Azure dependency. Until now the only proof this graph resolved was the app
+    /// starting in production - a missing registration reached customers as a 500 on first request.
+    /// </summary>
+    [TestMethod]
+    public void AddTelemetryServices_ProducesAResolvableGraph()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TelemetrySecret"] = "irrelevant-for-composition",
+                ["CosmosDb:AccountEndpoint"] = "https://composition-test.documents.azure.com:443/",
+                ["CosmosDb:DatabaseName"] = "telemetry-tests",
+                ["CosmosDb:ContainerNameCurrent"] = "current",
+                ["CosmosDb:ContainerNameHistory"] = "history",
+                ["AzureAd:Instance"] = "https://login.microsoftonline.com/",
+                ["AzureAd:TenantId"] = TelemetryWebAppFactory.TenantId,
+                ["AzureAd:ClientId"] = TelemetryWebAppFactory.ClientId,
+                ["AzureAd:Scopes"] = DashboardAuthorization.RequiredScope,
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTelemetryServices(configuration);
+
+        // ValidateOnBuild proves every constructor-injected registration can be satisfied - which is
+        // how CosmosSchemaInitializer's dependencies get checked - without instantiating anything,
+        // so no Cosmos client is ever built and no network call is attempted.
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true,
+        });
+
+        Assert.IsNotNull(provider.GetRequiredService<WebAppConfig>());
+    }
+
+    [TestMethod]
+    public void HostedFactory_ResolvesTheRealDomainServices()
+    {
+        using var factory = new TelemetryWebAppFactory();
+
+        // Forces the host to build. The services below are the production types; only the adaptors
+        // beneath them were substituted.
+        _ = factory.Services;
+
+        Assert.IsNotNull(factory.Services.GetRequiredService<StatsSaveService>());
+        Assert.IsNotNull(factory.Services.GetRequiredService<DashboardService>());
+        Assert.IsNotNull(factory.Services.GetRequiredService<WebAppConfig>());
+        Assert.AreSame<object>(
+            factory.Services.GetRequiredService<ITelemetrySaveAdaptor>(),
+            factory.Services.GetRequiredService<ITelemetryQueryAdaptor>(),
+            "Both interfaces must resolve to one instance, as they do in production.");
+    }
+}

--- a/src/TelemetryService/Tests.Unit/TelemetryWebAppFactory.cs
+++ b/src/TelemetryService/Tests.Unit/TelemetryWebAppFactory.cs
@@ -1,0 +1,197 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using UsageReporting;
+using Web.Auth;
+using Web.Startup;
+
+namespace Tests.Unit;
+
+/// <summary>
+/// Hosts the real telemetry service in-process so the wiring itself can be tested.
+///
+/// Everything the production composition root builds is kept, with three deliberate substitutions:
+/// the Cosmos-backed adaptors become <see cref="FakeTelemetryStore"/>, the Cosmos schema initialiser
+/// is removed, and JWT bearer validation is replaced by a header-driven test scheme. What remains
+/// under test is exactly what unit tests cannot reach - routing, the authorisation policy wiring,
+/// model binding, and the DI graph - running as it does in Azure.
+/// </summary>
+internal sealed class TelemetryWebAppFactory : WebApplicationFactory<Program>
+{
+    /// <summary>The shared secret uploads are signed with. Matches <c>TelemetrySecret</c> below.</summary>
+    public const string SharedSecret = "integration-test-shared-secret";
+
+    public const string TenantId = "00000000-0000-0000-0000-000000000000";
+    public const string ClientId = "11111111-1111-1111-1111-111111111111";
+
+    /// <summary>
+    /// Configuration is injected through environment variables rather than
+    /// <c>ConfigureAppConfiguration</c>, which does not work for this application.
+    ///
+    /// <c>Program.cs</c> reads <c>builder.Configuration</c> during service registration -
+    /// <c>AddTelemetryServices</c> constructs <c>WebAppConfig</c>, which throws on a missing
+    /// required value - and that happens inside <c>Main</c>, before WebApplicationFactory's
+    /// <c>ConfigureAppConfiguration</c> callbacks are applied at <c>Build()</c>. Environment
+    /// variables are read by <c>WebApplication.CreateBuilder</c> itself, so they are the only
+    /// injection point early enough.
+    ///
+    /// Set once per process from a static constructor: every test wants the same values, and the
+    /// assembly parallelises at method level so per-instance mutation would race.
+    /// </summary>
+    static TelemetryWebAppFactory()
+    {
+        // "__" is the .NET convention for nested configuration keys - the same form the Bicep
+        // template uses for the deployed app settings.
+        var settings = new Dictionary<string, string>
+        {
+            // Not "Development": that environment starts the Vite dev server through
+            // Microsoft.AspNetCore.SpaProxy and maps the OpenAPI endpoint, neither of which belongs
+            // in a test run - and the SPA proxy would block waiting for a server never coming.
+            ["ASPNETCORE_ENVIRONMENT"] = "Testing",
+
+            ["TelemetrySecret"] = SharedSecret,
+
+            // WebAppConfig treats these as required and refuses to construct without them.
+            // Nothing ever connects: both adaptors are replaced in ConfigureTestServices.
+            ["CosmosDb__AccountEndpoint"] = "https://telemetry-integration-tests.documents.azure.com:443/",
+            ["CosmosDb__DatabaseName"] = "telemetry-tests",
+            ["CosmosDb__ContainerNameCurrent"] = "current",
+            ["CosmosDb__ContainerNameHistory"] = "history",
+
+            ["AzureAd__Instance"] = "https://login.microsoftonline.com/",
+            ["AzureAd__TenantId"] = TenantId,
+            ["AzureAd__ClientId"] = ClientId,
+            ["AzureAd__Scopes"] = DashboardAuthorization.RequiredScope,
+
+            // Read straight through, so a record seeded by a test is visible to the very next
+            // request rather than hidden behind the 60s dashboard cache.
+            ["DashboardCacheSeconds"] = "0",
+        };
+
+        foreach (var (key, value) in settings)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+
+    /// <summary>Stands in for Cosmos. Seed it before a request, assert against it afterwards.</summary>
+    public FakeTelemetryStore Store { get; } = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Would reach for Cosmos on startup. It swallows the failure, but only after the SDK has
+            // exhausted its retries, so leaving it in makes every test pay that timeout.
+            var schemaInitialiser = services.SingleOrDefault(d =>
+                d.ServiceType == typeof(IHostedService) &&
+                d.ImplementationType == typeof(CosmosSchemaInitializer));
+            if (schemaInitialiser != null)
+            {
+                services.Remove(schemaInitialiser);
+            }
+
+            // Registered last, so these win for both interfaces. StatsSaveService and
+            // DashboardService are untouched and still the real implementations.
+            services.AddSingleton(Store);
+            services.AddSingleton<ITelemetrySaveAdaptor>(Store);
+            services.AddSingleton<ITelemetryQueryAdaptor>(Store);
+
+            // Overrides the JwtBearer default scheme set in Program.cs. ConfigureTestServices runs
+            // after the app's own registrations, so this configuration of AuthenticationOptions wins.
+            services.AddAuthentication(TestAuthHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+        });
+    }
+
+    /// <summary>A client that surfaces a redirect as a redirect instead of quietly following it.</summary>
+    public HttpClient CreateApiClient() =>
+        CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+}
+
+/// <summary>
+/// Stands in for JWT bearer validation. The caller's claims come from request headers so a test can
+/// describe the principal it wants - "has the role but not the scope" - without minting real Entra
+/// tokens or embedding signing keys in the repository.
+/// </summary>
+internal sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "IntegrationTest";
+    public const string RolesHeader = "X-Test-Roles";
+    public const string ScopesHeader = "X-Test-Scopes";
+
+    public TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        // Neither header present models a request carrying no bearer token at all. NoResult - rather
+        // than Fail - is what an absent token produces, so the pipeline challenges and returns 401.
+        if (!Request.Headers.ContainsKey(RolesHeader) && !Request.Headers.ContainsKey(ScopesHeader))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "integration-test-user"),
+            new("oid", "22222222-2222-2222-2222-222222222222"),
+        };
+
+        foreach (var role in Split(Request.Headers[RolesHeader].ToString()))
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var scopes = Request.Headers[ScopesHeader].ToString();
+        if (!string.IsNullOrWhiteSpace(scopes))
+        {
+            // "scp" is what Entra puts in an access token, and the claim Microsoft.Identity.Web's
+            // RequiredScopeAttribute looks for first.
+            claims.Add(new Claim("scp", scopes));
+        }
+
+        var identity = new ClaimsIdentity(claims, SchemeName, ClaimTypes.Name, ClaimTypes.Role);
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+
+    private static IEnumerable<string> Split(string value) =>
+        value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}
+
+/// <summary>Builds requests describing the caller, so each test reads as the case it covers.</summary>
+internal static class TestRequests
+{
+    /// <summary>Omit both arguments for an anonymous caller; omit one to leave that claim off.</summary>
+    public static HttpRequestMessage Get(string url, string? roles = null, string? scopes = null)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        if (roles != null)
+        {
+            request.Headers.Add(TestAuthHandler.RolesHeader, roles);
+        }
+
+        if (scopes != null)
+        {
+            request.Headers.Add(TestAuthHandler.ScopesHeader, scopes);
+        }
+
+        return request;
+    }
+}

--- a/src/TelemetryService/Web.Server/Auth/DashboardAuthorization.cs
+++ b/src/TelemetryService/Web.Server/Auth/DashboardAuthorization.cs
@@ -2,7 +2,24 @@ namespace Web.Auth
 {
     public static class DashboardAuthorization
     {
+        /// <summary>Entra app role a caller must be assigned to read the dashboard.</summary>
         public const string RequiredRole = "Telemetry.Dashboard.Read";
+
+        /// <summary>
+        /// Delegated scope the SPA requests and the API demands. Must match the scope exposed by the
+        /// app registration and the <c>AzureAd:Scopes</c> setting returned by the client bootstrap.
+        /// </summary>
         public const string RequiredScope = "Telemetry.Read";
+
+        /// <summary>
+        /// Policy demanding <see cref="RequiredRole"/> AND <see cref="RequiredScope"/>.
+        ///
+        /// Both must live in one policy rather than being expressed as <c>[Authorize(Roles = ...)]</c>
+        /// plus <c>[RequiredScope(...)]</c>. That combination looks correct but silently enforces
+        /// only the role: <c>RequiredScopeAttribute</c> is nothing but endpoint metadata, and the
+        /// handler that reads it is only reached through the default authorization policy - which
+        /// <c>[Authorize(Roles = ...)]</c> replaces rather than extends.
+        /// </summary>
+        public const string PolicyName = "DashboardRead";
     }
 }

--- a/src/TelemetryService/Web.Server/Controllers/TelemetryController.cs
+++ b/src/TelemetryService/Web.Server/Controllers/TelemetryController.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Identity.Web.Resource;
 using UsageReporting;
 using Web.Auth;
 using Web.Config;
@@ -53,8 +52,7 @@ namespace Web
         }
 
         [HttpGet("stats")]
-        [Authorize(Roles = DashboardAuthorization.RequiredRole)]
-        [RequiredScope(DashboardAuthorization.RequiredScope)]
+        [Authorize(Policy = DashboardAuthorization.PolicyName)]
         public async Task<ActionResult<DashboardStats>> GetStats()
         {
             var stats = await _dashboardService.GetStatsAsync();
@@ -62,8 +60,7 @@ namespace Web
         }
 
         [HttpGet("clients")]
-        [Authorize(Roles = DashboardAuthorization.RequiredRole)]
-        [RequiredScope(DashboardAuthorization.RequiredScope)]
+        [Authorize(Policy = DashboardAuthorization.PolicyName)]
         public async Task<ActionResult<IReadOnlyList<ClientSummary>>> GetClients()
         {
             var clients = await _dashboardService.GetClientsAsync();

--- a/src/TelemetryService/Web.Server/Program.cs
+++ b/src/TelemetryService/Web.Server/Program.cs
@@ -1,6 +1,7 @@
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Identity.Web;
+using Web.Auth;
 using Web.Startup;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -22,7 +23,20 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration["APPLICATIONINSIGHTS_CONNEC
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
-builder.Services.AddAuthorization();
+
+// Registers Microsoft.Identity.Web's ScopeAuthorizationHandler. Without it a ScopeAuthorizationRequirement
+// has nothing to evaluate it, so any scope check silently passes.
+builder.Services.AddRequiredScopeAuthorization();
+
+builder.Services.AddAuthorization(options =>
+{
+    // Role and scope are deliberately combined into a single policy - see DashboardAuthorization.PolicyName
+    // for why [Authorize(Roles = ...)] together with [RequiredScope(...)] only enforces the role.
+    options.AddPolicy(DashboardAuthorization.PolicyName, policy => policy
+        .RequireAuthenticatedUser()
+        .RequireRole(DashboardAuthorization.RequiredRole)
+        .RequireScope(DashboardAuthorization.RequiredScope));
+});
 
 // Config, Cosmos, telemetry store and dashboard services (see TelemetryServiceCollectionExtensions).
 builder.Services.AddTelemetryServices(builder.Configuration);


### PR DESCRIPTION
Closes #276.

Adds `WebApplicationFactory` integration tests for the telemetry service, and fixes a security-relevant wiring defect that the first run of those tests exposed.

---

## 1. The defect the tests found

**`Telemetry.Read` was not enforced on either dashboard endpoint.** A token holding the `Telemetry.Dashboard.Read` app role was accepted regardless of its scope — including a token carrying a scope for a completely different API, and an app-only token with no `scp` claim at all.

The endpoints were annotated like this:

```csharp
[Authorize(Roles = DashboardAuthorization.RequiredRole)]
[RequiredScope(DashboardAuthorization.RequiredScope)]
```

which reads as "role **and** scope", but is "role only". Two independent reasons, either of which alone is sufficient to disable the check:

1. **`RequiredScopeAttribute` is not a filter.** It is inert metadata (`IAuthRequiredScopeMetadata`). The thing that enforces it is `ScopeAuthorizationHandler`, registered only by `services.AddRequiredScopeAuthorization()` — which `Program.cs` never called. `Program.cs` called plain `AddAuthorization()`, so no handler for `ScopeAuthorizationRequirement` existed.
2. **`[Authorize(Roles = …)]` replaces the default policy rather than extending it.** Even with the handler registered, `AddRequiredScopeAuthorization()` injects the scope requirement by post-configuring `AuthorizationOptions.DefaultPolicy`. `AuthorizationPolicy.CombineAsync` only falls back to the default policy when an `IAuthorizeData` specifies neither `Policy` nor `Roles`; specifying `Roles` sets `useDefaultPolicy = false`, so the scope requirement is never combined in.

Measured on this branch, before the fix:

| Request | Before | After |
| --- | --- | --- |
| No token | 401 | 401 |
| Correct scope, no role | 403 | 403 |
| **Correct role, wrong scope** (`Some.Other.Scope`) | **200** ❌ | **403** ✅ |
| **Correct role, no `scp` claim at all** | **200** ❌ | **403** ✅ |
| Correct role and scope | 200 | 200 |

### Exposure

Lower than the raw table suggests, and worth stating plainly rather than overselling:

- The app role is still enforced, and it is assignment-gated in the Enterprise Application, so a caller already had to be explicitly assigned `Telemetry.Dashboard.Read`.
- EasyAuth in front of the app validates the audience and, since #264, `allowedApplications`.

So this was a defence-in-depth layer that was silently absent, not an open door. It is nonetheless a control the README has always claimed was enforced ("The API checks both the `Telemetry.Read` scope and the `Telemetry.Dashboard.Read` app role"), and the class of bug — auth that looks wired but is not — is exactly what #276 was opened to catch.

### The fix

Role and scope are combined into a single named policy:

```csharp
builder.Services.AddRequiredScopeAuthorization();      // registers ScopeAuthorizationHandler
builder.Services.AddAuthorization(options =>
{
    options.AddPolicy(DashboardAuthorization.PolicyName, policy => policy
        .RequireAuthenticatedUser()
        .RequireRole(DashboardAuthorization.RequiredRole)
        .RequireScope(DashboardAuthorization.RequiredScope));
});
```

and both actions become `[Authorize(Policy = DashboardAuthorization.PolicyName)]`. `DashboardAuthorization` carries a comment explaining why the attribute pair cannot be used, so it does not get "simplified" back.

### Will this lock anyone out?

No. The SPA already requests exactly this scope: `web.client/src/auth.ts` acquires tokens with `scopes: [config.scope]`, and `/api/auth/config` returns `api://{clientId}/Telemetry.Read` built from `AzureAd:Scopes`, which the Bicep template sets to `Telemetry.Read`. A delegated token from the dashboard therefore already carries `scp=Telemetry.Read` and is unaffected.

**The one case that changes:** any caller using an **app-only (client credentials) token** with the role but no `scp` claim now gets 403 where it previously got 200. There is no such caller in this repository — the importer uses the anonymous signed-upload endpoint, not the dashboard endpoints — but it is the thing to check before merging if any out-of-band script queries `/api/Telemetry/stats`.

---

## 2. The tests

`Tests.Unit/IntegrationTests.cs` (+ `TelemetryWebAppFactory.cs`), 20 new tests, in the existing `Tests.Unit` project so they run in the existing `telemetry-service` workflow with no workflow change.

| Area | Covered |
| --- | --- |
| Anonymous endpoints | `/health` returns 200; `/api/auth/config` returns 200 and the exact authority / clientId / scope the SPA needs |
| Dashboard authz | 401 with no token; 403 with scope but no role; 403 with role but wrong scope; 403 with role but no scope claim; 200 with both; 200 when extra roles are also present — each across both `/stats` and `/clients` |
| Signed upload | Valid signature accepted anonymously and persisted; wrong signature 401 and persists nothing; missing `Generated` 400; missing `StatsModel` 400 |
| DI composition | `AddTelemetryServices` builds with `ValidateOnBuild`/`ValidateScopes`; the hosted graph resolves `StatsSaveService`, `DashboardService`, `WebAppConfig`, and both adaptor interfaces resolve to the same instance |

**No Azure dependency.** The Cosmos adaptors are replaced with the existing `FakeTelemetryStore`, `CosmosSchemaInitializer` is removed from the hosted services (it would otherwise burn the Cosmos SDK's full retry budget on every test), and JWT bearer validation is replaced by a header-driven test scheme (`X-Test-Roles` / `X-Test-Scopes`) so no signing keys or real tokens are involved. `CosmosClient` is registered but never resolved, so it is never constructed.

### Two things worth knowing for the reviewer

**Configuration is injected via environment variables, not `ConfigureAppConfiguration`.** This is not a style choice. `Program.cs` reads `builder.Configuration` during service registration (`AddTelemetryServices` constructs `WebAppConfig`, which throws on a missing required value), and that runs inside `Main` — before `WebApplicationFactory` applies its configuration callbacks at `Build()`. The first version of these tests failed with `ConfigurationMissingException: Missing required configuration value 'TelemetrySecret'` for exactly this reason. Environment variables are read by `WebApplication.CreateBuilder` itself, so they are the only injection point early enough. They are set once per process from a static constructor because the assembly parallelises at method level.

**The host environment is `Testing`, not `Development`.** `Development` activates `Microsoft.AspNetCore.SpaProxy`, which would try to launch `npm run dev` and wait for a Vite server that is never coming.

Each test builds its own host — the fake store is shared mutable state and `MSTestSettings.cs` sets `ExecutionScope.MethodLevel`. Full suite: **78 passed, 0 failed, ~1s**.

---

## 3. Not covered

- `MapStaticAssets` / `MapFallbackToFile` and the SPA itself. `WebRootPath was not found` is logged during the test run; harmless for API tests, but it does mean these tests say nothing about static file serving.
- Real token validation. The JWT bearer handler is substituted, so signature, issuer and audience validation are not exercised — that is EasyAuth's and Microsoft.Identity.Web's job, and testing it would require either real tokens or a fake signing authority.

## 4. Files

| File | Change |
| --- | --- |
| `Web.Server/Program.cs` | `AddRequiredScopeAuthorization()`; combined role+scope policy |
| `Web.Server/Auth/DashboardAuthorization.cs` | Adds `PolicyName`; documents why the attribute pair does not work |
| `Web.Server/Controllers/TelemetryController.cs` | Both dashboard actions use the policy |
| `Tests.Unit/TelemetryWebAppFactory.cs` | New — factory, test auth handler, request helpers |
| `Tests.Unit/IntegrationTests.cs` | New — 20 tests |
| `src/TelemetryService/README.md` | Documents the combined policy and the integration tests |
