### PR TITLE
Detect Azure configuration drift between the Bicep template and the deployment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,3 +27,13 @@ are scoped to that path plus `reports/**` and their own workflow file. Changes e
 * Deploys on pushes to `main` and `dev`; never from a pull request or a fork.
 * Requires the repository secrets/variables listed in
   [`src/TelemetryService/README.md`](../../src/TelemetryService/README.md#continuous-delivery).
+
+## infra-drift
+
+* Weekly (and on demand) check that the deployed telemetry-service resource group still matches
+  `infra/TelemetryService/resources.bicep`, via read-only `az deployment group what-if`.
+* Deploys nothing and can change nothing — it only reports.
+* On a pull request only the filter's own unit tests run; the Azure job is skipped, so a PR never
+  needs Azure access.
+* Skips with a notice when the environment variables are not configured, so forks stay green.
+* See [`infra/TelemetryService/drift/README.md`](../../infra/TelemetryService/drift/README.md).

--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -1,0 +1,155 @@
+name: Infrastructure drift
+
+# Reports when the deployed telemetry-service resource group has drifted from the committed Bicep
+# template (infra/TelemetryService).
+#
+# This exists because two separate configuration drifts were found on the same service in one
+# afternoon, and nothing in the repository could have told you about either: `alwaysOn` had been
+# flipped to false (so the app cold-started after idle), and EasyAuth's
+# `defaultAuthorizationPolicy.allowedApplications` had materialised as an empty array, which EasyAuth
+# reads as "permit nothing" - a full dashboard outage that presented as a bare 403 on valid tokens
+# only. In both cases the template was right and the deployment was wrong.
+#
+# Strictly read-only: `what-if` computes a diff server-side and changes nothing. There is no
+# deployment step here on purpose - a drift check that can "fix" things is a deployment, and would
+# happily undo a deliberate out-of-band change.
+
+on:
+  schedule:
+    # Mondays 07:00 UTC. Drift is slow-moving; more often than this is just noise.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - infra/TelemetryService/**
+      - .github/workflows/infra-drift.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: infra-drift-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # The filter is the part that decides what counts as drift, so it is tested like any other code -
+  # and on a pull request this is the only job that runs, because a PR must never touch Azure.
+  filter_tests:
+    name: Test the drift filter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.x'
+
+      - name: Run filter tests
+        working-directory: infra/TelemetryService/drift
+        run: node --test
+
+  drift:
+    name: Check deployed resources against the template
+    needs: filter_tests
+    runs-on: ubuntu-latest
+    # Never from a pull request (no Azure access from forks, and no secrets on PR runs) and never
+    # from a fork of this repository.
+    if: >
+      github.event_name != 'pull_request'
+      && github.repository == 'pnp/Microsoft365-Analytics-Insights'
+    permissions:
+      contents: read
+      id-token: write # OIDC federated credential for azure/login
+    environment:
+      name: telemetry-service
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Everything identifying the environment comes from repository variables/secrets, never from
+      # the repository itself - this repo is public.
+      - name: Check the drift check is configured
+        id: config
+        env:
+          RESOURCE_GROUP: ${{ vars.TELEMETRY_RESOURCE_GROUP }}
+          INFRA_PARAMETERS: ${{ vars.TELEMETRY_INFRA_PARAMETERS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RESOURCE_GROUP}" ] || [ -z "${INFRA_PARAMETERS}" ]; then
+            echo "::notice::Drift checking is not configured (TELEMETRY_RESOURCE_GROUP and/or TELEMETRY_INFRA_PARAMETERS are unset). Skipping."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Azure login
+        if: steps.config.outputs.configured == 'true'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set up Node
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.x'
+
+      - name: Install Bicep
+        if: steps.config.outputs.configured == 'true'
+        run: az bicep install
+
+      # TELEMETRY_INFRA_PARAMETERS is the readable {"name": value} form because a human sets it;
+      # ARM wants {"name": {"value": ...}}. build-parameters.mjs does the conversion and is unit
+      # tested, so a malformed variable fails here with a clear message rather than inside az.
+      - name: Build the parameters file
+        if: steps.config.outputs.configured == 'true'
+        env:
+          TELEMETRY_INFRA_PARAMETERS: ${{ vars.TELEMETRY_INFRA_PARAMETERS }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        run: node infra/TelemetryService/drift/build-parameters.mjs "${RUNNER_TEMP}/drift-parameters.json"
+
+      - name: Run what-if
+        if: steps.config.outputs.configured == 'true'
+        env:
+          RESOURCE_GROUP: ${{ vars.TELEMETRY_RESOURCE_GROUP }}
+        run: |
+          set -euo pipefail
+          az deployment group what-if \
+            --resource-group "${RESOURCE_GROUP}" \
+            --template-file infra/TelemetryService/resources.bicep \
+            --parameters "@${RUNNER_TEMP}/drift-parameters.json" \
+            --result-format FullResourcePayloads \
+            --no-pretty-print \
+            --output json > "${RUNNER_TEMP}/what-if.json"
+
+      # Exits 1 on drift, 2 if the what-if output could not be evaluated (which must not be read as
+      # "no drift"). The summary deliberately prints only the provider-relative resource id.
+      - name: Evaluate drift
+        if: steps.config.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          node infra/TelemetryService/drift/filter-what-if.mjs \
+            "${RUNNER_TEMP}/what-if.json" \
+            infra/TelemetryService/drift/drift-ignore.json \
+            "${RUNNER_TEMP}/drift-summary.md"
+          cat "${RUNNER_TEMP}/drift-summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      # Raw what-if output contains subscription and resource-group identifiers, so it is NOT
+      # uploaded as an artifact. The filtered summary above is the reportable form.
+      - name: Publish summary on failure
+        if: failure() && steps.config.outputs.configured == 'true'
+        run: |
+          if [ -f "${RUNNER_TEMP}/drift-summary.md" ]; then
+            cat "${RUNNER_TEMP}/drift-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Azure logout
+        if: always()
+        run: az logout || true

--- a/infra/TelemetryService/drift/README.md
+++ b/infra/TelemetryService/drift/README.md
@@ -1,0 +1,114 @@
+# Azure configuration drift detection
+
+Detects when the deployed telemetry-service resource group no longer matches
+[`../resources.bicep`](../resources.bicep).
+
+## Why
+
+Deployed resources drift, and until now nothing noticed. Two examples found on the same service in
+one afternoon:
+
+| Drift | Symptom | How it presented |
+| --- | --- | --- |
+| `siteConfig.alwaysOn` was `false`, template said `true` | The app cold-started after idle | Slow first request, intermittently |
+| EasyAuth `defaultAuthorizationPolicy.allowedApplications` was an empty array | Every authenticated caller rejected | A bare `403` — but **only** for valid tokens. Anonymous requests succeeded, and a token with a bad signature also succeeded (it fails validation, so it is treated as anonymous). Diagnosing it from the outside was close to impossible. |
+
+In both cases the template in this repository was correct and the deployment was not, so reading the
+repository told you nothing about the actual state.
+
+## How it works
+
+[`../../../.github/workflows/infra-drift.yml`](../../../.github/workflows/infra-drift.yml) runs
+weekly and on demand:
+
+1. `az deployment group what-if` diffs the committed template against the deployed resource group.
+   **This is read-only.** ARM computes the diff server-side; nothing is deployed.
+2. `filter-what-if.mjs` removes the differences that are expected (see below) and turns the rest into
+   a job summary.
+3. The job fails if anything is left.
+
+There is deliberately **no** remediation step. A drift check that can "fix" things is a deployment,
+and would happily undo a deliberate out-of-band change at 07:00 on a Monday.
+
+## Configuration
+
+No environment identifiers are committed — this repository is public. Everything comes from
+repository secrets and variables, reusing what `telemetry-service.yml` already needs:
+
+| Kind | Name | Purpose |
+| --- | --- | --- |
+| Secret | `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` | OIDC federated sign-in. Already configured for deployment. |
+| Variable | `TELEMETRY_RESOURCE_GROUP` | Resource group to compare against. Already configured for deployment. |
+| Variable | `TELEMETRY_INFRA_PARAMETERS` | **New.** The non-secret template parameters, as a JSON object. |
+
+`TELEMETRY_INFRA_PARAMETERS` holds the values the resource group was deployed with:
+
+```json
+{
+  "location": "<region>",
+  "webAppName": "<app service name>",
+  "namePrefix": "<prefix>",
+  "vnetAddressPrefix": "10.0.0.0/16",
+  "appIntegrationSubnetPrefix": "10.0.1.0/24",
+  "privateEndpointSubnetPrefix": "10.0.2.0/24",
+  "azureAdClientId": "<app registration client id>"
+}
+```
+
+The workflow adds `azureAdTenantId` from `AZURE_TENANT_ID`, and a **placeholder** for the
+`@secure()` `telemetrySecret` parameter — its real value lives only in Key Vault, and `what-if`
+cannot read the deployed secret to compare against in any case. The resulting difference on the
+secret resource is suppressed by the ignore rules.
+
+The conversion into ARM's `{"name": {"value": …}}` form is done by
+[`build-parameters.mjs`](./build-parameters.mjs), which is unit tested — including a check that
+every non-secure `param` declared in `resources.bicep` is actually supplied, so adding a parameter
+to the template fails a pull request rather than silently breaking the weekly run.
+
+The credential needs only **Reader** on the resource group plus
+`Microsoft.Resources/deployments/whatIf/action`. It does not need Contributor; if you are reusing
+the deployment credential it already has more than enough.
+
+If either variable is unset the job logs a notice and skips, so a fork never sees a red check.
+
+## The ignore rules
+
+[`drift-ignore.json`](./drift-ignore.json). Without them the check is red on day one and muted by day
+two — the Key Vault secret value alone guarantees a permanent difference.
+
+Each rule needs a `reason`. `propertyPath` is a JavaScript regular expression matched against the
+flattened delta path, and `propertyChangeType` narrows a rule to one kind of difference. A rule with
+no `propertyPath` suppresses the whole resource; that is a blind spot, and a test asserts none are
+present.
+
+The precision matters. Platform-injected `WEBSITE_*` app settings are suppressed **only** when they
+are being *deleted* (the platform added something the template does not declare). A `WEBSITE_*`
+setting the template does own being *modified* is still reported — otherwise a drifted
+`WEBSITE_AAD_ENABLE_MISE` would slip through, which is the same class of failure as the EasyAuth bug
+above. There is a regression test for exactly this.
+
+### Adding a rule
+
+Do it reluctantly: every rule is somewhere the check has been told not to look. Both defects that
+motivated this feature were single properties on `Microsoft.Web` resources.
+
+1. Add the entry with a `reason` that explains *why the difference is expected*, not what it is.
+2. Add a test to `filter-what-if.test.mjs` proving the rule suppresses what it should, and — if the
+   rule is at all broad — that it does **not** suppress a neighbouring real difference.
+3. `node --test`.
+
+## Running the filter locally
+
+The filter is pure and needs no Azure access, so it can be run against saved `what-if` output:
+
+```bash
+az deployment group what-if -g <rg> --template-file ../resources.bicep \
+  --parameters @params.json --result-format FullResourcePayloads --no-pretty-print -o json > what-if.json
+
+node filter-what-if.mjs what-if.json drift-ignore.json
+node --test          # the filter's own tests
+```
+
+`what-if.json` contains subscription and resource-group identifiers. Do not commit it or paste it
+into an issue — the filter's summary output is deliberately trimmed to the provider-relative
+resource id for the same reason.

--- a/infra/TelemetryService/drift/build-parameters.mjs
+++ b/infra/TelemetryService/drift/build-parameters.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Builds the ARM parameters file the drift check feeds to `az deployment group what-if`.
+//
+// The repository variable holds the readable {"name": value} form, because a human has to set it;
+// ARM wants {"name": {"value": ...}}. Doing the conversion here rather than in a jq one-liner keeps
+// it unit-testable - a malformed parameters file otherwise fails inside the Azure job, which is the
+// slowest and least informative place to find out.
+//
+// Usage:
+//   node build-parameters.mjs <output-path>
+//
+// Reads TELEMETRY_INFRA_PARAMETERS (JSON object) and AZURE_TENANT_ID from the environment.
+// Exit codes: 0 = written, 2 = bad input.
+
+import { writeFileSync } from 'node:fs';
+
+/**
+ * The @secure() telemetrySecret parameter. Its real value lives only in Key Vault, and what-if
+ * cannot read the deployed secret to compare against in any case, so a placeholder is passed and
+ * the resulting difference is suppressed by drift-ignore.json.
+ */
+export const SECRET_PLACEHOLDER = 'placeholder-not-compared';
+
+export function buildParameters(rawInfraParameters, tenantId) {
+  if (!rawInfraParameters || !rawInfraParameters.trim()) {
+    throw new Error('TELEMETRY_INFRA_PARAMETERS is empty.');
+  }
+
+  let supplied;
+  try {
+    supplied = JSON.parse(rawInfraParameters);
+  } catch (error) {
+    throw new Error(`TELEMETRY_INFRA_PARAMETERS is not valid JSON: ${error.message}`);
+  }
+
+  if (supplied === null || typeof supplied !== 'object' || Array.isArray(supplied)) {
+    throw new Error('TELEMETRY_INFRA_PARAMETERS must be a JSON object of parameter names to values.');
+  }
+
+  if (!tenantId) {
+    throw new Error('AZURE_TENANT_ID is not set.');
+  }
+
+  const merged = {
+    ...supplied,
+    azureAdTenantId: tenantId,
+    telemetrySecret: SECRET_PLACEHOLDER,
+  };
+
+  const parameters = {};
+  for (const [name, value] of Object.entries(merged)) {
+    parameters[name] = { value };
+  }
+
+  return {
+    $schema: 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#',
+    contentVersion: '1.0.0.0',
+    parameters,
+  };
+}
+
+function main() {
+  const [outputPath] = process.argv.slice(2);
+  if (!outputPath) {
+    console.error('Usage: node build-parameters.mjs <output-path>');
+    process.exit(2);
+  }
+
+  try {
+    const built = buildParameters(process.env.TELEMETRY_INFRA_PARAMETERS, process.env.AZURE_TENANT_ID);
+    writeFileSync(outputPath, JSON.stringify(built, null, 2), 'utf8');
+    // Names only - the values identify the environment and this runs in a public repository.
+    console.log(`Wrote ${Object.keys(built.parameters).length} parameter(s): ${Object.keys(built.parameters).sort().join(', ')}`);
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(2);
+  }
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}`) {
+  main();
+}

--- a/infra/TelemetryService/drift/build-parameters.test.mjs
+++ b/infra/TelemetryService/drift/build-parameters.test.mjs
@@ -1,0 +1,79 @@
+// Unit tests for the ARM parameters builder. Run with: node --test
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { buildParameters, SECRET_PLACEHOLDER } from './build-parameters.mjs';
+
+const TENANT = '00000000-0000-0000-0000-000000000000';
+
+// Synthetic values only.
+const SUPPLIED = JSON.stringify({
+  location: 'westeurope',
+  webAppName: 'app-contoso-telemetry',
+  namePrefix: 'contoso-tel',
+  vnetAddressPrefix: '10.0.0.0/16',
+  appIntegrationSubnetPrefix: '10.0.1.0/24',
+  privateEndpointSubnetPrefix: '10.0.2.0/24',
+  azureAdClientId: '11111111-1111-1111-1111-111111111111',
+});
+
+describe('buildParameters', () => {
+  test('produces an ARM parameters file', () => {
+    const built = buildParameters(SUPPLIED, TENANT);
+
+    assert.equal(built.contentVersion, '1.0.0.0');
+    assert.match(built.$schema, /deploymentParameters\.json#$/);
+    assert.deepEqual(built.parameters.location, { value: 'westeurope' });
+    assert.deepEqual(built.parameters.vnetAddressPrefix, { value: '10.0.0.0/16' });
+  });
+
+  test('adds the tenant id from the environment rather than the repository', () => {
+    const built = buildParameters(SUPPLIED, TENANT);
+    assert.deepEqual(built.parameters.azureAdTenantId, { value: TENANT });
+  });
+
+  test('supplies a placeholder for the secure telemetrySecret parameter', () => {
+    const built = buildParameters(SUPPLIED, TENANT);
+    assert.deepEqual(built.parameters.telemetrySecret, { value: SECRET_PLACEHOLDER });
+  });
+
+  test('covers every non-secure parameter resources.bicep declares', () => {
+    // Guards against a parameter being added to the template and the drift check silently failing
+    // on every run afterwards.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const bicep = readFileSync(join(here, '..', 'resources.bicep'), 'utf8');
+
+    const declared = [...bicep.matchAll(/^param\s+(\w+)\s/gm)].map((m) => m[1]);
+    const provided = Object.keys(buildParameters(SUPPLIED, TENANT).parameters);
+
+    // `tags` has a default in the template only via main.bicep, so it is optional at RG scope.
+    const missing = declared.filter((name) => name !== 'tags' && !provided.includes(name));
+
+    assert.deepEqual(missing, [],
+      `TELEMETRY_INFRA_PARAMETERS (and drift/README.md) must be updated for: ${missing.join(', ')}`);
+  });
+
+  test('rejects input that is not JSON', () => {
+    assert.throws(() => buildParameters('{not json', TENANT), /not valid JSON/);
+  });
+
+  test('rejects input that is not an object', () => {
+    assert.throws(() => buildParameters('["a"]', TENANT), /must be a JSON object/);
+    assert.throws(() => buildParameters('"a"', TENANT), /must be a JSON object/);
+    assert.throws(() => buildParameters('null', TENANT), /must be a JSON object/);
+  });
+
+  test('rejects empty input', () => {
+    assert.throws(() => buildParameters('', TENANT), /empty/);
+    assert.throws(() => buildParameters('   ', TENANT), /empty/);
+  });
+
+  test('rejects a missing tenant id', () => {
+    assert.throws(() => buildParameters(SUPPLIED, ''), /AZURE_TENANT_ID/);
+    assert.throws(() => buildParameters(SUPPLIED, undefined), /AZURE_TENANT_ID/);
+  });
+});

--- a/infra/TelemetryService/drift/drift-ignore.json
+++ b/infra/TelemetryService/drift/drift-ignore.json
@@ -1,0 +1,55 @@
+{
+  "comment": [
+    "Differences between the committed Bicep template and the deployed resource group that are",
+    "expected, and are therefore suppressed by drift-check.yml so real drift stays visible.",
+    "",
+    "Every rule needs a reason. A rule with no propertyPath suppresses the whole resource, which is",
+    "a blunt instrument - prefer a propertyPath. propertyPath is a JavaScript regular expression",
+    "matched against the flattened delta path; propertyChangeType (Create/Delete/Modify/Array)",
+    "narrows a rule to one kind of difference.",
+    "",
+    "Keep this list short. Every entry is a place the check has been told not to look, and the two",
+    "defects that motivated this feature (siteConfig.alwaysOn, and an EasyAuth allowedApplications",
+    "array that had emptied itself) were both single properties on Microsoft.Web resources."
+  ],
+  "rules": [
+    {
+      "reason": "what-if cannot read a Key Vault secret's value, so it always reports the value as changing. The template only sets it at create time; rotation is done out-of-band.",
+      "resourceType": "Microsoft.KeyVault/vaults/secrets",
+      "propertyPath": "^properties\\.value$"
+    },
+    {
+      "reason": "The drift workflow passes a placeholder for the @secure() telemetrySecret parameter (it has no way to read the real one), so any diff on the secret resource is an artefact of the check itself.",
+      "resourceType": "Microsoft.KeyVault/vaults/secrets",
+      "propertyPath": "^properties\\.(attributes|contentType)"
+    },
+    {
+      "reason": "App Service injects its own WEBSITE_*/WEBSITES_* settings at deploy time that the template does not declare, so they show up as deletions. Only Delete is suppressed: if a setting the template DOES declare drifts, that is a Modify and still reported.",
+      "resourceType": "Microsoft.Web/sites/config",
+      "propertyPath": "^properties\\.(WEBSITE_|WEBSITES_)",
+      "propertyChangeType": "Delete"
+    },
+    {
+      "reason": "Application Insights codeless-attach and profiler settings are added by the platform / portal, never by this template.",
+      "resourceType": "Microsoft.Web/sites/config",
+      "propertyPath": "^properties\\.(APPINSIGHTS_|ApplicationInsightsAgent_|APPLICATIONINSIGHTS_AGENT_|DiagnosticServices_|InstrumentationEngine_|SnapshotDebugger_|XDT_)",
+      "propertyChangeType": "Delete"
+    },
+    {
+      "reason": "Deployment tooling stamps the site with its own deployment metadata; it is not configuration this template owns.",
+      "resourceType": "Microsoft.Web/sites/config",
+      "propertyPath": "^properties\\.(SCM_|ENABLE_ORYX_BUILD$|DOCKER_)",
+      "propertyChangeType": "Delete"
+    },
+    {
+      "reason": "ARM returns the Cosmos connection/endpoint sub-properties as read-only values that what-if reports as changing on every run even when nothing has moved.",
+      "resourceType": "Microsoft.DocumentDB/databaseAccounts",
+      "propertyPath": "^properties\\.(provisioningState|documentEndpoint|readLocations|writeLocations|failoverPolicies)"
+    },
+    {
+      "reason": "The App Service system-assigned identity's principalId and tenantId are assigned by the platform, so the template cannot predict them.",
+      "resourceType": "Microsoft.Web/sites",
+      "propertyPath": "^identity\\.(principalId|tenantId)$"
+    }
+  ]
+}

--- a/infra/TelemetryService/drift/filter-what-if.mjs
+++ b/infra/TelemetryService/drift/filter-what-if.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+// Turns `az deployment group what-if --no-pretty-print -o json` output into a drift verdict.
+//
+// Exists because raw what-if output is unusable as a signal: it always reports a handful of
+// differences that are correct and expected (a Key Vault secret value it cannot read, app settings
+// the platform injects at deploy time). Without suppressing those, a drift check is red on day one
+// and ignored by day two - so the two real defects that motivated this (an empty EasyAuth
+// allowedApplications array, and an alwaysOn that had been flipped to false) would still hide in
+// the noise.
+//
+// Usage:
+//   node filter-what-if.mjs <what-if.json> <ignore-rules.json> [summary.md]
+//
+// Exit codes: 0 = no drift, 1 = drift found, 2 = could not evaluate.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/** what-if change types that mean the deployed resource group does not match the template. */
+const DRIFT_CHANGE_TYPES = new Set(['Create', 'Delete', 'Modify']);
+
+/**
+ * Change types that are reported but are not drift.
+ * - NoChange / Ignore: what-if's own "nothing to do here" verdicts. `Ignore` means the resource is
+ *   outside the template, which is expected: the template does not own the whole resource group.
+ * - Deploy / Unsupported: ARM could not diff the resource, so it says so rather than guessing.
+ *   Treating "I don't know" as drift would make the check permanently red.
+ */
+const INFORMATIONAL_CHANGE_TYPES = new Set(['NoChange', 'Ignore', 'Deploy', 'Unsupported']);
+
+/**
+ * Derives the ARM resource type from a resource id.
+ * `/subscriptions/s/resourceGroups/r/providers/Microsoft.Web/sites/a/config/appsettings`
+ *   -> `Microsoft.Web/sites/config`
+ */
+export function resourceTypeOf(resourceId) {
+  if (typeof resourceId !== 'string') {
+    return '';
+  }
+
+  const marker = '/providers/';
+  const index = resourceId.toLowerCase().lastIndexOf(marker);
+  if (index === -1) {
+    return '';
+  }
+
+  const segments = resourceId.slice(index + marker.length).split('/').filter(Boolean);
+  if (segments.length < 2) {
+    return '';
+  }
+
+  // namespace, then every other segment: type/name/type/name...
+  const parts = [segments[0]];
+  for (let i = 1; i < segments.length; i += 2) {
+    parts.push(segments[i]);
+  }
+  return parts.join('/');
+}
+
+/**
+ * Flattens the nested delta tree into one entry per changed leaf property.
+ * Child `path` values from ARM are relative to their parent, so they are joined on the way down.
+ */
+export function flattenDelta(delta, parentPath = '') {
+  if (!Array.isArray(delta)) {
+    return [];
+  }
+
+  const leaves = [];
+  for (const node of delta) {
+    if (!node || typeof node !== 'object') {
+      continue;
+    }
+
+    // "NoEffect" means the template sets the value but ARM will not act on it. Not drift, and its
+    // children are not drift either.
+    if (node.propertyChangeType === 'NoEffect') {
+      continue;
+    }
+
+    const path = node.path === undefined || node.path === null || node.path === ''
+      ? parentPath
+      : (parentPath ? `${parentPath}.${node.path}` : String(node.path));
+
+    const children = Array.isArray(node.children) ? node.children : [];
+    if (children.length > 0) {
+      leaves.push(...flattenDelta(children, path));
+    } else {
+      leaves.push({
+        path,
+        propertyChangeType: node.propertyChangeType ?? 'Modify',
+        before: node.before,
+        after: node.after,
+      });
+    }
+  }
+
+  return leaves;
+}
+
+function ruleMatchesResource(rule, resourceType) {
+  if (!rule.resourceType) {
+    return true;
+  }
+  return rule.resourceType.toLowerCase() === resourceType.toLowerCase();
+}
+
+/** A rule with no propertyPath suppresses the whole resource. */
+export function isWholeResourceRule(rule) {
+  return !rule.propertyPath;
+}
+
+function ruleMatchesProperty(rule, leaf) {
+  if (rule.propertyChangeType && rule.propertyChangeType !== leaf.propertyChangeType) {
+    return false;
+  }
+  return new RegExp(rule.propertyPath).test(leaf.path);
+}
+
+/**
+ * @returns {{drift: object[], suppressed: object[], informational: object[]}}
+ */
+export function evaluate(whatIf, ignoreRules) {
+  const changes = Array.isArray(whatIf) ? whatIf : (whatIf?.changes ?? []);
+  const rules = ignoreRules?.rules ?? [];
+
+  const drift = [];
+  const suppressed = [];
+  const informational = [];
+
+  for (const change of changes) {
+    const changeType = change?.changeType ?? 'Modify';
+    const resourceId = change?.resourceId ?? '';
+    const resourceType = resourceTypeOf(resourceId);
+
+    if (INFORMATIONAL_CHANGE_TYPES.has(changeType) || !DRIFT_CHANGE_TYPES.has(changeType)) {
+      informational.push({ resourceId, resourceType, changeType });
+      continue;
+    }
+
+    const wholeResourceRule = rules
+      .filter(isWholeResourceRule)
+      .find((rule) => ruleMatchesResource(rule, resourceType));
+
+    if (wholeResourceRule) {
+      suppressed.push({ resourceId, resourceType, changeType, reason: wholeResourceRule.reason });
+      continue;
+    }
+
+    // Create/Delete of a whole resource has no useful delta - the resource itself is the finding.
+    if (changeType !== 'Modify') {
+      drift.push({ resourceId, resourceType, changeType, properties: [] });
+      continue;
+    }
+
+    const propertyRules = rules.filter(
+      (rule) => !isWholeResourceRule(rule) && ruleMatchesResource(rule, resourceType));
+    const remaining = [];
+
+    for (const leaf of flattenDelta(change.delta)) {
+      const rule = propertyRules.find((candidate) => ruleMatchesProperty(candidate, leaf));
+      if (rule) {
+        suppressed.push({ resourceId, resourceType, changeType, path: leaf.path, reason: rule.reason });
+      } else {
+        remaining.push(leaf);
+      }
+    }
+
+    // If every difference on this resource was expected, the resource is not drifted.
+    if (remaining.length > 0) {
+      drift.push({ resourceId, resourceType, changeType, properties: remaining });
+    }
+  }
+
+  return { drift, suppressed, informational };
+}
+
+function format(value) {
+  if (value === undefined) {
+    return '_(absent)_';
+  }
+  if (value === null) {
+    return '`null`';
+  }
+  const text = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  const trimmed = text.length > 120 ? `${text.slice(0, 117)}...` : text;
+  return `\`${trimmed.replace(/\|/g, '\\|')}\``;
+}
+
+/**
+ * Resource ids carry the subscription id and resource-group name. This repository is public and the
+ * job summary is world-readable on a public repo, so only the provider-relative part is published.
+ */
+export function shortenResourceId(resourceId) {
+  const marker = '/providers/';
+  const index = resourceId.toLowerCase().lastIndexOf(marker);
+  return index === -1 ? resourceId : resourceId.slice(index + marker.length);
+}
+
+export function buildSummary({ drift, suppressed, informational }) {
+  const lines = ['## Azure configuration drift', ''];
+
+  if (drift.length === 0) {
+    lines.push('No drift. The deployed resource group matches the committed Bicep template.', '');
+  } else {
+    lines.push(
+      `**${drift.length} resource(s) differ from the committed template.**`,
+      '',
+      'The template is the source of truth. Either redeploy it, or update the template if the',
+      'deployed value is the one you actually want.',
+      '',
+    );
+
+    for (const item of drift) {
+      lines.push(`### \`${shortenResourceId(item.resourceId)}\``, '');
+      lines.push(`Change type: **${item.changeType}**`, '');
+
+      if (item.properties.length > 0) {
+        lines.push('| Property | Deployed | Template |', '| --- | --- | --- |');
+        for (const property of item.properties) {
+          lines.push(`| \`${property.path}\` | ${format(property.before)} | ${format(property.after)} |`);
+        }
+        lines.push('');
+      }
+    }
+  }
+
+  lines.push(
+    `<sub>${suppressed.length} known-benign difference(s) suppressed, ` +
+    `${informational.length} resource(s) reported as no-change or outside the template.</sub>`,
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+function main() {
+  const [whatIfPath, rulesPath, summaryPath] = process.argv.slice(2);
+
+  if (!whatIfPath || !rulesPath) {
+    console.error('Usage: node filter-what-if.mjs <what-if.json> <ignore-rules.json> [summary.md]');
+    process.exit(2);
+  }
+
+  let whatIf;
+  let rules;
+  try {
+    whatIf = JSON.parse(readFileSync(whatIfPath, 'utf8'));
+    rules = JSON.parse(readFileSync(rulesPath, 'utf8'));
+  } catch (error) {
+    console.error(`Could not read what-if output or ignore rules: ${error.message}`);
+    process.exit(2);
+  }
+
+  // A what-if that failed server-side must never be read as "no drift".
+  if (whatIf?.status && whatIf.status !== 'Succeeded') {
+    console.error(`what-if did not succeed (status: ${whatIf.status}).`);
+    if (whatIf.error) {
+      console.error(JSON.stringify(whatIf.error, null, 2));
+    }
+    process.exit(2);
+  }
+
+  const result = evaluate(whatIf, rules);
+  const summary = buildSummary(result);
+
+  if (summaryPath) {
+    writeFileSync(summaryPath, summary, 'utf8');
+  }
+  console.log(summary);
+
+  process.exit(result.drift.length > 0 ? 1 : 0);
+}
+
+// Only run when executed directly, so the exported functions stay unit-testable.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}`) {
+  main();
+}

--- a/infra/TelemetryService/drift/filter-what-if.test.mjs
+++ b/infra/TelemetryService/drift/filter-what-if.test.mjs
@@ -1,0 +1,325 @@
+// Unit tests for the what-if drift filter. Run with: node --test
+//
+// These matter more than they look: the filter is the only thing standing between a useful drift
+// signal and a permanently-red check that everyone mutes. The two regression guards worth reading
+// are "a WEBSITE_ setting that is MODIFIED is still reported" and the two real-world cases the
+// feature was created for (alwaysOn, and an EasyAuth allowedApplications array that emptied itself).
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { evaluate, flattenDelta, resourceTypeOf, shortenResourceId, buildSummary } from './filter-what-if.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const shippedRules = JSON.parse(readFileSync(join(here, 'drift-ignore.json'), 'utf8'));
+
+// Synthetic ids only - never paste a real subscription, resource group or resource name in here.
+const RG = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-contoso-telemetry';
+const SITE = `${RG}/providers/Microsoft.Web/sites/app-contoso-telemetry`;
+const APPSETTINGS = `${SITE}/config/appsettings`;
+const AUTHSETTINGS = `${SITE}/config/authsettingsV2`;
+const KV_SECRET = `${RG}/providers/Microsoft.KeyVault/vaults/kvcontoso/secrets/telemetry-upload-signing-key`;
+
+describe('resourceTypeOf', () => {
+  test('reads a top-level type', () => {
+    assert.equal(resourceTypeOf(SITE), 'Microsoft.Web/sites');
+  });
+
+  test('reads a nested child type', () => {
+    assert.equal(resourceTypeOf(APPSETTINGS), 'Microsoft.Web/sites/config');
+    assert.equal(resourceTypeOf(KV_SECRET), 'Microsoft.KeyVault/vaults/secrets');
+  });
+
+  test('returns empty for something that is not a resource id', () => {
+    assert.equal(resourceTypeOf('not-an-id'), '');
+    assert.equal(resourceTypeOf(undefined), '');
+  });
+});
+
+describe('flattenDelta', () => {
+  test('joins nested child paths onto their parent', () => {
+    const leaves = flattenDelta([
+      {
+        path: 'properties.siteConfig',
+        propertyChangeType: 'Modify',
+        children: [
+          { path: 'alwaysOn', propertyChangeType: 'Modify', before: false, after: true },
+        ],
+      },
+    ]);
+
+    assert.deepEqual(leaves.map((l) => l.path), ['properties.siteConfig.alwaysOn']);
+    assert.equal(leaves[0].before, false);
+    assert.equal(leaves[0].after, true);
+  });
+
+  test('drops NoEffect nodes and everything under them', () => {
+    const leaves = flattenDelta([
+      { path: 'properties.provisioningState', propertyChangeType: 'NoEffect', after: 'Succeeded' },
+      {
+        path: 'properties.ignored',
+        propertyChangeType: 'NoEffect',
+        children: [{ path: 'child', propertyChangeType: 'Modify', before: 1, after: 2 }],
+      },
+      { path: 'properties.real', propertyChangeType: 'Modify', before: 1, after: 2 },
+    ]);
+
+    assert.deepEqual(leaves.map((l) => l.path), ['properties.real']);
+  });
+
+  test('tolerates a missing or non-array delta', () => {
+    assert.deepEqual(flattenDelta(undefined), []);
+    assert.deepEqual(flattenDelta(null), []);
+  });
+});
+
+describe('evaluate - the cases this feature exists for', () => {
+  test('alwaysOn flipped away from the template is reported as drift', () => {
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: SITE,
+          delta: [
+            {
+              path: 'properties.siteConfig',
+              propertyChangeType: 'Modify',
+              children: [
+                { path: 'alwaysOn', propertyChangeType: 'Modify', before: false, after: true },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { drift } = evaluate(whatIf, shippedRules);
+
+    assert.equal(drift.length, 1);
+    assert.equal(drift[0].resourceType, 'Microsoft.Web/sites');
+    assert.deepEqual(drift[0].properties.map((p) => p.path), ['properties.siteConfig.alwaysOn']);
+  });
+
+  test('an emptied EasyAuth allowedApplications array is reported as drift', () => {
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: AUTHSETTINGS,
+          delta: [
+            {
+              path: 'properties.identityProviders.azureActiveDirectory.validation',
+              propertyChangeType: 'Modify',
+              children: [
+                {
+                  path: 'defaultAuthorizationPolicy.allowedApplications',
+                  propertyChangeType: 'Array',
+                  before: [],
+                  after: ['11111111-1111-1111-1111-111111111111'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { drift } = evaluate(whatIf, shippedRules);
+
+    assert.equal(drift.length, 1);
+    assert.equal(
+      drift[0].properties[0].path,
+      'properties.identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedApplications');
+  });
+});
+
+describe('evaluate - suppression', () => {
+  test("a Key Vault secret's unreadable value is suppressed", () => {
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: KV_SECRET,
+          delta: [{ path: 'properties.value', propertyChangeType: 'Modify', before: null, after: 'placeholder' }],
+        },
+      ],
+    };
+
+    const { drift, suppressed } = evaluate(whatIf, shippedRules);
+
+    assert.equal(drift.length, 0, 'what-if can never read a secret value, so this is not drift');
+    assert.equal(suppressed.length, 1);
+    assert.match(suppressed[0].reason, /cannot read/i);
+  });
+
+  test('a platform-injected WEBSITE_ app setting being removed is suppressed', () => {
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: APPSETTINGS,
+          delta: [
+            { path: 'properties.WEBSITE_ENABLE_SYNC_UPDATE_SITE', propertyChangeType: 'Delete', before: '1' },
+          ],
+        },
+      ],
+    };
+
+    const { drift } = evaluate(whatIf, shippedRules);
+    assert.equal(drift.length, 0);
+  });
+
+  test('a WEBSITE_ app setting that the template owns being MODIFIED is still reported', () => {
+    // Regression guard. The Delete-only rule above must not widen into "ignore all WEBSITE_*",
+    // or a drifted WEBSITE_RUN_FROM_PACKAGE / WEBSITE_AAD_ENABLE_MISE would go unnoticed.
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: APPSETTINGS,
+          delta: [
+            { path: 'properties.WEBSITE_AAD_ENABLE_MISE', propertyChangeType: 'Modify', before: 'false', after: 'true' },
+          ],
+        },
+      ],
+    };
+
+    const { drift } = evaluate(whatIf, shippedRules);
+
+    assert.equal(drift.length, 1);
+    assert.equal(drift[0].properties[0].path, 'properties.WEBSITE_AAD_ENABLE_MISE');
+  });
+
+  test('a resource whose every difference is suppressed is not drift', () => {
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: KV_SECRET,
+          delta: [
+            { path: 'properties.value', propertyChangeType: 'Modify', before: null, after: 'x' },
+            { path: 'properties.attributes.enabled', propertyChangeType: 'Modify', before: true, after: true },
+          ],
+        },
+      ],
+    };
+
+    const { drift, suppressed } = evaluate(whatIf, shippedRules);
+    assert.equal(drift.length, 0);
+    assert.equal(suppressed.length, 2);
+  });
+
+  test('NoChange and Ignore are informational, not drift', () => {
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [
+        { changeType: 'NoChange', resourceId: SITE },
+        { changeType: 'Ignore', resourceId: `${RG}/providers/Microsoft.Insights/components/appi-contoso` },
+      ],
+    };
+
+    const { drift, informational } = evaluate(whatIf, shippedRules);
+    assert.equal(drift.length, 0);
+    assert.equal(informational.length, 2);
+  });
+
+  test('a resource the template declares but that does not exist is drift', () => {
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [{ changeType: 'Create', resourceId: `${RG}/providers/Microsoft.Web/sites/app-missing` }],
+    };
+
+    const { drift } = evaluate(whatIf, shippedRules);
+    assert.equal(drift.length, 1);
+    assert.equal(drift[0].changeType, 'Create');
+  });
+
+  test('accepts a bare array of changes as well as the full what-if envelope', () => {
+    const changes = [
+      {
+        changeType: 'Modify',
+        resourceId: SITE,
+        delta: [{ path: 'properties.siteConfig.alwaysOn', propertyChangeType: 'Modify', before: false, after: true }],
+      },
+    ];
+
+    assert.equal(evaluate(changes, shippedRules).drift.length, 1);
+  });
+
+  test('no rules at all means nothing is suppressed', () => {
+    const whatIf = {
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: KV_SECRET,
+          delta: [{ path: 'properties.value', propertyChangeType: 'Modify', before: null, after: 'x' }],
+        },
+      ],
+    };
+
+    assert.equal(evaluate(whatIf, {}).drift.length, 1);
+    assert.equal(evaluate(whatIf, { rules: [] }).drift.length, 1);
+  });
+});
+
+describe('summary output', () => {
+  test('does not publish the subscription id or resource group name', () => {
+    // The job summary is world-readable on this public repository.
+    const summary = buildSummary(evaluate({
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: SITE,
+          delta: [{ path: 'properties.siteConfig.alwaysOn', propertyChangeType: 'Modify', before: false, after: true }],
+        },
+      ],
+    }, shippedRules));
+
+    assert.doesNotMatch(summary, /subscriptions/);
+    assert.doesNotMatch(summary, /resourceGroups/);
+    assert.match(summary, /alwaysOn/);
+  });
+
+  test('shortenResourceId keeps only the provider-relative part', () => {
+    assert.equal(shortenResourceId(SITE), 'Microsoft.Web/sites/app-contoso-telemetry');
+  });
+
+  test('says so plainly when there is no drift', () => {
+    const summary = buildSummary(evaluate({ status: 'Succeeded', changes: [] }, shippedRules));
+    assert.match(summary, /No drift/);
+  });
+});
+
+describe('shipped ignore rules', () => {
+  test('every rule carries a reason', () => {
+    for (const rule of shippedRules.rules) {
+      assert.ok(rule.reason && rule.reason.length > 20, `rule ${JSON.stringify(rule)} needs a real reason`);
+    }
+  });
+
+  test('every propertyPath is a valid regular expression', () => {
+    for (const rule of shippedRules.rules) {
+      if (rule.propertyPath) {
+        assert.doesNotThrow(() => new RegExp(rule.propertyPath), `bad regex in ${rule.reason}`);
+      }
+    }
+  });
+
+  test('no rule suppresses a whole resource type', () => {
+    // A whole-resource rule is a blind spot. If one is ever genuinely needed, delete this test
+    // deliberately rather than letting a rule slip in unnoticed.
+    const blunt = shippedRules.rules.filter((r) => !r.propertyPath);
+    assert.deepEqual(blunt, []);
+  });
+});

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -148,9 +148,15 @@ environment, and grant it Website Contributor (or Contributor) on the target App
 | Secret | `AZURE_SUBSCRIPTION_ID` | Subscription containing the App Service. |
 | Variable | `TELEMETRY_APP_NAME` | App Service name to deploy to. |
 | Variable | `TELEMETRY_RESOURCE_GROUP` | Resource group containing that App Service. |
+| Variable | `TELEMETRY_INFRA_PARAMETERS` | Non-secret Bicep parameters as a JSON object, used by the [drift check](../../infra/TelemetryService/drift/README.md#configuration). Only needed for `infra-drift.yml`. |
 
 The deploy job is guarded so it can only ever run from this repository on a push — never from a
 pull request and never from a fork.
+
+Configuration drift between these deployed resources and `infra/TelemetryService/resources.bicep` is
+detected weekly by [`.github/workflows/infra-drift.yml`](../../.github/workflows/infra-drift.yml),
+which runs a read-only `az deployment group what-if` and deploys nothing. See
+[`infra/TelemetryService/drift/README.md`](../../infra/TelemetryService/drift/README.md).
 
 ## Configuration
 


### PR DESCRIPTION
Closes #272.

Adds a weekly, read-only check that the deployed telemetry-service resource group still matches [`infra/TelemetryService/resources.bicep`](infra/TelemetryService/resources.bicep).

## 1. Why

Two drifts were found on the same service in one afternoon, and nothing in the repository could have told you about either:

| Drift | Symptom |
| --- | --- |
| `siteConfig.alwaysOn` was `false`, template said `true` | App cold-started after idle |
| EasyAuth `defaultAuthorizationPolicy.allowedApplications` had materialised as an empty array | Full dashboard outage (#264). EasyAuth reads an empty allow-list as "permit nothing", so **valid** tokens got a bare `403` while anonymous requests and badly-signed tokens both succeeded |

In both cases the template was correct and the deployment was not.

## 2. What runs

`.github/workflows/infra-drift.yml`, Mondays 07:00 UTC and on `workflow_dispatch`:

1. `az deployment group what-if` — ARM computes the diff server-side. **Nothing is deployed.**
2. `filter-what-if.mjs` suppresses expected differences and renders a job summary.
3. The job fails if anything remains.

There is deliberately **no remediation step**. A drift check that can "fix" things is a deployment, and would happily undo a deliberate out-of-band change at 07:00 on a Monday.

## 3. The ignore list is the whole design problem

Raw `what-if` output is unusable as a signal: the Key Vault secret value alone guarantees a permanent difference, so an unfiltered check is red on day one and muted by day two — and the two defects above would still be invisible.

`drift-ignore.json` is therefore narrow and every rule carries a `reason`. The precision that matters most:

> Platform-injected `WEBSITE_*` app settings are suppressed **only** on `Delete` (the platform added something the template does not declare). A `WEBSITE_*` setting the template *does* own being **modified** is still reported.

Without that distinction a drifted `WEBSITE_AAD_ENABLE_MISE` would slip through — the same class of failure as the EasyAuth bug. There is a named regression test for it.

Tests also assert that no rule suppresses a whole resource type (a blind spot), that every rule has a real reason, and that every `propertyPath` compiles as a regex.

## 4. Verifiable without Azure

This is the part worth reviewing. The filter is pure and separately tested, so the logic that decides what counts as drift does not depend on having a subscription:

- **30 tests, `node --test`**, including reconstructions of both motivating defects (`alwaysOn`, and the emptied `allowedApplications` array) asserted as drift.
- On a **pull request only the `filter_tests` job runs** — the Azure job is skipped entirely, so a PR never needs Azure access and forks stay green.
- `build-parameters.mjs` replaced what began as a `jq` one-liner, specifically so the parameters transform is unit tested. One of its tests parses `resources.bicep` and asserts every non-secure `param` it declares is actually supplied, so **adding a parameter to the template fails a PR** instead of silently breaking the weekly run months later.

## 5. Nothing environment-identifying is committed

The repository is public, and the job summary on a public repo is world-readable.

- Resource group, region, app name, address prefixes and client id come from `vars.TELEMETRY_INFRA_PARAMETERS`; tenant/subscription from the existing OIDC secrets. Only `TELEMETRY_INFRA_PARAMETERS` is new — everything else is already configured for deployment.
- `shortenResourceId` trims every reported id to its provider-relative part, so the summary shows `Microsoft.Web/sites/<name>` and never the subscription id or resource-group name. A test asserts the rendered summary matches neither `/subscriptions/` nor `/resourceGroups/`.
- **Raw what-if output is deliberately not uploaded as an artifact** — it contains full resource payloads and ids.
- If the variables are unset the job logs a notice and skips.

## 6. Permissions

The credential needs only **Reader** + `Microsoft.Resources/deployments/whatIf/action` on the resource group — strictly less than the existing deploy credential already holds. Sign-in is the same OIDC federated credential; no new secret.

## 7. Reviewer notes

1. **`--result-format FullResourcePayloads`** is set explicitly. With `ResourceIdOnly` there is no `delta`, and the filter would report every changed resource with no properties — technically still drift, but useless.
2. **A failed what-if must never read as "no drift".** `filter-what-if.mjs` exits `2` when `status != Succeeded` or the output cannot be parsed, distinct from `1` for drift found.
3. **`Deploy` and `Unsupported` change types are treated as informational**, not drift. They mean ARM could not diff the resource; treating "I don't know" as drift would make the check permanently red.
4. **Scope is resource-group / `resources.bicep`**, not subscription / `main.bicep`, so the check does not need subscription-level rights and does not diff the resource group resource itself.
5. **Schedule caveat:** GitHub disables scheduled workflows on repositories with no activity for 60 days. Not a concern for an active repo, but it is why the workflow is also `workflow_dispatch`.

## 8. Files

| File | Purpose |
| --- | --- |
| `.github/workflows/infra-drift.yml` | The workflow |
| `infra/TelemetryService/drift/filter-what-if.mjs` | Suppression + summary rendering |
| `infra/TelemetryService/drift/filter-what-if.test.mjs` | 22 tests |
| `infra/TelemetryService/drift/build-parameters.mjs` | Repo variable → ARM parameters file |
| `infra/TelemetryService/drift/build-parameters.test.mjs` | 8 tests, incl. template parameter coverage |
| `infra/TelemetryService/drift/drift-ignore.json` | The ignore rules, each with a reason |
| `infra/TelemetryService/drift/README.md` | Why it exists, how to configure, how to add a rule |
| `.github/workflows/README.md`, `src/TelemetryService/README.md` | Documentation |
