### PR TITLE
Copilot licence adoption tool: find unused seats and unlicensed heavy users

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionExports.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionExports.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Common.Entities.CopilotAdoption
+{
+    /// <summary>
+    /// How the licensed-user list is filtered and ordered. A plain object rather than a set of method
+    /// arguments so the same shape can come from a query string today and from a scheduled report's
+    /// configuration later without changing any of the logic below.
+    /// </summary>
+    public class LicensedUserQuery
+    {
+        /// <summary>Free-text match against UPN, mail, department, job title or manager.</summary>
+        public string Search { get; set; }
+
+        /// <summary>Restrict to these engagement bands; empty means all.</summary>
+        public List<AdoptionBand> Bands { get; set; } = new List<AdoptionBand>();
+
+        public string Department { get; set; }
+
+        public string Country { get; set; }
+
+        /// <summary>Only users who have used Microsoft 365 Copilot Cowork.</summary>
+        public bool CoworkOnly { get; set; }
+
+        /// <summary>Only users whose account is disabled - the clearest reclaim candidates of all.</summary>
+        public bool DisabledAccountsOnly { get; set; }
+
+        public double? MinScore { get; set; }
+
+        public double? MaxScore { get; set; }
+
+        /// <summary>One of <see cref="LicensedUserSortFields"/>.</summary>
+        public string SortBy { get; set; } = LicensedUserSortFields.Score;
+
+        /// <summary>
+        /// Ascending by default for the score, because the whole point of the list is finding the
+        /// people who are <i>not</i> using their licence.
+        /// </summary>
+        public bool SortDescending { get; set; }
+    }
+
+    /// <summary>Sortable columns of the licensed-user list. An allow-list: nothing here reaches SQL.</summary>
+    public static class LicensedUserSortFields
+    {
+        public const string Score = "score";
+        public const string UserPrincipalName = "upn";
+        public const string Interactions = "interactions";
+        public const string ActiveDays = "activeDays";
+        public const string LastUse = "lastUse";
+        public const string Department = "department";
+        public const string Cowork = "cowork";
+    }
+
+    /// <summary>How the licence-opportunity list is filtered and ordered.</summary>
+    public class LicenceOpportunityQuery
+    {
+        public string Search { get; set; }
+
+        public string Department { get; set; }
+
+        public string Country { get; set; }
+
+        /// <summary>Only candidates that clear the recommendation threshold.</summary>
+        public bool RecommendedOnly { get; set; }
+
+        /// <summary>Only candidates who are already using Copilot Chat without a licence.</summary>
+        public bool ExistingCopilotUsersOnly { get; set; }
+
+        public double? MinScore { get; set; }
+
+        /// <summary>One of <see cref="LicenceOpportunitySortFields"/>.</summary>
+        public string SortBy { get; set; } = LicenceOpportunitySortFields.Score;
+
+        /// <summary>Descending by default: the strongest business cases first.</summary>
+        public bool SortDescending { get; set; } = true;
+    }
+
+    /// <summary>Sortable columns of the licence-opportunity list.</summary>
+    public static class LicenceOpportunitySortFields
+    {
+        public const string Score = "score";
+        public const string UserPrincipalName = "upn";
+        public const string CopilotUse = "copilot";
+        public const string Collaboration = "collaboration";
+        public const string Email = "email";
+        public const string Documents = "documents";
+        public const string Department = "department";
+    }
+
+    /// <summary>
+    /// Filtering, sorting and paging over an analysis result, plus the CSV export schemas.
+    ///
+    /// All of it operates on the already-scored, already-materialised lists rather than going back to
+    /// the database, which is what guarantees the exported CSV is exactly the data behind the summary
+    /// the user is looking at. Nothing is more damaging to a report used in a licence negotiation than
+    /// a spreadsheet that disagrees with the chart it was exported from.
+    /// </summary>
+    public static class CopilotAdoptionExports
+    {
+        #region Licensed users
+
+        /// <summary>Applies the filter, then the sort. Returns a new list; the source is not mutated.</summary>
+        public static List<LicensedUserAdoptionRow> Apply(
+            IEnumerable<LicensedUserAdoptionRow> rows,
+            LicensedUserQuery query)
+        {
+            var source = rows ?? Enumerable.Empty<LicensedUserAdoptionRow>();
+            var q = query ?? new LicensedUserQuery();
+
+            var filtered = source.Where(row => MatchesLicensedUser(row, q));
+            return SortLicensedUsers(filtered, q).ToList();
+        }
+
+        private static bool MatchesLicensedUser(LicensedUserAdoptionRow row, LicensedUserQuery q)
+        {
+            if (q.Bands != null && q.Bands.Count > 0 && !q.Bands.Contains(row.Band))
+            {
+                return false;
+            }
+
+            if (q.CoworkOnly && !row.UsedCowork) return false;
+
+            // AccountEnabled is nullable: null means "we have not imported that flag", which is not the
+            // same as "disabled", so it must not be swept into a reclaim list.
+            if (q.DisabledAccountsOnly && row.AccountEnabled != false) return false;
+
+            if (q.MinScore.HasValue && row.AdoptionScore < q.MinScore.Value) return false;
+            if (q.MaxScore.HasValue && row.AdoptionScore > q.MaxScore.Value) return false;
+
+            if (!EqualsOrEmpty(q.Department, row.Department)) return false;
+            if (!EqualsOrEmpty(q.Country, row.Country)) return false;
+
+            return MatchesSearch(q.Search,
+                row.UserPrincipalName, row.Mail, row.Department, row.JobTitle,
+                row.ManagerUserPrincipalName, row.OfficeLocation, row.CompanyName);
+        }
+
+        private static IEnumerable<LicensedUserAdoptionRow> SortLicensedUsers(
+            IEnumerable<LicensedUserAdoptionRow> rows,
+            LicensedUserQuery q)
+        {
+            // The tie-break is always UPN so paging is stable: without it, two users on the same score
+            // can swap places between page 1 and page 2 and appear twice (or not at all) in an export.
+            switch (q.SortBy)
+            {
+                case LicensedUserSortFields.UserPrincipalName:
+                    return Order(rows, r => r.UserPrincipalName ?? string.Empty, q.SortDescending);
+                case LicensedUserSortFields.Interactions:
+                    return OrderThenUpn(rows, r => (double)r.Interactions, q.SortDescending);
+                case LicensedUserSortFields.ActiveDays:
+                    return OrderThenUpn(rows, r => (double)r.ActiveDays, q.SortDescending);
+                case LicensedUserSortFields.LastUse:
+                    // Never-used sorts as the beginning of time so it lands at the "needs attention"
+                    // end of an ascending sort rather than being scattered by a null.
+                    return OrderThenUpn(rows, r => (r.LastInteractionUtc ?? DateTime.MinValue).Ticks, q.SortDescending);
+                case LicensedUserSortFields.Department:
+                    return Order(rows, r => r.Department ?? string.Empty, q.SortDescending);
+                case LicensedUserSortFields.Cowork:
+                    return OrderThenUpn(rows, r => (double)r.CoworkInteractions, q.SortDescending);
+                default:
+                    return OrderThenUpn(rows, r => r.AdoptionScore, q.SortDescending);
+            }
+        }
+
+        /// <summary>
+        /// The licensed-user CSV. Column order tells the story the export exists to tell: who they are,
+        /// how much they are using Copilot, how that scores, and what to do about it.
+        /// </summary>
+        public static IReadOnlyList<CsvColumn<LicensedUserAdoptionRow>> LicensedUserColumns()
+        {
+            return new List<CsvColumn<LicensedUserAdoptionRow>>
+            {
+                new CsvColumn<LicensedUserAdoptionRow>("User principal name", r => r.UserPrincipalName),
+                new CsvColumn<LicensedUserAdoptionRow>("Email", r => r.Mail),
+                new CsvColumn<LicensedUserAdoptionRow>("Department", r => r.Department),
+                new CsvColumn<LicensedUserAdoptionRow>("Job title", r => r.JobTitle),
+                new CsvColumn<LicensedUserAdoptionRow>("Manager", r => r.ManagerUserPrincipalName),
+                new CsvColumn<LicensedUserAdoptionRow>("Office", r => r.OfficeLocation),
+                new CsvColumn<LicensedUserAdoptionRow>("Country", r => r.Country),
+                new CsvColumn<LicensedUserAdoptionRow>("Company", r => r.CompanyName),
+                new CsvColumn<LicensedUserAdoptionRow>("Account enabled", r => r.AccountEnabled),
+                new CsvColumn<LicensedUserAdoptionRow>("Copilot licences", r => r.SeatLicences),
+
+                new CsvColumn<LicensedUserAdoptionRow>("Adoption score (0-100)", r => r.AdoptionScore),
+                new CsvColumn<LicensedUserAdoptionRow>("Engagement band", r => r.BandName),
+                new CsvColumn<LicensedUserAdoptionRow>("Frequency score", r => r.FrequencyScore),
+                new CsvColumn<LicensedUserAdoptionRow>("Depth score", r => r.DepthScore),
+                new CsvColumn<LicensedUserAdoptionRow>("Breadth score", r => r.BreadthScore),
+
+                new CsvColumn<LicensedUserAdoptionRow>("Interactions in period", r => r.Interactions),
+                new CsvColumn<LicensedUserAdoptionRow>("Active days in period", r => r.ActiveDays),
+                new CsvColumn<LicensedUserAdoptionRow>("Active days for full marks", r => r.ExpectedActiveDays),
+                new CsvColumn<LicensedUserAdoptionRow>("Copilot apps used", r => r.AppsUsed),
+                new CsvColumn<LicensedUserAdoptionRow>("Copilot agents used", r => r.AgentsUsed),
+                new CsvColumn<LicensedUserAdoptionRow>("Used Cowork", r => r.UsedCowork),
+                new CsvColumn<LicensedUserAdoptionRow>("Cowork interactions", r => r.CoworkInteractions),
+
+                new CsvColumn<LicensedUserAdoptionRow>("First use (UTC)", r => r.FirstInteractionUtc),
+                new CsvColumn<LicensedUserAdoptionRow>("Last use (UTC)", r => r.LastInteractionUtc),
+                new CsvColumn<LicensedUserAdoptionRow>("Days since last use", r => r.DaysSinceLastUse),
+
+                new CsvColumn<LicensedUserAdoptionRow>("Microsoft report prompts", r => r.ReportPrompts),
+                new CsvColumn<LicensedUserAdoptionRow>("Microsoft report active days", r => r.ReportActiveDays),
+                new CsvColumn<LicensedUserAdoptionRow>("Microsoft report last activity", r => r.ReportLastActivityUtc),
+                new CsvColumn<LicensedUserAdoptionRow>("Signal source", r => r.SignalSource),
+
+                new CsvColumn<LicensedUserAdoptionRow>("Recommended action", r => r.RecommendedAction),
+            };
+        }
+
+        #endregion
+
+        #region Licence opportunities
+
+        public static List<LicenceOpportunityRow> Apply(
+            IEnumerable<LicenceOpportunityRow> rows,
+            LicenceOpportunityQuery query)
+        {
+            var source = rows ?? Enumerable.Empty<LicenceOpportunityRow>();
+            var q = query ?? new LicenceOpportunityQuery();
+
+            var filtered = source.Where(row => MatchesOpportunity(row, q));
+            return SortOpportunities(filtered, q).ToList();
+        }
+
+        private static bool MatchesOpportunity(LicenceOpportunityRow row, LicenceOpportunityQuery q)
+        {
+            if (q.RecommendedOnly && !row.Recommended) return false;
+            if (q.ExistingCopilotUsersOnly && row.UnlicensedCopilotInteractions <= 0) return false;
+            if (q.MinScore.HasValue && row.OpportunityScore < q.MinScore.Value) return false;
+
+            if (!EqualsOrEmpty(q.Department, row.Department)) return false;
+            if (!EqualsOrEmpty(q.Country, row.Country)) return false;
+
+            return MatchesSearch(q.Search,
+                row.UserPrincipalName, row.Mail, row.Department, row.JobTitle,
+                row.ManagerUserPrincipalName, row.OfficeLocation, row.CompanyName);
+        }
+
+        private static IEnumerable<LicenceOpportunityRow> SortOpportunities(
+            IEnumerable<LicenceOpportunityRow> rows,
+            LicenceOpportunityQuery q)
+        {
+            switch (q.SortBy)
+            {
+                case LicenceOpportunitySortFields.UserPrincipalName:
+                    return Order(rows, r => r.UserPrincipalName ?? string.Empty, q.SortDescending);
+                case LicenceOpportunitySortFields.CopilotUse:
+                    return OrderThenUpn(rows, r => (double)r.UnlicensedCopilotInteractions, q.SortDescending);
+                case LicenceOpportunitySortFields.Collaboration:
+                    return OrderThenUpn(rows, r => (double)(r.TeamsMessages + r.TeamsMeetings), q.SortDescending);
+                case LicenceOpportunitySortFields.Email:
+                    return OrderThenUpn(rows, r => (double)(r.EmailsSent + r.EmailsRead), q.SortDescending);
+                case LicenceOpportunitySortFields.Documents:
+                    return OrderThenUpn(rows, r => (double)r.FilesViewedOrEdited, q.SortDescending);
+                case LicenceOpportunitySortFields.Department:
+                    return Order(rows, r => r.Department ?? string.Empty, q.SortDescending);
+                default:
+                    return OrderThenUpn(rows, r => r.OpportunityScore, q.SortDescending);
+            }
+        }
+
+        /// <summary>
+        /// The licence-opportunity CSV. Leads with the evidence (existing unlicensed Copilot use) and
+        /// ends with a ready-written justification, so the file can go straight to whoever signs off
+        /// the spend.
+        /// </summary>
+        public static IReadOnlyList<CsvColumn<LicenceOpportunityRow>> LicenceOpportunityColumns()
+        {
+            return new List<CsvColumn<LicenceOpportunityRow>>
+            {
+                new CsvColumn<LicenceOpportunityRow>("User principal name", r => r.UserPrincipalName),
+                new CsvColumn<LicenceOpportunityRow>("Email", r => r.Mail),
+                new CsvColumn<LicenceOpportunityRow>("Department", r => r.Department),
+                new CsvColumn<LicenceOpportunityRow>("Job title", r => r.JobTitle),
+                new CsvColumn<LicenceOpportunityRow>("Manager", r => r.ManagerUserPrincipalName),
+                new CsvColumn<LicenceOpportunityRow>("Office", r => r.OfficeLocation),
+                new CsvColumn<LicenceOpportunityRow>("Country", r => r.Country),
+                new CsvColumn<LicenceOpportunityRow>("Company", r => r.CompanyName),
+
+                new CsvColumn<LicenceOpportunityRow>("Opportunity score (0-100)", r => r.OpportunityScore),
+                new CsvColumn<LicenceOpportunityRow>("Recommended for a licence", r => r.Recommended),
+
+                new CsvColumn<LicenceOpportunityRow>("Unlicensed Copilot interactions", r => r.UnlicensedCopilotInteractions),
+                new CsvColumn<LicenceOpportunityRow>("Unlicensed Copilot active days", r => r.UnlicensedCopilotActiveDays),
+                new CsvColumn<LicenceOpportunityRow>("Last Copilot use (UTC)", r => r.LastCopilotInteractionUtc),
+
+                new CsvColumn<LicenceOpportunityRow>("Teams messages", r => r.TeamsMessages),
+                new CsvColumn<LicenceOpportunityRow>("Teams meetings", r => r.TeamsMeetings),
+                new CsvColumn<LicenceOpportunityRow>("Emails sent", r => r.EmailsSent),
+                new CsvColumn<LicenceOpportunityRow>("Emails read", r => r.EmailsRead),
+                new CsvColumn<LicenceOpportunityRow>("Files viewed or edited", r => r.FilesViewedOrEdited),
+                new CsvColumn<LicenceOpportunityRow>("Last Microsoft 365 activity", r => r.LastM365ActivityUtc),
+
+                new CsvColumn<LicenceOpportunityRow>("Copilot demand score", r => r.CopilotDemandScore),
+                new CsvColumn<LicenceOpportunityRow>("Collaboration score", r => r.CollaborationScore),
+                new CsvColumn<LicenceOpportunityRow>("Email score", r => r.EmailScore),
+                new CsvColumn<LicenceOpportunityRow>("Document score", r => r.DocumentScore),
+
+                new CsvColumn<LicenceOpportunityRow>("Justification", r => r.Rationale),
+            };
+        }
+
+        #endregion
+
+        #region Shared helpers
+
+        /// <summary>
+        /// Case-insensitive "contains" across several fields. Ordinal-ignore-case rather than a culture
+        /// comparison so a search behaves identically on a Turkish-locale server as on an English one.
+        /// </summary>
+        private static bool MatchesSearch(string search, params string[] fields)
+        {
+            if (string.IsNullOrWhiteSpace(search))
+            {
+                return true;
+            }
+
+            var term = search.Trim();
+            return fields.Any(field =>
+                !string.IsNullOrEmpty(field)
+                && field.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        /// <summary>An unset filter matches everything; a set one is an exact, case-insensitive match.</summary>
+        private static bool EqualsOrEmpty(string filter, string value)
+        {
+            return string.IsNullOrWhiteSpace(filter)
+                || string.Equals(filter.Trim(), (value ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static IOrderedEnumerable<T> Order<T, TKey>(
+            IEnumerable<T> rows, Func<T, TKey> key, bool descending)
+        {
+            return descending ? rows.OrderByDescending(key) : rows.OrderBy(key);
+        }
+
+        private static IOrderedEnumerable<LicensedUserAdoptionRow> OrderThenUpn<TKey>(
+            IEnumerable<LicensedUserAdoptionRow> rows, Func<LicensedUserAdoptionRow, TKey> key, bool descending)
+        {
+            return Order(rows, key, descending)
+                .ThenBy(r => r.UserPrincipalName ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static IOrderedEnumerable<LicenceOpportunityRow> OrderThenUpn<TKey>(
+            IEnumerable<LicenceOpportunityRow> rows, Func<LicenceOpportunityRow, TKey> key, bool descending)
+        {
+            return Order(rows, key, descending)
+                .ThenBy(r => r.UserPrincipalName ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// One page of a filtered list. <paramref name="take"/> is clamped so a stray query string
+        /// cannot ask the server to serialise a whole tenant into a single JSON response.
+        /// </summary>
+        public static List<T> Page<T>(IReadOnlyList<T> rows, int skip, int take, int maxTake = 500)
+        {
+            if (rows == null || rows.Count == 0) return new List<T>();
+
+            var safeSkip = Math.Max(0, skip);
+            var safeTake = Math.Min(Math.Max(1, take), maxTake);
+
+            return rows.Skip(safeSkip).Take(safeTake).ToList();
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionModels.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionModels.cs
@@ -1,0 +1,858 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Common.Entities.CopilotAdoption
+{
+    #region Tuning
+
+    /// <summary>
+    /// Every threshold and weight the adoption maths uses, in one overridable place.
+    ///
+    /// These are judgement calls, not facts, and this tool is used to justify licence spend and to
+    /// pick who gets training - so they must be inspectable, adjustable and unit-testable rather than
+    /// buried as magic numbers inside a query. The API returns the values it used alongside the
+    /// numbers, so a figure in a board pack can always be traced back to the rule that produced it.
+    /// </summary>
+    public class CopilotAdoptionOptions
+    {
+        /// <summary>Length of the reporting window in days. 28 matches Microsoft's own D28 usage reports.</summary>
+        public int WindowDays { get; set; } = 28;
+
+        /// <summary>
+        /// How far back to look for <i>any</i> prior Copilot activity, used to tell "never touched it"
+        /// apart from "used to use it and stopped" - two populations that need completely different
+        /// interventions (onboarding vs re-engagement, or reclaiming the seat).
+        ///
+        /// Bounded rather than unlimited because it decides how much of <c>copilot_chats</c> the query
+        /// reads: on a large tenant an unbounded lifetime scan of the audit history is the difference
+        /// between a report that returns and one that times out.
+        /// </summary>
+        public int HistoryDays { get; set; } = 365;
+
+        /// <summary>
+        /// Working days per calendar week, used to convert the window into the number of days a fully
+        /// engaged user could realistically be active. Scoring against calendar days would cap even a
+        /// daily user at ~71%, which is not a number anyone should have to explain to a CFO.
+        /// </summary>
+        public double WorkingDaysPerWeek { get; set; } = 5;
+
+        /// <summary>
+        /// Share of available working days a user must be active on to score full marks for frequency.
+        /// 0.6 = active on ~3 days in a typical 5-day week, which is a genuine habit rather than
+        /// perfection.
+        /// </summary>
+        public double FrequencyTargetRatio { get; set; } = 0.6;
+
+        /// <summary>Interactions per active day that score full marks for depth of use.</summary>
+        public double DepthTargetInteractionsPerActiveDay { get; set; } = 5;
+
+        /// <summary>Distinct Copilot surfaces (Teams, Word, Outlook, Chat...) that score full marks for breadth.</summary>
+        public double BreadthTargetApps { get; set; } = 3;
+
+        /// <summary>Weight of the frequency component in the engagement score. The three weights should sum to 1.</summary>
+        public double FrequencyWeight { get; set; } = 0.5;
+
+        /// <summary>Weight of the depth component in the engagement score.</summary>
+        public double DepthWeight { get; set; } = 0.3;
+
+        /// <summary>Weight of the breadth component in the engagement score.</summary>
+        public double BreadthWeight { get; set; } = 0.2;
+
+        /// <summary>Score at or above which a user is a <see cref="AdoptionBand.Champion"/>.</summary>
+        public double ChampionScore { get; set; } = 75;
+
+        /// <summary>Score at or above which a user is <see cref="AdoptionBand.Established"/> (the "habit formed" line).</summary>
+        public double EstablishedScore { get; set; } = 50;
+
+        /// <summary>Score at or above which a user is <see cref="AdoptionBand.Developing"/>.</summary>
+        public double DevelopingScore { get; set; } = 25;
+
+        #region Licence-opportunity tuning
+
+        /// <summary>
+        /// Weight of "already using Copilot Chat without a seat" in the licence-opportunity score.
+        /// The heaviest weight by design: it is the only signal that is evidence of demand for Copilot
+        /// specifically, rather than an inference from general Microsoft 365 activity.
+        /// </summary>
+        public double OpportunityUnlicensedCopilotWeight { get; set; } = 35;
+
+        /// <summary>Weight of Teams collaboration volume (messages, meetings, calls).</summary>
+        public double OpportunityCollaborationWeight { get; set; } = 25;
+
+        /// <summary>Weight of email volume (sent + read).</summary>
+        public double OpportunityEmailWeight { get; set; } = 20;
+
+        /// <summary>Weight of document work (SharePoint / OneDrive files viewed or edited).</summary>
+        public double OpportunityDocumentWeight { get; set; } = 20;
+
+        /// <summary>Unlicensed Copilot interactions in the window that score full marks for that component.</summary>
+        public double OpportunityCopilotTarget { get; set; } = 20;
+
+        /// <summary>Teams messages + meetings on the latest daily snapshot that score full marks.</summary>
+        public double OpportunityCollaborationTarget { get; set; } = 60;
+
+        /// <summary>Emails sent + read on the latest daily snapshot that score full marks.</summary>
+        public double OpportunityEmailTarget { get; set; } = 80;
+
+        /// <summary>Files viewed or edited on the latest daily snapshot that score full marks.</summary>
+        public double OpportunityDocumentTarget { get; set; } = 40;
+
+        /// <summary>
+        /// Opportunity score at or above which an unlicensed user is counted as a recommended licence
+        /// candidate in the headline figures.
+        /// </summary>
+        public double OpportunityRecommendScore { get; set; } = 50;
+
+        #endregion
+
+        /// <summary>
+        /// Hard ceiling on how many licensed users are pulled into memory to be scored. The scored set
+        /// is held in C# (not SQL) so that the scoring rules have exactly one implementation, which is
+        /// unit-testable and shared with any future scheduled report - see
+        /// <see cref="CopilotAdoptionScoring"/>. Copilot seats are purchased individually, so even a
+        /// very large customer is far below this; if it is ever hit the result carries an explicit
+        /// warning rather than silently truncating a licence-spend report.
+        /// </summary>
+        public int MaxLicensedUsersScored { get; set; } = 50000;
+
+        /// <summary>How many unlicensed candidates the database ranks and returns for the opportunity list.</summary>
+        public int MaxOpportunityCandidates { get; set; } = 5000;
+
+        /// <summary>
+        /// Microsoft publishes the usage reports a couple of days in arrears and keeps back-filling a
+        /// report date for a short while after it appears, so snapshots newer than this are ignored.
+        /// Mirrors the Reports area's <c>UsageReportLagDays</c>.
+        /// </summary>
+        public int UsageReportLagDays { get; set; } = 3;
+
+        /// <summary>Number of segments (departments, countries...) returned in the breakdown charts.</summary>
+        public int TopSegments { get; set; } = 10;
+
+        /// <summary>
+        /// Minimum seats a segment needs before it appears in the "adoption by department" chart. A
+        /// department with two seats and one active user is a 50% data point that means nothing, and
+        /// putting it in front of an executive invites the wrong decision.
+        /// </summary>
+        public int MinSeatsPerSegment { get; set; } = 5;
+
+        public static CopilotAdoptionOptions Default => new CopilotAdoptionOptions();
+    }
+
+    #endregion
+
+    #region Licence classification
+
+    /// <summary>A row of <c>dbo.license_types</c> plus how many users hold it.</summary>
+    public class LicenceTypeRow
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string SkuPartNumber { get; set; }
+
+        public int AssignedUsers { get; set; }
+    }
+
+    /// <summary>A licence type and whether the tool counted it as a Microsoft 365 Copilot seat.</summary>
+    public class LicenceTypeClassification
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("skuPartNumber")]
+        public string SkuPartNumber { get; set; }
+
+        [JsonProperty("assignedUsers")]
+        public int AssignedUsers { get; set; }
+
+        [JsonProperty("isCopilotSeat")]
+        public bool IsCopilotSeat { get; set; }
+    }
+
+    #endregion
+
+    #region Adoption bands
+
+    /// <summary>
+    /// How embedded Copilot is in one licensed user's working week. Ordered from worst to best so a
+    /// distribution reads left to right as a maturity curve.
+    ///
+    /// The split between <see cref="NeverUsed"/> and <see cref="Dormant"/> is the one that pays for
+    /// itself: a user who never started needs onboarding, a user who tried Copilot and stopped needs
+    /// either a conversation or their seat reclaiming, and averaging the two together hides both.
+    /// </summary>
+    public enum AdoptionBand
+    {
+        /// <summary>Holds a seat and has no recorded Copilot activity at all within the history window.</summary>
+        NeverUsed = 0,
+
+        /// <summary>Used Copilot before the reporting window but not once inside it.</summary>
+        Dormant = 1,
+
+        /// <summary>Some activity in the window, but well below a working habit.</summary>
+        Trialling = 2,
+
+        /// <summary>Using Copilot regularly enough to be building a habit.</summary>
+        Developing = 3,
+
+        /// <summary>Copilot is part of the working week.</summary>
+        Established = 4,
+
+        /// <summary>Deep, frequent, multi-app use - the people to recruit as internal advocates.</summary>
+        Champion = 5,
+    }
+
+    #endregion
+
+    #region Per-user rows
+
+    /// <summary>
+    /// One licensed user's raw, un-scored signals, exactly as the database returns them. Kept separate
+    /// from the scored row so the scoring rules can be unit-tested against hand-written inputs with no
+    /// database involved.
+    /// </summary>
+    public class LicensedUserUsageRow
+    {
+        public int UserId { get; set; }
+
+        public string UserPrincipalName { get; set; }
+
+        public string Mail { get; set; }
+
+        public string Department { get; set; }
+
+        public string JobTitle { get; set; }
+
+        public string Country { get; set; }
+
+        public string OfficeLocation { get; set; }
+
+        public string CompanyName { get; set; }
+
+        public string ManagerUserPrincipalName { get; set; }
+
+        public bool? AccountEnabled { get; set; }
+
+        /// <summary>Copilot seat SKUs held, comma separated (a user can hold more than one).</summary>
+        public string SeatLicences { get; set; }
+
+        #region Audit-log derived (all users, including Copilot Chat with no seat)
+
+        /// <summary>Copilot interactions inside the reporting window.</summary>
+        public long Interactions { get; set; }
+
+        /// <summary>Distinct calendar days inside the window with at least one interaction.</summary>
+        public int ActiveDays { get; set; }
+
+        /// <summary>Distinct Copilot surfaces (app hosts) used inside the window.</summary>
+        public int AppsUsed { get; set; }
+
+        /// <summary>Interactions inside the window attributed to Microsoft 365 Copilot Cowork.</summary>
+        public long CoworkInteractions { get; set; }
+
+        /// <summary>Distinct Copilot agents used inside the window.</summary>
+        public int AgentsUsed { get; set; }
+
+        /// <summary>Earliest interaction within the history window (not necessarily all time).</summary>
+        public DateTime? FirstInteractionUtc { get; set; }
+
+        /// <summary>Most recent interaction within the history window.</summary>
+        public DateTime? LastInteractionUtc { get; set; }
+
+        /// <summary>Interactions between the start of the history window and the start of the reporting window.</summary>
+        public long PriorInteractions { get; set; }
+
+        #endregion
+
+        #region Microsoft Graph Copilot usage report (licensed users only)
+
+        /// <summary>Prompts submitted across all Copilot apps, per Microsoft's own report.</summary>
+        public int? ReportPrompts { get; set; }
+
+        /// <summary>Days active in Microsoft's report window.</summary>
+        public int? ReportActiveDays { get; set; }
+
+        /// <summary>
+        /// How many Copilot apps Microsoft's report shows activity in during the reporting window,
+        /// counted from its per-app last-activity dates. Only used when the audit import is
+        /// unavailable, where it is the sole breadth-of-use signal.
+        /// </summary>
+        public int? ReportAppsUsed { get; set; }
+
+        /// <summary>Last activity date Microsoft reports for this user, across any Copilot app.</summary>
+        public DateTime? ReportLastActivityUtc { get; set; }
+
+        /// <summary>Last date Microsoft reports the user used a Copilot agent.</summary>
+        public DateTime? ReportAgentLastActivityUtc { get; set; }
+
+        #endregion
+    }
+
+    /// <summary>A licensed user with the adoption maths applied. This is what the UI lists and the CSV exports.</summary>
+    public class LicensedUserAdoptionRow
+    {
+        [JsonProperty("userId")]
+        public int UserId { get; set; }
+
+        [JsonProperty("userPrincipalName")]
+        public string UserPrincipalName { get; set; }
+
+        [JsonProperty("mail")]
+        public string Mail { get; set; }
+
+        [JsonProperty("department")]
+        public string Department { get; set; }
+
+        [JsonProperty("jobTitle")]
+        public string JobTitle { get; set; }
+
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("officeLocation")]
+        public string OfficeLocation { get; set; }
+
+        [JsonProperty("companyName")]
+        public string CompanyName { get; set; }
+
+        [JsonProperty("manager")]
+        public string ManagerUserPrincipalName { get; set; }
+
+        [JsonProperty("accountEnabled")]
+        public bool? AccountEnabled { get; set; }
+
+        [JsonProperty("seatLicences")]
+        public string SeatLicences { get; set; }
+
+        [JsonProperty("interactions")]
+        public long Interactions { get; set; }
+
+        [JsonProperty("activeDays")]
+        public int ActiveDays { get; set; }
+
+        [JsonProperty("expectedActiveDays")]
+        public double ExpectedActiveDays { get; set; }
+
+        [JsonProperty("appsUsed")]
+        public int AppsUsed { get; set; }
+
+        [JsonProperty("agentsUsed")]
+        public int AgentsUsed { get; set; }
+
+        [JsonProperty("coworkInteractions")]
+        public long CoworkInteractions { get; set; }
+
+        [JsonProperty("usedCowork")]
+        public bool UsedCowork { get; set; }
+
+        [JsonProperty("firstInteractionUtc")]
+        public DateTime? FirstInteractionUtc { get; set; }
+
+        [JsonProperty("lastInteractionUtc")]
+        public DateTime? LastInteractionUtc { get; set; }
+
+        [JsonProperty("daysSinceLastUse")]
+        public int? DaysSinceLastUse { get; set; }
+
+        [JsonProperty("reportPrompts")]
+        public int? ReportPrompts { get; set; }
+
+        [JsonProperty("reportActiveDays")]
+        public int? ReportActiveDays { get; set; }
+
+        [JsonProperty("reportLastActivityUtc")]
+        public DateTime? ReportLastActivityUtc { get; set; }
+
+        /// <summary>Overall engagement, 0-100. See <see cref="CopilotAdoptionScoring"/> for the formula.</summary>
+        [JsonProperty("adoptionScore")]
+        public double AdoptionScore { get; set; }
+
+        /// <summary>Frequency component, 0-100 (how many of the available working days were used).</summary>
+        [JsonProperty("frequencyScore")]
+        public double FrequencyScore { get; set; }
+
+        /// <summary>Depth component, 0-100 (interactions per active day).</summary>
+        [JsonProperty("depthScore")]
+        public double DepthScore { get; set; }
+
+        /// <summary>Breadth component, 0-100 (how many Copilot surfaces were used).</summary>
+        [JsonProperty("breadthScore")]
+        public double BreadthScore { get; set; }
+
+        [JsonProperty("band")]
+        public AdoptionBand Band { get; set; }
+
+        /// <summary>Human-readable band, so the CSV and the UI never disagree about the wording.</summary>
+        [JsonProperty("bandName")]
+        public string BandName { get; set; }
+
+        /// <summary>
+        /// Which signal the score was built from: <c>audit</c> (our own Copilot audit-log import, which
+        /// matches the requested window exactly) or <c>usageReport</c> (Microsoft's per-user report,
+        /// used when the audit import is unavailable - its window is Microsoft's, not ours).
+        /// Exported so a number can never be quoted without knowing where it came from.
+        /// </summary>
+        [JsonProperty("signalSource")]
+        public string SignalSource { get; set; }
+
+        /// <summary>
+        /// The single recommended next step for this user, in plain English. This is what makes the
+        /// export actionable rather than merely informative.
+        /// </summary>
+        [JsonProperty("recommendedAction")]
+        public string RecommendedAction { get; set; }
+    }
+
+    /// <summary>
+    /// One unlicensed user's raw signals: their Microsoft 365 activity, plus any Copilot Chat use they
+    /// already have without a seat.
+    /// </summary>
+    public class UnlicensedUserSignalRow
+    {
+        public int UserId { get; set; }
+
+        public string UserPrincipalName { get; set; }
+
+        public string Mail { get; set; }
+
+        public string Department { get; set; }
+
+        public string JobTitle { get; set; }
+
+        public string Country { get; set; }
+
+        public string OfficeLocation { get; set; }
+
+        public string CompanyName { get; set; }
+
+        public string ManagerUserPrincipalName { get; set; }
+
+        /// <summary>Copilot interactions in the window with no Copilot seat assigned (i.e. Copilot Chat).</summary>
+        public long UnlicensedCopilotInteractions { get; set; }
+
+        public int UnlicensedCopilotActiveDays { get; set; }
+
+        public DateTime? LastCopilotInteractionUtc { get; set; }
+
+        /// <summary>Teams chat + channel messages on the latest settled usage-report snapshot.</summary>
+        public long TeamsMessages { get; set; }
+
+        /// <summary>Teams meetings attended on the latest settled usage-report snapshot.</summary>
+        public long TeamsMeetings { get; set; }
+
+        public long EmailsSent { get; set; }
+
+        public long EmailsRead { get; set; }
+
+        /// <summary>SharePoint + OneDrive files viewed or edited on the latest settled snapshot.</summary>
+        public long FilesViewedOrEdited { get; set; }
+
+        /// <summary>Most recent activity date across the Microsoft 365 usage reports.</summary>
+        public DateTime? LastM365ActivityUtc { get; set; }
+    }
+
+    /// <summary>An unlicensed user ranked as a candidate for a Copilot seat.</summary>
+    public class LicenceOpportunityRow
+    {
+        [JsonProperty("userId")]
+        public int UserId { get; set; }
+
+        [JsonProperty("userPrincipalName")]
+        public string UserPrincipalName { get; set; }
+
+        [JsonProperty("mail")]
+        public string Mail { get; set; }
+
+        [JsonProperty("department")]
+        public string Department { get; set; }
+
+        [JsonProperty("jobTitle")]
+        public string JobTitle { get; set; }
+
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("officeLocation")]
+        public string OfficeLocation { get; set; }
+
+        [JsonProperty("companyName")]
+        public string CompanyName { get; set; }
+
+        [JsonProperty("manager")]
+        public string ManagerUserPrincipalName { get; set; }
+
+        [JsonProperty("unlicensedCopilotInteractions")]
+        public long UnlicensedCopilotInteractions { get; set; }
+
+        [JsonProperty("unlicensedCopilotActiveDays")]
+        public int UnlicensedCopilotActiveDays { get; set; }
+
+        [JsonProperty("lastCopilotInteractionUtc")]
+        public DateTime? LastCopilotInteractionUtc { get; set; }
+
+        [JsonProperty("teamsMessages")]
+        public long TeamsMessages { get; set; }
+
+        [JsonProperty("teamsMeetings")]
+        public long TeamsMeetings { get; set; }
+
+        [JsonProperty("emailsSent")]
+        public long EmailsSent { get; set; }
+
+        [JsonProperty("emailsRead")]
+        public long EmailsRead { get; set; }
+
+        [JsonProperty("filesViewedOrEdited")]
+        public long FilesViewedOrEdited { get; set; }
+
+        [JsonProperty("lastM365ActivityUtc")]
+        public DateTime? LastM365ActivityUtc { get; set; }
+
+        /// <summary>0-100. Higher means a stronger business case for giving this person a seat.</summary>
+        [JsonProperty("opportunityScore")]
+        public double OpportunityScore { get; set; }
+
+        [JsonProperty("copilotDemandScore")]
+        public double CopilotDemandScore { get; set; }
+
+        [JsonProperty("collaborationScore")]
+        public double CollaborationScore { get; set; }
+
+        [JsonProperty("emailScore")]
+        public double EmailScore { get; set; }
+
+        [JsonProperty("documentScore")]
+        public double DocumentScore { get; set; }
+
+        /// <summary>True when the score clears <see cref="CopilotAdoptionOptions.OpportunityRecommendScore"/>.</summary>
+        [JsonProperty("recommended")]
+        public bool Recommended { get; set; }
+
+        /// <summary>Plain-English justification, safe to paste into a licence request.</summary>
+        [JsonProperty("rationale")]
+        public string Rationale { get; set; }
+    }
+
+    #endregion
+
+    #region Charts and summary
+
+    /// <summary>
+    /// One point of a weekly series. Serialises to the same JSON shape as the Reports area's
+    /// <c>ReportTimePoint</c> so the SPA's existing chart components render this with no new code.
+    /// A null value means "unknown" (e.g. the week's usage report never arrived) and is drawn as a
+    /// gap rather than a misleading drop to zero.
+    /// </summary>
+    public class AdoptionTimePoint
+    {
+        [JsonProperty("weekStart")]
+        public DateTime WeekStart { get; set; }
+
+        [JsonProperty("value")]
+        public double? Value { get; set; }
+    }
+
+    /// <summary>A named line in a weekly chart. Same JSON shape as the Reports area's <c>ReportSeries</c>.</summary>
+    public class AdoptionSeries
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("points")]
+        public List<AdoptionTimePoint> Points { get; set; } = new List<AdoptionTimePoint>();
+    }
+
+    /// <summary>One bar of a categorical chart. Same JSON shape as the Reports area's <c>ReportCategory</c>.</summary>
+    public class AdoptionCategory
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("value")]
+        public double Value { get; set; }
+    }
+
+    /// <summary>
+    /// Adoption for one slice of the organisation (a department, country, office...). Carries the raw
+    /// counts as well as the percentage: "40% adopted" means something very different across 5 seats
+    /// and across 500, and an executive summary that shows only the percentage invites the wrong call.
+    /// </summary>
+    public class AdoptionSegmentRow
+    {
+        [JsonProperty("segment")]
+        public string Segment { get; set; }
+
+        [JsonProperty("licensedUsers")]
+        public int LicensedUsers { get; set; }
+
+        [JsonProperty("activeUsers")]
+        public int ActiveUsers { get; set; }
+
+        [JsonProperty("habitualUsers")]
+        public int HabitualUsers { get; set; }
+
+        [JsonProperty("neverUsedUsers")]
+        public int NeverUsedUsers { get; set; }
+
+        [JsonProperty("adoptionRatePct")]
+        public double AdoptionRatePct { get; set; }
+
+        [JsonProperty("averageAdoptionScore")]
+        public double AverageAdoptionScore { get; set; }
+    }
+
+    /// <summary>Which underlying imports actually supplied data, so no headline number is silently wrong.</summary>
+    public class AdoptionDataSources
+    {
+        /// <summary>The Copilot audit-log import (<c>copilot_chats</c>) is enabled and has data.</summary>
+        [JsonProperty("auditAvailable")]
+        public bool AuditAvailable { get; set; }
+
+        /// <summary>Microsoft's own per-user Copilot usage report has been imported.</summary>
+        [JsonProperty("copilotUsageReportAvailable")]
+        public bool CopilotUsageReportAvailable { get; set; }
+
+        /// <summary>The Microsoft 365 workload usage reports (Teams/Outlook/SharePoint/OneDrive) have data.</summary>
+        [JsonProperty("m365UsageReportsAvailable")]
+        public bool M365UsageReportsAvailable { get; set; }
+
+        /// <summary>User metadata (departments, managers, licences) has been imported.</summary>
+        [JsonProperty("userMetadataAvailable")]
+        public bool UserMetadataAvailable { get; set; }
+
+        /// <summary>The report snapshot date the per-user Copilot figures came from.</summary>
+        [JsonProperty("copilotUsageReportDate")]
+        public DateTime? CopilotUsageReportDate { get; set; }
+
+        /// <summary>The snapshot date the Microsoft 365 workload figures came from.</summary>
+        [JsonProperty("m365UsageReportDate")]
+        public DateTime? M365UsageReportDate { get; set; }
+
+        /// <summary>
+        /// True when the tenant has "concealed user information" switched on, so Microsoft's per-user
+        /// report is unusable. Audit-derived figures are unaffected, which is worth saying out loud
+        /// because the two sources otherwise appear to contradict each other.
+        /// </summary>
+        [JsonProperty("copilotUsageReportObfuscated")]
+        public bool CopilotUsageReportObfuscated { get; set; }
+    }
+
+    /// <summary>The executive view: headline numbers, the adoption funnel and the breakdown charts.</summary>
+    public class CopilotAdoptionSummary
+    {
+        [JsonProperty("generatedUtc")]
+        public DateTime GeneratedUtc { get; set; }
+
+        [JsonProperty("windowDays")]
+        public int WindowDays { get; set; }
+
+        [JsonProperty("fromUtc")]
+        public DateTime FromUtc { get; set; }
+
+        [JsonProperty("toUtc")]
+        public DateTime ToUtc { get; set; }
+
+        [JsonProperty("dataSources")]
+        public AdoptionDataSources DataSources { get; set; } = new AdoptionDataSources();
+
+        /// <summary>Which licence types were counted as Copilot seats, so the population is auditable.</summary>
+        [JsonProperty("seatLicenceTypes")]
+        public List<LicenceTypeClassification> SeatLicenceTypes { get; set; } = new List<LicenceTypeClassification>();
+
+        #region Headline figures
+
+        /// <summary>Users holding at least one Microsoft 365 Copilot seat.</summary>
+        [JsonProperty("licensedUsers")]
+        public int LicensedUsers { get; set; }
+
+        /// <summary>Licensed users with at least one Copilot interaction inside the window.</summary>
+        [JsonProperty("activeUsers")]
+        public int ActiveUsers { get; set; }
+
+        /// <summary>Licensed users with no recorded Copilot activity at all in the history window.</summary>
+        [JsonProperty("neverUsedUsers")]
+        public int NeverUsedUsers { get; set; }
+
+        /// <summary>Licensed users who used Copilot before the window but not inside it.</summary>
+        [JsonProperty("dormantUsers")]
+        public int DormantUsers { get; set; }
+
+        /// <summary>Active licensed users as a percentage of all licensed users.</summary>
+        [JsonProperty("adoptionRatePct")]
+        public double AdoptionRatePct { get; set; }
+
+        /// <summary>Licensed users whose engagement is Established or Champion - i.e. Copilot is a habit.</summary>
+        [JsonProperty("habitualUsers")]
+        public int HabitualUsers { get; set; }
+
+        [JsonProperty("habitRatePct")]
+        public double HabitRatePct { get; set; }
+
+        /// <summary>
+        /// Seats held by users who did nothing in the window: the directly actionable number. These are
+        /// candidates for reassignment to the people on the opportunity list, or for a targeted
+        /// enablement push before the next renewal.
+        /// </summary>
+        [JsonProperty("reclaimableSeats")]
+        public int ReclaimableSeats { get; set; }
+
+        /// <summary>Mean engagement score across all licensed users, including the ones scoring zero.</summary>
+        [JsonProperty("averageAdoptionScore")]
+        public double AverageAdoptionScore { get; set; }
+
+        /// <summary>Median engagement score - reported alongside the mean because a few Champions skew the mean upwards.</summary>
+        [JsonProperty("medianAdoptionScore")]
+        public double MedianAdoptionScore { get; set; }
+
+        [JsonProperty("totalInteractions")]
+        public long TotalInteractions { get; set; }
+
+        #endregion
+
+        #region Cowork
+
+        /// <summary>Licensed users who used Microsoft 365 Copilot Cowork inside the window.</summary>
+        [JsonProperty("coworkUsers")]
+        public int CoworkUsers { get; set; }
+
+        [JsonProperty("coworkAdoptionPct")]
+        public double CoworkAdoptionPct { get; set; }
+
+        [JsonProperty("coworkInteractions")]
+        public long CoworkInteractions { get; set; }
+
+        /// <summary>
+        /// False when nothing in the data identifies Cowork at all - which on a tenant that has not
+        /// been enabled for it is the correct and expected answer, and must not be shown as "0% adoption".
+        /// </summary>
+        [JsonProperty("coworkDetected")]
+        public bool CoworkDetected { get; set; }
+
+        #endregion
+
+        #region Licence opportunity
+
+        /// <summary>Users with no Copilot seat who nevertheless used Copilot Chat inside the window.</summary>
+        [JsonProperty("unlicensedActiveUsers")]
+        public int UnlicensedActiveUsers { get; set; }
+
+        /// <summary>Unlicensed users scoring at or above the recommendation threshold.</summary>
+        [JsonProperty("recommendedForLicence")]
+        public int RecommendedForLicence { get; set; }
+
+        #endregion
+
+        #region Charts
+
+        /// <summary>Licensed -&gt; ever used -&gt; active -&gt; habitual -&gt; champion. The story in one chart.</summary>
+        [JsonProperty("funnel")]
+        public List<AdoptionCategory> Funnel { get; set; } = new List<AdoptionCategory>();
+
+        /// <summary>How many licensed users fall in each <see cref="AdoptionBand"/>.</summary>
+        [JsonProperty("bandBreakdown")]
+        public List<AdoptionCategory> BandBreakdown { get; set; } = new List<AdoptionCategory>();
+
+        /// <summary>Adoption by department, worst first - i.e. where enablement effort should go.</summary>
+        [JsonProperty("adoptionByDepartment")]
+        public List<AdoptionSegmentRow> AdoptionByDepartment { get; set; } = new List<AdoptionSegmentRow>();
+
+        /// <summary>Adoption by country, for organisations that run enablement regionally.</summary>
+        [JsonProperty("adoptionByCountry")]
+        public List<AdoptionSegmentRow> AdoptionByCountry { get; set; } = new List<AdoptionSegmentRow>();
+
+        /// <summary>Where Copilot is actually being used (Teams, Word, Outlook, Copilot Chat...).</summary>
+        [JsonProperty("usageByApp")]
+        public List<AdoptionCategory> UsageByApp { get; set; } = new List<AdoptionCategory>();
+
+        /// <summary>Departments with the most unlicensed users who would benefit from a seat.</summary>
+        [JsonProperty("opportunityByDepartment")]
+        public List<AdoptionCategory> OpportunityByDepartment { get; set; } = new List<AdoptionCategory>();
+
+        /// <summary>Weekly active licensed users, so a trend is visible rather than a single snapshot.</summary>
+        [JsonProperty("weeklyTrend")]
+        public List<AdoptionSeries> WeeklyTrend { get; set; } = new List<AdoptionSeries>();
+
+        #endregion
+
+        /// <summary>The tuning actually used, echoed back so every figure can be traced to its rule.</summary>
+        [JsonProperty("options")]
+        public CopilotAdoptionOptions Options { get; set; }
+
+        /// <summary>
+        /// Anything that makes a number less trustworthy than it looks - a missing import, a capped
+        /// result set, a query that failed. Surfaced prominently rather than logged, because this
+        /// report is used to make spending decisions.
+        /// </summary>
+        [JsonProperty("warnings")]
+        public List<string> Warnings { get; set; } = new List<string>();
+    }
+
+    /// <summary>Which parts of the adoption tool this deployment can actually show.</summary>
+    public class CopilotAdoptionAvailability
+    {
+        /// <summary>False when neither Copilot data source is imported - the tool then has nothing to say.</summary>
+        [JsonProperty("available")]
+        public bool Available { get; set; }
+
+        [JsonProperty("copilotAuditImportEnabled")]
+        public bool CopilotAuditImportEnabled { get; set; }
+
+        [JsonProperty("copilotUsageReportImportEnabled")]
+        public bool CopilotUsageReportImportEnabled { get; set; }
+
+        [JsonProperty("userMetadataImportEnabled")]
+        public bool UserMetadataImportEnabled { get; set; }
+
+        [JsonProperty("m365UsageReportImportEnabled")]
+        public bool M365UsageReportImportEnabled { get; set; }
+
+        /// <summary>Explains, in plain English, anything that is switched off and what it costs the report.</summary>
+        [JsonProperty("messages")]
+        public List<string> Messages { get; set; } = new List<string>();
+    }
+
+    /// <summary>A page of scored licensed users, plus the totals for the filtered set.</summary>
+    public class LicensedUserPage
+    {
+        [JsonProperty("total")]
+        public int Total { get; set; }
+
+        [JsonProperty("skip")]
+        public int Skip { get; set; }
+
+        [JsonProperty("take")]
+        public int Take { get; set; }
+
+        [JsonProperty("rows")]
+        public List<LicensedUserAdoptionRow> Rows { get; set; } = new List<LicensedUserAdoptionRow>();
+
+        [JsonProperty("warnings")]
+        public List<string> Warnings { get; set; } = new List<string>();
+    }
+
+    /// <summary>A page of ranked licence-opportunity candidates.</summary>
+    public class LicenceOpportunityPage
+    {
+        [JsonProperty("total")]
+        public int Total { get; set; }
+
+        [JsonProperty("skip")]
+        public int Skip { get; set; }
+
+        [JsonProperty("take")]
+        public int Take { get; set; }
+
+        [JsonProperty("rows")]
+        public List<LicenceOpportunityRow> Rows { get; set; } = new List<LicenceOpportunityRow>();
+
+        [JsonProperty("warnings")]
+        public List<string> Warnings { get; set; } = new List<string>();
+    }
+
+    #endregion
+}

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionScoring.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionScoring.cs
@@ -1,0 +1,516 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Common.Entities.CopilotAdoption
+{
+    /// <summary>
+    /// Every adoption calculation in this feature, as pure functions over plain inputs.
+    ///
+    /// This is deliberately the <b>only</b> implementation of the maths. Nothing is computed in SQL
+    /// that is also computed here, because the output of this tool is used to justify licence spend
+    /// and to decide who gets training: a rule that exists twice will eventually disagree with itself,
+    /// and the version an executive sees would then depend on which screen they opened. Keeping it in
+    /// C# also means it can be unit-tested against hand-written inputs, and reused verbatim by a
+    /// scheduled e-mail report later without lifting any of it out of a controller.
+    ///
+    /// The one exception is <see cref="BuildOpportunityScoreSql"/>, which emits a SQL expression for
+    /// the same formula so the database can rank hundreds of thousands of unlicensed users and return
+    /// only the top candidates. It is generated from the same <see cref="CopilotAdoptionOptions"/>
+    /// instance, and the returned rows are always re-scored here before display, so the SQL is a
+    /// ranking aid rather than a second source of truth.
+    /// </summary>
+    public static class CopilotAdoptionScoring
+    {
+        /// <summary>Score built from our own Copilot audit-log import.</summary>
+        public const string SignalSourceAudit = "audit";
+
+        /// <summary>Score built from Microsoft's per-user Copilot usage report.</summary>
+        public const string SignalSourceUsageReport = "usageReport";
+
+        #region Licensed-user engagement
+
+        /// <summary>
+        /// Working days available in the window - the denominator a fully engaged user is measured
+        /// against. Calendar days would be the wrong denominator: someone using Copilot every single
+        /// working day would top out around 71% and look like a partial adopter.
+        /// </summary>
+        public static double AvailableWorkingDays(CopilotAdoptionOptions options)
+        {
+            var o = options ?? CopilotAdoptionOptions.Default;
+            var windowDays = Math.Max(1, o.WindowDays);
+            var perWeek = o.WorkingDaysPerWeek <= 0 ? 5 : o.WorkingDaysPerWeek;
+            return windowDays * perWeek / 7d;
+        }
+
+        /// <summary>
+        /// Days of use inside the window that earn full marks for frequency. Reported to the user next
+        /// to their actual active days so "62%" is never an unexplained number.
+        /// </summary>
+        public static double TargetActiveDays(CopilotAdoptionOptions options)
+        {
+            var o = options ?? CopilotAdoptionOptions.Default;
+            var ratio = o.FrequencyTargetRatio <= 0 ? 1 : o.FrequencyTargetRatio;
+            return Math.Max(1d, AvailableWorkingDays(o) * ratio);
+        }
+
+        /// <summary>
+        /// Turns one licensed user's raw signals into a scored, banded, actionable row.
+        /// </summary>
+        /// <param name="row">The user's raw counters, straight from the database.</param>
+        /// <param name="windowStartUtc">Start of the reporting window (inclusive).</param>
+        /// <param name="nowUtc">"Now", used for the days-since-last-use figure. Passed in so tests are deterministic.</param>
+        /// <param name="auditAvailable">
+        /// Whether the Copilot audit-log import supplied data. When it did not, Microsoft's per-user
+        /// usage report is used instead - otherwise every user would score zero and the entire licensed
+        /// population would be reported as "never used", which is both wrong and expensive.
+        /// </param>
+        /// <param name="options">Tuning; <see cref="CopilotAdoptionOptions.Default"/> when null.</param>
+        public static LicensedUserAdoptionRow Score(
+            LicensedUserUsageRow row,
+            DateTime windowStartUtc,
+            DateTime nowUtc,
+            bool auditAvailable,
+            CopilotAdoptionOptions options = null)
+        {
+            if (row == null) throw new ArgumentNullException(nameof(row));
+            var o = options ?? CopilotAdoptionOptions.Default;
+
+            // Prefer our own audit data: it is bucketed to exactly the window that was asked for.
+            // Microsoft's report is the fallback, used in two cases: when the audit import supplied
+            // nothing at all, and - just as importantly - when it supplied nothing *for this user*
+            // while Microsoft says they were active. The second case is the dangerous one: an audit
+            // import that is lagging or partially failed would otherwise report active people as
+            // "never used", and this list is used to decide whose seat gets taken away. The choice is
+            // recorded on the row rather than silently applied, because the report's window is
+            // Microsoft's own rather than the one that was requested here.
+            var auditHasSignal = row.Interactions > 0 || row.ActiveDays > 0;
+            var reportHasSignal = (row.ReportActiveDays ?? 0) > 0 || (row.ReportPrompts ?? 0) > 0;
+            var useReport = (!auditAvailable || !auditHasSignal) && reportHasSignal;
+
+            var activeDays = useReport ? (row.ReportActiveDays ?? 0) : row.ActiveDays;
+            var interactions = useReport ? (row.ReportPrompts ?? 0) : row.Interactions;
+            var appsUsed = useReport ? (row.ReportAppsUsed ?? 0) : row.AppsUsed;
+            var lastUse = useReport
+                ? row.ReportLastActivityUtc
+                : (row.LastInteractionUtc ?? row.ReportLastActivityUtc);
+
+            var targetActiveDays = TargetActiveDays(o);
+            var frequency = Ratio(activeDays, targetActiveDays);
+            var depth = activeDays > 0
+                ? Ratio((double)interactions / activeDays, o.DepthTargetInteractionsPerActiveDay)
+                : 0d;
+            var breadth = Ratio(appsUsed, o.BreadthTargetApps);
+
+            var weightSum = o.FrequencyWeight + o.DepthWeight + o.BreadthWeight;
+            var score = weightSum <= 0
+                ? 0d
+                : (frequency * o.FrequencyWeight + depth * o.DepthWeight + breadth * o.BreadthWeight)
+                  / weightSum * 100d;
+
+            var usedInWindow = interactions > 0 || activeDays > 0;
+            // "Ever" means "inside the history window we actually queried" - see
+            // CopilotAdoptionOptions.HistoryDays. Prior audit interactions are the primary signal; a
+            // report last-activity date before the window covers the report-only case.
+            var usedBeforeWindow = row.PriorInteractions > 0
+                || (lastUse.HasValue && lastUse.Value < windowStartUtc)
+                || (row.FirstInteractionUtc.HasValue && row.FirstInteractionUtc.Value < windowStartUtc);
+
+            var band = BandFor(score, usedInWindow, usedBeforeWindow, o);
+
+            var scored = new LicensedUserAdoptionRow
+            {
+                UserId = row.UserId,
+                UserPrincipalName = row.UserPrincipalName,
+                Mail = row.Mail,
+                Department = row.Department,
+                JobTitle = row.JobTitle,
+                Country = row.Country,
+                OfficeLocation = row.OfficeLocation,
+                CompanyName = row.CompanyName,
+                ManagerUserPrincipalName = row.ManagerUserPrincipalName,
+                AccountEnabled = row.AccountEnabled,
+                SeatLicences = row.SeatLicences,
+
+                Interactions = interactions,
+                ActiveDays = activeDays,
+                ExpectedActiveDays = Round(targetActiveDays, 1),
+                AppsUsed = appsUsed,
+                AgentsUsed = row.AgentsUsed,
+                CoworkInteractions = row.CoworkInteractions,
+                UsedCowork = row.CoworkInteractions > 0,
+                FirstInteractionUtc = row.FirstInteractionUtc,
+                LastInteractionUtc = lastUse,
+                DaysSinceLastUse = lastUse.HasValue
+                    ? (int?)Math.Max(0, (int)(nowUtc.Date - lastUse.Value.Date).TotalDays)
+                    : null,
+
+                ReportPrompts = row.ReportPrompts,
+                ReportActiveDays = row.ReportActiveDays,
+                ReportLastActivityUtc = row.ReportLastActivityUtc,
+
+                FrequencyScore = Round(frequency * 100d, 1),
+                DepthScore = Round(depth * 100d, 1),
+                BreadthScore = Round(breadth * 100d, 1),
+                AdoptionScore = Round(score, 1),
+                Band = band,
+                BandName = BandDisplayName(band),
+                SignalSource = useReport ? SignalSourceUsageReport : SignalSourceAudit,
+            };
+
+            scored.RecommendedAction = RecommendedAction(scored, o);
+            return scored;
+        }
+
+        /// <summary>
+        /// Which band a score falls in.
+        ///
+        /// Zero-score users are split into two very different populations before the thresholds are
+        /// applied at all: someone who has never used Copilot needs onboarding (or has a seat that
+        /// should go to someone else), whereas someone who used it and stopped needs a conversation
+        /// about what went wrong. Averaging them into one "not using it" bucket hides both problems.
+        /// </summary>
+        public static AdoptionBand BandFor(
+            double score,
+            bool usedInWindow,
+            bool usedBeforeWindow,
+            CopilotAdoptionOptions options = null)
+        {
+            var o = options ?? CopilotAdoptionOptions.Default;
+
+            if (!usedInWindow)
+            {
+                return usedBeforeWindow ? AdoptionBand.Dormant : AdoptionBand.NeverUsed;
+            }
+
+            if (score >= o.ChampionScore) return AdoptionBand.Champion;
+            if (score >= o.EstablishedScore) return AdoptionBand.Established;
+            if (score >= o.DevelopingScore) return AdoptionBand.Developing;
+            return AdoptionBand.Trialling;
+        }
+
+        /// <summary>Band name as shown in the UI, the charts and the CSV - one definition, so they agree.</summary>
+        public static string BandDisplayName(AdoptionBand band)
+        {
+            switch (band)
+            {
+                case AdoptionBand.NeverUsed: return "Never used";
+                case AdoptionBand.Dormant: return "Dormant";
+                case AdoptionBand.Trialling: return "Trialling";
+                case AdoptionBand.Developing: return "Developing";
+                case AdoptionBand.Established: return "Established";
+                case AdoptionBand.Champion: return "Champion";
+                default: return band.ToString();
+            }
+        }
+
+        /// <summary>All bands worst-first, so a distribution chart always shows every bucket - including
+        /// the empty ones, which are themselves informative.</summary>
+        public static IReadOnlyList<AdoptionBand> AllBands { get; } = new[]
+        {
+            AdoptionBand.NeverUsed,
+            AdoptionBand.Dormant,
+            AdoptionBand.Trialling,
+            AdoptionBand.Developing,
+            AdoptionBand.Established,
+            AdoptionBand.Champion,
+        };
+
+        /// <summary>
+        /// True when the user has made Copilot part of their working week. Used for the "habit rate"
+        /// headline, which is the figure that actually correlates with realised value - "has used it at
+        /// least once" is easy to hit and tells an executive nothing.
+        /// </summary>
+        public static bool IsHabitual(AdoptionBand band)
+        {
+            return band == AdoptionBand.Established || band == AdoptionBand.Champion;
+        }
+
+        /// <summary>
+        /// The single next step for this user, in plain English. Exported in the CSV so the list can be
+        /// handed to a department lead and acted on without further interpretation.
+        /// </summary>
+        public static string RecommendedAction(LicensedUserAdoptionRow row, CopilotAdoptionOptions options = null)
+        {
+            if (row == null) throw new ArgumentNullException(nameof(row));
+            var o = options ?? CopilotAdoptionOptions.Default;
+
+            switch (row.Band)
+            {
+                case AdoptionBand.NeverUsed:
+                    return $"Reclaim or onboard - no Copilot activity in the last {o.HistoryDays} days. "
+                         + "Confirm the seat is still needed before renewal.";
+
+                case AdoptionBand.Dormant:
+                    var since = row.DaysSinceLastUse.HasValue
+                        ? $"last used it {row.DaysSinceLastUse.Value} days ago"
+                        : "has used it in the past";
+                    return $"Re-engage - {since} but not once in this period. "
+                         + "Ask what stopped and offer a refresher, or reassign the seat.";
+
+                case AdoptionBand.Trialling:
+                    return "Coach - occasional use only. Target one repeatable Copilot habit in the app they "
+                         + "already live in.";
+
+                case AdoptionBand.Developing:
+                    return row.BreadthScore < 34
+                        ? $"Broaden - building a habit but only in {AppsPhrase(row.AppsUsed)}. Introduce a second "
+                          + "surface such as Outlook or Teams meeting recaps."
+                        : "Grow - a habit is forming. A short scenario-based session should move them to daily use.";
+
+                case AdoptionBand.Established:
+                    return row.BreadthScore < 50
+                        ? $"Sustain and broaden - solid regular use in {AppsPhrase(row.AppsUsed)}; "
+                          + "showing them one more surface is the cheapest remaining gain."
+                        : "Sustain - Copilot is part of their working week. No action needed.";
+
+                case AdoptionBand.Champion:
+                    // A Champion who only ever works in one surface is still leaving value on the
+                    // table, and is the cheapest possible win - so say so rather than congratulating
+                    // them and moving on.
+                    return row.BreadthScore < 50
+                        ? $"Recruit as an advocate, and broaden - deep, frequent use but only in "
+                          + $"{AppsPhrase(row.AppsUsed)}. Showing them one more surface is the cheapest gain available."
+                        : "Recruit as an advocate - among your deepest users. Ask them to run a peer session "
+                          + "for their department.";
+
+                default:
+                    return string.Empty;
+            }
+        }
+
+        #endregion
+
+        #region Licence opportunity (unlicensed users)
+
+        /// <summary>
+        /// Scores an unlicensed user as a candidate for a Copilot seat.
+        ///
+        /// The components are weighted so that <b>evidence beats inference</b>: someone already using
+        /// Copilot Chat without a seat has demonstrated demand for Copilot itself, which is a far
+        /// stronger argument than "sends a lot of email". The Microsoft 365 activity signals still
+        /// matter - they are what identifies the heavy knowledge workers who would benefit but have
+        /// never had the chance to try it - but they cannot on their own reach the recommendation
+        /// threshold from a standing start unless the user is heavy across several workloads.
+        /// </summary>
+        public static LicenceOpportunityRow ScoreOpportunity(
+            UnlicensedUserSignalRow row,
+            CopilotAdoptionOptions options = null)
+        {
+            if (row == null) throw new ArgumentNullException(nameof(row));
+            var o = options ?? CopilotAdoptionOptions.Default;
+
+            var copilot = Ratio(row.UnlicensedCopilotInteractions, o.OpportunityCopilotTarget);
+            var collaboration = Ratio(row.TeamsMessages + row.TeamsMeetings, o.OpportunityCollaborationTarget);
+            var email = Ratio(row.EmailsSent + row.EmailsRead, o.OpportunityEmailTarget);
+            var documents = Ratio(row.FilesViewedOrEdited, o.OpportunityDocumentTarget);
+
+            var score = copilot * o.OpportunityUnlicensedCopilotWeight
+                      + collaboration * o.OpportunityCollaborationWeight
+                      + email * o.OpportunityEmailWeight
+                      + documents * o.OpportunityDocumentWeight;
+
+            var scored = new LicenceOpportunityRow
+            {
+                UserId = row.UserId,
+                UserPrincipalName = row.UserPrincipalName,
+                Mail = row.Mail,
+                Department = row.Department,
+                JobTitle = row.JobTitle,
+                Country = row.Country,
+                OfficeLocation = row.OfficeLocation,
+                CompanyName = row.CompanyName,
+                ManagerUserPrincipalName = row.ManagerUserPrincipalName,
+
+                UnlicensedCopilotInteractions = row.UnlicensedCopilotInteractions,
+                UnlicensedCopilotActiveDays = row.UnlicensedCopilotActiveDays,
+                LastCopilotInteractionUtc = row.LastCopilotInteractionUtc,
+                TeamsMessages = row.TeamsMessages,
+                TeamsMeetings = row.TeamsMeetings,
+                EmailsSent = row.EmailsSent,
+                EmailsRead = row.EmailsRead,
+                FilesViewedOrEdited = row.FilesViewedOrEdited,
+                LastM365ActivityUtc = row.LastM365ActivityUtc,
+
+                CopilotDemandScore = Round(copilot * 100d, 1),
+                CollaborationScore = Round(collaboration * 100d, 1),
+                EmailScore = Round(email * 100d, 1),
+                DocumentScore = Round(documents * 100d, 1),
+                OpportunityScore = Round(score, 1),
+            };
+
+            scored.Recommended = scored.OpportunityScore >= o.OpportunityRecommendScore;
+            scored.Rationale = OpportunityRationale(scored);
+            return scored;
+        }
+
+        /// <summary>
+        /// A one-line, quotable justification for giving this person a seat. Written to be pasted
+        /// straight into a licence request, so it leads with the strongest evidence available.
+        /// </summary>
+        public static string OpportunityRationale(LicenceOpportunityRow row)
+        {
+            if (row == null) throw new ArgumentNullException(nameof(row));
+
+            var reasons = new List<string>();
+
+            if (row.UnlicensedCopilotInteractions > 0)
+            {
+                reasons.Add(
+                    $"already using Copilot Chat without a licence ({row.UnlicensedCopilotInteractions:N0} "
+                    + $"interaction{(row.UnlicensedCopilotInteractions == 1 ? string.Empty : "s")} "
+                    + $"across {row.UnlicensedCopilotActiveDays:N0} day{(row.UnlicensedCopilotActiveDays == 1 ? string.Empty : "s")})");
+            }
+
+            if (row.TeamsMessages + row.TeamsMeetings > 0)
+            {
+                reasons.Add($"{row.TeamsMessages:N0} Teams messages and {row.TeamsMeetings:N0} meetings");
+            }
+
+            if (row.EmailsSent + row.EmailsRead > 0)
+            {
+                reasons.Add($"{row.EmailsSent:N0} emails sent, {row.EmailsRead:N0} read");
+            }
+
+            if (row.FilesViewedOrEdited > 0)
+            {
+                reasons.Add($"{row.FilesViewedOrEdited:N0} files viewed or edited");
+            }
+
+            if (reasons.Count == 0)
+            {
+                return "No qualifying Microsoft 365 activity recorded in this period.";
+            }
+
+            return (row.Recommended ? "Recommended: " : "Candidate: ") + string.Join("; ", reasons) + ".";
+        }
+
+        /// <summary>
+        /// The <see cref="ScoreOpportunity"/> formula as a SQL expression, so the database can rank a
+        /// 200,000-user tenant and hand back only the strongest candidates. Pulling every unlicensed
+        /// user into memory to score them in C# is not an option at that size.
+        ///
+        /// Generated from the same options instance the C# scorer is given, and every returned row is
+        /// re-scored in C# before it is displayed or exported - so this expression decides <i>which</i>
+        /// users come back, never what their published score is.
+        /// </summary>
+        /// <param name="options">Tuning; must be the same instance/values used for the C# scoring.</param>
+        /// <param name="copilotColumn">SQL expression yielding the user's unlicensed Copilot interactions.</param>
+        /// <param name="teamsColumn">SQL expression yielding Teams messages.</param>
+        /// <param name="meetingsColumn">SQL expression yielding Teams meetings.</param>
+        /// <param name="emailSentColumn">SQL expression yielding emails sent.</param>
+        /// <param name="emailReadColumn">SQL expression yielding emails read.</param>
+        /// <param name="filesColumn">SQL expression yielding files viewed or edited.</param>
+        public static string BuildOpportunityScoreSql(
+            CopilotAdoptionOptions options,
+            string copilotColumn,
+            string teamsColumn,
+            string meetingsColumn,
+            string emailSentColumn,
+            string emailReadColumn,
+            string filesColumn)
+        {
+            var o = options ?? CopilotAdoptionOptions.Default;
+
+            // All column arguments are compile-time constants supplied by CopilotAdoptionSql, never
+            // user input, so there is no injection surface here.
+            return
+                Component(copilotColumn, o.OpportunityCopilotTarget, o.OpportunityUnlicensedCopilotWeight)
+                + " + " + Component($"({teamsColumn} + {meetingsColumn})", o.OpportunityCollaborationTarget, o.OpportunityCollaborationWeight)
+                + " + " + Component($"({emailSentColumn} + {emailReadColumn})", o.OpportunityEmailTarget, o.OpportunityEmailWeight)
+                + " + " + Component(filesColumn, o.OpportunityDocumentTarget, o.OpportunityDocumentWeight);
+        }
+
+        /// <summary>One weighted, capped component of the SQL opportunity score.</summary>
+        private static string Component(string valueSql, double target, double weight)
+        {
+            var safeTarget = target <= 0 ? 1 : target;
+            // CAST to float first so integer division never silently floors the ratio to 0 or 1.
+            return $"(CASE WHEN CAST({valueSql} AS float) / {Num(safeTarget)} > 1 THEN 1.0 "
+                 + $"ELSE CAST({valueSql} AS float) / {Num(safeTarget)} END) * {Num(weight)}";
+        }
+
+        #endregion
+
+        #region Aggregation helpers
+
+        /// <summary>
+        /// Rolls a scored population up into one segment row (a department, a country, the whole
+        /// tenant). Shared by the summary and by the per-segment charts so a department's adoption rate
+        /// is computed identically wherever it appears.
+        /// </summary>
+        public static AdoptionSegmentRow Summarise(string segment, IEnumerable<LicensedUserAdoptionRow> users)
+        {
+            var list = users as IList<LicensedUserAdoptionRow> ?? users?.ToList() ?? new List<LicensedUserAdoptionRow>();
+
+            var licensed = list.Count;
+            var active = list.Count(u => u.Band > AdoptionBand.Dormant);
+            var habitual = list.Count(u => IsHabitual(u.Band));
+            var never = list.Count(u => u.Band == AdoptionBand.NeverUsed);
+
+            return new AdoptionSegmentRow
+            {
+                Segment = segment,
+                LicensedUsers = licensed,
+                ActiveUsers = active,
+                HabitualUsers = habitual,
+                NeverUsedUsers = never,
+                AdoptionRatePct = Percentage(active, licensed),
+                AverageAdoptionScore = licensed == 0 ? 0 : Round(list.Average(u => u.AdoptionScore), 1),
+            };
+        }
+
+        /// <summary><paramref name="part"/> as a percentage of <paramref name="total"/>, to one decimal place; 0 when there is no total.</summary>
+        public static double Percentage(double part, double total)
+        {
+            if (total <= 0) return 0;
+            return Round(part / total * 100d, 1);
+        }
+
+        /// <summary>Median of a sequence, to one decimal place. 0 for an empty sequence.</summary>
+        public static double Median(IEnumerable<double> values)
+        {
+            var ordered = values?.OrderBy(v => v).ToList() ?? new List<double>();
+            if (ordered.Count == 0) return 0;
+
+            var mid = ordered.Count / 2;
+            var median = ordered.Count % 2 == 1
+                ? ordered[mid]
+                : (ordered[mid - 1] + ordered[mid]) / 2d;
+            return Round(median, 1);
+        }
+
+        #endregion
+
+        #region Primitives
+
+        /// <summary>A 0..1 ratio of value against target, guarding against a zero or negative target.</summary>
+        private static double Ratio(double value, double target)
+        {
+            if (target <= 0) return value > 0 ? 1d : 0d;
+            if (value <= 0) return 0d;
+            var ratio = value / target;
+            return ratio > 1d ? 1d : ratio;
+        }
+
+        private static double Round(double value, int decimals)
+        {
+            return Math.Round(value, decimals, MidpointRounding.AwayFromZero);
+        }
+
+        /// <summary>Formats a double for embedding in SQL - invariant culture, so a comma decimal
+        /// separator on a European server can never produce syntactically broken SQL.</summary>
+        private static string Num(double value)
+        {
+            return value.ToString("0.###############", CultureInfo.InvariantCulture);
+        }
+
+        private static string AppsPhrase(int appsUsed)
+        {
+            return appsUsed == 1 ? "a single Copilot app" : $"{appsUsed} Copilot apps";
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
@@ -1,0 +1,705 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Common.Entities.CopilotAdoption
+{
+    /// <summary>
+    /// The complete, scored output of one adoption analysis: the executive summary, every scored
+    /// licensed user and every ranked licence candidate.
+    ///
+    /// Produced in a single pass and then sliced in memory, so paging, filtering, sorting and CSV
+    /// export never re-run the heavy queries - and, more importantly, so the list an admin exports is
+    /// guaranteed to be the same data the summary on screen was calculated from. A CSV that quietly
+    /// disagrees with the chart above it is worse than no CSV.
+    /// </summary>
+    public class CopilotAdoptionAnalysis
+    {
+        public CopilotAdoptionSummary Summary { get; set; } = new CopilotAdoptionSummary();
+
+        public List<LicensedUserAdoptionRow> LicensedUsers { get; set; } = new List<LicensedUserAdoptionRow>();
+
+        public List<LicenceOpportunityRow> Opportunities { get; set; } = new List<LicenceOpportunityRow>();
+
+        /// <summary>
+        /// The queries that produced this analysis, keyed by a short name, for the SQL popover the rest
+        /// of the admin site uses. Showing the working is part of the point: these numbers get quoted
+        /// in licence negotiations, so an admin has to be able to verify them independently.
+        /// </summary>
+        public Dictionary<string, string> Sql { get; set; } = new Dictionary<string, string>();
+    }
+
+    /// <summary>
+    /// Runs the Copilot licence-adoption analysis.
+    ///
+    /// Lives in Common.Entities rather than in the web project so the same analysis can be driven from
+    /// a web-job later (scheduled adoption e-mails were an explicit requirement) without any of it
+    /// having to be lifted out of a controller first. The controller's only job is caching, paging and
+    /// serialisation.
+    ///
+    /// Every query is individually guarded: a failure degrades to a warning on the result rather than
+    /// failing the whole report, matching how the Reports area handles its heavy queries. A partially
+    /// complete report with an explicit caveat is far more useful to someone preparing a licence review
+    /// than an error page.
+    /// </summary>
+    public class CopilotAdoptionService
+    {
+        /// <summary>
+        /// Per-query timeout. Higher than the Reports area's 25s because this analysis is deliberate
+        /// and on-demand rather than a dashboard refresh, but still far below the ~230s at which Azure
+        /// App Service kills the request - so a struggling database produces a warning, not a 500.
+        /// </summary>
+        public const int QueryTimeoutSecs = 90;
+
+        /// <summary>How far back the weekly trend chart looks. Long enough to show whether an enablement push worked.</summary>
+        public const int TrendMonths = 6;
+
+        private readonly CopilotAdoptionOptions _options;
+        private readonly Func<AnalyticsEntitiesContext> _contextFactory;
+
+        public CopilotAdoptionService(
+            CopilotAdoptionOptions options = null,
+            Func<AnalyticsEntitiesContext> contextFactory = null)
+        {
+            _options = options ?? CopilotAdoptionOptions.Default;
+            _contextFactory = contextFactory ?? (() => new AnalyticsEntitiesContext());
+        }
+
+        public CopilotAdoptionOptions Options => _options;
+
+        /// <summary>
+        /// Runs the whole analysis.
+        /// </summary>
+        /// <param name="seatLicenceTypeIdOverride">
+        /// Optional explicit set of licence-type ids to treat as Copilot seats, for the case where the
+        /// automatic classification gets a new or unusual SKU wrong. Null means "classify automatically".
+        /// </param>
+        public async Task<CopilotAdoptionAnalysis> AnalyseAsync(
+            IEnumerable<int> seatLicenceTypeIdOverride = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var nowUtc = DateTime.UtcNow;
+            var windowStart = nowUtc.Date.AddDays(-Math.Max(1, _options.WindowDays));
+            var historyStart = nowUtc.Date.AddDays(-Math.Max(_options.WindowDays, _options.HistoryDays));
+            var settled = nowUtc.Date.AddDays(-Math.Max(0, _options.UsageReportLagDays));
+            var trendStart = MondayOf(nowUtc.Date.AddMonths(-TrendMonths));
+
+            var analysis = new CopilotAdoptionAnalysis();
+            var summary = analysis.Summary;
+            summary.GeneratedUtc = nowUtc;
+            summary.WindowDays = _options.WindowDays;
+            summary.FromUtc = windowStart;
+            summary.ToUtc = nowUtc;
+            summary.Options = _options;
+
+            // ----- 1. Which licence types count as a Copilot seat -------------------------------
+            var licenceTypes = await SafeAsync(
+                () => QueryAsync<LicenceTypeRow>(CopilotAdoptionSql.LicenceTypesSql, cancellationToken),
+                summary.Warnings,
+                "licence types");
+
+            if (licenceTypes == null || licenceTypes.Count == 0)
+            {
+                summary.Warnings.Add(
+                    "No licence information has been imported, so Copilot seats cannot be identified. "
+                    + "Enable the user metadata import to use this tool.");
+                return analysis;
+            }
+
+            summary.SeatLicenceTypes = CopilotLicenceClassifier.Classify(licenceTypes);
+            var seatIds = CopilotLicenceClassifier.ResolveSeatLicenceTypeIds(licenceTypes, seatLicenceTypeIdOverride);
+            summary.DataSources.UserMetadataAvailable = true;
+
+            if (seatIds.Count == 0)
+            {
+                summary.Warnings.Add(
+                    "No Microsoft 365 Copilot licences were found in this tenant. Adoption cannot be reported "
+                    + "until at least one Copilot seat is assigned and the user import has run.");
+                // The licence-opportunity side still works with no seats at all - that is exactly the
+                // "should we buy Copilot?" case - so carry on rather than returning here.
+            }
+
+            // ----- 2. Availability probes -------------------------------------------------------
+            summary.DataSources.AuditAvailable = await SafeScalarAsync(
+                CopilotAdoptionSql.HasCopilotAuditDataSql,
+                summary.Warnings,
+                "Copilot audit data probe",
+                cancellationToken,
+                new SqlParameter("@from", windowStart)) == 1;
+
+            summary.DataSources.CopilotUsageReportDate = await SafeDateAsync(
+                CopilotAdoptionSql.LatestCopilotReportDateSql,
+                summary.Warnings,
+                "Copilot usage-report snapshot date",
+                cancellationToken,
+                new SqlParameter("@settled", settled));
+            summary.DataSources.CopilotUsageReportAvailable = summary.DataSources.CopilotUsageReportDate.HasValue;
+
+            summary.DataSources.M365UsageReportDate = await SafeDateAsync(
+                CopilotAdoptionSql.LatestM365ReportDateSql,
+                summary.Warnings,
+                "Microsoft 365 usage-report snapshot date",
+                cancellationToken,
+                new SqlParameter("@settled", settled));
+            summary.DataSources.M365UsageReportsAvailable = summary.DataSources.M365UsageReportDate.HasValue;
+
+            summary.DataSources.CopilotUsageReportObfuscated = await SafeScalarAsync(
+                CopilotAdoptionSql.CopilotReportObfuscatedSql,
+                summary.Warnings,
+                "Copilot usage-report anonymisation check",
+                cancellationToken) == 1;
+
+            if (summary.DataSources.CopilotUsageReportObfuscated)
+            {
+                summary.Warnings.Add(
+                    "This tenant has 'concealed user information' enabled, so Microsoft's per-user Copilot "
+                    + "report returns hashed identities and cannot be used. Per-user figures below come from "
+                    + "the Copilot audit log, which is unaffected by that setting.");
+            }
+
+            if (!summary.DataSources.AuditAvailable && !summary.DataSources.CopilotUsageReportAvailable)
+            {
+                summary.Warnings.Add(
+                    "Neither the Copilot audit import nor Microsoft's Copilot usage report has any data for "
+                    + "this period, so every licensed user will appear as unused. Check the Health page before "
+                    + "acting on these numbers.");
+            }
+
+            if (!summary.DataSources.AuditAvailable && summary.DataSources.CopilotUsageReportAvailable)
+            {
+                summary.Warnings.Add(
+                    "The Copilot audit import has no data for this period, so per-user engagement is derived "
+                    + "from Microsoft's own usage report. That report covers Microsoft's aggregation window "
+                    + "rather than the period selected here, and excludes unlicensed Copilot Chat use entirely.");
+            }
+
+            // ----- 3. Licensed users ------------------------------------------------------------
+            if (seatIds.Count > 0)
+            {
+                await BuildLicensedUsersAsync(analysis, seatIds, windowStart, historyStart, nowUtc, cancellationToken);
+                await BuildUsageByAppAsync(analysis, seatIds, windowStart, cancellationToken);
+                await BuildWeeklyTrendAsync(analysis, seatIds, trendStart, cancellationToken);
+            }
+
+            // ----- 4. Licence opportunities -----------------------------------------------------
+            await BuildOpportunitiesAsync(analysis, seatIds, windowStart, cancellationToken);
+
+            FinaliseSummary(analysis);
+            return analysis;
+        }
+
+        #region Licensed users
+
+        private async Task BuildLicensedUsersAsync(
+            CopilotAdoptionAnalysis analysis,
+            List<int> seatIds,
+            DateTime windowStart,
+            DateTime historyStart,
+            DateTime nowUtc,
+            CancellationToken cancellationToken)
+        {
+            var summary = analysis.Summary;
+
+            // Seat assignments are read separately from the detail query for two reasons: it is the
+            // only way to name every seat SKU a user holds (a user can hold more than one), and it
+            // gives an exact licensed-user count that is not subject to the detail query's row cap.
+            var assignmentsSql = CopilotAdoptionSql.SeatAssignmentsSql(seatIds);
+            analysis.Sql["seatAssignments"] = assignmentsSql;
+
+            var assignments = await SafeAsync(
+                () => QueryAsync<SeatAssignmentRow>(assignmentsSql, cancellationToken),
+                summary.Warnings,
+                "Copilot seat assignments") ?? new List<SeatAssignmentRow>();
+
+            var licencesByUser = assignments
+                .GroupBy(a => a.UserId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => string.Join(", ", g.Select(a => a.LicenceName)
+                                            .Where(n => !string.IsNullOrWhiteSpace(n))
+                                            .Distinct()
+                                            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)));
+
+            summary.LicensedUsers = licencesByUser.Count;
+
+            var includeReport = summary.DataSources.CopilotUsageReportDate.HasValue
+                                && !summary.DataSources.CopilotUsageReportObfuscated;
+
+            var coworkAgentIds = await SafeAsync(
+                () => QueryAsync<IntValueRow>(CopilotAdoptionSql.CoworkAgentIdsSql, cancellationToken),
+                summary.Warnings,
+                "Cowork agent lookup") ?? new List<IntValueRow>();
+
+            var coworkIds = coworkAgentIds.Select(r => r.Value).ToList();
+
+            var detailSql = CopilotAdoptionSql.LicensedUsersSql(seatIds, coworkIds, includeReport);
+            var parameters = new Dictionary<string, object>
+            {
+                { "@from", windowStart },
+                { "@historyFrom", historyStart },
+                { "@maxRows", _options.MaxLicensedUsersScored },
+            };
+            if (includeReport)
+            {
+                parameters["@copilotReportDate"] = summary.DataSources.CopilotUsageReportDate.Value;
+            }
+
+            analysis.Sql["licensedUsers"] = CopilotAdoptionSql.ForDisplay(detailSql, parameters);
+
+            var rows = await SafeAsync(
+                () => QueryAsync<LicensedUserUsageRow>(detailSql, cancellationToken, ToSqlParameters(parameters)),
+                summary.Warnings,
+                "licensed user detail");
+
+            if (rows == null)
+            {
+                return;
+            }
+
+            if (rows.Count >= _options.MaxLicensedUsersScored)
+            {
+                summary.Warnings.Add(
+                    $"Only the first {_options.MaxLicensedUsersScored:N0} licensed users were analysed. "
+                    + "The figures below therefore describe that subset, not the whole tenant.");
+            }
+
+            foreach (var row in rows)
+            {
+                string licences;
+                row.SeatLicences = licencesByUser.TryGetValue(row.UserId, out licences) ? licences : null;
+            }
+
+            analysis.LicensedUsers = rows
+                .Select(row => CopilotAdoptionScoring.Score(
+                    row, windowStart, nowUtc, summary.DataSources.AuditAvailable, _options))
+                .ToList();
+
+            // The exact count comes from the seat-assignment read; fall back to what was scored if
+            // that query is the one that failed, so the percentages still have a sane denominator.
+            if (summary.LicensedUsers == 0)
+            {
+                summary.LicensedUsers = analysis.LicensedUsers.Count;
+            }
+        }
+
+        private async Task BuildUsageByAppAsync(
+            CopilotAdoptionAnalysis analysis,
+            List<int> seatIds,
+            DateTime windowStart,
+            CancellationToken cancellationToken)
+        {
+            if (!analysis.Summary.DataSources.AuditAvailable)
+            {
+                return;
+            }
+
+            var sql = CopilotAdoptionSql.UsageByAppSql(seatIds);
+            var parameters = new Dictionary<string, object>
+            {
+                { "@from", windowStart },
+                { "@top", _options.TopSegments },
+            };
+            analysis.Sql["usageByApp"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+
+            var rows = await SafeAsync(
+                () => QueryAsync<CategoryQueryRow>(sql, cancellationToken, ToSqlParameters(parameters)),
+                analysis.Summary.Warnings,
+                "Copilot usage by app");
+
+            if (rows == null) return;
+
+            analysis.Summary.UsageByApp = rows
+                .Select(r => new AdoptionCategory { Label = r.Label, Value = r.Value })
+                .ToList();
+        }
+
+        private async Task BuildWeeklyTrendAsync(
+            CopilotAdoptionAnalysis analysis,
+            List<int> seatIds,
+            DateTime trendStart,
+            CancellationToken cancellationToken)
+        {
+            if (!analysis.Summary.DataSources.AuditAvailable)
+            {
+                return;
+            }
+
+            var coworkAgentIds = await SafeAsync(
+                () => QueryAsync<IntValueRow>(CopilotAdoptionSql.CoworkAgentIdsSql, cancellationToken),
+                analysis.Summary.Warnings,
+                "Cowork agent lookup") ?? new List<IntValueRow>();
+
+            var sql = CopilotAdoptionSql.WeeklyAdoptionTrendSql(seatIds, coworkAgentIds.Select(r => r.Value));
+            var parameters = new Dictionary<string, object> { { "@trendFrom", trendStart } };
+            analysis.Sql["weeklyTrend"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+
+            var rows = await SafeAsync(
+                () => QueryAsync<NamedWeekRow>(sql, cancellationToken, ToSqlParameters(parameters)),
+                analysis.Summary.Warnings,
+                "weekly adoption trend");
+
+            if (rows == null) return;
+
+            var weekSpine = WeekSpine(trendStart, MondayOf(DateTime.UtcNow.Date));
+
+            analysis.Summary.WeeklyTrend = rows
+                .GroupBy(r => r.SeriesName)
+                .OrderBy(g => g.Key)
+                .Select(g => new AdoptionSeries
+                {
+                    Name = g.Key,
+                    Points = FillWeeks(weekSpine, g.ToList()),
+                })
+                .ToList();
+        }
+
+        #endregion
+
+        #region Licence opportunities
+
+        private async Task BuildOpportunitiesAsync(
+            CopilotAdoptionAnalysis analysis,
+            List<int> seatIds,
+            DateTime windowStart,
+            CancellationToken cancellationToken)
+        {
+            var summary = analysis.Summary;
+
+            if (summary.DataSources.AuditAvailable && seatIds.Count > 0)
+            {
+                var unlicensedSql = CopilotAdoptionSql.UnlicensedActiveUsersSql(seatIds);
+                analysis.Sql["unlicensedActiveUsers"] = CopilotAdoptionSql.ForDisplay(
+                    unlicensedSql, new Dictionary<string, object> { { "@from", windowStart } });
+
+                summary.UnlicensedActiveUsers = await SafeScalarAsync(
+                    unlicensedSql,
+                    summary.Warnings,
+                    "unlicensed Copilot users",
+                    cancellationToken,
+                    new SqlParameter("@from", windowStart));
+            }
+
+            var includeAudit = summary.DataSources.AuditAvailable;
+            var includeM365 = summary.DataSources.M365UsageReportsAvailable;
+
+            if (!includeAudit && !includeM365)
+            {
+                summary.Warnings.Add(
+                    "Licence opportunities need either the Copilot audit import or the Microsoft 365 usage "
+                    + "reports. Neither has data, so no candidates can be identified.");
+                return;
+            }
+
+            var sql = CopilotAdoptionSql.LicenceOpportunitiesSql(seatIds, _options, includeAudit, includeM365);
+            var parameters = new Dictionary<string, object>
+            {
+                { "@maxRows", _options.MaxOpportunityCandidates },
+            };
+            if (includeAudit) parameters["@from"] = windowStart;
+            if (includeM365) parameters["@m365ReportDate"] = summary.DataSources.M365UsageReportDate.Value;
+
+            analysis.Sql["licenceOpportunities"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+
+            var rows = await SafeAsync(
+                () => QueryAsync<UnlicensedUserSignalRow>(sql, cancellationToken, ToSqlParameters(parameters)),
+                summary.Warnings,
+                "licence opportunities");
+
+            if (rows == null) return;
+
+            if (!includeM365)
+            {
+                summary.Warnings.Add(
+                    "The Microsoft 365 usage reports are not available, so licence candidates are ranked only "
+                    + "on unlicensed Copilot Chat use. Heavy Microsoft 365 users who have never tried Copilot "
+                    + "will not appear.");
+            }
+
+            analysis.Opportunities = rows
+                .Select(r => CopilotAdoptionScoring.ScoreOpportunity(r, _options))
+                .OrderByDescending(r => r.OpportunityScore)
+                .ThenBy(r => r.UserPrincipalName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        #endregion
+
+        #region Summary assembly
+
+        /// <summary>
+        /// Turns the scored rows into the headline figures and breakdown charts. Pure - no database -
+        /// so the whole executive view can be unit-tested from hand-written user rows.
+        /// </summary>
+        public void FinaliseSummary(CopilotAdoptionAnalysis analysis)
+        {
+            if (analysis == null) throw new ArgumentNullException(nameof(analysis));
+
+            var summary = analysis.Summary;
+            var users = analysis.LicensedUsers ?? new List<LicensedUserAdoptionRow>();
+
+            if (summary.LicensedUsers == 0)
+            {
+                summary.LicensedUsers = users.Count;
+            }
+
+            summary.ActiveUsers = users.Count(u => u.Band > AdoptionBand.Dormant);
+            summary.NeverUsedUsers = users.Count(u => u.Band == AdoptionBand.NeverUsed);
+            summary.DormantUsers = users.Count(u => u.Band == AdoptionBand.Dormant);
+            summary.HabitualUsers = users.Count(u => CopilotAdoptionScoring.IsHabitual(u.Band));
+            summary.ReclaimableSeats = summary.NeverUsedUsers + summary.DormantUsers;
+            summary.TotalInteractions = users.Sum(u => u.Interactions);
+
+            summary.AdoptionRatePct = CopilotAdoptionScoring.Percentage(summary.ActiveUsers, summary.LicensedUsers);
+            summary.HabitRatePct = CopilotAdoptionScoring.Percentage(summary.HabitualUsers, summary.LicensedUsers);
+            summary.AverageAdoptionScore = users.Count == 0
+                ? 0
+                : Math.Round(users.Average(u => u.AdoptionScore), 1, MidpointRounding.AwayFromZero);
+            summary.MedianAdoptionScore = CopilotAdoptionScoring.Median(users.Select(u => u.AdoptionScore));
+
+            summary.CoworkUsers = users.Count(u => u.UsedCowork);
+            summary.CoworkInteractions = users.Sum(u => u.CoworkInteractions);
+            summary.CoworkAdoptionPct = CopilotAdoptionScoring.Percentage(summary.CoworkUsers, summary.LicensedUsers);
+            // Only claim a Cowork adoption rate when Cowork was actually seen. On a tenant that has not
+            // been enabled for it, "0% Cowork adoption" reads as a failure rather than as "not available".
+            summary.CoworkDetected = summary.CoworkInteractions > 0;
+
+            summary.Funnel = BuildFunnel(summary, users);
+            summary.BandBreakdown = BuildBandBreakdown(users);
+            summary.AdoptionByDepartment = BuildSegments(users, u => u.Department, "(no department)");
+            summary.AdoptionByCountry = BuildSegments(users, u => u.Country, "(no country)");
+
+            var opportunities = analysis.Opportunities ?? new List<LicenceOpportunityRow>();
+            summary.RecommendedForLicence = opportunities.Count(o => o.Recommended);
+            summary.OpportunityByDepartment = opportunities
+                .Where(o => o.Recommended)
+                .GroupBy(o => string.IsNullOrWhiteSpace(o.Department) ? "(no department)" : o.Department)
+                .Select(g => new AdoptionCategory { Label = g.Key, Value = g.Count() })
+                .OrderByDescending(c => c.Value)
+                .Take(_options.TopSegments)
+                .ToList();
+        }
+
+        /// <summary>
+        /// The adoption funnel: every stage is a subset of the one before it, so the biggest drop-off
+        /// is visible at a glance and points straight at the intervention that is needed.
+        /// </summary>
+        private static List<AdoptionCategory> BuildFunnel(
+            CopilotAdoptionSummary summary,
+            IReadOnlyCollection<LicensedUserAdoptionRow> users)
+        {
+            var everUsed = users.Count(u => u.Band != AdoptionBand.NeverUsed);
+            var champions = users.Count(u => u.Band == AdoptionBand.Champion);
+
+            return new List<AdoptionCategory>
+            {
+                new AdoptionCategory { Label = "Licensed", Value = summary.LicensedUsers },
+                new AdoptionCategory { Label = "Ever used Copilot", Value = everUsed },
+                new AdoptionCategory { Label = "Active this period", Value = summary.ActiveUsers },
+                new AdoptionCategory { Label = "Habitual users", Value = summary.HabitualUsers },
+                new AdoptionCategory { Label = "Champions", Value = champions },
+            };
+        }
+
+        /// <summary>Band distribution, always including empty bands - an empty "Champions" bar is itself the finding.</summary>
+        private static List<AdoptionCategory> BuildBandBreakdown(IReadOnlyCollection<LicensedUserAdoptionRow> users)
+        {
+            return CopilotAdoptionScoring.AllBands
+                .Select(band => new AdoptionCategory
+                {
+                    Label = CopilotAdoptionScoring.BandDisplayName(band),
+                    Value = users.Count(u => u.Band == band),
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Adoption per organisational segment, worst first - the running order for an enablement plan.
+        /// Segments below <see cref="CopilotAdoptionOptions.MinSeatsPerSegment"/> are dropped because a
+        /// 0%-of-two-seats department at the top of an executive chart is noise that invites a bad call.
+        /// </summary>
+        private List<AdoptionSegmentRow> BuildSegments(
+            IEnumerable<LicensedUserAdoptionRow> users,
+            Func<LicensedUserAdoptionRow, string> selector,
+            string emptyLabel)
+        {
+            return users
+                .GroupBy(u => string.IsNullOrWhiteSpace(selector(u)) ? emptyLabel : selector(u).Trim())
+                .Where(g => g.Count() >= _options.MinSeatsPerSegment)
+                .Select(g => CopilotAdoptionScoring.Summarise(g.Key, g.ToList()))
+                .OrderBy(s => s.AdoptionRatePct)
+                .ThenByDescending(s => s.LicensedUsers)
+                .Take(_options.TopSegments)
+                .ToList();
+        }
+
+        #endregion
+
+        #region Query plumbing
+
+        /// <summary>Runs a query on its own short-lived context, so one slow report cannot hold a context open.</summary>
+        private async Task<List<T>> QueryAsync<T>(
+            string sql,
+            CancellationToken cancellationToken,
+            params SqlParameter[] parameters)
+        {
+            using (var db = _contextFactory())
+            {
+                db.Database.CommandTimeout = QueryTimeoutSecs;
+                return await db.Database.SqlQuery<T>(sql, parameters).ToListAsync(cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Runs a query, turning any failure into a warning on the result. One heavy query timing out
+        /// should cost that one chart, not the whole licence review.
+        /// </summary>
+        private static async Task<List<T>> SafeAsync<T>(
+            Func<Task<List<T>>> query,
+            List<string> warnings,
+            string description)
+        {
+            try
+            {
+                return await query();
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Could not load {description}: {InnermostMessage(ex)}");
+                return null;
+            }
+        }
+
+        private async Task<int> SafeScalarAsync(
+            string sql,
+            List<string> warnings,
+            string description,
+            CancellationToken cancellationToken,
+            params SqlParameter[] parameters)
+        {
+            var rows = await SafeAsync(
+                () => QueryAsync<int?>(sql, cancellationToken, parameters),
+                warnings,
+                description);
+
+            return rows?.FirstOrDefault() ?? 0;
+        }
+
+        private async Task<DateTime?> SafeDateAsync(
+            string sql,
+            List<string> warnings,
+            string description,
+            CancellationToken cancellationToken,
+            params SqlParameter[] parameters)
+        {
+            var rows = await SafeAsync(
+                () => QueryAsync<DateTime?>(sql, cancellationToken, parameters),
+                warnings,
+                description);
+
+            return rows?.FirstOrDefault();
+        }
+
+        private static SqlParameter[] ToSqlParameters(IDictionary<string, object> parameters)
+        {
+            return parameters
+                .Select(p => new SqlParameter(p.Key, p.Value ?? DBNull.Value))
+                .ToArray();
+        }
+
+        /// <summary>The innermost exception message - the one that actually says what went wrong.</summary>
+        internal static string InnermostMessage(Exception ex)
+        {
+            var current = ex;
+            while (current.InnerException != null)
+            {
+                current = current.InnerException;
+            }
+            return current.Message;
+        }
+
+        #endregion
+
+        #region Week helpers
+
+        /// <summary>The Monday of the week containing <paramref name="date"/>.</summary>
+        internal static DateTime MondayOf(DateTime date)
+        {
+            return date.Date.AddDays(-(((int)date.DayOfWeek + 6) % 7));
+        }
+
+        /// <summary>Every Monday from first to last inclusive.</summary>
+        internal static List<DateTime> WeekSpine(DateTime firstMonday, DateTime lastMonday)
+        {
+            var weeks = new List<DateTime>();
+            for (var week = firstMonday; week <= lastMonday; week = week.AddDays(7))
+            {
+                weeks.Add(week);
+            }
+            return weeks;
+        }
+
+        /// <summary>
+        /// Projects query rows onto the full week spine, filling missing weeks with zero. Zero (rather
+        /// than a gap) is right here: these series count audit events, and no events genuinely does
+        /// mean nobody used Copilot that week.
+        /// </summary>
+        internal static List<AdoptionTimePoint> FillWeeks(List<DateTime> weekSpine, List<NamedWeekRow> rows)
+        {
+            var byWeek = new Dictionary<DateTime, double>();
+            foreach (var row in rows)
+            {
+                byWeek[row.WeekStart.Date] = row.Value;
+            }
+
+            return weekSpine
+                .Select(week => new AdoptionTimePoint
+                {
+                    WeekStart = week,
+                    Value = byWeek.TryGetValue(week, out var value) ? value : 0,
+                })
+                .ToList();
+        }
+
+        #endregion
+
+        #region Raw query row shapes
+
+        /// <summary>One (user, Copilot seat SKU) assignment.</summary>
+        public class SeatAssignmentRow
+        {
+            public int UserId { get; set; }
+
+            public string LicenceName { get; set; }
+        }
+
+        /// <summary>A single integer column, for id lookups.</summary>
+        public class IntValueRow
+        {
+            public int Value { get; set; }
+        }
+
+        /// <summary>A label/value pair for the categorical charts.</summary>
+        public class CategoryQueryRow
+        {
+            public string Label { get; set; }
+
+            public double Value { get; set; }
+        }
+
+        /// <summary>A point of a named weekly series.</summary>
+        public class NamedWeekRow
+        {
+            public string SeriesName { get; set; }
+
+            public DateTime WeekStart { get; set; }
+
+            public double Value { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
@@ -1,0 +1,690 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Common.Entities.CopilotAdoption
+{
+    /// <summary>
+    /// Every query behind the Copilot licence-adoption tool, built as strings so each one can be
+    /// asserted in a unit test and shown to the admin in the SQL popover the rest of the admin site
+    /// uses. No query here is assembled from user input: the only values interpolated are integer
+    /// licence-type ids that this code read out of <c>dbo.license_types</c> itself, and constants from
+    /// <see cref="CopilotAdoptionOptions"/>. Everything a caller supplies is a real SQL parameter.
+    ///
+    /// Performance notes (the target is a ~200,000-user tenant):
+    ///
+    /// <list type="bullet">
+    ///   <item>Queries hit base tables, never the <c>vw*</c> views, matching the Reports area.</item>
+    ///   <item>The licensed population is derived from <c>user_license_type_lookups</c> filtered by
+    ///   licence-type id. That table has a unique index on <c>(license_type_id, user_id)</c>, so this
+    ///   is an index-only seek on the leading column - not a scan of <c>users</c>.</item>
+    ///   <item>The Copilot audit history is read <b>once</b> per report, over a bounded date range,
+    ///   with the window-versus-history split done by <c>CASE</c> inside a single aggregate. Running
+    ///   separate "in the window" and "ever" passes would double the cost of the most expensive join
+    ///   in the product.</item>
+    ///   <item>Microsoft 365 usage figures come from <b>one</b> snapshot date, resolved up-front, so
+    ///   each usage table is an equality seek on its <c>IX_date</c> index rather than a range scan.</item>
+    ///   <item>The unlicensed candidate list is driven <i>from the activity tables</i> and anti-joined
+    ///   against the licensed set. Driving it from <c>users</c> would scan every account in the tenant
+    ///   to discard the overwhelming majority that have no activity at all.</item>
+    ///   <item><c>OPTION (RECOMPILE)</c> throughout, so the real window drives the plan - the same
+    ///   reasoning (and the same measurements) as the Reports area.</item>
+    /// </list>
+    /// </summary>
+    public static class CopilotAdoptionSql
+    {
+        /// <summary>
+        /// The join from <c>copilot_chats</c> to its audit event. Copilot interactions have no date of
+        /// their own; the audit event carries the timestamp and the user. Deliberately un-hinted: a
+        /// forced MERGE join was measured on this join in the Reports area and degraded to a full scan
+        /// of <c>audit_events</c> at every window. Do not add a hint here without re-measuring.
+        /// </summary>
+        public const string AuditJoin = "INNER JOIN dbo.audit_events AS au ON c.event_id = au.id";
+
+        /// <summary>
+        /// Microsoft 365 Copilot Cowork surfaces itself in the audit log as the app host "cowork" and,
+        /// where the agent was dimensioned, as a first-party agent whose id starts
+        /// <c>Copilot.M365Copilot.Cowork</c>. Both are checked: the app host is present on every
+        /// interaction, while the agent id only exists once the agent has been imported.
+        /// </summary>
+        public const string CoworkAppHost = "cowork";
+
+        /// <summary>Finds the <c>copilot_agents</c> rows that represent Cowork.</summary>
+        public const string CoworkAgentIdsSql =
+            "SELECT ag.id AS Value\r\n" +
+            "FROM dbo.copilot_agents AS ag\r\n" +
+            "WHERE ag.agent_id LIKE 'Copilot.M365Copilot.Cowork%'\r\n" +
+            "   OR ag.name LIKE '%Cowork%';";
+
+        /// <summary>
+        /// Every licence type with how many users hold it, so the tool can classify them and show the
+        /// admin exactly which SKUs it counted as Copilot seats.
+        /// </summary>
+        public const string LicenceTypesSql =
+            "SELECT lt.id AS Id,\r\n" +
+            "       lt.name AS Name,\r\n" +
+            "       lt.sku_id AS SkuPartNumber,\r\n" +
+            "       COUNT(ul.user_id) AS AssignedUsers\r\n" +
+            "FROM dbo.license_types AS lt\r\n" +
+            "LEFT JOIN dbo.user_license_type_lookups AS ul ON ul.license_type_id = lt.id\r\n" +
+            "GROUP BY lt.id, lt.name, lt.sku_id\r\n" +
+            "ORDER BY AssignedUsers DESC, lt.name;";
+
+        /// <summary>
+        /// The most recent per-user Copilot usage-report snapshot that Microsoft has settled.
+        /// Resolved separately so the detail query can seek one date instead of scanning a range.
+        /// </summary>
+        public const string LatestCopilotReportDateSql =
+            "SELECT MAX(r.[date]) AS Value\r\n" +
+            "FROM dbo.copilot_usage_user_activity_log AS r\r\n" +
+            "WHERE r.[date] <= @settled;";
+
+        /// <summary>
+        /// The most recent settled Microsoft 365 usage-report snapshot. Teams is used as the reference
+        /// workload because every tenant that imports usage reports at all imports Teams, and mixing
+        /// snapshot dates across workloads would compare a user's Monday against someone else's Friday.
+        /// </summary>
+        public const string LatestM365ReportDateSql =
+            "SELECT MAX(t.[date]) AS Value\r\n" +
+            "FROM dbo.teams_user_activity_log AS t\r\n" +
+            "WHERE t.[date] <= @settled;";
+
+        /// <summary>
+        /// Whether the last per-user Copilot usage-report import came back with hashed identities
+        /// (the tenant's "concealed user information" setting). That makes Microsoft's per-user numbers
+        /// unusable while leaving the audit-derived ones untouched, which is worth saying out loud
+        /// rather than letting the two sources appear to contradict each other.
+        /// </summary>
+        public const string CopilotReportObfuscatedSql =
+            "SELECT TOP 1 CAST(l.is_upn_obfuscated AS int) AS Value\r\n" +
+            "FROM dbo.copilot_usage_report_import_log AS l\r\n" +
+            "WHERE l.report_name = 'getMicrosoft365CopilotUsageUserDetail'\r\n" +
+            "ORDER BY l.imported_utc DESC;";
+
+        /// <summary>Cheap existence probe: has any Copilot interaction been imported in the window?</summary>
+        public const string HasCopilotAuditDataSql =
+            "SELECT CASE WHEN EXISTS (\r\n" +
+            "    SELECT 1 FROM dbo.copilot_chats AS c\r\n" +
+            "    " + AuditJoin + "\r\n" +
+            "    WHERE au.time_stamp >= @from\r\n" +
+            ") THEN 1 ELSE 0 END AS Value;";
+
+        #region Licensed users
+
+        /// <summary>
+        /// One row per (user, Copilot seat SKU). Used both to name the seats a user holds and to count
+        /// the licensed population exactly - the detail query is capped, so it cannot be trusted for a
+        /// headline figure, whereas this index-only read can.
+        /// </summary>
+        public static string SeatAssignmentsSql(IEnumerable<int> seatLicenceTypeIds)
+        {
+            return
+                "SELECT ul.user_id AS UserId,\r\n" +
+                "       lt.name AS LicenceName\r\n" +
+                "FROM dbo.user_license_type_lookups AS ul\r\n" +
+                "JOIN dbo.license_types AS lt ON lt.id = ul.license_type_id\r\n" +
+                $"WHERE ul.license_type_id IN ({IdList(seatLicenceTypeIds)})\r\n" +
+                "ORDER BY ul.user_id;";
+        }
+
+        /// <summary>
+        /// The core query: every Copilot-licensed user with their metadata, their audit-derived usage
+        /// split into "inside the reporting window" and "earlier", and Microsoft's own per-user figures
+        /// from the latest settled snapshot.
+        ///
+        /// The window/history split is what separates a user who has never touched Copilot from one who
+        /// tried it and stopped - the single most valuable distinction this tool makes, and the reason
+        /// the aggregate reaches back to <c>@historyFrom</c> rather than only <c>@from</c>.
+        ///
+        /// No scoring happens here. Ranking, banding and percentages are all applied in
+        /// <see cref="CopilotAdoptionScoring"/> so there is exactly one implementation of the rules.
+        /// </summary>
+        /// <param name="seatLicenceTypeIds">Licence-type ids classified as Copilot seats.</param>
+        /// <param name="coworkAgentIds">Agent ids identified as Cowork; may be empty.</param>
+        /// <param name="includeCopilotReport">
+        /// False when Microsoft's per-user report has no usable snapshot, in which case its joins are
+        /// omitted entirely rather than joined against a NULL date.
+        /// </param>
+        public static string LicensedUsersSql(
+            IEnumerable<int> seatLicenceTypeIds,
+            IEnumerable<int> coworkAgentIds,
+            bool includeCopilotReport)
+        {
+            var cowork = CoworkPredicate(coworkAgentIds);
+
+            var sql =
+                "WITH SeatUsers AS (\r\n" +
+                "    SELECT DISTINCT ul.user_id AS user_id\r\n" +
+                "    FROM dbo.user_license_type_lookups AS ul\r\n" +
+                $"    WHERE ul.license_type_id IN ({IdList(seatLicenceTypeIds)})\r\n" +
+                "),\r\n" +
+                "-- One bounded pass over the Copilot audit history. The reporting window and the\r\n" +
+                "-- earlier history are separated with CASE rather than by running the join twice.\r\n" +
+                "CopilotUsage AS (\r\n" +
+                "    SELECT au.user_id AS user_id,\r\n" +
+                "           SUM(CASE WHEN au.time_stamp >= @from THEN 1 ELSE 0 END) AS Interactions,\r\n" +
+                "           SUM(CASE WHEN au.time_stamp <  @from THEN 1 ELSE 0 END) AS PriorInteractions,\r\n" +
+                "           COUNT(DISTINCT CASE WHEN au.time_stamp >= @from THEN CAST(au.time_stamp AS date) END) AS ActiveDays,\r\n" +
+                "           COUNT(DISTINCT CASE WHEN au.time_stamp >= @from THEN c.app_host END) AS AppsUsed,\r\n" +
+                "           COUNT(DISTINCT CASE WHEN au.time_stamp >= @from THEN c.agent_id END) AS AgentsUsed,\r\n" +
+                $"           SUM(CASE WHEN au.time_stamp >= @from AND ({cowork}) THEN 1 ELSE 0 END) AS CoworkInteractions,\r\n" +
+                "           MIN(au.time_stamp) AS FirstInteractionUtc,\r\n" +
+                "           MAX(au.time_stamp) AS LastInteractionUtc\r\n" +
+                "    FROM dbo.copilot_chats AS c\r\n" +
+                "    " + AuditJoin + "\r\n" +
+                "    JOIN SeatUsers AS seats ON seats.user_id = au.user_id\r\n" +
+                "    WHERE au.time_stamp >= @historyFrom\r\n" +
+                "    GROUP BY au.user_id\r\n" +
+                ")";
+
+            if (includeCopilotReport)
+            {
+                sql +=
+                    ",\r\n" +
+                    "-- Microsoft's own per-user figures, from a single settled snapshot date.\r\n" +
+                    "ReportSnapshot AS (\r\n" +
+                    "    SELECT r.user_id AS user_id,\r\n" +
+                    "           r.prompts_all_apps AS ReportPrompts,\r\n" +
+                    "           r.active_usage_days AS ReportActiveDays,\r\n" +
+                    "           " + ReportAppsUsedExpression() + " AS ReportAppsUsed,\r\n" +
+                    "           " + ReportLastActivityExpression() + " AS ReportLastActivityUtc,\r\n" +
+                    "           r.agent_last_activity_date AS ReportAgentLastActivityUtc\r\n" +
+                    "    FROM dbo.copilot_usage_user_activity_log AS r\r\n" +
+                    "    WHERE r.[date] = @copilotReportDate\r\n" +
+                    ")";
+            }
+
+            sql +=
+                "\r\n" +
+                "SELECT TOP (@maxRows)\r\n" +
+                "       u.id AS UserId,\r\n" +
+                "       u.user_name AS UserPrincipalName,\r\n" +
+                "       u.mail AS Mail,\r\n" +
+                "       dept.name AS Department,\r\n" +
+                "       title.name AS JobTitle,\r\n" +
+                "       country.name AS Country,\r\n" +
+                "       office.name AS OfficeLocation,\r\n" +
+                "       company.name AS CompanyName,\r\n" +
+                "       manager.user_name AS ManagerUserPrincipalName,\r\n" +
+                "       u.account_enabled AS AccountEnabled,\r\n" +
+                "       CAST(ISNULL(chats.Interactions, 0) AS bigint) AS Interactions,\r\n" +
+                "       CAST(ISNULL(chats.PriorInteractions, 0) AS bigint) AS PriorInteractions,\r\n" +
+                "       ISNULL(chats.ActiveDays, 0) AS ActiveDays,\r\n" +
+                "       ISNULL(chats.AppsUsed, 0) AS AppsUsed,\r\n" +
+                "       ISNULL(chats.AgentsUsed, 0) AS AgentsUsed,\r\n" +
+                "       CAST(ISNULL(chats.CoworkInteractions, 0) AS bigint) AS CoworkInteractions,\r\n" +
+                "       chats.FirstInteractionUtc AS FirstInteractionUtc,\r\n" +
+                "       chats.LastInteractionUtc AS LastInteractionUtc,\r\n" +
+                (includeCopilotReport
+                    ? "       report.ReportPrompts AS ReportPrompts,\r\n" +
+                      "       report.ReportActiveDays AS ReportActiveDays,\r\n" +
+                      "       report.ReportAppsUsed AS ReportAppsUsed,\r\n" +
+                      "       report.ReportLastActivityUtc AS ReportLastActivityUtc,\r\n" +
+                      "       report.ReportAgentLastActivityUtc AS ReportAgentLastActivityUtc\r\n"
+                    : "       CAST(NULL AS int) AS ReportPrompts,\r\n" +
+                      "       CAST(NULL AS int) AS ReportActiveDays,\r\n" +
+                      "       CAST(NULL AS int) AS ReportAppsUsed,\r\n" +
+                      "       CAST(NULL AS datetime) AS ReportLastActivityUtc,\r\n" +
+                      "       CAST(NULL AS datetime) AS ReportAgentLastActivityUtc\r\n") +
+                "FROM SeatUsers AS seats\r\n" +
+                "JOIN dbo.users AS u ON u.id = seats.user_id\r\n" +
+                "LEFT JOIN dbo.user_departments AS dept ON dept.id = u.department_id\r\n" +
+                "LEFT JOIN dbo.user_job_titles AS title ON title.id = u.job_title_id\r\n" +
+                "LEFT JOIN dbo.user_country_or_region AS country ON country.id = u.country_or_region_id\r\n" +
+                "LEFT JOIN dbo.user_office_locations AS office ON office.id = u.office_location_id\r\n" +
+                "LEFT JOIN dbo.user_company_name AS company ON company.id = u.company_name_id\r\n" +
+                "LEFT JOIN dbo.users AS manager ON manager.id = u.manager_id\r\n" +
+                "LEFT JOIN CopilotUsage AS chats ON chats.user_id = u.id\r\n" +
+                (includeCopilotReport ? "LEFT JOIN ReportSnapshot AS report ON report.user_id = u.id\r\n" : string.Empty) +
+                // Ordered by id so the cap truncates deterministically: the same users are dropped on
+                // every run, which makes a capped report reproducible instead of randomly different.
+                "ORDER BY u.id\r\n" +
+                "OPTION (RECOMPILE);";
+
+            return sql;
+        }
+
+        /// <summary>
+        /// How many distinct Copilot surfaces Microsoft's report shows activity in during the window.
+        /// Only used when the audit import is unavailable, where it is the only breadth signal.
+        ///
+        /// The three chat columns are collapsed into one surface on purpose: report version 1 reported
+        /// a single "chat" date and version 2 split it into work and web, so counting all three would
+        /// make a v2 tenant look broader than a v1 tenant purely because Microsoft changed the CSV.
+        /// </summary>
+        private static string ReportAppsUsedExpression()
+        {
+            var singleApps = new[]
+            {
+                "r.teams_last_activity_date",
+                "r.word_last_activity_date",
+                "r.excel_last_activity_date",
+                "r.powerpoint_last_activity_date",
+                "r.outlook_last_activity_date",
+                "r.onenote_last_activity_date",
+                "r.loop_last_activity_date",
+                "r.edge_last_activity_date",
+                "r.m365_copilot_last_activity_date",
+            };
+
+            var parts = singleApps
+                .Select(col => $"CASE WHEN {col} >= @from THEN 1 ELSE 0 END")
+                .ToList();
+
+            parts.Add(
+                "CASE WHEN r.chat_last_activity_date >= @from "
+                + "OR r.chat_work_last_activity_date >= @from "
+                + "OR r.chat_web_last_activity_date >= @from THEN 1 ELSE 0 END");
+
+            return "(" + string.Join("\r\n              + ", parts) + ")";
+        }
+
+        /// <summary>
+        /// The latest of the report's per-app activity dates. Written as a MAX over a VALUES list
+        /// rather than GREATEST() because GREATEST needs SQL Server 2022, and customers run this on
+        /// everything from SQL Server 2016 upwards.
+        /// </summary>
+        private static string ReportLastActivityExpression()
+        {
+            var columns = new[]
+            {
+                "r.last_activity_date",
+                "r.chat_last_activity_date",
+                "r.chat_work_last_activity_date",
+                "r.chat_web_last_activity_date",
+                "r.teams_last_activity_date",
+                "r.word_last_activity_date",
+                "r.excel_last_activity_date",
+                "r.powerpoint_last_activity_date",
+                "r.outlook_last_activity_date",
+                "r.onenote_last_activity_date",
+                "r.loop_last_activity_date",
+                "r.edge_last_activity_date",
+                "r.m365_copilot_last_activity_date",
+                "r.agent_last_activity_date",
+            };
+
+            var values = string.Join(", ", columns.Select(c => $"({c})"));
+            return $"(SELECT MAX(activity.dt) FROM (VALUES {values}) AS activity(dt))";
+        }
+
+        #endregion
+
+        #region Licence opportunities (unlicensed users)
+
+        /// <summary>
+        /// Ranks unlicensed users as candidates for a Copilot seat and returns the strongest
+        /// <c>@maxRows</c>.
+        ///
+        /// Driven from the activity tables and anti-joined against the licensed set, so the cost scales
+        /// with the number of <i>active</i> users rather than with the size of the directory - the
+        /// difference between a report that returns on a 200,000-user tenant and one that does not.
+        ///
+        /// The ranking expression is generated from the same <see cref="CopilotAdoptionOptions"/> the
+        /// C# scorer uses (see <see cref="CopilotAdoptionScoring.BuildOpportunityScoreSql"/>), and every
+        /// returned row is re-scored in C# before it is shown. This decides which users come back, not
+        /// what their published score is.
+        /// </summary>
+        public static string LicenceOpportunitiesSql(
+            IEnumerable<int> seatLicenceTypeIds,
+            CopilotAdoptionOptions options,
+            bool includeCopilotAudit,
+            bool includeM365Usage)
+        {
+            var o = options ?? CopilotAdoptionOptions.Default;
+
+            if (!includeCopilotAudit && !includeM365Usage)
+            {
+                // With neither source there is nothing to rank against, and an empty candidate CTE
+                // would be a syntax error. Callers check availability first; this is the backstop.
+                throw new ArgumentException(
+                    "At least one of the Copilot audit import or the Microsoft 365 usage reports must be available to rank licence opportunities.",
+                    nameof(includeCopilotAudit));
+            }
+
+            // The ranking expression must only reference CTEs that are actually in the query: when a
+            // data source is unavailable its CTE (and its join) is omitted entirely, so its component
+            // has to collapse to a literal zero rather than to an unbound column reference.
+            var score = CopilotAdoptionScoring.BuildOpportunityScoreSql(
+                o,
+                copilotColumn: includeCopilotAudit ? "ISNULL(copilot.Interactions, 0)" : "0",
+                teamsColumn: includeM365Usage ? "ISNULL(teams.Messages, 0)" : "0",
+                meetingsColumn: includeM365Usage ? "ISNULL(teams.Meetings, 0)" : "0",
+                emailSentColumn: includeM365Usage ? "ISNULL(mail.EmailsSent, 0)" : "0",
+                emailReadColumn: includeM365Usage ? "ISNULL(mail.EmailsRead, 0)" : "0",
+                filesColumn: includeM365Usage ? "ISNULL(files.ViewedOrEdited, 0)" : "0");
+
+            var ctes = new List<string>
+            {
+                "SeatUsers AS (\r\n" +
+                "    SELECT DISTINCT ul.user_id AS user_id\r\n" +
+                "    FROM dbo.user_license_type_lookups AS ul\r\n" +
+                $"    WHERE ul.license_type_id IN ({IdList(seatLicenceTypeIds)})\r\n" +
+                ")"
+            };
+
+            if (includeCopilotAudit)
+            {
+                ctes.Add(
+                    "-- Copilot use by people who do not hold a seat: unlicensed Copilot Chat. The\r\n" +
+                    "-- strongest possible signal, because it is evidence rather than inference.\r\n" +
+                    "CopilotUsage AS (\r\n" +
+                    "    SELECT au.user_id AS user_id,\r\n" +
+                    "           COUNT_BIG(*) AS Interactions,\r\n" +
+                    "           COUNT(DISTINCT CAST(au.time_stamp AS date)) AS ActiveDays,\r\n" +
+                    "           MAX(au.time_stamp) AS LastInteractionUtc\r\n" +
+                    "    FROM dbo.copilot_chats AS c\r\n" +
+                    "    " + AuditJoin + "\r\n" +
+                    "    WHERE au.time_stamp >= @from AND au.user_id IS NOT NULL\r\n" +
+                    "    GROUP BY au.user_id\r\n" +
+                    ")");
+            }
+
+            if (includeM365Usage)
+            {
+                ctes.Add(
+                    "-- One settled snapshot per workload: an equality seek on IX_date, not a range scan.\r\n" +
+                    "TeamsUsage AS (\r\n" +
+                    "    SELECT t.user_id AS user_id,\r\n" +
+                    "           t.private_chat_count + t.team_chat_count + t.post_messages + t.reply_messages AS Messages,\r\n" +
+                    "           t.meetings_attended_count + t.meetings_organized_count AS Meetings,\r\n" +
+                    "           t.last_activity_date AS LastActivity\r\n" +
+                    "    FROM dbo.teams_user_activity_log AS t\r\n" +
+                    "    WHERE t.[date] = @m365ReportDate\r\n" +
+                    ")");
+
+                ctes.Add(
+                    "MailUsage AS (\r\n" +
+                    "    SELECT o.user_id AS user_id,\r\n" +
+                    // Named EmailsSent/EmailsRead, not Sent/Read: READ is a reserved word in T-SQL and
+                    // an unbracketed alias produces a syntax error the moment it is referenced.
+                    "           o.email_send_count AS EmailsSent,\r\n" +
+                    "           o.email_read_count AS EmailsRead,\r\n" +
+                    "           o.last_activity_date AS LastActivity\r\n" +
+                    "    FROM dbo.outlook_user_activity_log AS o\r\n" +
+                    "    WHERE o.[date] = @m365ReportDate\r\n" +
+                    ")");
+
+                ctes.Add(
+                    "-- SharePoint and OneDrive are one signal (\"works with documents\"), so they are\r\n" +
+                    "-- summed rather than shown as two weak ones.\r\n" +
+                    "FileUsage AS (\r\n" +
+                    "    SELECT f.user_id AS user_id,\r\n" +
+                    "           SUM(f.viewed_or_edited) AS ViewedOrEdited,\r\n" +
+                    "           MAX(f.last_activity_date) AS LastActivity\r\n" +
+                    "    FROM (\r\n" +
+                    "        SELECT sp.user_id, sp.viewed_or_edited, sp.last_activity_date\r\n" +
+                    "        FROM dbo.sharepoint_user_activity_log AS sp WHERE sp.[date] = @m365ReportDate\r\n" +
+                    "        UNION ALL\r\n" +
+                    "        SELECT od.user_id, od.viewed_or_edited, od.last_activity_date\r\n" +
+                    "        FROM dbo.onedrive_user_activity_log AS od WHERE od.[date] = @m365ReportDate\r\n" +
+                    "    ) AS f\r\n" +
+                    "    GROUP BY f.user_id\r\n" +
+                    ")");
+            }
+
+            var candidateSources = new List<string>();
+            if (includeCopilotAudit) candidateSources.Add("    SELECT user_id FROM CopilotUsage");
+            if (includeM365Usage)
+            {
+                candidateSources.Add("    SELECT user_id FROM TeamsUsage");
+                candidateSources.Add("    SELECT user_id FROM MailUsage");
+                candidateSources.Add("    SELECT user_id FROM FileUsage");
+            }
+
+            ctes.Add(
+                "-- UNION (not UNION ALL) so a user active in several workloads is one candidate.\r\n" +
+                "Candidates AS (\r\n" +
+                string.Join("\r\n    UNION\r\n", candidateSources) + "\r\n" +
+                ")");
+
+            var copilotSelect = includeCopilotAudit
+                ? "       CAST(ISNULL(copilot.Interactions, 0) AS bigint) AS UnlicensedCopilotInteractions,\r\n" +
+                  "       ISNULL(copilot.ActiveDays, 0) AS UnlicensedCopilotActiveDays,\r\n" +
+                  "       copilot.LastInteractionUtc AS LastCopilotInteractionUtc,\r\n"
+                : "       CAST(0 AS bigint) AS UnlicensedCopilotInteractions,\r\n" +
+                  "       0 AS UnlicensedCopilotActiveDays,\r\n" +
+                  "       CAST(NULL AS datetime) AS LastCopilotInteractionUtc,\r\n";
+
+            var m365Select = includeM365Usage
+                ? "       CAST(ISNULL(teams.Messages, 0) AS bigint) AS TeamsMessages,\r\n" +
+                  "       CAST(ISNULL(teams.Meetings, 0) AS bigint) AS TeamsMeetings,\r\n" +
+                  "       CAST(ISNULL(mail.EmailsSent, 0) AS bigint) AS EmailsSent,\r\n" +
+                  "       CAST(ISNULL(mail.EmailsRead, 0) AS bigint) AS EmailsRead,\r\n" +
+                  "       CAST(ISNULL(files.ViewedOrEdited, 0) AS bigint) AS FilesViewedOrEdited,\r\n" +
+                  "       (SELECT MAX(activity.dt) FROM (VALUES (teams.LastActivity), (mail.LastActivity), (files.LastActivity)) AS activity(dt)) AS LastM365ActivityUtc,\r\n"
+                : "       CAST(0 AS bigint) AS TeamsMessages,\r\n" +
+                  "       CAST(0 AS bigint) AS TeamsMeetings,\r\n" +
+                  "       CAST(0 AS bigint) AS EmailsSent,\r\n" +
+                  "       CAST(0 AS bigint) AS EmailsRead,\r\n" +
+                  "       CAST(0 AS bigint) AS FilesViewedOrEdited,\r\n" +
+                  "       CAST(NULL AS datetime) AS LastM365ActivityUtc,\r\n";
+
+            return
+                "WITH " + string.Join(",\r\n", ctes) + "\r\n" +
+                "SELECT TOP (@maxRows)\r\n" +
+                "       u.id AS UserId,\r\n" +
+                "       u.user_name AS UserPrincipalName,\r\n" +
+                "       u.mail AS Mail,\r\n" +
+                "       dept.name AS Department,\r\n" +
+                "       title.name AS JobTitle,\r\n" +
+                "       country.name AS Country,\r\n" +
+                "       office.name AS OfficeLocation,\r\n" +
+                "       company.name AS CompanyName,\r\n" +
+                "       manager.user_name AS ManagerUserPrincipalName,\r\n" +
+                copilotSelect +
+                m365Select +
+                $"       CAST({score} AS float) AS RankScore\r\n" +
+                "FROM Candidates AS cand\r\n" +
+                "JOIN dbo.users AS u ON u.id = cand.user_id\r\n" +
+                "LEFT JOIN dbo.user_departments AS dept ON dept.id = u.department_id\r\n" +
+                "LEFT JOIN dbo.user_job_titles AS title ON title.id = u.job_title_id\r\n" +
+                "LEFT JOIN dbo.user_country_or_region AS country ON country.id = u.country_or_region_id\r\n" +
+                "LEFT JOIN dbo.user_office_locations AS office ON office.id = u.office_location_id\r\n" +
+                "LEFT JOIN dbo.user_company_name AS company ON company.id = u.company_name_id\r\n" +
+                "LEFT JOIN dbo.users AS manager ON manager.id = u.manager_id\r\n" +
+                (includeCopilotAudit ? "LEFT JOIN CopilotUsage AS copilot ON copilot.user_id = u.id\r\n" : string.Empty) +
+                (includeM365Usage
+                    ? "LEFT JOIN TeamsUsage AS teams ON teams.user_id = u.id\r\n" +
+                      "LEFT JOIN MailUsage AS mail ON mail.user_id = u.id\r\n" +
+                      "LEFT JOIN FileUsage AS files ON files.user_id = u.id\r\n"
+                    : string.Empty) +
+                "WHERE NOT EXISTS (SELECT 1 FROM SeatUsers AS seats WHERE seats.user_id = u.id)\r\n" +
+                // A disabled account cannot use a licence, so proposing one would discredit the list.
+                "  AND (u.account_enabled IS NULL OR u.account_enabled = 1)\r\n" +
+                $"ORDER BY RankScore DESC, u.id\r\n" +
+                "OPTION (RECOMPILE);";
+        }
+
+        /// <summary>
+        /// How many users used Copilot inside the window without holding a seat. Counted separately
+        /// from the candidate list because it is a headline figure - proven, unmet demand for Copilot -
+        /// and must not be limited by the candidate list's row cap.
+        /// </summary>
+        public static string UnlicensedActiveUsersSql(IEnumerable<int> seatLicenceTypeIds)
+        {
+            return
+                "SELECT COUNT(*) AS Value\r\n" +
+                "FROM (\r\n" +
+                "    SELECT DISTINCT au.user_id\r\n" +
+                "    FROM dbo.copilot_chats AS c\r\n" +
+                "    " + AuditJoin + "\r\n" +
+                "    WHERE au.time_stamp >= @from\r\n" +
+                "      AND au.user_id IS NOT NULL\r\n" +
+                "      AND NOT EXISTS (\r\n" +
+                "          SELECT 1 FROM dbo.user_license_type_lookups AS ul\r\n" +
+                "          WHERE ul.user_id = au.user_id\r\n" +
+                $"            AND ul.license_type_id IN ({IdList(seatLicenceTypeIds)})\r\n" +
+                "      )\r\n" +
+                ") AS unlicensed\r\n" +
+                "OPTION (RECOMPILE);";
+        }
+
+        #endregion
+
+        #region Charts
+
+        /// <summary>
+        /// Where licensed users actually use Copilot. Answers "we bought it for Word and they only use
+        /// it in Teams", which usually changes the enablement plan more than the headline rate does.
+        /// </summary>
+        public static string UsageByAppSql(IEnumerable<int> seatLicenceTypeIds)
+        {
+            return
+                "WITH SeatUsers AS (\r\n" +
+                "    SELECT DISTINCT ul.user_id AS user_id\r\n" +
+                "    FROM dbo.user_license_type_lookups AS ul\r\n" +
+                $"    WHERE ul.license_type_id IN ({IdList(seatLicenceTypeIds)})\r\n" +
+                ")\r\n" +
+                "SELECT TOP (@top) ISNULL(c.app_host, '(unknown)') AS Label,\r\n" +
+                "       CAST(COUNT_BIG(*) AS float) AS Value\r\n" +
+                "FROM dbo.copilot_chats AS c\r\n" +
+                "" + AuditJoin + "\r\n" +
+                "JOIN SeatUsers AS seats ON seats.user_id = au.user_id\r\n" +
+                "WHERE au.time_stamp >= @from\r\n" +
+                "GROUP BY ISNULL(c.app_host, '(unknown)')\r\n" +
+                "ORDER BY Value DESC\r\n" +
+                "OPTION (RECOMPILE);";
+        }
+
+        /// <summary>
+        /// Weekly active licensed users, and how many of them used Cowork. A single point-in-time
+        /// adoption rate cannot show whether an enablement programme is working; this can.
+        ///
+        /// Weeks are bucketed to their Monday with day arithmetic rather than DATEDIFF(WEEK, ...),
+        /// which splits weeks on Sunday and would push Sunday's rows into the following week. The same
+        /// bucketing as the Reports area, so the two agree.
+        /// </summary>
+        public static string WeeklyAdoptionTrendSql(IEnumerable<int> seatLicenceTypeIds, IEnumerable<int> coworkAgentIds)
+        {
+            var week = WeekBucket("au.time_stamp");
+            var cowork = CoworkPredicate(coworkAgentIds);
+            var seats = IdList(seatLicenceTypeIds);
+
+            return
+                "WITH SeatUsers AS (\r\n" +
+                "    SELECT DISTINCT ul.user_id AS user_id\r\n" +
+                "    FROM dbo.user_license_type_lookups AS ul\r\n" +
+                $"    WHERE ul.license_type_id IN ({seats})\r\n" +
+                ")\r\n" +
+                "SELECT 'Active licensed users' AS SeriesName,\r\n" +
+                $"       {week} AS WeekStart,\r\n" +
+                "       CAST(COUNT(DISTINCT au.user_id) AS float) AS Value\r\n" +
+                "FROM dbo.copilot_chats AS c\r\n" +
+                "" + AuditJoin + "\r\n" +
+                "JOIN SeatUsers AS seats ON seats.user_id = au.user_id\r\n" +
+                "WHERE au.time_stamp >= @trendFrom\r\n" +
+                $"GROUP BY {week}\r\n" +
+                "UNION ALL\r\n" +
+                "SELECT 'Cowork users' AS SeriesName,\r\n" +
+                $"       {week} AS WeekStart,\r\n" +
+                "       CAST(COUNT(DISTINCT au.user_id) AS float) AS Value\r\n" +
+                "FROM dbo.copilot_chats AS c\r\n" +
+                "" + AuditJoin + "\r\n" +
+                "JOIN SeatUsers AS seats ON seats.user_id = au.user_id\r\n" +
+                $"WHERE au.time_stamp >= @trendFrom AND ({cowork})\r\n" +
+                $"GROUP BY {week}\r\n" +
+                "ORDER BY SeriesName, WeekStart\r\n" +
+                "OPTION (RECOMPILE);";
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// The predicate that identifies a Cowork interaction. <c>app_host</c> is compared directly
+        /// rather than through LOWER(): SQL Server's default collation here is case-insensitive, and
+        /// wrapping the column in a function would make the predicate non-SARGable for no benefit.
+        /// </summary>
+        internal static string CoworkPredicate(IEnumerable<int> coworkAgentIds)
+        {
+            var ids = (coworkAgentIds ?? Enumerable.Empty<int>()).Distinct().ToList();
+            var host = $"c.app_host = '{CoworkAppHost}'";
+
+            return ids.Count == 0
+                ? host
+                : $"{host} OR c.agent_id IN ({IdList(ids)})";
+        }
+
+        /// <summary>
+        /// Buckets a datetime to the Monday on or before it. 1900-01-01 was a Monday, so "days since
+        /// then modulo 7" is zero exactly on Mondays - independent of DATEFIRST and language settings.
+        /// </summary>
+        internal static string WeekBucket(string column)
+        {
+            return $"DATEADD(DAY, -(DATEDIFF(DAY, 0, {column}) % 7), CAST({column} AS date))";
+        }
+
+        /// <summary>
+        /// Renders integer ids as a SQL <c>IN</c> list.
+        ///
+        /// These ids always come from this application's own query against <c>dbo.license_types</c> /
+        /// <c>dbo.copilot_agents</c> and are typed <c>int</c>, so there is no injection surface - but an
+        /// empty list would produce <c>IN ()</c>, which is a syntax error, so it yields a predicate that
+        /// is simply always false. A tenant that has bought no Copilot licences then gets an empty
+        /// report rather than a 500.
+        /// </summary>
+        internal static string IdList(IEnumerable<int> ids)
+        {
+            var list = (ids ?? Enumerable.Empty<int>()).Distinct().ToList();
+
+            return list.Count == 0
+                ? "-1"
+                : string.Join(", ", list.Select(id => id.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        /// <summary>
+        /// Replaces the parameters with literals for display only, so the SQL popover shows a query an
+        /// admin can paste straight into SQL Server Management Studio. Never used for execution.
+        /// </summary>
+        public static string ForDisplay(string sql, IDictionary<string, object> parameters)
+        {
+            if (string.IsNullOrEmpty(sql)) return sql;
+
+            var declarations = new List<string>();
+            foreach (var parameter in parameters ?? new Dictionary<string, object>())
+            {
+                declarations.Add($"DECLARE {parameter.Key} {SqlLiteralType(parameter.Value)} = {SqlLiteral(parameter.Value)};");
+            }
+
+            return declarations.Count == 0
+                ? sql
+                : string.Join("\r\n", declarations) + "\r\n\r\n" + sql;
+        }
+
+        private static string SqlLiteralType(object value)
+        {
+            switch (value)
+            {
+                case DateTime _: return "datetime";
+                case int _: return "int";
+                case long _: return "bigint";
+                case double _: return "float";
+                default: return "nvarchar(200)";
+            }
+        }
+
+        private static string SqlLiteral(object value)
+        {
+            switch (value)
+            {
+                case null:
+                    return "NULL";
+                case DateTime dt:
+                    return $"'{dt:yyyy-MM-dd HH:mm:ss}'";
+                case int i:
+                    return i.ToString(CultureInfo.InvariantCulture);
+                case long l:
+                    return l.ToString(CultureInfo.InvariantCulture);
+                case double d:
+                    return d.ToString(CultureInfo.InvariantCulture);
+                default:
+                    return "N'" + value.ToString().Replace("'", "''") + "'";
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotLicenceClassifier.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotLicenceClassifier.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Common.Entities.CopilotAdoption
+{
+    /// <summary>
+    /// Decides which rows of <c>dbo.license_types</c> represent a paid <b>Microsoft 365 Copilot seat</b>
+    /// - the licence the adoption tool is about - as opposed to the many other Microsoft products that
+    /// merely have the word "Copilot" in their name (Copilot Studio, Copilot for Sales, Sales Copilot,
+    /// Power Virtual Agents...).
+    ///
+    /// Why this needs to be more than a name match: the user import stores the SKU <i>part number</i> in
+    /// <see cref="LicenseType.SKUID"/> and a friendly product name in <see cref="LicenseType.Name"/>,
+    /// resolved from Microsoft's published licensing CSV. When Microsoft ships a SKU that is newer than
+    /// the CSV shipped in this build, the resolver has no display name and the part number is stored as
+    /// the name as well. So a classifier that only looked at the display name would silently miss every
+    /// brand-new Copilot SKU - exactly the ones a customer is most likely to have just bought - and a
+    /// classifier that only looked at a hard-coded list of exact SKUs would miss them too.
+    ///
+    /// The rules below are therefore, in order:
+    /// <list type="number">
+    ///   <item>An explicit exclusion list of "Copilot-branded but not a Microsoft 365 Copilot seat" SKUs.</item>
+    ///   <item>A prefix match on the SKU part number, which catches present and future variants
+    ///         (<c>M365_Copilot</c>, <c>Microsoft_365_Copilot</c>, <c>Microsoft_365_Copilot_EDU</c>, ...).</item>
+    ///   <item>A conservative display-name fallback for SKUs whose part number Microsoft renames.</item>
+    /// </list>
+    ///
+    /// Classification is deliberately <b>visible and overridable</b> rather than silent: the API exposes
+    /// what it decided for every licence type, and callers can override the set of licence-type ids for
+    /// a request. A misclassified SKU is then an obvious, correctable fact on screen rather than a wrong
+    /// number in a board pack.
+    /// </summary>
+    public static class CopilotLicenceClassifier
+    {
+        /// <summary>
+        /// SKU part-number prefixes that identify a Microsoft 365 Copilot seat. Matched
+        /// case-insensitively, after <see cref="ExcludedSkuPrefixes"/> has had its say.
+        ///
+        /// Prefixes (not exact values) so variants Microsoft has not shipped yet - regional, education,
+        /// government and "business" editions all follow the same stem - are counted automatically
+        /// instead of quietly dropping out of the adoption numbers until this file is next edited.
+        /// </summary>
+        public static readonly string[] SeatSkuPrefixes = new[]
+        {
+            "M365_COPILOT",             // e.g. M365_Copilot
+            "MICROSOFT_365_COPILOT",    // e.g. Microsoft_365_Copilot, Microsoft_365_Copilot_EDU
+        };
+
+        /// <summary>
+        /// SKU part-number prefixes that are Copilot-branded but are NOT a Microsoft 365 Copilot seat.
+        /// Checked first, so a future SKU that matches both a seat prefix and an exclusion is excluded.
+        ///
+        /// These are real, separately-sold products. Counting them as seats would inflate the licensed
+        /// population and make the adoption rate look far worse than it is - the failure mode that
+        /// matters most here, because this tool is used to justify spend.
+        /// </summary>
+        public static readonly string[] ExcludedSkuPrefixes = new[]
+        {
+            "MICROSOFT_COPILOT_FOR_SALES",  // Microsoft 365 Copilot for Sales - a separate add-on
+            "MICROSOFT_VIVA_SALES",         // Microsoft Sales Copilot (the former name of the above)
+            "MICROSOFT_COPILOT_STUDIO",     // Copilot Studio - an authoring tool, not a Copilot seat
+            "COPILOT_STUDIO",
+            "POWER_VIRTUAL_AGENTS",         // Copilot Studio's previous name
+            "VIRTUAL_AGENT_USL",            // Copilot Studio user licences
+            "CCIBOTS",                      // Copilot Studio viral trial
+        };
+
+        /// <summary>
+        /// Words that disqualify a display-name match in the fallback rule. A display name only counts
+        /// when it looks like the Microsoft 365 Copilot product AND contains none of these.
+        /// </summary>
+        private static readonly string[] ExcludedNameWords = new[]
+        {
+            "studio", "sales", "virtual agent", "github", "security", "dynamics", "power ", "bot",
+        };
+
+        /// <summary>
+        /// Display-name fragments that, combined with the word "copilot", indicate the Microsoft 365
+        /// Copilot seat. Microsoft has already renamed this product once ("Microsoft Copilot for
+        /// Microsoft 365" -> "Microsoft 365 Copilot"), so both orderings are accepted.
+        /// </summary>
+        private static readonly string[] SeatNameQualifiers = new[]
+        {
+            "microsoft 365", "m365", "office 365",
+        };
+
+        /// <summary>
+        /// True when this licence type is a paid Microsoft 365 Copilot seat.
+        /// </summary>
+        /// <param name="skuPartNumber">
+        /// <c>license_types.sku_id</c> - despite the column name this holds the SKU <i>part number</i>
+        /// (e.g. <c>Microsoft_365_Copilot</c>), which is what the user import writes.
+        /// </param>
+        /// <param name="displayName">
+        /// <c>license_types.name</c> - the resolved product name, or the part number again when the
+        /// shipped licensing CSV had no entry for it.
+        /// </param>
+        public static bool IsCopilotSeat(string skuPartNumber, string displayName)
+        {
+            var sku = Normalise(skuPartNumber);
+
+            if (sku.Length > 0)
+            {
+                if (StartsWithAny(sku, ExcludedSkuPrefixes))
+                {
+                    return false;
+                }
+
+                if (StartsWithAny(sku, SeatSkuPrefixes))
+                {
+                    return true;
+                }
+            }
+
+            return IsSeatDisplayName(displayName);
+        }
+
+        /// <summary>
+        /// The display-name fallback: a name that mentions Copilot together with the Microsoft 365
+        /// family, and mentions none of the other Copilot-branded products.
+        ///
+        /// Deliberately conservative. A false positive here silently adds seats that were never bought,
+        /// which would understate adoption; a false negative is visible in the licence-types list and
+        /// can be corrected with an explicit override.
+        /// </summary>
+        private static bool IsSeatDisplayName(string displayName)
+        {
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                return false;
+            }
+
+            var name = displayName.Trim().ToLowerInvariant();
+
+            if (!name.Contains("copilot"))
+            {
+                return false;
+            }
+
+            if (ExcludedNameWords.Any(word => name.Contains(word)))
+            {
+                return false;
+            }
+
+            return SeatNameQualifiers.Any(qualifier => name.Contains(qualifier));
+        }
+
+        /// <summary>
+        /// Classifies every supplied licence type, preserving input order. Used by the API so an admin
+        /// can see - and challenge - exactly which SKUs were counted as Copilot seats.
+        /// </summary>
+        public static List<LicenceTypeClassification> Classify(IEnumerable<LicenceTypeRow> licenceTypes)
+        {
+            if (licenceTypes == null)
+            {
+                return new List<LicenceTypeClassification>();
+            }
+
+            return licenceTypes
+                .Select(licenceType => new LicenceTypeClassification
+                {
+                    Id = licenceType.Id,
+                    Name = licenceType.Name,
+                    SkuPartNumber = licenceType.SkuPartNumber,
+                    AssignedUsers = licenceType.AssignedUsers,
+                    IsCopilotSeat = IsCopilotSeat(licenceType.SkuPartNumber, licenceType.Name),
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// The licence-type ids to treat as Copilot seats for a request: the caller's explicit override
+        /// when supplied (intersected with what actually exists, so a stale id cannot silently widen or
+        /// break the query), otherwise everything <see cref="IsCopilotSeat"/> accepts.
+        /// </summary>
+        public static List<int> ResolveSeatLicenceTypeIds(
+            IEnumerable<LicenceTypeRow> licenceTypes,
+            IEnumerable<int> overrideIds)
+        {
+            var all = Classify(licenceTypes);
+
+            if (overrideIds != null)
+            {
+                var requested = new HashSet<int>(overrideIds);
+                if (requested.Count > 0)
+                {
+                    return all.Where(l => requested.Contains(l.Id)).Select(l => l.Id).ToList();
+                }
+            }
+
+            return all.Where(l => l.IsCopilotSeat).Select(l => l.Id).ToList();
+        }
+
+        private static bool StartsWithAny(string normalisedSku, IEnumerable<string> prefixes)
+        {
+            return prefixes.Any(prefix => normalisedSku.StartsWith(prefix, StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// Upper-cases and trims a SKU part number for prefix matching. A tenant has tens of licence
+        /// types, not thousands, so the allocation is irrelevant here.
+        /// </summary>
+        private static string Normalise(string skuPartNumber)
+        {
+            return string.IsNullOrWhiteSpace(skuPartNumber)
+                ? string.Empty
+                : skuPartNumber.Trim().ToUpperInvariant();
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CsvSerialiser.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CsvSerialiser.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Common.Entities.CopilotAdoption
+{
+    /// <summary>
+    /// One column of a CSV export: its heading and how to get the value out of a row.
+    /// </summary>
+    public class CsvColumn<T>
+    {
+        public CsvColumn(string header, Func<T, object> value)
+        {
+            Header = header;
+            Value = value;
+        }
+
+        public string Header { get; }
+
+        public Func<T, object> Value { get; }
+    }
+
+    /// <summary>
+    /// RFC 4180 CSV writing for the adoption exports.
+    ///
+    /// Written by hand rather than pulled from a library because the three things that actually go
+    /// wrong with exported user lists all need deliberate handling, and all three are invisible until a
+    /// customer hits them:
+    ///
+    /// <list type="number">
+    ///   <item><b>Unicode.</b> Real tenants have users, departments and file names in Greek, Cyrillic,
+    ///   Japanese and so on. The output is UTF-8 <i>with a BOM</i>, because Excel on Windows assumes the
+    ///   local ANSI code page for a BOM-less CSV and will render "Καλημέρα" as mojibake - in a document
+    ///   that is about to be sent to an executive.</item>
+    ///
+    ///   <item><b>CSV injection.</b> Values that begin with <c>=</c>, <c>+</c>, <c>-</c>, <c>@</c> or a
+    ///   control character are treated as formulas by Excel and Google Sheets. Job titles and department
+    ///   names come from the customer's own directory and are not trusted input, so they are prefixed
+    ///   with an apostrophe, which Excel strips on display.</item>
+    ///
+    ///   <item><b>Culture.</b> Numbers and dates are written invariantly (ISO-8601 for dates), so a file
+    ///   generated on a server with a comma decimal separator is not silently misread as two columns.</item>
+    /// </list>
+    /// </summary>
+    public static class CsvSerialiser
+    {
+        /// <summary>Characters that make a spreadsheet treat a cell as a formula.</summary>
+        private static readonly char[] FormulaTriggers = { '=', '+', '-', '@', '\t', '\r' };
+
+        /// <summary>
+        /// Serialises rows to an RFC 4180 CSV document (CRLF line endings, quoted where required).
+        /// Does not include a byte-order mark - see <see cref="ToBytes{T}"/> for the file payload.
+        /// </summary>
+        public static string ToCsv<T>(IEnumerable<T> rows, IReadOnlyList<CsvColumn<T>> columns)
+        {
+            if (columns == null) throw new ArgumentNullException(nameof(columns));
+
+            var sb = new StringBuilder();
+
+            sb.Append(string.Join(",", columns.Select(c => Escape(c.Header))));
+            sb.Append("\r\n");
+
+            foreach (var row in rows ?? Enumerable.Empty<T>())
+            {
+                sb.Append(string.Join(",", columns.Select(c => Escape(Format(SafeValue(c, row))))));
+                sb.Append("\r\n");
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// The bytes to hand back as a downloadable file: UTF-8 with a BOM so Excel reads non-ASCII
+        /// user and department names correctly.
+        /// </summary>
+        public static byte[] ToBytes<T>(IEnumerable<T> rows, IReadOnlyList<CsvColumn<T>> columns)
+        {
+            var csv = ToCsv(rows, columns);
+            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+            return encoding.GetPreamble().Concat(encoding.GetBytes(csv)).ToArray();
+        }
+
+        /// <summary>
+        /// A download file name that is stable, sortable and safe on every OS, e.g.
+        /// <c>copilot-licensed-users-2026-08-20.csv</c>.
+        /// </summary>
+        public static string FileName(string prefix, DateTime generatedUtc)
+        {
+            var safePrefix = new string((prefix ?? "export")
+                .Select(ch => char.IsLetterOrDigit(ch) || ch == '-' || ch == '_' ? ch : '-')
+                .ToArray());
+
+            return $"{safePrefix}-{generatedUtc:yyyy-MM-dd}.csv";
+        }
+
+        /// <summary>
+        /// Reads one cell, turning an accessor failure into an empty cell rather than a failed export.
+        /// A 20,000-row licence report should not be lost to one null navigation property.
+        /// </summary>
+        private static object SafeValue<T>(CsvColumn<T> column, T row)
+        {
+            try
+            {
+                return column.Value(row);
+            }
+            catch (NullReferenceException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>Culture-invariant rendering of a cell value.</summary>
+        private static string Format(object value)
+        {
+            switch (value)
+            {
+                case null:
+                    return string.Empty;
+
+                case string s:
+                    return s;
+
+                case bool b:
+                    // "Yes"/"No" rather than "True"/"False": these files are read by people, and Excel
+                    // does not coerce them into anything unexpected.
+                    return b ? "Yes" : "No";
+
+                case DateTime dt:
+                    return dt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+
+                case double d:
+                    return d.ToString("0.##", CultureInfo.InvariantCulture);
+
+                case float f:
+                    return f.ToString("0.##", CultureInfo.InvariantCulture);
+
+                case decimal m:
+                    return m.ToString("0.##", CultureInfo.InvariantCulture);
+
+                case IFormattable formattable:
+                    return formattable.ToString(null, CultureInfo.InvariantCulture);
+
+                default:
+                    return value.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Quotes and escapes a single field per RFC 4180, and neutralises spreadsheet formula
+        /// injection. Internal so the behaviour can be asserted directly by unit tests.
+        /// </summary>
+        internal static string Escape(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            var text = value;
+
+            // Defuse formulas before quoting. The apostrophe is inside the quoted field, which is what
+            // Excel and Sheets look for; they strip it when displaying the cell.
+            if (FormulaTriggers.Contains(text[0]))
+            {
+                text = "'" + text;
+            }
+
+            var mustQuote = text.IndexOfAny(new[] { ',', '"', '\r', '\n' }) >= 0
+                            || text != text.Trim();
+
+            if (!mustQuote)
+            {
+                return text;
+            }
+
+            return "\"" + text.Replace("\"", "\"\"") + "\"";
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -81,6 +81,13 @@
     <Compile Include="BuildConstants.cs" />
     <Compile Include="Config\AppConfig.cs" />
     <Compile Include="Config\AppConnectionStrings.cs" />
+    <Compile Include="CopilotAdoption\CopilotAdoptionExports.cs" />
+    <Compile Include="CopilotAdoption\CopilotAdoptionModels.cs" />
+    <Compile Include="CopilotAdoption\CopilotAdoptionScoring.cs" />
+    <Compile Include="CopilotAdoption\CopilotAdoptionService.cs" />
+    <Compile Include="CopilotAdoption\CopilotAdoptionSql.cs" />
+    <Compile Include="CopilotAdoption\CopilotLicenceClassifier.cs" />
+    <Compile Include="CopilotAdoption\CsvSerialiser.cs" />
     <Compile Include="Config\ImportConfig.cs" />
     <Compile Include="Config\UserGroupsFilterModel.cs" />
     <Compile Include="Entities\AuditLog\CopilotEvents.cs" />

--- a/src/AnalyticsEngine/Common/Entities/Properties/AssemblyInfo.cs
+++ b/src/AnalyticsEngine/Common/Entities/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -17,6 +18,10 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+// Matches the convention already used by App.ControlPanel.Engine, the web-job engines and Web: internal
+// helpers stay internal in the shipped API surface but can be asserted directly by the unit tests.
+[assembly: InternalsVisibleTo("Tests.UnitTests")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("637930bd-073b-421e-9f33-fe90bf2103c5")]

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSqlIntegrationTests.cs
@@ -1,0 +1,623 @@
+using Common.Entities.CopilotAdoption;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Data.SqlClient;
+using System.Linq;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Runs the Copilot licence-adoption queries against a real, throwaway SQL Server database.
+    ///
+    /// The pure-logic tests in <see cref="CopilotAdoptionTests"/> cannot catch the failures that
+    /// actually break this feature in production: a query that does not parse, a column that does not
+    /// exist, a result column that does not map onto its DTO, or an aggregate that quietly counts the
+    /// wrong rows. All of those only show up against a real database, and the queries here are
+    /// hand-written SQL rather than LINQ, so nothing else would catch them before a customer did.
+    ///
+    /// Each test builds only the tables its query touches, seeds a handful of rows and drops the
+    /// database again, following the same pattern as the migration tests.
+    /// </summary>
+    [TestClass]
+    public class CopilotAdoptionSqlIntegrationTests
+    {
+        /// <summary>
+        /// A bare EF context used purely to execute raw SQL, so the tests exercise the exact
+        /// materialisation path the service uses (<c>Database.SqlQuery&lt;T&gt;</c>) rather than a
+        /// hand-rolled reader that could mask a column/property mismatch.
+        /// </summary>
+        private sealed class RawSqlContext : DbContext
+        {
+            static RawSqlContext()
+            {
+                // Nothing here owns a model, and the scratch database is built by the test itself.
+                Database.SetInitializer<RawSqlContext>(null);
+            }
+
+            public RawSqlContext(string connectionString) : base(connectionString)
+            {
+            }
+        }
+
+        #region Licensed users
+
+        [TestMethod]
+        public void LicensedUsersQuery_RunsAndSplitsWindowFromHistory()
+        {
+            using (var db = ScratchDatabase.Create("CopilotAdoptLic"))
+            {
+                CreateUserTables(db);
+                CreateCopilotTables(db);
+                CreateCopilotReportTable(db);
+
+                db.Execute(
+                    @"INSERT INTO dbo.user_departments (id, name) VALUES (1, N'Engineering');
+                      INSERT INTO dbo.license_types (id, name, sku_id)
+                          VALUES (1, N'Microsoft Copilot for Microsoft 365', N'Microsoft_365_Copilot'),
+                                 (2, N'Office 365 E3', N'ENTERPRISEPACK');
+
+                      -- Deliberately non-ASCII: real tenants have Greek, Cyrillic and CJK display
+                      -- names, and a varchar column anywhere in this path would silently mangle them.
+                      INSERT INTO dbo.users (id, user_name, mail, account_enabled, department_id)
+                          VALUES (10, N'active@contoso.com',  N'active@contoso.com',  1, 1),
+                                 (11, N'dormant@contoso.com', N'dormant@contoso.com', 1, 1),
+                                 (12, N'never@contoso.com',   N'never@contoso.com',   0, 1),
+                                 (13, N'unlicensed@contoso.com', N'unlicensed@contoso.com', 1, 1),
+                                 (14, N'καλημέρα@contoso.com', N'καλημέρα@contoso.com', 1, 1);
+
+                      INSERT INTO dbo.user_license_type_lookups (id, user_id, license_type_id)
+                          VALUES (1, 10, 1), (2, 11, 1), (3, 12, 1), (4, 14, 1),
+                                 (5, 13, 2);   -- E3 only: not a Copilot seat
+
+                      INSERT INTO dbo.copilot_agents (id, name, agent_id)
+                          VALUES (1, N'Copilot Cowork', N'Copilot.M365Copilot.CoworkChat');");
+
+                // 'active' used Copilot on two days inside the window across two app hosts, one of
+                // them Cowork; 'dormant' only used it before the window; 'never' has nothing at all.
+                SeedCopilotInteraction(db, userId: 10, daysAgo: 1, appHost: "Teams");
+                SeedCopilotInteraction(db, userId: 10, daysAgo: 1, appHost: "Teams");
+                SeedCopilotInteraction(db, userId: 10, daysAgo: 5, appHost: "cowork", agentId: 1);
+                SeedCopilotInteraction(db, userId: 11, daysAgo: 120, appHost: "Word");
+                SeedCopilotInteraction(db, userId: 13, daysAgo: 2, appHost: "Copilot Chat");
+
+                var sql = CopilotAdoptionSql.LicensedUsersSql(
+                    new[] { 1 },
+                    new[] { 1 },
+                    includeCopilotReport: false);
+
+                var rows = Query<LicensedUserUsageRow>(db, sql,
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@historyFrom", DateTime.UtcNow.Date.AddDays(-365)),
+                    new SqlParameter("@maxRows", 1000));
+
+                Assert.AreEqual(4, rows.Count, "Only the four Copilot-licensed users should be returned.");
+                Assert.IsFalse(rows.Any(r => r.UserPrincipalName == "unlicensed@contoso.com"),
+                    "A user with only an E3 licence must not be counted as a Copilot seat.");
+                Assert.IsTrue(rows.Any(r => r.UserPrincipalName == "καλημέρα@contoso.com"),
+                    "A non-ASCII user principal name must survive the query unchanged.");
+
+                var active = rows.Single(r => r.UserPrincipalName == "active@contoso.com");
+                Assert.AreEqual(3, active.Interactions);
+                Assert.AreEqual(2, active.ActiveDays, "Two distinct days inside the window.");
+                Assert.AreEqual(2, active.AppsUsed, "Teams and Cowork are two distinct app hosts.");
+                Assert.AreEqual(1, active.CoworkInteractions, "The Cowork interaction must be identified.");
+                Assert.AreEqual(0, active.PriorInteractions);
+                Assert.AreEqual("Engineering", active.Department);
+
+                var dormant = rows.Single(r => r.UserPrincipalName == "dormant@contoso.com");
+                Assert.AreEqual(0, dormant.Interactions, "Nothing inside the window...");
+                Assert.AreEqual(1, dormant.PriorInteractions, "...but history within the lookback, which is what makes them dormant rather than never-used.");
+                Assert.IsNotNull(dormant.LastInteractionUtc);
+
+                var never = rows.Single(r => r.UserPrincipalName == "never@contoso.com");
+                Assert.AreEqual(0, never.Interactions);
+                Assert.AreEqual(0, never.PriorInteractions);
+                Assert.IsNull(never.LastInteractionUtc);
+                Assert.AreEqual(false, never.AccountEnabled,
+                    "A disabled account still holding a seat is the clearest reclaim there is, so the flag must survive.");
+            }
+        }
+
+        [TestMethod]
+        public void LicensedUsersQuery_PreservesNonLatinMetadata()
+        {
+            // Guards the Unicode requirement end to end: a varchar column or a non-N string literal
+            // anywhere on this path turns a Greek display name into question marks, in an export that
+            // is about to be sent to an executive.
+            using (var db = ScratchDatabase.Create("CopilotAdoptUni"))
+            {
+                CreateUserTables(db);
+                CreateCopilotTables(db);
+
+                db.Execute(
+                    @"INSERT INTO dbo.user_departments (id, name) VALUES (1, N'Καλημέρα κόσμε');
+                      INSERT INTO dbo.license_types (id, name, sku_id)
+                          VALUES (1, N'Microsoft Copilot for Microsoft 365', N'Microsoft_365_Copilot');
+                      INSERT INTO dbo.users (id, user_name, mail, account_enabled, department_id)
+                          VALUES (1, N'καλημέρα@contoso.com', N'καλημέρα@contoso.com', 1, 1);
+                      INSERT INTO dbo.user_license_type_lookups (id, user_id, license_type_id) VALUES (1, 1, 1);");
+
+                var rows = Query<LicensedUserUsageRow>(
+                    db,
+                    CopilotAdoptionSql.LicensedUsersSql(new[] { 1 }, new int[0], includeCopilotReport: false),
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@historyFrom", DateTime.UtcNow.Date.AddDays(-365)),
+                    new SqlParameter("@maxRows", 1000));
+
+                Assert.AreEqual(1, rows.Count);
+                Assert.AreEqual("καλημέρα@contoso.com", rows[0].UserPrincipalName);
+                Assert.AreEqual("Καλημέρα κόσμε", rows[0].Department);
+            }
+        }
+
+        [TestMethod]
+        public void LicensedUsersQuery_ReadsMicrosoftsPerUserReportSnapshot()
+        {
+            using (var db = ScratchDatabase.Create("CopilotAdoptRpt"))
+            {
+                CreateUserTables(db);
+                CreateCopilotTables(db);
+                CreateCopilotReportTable(db);
+
+                var snapshot = DateTime.UtcNow.Date.AddDays(-3);
+                var inWindow = DateTime.UtcNow.Date.AddDays(-5);
+                var beforeWindow = DateTime.UtcNow.Date.AddDays(-200);
+
+                db.Execute(
+                    $@"INSERT INTO dbo.license_types (id, name, sku_id)
+                           VALUES (1, N'Microsoft Copilot for Microsoft 365', N'Microsoft_365_Copilot');
+                       INSERT INTO dbo.users (id, user_name, account_enabled) VALUES (1, N'rpt@contoso.com', 1);
+                       INSERT INTO dbo.user_license_type_lookups (id, user_id, license_type_id) VALUES (1, 1, 1);
+
+                       INSERT INTO dbo.copilot_usage_user_activity_log
+                           (id, [date], user_id, last_activity_date, report_period_days,
+                            prompts_all_apps, active_usage_days,
+                            teams_last_activity_date, word_last_activity_date, excel_last_activity_date,
+                            chat_last_activity_date)
+                       VALUES (1, '{snapshot:yyyy-MM-dd}', 1, '{inWindow:yyyy-MM-dd}', 28,
+                               47, 12,
+                               '{inWindow:yyyy-MM-dd}', '{inWindow:yyyy-MM-dd}', '{beforeWindow:yyyy-MM-dd}',
+                               '{inWindow:yyyy-MM-dd}');");
+
+                var rows = Query<LicensedUserUsageRow>(
+                    db,
+                    CopilotAdoptionSql.LicensedUsersSql(new[] { 1 }, new int[0], includeCopilotReport: true),
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@historyFrom", DateTime.UtcNow.Date.AddDays(-365)),
+                    new SqlParameter("@copilotReportDate", snapshot),
+                    new SqlParameter("@maxRows", 1000));
+
+                Assert.AreEqual(1, rows.Count);
+                var row = rows[0];
+
+                Assert.AreEqual(47, row.ReportPrompts);
+                Assert.AreEqual(12, row.ReportActiveDays);
+                Assert.AreEqual(3, row.ReportAppsUsed,
+                    "Teams, Word and the collapsed chat surface are inside the window; Excel is not.");
+                Assert.AreEqual(inWindow, row.ReportLastActivityUtc,
+                    "The last-activity date is the latest across every per-app column.");
+            }
+        }
+
+        #endregion
+
+        #region Licence opportunities
+
+        [TestMethod]
+        public void OpportunitiesQuery_RanksUnlicensedUsersAndAgreesWithTheCsharpScore()
+        {
+            // The database ranks candidates so a 200,000-user tenant does not have to be pulled into
+            // memory, but the score shown to the user is always recomputed in C#. If the two ever drift
+            // apart the report would return the wrong people while still looking self-consistent, so
+            // the agreement is asserted explicitly here.
+            using (var db = ScratchDatabase.Create("CopilotAdoptOpp"))
+            {
+                CreateUserTables(db);
+                CreateCopilotTables(db);
+                CreateM365UsageTables(db);
+
+                var snapshot = DateTime.UtcNow.Date.AddDays(-3);
+
+                db.Execute(
+                    $@"INSERT INTO dbo.user_departments (id, name) VALUES (1, N'Finance');
+                       INSERT INTO dbo.license_types (id, name, sku_id)
+                           VALUES (1, N'Microsoft Copilot for Microsoft 365', N'Microsoft_365_Copilot');
+
+                       INSERT INTO dbo.users (id, user_name, account_enabled, department_id)
+                           VALUES (1, N'licensed@contoso.com',   1, 1),
+                                  (2, N'heavy@contoso.com',      1, 1),
+                                  (3, N'light@contoso.com',      1, 1),
+                                  (4, N'disabled@contoso.com',   0, 1),
+                                  (5, N'inactive@contoso.com',   1, 1);
+
+                       INSERT INTO dbo.user_license_type_lookups (id, user_id, license_type_id) VALUES (1, 1, 1);
+
+                       INSERT INTO dbo.teams_user_activity_log
+                           (id, [date], user_id, last_activity_date, private_chat_count, team_chat_count,
+                            post_messages, reply_messages, meetings_attended_count, meetings_organized_count)
+                       VALUES (1, '{snapshot:yyyy-MM-dd}', 1, '{snapshot:yyyy-MM-dd}', 10, 10, 0, 0, 5, 5),
+                              (2, '{snapshot:yyyy-MM-dd}', 2, '{snapshot:yyyy-MM-dd}', 40, 20, 10, 10, 20, 10),
+                              (3, '{snapshot:yyyy-MM-dd}', 3, '{snapshot:yyyy-MM-dd}',  2,  0,  0,  0,  1,  0),
+                              (4, '{snapshot:yyyy-MM-dd}', 4, '{snapshot:yyyy-MM-dd}', 90, 90, 90, 90, 90, 90);
+
+                       INSERT INTO dbo.outlook_user_activity_log
+                           (id, [date], user_id, last_activity_date, email_send_count, email_receive_count, email_read_count)
+                       VALUES (1, '{snapshot:yyyy-MM-dd}', 2, '{snapshot:yyyy-MM-dd}', 60, 100, 90),
+                              (2, '{snapshot:yyyy-MM-dd}', 3, '{snapshot:yyyy-MM-dd}',  1,   2,   1);
+
+                       INSERT INTO dbo.sharepoint_user_activity_log (id, [date], user_id, last_activity_date, viewed_or_edited)
+                       VALUES (1, '{snapshot:yyyy-MM-dd}', 2, '{snapshot:yyyy-MM-dd}', 30);
+
+                       INSERT INTO dbo.onedrive_user_activity_log (id, [date], user_id, last_activity_date, viewed_or_edited)
+                       VALUES (1, '{snapshot:yyyy-MM-dd}', 2, '{snapshot:yyyy-MM-dd}', 25);");
+
+                // The heavy user is already using Copilot Chat without a seat - the strongest signal.
+                SeedCopilotInteraction(db, userId: 2, daysAgo: 1, appHost: "Copilot Chat");
+                SeedCopilotInteraction(db, userId: 2, daysAgo: 4, appHost: "Copilot Chat");
+                SeedCopilotInteraction(db, userId: 1, daysAgo: 1, appHost: "Teams");
+
+                var options = CopilotAdoptionOptions.Default;
+                var sql = CopilotAdoptionSql.LicenceOpportunitiesSql(
+                    new[] { 1 }, options, includeCopilotAudit: true, includeM365Usage: true);
+
+                var rows = Query<UnlicensedUserSignalRow>(db, sql,
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@m365ReportDate", snapshot),
+                    new SqlParameter("@maxRows", 1000));
+
+                var upns = rows.Select(r => r.UserPrincipalName).ToList();
+                CollectionAssert.DoesNotContain(upns, "licensed@contoso.com",
+                    "A user who already holds a Copilot seat is not a licence opportunity.");
+                CollectionAssert.DoesNotContain(upns, "disabled@contoso.com",
+                    "A disabled account cannot use a licence, and proposing one would discredit the list.");
+                CollectionAssert.DoesNotContain(upns, "inactive@contoso.com",
+                    "A user with no activity at all is not a candidate and must not be scanned into the result.");
+                CollectionAssert.Contains(upns, "heavy@contoso.com");
+                CollectionAssert.Contains(upns, "light@contoso.com");
+
+                var heavy = rows.Single(r => r.UserPrincipalName == "heavy@contoso.com");
+                Assert.AreEqual(2, heavy.UnlicensedCopilotInteractions);
+                Assert.AreEqual(2, heavy.UnlicensedCopilotActiveDays);
+                Assert.AreEqual(80, heavy.TeamsMessages, "40 + 20 chat plus 10 + 10 channel messages.");
+                Assert.AreEqual(30, heavy.TeamsMeetings, "20 attended plus 10 organised.");
+                Assert.AreEqual(60, heavy.EmailsSent);
+                Assert.AreEqual(90, heavy.EmailsRead);
+                Assert.AreEqual(55, heavy.FilesViewedOrEdited, "SharePoint and OneDrive are one document signal.");
+                Assert.AreEqual("Finance", heavy.Department);
+
+                // The database returned the candidates in its own ranked order. Re-scoring in C# must
+                // reproduce that order, which is the guarantee that the SQL selects the right people.
+                var scored = rows.Select(r => CopilotAdoptionScoring.ScoreOpportunity(r, options)).ToList();
+
+                CollectionAssert.AreEqual(
+                    rows.Select(r => r.UserPrincipalName).ToArray(),
+                    scored.OrderByDescending(s => s.OpportunityScore)
+                          .ThenBy(s => s.UserId)
+                          .Select(s => s.UserPrincipalName)
+                          .ToArray(),
+                    "The SQL ranking and the C# score must agree - otherwise the report returns the wrong candidates.");
+
+                var heavyScored = scored.Single(s => s.UserPrincipalName == "heavy@contoso.com");
+                Assert.IsTrue(heavyScored.Recommended, "A heavy user across every workload is a clear recommendation.");
+                Assert.IsFalse(
+                    scored.Single(s => s.UserPrincipalName == "light@contoso.com").Recommended,
+                    "A barely-active user must not be recommended for a paid seat.");
+            }
+        }
+
+        [TestMethod]
+        public void OpportunitiesQuery_WorksWithoutTheMicrosoft365UsageReports()
+        {
+            // A deployment that imports only the Copilot audit log must still be able to find the
+            // people already using Copilot Chat without a seat - the highest-value candidates.
+            using (var db = ScratchDatabase.Create("CopilotAdoptOppNoUsage"))
+            {
+                CreateUserTables(db);
+                CreateCopilotTables(db);
+
+                db.Execute(
+                    @"INSERT INTO dbo.license_types (id, name, sku_id)
+                          VALUES (1, N'Microsoft Copilot for Microsoft 365', N'Microsoft_365_Copilot');
+                      INSERT INTO dbo.users (id, user_name, account_enabled)
+                          VALUES (1, N'chatuser@contoso.com', 1);");
+
+                SeedCopilotInteraction(db, userId: 1, daysAgo: 2, appHost: "Copilot Chat");
+
+                var rows = Query<UnlicensedUserSignalRow>(
+                    db,
+                    CopilotAdoptionSql.LicenceOpportunitiesSql(
+                        new[] { 1 }, CopilotAdoptionOptions.Default, includeCopilotAudit: true, includeM365Usage: false),
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@maxRows", 1000));
+
+                Assert.AreEqual(1, rows.Count);
+                Assert.AreEqual(1, rows[0].UnlicensedCopilotInteractions);
+                Assert.AreEqual(0, rows[0].TeamsMessages, "The Microsoft 365 columns must still materialise, as zero.");
+                Assert.IsNull(rows[0].LastM365ActivityUtc);
+            }
+        }
+
+        #endregion
+
+        #region Charts and lookups
+
+        [TestMethod]
+        public void SupportingQueries_AllRunAgainstTheRealSchema()
+        {
+            // These are small, but they are hand-written SQL against real column names, so a typo in
+            // any of them is a broken chart that only shows up in a customer's browser.
+            using (var db = ScratchDatabase.Create("CopilotAdoptCharts"))
+            {
+                CreateUserTables(db);
+                CreateCopilotTables(db);
+                CreateCopilotReportTable(db);
+                CreateM365UsageTables(db);
+                CreateCopilotImportLogTable(db);
+
+                db.Execute(
+                    @"INSERT INTO dbo.license_types (id, name, sku_id)
+                          VALUES (1, N'Microsoft Copilot for Microsoft 365', N'Microsoft_365_Copilot');
+                      INSERT INTO dbo.users (id, user_name, account_enabled) VALUES (1, N'a@contoso.com', 1);
+                      INSERT INTO dbo.user_license_type_lookups (id, user_id, license_type_id) VALUES (1, 1, 1);
+                      INSERT INTO dbo.copilot_agents (id, name, agent_id)
+                          VALUES (1, N'Copilot Cowork', N'Copilot.M365Copilot.CoworkChat'),
+                                 (2, N'Sales helper', N'SPO_1234');");
+
+                SeedCopilotInteraction(db, userId: 1, daysAgo: 2, appHost: "Teams");
+                SeedCopilotInteraction(db, userId: 1, daysAgo: 2, appHost: "cowork", agentId: 1);
+
+                var from = DateTime.UtcNow.Date.AddDays(-28);
+                var settled = DateTime.UtcNow.Date.AddDays(-3);
+
+                var licenceTypes = Query<LicenceTypeRow>(db, CopilotAdoptionSql.LicenceTypesSql);
+                Assert.AreEqual(1, licenceTypes.Count);
+                Assert.AreEqual(1, licenceTypes[0].AssignedUsers);
+                Assert.IsTrue(CopilotLicenceClassifier.IsCopilotSeat(licenceTypes[0].SkuPartNumber, licenceTypes[0].Name));
+
+                var coworkAgents = Query<CopilotAdoptionService.IntValueRow>(db, CopilotAdoptionSql.CoworkAgentIdsSql);
+                CollectionAssert.AreEqual(new[] { 1 }, coworkAgents.Select(a => a.Value).ToArray(),
+                    "Only the Cowork agent should match - a SharePoint agent must not.");
+
+                var seats = Query<CopilotAdoptionService.SeatAssignmentRow>(db, CopilotAdoptionSql.SeatAssignmentsSql(new[] { 1 }));
+                Assert.AreEqual(1, seats.Count);
+                Assert.AreEqual("Microsoft Copilot for Microsoft 365", seats[0].LicenceName);
+
+                var byApp = Query<CopilotAdoptionService.CategoryQueryRow>(db,
+                    CopilotAdoptionSql.UsageByAppSql(new[] { 1 }),
+                    new SqlParameter("@from", from),
+                    new SqlParameter("@top", 10));
+                Assert.AreEqual(2, byApp.Count, "Teams and Cowork.");
+
+                var trend = Query<CopilotAdoptionService.NamedWeekRow>(db,
+                    CopilotAdoptionSql.WeeklyAdoptionTrendSql(new[] { 1 }, new[] { 1 }),
+                    new SqlParameter("@trendFrom", DateTime.UtcNow.Date.AddMonths(-6)));
+                Assert.IsTrue(trend.Any(t => t.SeriesName == "Active licensed users"));
+                Assert.IsTrue(trend.Any(t => t.SeriesName == "Cowork users"),
+                    "The Cowork series must be produced when Cowork interactions exist.");
+
+                var unlicensed = Query<int?>(db,
+                    CopilotAdoptionSql.UnlicensedActiveUsersSql(new[] { 1 }),
+                    new SqlParameter("@from", from));
+                Assert.AreEqual(0, unlicensed.Single(), "The only Copilot user in this fixture holds a seat.");
+
+                var hasAudit = Query<int?>(db, CopilotAdoptionSql.HasCopilotAuditDataSql, new SqlParameter("@from", from));
+                Assert.AreEqual(1, hasAudit.Single());
+
+                // These two return NULL against an empty table, which must materialise rather than throw.
+                Assert.IsNull(Query<DateTime?>(db, CopilotAdoptionSql.LatestCopilotReportDateSql,
+                    new SqlParameter("@settled", settled)).Single());
+                Assert.IsNull(Query<DateTime?>(db, CopilotAdoptionSql.LatestM365ReportDateSql,
+                    new SqlParameter("@settled", settled)).Single());
+                Assert.AreEqual(0, Query<int?>(db, CopilotAdoptionSql.CopilotReportObfuscatedSql).Count,
+                    "With no import log rows, the anonymisation probe returns nothing rather than failing.");
+            }
+        }
+
+        [TestMethod]
+        public void QueriesSurviveATenantWithNoCopilotLicencesAtAll()
+        {
+            // "Should we buy Copilot?" is a legitimate use of this tool, so no seats must produce an
+            // empty report rather than an IN () syntax error.
+            using (var db = ScratchDatabase.Create("CopilotAdoptNoSeats"))
+            {
+                CreateUserTables(db);
+                CreateCopilotTables(db);
+                CreateM365UsageTables(db);
+
+                db.Execute(@"INSERT INTO dbo.users (id, user_name, account_enabled) VALUES (1, N'a@contoso.com', 1);");
+                SeedCopilotInteraction(db, userId: 1, daysAgo: 1, appHost: "Copilot Chat");
+
+                var licensed = Query<LicensedUserUsageRow>(
+                    db,
+                    CopilotAdoptionSql.LicensedUsersSql(new int[0], new int[0], includeCopilotReport: false),
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@historyFrom", DateTime.UtcNow.Date.AddDays(-365)),
+                    new SqlParameter("@maxRows", 1000));
+                Assert.AreEqual(0, licensed.Count);
+
+                var opportunities = Query<UnlicensedUserSignalRow>(
+                    db,
+                    CopilotAdoptionSql.LicenceOpportunitiesSql(
+                        new int[0], CopilotAdoptionOptions.Default, includeCopilotAudit: true, includeM365Usage: false),
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@maxRows", 1000));
+
+                Assert.AreEqual(1, opportunities.Count,
+                    "With no seats at all, everyone using Copilot Chat is a licence opportunity.");
+            }
+        }
+
+        #endregion
+
+        #region Fixture
+
+        private static List<T> Query<T>(ScratchDatabase db, string sql, params SqlParameter[] parameters)
+        {
+            using (var context = new RawSqlContext(db.ConnectionString))
+            {
+                context.Database.CommandTimeout = 120;
+                return context.Database.SqlQuery<T>(sql, parameters).ToList();
+            }
+        }
+
+        /// <summary>Users plus the metadata lookup tables the detail queries join to.</summary>
+        private static void CreateUserTables(ScratchDatabase db)
+        {
+            db.Execute(
+                @"CREATE TABLE dbo.user_departments (id int NOT NULL PRIMARY KEY, name nvarchar(200) NULL);
+                  CREATE TABLE dbo.user_job_titles (id int NOT NULL PRIMARY KEY, name nvarchar(200) NULL);
+                  CREATE TABLE dbo.user_country_or_region (id int NOT NULL PRIMARY KEY, name nvarchar(200) NULL);
+                  CREATE TABLE dbo.user_office_locations (id int NOT NULL PRIMARY KEY, name nvarchar(200) NULL);
+                  CREATE TABLE dbo.user_company_name (id int NOT NULL PRIMARY KEY, name nvarchar(200) NULL);
+
+                  CREATE TABLE dbo.users (
+                      id int NOT NULL PRIMARY KEY,
+                      user_name nvarchar(400) NULL,
+                      mail nvarchar(400) NULL,
+                      account_enabled bit NULL,
+                      department_id int NULL,
+                      job_title_id int NULL,
+                      country_or_region_id int NULL,
+                      office_location_id int NULL,
+                      company_name_id int NULL,
+                      manager_id int NULL);
+
+                  CREATE TABLE dbo.license_types (
+                      id int NOT NULL PRIMARY KEY,
+                      name nvarchar(200) NULL,
+                      sku_id nvarchar(200) NULL);
+
+                  CREATE TABLE dbo.user_license_type_lookups (
+                      id int NOT NULL PRIMARY KEY,
+                      user_id int NOT NULL,
+                      license_type_id int NOT NULL);
+
+                  CREATE UNIQUE NONCLUSTERED INDEX IX_license_type_id_user_id
+                      ON dbo.user_license_type_lookups (license_type_id, user_id);");
+        }
+
+        private static void CreateCopilotTables(ScratchDatabase db)
+        {
+            db.Execute(
+                @"CREATE TABLE dbo.audit_events (
+                      id uniqueidentifier NOT NULL PRIMARY KEY,
+                      time_stamp datetime NOT NULL,
+                      operation_id int NULL,
+                      user_id int NULL,
+                      event_data nvarchar(max) NULL);
+
+                  CREATE TABLE dbo.copilot_chats (
+                      event_id uniqueidentifier NOT NULL PRIMARY KEY,
+                      app_host nvarchar(200) NULL,
+                      agent_id int NULL);
+
+                  CREATE TABLE dbo.copilot_agents (
+                      id int NOT NULL PRIMARY KEY,
+                      name nvarchar(400) NULL,
+                      agent_id nvarchar(400) NULL,
+                      is_custom_agent bit NULL);");
+        }
+
+        private static void CreateCopilotReportTable(ScratchDatabase db)
+        {
+            db.Execute(
+                @"CREATE TABLE dbo.copilot_usage_user_activity_log (
+                      id int NOT NULL PRIMARY KEY,
+                      [date] datetime NOT NULL,
+                      user_id int NOT NULL,
+                      last_activity_date datetime NULL,
+                      report_period_days int NOT NULL,
+                      prompts_all_apps int NULL,
+                      prompts_chat_work int NULL,
+                      prompts_chat_web int NULL,
+                      active_usage_days int NULL,
+                      chat_last_activity_date datetime NULL,
+                      teams_last_activity_date datetime NULL,
+                      word_last_activity_date datetime NULL,
+                      excel_last_activity_date datetime NULL,
+                      powerpoint_last_activity_date datetime NULL,
+                      outlook_last_activity_date datetime NULL,
+                      onenote_last_activity_date datetime NULL,
+                      loop_last_activity_date datetime NULL,
+                      chat_work_last_activity_date datetime NULL,
+                      chat_web_last_activity_date datetime NULL,
+                      m365_copilot_last_activity_date datetime NULL,
+                      edge_last_activity_date datetime NULL,
+                      agent_last_activity_date datetime NULL,
+                      is_upn_obfuscated bit NOT NULL DEFAULT(0));");
+        }
+
+        private static void CreateCopilotImportLogTable(ScratchDatabase db)
+        {
+            db.Execute(
+                @"CREATE TABLE dbo.copilot_usage_report_import_log (
+                      id int NOT NULL PRIMARY KEY,
+                      report_name nvarchar(100) NULL,
+                      report_refresh_date datetime NULL,
+                      report_version nvarchar(10) NULL,
+                      report_period nvarchar(10) NULL,
+                      imported_utc datetime NOT NULL,
+                      rows_read int NOT NULL,
+                      rows_saved int NOT NULL,
+                      is_upn_obfuscated bit NOT NULL,
+                      error nvarchar(1000) NULL);");
+        }
+
+        private static void CreateM365UsageTables(ScratchDatabase db)
+        {
+            db.Execute(
+                @"CREATE TABLE dbo.teams_user_activity_log (
+                      id int NOT NULL PRIMARY KEY,
+                      [date] datetime NOT NULL,
+                      user_id int NOT NULL,
+                      last_activity_date datetime NULL,
+                      private_chat_count bigint NOT NULL DEFAULT(0),
+                      team_chat_count bigint NOT NULL DEFAULT(0),
+                      post_messages bigint NOT NULL DEFAULT(0),
+                      reply_messages bigint NOT NULL DEFAULT(0),
+                      meetings_attended_count bigint NOT NULL DEFAULT(0),
+                      meetings_organized_count bigint NOT NULL DEFAULT(0));
+
+                  CREATE TABLE dbo.outlook_user_activity_log (
+                      id int NOT NULL PRIMARY KEY,
+                      [date] datetime NOT NULL,
+                      user_id int NOT NULL,
+                      last_activity_date datetime NULL,
+                      email_send_count bigint NOT NULL DEFAULT(0),
+                      email_receive_count bigint NOT NULL DEFAULT(0),
+                      email_read_count bigint NOT NULL DEFAULT(0));
+
+                  CREATE TABLE dbo.sharepoint_user_activity_log (
+                      id int NOT NULL PRIMARY KEY,
+                      [date] datetime NOT NULL,
+                      user_id int NOT NULL,
+                      last_activity_date datetime NULL,
+                      viewed_or_edited bigint NOT NULL DEFAULT(0));
+
+                  CREATE TABLE dbo.onedrive_user_activity_log (
+                      id int NOT NULL PRIMARY KEY,
+                      [date] datetime NOT NULL,
+                      user_id int NOT NULL,
+                      last_activity_date datetime NULL,
+                      viewed_or_edited bigint NOT NULL DEFAULT(0));");
+        }
+
+        /// <summary>One Copilot interaction: an audit event plus its copilot_chats row.</summary>
+        private static void SeedCopilotInteraction(
+            ScratchDatabase db, int userId, int daysAgo, string appHost, int? agentId = null)
+        {
+            var id = Guid.NewGuid();
+            var when = DateTime.UtcNow.Date.AddDays(-daysAgo).AddHours(9);
+
+            db.Execute(
+                $@"INSERT INTO dbo.audit_events (id, time_stamp, user_id)
+                       VALUES ('{id}', '{when:yyyy-MM-dd HH:mm:ss}', {userId});
+                   INSERT INTO dbo.copilot_chats (event_id, app_host, agent_id)
+                       VALUES ('{id}', N'{appHost}', {(agentId.HasValue ? agentId.Value.ToString() : "NULL")});");
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionTests.cs
@@ -1,0 +1,1052 @@
+extern alias AnalyticsWeb;
+
+using Common.Entities.CopilotAdoption;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using CopilotAdoptionAPIController = AnalyticsWeb::Web.AnalyticsWeb.Controllers.CopilotAdoptionAPIController;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests for the Copilot licence-adoption engine.
+    ///
+    /// All the rules that decide what an executive sees - which SKUs count as a Copilot seat, how a
+    /// user is scored and banded, how a licence candidate is ranked - live in pure functions in
+    /// Common.Entities precisely so they can be pinned down here. These outputs are used to justify
+    /// licence spend and to pick who gets training, so a silent change in any of them is a real cost
+    /// to a customer, not a cosmetic regression.
+    /// </summary>
+    [TestClass]
+    public class CopilotAdoptionTests
+    {
+        private static readonly DateTime WindowStart = new DateTime(2026, 7, 24, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime Now = new DateTime(2026, 8, 21, 0, 0, 0, DateTimeKind.Utc);
+
+        #region Licence classification
+
+        [TestMethod]
+        public void CopilotSeatSkus_AreRecognised()
+        {
+            // The two SKU part numbers Microsoft has shipped the Microsoft 365 Copilot seat under, plus
+            // the education variant - all three appear in the licensing CSV this product ships with.
+            Assert.IsTrue(CopilotLicenceClassifier.IsCopilotSeat("M365_Copilot", "Microsoft Copilot for Microsoft 365"));
+            Assert.IsTrue(CopilotLicenceClassifier.IsCopilotSeat("Microsoft_365_Copilot", "Microsoft Copilot for Microsoft 365"));
+            Assert.IsTrue(CopilotLicenceClassifier.IsCopilotSeat("Microsoft_365_Copilot_EDU", "Microsoft 365 Copilot (Education Faculty)"));
+        }
+
+        [TestMethod]
+        public void FutureCopilotSeatSku_IsRecognisedByPrefix()
+        {
+            // A SKU newer than the licensing CSV shipped in this build has no display name, so the
+            // importer stores the part number as the name too. Prefix matching is what stops a
+            // customer's newest (and most expensive) seats from silently vanishing from the report.
+            Assert.IsTrue(
+                CopilotLicenceClassifier.IsCopilotSeat("Microsoft_365_Copilot_Business_Preview", "Microsoft_365_Copilot_Business_Preview"),
+                "An unrecognised Microsoft_365_Copilot* SKU must still be counted as a seat.");
+        }
+
+        [TestMethod]
+        public void CopilotBrandedProductsThatAreNotSeats_AreExcluded()
+        {
+            // These are separately-sold products. Counting them would inflate the licensed population
+            // and make adoption look far worse than it is - the failure mode that matters most, because
+            // this number is used to argue about spend.
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat("Microsoft_Copilot_for_Sales", "Microsoft 365 Copilot for Sales"));
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat("Microsoft_Viva_Sales", "Microsoft Sales Copilot"));
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat("Power_Virtual_Agents", "Microsoft Copilot Studio"));
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat("VIRTUAL_AGENT_USL", "Microsoft Copilot Studio User License"));
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat("CCIBOTS_PRIVPREV_VIRAL", "Microsoft Copilot Studio Viral Trial"));
+        }
+
+        [TestMethod]
+        public void NonCopilotProducts_AreNotSeats()
+        {
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat("ENTERPRISEPACK", "Office 365 E3"));
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat("SPE_E5", "Microsoft 365 E5"));
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat(null, null));
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat(string.Empty, string.Empty));
+        }
+
+        [TestMethod]
+        public void RenamedSeatSku_IsRecognisedByDisplayName()
+        {
+            // Fallback path: an unrecognised part number, but a display name that clearly identifies the
+            // Microsoft 365 Copilot product.
+            Assert.IsTrue(CopilotLicenceClassifier.IsCopilotSeat("SOME_NEW_STEM", "Microsoft 365 Copilot"));
+
+            // ...and the fallback must not swallow the other Copilot-branded products.
+            Assert.IsFalse(CopilotLicenceClassifier.IsCopilotSeat("SOME_NEW_STEM", "Microsoft 365 Copilot Studio"));
+        }
+
+        [TestMethod]
+        public void ExplicitOverride_ReplacesTheAutomaticClassification()
+        {
+            var licenceTypes = new List<LicenceTypeRow>
+            {
+                new LicenceTypeRow { Id = 1, SkuPartNumber = "Microsoft_365_Copilot", Name = "Microsoft Copilot for Microsoft 365" },
+                new LicenceTypeRow { Id = 2, SkuPartNumber = "ENTERPRISEPACK", Name = "Office 365 E3" },
+                new LicenceTypeRow { Id = 3, SkuPartNumber = "WEIRD_PARTNER_SKU", Name = "Bundled Copilot Seat (reseller)" },
+            };
+
+            CollectionAssert.AreEqual(
+                new[] { 1 },
+                CopilotLicenceClassifier.ResolveSeatLicenceTypeIds(licenceTypes, null).ToArray(),
+                "With no override, only the automatically classified seat should count.");
+
+            CollectionAssert.AreEqual(
+                new[] { 1, 3 },
+                CopilotLicenceClassifier.ResolveSeatLicenceTypeIds(licenceTypes, new[] { 1, 3 }).ToArray(),
+                "An admin override must be honoured for SKUs the classifier cannot know about.");
+
+            CollectionAssert.AreEqual(
+                new[] { 2 },
+                CopilotLicenceClassifier.ResolveSeatLicenceTypeIds(licenceTypes, new[] { 2, 99 }).ToArray(),
+                "Ids that do not exist must be dropped rather than reaching the query.");
+        }
+
+        #endregion
+
+        #region Engagement scoring
+
+        [TestMethod]
+        public void DailyMultiAppUser_ScoresAsAChampion()
+        {
+            // 20 active days over a 28-day window (every working day), 6 interactions a day, 4 apps:
+            // full marks on all three components.
+            var row = UsageRow(interactions: 120, activeDays: 20, appsUsed: 4, lastUse: Now.AddDays(-1));
+
+            var scored = CopilotAdoptionScoring.Score(row, WindowStart, Now, auditAvailable: true);
+
+            Assert.AreEqual(100, scored.AdoptionScore, "Maximum on every component should be 100.");
+            Assert.AreEqual(AdoptionBand.Champion, scored.Band);
+            Assert.IsTrue(CopilotAdoptionScoring.IsHabitual(scored.Band));
+        }
+
+        [TestMethod]
+        public void ScoreIsGraded_NotBinary()
+        {
+            // The requirement this feature exists for: usage is "rarely a yes/no". Two users who both
+            // count as "active" in Microsoft's reports must be clearly separated here.
+            var occasional = CopilotAdoptionScoring.Score(
+                UsageRow(interactions: 3, activeDays: 2, appsUsed: 1, lastUse: Now.AddDays(-6)),
+                WindowStart, Now, auditAvailable: true);
+
+            var regular = CopilotAdoptionScoring.Score(
+                UsageRow(interactions: 60, activeDays: 15, appsUsed: 3, lastUse: Now.AddDays(-1)),
+                WindowStart, Now, auditAvailable: true);
+
+            Assert.IsTrue(occasional.AdoptionScore > 0, "Some use must never score zero - that is the dormant band.");
+            Assert.IsTrue(
+                regular.AdoptionScore > occasional.AdoptionScore + 40,
+                $"A regular user ({regular.AdoptionScore}) must be clearly separated from an occasional one ({occasional.AdoptionScore}).");
+            Assert.AreEqual(AdoptionBand.Trialling, occasional.Band);
+            Assert.AreEqual(AdoptionBand.Champion, regular.Band);
+        }
+
+        [TestMethod]
+        public void NeverUsed_AndDormant_AreDifferentBands()
+        {
+            // The distinction that pays for the feature: one needs onboarding, the other needs a
+            // conversation or the seat back. Averaging them into "not using it" hides both.
+            var neverUsed = CopilotAdoptionScoring.Score(
+                UsageRow(interactions: 0, activeDays: 0, appsUsed: 0, lastUse: null),
+                WindowStart, Now, auditAvailable: true);
+
+            var dormantRow = UsageRow(interactions: 0, activeDays: 0, appsUsed: 0, lastUse: WindowStart.AddDays(-30));
+            dormantRow.PriorInteractions = 42;
+            var dormant = CopilotAdoptionScoring.Score(dormantRow, WindowStart, Now, auditAvailable: true);
+
+            Assert.AreEqual(AdoptionBand.NeverUsed, neverUsed.Band);
+            Assert.AreEqual(AdoptionBand.Dormant, dormant.Band);
+            Assert.AreEqual(0, neverUsed.AdoptionScore);
+            Assert.AreEqual(0, dormant.AdoptionScore);
+            StringAssert.Contains(neverUsed.RecommendedAction, "Reclaim");
+            StringAssert.Contains(dormant.RecommendedAction, "Re-engage");
+        }
+
+        [TestMethod]
+        public void BreadthIsScoredSeparatelyFromFrequency()
+        {
+            // Someone using Copilot every day but only in one app is a different (and much cheaper to
+            // fix) problem than someone using it rarely across many apps. The components must not be
+            // collapsed into a single number that treats them the same.
+            var deepButNarrow = CopilotAdoptionScoring.Score(
+                UsageRow(interactions: 100, activeDays: 20, appsUsed: 1, lastUse: Now),
+                WindowStart, Now, auditAvailable: true);
+
+            Assert.AreEqual(100, deepButNarrow.FrequencyScore);
+            Assert.AreEqual(100, deepButNarrow.DepthScore);
+            Assert.IsTrue(deepButNarrow.BreadthScore < 40, "One app out of a target of three is a low breadth score.");
+            Assert.IsTrue(deepButNarrow.AdoptionScore < 100, "A narrow user must not score full marks overall.");
+            StringAssert.Contains(deepButNarrow.RecommendedAction, "broaden",
+                "Even a deep user working in a single surface should be told the cheapest available gain.");
+        }
+
+        [TestMethod]
+        public void WhenAuditIsUnavailable_MicrosoftsReportIsUsedInstead()
+        {
+            // Without this fallback, a deployment that only imports Microsoft's Copilot usage report
+            // would report its entire licensed population as "never used" - both wrong and expensive.
+            var row = UsageRow(interactions: 0, activeDays: 0, appsUsed: 0, lastUse: null);
+            row.ReportPrompts = 90;
+            row.ReportActiveDays = 18;
+            row.ReportAppsUsed = 3;
+            row.ReportLastActivityUtc = Now.AddDays(-2);
+
+            var scored = CopilotAdoptionScoring.Score(row, WindowStart, Now, auditAvailable: false);
+
+            Assert.AreEqual(CopilotAdoptionScoring.SignalSourceUsageReport, scored.SignalSource,
+                "The row must record which source it was scored from.");
+            Assert.AreEqual(AdoptionBand.Champion, scored.Band);
+            Assert.AreEqual(18, scored.ActiveDays);
+        }
+
+        [TestMethod]
+        public void AGapInTheAuditDataForOneUser_DoesNotMarkThemNeverUsed()
+        {
+            // The dangerous case: the audit import is working overall, but has nothing for this user
+            // while Microsoft says they were active. Reporting them as "never used" would put an
+            // actively working person on a list of seats to take away.
+            var row = UsageRow(interactions: 0, activeDays: 0, appsUsed: 0, lastUse: null);
+            row.ReportPrompts = 90;
+            row.ReportActiveDays = 18;
+            row.ReportAppsUsed = 3;
+            row.ReportLastActivityUtc = Now.AddDays(-2);
+
+            var scored = CopilotAdoptionScoring.Score(row, WindowStart, Now, auditAvailable: true);
+
+            Assert.AreEqual(CopilotAdoptionScoring.SignalSourceUsageReport, scored.SignalSource);
+            Assert.AreNotEqual(AdoptionBand.NeverUsed, scored.Band,
+                "Microsoft's report says this user is active; they must not be listed as never having used Copilot.");
+            Assert.AreEqual(AdoptionBand.Champion, scored.Band);
+        }
+
+        [TestMethod]
+        public void AuditDataWinsWhenItHasSomethingToSay()
+        {
+            // When both sources have data for a user, the audit log wins: it is bucketed to exactly
+            // the window that was requested, whereas Microsoft's report uses its own.
+            var row = UsageRow(interactions: 4, activeDays: 2, appsUsed: 1, lastUse: Now.AddDays(-3));
+            row.ReportPrompts = 500;
+            row.ReportActiveDays = 20;
+            row.ReportAppsUsed = 6;
+            row.ReportLastActivityUtc = Now.AddDays(-1);
+
+            var scored = CopilotAdoptionScoring.Score(row, WindowStart, Now, auditAvailable: true);
+
+            Assert.AreEqual(CopilotAdoptionScoring.SignalSourceAudit, scored.SignalSource);
+            Assert.AreEqual(2, scored.ActiveDays, "The audit figures, not Microsoft's.");
+            Assert.AreEqual(4, scored.Interactions);
+            Assert.AreEqual(AdoptionBand.Developing, scored.Band,
+                "Scored on the audit figures this is a light user; Microsoft's much larger numbers must not leak in.");
+        }
+
+        [TestMethod]
+        public void SqlScoreExpression_CollapsesUnavailableSourcesToZero()
+        {
+            // When a data source is unavailable its CTE and join are omitted from the query, so the
+            // ranking expression must not still reference them - that is an unbound-identifier error at
+            // run time, not a compile-time one, so only a real database (or this test) catches it.
+            var auditOnly = CopilotAdoptionSql.LicenceOpportunitiesSql(
+                new[] { 1 }, CopilotAdoptionOptions.Default, includeCopilotAudit: true, includeM365Usage: false);
+
+            Assert.IsFalse(auditOnly.Contains("teams."), "The Teams CTE is not in this query, so nothing may reference it.");
+            Assert.IsFalse(auditOnly.Contains("mail."), "The Outlook CTE is not in this query.");
+            Assert.IsFalse(auditOnly.Contains("files."), "The file CTE is not in this query.");
+
+            var usageOnly = CopilotAdoptionSql.LicenceOpportunitiesSql(
+                new[] { 1 }, CopilotAdoptionOptions.Default, includeCopilotAudit: false, includeM365Usage: true);
+
+            Assert.IsFalse(usageOnly.Contains("copilot."), "The Copilot CTE is not in this query.");
+            StringAssert.Contains(usageOnly, "teams.Messages");
+        }
+
+        [TestMethod]
+        public void TargetActiveDays_UsesWorkingDaysNotCalendarDays()
+        {
+            // Scoring against calendar days would cap a genuinely daily user at ~71%, which is not a
+            // number anyone should have to explain to a CFO.
+            var options = new CopilotAdoptionOptions { WindowDays = 28 };
+
+            Assert.AreEqual(20d, CopilotAdoptionScoring.AvailableWorkingDays(options), 0.001);
+            Assert.AreEqual(12d, CopilotAdoptionScoring.TargetActiveDays(options), 0.001);
+        }
+
+        [TestMethod]
+        public void CustomWeights_StillProduceAScoreOutOfOneHundred()
+        {
+            // The weights are tunable, so a set that does not sum to 1 must still normalise rather than
+            // silently producing scores above 100 or capping everyone at a fraction of the range.
+            var options = new CopilotAdoptionOptions
+            {
+                FrequencyWeight = 2,
+                DepthWeight = 2,
+                BreadthWeight = 2,
+            };
+
+            var scored = CopilotAdoptionScoring.Score(
+                UsageRow(interactions: 200, activeDays: 20, appsUsed: 5, lastUse: Now),
+                WindowStart, Now, auditAvailable: true, options: options);
+
+            Assert.AreEqual(100, scored.AdoptionScore);
+        }
+
+        [TestMethod]
+        public void ScoreIsCapped_ByExtremeUsage()
+        {
+            // A runaway automation account must not produce a score of 4,000 and distort every average
+            // and department breakdown on the page.
+            var scored = CopilotAdoptionScoring.Score(
+                UsageRow(interactions: 100000, activeDays: 28, appsUsed: 25, lastUse: Now),
+                WindowStart, Now, auditAvailable: true);
+
+            Assert.AreEqual(100, scored.AdoptionScore);
+            Assert.AreEqual(100, scored.FrequencyScore);
+            Assert.AreEqual(100, scored.BreadthScore);
+        }
+
+        #endregion
+
+        #region Licence-opportunity scoring
+
+        [TestMethod]
+        public void ExistingUnlicensedCopilotUse_IsTheStrongestSignal()
+        {
+            // Evidence must beat inference: someone already using Copilot Chat has demonstrated demand
+            // for Copilot, which is a better argument than "sends a lot of email".
+            var provenDemand = CopilotAdoptionScoring.ScoreOpportunity(new UnlicensedUserSignalRow
+            {
+                UnlicensedCopilotInteractions = 40,
+                UnlicensedCopilotActiveDays = 12,
+            });
+
+            var busyButUntried = CopilotAdoptionScoring.ScoreOpportunity(new UnlicensedUserSignalRow
+            {
+                TeamsMessages = 30,
+                TeamsMeetings = 10,
+                EmailsSent = 20,
+                EmailsRead = 20,
+            });
+
+            Assert.AreEqual(35, provenDemand.OpportunityScore,
+                "Maxing the Copilot-demand component alone should award its full weight.");
+            Assert.IsTrue(
+                provenDemand.OpportunityScore > busyButUntried.OpportunityScore,
+                "Proven Copilot demand must outrank general Microsoft 365 busyness.");
+            StringAssert.Contains(provenDemand.Rationale, "already using Copilot Chat without a licence");
+        }
+
+        [TestMethod]
+        public void HeavyUserAcrossEveryWorkload_IsRecommended()
+        {
+            var heavy = CopilotAdoptionScoring.ScoreOpportunity(new UnlicensedUserSignalRow
+            {
+                UserPrincipalName = "someone@contoso.com",
+                UnlicensedCopilotInteractions = 25,
+                UnlicensedCopilotActiveDays = 10,
+                TeamsMessages = 50,
+                TeamsMeetings = 20,
+                EmailsSent = 40,
+                EmailsRead = 60,
+                FilesViewedOrEdited = 55,
+            });
+
+            Assert.AreEqual(100, heavy.OpportunityScore);
+            Assert.IsTrue(heavy.Recommended);
+            StringAssert.StartsWith(heavy.Rationale, "Recommended:");
+        }
+
+        [TestMethod]
+        public void UserWithNoActivity_ScoresZeroAndIsNotRecommended()
+        {
+            var idle = CopilotAdoptionScoring.ScoreOpportunity(new UnlicensedUserSignalRow());
+
+            Assert.AreEqual(0, idle.OpportunityScore);
+            Assert.IsFalse(idle.Recommended);
+            StringAssert.Contains(idle.Rationale, "No qualifying");
+        }
+
+        [TestMethod]
+        public void OpportunitySqlExpression_UsesTheSameWeightsAsTheCsharpScorer()
+        {
+            // The database ranks candidates so a 200k-user tenant does not have to be pulled into
+            // memory. The expression is generated from the same options object, so if the weights ever
+            // drift apart the SQL would return the wrong people - even though the displayed score
+            // (always recomputed in C#) would still look right.
+            var options = CopilotAdoptionOptions.Default;
+
+            var sql = CopilotAdoptionScoring.BuildOpportunityScoreSql(
+                options, "cop", "teams", "meetings", "sent", "read", "files");
+
+            foreach (var weight in new[]
+            {
+                options.OpportunityUnlicensedCopilotWeight,
+                options.OpportunityCollaborationWeight,
+                options.OpportunityEmailWeight,
+                options.OpportunityDocumentWeight,
+            })
+            {
+                StringAssert.Contains(sql, weight.ToString(CultureInfo.InvariantCulture),
+                    "Every C# weight must appear in the generated ranking expression.");
+            }
+
+            foreach (var target in new[]
+            {
+                options.OpportunityCopilotTarget,
+                options.OpportunityCollaborationTarget,
+                options.OpportunityEmailTarget,
+                options.OpportunityDocumentTarget,
+            })
+            {
+                StringAssert.Contains(sql, target.ToString(CultureInfo.InvariantCulture));
+            }
+
+            StringAssert.Contains(sql, "CAST(cop AS float)", "Integer division would floor every ratio to 0 or 1.");
+            StringAssert.Contains(sql, "(teams + meetings)");
+            StringAssert.Contains(sql, "(sent + read)");
+        }
+
+        [TestMethod]
+        public void OpportunitySqlExpression_IsCultureInvariant()
+        {
+            // A server running a European culture would otherwise emit "0,35" and produce SQL that is
+            // either a syntax error or - far worse - silently parsed as two arguments.
+            var original = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+
+                var sql = CopilotAdoptionScoring.BuildOpportunityScoreSql(
+                    new CopilotAdoptionOptions { OpportunityCopilotTarget = 2.5, OpportunityUnlicensedCopilotWeight = 12.5 },
+                    "cop", "teams", "meetings", "sent", "read", "files");
+
+                StringAssert.Contains(sql, "2.5");
+                StringAssert.Contains(sql, "12.5");
+                Assert.IsFalse(sql.Contains("2,5"), "A comma decimal separator would break the generated SQL.");
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+
+        #endregion
+
+        #region SQL construction
+
+        [TestMethod]
+        public void EmptyLicenceTypeList_ProducesAValidAlwaysFalsePredicate()
+        {
+            // A tenant that has bought no Copilot licences must get an empty report, not a 500 from
+            // "IN ()".
+            Assert.AreEqual("-1", CopilotAdoptionSql.IdList(new int[0]));
+            Assert.AreEqual("-1", CopilotAdoptionSql.IdList(null));
+            Assert.AreEqual("3, 7", CopilotAdoptionSql.IdList(new[] { 3, 7, 3 }));
+        }
+
+        [TestMethod]
+        public void CoworkPredicate_MatchesTheAppHostAndAnyKnownCoworkAgent()
+        {
+            var withoutAgents = CopilotAdoptionSql.CoworkPredicate(new int[0]);
+            Assert.AreEqual("c.app_host = 'cowork'", withoutAgents);
+            Assert.IsFalse(withoutAgents.Contains("LOWER("),
+                "Wrapping an indexed column in LOWER() makes the predicate non-SARGable for no benefit - the collation is already case-insensitive.");
+
+            var withAgents = CopilotAdoptionSql.CoworkPredicate(new[] { 4, 9 });
+            StringAssert.Contains(withAgents, "c.app_host = 'cowork'");
+            StringAssert.Contains(withAgents, "c.agent_id IN (4, 9)");
+        }
+
+        [TestMethod]
+        public void WeekBucket_UsesDayArithmeticNotDatediffWeek()
+        {
+            // DATEDIFF(WEEK, ...) splits weeks on Sunday, which would push every Sunday's rows into the
+            // following week and quietly disagree with the Reports area's charts.
+            var bucket = CopilotAdoptionSql.WeekBucket("au.time_stamp");
+
+            StringAssert.Contains(bucket, "DATEDIFF(DAY, 0, au.time_stamp) % 7");
+            Assert.IsFalse(bucket.ToUpperInvariant().Contains("DATEDIFF(WEEK"));
+        }
+
+        [TestMethod]
+        public void LicensedUsersQuery_SplitsTheWindowFromTheHistoryInOnePass()
+        {
+            var sql = CopilotAdoptionSql.LicensedUsersSql(new[] { 1 }, new int[0], includeCopilotReport: true);
+
+            // One bounded scan of the audit history: the "in the window" and "before the window"
+            // aggregates are CASE expressions over the same pass, not two joins.
+            Assert.AreEqual(1, CountOccurrences(sql, "dbo.copilot_chats"),
+                "The Copilot audit history must be read exactly once - it is the most expensive join in the product.");
+            StringAssert.Contains(sql, "au.time_stamp >= @historyFrom");
+            StringAssert.Contains(sql, "SUM(CASE WHEN au.time_stamp >= @from THEN 1 ELSE 0 END) AS Interactions");
+            StringAssert.Contains(sql, "SUM(CASE WHEN au.time_stamp <  @from THEN 1 ELSE 0 END) AS PriorInteractions");
+
+            // Deterministic truncation, so a capped report is reproducible rather than randomly
+            // different between runs.
+            StringAssert.Contains(sql, "TOP (@maxRows)");
+            StringAssert.Contains(sql, "ORDER BY u.id");
+            StringAssert.Contains(sql, "OPTION (RECOMPILE)");
+        }
+
+        [TestMethod]
+        public void LicensedUsersQuery_OmitsTheReportJoinWhenThereIsNoSnapshot()
+        {
+            var sql = CopilotAdoptionSql.LicensedUsersSql(new[] { 1 }, new int[0], includeCopilotReport: false);
+
+            Assert.IsFalse(sql.Contains("copilot_usage_user_activity_log"),
+                "With no settled snapshot the report table must not be joined at all.");
+            StringAssert.Contains(sql, "CAST(NULL AS int) AS ReportPrompts",
+                "The result shape must stay the same so the row still materialises.");
+        }
+
+        [TestMethod]
+        public void OpportunitiesQuery_IsDrivenFromActivityNotFromTheDirectory()
+        {
+            var sql = CopilotAdoptionSql.LicenceOpportunitiesSql(
+                new[] { 1 }, CopilotAdoptionOptions.Default, includeCopilotAudit: true, includeM365Usage: true);
+
+            // Driving from dbo.users would scan every account in a 200k-user tenant to discard the
+            // overwhelming majority that have no activity at all.
+            StringAssert.Contains(sql, "FROM Candidates AS cand");
+            StringAssert.Contains(sql, "JOIN dbo.users AS u ON u.id = cand.user_id");
+            StringAssert.Contains(sql, "NOT EXISTS (SELECT 1 FROM SeatUsers");
+
+            // Disabled accounts cannot use a licence, so proposing one would discredit the whole list.
+            StringAssert.Contains(sql, "u.account_enabled IS NULL OR u.account_enabled = 1");
+
+            // One snapshot date per workload = an equality seek on IX_date rather than a range scan.
+            Assert.AreEqual(1, CountOccurrences(sql, "FROM dbo.teams_user_activity_log AS t"));
+            StringAssert.Contains(sql, "t.[date] = @m365ReportDate");
+        }
+
+        [TestMethod]
+        public void OpportunitiesQuery_RefusesToBuildWithNoDataSource()
+        {
+            // An empty candidate CTE would be a syntax error; failing loudly here is better than
+            // producing SQL that cannot run.
+            Assert.ThrowsException<ArgumentException>(() =>
+                CopilotAdoptionSql.LicenceOpportunitiesSql(
+                    new[] { 1 }, CopilotAdoptionOptions.Default, includeCopilotAudit: false, includeM365Usage: false));
+        }
+
+        [TestMethod]
+        public void DisplaySql_DeclaresItsParametersSoItCanBePastedIntoSsms()
+        {
+            var display = CopilotAdoptionSql.ForDisplay(
+                "SELECT 1 WHERE x >= @from;",
+                new Dictionary<string, object>
+                {
+                    { "@from", new DateTime(2026, 8, 1) },
+                    { "@maxRows", 500 },
+                });
+
+            StringAssert.Contains(display, "DECLARE @from datetime = '2026-08-01 00:00:00';");
+            StringAssert.Contains(display, "DECLARE @maxRows int = 500;");
+            StringAssert.Contains(display, "SELECT 1 WHERE x >= @from;");
+        }
+
+        #endregion
+
+        #region CSV export
+
+        [TestMethod]
+        public void Csv_QuotesAndEscapesPerRfc4180()
+        {
+            Assert.AreEqual("plain", CsvSerialiser.Escape("plain"));
+            Assert.AreEqual("\"has, comma\"", CsvSerialiser.Escape("has, comma"));
+            Assert.AreEqual("\"has \"\"quotes\"\"\"", CsvSerialiser.Escape("has \"quotes\""));
+            Assert.AreEqual("\"line\r\nbreak\"", CsvSerialiser.Escape("line\r\nbreak"));
+            Assert.AreEqual("\" leading space\"", CsvSerialiser.Escape(" leading space"));
+        }
+
+        [TestMethod]
+        public void Csv_NeutralisesSpreadsheetFormulaInjection()
+        {
+            // Department and job title come from the customer's own directory and are not trusted
+            // input. A cell starting "=" is executed as a formula by Excel and Google Sheets.
+            foreach (var dangerous in new[] { "=cmd|'/c calc'!A1", "+1+1", "-1+1", "@SUM(A1)" })
+            {
+                var escaped = CsvSerialiser.Escape(dangerous);
+                Assert.IsTrue(
+                    escaped.StartsWith("'") || escaped.StartsWith("\"'"),
+                    $"'{dangerous}' must be prefixed so a spreadsheet treats it as text, but was '{escaped}'.");
+            }
+        }
+
+        [TestMethod]
+        public void Csv_IsUtf8WithABomSoExcelRendersNonLatinNames()
+        {
+            // Real tenants have users and departments in Greek, Cyrillic, Japanese and so on. Without a
+            // BOM, Excel on Windows assumes the local ANSI code page and renders them as mojibake - in
+            // a document that is about to be sent to an executive.
+            var rows = new[]
+            {
+                new LicensedUserAdoptionRow
+                {
+                    UserPrincipalName = "\u03BA\u03B1\u03BB\u03B7\u03BC\u03B5\u03C1\u03B1@contoso.com",
+                    Department = "\u039A\u03B1\u03BB\u03B7\u03BC\u03AD\u03C1\u03B1 \u03BA\u03CC\u03C3\u03BC\u03B5",
+                    BandName = "Champion",
+                },
+            };
+
+            var bytes = CsvSerialiser.ToBytes(rows, CopilotAdoptionExports.LicensedUserColumns());
+
+            CollectionAssert.AreEqual(
+                new byte[] { 0xEF, 0xBB, 0xBF },
+                bytes.Take(3).ToArray(),
+                "The file must start with a UTF-8 BOM.");
+
+            var text = new UTF8Encoding(false).GetString(bytes.Skip(3).ToArray());
+            StringAssert.Contains(text, "\u039A\u03B1\u03BB\u03B7\u03BC\u03AD\u03C1\u03B1 \u03BA\u03CC\u03C3\u03BC\u03B5",
+                "Greek text must survive the round trip unchanged.");
+        }
+
+        [TestMethod]
+        public void Csv_WritesNumbersAndDatesInvariantly()
+        {
+            var original = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+
+                var csv = CsvSerialiser.ToCsv(
+                    new[] { new LicensedUserAdoptionRow { AdoptionScore = 12.5, UsedCowork = true, LastInteractionUtc = new DateTime(2026, 8, 20, 9, 30, 0) } },
+                    CopilotAdoptionExports.LicensedUserColumns());
+
+                StringAssert.Contains(csv, "12.5", "A comma decimal separator would be read as a column break.");
+                StringAssert.Contains(csv, "2026-08-20 09:30:00");
+                StringAssert.Contains(csv, "Yes", "Booleans are written for people to read, not as True/False.");
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+
+        [TestMethod]
+        public void Csv_HeaderMatchesTheColumnCountOnEveryRow()
+        {
+            var rows = new[]
+            {
+                ScoredUser("a@contoso.com", 10, AdoptionBand.Trialling),
+                ScoredUser("b@contoso.com", 80, AdoptionBand.Champion),
+            };
+
+            var columns = CopilotAdoptionExports.LicensedUserColumns();
+            var lines = CsvSerialiser.ToCsv(rows, columns)
+                .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.AreEqual(3, lines.Length, "One header plus one line per row.");
+            foreach (var line in lines)
+            {
+                Assert.AreEqual(columns.Count - 1, line.Count(c => c == ','),
+                    $"Every line must have the same number of fields: '{line}'");
+            }
+        }
+
+        [TestMethod]
+        public void ExportFileName_IsSafeAndDated()
+        {
+            Assert.AreEqual(
+                "copilot-licensed-users-2026-08-20.csv",
+                CsvSerialiser.FileName("copilot-licensed-users", new DateTime(2026, 8, 20)));
+
+            Assert.AreEqual(
+                "a-b-c-2026-08-20.csv",
+                CsvSerialiser.FileName("a/b\\c", new DateTime(2026, 8, 20)),
+                "Path separators must never reach a Content-Disposition file name.");
+        }
+
+        #endregion
+
+        #region Filtering, sorting and paging
+
+        [TestMethod]
+        public void BandFilter_SelectsOnlyTheRequestedBands()
+        {
+            var rows = new[]
+            {
+                ScoredUser("never@contoso.com", 0, AdoptionBand.NeverUsed),
+                ScoredUser("dormant@contoso.com", 0, AdoptionBand.Dormant),
+                ScoredUser("champ@contoso.com", 90, AdoptionBand.Champion),
+            };
+
+            var reclaimable = CopilotAdoptionExports.Apply(rows, new LicensedUserQuery
+            {
+                Bands = new List<AdoptionBand> { AdoptionBand.NeverUsed, AdoptionBand.Dormant },
+            });
+
+            Assert.AreEqual(2, reclaimable.Count);
+            CollectionAssert.AreEquivalent(
+                new[] { "never@contoso.com", "dormant@contoso.com" },
+                reclaimable.Select(r => r.UserPrincipalName).ToArray());
+        }
+
+        [TestMethod]
+        public void DisabledAccountFilter_TreatsUnknownAsNotDisabled()
+        {
+            // AccountEnabled is nullable: null means "we have not imported that flag", which is not the
+            // same as "disabled" and must not be swept into a list of seats to reclaim.
+            var enabled = ScoredUser("on@contoso.com", 50, AdoptionBand.Established);
+            enabled.AccountEnabled = true;
+            var disabled = ScoredUser("off@contoso.com", 0, AdoptionBand.NeverUsed);
+            disabled.AccountEnabled = false;
+            var unknown = ScoredUser("unknown@contoso.com", 0, AdoptionBand.NeverUsed);
+            unknown.AccountEnabled = null;
+
+            var result = CopilotAdoptionExports.Apply(
+                new[] { enabled, disabled, unknown },
+                new LicensedUserQuery { DisabledAccountsOnly = true });
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("off@contoso.com", result[0].UserPrincipalName);
+        }
+
+        [TestMethod]
+        public void Sorting_IsStableSoPagingCannotDuplicateOrDropUsers()
+        {
+            // Without a deterministic tie-break, two users on the same score can swap places between
+            // page 1 and page 2 and appear twice - or not at all - in an export.
+            var rows = new[]
+            {
+                ScoredUser("charlie@contoso.com", 40, AdoptionBand.Developing),
+                ScoredUser("alice@contoso.com", 40, AdoptionBand.Developing),
+                ScoredUser("bob@contoso.com", 40, AdoptionBand.Developing),
+            };
+
+            var first = CopilotAdoptionExports.Apply(rows, new LicensedUserQuery());
+            var second = CopilotAdoptionExports.Apply(rows.Reverse().ToArray(), new LicensedUserQuery());
+
+            CollectionAssert.AreEqual(
+                first.Select(r => r.UserPrincipalName).ToArray(),
+                second.Select(r => r.UserPrincipalName).ToArray(),
+                "The same set in a different input order must sort identically.");
+            Assert.AreEqual("alice@contoso.com", first[0].UserPrincipalName);
+        }
+
+        [TestMethod]
+        public void DefaultSort_PutsTheLeastEngagedFirst()
+        {
+            // The entire purpose of the list is finding people who are not getting value from a licence
+            // somebody is paying for, so the default must not bury them on the last page.
+            var rows = new[]
+            {
+                ScoredUser("champ@contoso.com", 95, AdoptionBand.Champion),
+                ScoredUser("never@contoso.com", 0, AdoptionBand.NeverUsed),
+                ScoredUser("mid@contoso.com", 45, AdoptionBand.Developing),
+            };
+
+            var sorted = CopilotAdoptionExports.Apply(rows, new LicensedUserQuery());
+
+            Assert.AreEqual("never@contoso.com", sorted[0].UserPrincipalName);
+            Assert.AreEqual("champ@contoso.com", sorted[2].UserPrincipalName);
+        }
+
+        [TestMethod]
+        public void Search_MatchesAcrossMetadataAndIgnoresCase()
+        {
+            var row = ScoredUser("someone@contoso.com", 20, AdoptionBand.Trialling);
+            row.Department = "Finance";
+            row.JobTitle = "Financial Controller";
+            row.ManagerUserPrincipalName = "cfo@contoso.com";
+
+            Assert.AreEqual(1, CopilotAdoptionExports.Apply(new[] { row }, new LicensedUserQuery { Search = "finance" }).Count);
+            Assert.AreEqual(1, CopilotAdoptionExports.Apply(new[] { row }, new LicensedUserQuery { Search = "CFO@" }).Count);
+            Assert.AreEqual(0, CopilotAdoptionExports.Apply(new[] { row }, new LicensedUserQuery { Search = "marketing" }).Count);
+        }
+
+        [TestMethod]
+        public void Paging_ClampsAnOversizedPageRequest()
+        {
+            var rows = Enumerable.Range(0, 200).Select(i => ScoredUser($"u{i:D3}@contoso.com", i % 100, AdoptionBand.Developing)).ToList();
+
+            Assert.AreEqual(50, CopilotAdoptionExports.Page(rows, 0, 50).Count);
+            Assert.AreEqual(100, CopilotAdoptionExports.Page(rows, 0, 100000, maxTake: 100).Count,
+                "A stray query string must not be able to ask for an unbounded page.");
+            Assert.AreEqual(0, CopilotAdoptionExports.Page(rows, 500, 50).Count);
+        }
+
+        [TestMethod]
+        public void OpportunityFilters_IsolateTheProvenDemandGroup()
+        {
+            var alreadyUsing = CopilotAdoptionScoring.ScoreOpportunity(new UnlicensedUserSignalRow
+            {
+                UserPrincipalName = "using@contoso.com",
+                UnlicensedCopilotInteractions = 5,
+                UnlicensedCopilotActiveDays = 3,
+            });
+            var neverTried = CopilotAdoptionScoring.ScoreOpportunity(new UnlicensedUserSignalRow
+            {
+                UserPrincipalName = "untried@contoso.com",
+                TeamsMessages = 100,
+            });
+
+            var result = CopilotAdoptionExports.Apply(
+                new[] { alreadyUsing, neverTried },
+                new LicenceOpportunityQuery { ExistingCopilotUsersOnly = true });
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("using@contoso.com", result[0].UserPrincipalName);
+        }
+
+        #endregion
+
+        #region Summary assembly
+
+        [TestMethod]
+        public void Funnel_NarrowsMonotonically()
+        {
+            var analysis = SampleAnalysis();
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+
+            var funnel = analysis.Summary.Funnel;
+            Assert.AreEqual(5, funnel.Count);
+            for (var i = 1; i < funnel.Count; i++)
+            {
+                Assert.IsTrue(
+                    funnel[i].Value <= funnel[i - 1].Value,
+                    $"'{funnel[i].Label}' ({funnel[i].Value}) cannot exceed '{funnel[i - 1].Label}' ({funnel[i - 1].Value}) - each stage is a subset of the last.");
+            }
+        }
+
+        [TestMethod]
+        public void HeadlineFigures_AreConsistentWithEachOther()
+        {
+            var analysis = SampleAnalysis();
+            var summary = analysis.Summary;
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+
+            Assert.AreEqual(6, summary.LicensedUsers);
+            Assert.AreEqual(3, summary.ActiveUsers, "Trialling, Established and Champion are active.");
+            Assert.AreEqual(2, summary.NeverUsedUsers);
+            Assert.AreEqual(1, summary.DormantUsers);
+            Assert.AreEqual(3, summary.ReclaimableSeats, "Never-used plus dormant seats are the reclaim candidates.");
+            Assert.AreEqual(2, summary.HabitualUsers, "Established and Champion only.");
+            Assert.AreEqual(50, summary.AdoptionRatePct);
+            Assert.AreEqual(
+                summary.LicensedUsers,
+                summary.ActiveUsers + summary.NeverUsedUsers + summary.DormantUsers,
+                "Every licensed user must land in exactly one of active / dormant / never used.");
+        }
+
+        [TestMethod]
+        public void BandBreakdown_AlwaysShowsEveryBand()
+        {
+            // An empty "Champions" bar is itself the finding, so the chart must not silently drop it.
+            var analysis = SampleAnalysis();
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+
+            CollectionAssert.AreEqual(
+                CopilotAdoptionScoring.AllBands.Select(CopilotAdoptionScoring.BandDisplayName).ToArray(),
+                analysis.Summary.BandBreakdown.Select(b => b.Label).ToArray());
+        }
+
+        [TestMethod]
+        public void CoworkIsNotReportedAsZeroPercentWhenItWasNeverSeen()
+        {
+            // On a tenant that has not been enabled for Cowork, "0% Cowork adoption" reads as a failure
+            // rather than as "not available here" - and would be quoted as one.
+            var analysis = SampleAnalysis();
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+            Assert.IsFalse(analysis.Summary.CoworkDetected);
+
+            analysis.LicensedUsers[0].UsedCowork = true;
+            analysis.LicensedUsers[0].CoworkInteractions = 12;
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+
+            Assert.IsTrue(analysis.Summary.CoworkDetected);
+            Assert.AreEqual(1, analysis.Summary.CoworkUsers);
+            Assert.AreEqual(12, analysis.Summary.CoworkInteractions);
+        }
+
+        [TestMethod]
+        public void SmallDepartmentsAreExcludedFromTheBreakdown()
+        {
+            // "0% adopted" across two seats at the top of an executive chart is noise that invites the
+            // wrong decision.
+            var analysis = new CopilotAdoptionAnalysis();
+            analysis.LicensedUsers.AddRange(
+                Enumerable.Range(0, 6).Select(i => Departmental($"big{i}@contoso.com", "Engineering", i * 20)));
+            analysis.LicensedUsers.AddRange(
+                Enumerable.Range(0, 2).Select(i => Departmental($"small{i}@contoso.com", "Legal", 0)));
+
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+
+            var departments = analysis.Summary.AdoptionByDepartment.Select(d => d.Segment).ToList();
+            CollectionAssert.Contains(departments, "Engineering");
+            CollectionAssert.DoesNotContain(departments, "Legal");
+        }
+
+        [TestMethod]
+        public void DepartmentBreakdown_IsOrderedWorstFirst()
+        {
+            var analysis = new CopilotAdoptionAnalysis();
+            analysis.LicensedUsers.AddRange(
+                Enumerable.Range(0, 6).Select(i => Departmental($"good{i}@contoso.com", "Sales", 90)));
+            analysis.LicensedUsers.AddRange(
+                Enumerable.Range(0, 6).Select(i => Departmental($"bad{i}@contoso.com", "Operations", 0)));
+
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+
+            Assert.AreEqual("Operations", analysis.Summary.AdoptionByDepartment.First().Segment,
+                "The department needing the most help must be first - it is the running order for an enablement plan.");
+        }
+
+        [TestMethod]
+        public void MedianIsReportedAlongsideTheMean()
+        {
+            // A handful of Champions pulls the mean up and makes adoption look healthier than it is.
+            var analysis = new CopilotAdoptionAnalysis();
+            analysis.LicensedUsers.AddRange(new[]
+            {
+                ScoredUser("a@contoso.com", 0, AdoptionBand.NeverUsed),
+                ScoredUser("b@contoso.com", 0, AdoptionBand.NeverUsed),
+                ScoredUser("c@contoso.com", 0, AdoptionBand.NeverUsed),
+                ScoredUser("d@contoso.com", 100, AdoptionBand.Champion),
+                ScoredUser("e@contoso.com", 100, AdoptionBand.Champion),
+            });
+
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+
+            Assert.AreEqual(40, analysis.Summary.AverageAdoptionScore);
+            Assert.AreEqual(0, analysis.Summary.MedianAdoptionScore,
+                "The median exposes what the mean hides: most of this population is not using Copilot at all.");
+        }
+
+        [TestMethod]
+        public void Median_HandlesEvenAndEmptyPopulations()
+        {
+            Assert.AreEqual(0, CopilotAdoptionScoring.Median(new double[0]));
+            Assert.AreEqual(30, CopilotAdoptionScoring.Median(new double[] { 10, 50 }));
+            Assert.AreEqual(50, CopilotAdoptionScoring.Median(new double[] { 10, 50, 90 }));
+        }
+
+        [TestMethod]
+        public void PercentagesNeverDivideByZero()
+        {
+            var analysis = new CopilotAdoptionAnalysis();
+            new CopilotAdoptionService().FinaliseSummary(analysis);
+
+            Assert.AreEqual(0, analysis.Summary.AdoptionRatePct);
+            Assert.AreEqual(0, analysis.Summary.HabitRatePct);
+            Assert.AreEqual(0, analysis.Summary.CoworkAdoptionPct);
+            Assert.AreEqual(0, CopilotAdoptionScoring.Percentage(5, 0));
+        }
+
+        #endregion
+
+        #region Controller parameter handling
+
+        [TestMethod]
+        public void RequestedWindow_IsSnappedToASupportedValue()
+        {
+            // A free-form window would let a hand-edited URL ask for an arbitrarily long scan of the
+            // Copilot audit history.
+            Assert.AreEqual(28, CopilotAdoptionAPIController.NormaliseWindowDays(28));
+            Assert.AreEqual(28, CopilotAdoptionAPIController.NormaliseWindowDays(30));
+            Assert.AreEqual(7, CopilotAdoptionAPIController.NormaliseWindowDays(1));
+            Assert.AreEqual(180, CopilotAdoptionAPIController.NormaliseWindowDays(9999));
+            Assert.AreEqual(7, CopilotAdoptionAPIController.NormaliseWindowDays(-5));
+        }
+
+        [TestMethod]
+        public void LicenceIdParameter_DiscardsAnythingThatIsNotAnInteger()
+        {
+            // These ids are interpolated into SQL after being checked against the licence types that
+            // actually exist. Discarding non-numeric input here is the first of the two gates.
+            CollectionAssert.AreEqual(
+                new[] { 1, 4 },
+                CopilotAdoptionAPIController.ParseIds("1, 4, 1, abc, 1; DROP TABLE users").ToArray());
+
+            Assert.AreEqual(0, CopilotAdoptionAPIController.ParseIds(null).Count);
+            Assert.AreEqual(0, CopilotAdoptionAPIController.ParseIds("   ").Count);
+        }
+
+        [TestMethod]
+        public void BandParameter_AcceptsNumbersAndNames()
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { AdoptionBand.NeverUsed, AdoptionBand.Dormant },
+                CopilotAdoptionAPIController.ParseBands("0,1").ToArray());
+
+            CollectionAssert.AreEquivalent(
+                new[] { AdoptionBand.Champion },
+                CopilotAdoptionAPIController.ParseBands("champion").ToArray());
+
+            Assert.AreEqual(0, CopilotAdoptionAPIController.ParseBands("99,not-a-band").Count);
+        }
+
+        #endregion
+
+        #region Test data helpers
+
+        private static LicensedUserUsageRow UsageRow(long interactions, int activeDays, int appsUsed, DateTime? lastUse)
+        {
+            return new LicensedUserUsageRow
+            {
+                UserId = 1,
+                UserPrincipalName = "user@contoso.com",
+                Interactions = interactions,
+                ActiveDays = activeDays,
+                AppsUsed = appsUsed,
+                LastInteractionUtc = lastUse,
+                FirstInteractionUtc = lastUse,
+            };
+        }
+
+        private static LicensedUserAdoptionRow ScoredUser(string upn, double score, AdoptionBand band)
+        {
+            return new LicensedUserAdoptionRow
+            {
+                UserId = upn.GetHashCode(),
+                UserPrincipalName = upn,
+                AdoptionScore = score,
+                Band = band,
+                BandName = CopilotAdoptionScoring.BandDisplayName(band),
+            };
+        }
+
+        private static LicensedUserAdoptionRow Departmental(string upn, string department, double score)
+        {
+            var row = ScoredUser(upn, score, score >= 50 ? AdoptionBand.Established : score > 0 ? AdoptionBand.Trialling : AdoptionBand.NeverUsed);
+            row.Department = department;
+            return row;
+        }
+
+        /// <summary>Six licensed users spread across the bands, for the summary assembly tests.</summary>
+        private static CopilotAdoptionAnalysis SampleAnalysis()
+        {
+            var analysis = new CopilotAdoptionAnalysis();
+            analysis.LicensedUsers.AddRange(new[]
+            {
+                ScoredUser("champ@contoso.com", 90, AdoptionBand.Champion),
+                ScoredUser("established@contoso.com", 60, AdoptionBand.Established),
+                ScoredUser("trialling@contoso.com", 10, AdoptionBand.Trialling),
+                ScoredUser("dormant@contoso.com", 0, AdoptionBand.Dormant),
+                ScoredUser("never1@contoso.com", 0, AdoptionBand.NeverUsed),
+                ScoredUser("never2@contoso.com", 0, AdoptionBand.NeverUsed),
+            });
+            analysis.Summary.LicensedUsers = analysis.LicensedUsers.Count;
+            return analysis;
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            var count = 0;
+            var index = 0;
+            while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += needle.Length;
+            }
+            return count;
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -145,6 +145,8 @@
     <Compile Include="PowerPlatformAuditEventManagerTests.cs" />
     <Compile Include="PowerPlatformAdminActivityRecordParseTests.cs" />
     <Compile Include="ProfilingStoredProcedureTests.cs" />
+    <Compile Include="CopilotAdoptionSqlIntegrationTests.cs" />
+    <Compile Include="CopilotAdoptionTests.cs" />
     <Compile Include="ReportsAPIControllerTests.cs" />
     <Compile Include="SimplePropsDicTests.cs" />
     <Compile Include="PageUpdateEventListParseTests.cs" />

--- a/src/AnalyticsEngine/Web/Controllers/CopilotAdoptionAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/CopilotAdoptionAPIController.cs
@@ -1,0 +1,552 @@
+using Common.Entities;
+using Common.Entities.Config;
+using Common.Entities.CopilotAdoption;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.Caching;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace Web.AnalyticsWeb.Controllers
+{
+    /// <summary>
+    /// Powers the SPA's "Copilot Adoption" area - the licence-adoption tool.
+    ///
+    /// It answers two questions that decide real money:
+    /// <list type="number">
+    ///   <item><b>Who holds a Microsoft 365 Copilot licence and is not getting value from it?</b> Not as
+    ///   a yes/no, but as a graded engagement score, because almost nobody is either a power user or a
+    ///   complete non-user - and "50 people used it once" and "50 people use it daily" produce identical
+    ///   "active user" counts while calling for opposite responses.</item>
+    ///   <item><b>Who is a heavy Microsoft 365 user without a licence?</b> Ranked by a business case,
+    ///   led by the strongest evidence there is: people already using Copilot Chat without a seat.</item>
+    /// </list>
+    ///
+    /// Design notes:
+    /// <list type="bullet">
+    ///   <item>All the analysis lives in <see cref="CopilotAdoptionService"/> in Common.Entities, not
+    ///   here. This controller caches, filters, pages and serialises. That keeps the whole thing
+    ///   reusable by a scheduled report web-job later without lifting logic out of a controller.</item>
+    ///   <item>The heavy work runs <b>once</b> per (window, licence override) and is cached, so paging,
+    ///   sorting, filtering and CSV export are all served from the same in-memory result. That is a
+    ///   performance decision, but mostly a correctness one: an exported spreadsheet is guaranteed to
+    ///   match the summary it was exported from.</item>
+    ///   <item>Concurrent first-hits share one execution (the cache holds the <see cref="Task{T}"/>),
+    ///   so a page refresh during a slow analysis cannot start a second full scan of the audit history.</item>
+    /// </list>
+    /// </summary>
+    [Authorize]
+    [RoutePrefix("api/CopilotAdoption")]
+    public class CopilotAdoptionAPIController : ApiController
+    {
+        private const string CacheKeyPrefix = "CopilotAdoption::Analysis::";
+
+        /// <summary>
+        /// How long a completed analysis is reused. Long enough that working through the list - sorting,
+        /// filtering, exporting - never re-runs the queries, short enough that a refresh after an import
+        /// shows new data. The imports themselves run far less often than this.
+        /// </summary>
+        private const int CacheMinutes = 10;
+
+        /// <summary>Windows the UI offers. Anything else is snapped to the nearest, so a hand-edited URL cannot force a year-long scan.</summary>
+        private static readonly int[] AllowedWindowDays = { 7, 28, 90, 180 };
+
+        private const int DefaultTake = 50;
+        private const int MaxTake = 500;
+
+        /// <summary>
+        /// Hard cap on a CSV export. Comfortably above any realistic Copilot seat count while stopping a
+        /// single request from materialising an entire directory into one HTTP response.
+        /// </summary>
+        private const int MaxCsvRows = 100000;
+
+        #region Availability
+
+        /// <summary>
+        /// Whether this deployment can show the tool at all, and what is missing if it cannot. Called
+        /// before anything heavy so the SPA can hide the tab (or explain itself) rather than showing an
+        /// empty dashboard that looks like zero adoption.
+        /// </summary>
+        // GET: api/CopilotAdoption/availability
+        [HttpGet]
+        [Route("availability")]
+        public IHttpActionResult Availability()
+        {
+            var settings = new AppConfig().ImportJobSettings ?? new ImportTaskSettings();
+
+            var model = new CopilotAdoptionAvailability
+            {
+                CopilotAuditImportEnabled = settings.Copilot,
+                CopilotUsageReportImportEnabled = settings.GraphCopilotUsageReports,
+                UserMetadataImportEnabled = settings.GraphUsersMetadata,
+                M365UsageReportImportEnabled = settings.GraphUsageReports,
+            };
+
+            // Licence data is what makes this a *licence* adoption tool - without the user metadata
+            // import there is no way to know who holds a Copilot seat, so nothing here works.
+            model.Available = model.UserMetadataImportEnabled
+                              && (model.CopilotAuditImportEnabled || model.CopilotUsageReportImportEnabled);
+
+            if (!model.UserMetadataImportEnabled)
+            {
+                model.Messages.Add(
+                    "The user metadata import is disabled, so licence assignments are unknown. Enable it in the "
+                    + "installer to identify who holds a Microsoft 365 Copilot licence.");
+            }
+
+            if (!model.CopilotAuditImportEnabled && !model.CopilotUsageReportImportEnabled)
+            {
+                model.Messages.Add(
+                    "Neither the Copilot audit import nor the Copilot usage-report import is enabled, so there is "
+                    + "no Copilot usage to measure. Enable at least one in the installer.");
+            }
+
+            if (!model.CopilotAuditImportEnabled && model.CopilotUsageReportImportEnabled)
+            {
+                model.Messages.Add(
+                    "The Copilot audit import is disabled. Engagement will be based on Microsoft's own usage "
+                    + "report, which covers licensed users only - unlicensed Copilot Chat use, per-app breakdowns "
+                    + "and Cowork adoption will not be visible.");
+            }
+
+            if (!model.M365UsageReportImportEnabled)
+            {
+                model.Messages.Add(
+                    "The Microsoft 365 usage-report import is disabled, so licence candidates can only be ranked "
+                    + "on existing unlicensed Copilot use. Enable it to also find heavy Microsoft 365 users who "
+                    + "have never tried Copilot.");
+            }
+
+            return Ok(model);
+        }
+
+        #endregion
+
+        #region Summary and licence types
+
+        /// <summary>The executive view: headline figures, the adoption funnel and the breakdown charts.</summary>
+        // GET: api/CopilotAdoption/summary?windowDays=28
+        [HttpGet]
+        [Route("summary")]
+        public async Task<IHttpActionResult> Summary(
+            int windowDays = 28,
+            string seatLicenceTypeIds = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var analysis = await GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
+            return Ok(analysis.Summary);
+        }
+
+        /// <summary>
+        /// Every licence type in the tenant and whether it was counted as a Copilot seat.
+        ///
+        /// Exposed deliberately: Microsoft ships new Copilot SKUs faster than any shipped classification
+        /// list can track, so an admin has to be able to see what the tool decided - and override it -
+        /// rather than discover from a wrong headline number that a SKU was missed.
+        /// </summary>
+        // GET: api/CopilotAdoption/licence-types
+        [HttpGet]
+        [Route("licence-types")]
+        public async Task<IHttpActionResult> LicenceTypes(
+            int windowDays = 28,
+            string seatLicenceTypeIds = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var analysis = await GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
+            return Ok(analysis.Summary.SeatLicenceTypes);
+        }
+
+        /// <summary>The queries behind the numbers, for the SQL popover the rest of the admin site uses.</summary>
+        // GET: api/CopilotAdoption/sql
+        [HttpGet]
+        [Route("sql")]
+        public async Task<IHttpActionResult> Sql(
+            int windowDays = 28,
+            string seatLicenceTypeIds = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var analysis = await GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
+            return Ok(analysis.Sql);
+        }
+
+        /// <summary>
+        /// The distinct departments and countries present in the analysis, for the filter drop-downs.
+        /// Derived from the already-loaded result rather than from another query.
+        /// </summary>
+        // GET: api/CopilotAdoption/filters
+        [HttpGet]
+        [Route("filters")]
+        public async Task<IHttpActionResult> Filters(
+            int windowDays = 28,
+            string seatLicenceTypeIds = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var analysis = await GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
+
+            return Ok(new
+            {
+                departments = Distinct(
+                    analysis.LicensedUsers.Select(u => u.Department)
+                        .Concat(analysis.Opportunities.Select(o => o.Department))),
+                countries = Distinct(
+                    analysis.LicensedUsers.Select(u => u.Country)
+                        .Concat(analysis.Opportunities.Select(o => o.Country))),
+                bands = CopilotAdoptionScoring.AllBands
+                    .Select(b => new { value = (int)b, name = CopilotAdoptionScoring.BandDisplayName(b) })
+                    .ToList(),
+            });
+        }
+
+        #endregion
+
+        #region Licensed users
+
+        /// <summary>
+        /// The licensed-user list: who holds a seat, how much they use it, and what to do about it.
+        /// Defaults to the lowest scores first, because the people who need attention are the point.
+        /// </summary>
+        // GET: api/CopilotAdoption/licensed-users?windowDays=28&skip=0&take=50
+        [HttpGet]
+        [Route("licensed-users")]
+        public async Task<IHttpActionResult> LicensedUsers(
+            int windowDays = 28,
+            string seatLicenceTypeIds = null,
+            string search = null,
+            string bands = null,
+            string department = null,
+            string country = null,
+            bool coworkOnly = false,
+            bool disabledOnly = false,
+            double? minScore = null,
+            double? maxScore = null,
+            string sortBy = LicensedUserSortFields.Score,
+            bool sortDesc = false,
+            int skip = 0,
+            int take = DefaultTake,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var analysis = await GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
+
+            var query = BuildLicensedUserQuery(
+                search, bands, department, country, coworkOnly, disabledOnly, minScore, maxScore, sortBy, sortDesc);
+
+            var matched = CopilotAdoptionExports.Apply(analysis.LicensedUsers, query);
+
+            return Ok(new LicensedUserPage
+            {
+                Total = matched.Count,
+                Skip = Math.Max(0, skip),
+                Take = Math.Min(Math.Max(1, take), MaxTake),
+                Rows = CopilotAdoptionExports.Page(matched, skip, take, MaxTake),
+                Warnings = analysis.Summary.Warnings,
+            });
+        }
+
+        /// <summary>
+        /// The same list as a CSV download. Takes the identical filter parameters, so what is exported
+        /// is exactly what is on screen - just without the paging.
+        /// </summary>
+        // GET: api/CopilotAdoption/licensed-users/export
+        [HttpGet]
+        [Route("licensed-users/export")]
+        public async Task<HttpResponseMessage> ExportLicensedUsers(
+            int windowDays = 28,
+            string seatLicenceTypeIds = null,
+            string search = null,
+            string bands = null,
+            string department = null,
+            string country = null,
+            bool coworkOnly = false,
+            bool disabledOnly = false,
+            double? minScore = null,
+            double? maxScore = null,
+            string sortBy = LicensedUserSortFields.Score,
+            bool sortDesc = false,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var analysis = await GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
+
+            var query = BuildLicensedUserQuery(
+                search, bands, department, country, coworkOnly, disabledOnly, minScore, maxScore, sortBy, sortDesc);
+
+            var rows = CopilotAdoptionExports.Apply(analysis.LicensedUsers, query).Take(MaxCsvRows).ToList();
+
+            return CsvResponse(
+                CsvSerialiser.ToBytes(rows, CopilotAdoptionExports.LicensedUserColumns()),
+                CsvSerialiser.FileName("copilot-licensed-users", analysis.Summary.GeneratedUtc));
+        }
+
+        #endregion
+
+        #region Licence opportunities
+
+        /// <summary>
+        /// Unlicensed users ranked as candidates for a Copilot seat, strongest business case first.
+        /// </summary>
+        // GET: api/CopilotAdoption/opportunities?windowDays=28&skip=0&take=50
+        [HttpGet]
+        [Route("opportunities")]
+        public async Task<IHttpActionResult> Opportunities(
+            int windowDays = 28,
+            string seatLicenceTypeIds = null,
+            string search = null,
+            string department = null,
+            string country = null,
+            bool recommendedOnly = false,
+            bool existingCopilotUsersOnly = false,
+            double? minScore = null,
+            string sortBy = LicenceOpportunitySortFields.Score,
+            bool sortDesc = true,
+            int skip = 0,
+            int take = DefaultTake,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var analysis = await GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
+
+            var query = BuildOpportunityQuery(
+                search, department, country, recommendedOnly, existingCopilotUsersOnly, minScore, sortBy, sortDesc);
+
+            var matched = CopilotAdoptionExports.Apply(analysis.Opportunities, query);
+
+            return Ok(new LicenceOpportunityPage
+            {
+                Total = matched.Count,
+                Skip = Math.Max(0, skip),
+                Take = Math.Min(Math.Max(1, take), MaxTake),
+                Rows = CopilotAdoptionExports.Page(matched, skip, take, MaxTake),
+                Warnings = analysis.Summary.Warnings,
+            });
+        }
+
+        // GET: api/CopilotAdoption/opportunities/export
+        [HttpGet]
+        [Route("opportunities/export")]
+        public async Task<HttpResponseMessage> ExportOpportunities(
+            int windowDays = 28,
+            string seatLicenceTypeIds = null,
+            string search = null,
+            string department = null,
+            string country = null,
+            bool recommendedOnly = false,
+            bool existingCopilotUsersOnly = false,
+            double? minScore = null,
+            string sortBy = LicenceOpportunitySortFields.Score,
+            bool sortDesc = true,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var analysis = await GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
+
+            var query = BuildOpportunityQuery(
+                search, department, country, recommendedOnly, existingCopilotUsersOnly, minScore, sortBy, sortDesc);
+
+            var rows = CopilotAdoptionExports.Apply(analysis.Opportunities, query).Take(MaxCsvRows).ToList();
+
+            return CsvResponse(
+                CsvSerialiser.ToBytes(rows, CopilotAdoptionExports.LicenceOpportunityColumns()),
+                CsvSerialiser.FileName("copilot-licence-opportunities", analysis.Summary.GeneratedUtc));
+        }
+
+        #endregion
+
+        #region Analysis cache
+
+        /// <summary>
+        /// The cached analysis for this window and licence override, running it if necessary.
+        ///
+        /// The <see cref="Task{T}"/> itself is cached, not its result, so several requests arriving
+        /// while the first analysis is still running all await the same execution instead of each
+        /// starting their own scan of the Copilot audit history. A failed analysis is evicted so the
+        /// next request retries rather than serving a cached error for ten minutes.
+        /// </summary>
+        private static Task<CopilotAdoptionAnalysis> GetAnalysisAsync(
+            int windowDays,
+            string seatLicenceTypeIds,
+            CancellationToken cancellationToken)
+        {
+            var window = NormaliseWindowDays(windowDays);
+            var overrideIds = ParseIds(seatLicenceTypeIds);
+            var cacheKey = CacheKeyPrefix + window + "::"
+                           + (overrideIds.Count == 0 ? "auto" : string.Join(",", overrideIds.OrderBy(i => i)));
+
+            var existing = MemoryCache.Default.Get(cacheKey) as Task<CopilotAdoptionAnalysis>;
+            if (existing != null && !existing.IsFaulted && !existing.IsCanceled)
+            {
+                return existing;
+            }
+
+            var options = CopilotAdoptionOptions.Default;
+            options.WindowDays = window;
+
+            var service = new CopilotAdoptionService(options);
+            var task = service.AnalyseAsync(overrideIds.Count == 0 ? null : overrideIds, cancellationToken);
+
+            // AddOrGetExisting is atomic, so if another request got there first we use its task and
+            // abandon ours rather than running the analysis twice.
+            var winner = MemoryCache.Default.AddOrGetExisting(
+                cacheKey, task, DateTimeOffset.UtcNow.AddMinutes(CacheMinutes)) as Task<CopilotAdoptionAnalysis>;
+
+            var effective = winner ?? task;
+
+            effective.ContinueWith(
+                completed =>
+                {
+                    if (completed.IsFaulted || completed.IsCanceled)
+                    {
+                        MemoryCache.Default.Remove(cacheKey);
+                    }
+                },
+                TaskContinuationOptions.ExecuteSynchronously);
+
+            return effective;
+        }
+
+        #endregion
+
+        #region Parameter handling
+
+        /// <summary>
+        /// Snaps a requested window to one of the supported values. A free-form window would let a
+        /// hand-edited URL ask for an arbitrarily long scan of the audit history.
+        /// </summary>
+        internal static int NormaliseWindowDays(int windowDays)
+        {
+            if (AllowedWindowDays.Contains(windowDays))
+            {
+                return windowDays;
+            }
+
+            return AllowedWindowDays
+                .OrderBy(allowed => Math.Abs(allowed - windowDays))
+                .ThenBy(allowed => allowed)
+                .First();
+        }
+
+        /// <summary>
+        /// Parses a comma-separated id list, ignoring anything that is not an integer. These ids are
+        /// interpolated into SQL after being checked against the licence types that actually exist, so
+        /// discarding non-numeric input here is the first of two gates rather than the only one.
+        /// </summary>
+        internal static List<int> ParseIds(string commaSeparated)
+        {
+            if (string.IsNullOrWhiteSpace(commaSeparated))
+            {
+                return new List<int>();
+            }
+
+            return commaSeparated
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Trim())
+                .Select(part => int.TryParse(part, out var id) ? (int?)id : null)
+                .Where(id => id.HasValue)
+                .Select(id => id.Value)
+                .Distinct()
+                .ToList();
+        }
+
+        /// <summary>Parses the band filter, accepting either the numeric value or the enum name.</summary>
+        internal static List<AdoptionBand> ParseBands(string commaSeparated)
+        {
+            var result = new List<AdoptionBand>();
+            if (string.IsNullOrWhiteSpace(commaSeparated))
+            {
+                return result;
+            }
+
+            foreach (var part in commaSeparated.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var token = part.Trim();
+
+                if (int.TryParse(token, out var numeric) && Enum.IsDefined(typeof(AdoptionBand), numeric))
+                {
+                    result.Add((AdoptionBand)numeric);
+                }
+                else if (Enum.TryParse(token, ignoreCase: true, result: out AdoptionBand band)
+                         && Enum.IsDefined(typeof(AdoptionBand), band))
+                {
+                    // Enum.TryParse happily accepts any numeric string - "99" would parse to
+                    // (AdoptionBand)99 - so the IsDefined check is what stops an out-of-range value
+                    // reaching the filter and silently matching nothing.
+                    result.Add(band);
+                }
+            }
+
+            return result.Distinct().ToList();
+        }
+
+        private static LicensedUserQuery BuildLicensedUserQuery(
+            string search, string bands, string department, string country,
+            bool coworkOnly, bool disabledOnly, double? minScore, double? maxScore,
+            string sortBy, bool sortDesc)
+        {
+            return new LicensedUserQuery
+            {
+                Search = search,
+                Bands = ParseBands(bands),
+                Department = department,
+                Country = country,
+                CoworkOnly = coworkOnly,
+                DisabledAccountsOnly = disabledOnly,
+                MinScore = minScore,
+                MaxScore = maxScore,
+                SortBy = sortBy,
+                SortDescending = sortDesc,
+            };
+        }
+
+        private static LicenceOpportunityQuery BuildOpportunityQuery(
+            string search, string department, string country,
+            bool recommendedOnly, bool existingCopilotUsersOnly, double? minScore,
+            string sortBy, bool sortDesc)
+        {
+            return new LicenceOpportunityQuery
+            {
+                Search = search,
+                Department = department,
+                Country = country,
+                RecommendedOnly = recommendedOnly,
+                ExistingCopilotUsersOnly = existingCopilotUsersOnly,
+                MinScore = minScore,
+                SortBy = sortBy,
+                SortDescending = sortDesc,
+            };
+        }
+
+        private static List<string> Distinct(IEnumerable<string> values)
+        {
+            return values
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(v => v, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
+        /// A CSV file download. The bytes already carry a UTF-8 BOM (see <see cref="CsvSerialiser"/>)
+        /// so Excel renders non-ASCII names correctly, and the charset is declared explicitly for
+        /// everything that is not Excel.
+        /// </summary>
+        private static HttpResponseMessage CsvResponse(byte[] csv, string fileName)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(csv),
+            };
+
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/csv") { CharSet = "utf-8" };
+            response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+            {
+                FileName = fileName,
+            };
+
+            return response;
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/README.md
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/README.md
@@ -42,6 +42,7 @@ analytics. If `SiteTokenAPI` can't return a token, the SPA falls back to client-
 | `o365AnalyticsInstallLogAPI` | `api/InstallLog` | Install log (config history from `sys_configs`) for the Install Log page. |
 | `o365AnalyticsProfilingStatusAPI` | `api/ProfilingStatus` | Profiling data freshness + paged `profiling.TraceLogs` for the Profiling page. |
 | `o365AnalyticsReportsAPI` | `api/Reports` | Lite in-app reports: enabled areas (`/areas`) + weekly usage charts per area (`/copilot`, `/usage`, `/spo-audit`, `/web-traffic`, `/calls`, `/emails`). |
+| `o365AnalyticsCopilotAdoptionAPI` | `api/CopilotAdoption` | Copilot licence adoption: availability, executive summary, licensed-user and licence-opportunity lists, and their CSV exports. |
 
 ## Local development
 

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/index.html
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/index.html
@@ -29,6 +29,7 @@
     window.o365AnalyticsInstallLogAPI = baseUrl + "api/InstallLog";
     window.o365AnalyticsProfilingStatusAPI = baseUrl + "api/ProfilingStatus";
     window.o365AnalyticsReportsAPI = baseUrl + "api/Reports";
+    window.o365AnalyticsCopilotAdoptionAPI = baseUrl + "api/CopilotAdoption";
     window.o365AnalyticsHealthAPI = baseUrl + "api/Health";
   </script>
 </head>

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/App.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/App.tsx
@@ -16,6 +16,7 @@ import Spinner from './components/Spinner';
 // Code-split the pages so each route is a separate chunk (smaller initial load).
 const HomePage = lazy(() => import('./pages/HomePage'));
 const ReportsPage = lazy(() => import('./pages/ReportsPage'));
+const CopilotAdoptionPage = lazy(() => import('./pages/CopilotAdoptionPage'));
 const TeamsPermissionsPage = lazy(() => import('./pages/TeamsPermissionsPage'));
 const UserLookupPage = lazy(() => import('./pages/UserLookupPage'));
 const ProfilingStatusPage = lazy(() => import('./pages/ProfilingStatusPage'));
@@ -62,17 +63,19 @@ export default function App() {
 
   const selectedTab = location.pathname.startsWith('/reports')
     ? 'reports'
-    : location.pathname.startsWith('/teams')
-      ? 'teams'
-      : location.pathname.startsWith('/user-lookup')
-        ? 'user-lookup'
-        : location.pathname.startsWith('/profiling')
-          ? 'profiling'
-          : location.pathname.startsWith('/install-log')
-            ? 'install-log'
-            : location.pathname.startsWith('/health')
-              ? 'health'
-              : 'home';
+    : location.pathname.startsWith('/copilot-adoption')
+      ? 'copilot-adoption'
+      : location.pathname.startsWith('/teams')
+        ? 'teams'
+        : location.pathname.startsWith('/user-lookup')
+          ? 'user-lookup'
+          : location.pathname.startsWith('/profiling')
+            ? 'profiling'
+            : location.pathname.startsWith('/install-log')
+              ? 'install-log'
+              : location.pathname.startsWith('/health')
+                ? 'health'
+                : 'home';
 
   const onTabSelect: SelectTabEventHandler = (_event, data) => {
     navigate(`/${data.value}`);
@@ -102,6 +105,7 @@ export default function App() {
         <TabList selectedValue={selectedTab} onTabSelect={onTabSelect} size="large">
           <Tab value="home">Home</Tab>
           <Tab value="reports">Reports</Tab>
+          <Tab value="copilot-adoption">Copilot Adoption</Tab>
           <Tab value="teams">Teams Permissions</Tab>
           <Tab value="user-lookup">User Data Lookup</Tab>
           <Tab value="profiling">Profiling</Tab>
@@ -122,6 +126,7 @@ export default function App() {
             <Route path="/" element={<Navigate to="/home" replace />} />
             <Route path="/home" element={<HomePage />} />
             <Route path="/reports" element={<ReportsPage />} />
+            <Route path="/copilot-adoption" element={<CopilotAdoptionPage />} />
             <Route path="/teams" element={<TeamsPermissionsPage />} />
             <Route path="/user-lookup" element={<UserLookupPage />} />
             <Route path="/profiling" element={<ProfilingStatusPage />} />

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/api/copilotAdoptionApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/api/copilotAdoptionApi.ts
@@ -1,0 +1,147 @@
+import type {
+  AdoptionFilterOptions,
+  CopilotAdoptionAvailability,
+  CopilotAdoptionSummary,
+  LicenceOpportunityPage,
+  LicensedUserFilters,
+  LicensedUserPage,
+  OpportunityFilters,
+} from '../types/copilotAdoption';
+
+const baseUrl = (): string =>
+  window.o365AnalyticsCopilotAdoptionAPI ?? `${window.location.origin}/api/CopilotAdoption`;
+
+async function getJson<T>(path: string, what: string): Promise<T> {
+  const response = await fetch(`${baseUrl()}${path}`, {
+    method: 'GET',
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Couldn't load ${what} (${response.status}).`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/** Common query parameters: every endpoint is scoped by the window and the seat-licence selection. */
+function scopeParams(windowDays: number, seatLicenceTypeIds?: number[]): URLSearchParams {
+  const params = new URLSearchParams({ windowDays: String(windowDays) });
+  if (seatLicenceTypeIds && seatLicenceTypeIds.length > 0) {
+    params.set('seatLicenceTypeIds', seatLicenceTypeIds.join(','));
+  }
+  return params;
+}
+
+/** Adds the licensed-user filter state to a parameter set. */
+function applyLicensedUserFilters(params: URLSearchParams, filters: LicensedUserFilters): URLSearchParams {
+  if (filters.search.trim()) params.set('search', filters.search.trim());
+  if (filters.bands.length > 0) params.set('bands', filters.bands.join(','));
+  if (filters.department) params.set('department', filters.department);
+  if (filters.country) params.set('country', filters.country);
+  if (filters.coworkOnly) params.set('coworkOnly', 'true');
+  if (filters.disabledOnly) params.set('disabledOnly', 'true');
+  params.set('sortBy', filters.sortBy);
+  params.set('sortDesc', String(filters.sortDesc));
+  return params;
+}
+
+/** Adds the licence-opportunity filter state to a parameter set. */
+function applyOpportunityFilters(params: URLSearchParams, filters: OpportunityFilters): URLSearchParams {
+  if (filters.search.trim()) params.set('search', filters.search.trim());
+  if (filters.department) params.set('department', filters.department);
+  if (filters.country) params.set('country', filters.country);
+  if (filters.recommendedOnly) params.set('recommendedOnly', 'true');
+  if (filters.existingCopilotUsersOnly) params.set('existingCopilotUsersOnly', 'true');
+  params.set('sortBy', filters.sortBy);
+  params.set('sortDesc', String(filters.sortDesc));
+  return params;
+}
+
+export function fetchAdoptionAvailability(): Promise<CopilotAdoptionAvailability> {
+  return getJson<CopilotAdoptionAvailability>('/availability', 'the Copilot adoption availability');
+}
+
+export function fetchAdoptionSummary(
+  windowDays: number,
+  seatLicenceTypeIds?: number[],
+): Promise<CopilotAdoptionSummary> {
+  return getJson<CopilotAdoptionSummary>(
+    `/summary?${scopeParams(windowDays, seatLicenceTypeIds)}`,
+    'the Copilot adoption summary',
+  );
+}
+
+export function fetchAdoptionFilters(
+  windowDays: number,
+  seatLicenceTypeIds?: number[],
+): Promise<AdoptionFilterOptions> {
+  return getJson<AdoptionFilterOptions>(
+    `/filters?${scopeParams(windowDays, seatLicenceTypeIds)}`,
+    'the Copilot adoption filters',
+  );
+}
+
+export function fetchLicensedUsers(
+  windowDays: number,
+  filters: LicensedUserFilters,
+  skip: number,
+  take: number,
+  seatLicenceTypeIds?: number[],
+): Promise<LicensedUserPage> {
+  const params = applyLicensedUserFilters(scopeParams(windowDays, seatLicenceTypeIds), filters);
+  params.set('skip', String(skip));
+  params.set('take', String(take));
+
+  return getJson<LicensedUserPage>(`/licensed-users?${params}`, 'the licensed Copilot users');
+}
+
+export function fetchOpportunities(
+  windowDays: number,
+  filters: OpportunityFilters,
+  skip: number,
+  take: number,
+  seatLicenceTypeIds?: number[],
+): Promise<LicenceOpportunityPage> {
+  const params = applyOpportunityFilters(scopeParams(windowDays, seatLicenceTypeIds), filters);
+  params.set('skip', String(skip));
+  params.set('take', String(take));
+
+  return getJson<LicenceOpportunityPage>(`/opportunities?${params}`, 'the Copilot licence opportunities');
+}
+
+export function fetchAdoptionSql(
+  windowDays: number,
+  seatLicenceTypeIds?: number[],
+): Promise<Record<string, string>> {
+  return getJson<Record<string, string>>(
+    `/sql?${scopeParams(windowDays, seatLicenceTypeIds)}`,
+    'the Copilot adoption queries',
+  );
+}
+
+/**
+ * URL of the CSV export for the current filters.
+ *
+ * Returned as a URL for a plain link rather than fetched and turned into a blob, so the browser's
+ * own download UI handles it and the session cookie is sent automatically. The export takes the
+ * same filter parameters as the list, so the file always matches what is on screen.
+ */
+export function licensedUsersExportUrl(
+  windowDays: number,
+  filters: LicensedUserFilters,
+  seatLicenceTypeIds?: number[],
+): string {
+  const params = applyLicensedUserFilters(scopeParams(windowDays, seatLicenceTypeIds), filters);
+  return `${baseUrl()}/licensed-users/export?${params}`;
+}
+
+export function opportunitiesExportUrl(
+  windowDays: number,
+  filters: OpportunityFilters,
+  seatLicenceTypeIds?: number[],
+): string {
+  const params = applyOpportunityFilters(scopeParams(windowDays, seatLicenceTypeIds), filters);
+  return `${baseUrl()}/opportunities/export?${params}`;
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/AdoptionFunnel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/AdoptionFunnel.tsx
@@ -1,0 +1,122 @@
+import { makeStyles, tokens, Text } from '@fluentui/react-components';
+import type { ReportCategory } from '../../types/reports';
+import { formatCount, formatPct } from './KpiGrid';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    paddingTop: '4px',
+  },
+  stage: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(120px, 170px) 1fr auto',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  label: {
+    color: tokens.colorNeutralForeground2,
+  },
+  track: {
+    position: 'relative',
+    height: '26px',
+    borderRadius: tokens.borderRadiusSmall,
+    backgroundColor: tokens.colorNeutralBackground3,
+    overflow: 'hidden',
+  },
+  bar: {
+    height: '100%',
+    borderRadius: tokens.borderRadiusSmall,
+    minWidth: '2px',
+    transition: 'width 200ms ease',
+  },
+  barLabel: {
+    position: 'absolute',
+    insetBlockStart: 0,
+    insetInlineStart: '10px',
+    height: '26px',
+    display: 'flex',
+    alignItems: 'center',
+    color: tokens.colorNeutralForegroundOnBrand,
+    fontVariantNumeric: 'tabular-nums',
+  },
+  dropOff: {
+    textAlign: 'right',
+    minWidth: '120px',
+    fontVariantNumeric: 'tabular-nums',
+  },
+  loss: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  baseline: {
+    color: tokens.colorNeutralForeground3,
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '24px 0',
+    textAlign: 'center',
+  },
+});
+
+/**
+ * Progressively darker blues down the funnel, so the shape reads as a narrowing pipeline rather
+ * than as five unrelated bars.
+ */
+const STAGE_COLOURS = ['#a3c8ea', '#7cb0e0', '#4f93d3', '#2b7cc4', '#0f6cbd'];
+
+/**
+ * The adoption funnel: licensed -> ever used -> active -> habitual -> champion.
+ *
+ * Each stage is drawn as a share of the first and, the part that actually drives decisions, the
+ * drop-off from the previous stage is spelled out next to it. A single "38% adoption" figure tells
+ * an executive that something is wrong; this tells them *where*, which is the difference between
+ * commissioning a training programme and reclaiming seats.
+ */
+export default function AdoptionFunnel({ stages }: { stages: ReportCategory[] }) {
+  const styles = useStyles();
+
+  if (stages.length === 0) {
+    return <div className={styles.empty}>No licensed users to chart.</div>;
+  }
+
+  const top = Math.max(stages[0]?.value ?? 0, 1);
+
+  return (
+    <div className={styles.root}>
+      {stages.map((stage, index) => {
+        const previous = index === 0 ? null : stages[index - 1].value;
+        const lost = previous === null ? 0 : previous - stage.value;
+        const conversion = previous === null || previous === 0 ? 100 : (stage.value / previous) * 100;
+        const widthPct = Math.max(1.5, (stage.value / top) * 100);
+
+        return (
+          <div className={styles.stage} key={stage.label}>
+            <Text size={200} className={styles.label}>
+              {stage.label}
+            </Text>
+            <div className={styles.track}>
+              <div
+                className={styles.bar}
+                style={{ width: `${widthPct}%`, backgroundColor: STAGE_COLOURS[index % STAGE_COLOURS.length] }}
+              />
+              <Text size={200} weight="semibold" className={styles.barLabel}>
+                {formatCount(stage.value)}
+              </Text>
+            </div>
+            <Text size={200} className={styles.dropOff}>
+              {previous === null ? (
+                <span className={styles.baseline}>baseline</span>
+              ) : (
+                <>
+                  {formatPct(conversion)}
+                  {lost > 0 && <span className={styles.loss}> ({formatCount(lost)} lost)</span>}
+                </>
+              )}
+            </Text>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/KpiGrid.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/KpiGrid.tsx
@@ -1,0 +1,104 @@
+import { makeStyles, tokens, Text, Card } from '@fluentui/react-components';
+import type { ReactNode } from 'react';
+
+/**
+ * Visual weight of a headline figure. This is judgement, not decoration: on a page that is used to
+ * justify licence spend, colouring "42 unused seats" the same as "1,204 interactions" buries the
+ * number the reader is supposed to act on.
+ */
+export type KpiTone = 'neutral' | 'good' | 'warning' | 'critical' | 'opportunity';
+
+const useStyles = makeStyles({
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))',
+    gap: '12px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    padding: '14px 16px',
+    borderLeftWidth: '4px',
+    borderLeftStyle: 'solid',
+  },
+  label: {
+    color: tokens.colorNeutralForeground3,
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+  },
+  value: {
+    fontSize: '30px',
+    lineHeight: '36px',
+    fontWeight: tokens.fontWeightSemibold,
+    fontVariantNumeric: 'tabular-nums',
+  },
+  hint: {
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+const TONE_COLOUR: Record<KpiTone, string> = {
+  neutral: tokens.colorNeutralStroke1,
+  good: tokens.colorPaletteGreenBorderActive,
+  warning: tokens.colorPaletteYellowBorderActive,
+  critical: tokens.colorPaletteRedBorderActive,
+  opportunity: tokens.colorBrandStroke1,
+};
+
+export type KpiDefinition = {
+  key: string;
+  label: string;
+  value: ReactNode;
+  hint?: string;
+  tone?: KpiTone;
+};
+
+/** A responsive row of headline figures. */
+export function KpiGrid({ items }: { items: KpiDefinition[] }) {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.grid}>
+      {items.map((item) => (
+        <Card
+          key={item.key}
+          className={styles.card}
+          style={{ borderLeftColor: TONE_COLOUR[item.tone ?? 'neutral'] }}
+        >
+          <Text size={200} className={styles.label}>
+            {item.label}
+          </Text>
+          <span className={styles.value}>{item.value}</span>
+          {item.hint && (
+            <Text size={200} className={styles.hint}>
+              {item.hint}
+            </Text>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+/** Formats a whole number for display, e.g. 12345 -> "12,345". */
+export function formatCount(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+/** Formats a percentage to one decimal place, dropping a trailing ".0". */
+export function formatPct(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return `${rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toFixed(1)}%`;
+}
+
+/** A UTC ISO date as a short local-format date, or a dash when absent. */
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '\u2014';
+  return new Date(iso).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/LicensedUsersPanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/LicensedUsersPanel.tsx
@@ -1,0 +1,371 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  makeStyles,
+  tokens,
+  Text,
+  Card,
+  Input,
+  Select,
+  Checkbox,
+  Button,
+  MessageBar,
+  MessageBarBody,
+  Tooltip,
+} from '@fluentui/react-components';
+import { ArrowDownload16Regular, ArrowClockwise16Regular } from '@fluentui/react-icons';
+import { fetchLicensedUsers, licensedUsersExportUrl } from '../../api/copilotAdoptionApi';
+import { AdoptionBand } from '../../types/copilotAdoption';
+import type {
+  AdoptionFilterOptions,
+  LicensedUserFilters,
+  LicensedUserPage,
+} from '../../types/copilotAdoption';
+import Spinner from '../Spinner';
+import { BandBadge, ScoreBar, useAdoptionTableStyles } from './adoptionShared';
+import { formatCount, formatDate } from './KpiGrid';
+
+const PAGE_SIZE = 50;
+
+/**
+ * Sort options, phrased as the question the admin is actually asking rather than as column names.
+ * "Least engaged first" is the default because the entire purpose of the list is finding the people
+ * who are not getting value from a licence somebody is paying for.
+ */
+const SORT_OPTIONS = [
+  { value: 'score:asc', label: 'Least engaged first' },
+  { value: 'score:desc', label: 'Most engaged first' },
+  { value: 'lastUse:asc', label: 'Longest since last use' },
+  { value: 'interactions:desc', label: 'Most interactions' },
+  { value: 'activeDays:desc', label: 'Most active days' },
+  { value: 'cowork:desc', label: 'Most Cowork use' },
+  { value: 'department:asc', label: 'Department (A-Z)' },
+  { value: 'upn:asc', label: 'User name (A-Z)' },
+];
+
+const useStyles = makeStyles({
+  filters: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: '8px',
+    marginBottom: '12px',
+  },
+  grow: {
+    flexGrow: 1,
+    minWidth: '200px',
+  },
+  spacer: {
+    flexGrow: 1,
+  },
+  tableWrap: {
+    overflowX: 'auto',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+    marginTop: '12px',
+    flexWrap: 'wrap',
+  },
+  action: {
+    maxWidth: '340px',
+    color: tokens.colorNeutralForeground2,
+  },
+  upn: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  disabled: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+});
+
+const DEFAULT_FILTERS: LicensedUserFilters = {
+  search: '',
+  bands: [],
+  department: '',
+  country: '',
+  coworkOnly: false,
+  disabledOnly: false,
+  sortBy: 'score',
+  sortDesc: false,
+};
+
+/**
+ * The licensed-user list: everyone holding a Microsoft 365 Copilot seat, how much they actually use
+ * it, and the single recommended next step for each of them.
+ *
+ * Filtering and sorting happen server-side against the cached analysis, so the CSV export - which
+ * takes the identical parameters - is always exactly what is on screen.
+ */
+export default function LicensedUsersPanel({
+  windowDays,
+  filterOptions,
+  seatLicenceTypeIds,
+  initialBands,
+}: {
+  windowDays: number;
+  filterOptions: AdoptionFilterOptions | null;
+  seatLicenceTypeIds?: number[];
+  initialBands?: AdoptionBand[];
+}) {
+  const styles = useStyles();
+  const table = useAdoptionTableStyles();
+
+  const [filters, setFilters] = useState<LicensedUserFilters>({
+    ...DEFAULT_FILTERS,
+    bands: initialBands ?? [],
+  });
+  const [searchDraft, setSearchDraft] = useState('');
+  const [page, setPage] = useState(0);
+  const [data, setData] = useState<LicensedUserPage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  // Any filter change invalidates the current page number - staying on page 5 of a result set that
+  // now has two pages shows an empty table and looks like a bug.
+  useEffect(() => setPage(0), [filters, windowDays]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetchLicensedUsers(windowDays, filters, page * PAGE_SIZE, PAGE_SIZE, seatLicenceTypeIds)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load licensed users.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [windowDays, filters, page, seatLicenceTypeIds, reloadKey]);
+
+  const sortValue = `${filters.sortBy}:${filters.sortDesc ? 'desc' : 'asc'}`;
+  const exportUrl = useMemo(
+    () => licensedUsersExportUrl(windowDays, filters, seatLicenceTypeIds),
+    [windowDays, filters, seatLicenceTypeIds],
+  );
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / PAGE_SIZE)) : 1;
+
+  return (
+    <Card>
+      <div className={styles.filters}>
+        <Input
+          className={styles.grow}
+          value={searchDraft}
+          placeholder="Search name, email, department, job title or manager"
+          aria-label="Search licensed Copilot users"
+          onChange={(_e, d) => setSearchDraft(d.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') setFilters((f) => ({ ...f, search: searchDraft }));
+          }}
+        />
+        <Button size="small" onClick={() => setFilters((f) => ({ ...f, search: searchDraft }))}>
+          Search
+        </Button>
+
+        <Select
+          value={filters.bands.length === 1 ? String(filters.bands[0]) : ''}
+          aria-label="Filter by engagement band"
+          onChange={(_e, d) =>
+            setFilters((f) => ({ ...f, bands: d.value === '' ? [] : [Number(d.value) as AdoptionBand] }))
+          }
+        >
+          <option value="">All engagement bands</option>
+          {(filterOptions?.bands ?? []).map((b) => (
+            <option key={b.value} value={b.value}>
+              {b.name}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          value={filters.department}
+          aria-label="Filter by department"
+          onChange={(_e, d) => setFilters((f) => ({ ...f, department: d.value }))}
+        >
+          <option value="">All departments</option>
+          {(filterOptions?.departments ?? []).map((dept) => (
+            <option key={dept} value={dept}>
+              {dept}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          value={sortValue}
+          aria-label="Sort licensed users"
+          onChange={(_e, d) => {
+            const [sortBy, direction] = d.value.split(':');
+            setFilters((f) => ({ ...f, sortBy, sortDesc: direction === 'desc' }));
+          }}
+        >
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </Select>
+
+        <Checkbox
+          label="Cowork users only"
+          checked={filters.coworkOnly}
+          onChange={(_e, d) => setFilters((f) => ({ ...f, coworkOnly: !!d.checked }))}
+        />
+        <Tooltip
+          content="Disabled accounts still holding a Copilot licence - the clearest seats to reclaim."
+          relationship="description"
+        >
+          <Checkbox
+            label="Disabled accounts only"
+            checked={filters.disabledOnly}
+            onChange={(_e, d) => setFilters((f) => ({ ...f, disabledOnly: !!d.checked }))}
+          />
+        </Tooltip>
+
+        <div className={styles.spacer} />
+
+        <Button
+          size="small"
+          appearance="subtle"
+          icon={<ArrowClockwise16Regular />}
+          onClick={() => setReloadKey((k) => k + 1)}
+        >
+          Refresh
+        </Button>
+        <Button size="small" icon={<ArrowDownload16Regular />} as="a" href={exportUrl}>
+          Export CSV
+        </Button>
+      </div>
+
+      {error && (
+        <MessageBar intent="error">
+          <MessageBarBody>{error}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {loading && (
+        <div style={{ textAlign: 'center', padding: '28px' }}>
+          <Spinner size={56} label="Loading users..." />
+        </div>
+      )}
+
+      {!loading && data && data.rows.length === 0 && (
+        <Text className={styles.muted}>No licensed users match these filters.</Text>
+      )}
+
+      {!loading && data && data.rows.length > 0 && (
+        <div className={styles.tableWrap}>
+          <table className={table.table}>
+            <thead>
+              <tr>
+                <th className={table.th}>User</th>
+                <th className={table.th}>Department</th>
+                <th className={table.th}>Engagement</th>
+                <th className={table.th}>Band</th>
+                <th className={`${table.th} ${table.thNumeric}`}>Interactions</th>
+                <th className={`${table.th} ${table.thNumeric}`}>Active days</th>
+                <th className={`${table.th} ${table.thNumeric}`}>Apps</th>
+                <th className={table.th}>Cowork</th>
+                <th className={table.th}>Last used</th>
+                <th className={table.th}>Recommended action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row) => (
+                <tr key={row.userId}>
+                  <td className={table.td}>
+                    <span className={styles.upn}>
+                      <Text size={200} weight="semibold">
+                        {row.userPrincipalName}
+                      </Text>
+                      <Text size={100} className={row.accountEnabled === false ? styles.disabled : styles.muted}>
+                        {row.accountEnabled === false ? 'Account disabled' : row.jobTitle || row.mail || ''}
+                      </Text>
+                    </span>
+                  </td>
+                  <td className={table.td}>{row.department || '\u2014'}</td>
+                  <td className={table.td}>
+                    <Tooltip
+                      relationship="description"
+                      content={`Frequency ${Math.round(row.frequencyScore)} / Depth ${Math.round(
+                        row.depthScore,
+                      )} / Breadth ${Math.round(row.breadthScore)}. Active on ${row.activeDays} of ${
+                        row.expectedActiveDays
+                      } days needed for full marks.`}
+                    >
+                      <div>
+                        <ScoreBar score={row.adoptionScore} />
+                      </div>
+                    </Tooltip>
+                  </td>
+                  <td className={table.td}>
+                    <BandBadge band={row.band} name={row.bandName} />
+                  </td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>{formatCount(row.interactions)}</td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>
+                    {row.activeDays} <span className={styles.muted}>/ {Math.round(row.expectedActiveDays)}</span>
+                  </td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>{row.appsUsed}</td>
+                  <td className={table.td}>
+                    {row.usedCowork ? `Yes (${formatCount(row.coworkInteractions)})` : 'No'}
+                  </td>
+                  <td className={table.td}>
+                    {formatDate(row.lastInteractionUtc)}
+                    {row.daysSinceLastUse !== null && row.daysSinceLastUse > 0 && (
+                      <Text size={100} block className={styles.muted}>
+                        {row.daysSinceLastUse} days ago
+                      </Text>
+                    )}
+                  </td>
+                  <td className={table.td}>
+                    <Text size={200} className={styles.action}>
+                      {row.recommendedAction}
+                    </Text>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading && data && data.total > 0 && (
+        <div className={styles.footer}>
+          <Text size={200} className={styles.muted}>
+            Showing {formatCount(data.skip + 1)}-{formatCount(Math.min(data.skip + PAGE_SIZE, data.total))} of{' '}
+            {formatCount(data.total)} licensed users
+          </Text>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+            <Button size="small" disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))}>
+              Previous
+            </Button>
+            <Text size={200} className={styles.muted}>
+              Page {page + 1} of {totalPages}
+            </Text>
+            <Button
+              size="small"
+              disabled={page + 1 >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/OpportunitiesPanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/OpportunitiesPanel.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  makeStyles,
+  tokens,
+  Text,
+  Card,
+  Input,
+  Select,
+  Checkbox,
+  Button,
+  Badge,
+  MessageBar,
+  MessageBarBody,
+  Tooltip,
+} from '@fluentui/react-components';
+import { ArrowDownload16Regular, ArrowClockwise16Regular } from '@fluentui/react-icons';
+import { fetchOpportunities, opportunitiesExportUrl } from '../../api/copilotAdoptionApi';
+import type {
+  AdoptionFilterOptions,
+  LicenceOpportunityPage,
+  OpportunityFilters,
+} from '../../types/copilotAdoption';
+import Spinner from '../Spinner';
+import { ScoreBar, useAdoptionTableStyles } from './adoptionShared';
+import { formatCount, formatDate } from './KpiGrid';
+
+const PAGE_SIZE = 50;
+
+const SORT_OPTIONS = [
+  { value: 'score:desc', label: 'Strongest case first' },
+  { value: 'copilot:desc', label: 'Most unlicensed Copilot use' },
+  { value: 'collaboration:desc', label: 'Most Teams activity' },
+  { value: 'email:desc', label: 'Most email activity' },
+  { value: 'documents:desc', label: 'Most document activity' },
+  { value: 'department:asc', label: 'Department (A-Z)' },
+  { value: 'upn:asc', label: 'User name (A-Z)' },
+];
+
+const useStyles = makeStyles({
+  filters: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: '8px',
+    marginBottom: '12px',
+  },
+  grow: {
+    flexGrow: 1,
+    minWidth: '200px',
+  },
+  spacer: {
+    flexGrow: 1,
+  },
+  tableWrap: {
+    overflowX: 'auto',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+    marginTop: '12px',
+    flexWrap: 'wrap',
+  },
+  rationale: {
+    maxWidth: '360px',
+    color: tokens.colorNeutralForeground2,
+  },
+  upn: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  evidence: {
+    color: tokens.colorNeutralForegroundOnBrand,
+    backgroundColor: '#107c10',
+    whiteSpace: 'nowrap',
+  },
+});
+
+const DEFAULT_FILTERS: OpportunityFilters = {
+  search: '',
+  department: '',
+  country: '',
+  recommendedOnly: false,
+  existingCopilotUsersOnly: false,
+  sortBy: 'score',
+  sortDesc: true,
+};
+
+/**
+ * The licence-opportunity list: users with no Copilot seat, ranked by how strong the business case
+ * for giving them one is.
+ *
+ * The "already using Copilot Chat" badge is the single most persuasive thing on this screen - it is
+ * evidence of demand rather than an inference from general Microsoft 365 activity - so it is
+ * surfaced as its own column and its own filter rather than being buried in the score.
+ */
+export default function OpportunitiesPanel({
+  windowDays,
+  filterOptions,
+  seatLicenceTypeIds,
+}: {
+  windowDays: number;
+  filterOptions: AdoptionFilterOptions | null;
+  seatLicenceTypeIds?: number[];
+}) {
+  const styles = useStyles();
+  const table = useAdoptionTableStyles();
+
+  const [filters, setFilters] = useState<OpportunityFilters>(DEFAULT_FILTERS);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [page, setPage] = useState(0);
+  const [data, setData] = useState<LicenceOpportunityPage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => setPage(0), [filters, windowDays]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetchOpportunities(windowDays, filters, page * PAGE_SIZE, PAGE_SIZE, seatLicenceTypeIds)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load licence opportunities.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [windowDays, filters, page, seatLicenceTypeIds, reloadKey]);
+
+  const sortValue = `${filters.sortBy}:${filters.sortDesc ? 'desc' : 'asc'}`;
+  const exportUrl = useMemo(
+    () => opportunitiesExportUrl(windowDays, filters, seatLicenceTypeIds),
+    [windowDays, filters, seatLicenceTypeIds],
+  );
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / PAGE_SIZE)) : 1;
+
+  return (
+    <Card>
+      <div className={styles.filters}>
+        <Input
+          className={styles.grow}
+          value={searchDraft}
+          placeholder="Search name, email, department, job title or manager"
+          aria-label="Search licence candidates"
+          onChange={(_e, d) => setSearchDraft(d.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') setFilters((f) => ({ ...f, search: searchDraft }));
+          }}
+        />
+        <Button size="small" onClick={() => setFilters((f) => ({ ...f, search: searchDraft }))}>
+          Search
+        </Button>
+
+        <Select
+          value={filters.department}
+          aria-label="Filter candidates by department"
+          onChange={(_e, d) => setFilters((f) => ({ ...f, department: d.value }))}
+        >
+          <option value="">All departments</option>
+          {(filterOptions?.departments ?? []).map((dept) => (
+            <option key={dept} value={dept}>
+              {dept}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          value={sortValue}
+          aria-label="Sort licence candidates"
+          onChange={(_e, d) => {
+            const [sortBy, direction] = d.value.split(':');
+            setFilters((f) => ({ ...f, sortBy, sortDesc: direction === 'desc' }));
+          }}
+        >
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </Select>
+
+        <Checkbox
+          label="Recommended only"
+          checked={filters.recommendedOnly}
+          onChange={(_e, d) => setFilters((f) => ({ ...f, recommendedOnly: !!d.checked }))}
+        />
+        <Tooltip
+          content="People already using Copilot Chat without a licence - proven demand, not an inference."
+          relationship="description"
+        >
+          <Checkbox
+            label="Already using Copilot"
+            checked={filters.existingCopilotUsersOnly}
+            onChange={(_e, d) => setFilters((f) => ({ ...f, existingCopilotUsersOnly: !!d.checked }))}
+          />
+        </Tooltip>
+
+        <div className={styles.spacer} />
+
+        <Button
+          size="small"
+          appearance="subtle"
+          icon={<ArrowClockwise16Regular />}
+          onClick={() => setReloadKey((k) => k + 1)}
+        >
+          Refresh
+        </Button>
+        <Button size="small" icon={<ArrowDownload16Regular />} as="a" href={exportUrl}>
+          Export CSV
+        </Button>
+      </div>
+
+      {error && (
+        <MessageBar intent="error">
+          <MessageBarBody>{error}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {loading && (
+        <div style={{ textAlign: 'center', padding: '28px' }}>
+          <Spinner size={56} label="Ranking candidates..." />
+        </div>
+      )}
+
+      {!loading && data && data.rows.length === 0 && (
+        <Text className={styles.muted}>No unlicensed users match these filters.</Text>
+      )}
+
+      {!loading && data && data.rows.length > 0 && (
+        <div className={styles.tableWrap}>
+          <table className={table.table}>
+            <thead>
+              <tr>
+                <th className={table.th}>User</th>
+                <th className={table.th}>Department</th>
+                <th className={table.th}>Business case</th>
+                <th className={table.th}>Already using Copilot</th>
+                <th className={`${table.th} ${table.thNumeric}`}>Teams</th>
+                <th className={`${table.th} ${table.thNumeric}`}>Email</th>
+                <th className={`${table.th} ${table.thNumeric}`}>Files</th>
+                <th className={table.th}>Last M365 activity</th>
+                <th className={table.th}>Justification</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row) => (
+                <tr key={row.userId}>
+                  <td className={table.td}>
+                    <span className={styles.upn}>
+                      <Text size={200} weight="semibold">
+                        {row.userPrincipalName}
+                      </Text>
+                      <Text size={100} className={styles.muted}>
+                        {row.jobTitle || row.mail || ''}
+                      </Text>
+                    </span>
+                  </td>
+                  <td className={table.td}>{row.department || '\u2014'}</td>
+                  <td className={table.td}>
+                    <Tooltip
+                      relationship="description"
+                      content={`Copilot demand ${Math.round(row.copilotDemandScore)} / Collaboration ${Math.round(
+                        row.collaborationScore,
+                      )} / Email ${Math.round(row.emailScore)} / Documents ${Math.round(row.documentScore)}`}
+                    >
+                      <div>
+                        <ScoreBar score={row.opportunityScore} />
+                      </div>
+                    </Tooltip>
+                  </td>
+                  <td className={table.td}>
+                    {row.unlicensedCopilotInteractions > 0 ? (
+                      <Badge className={styles.evidence} size="small">
+                        {formatCount(row.unlicensedCopilotInteractions)} in {row.unlicensedCopilotActiveDays}d
+                      </Badge>
+                    ) : (
+                      <Text size={200} className={styles.muted}>
+                        Not yet
+                      </Text>
+                    )}
+                  </td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>
+                    {formatCount(row.teamsMessages)}
+                    <Text size={100} block className={styles.muted}>
+                      {formatCount(row.teamsMeetings)} mtgs
+                    </Text>
+                  </td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>
+                    {formatCount(row.emailsSent)}
+                    <Text size={100} block className={styles.muted}>
+                      {formatCount(row.emailsRead)} read
+                    </Text>
+                  </td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>{formatCount(row.filesViewedOrEdited)}</td>
+                  <td className={table.td}>{formatDate(row.lastM365ActivityUtc)}</td>
+                  <td className={table.td}>
+                    <Text size={200} className={styles.rationale}>
+                      {row.rationale}
+                    </Text>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading && data && data.total > 0 && (
+        <div className={styles.footer}>
+          <Text size={200} className={styles.muted}>
+            Showing {formatCount(data.skip + 1)}-{formatCount(Math.min(data.skip + PAGE_SIZE, data.total))} of{' '}
+            {formatCount(data.total)} candidates
+          </Text>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+            <Button size="small" disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))}>
+              Previous
+            </Button>
+            <Text size={200} className={styles.muted}>
+              Page {page + 1} of {totalPages}
+            </Text>
+            <Button size="small" disabled={page + 1 >= totalPages} onClick={() => setPage((p) => p + 1)}>
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/adoptionShared.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/copilotAdoption/adoptionShared.tsx
@@ -1,0 +1,196 @@
+import { makeStyles, tokens, Text, Badge } from '@fluentui/react-components';
+import { AdoptionBand } from '../../types/copilotAdoption';
+import type { AdoptionSegmentRow } from '../../types/copilotAdoption';
+import { formatCount, formatPct } from './KpiGrid';
+
+/**
+ * Band colours run cold-to-warm with maturity, and the two zero-usage bands are deliberately the
+ * only red ones - they are the seats that are costing money for nothing.
+ */
+const BAND_COLOUR: Record<AdoptionBand, string> = {
+  [AdoptionBand.NeverUsed]: '#d13438',
+  [AdoptionBand.Dormant]: '#ca5010',
+  [AdoptionBand.Trialling]: '#c19c00',
+  [AdoptionBand.Developing]: '#0f6cbd',
+  [AdoptionBand.Established]: '#008272',
+  [AdoptionBand.Champion]: '#107c10',
+};
+
+const useStyles = makeStyles({
+  badge: {
+    color: tokens.colorNeutralForegroundOnBrand,
+    whiteSpace: 'nowrap',
+  },
+  scoreCell: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    minWidth: '108px',
+  },
+  scoreTrack: {
+    position: 'relative',
+    flexGrow: 1,
+    height: '8px',
+    borderRadius: tokens.borderRadiusSmall,
+    backgroundColor: tokens.colorNeutralBackground3,
+    overflow: 'hidden',
+    minWidth: '46px',
+  },
+  scoreBar: {
+    height: '100%',
+    borderRadius: tokens.borderRadiusSmall,
+  },
+  scoreValue: {
+    fontVariantNumeric: 'tabular-nums',
+    minWidth: '34px',
+    textAlign: 'right',
+  },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+  },
+  th: {
+    textAlign: 'left',
+    padding: '6px 10px',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: tokens.colorNeutralStroke2,
+    color: tokens.colorNeutralForeground3,
+    fontWeight: tokens.fontWeightSemibold,
+    whiteSpace: 'nowrap',
+  },
+  thNumeric: {
+    textAlign: 'right',
+  },
+  td: {
+    padding: '6px 10px',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: tokens.colorNeutralStroke3,
+    verticalAlign: 'middle',
+  },
+  tdNumeric: {
+    textAlign: 'right',
+    fontVariantNumeric: 'tabular-nums',
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '20px 0',
+    textAlign: 'center',
+  },
+});
+
+/** The engagement band as a coloured pill. */
+export function BandBadge({ band, name }: { band: AdoptionBand; name: string }) {
+  const styles = useStyles();
+  return (
+    <Badge className={styles.badge} style={{ backgroundColor: BAND_COLOUR[band] ?? '#605e5c' }} size="small">
+      {name}
+    </Badge>
+  );
+}
+
+/**
+ * A 0-100 score as a small inline bar plus the number.
+ *
+ * The bar matters: a column of bare numbers makes an executive read every row, whereas a column of
+ * bars makes the shape of the problem visible in one glance - which is the whole reason this list
+ * exists rather than a raw data dump.
+ */
+export function ScoreBar({ score, colour }: { score: number; colour?: string }) {
+  const styles = useStyles();
+  const clamped = Math.max(0, Math.min(100, score));
+
+  return (
+    <div className={styles.scoreCell}>
+      <div className={styles.scoreTrack}>
+        <div
+          className={styles.scoreBar}
+          style={{ width: `${clamped}%`, backgroundColor: colour ?? scoreColour(clamped) }}
+        />
+      </div>
+      <Text size={200} weight="semibold" className={styles.scoreValue}>
+        {Math.round(clamped)}
+      </Text>
+    </div>
+  );
+}
+
+/** Score-to-colour, using the same thresholds as the engagement bands so the two never disagree. */
+export function scoreColour(score: number): string {
+  if (score >= 75) return BAND_COLOUR[AdoptionBand.Champion];
+  if (score >= 50) return BAND_COLOUR[AdoptionBand.Established];
+  if (score >= 25) return BAND_COLOUR[AdoptionBand.Developing];
+  if (score > 0) return BAND_COLOUR[AdoptionBand.Trialling];
+  return BAND_COLOUR[AdoptionBand.NeverUsed];
+}
+
+/**
+ * Adoption per department or country, worst first.
+ *
+ * Shows the seat count next to the percentage on purpose: "0% adopted" across six seats and across
+ * six hundred are the same percentage and completely different decisions, and a chart that shows
+ * only the rate invites the wrong one.
+ */
+export function SegmentTable({ rows, segmentLabel }: { rows: AdoptionSegmentRow[]; segmentLabel: string }) {
+  const styles = useStyles();
+
+  if (rows.length === 0) {
+    return (
+      <div className={styles.empty}>
+        Not enough licensed users in any {segmentLabel.toLowerCase()} to break down reliably.
+      </div>
+    );
+  }
+
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th className={styles.th}>{segmentLabel}</th>
+          <th className={`${styles.th} ${styles.thNumeric}`}>Seats</th>
+          <th className={`${styles.th} ${styles.thNumeric}`}>Active</th>
+          <th className={`${styles.th} ${styles.thNumeric}`}>Habitual</th>
+          <th className={`${styles.th} ${styles.thNumeric}`}>Never used</th>
+          <th className={styles.th}>Adoption rate</th>
+          <th className={styles.th}>Avg. score</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.segment}>
+            <td className={styles.td}>{row.segment}</td>
+            <td className={`${styles.td} ${styles.tdNumeric}`}>{formatCount(row.licensedUsers)}</td>
+            <td className={`${styles.td} ${styles.tdNumeric}`}>{formatCount(row.activeUsers)}</td>
+            <td className={`${styles.td} ${styles.tdNumeric}`}>{formatCount(row.habitualUsers)}</td>
+            <td className={`${styles.td} ${styles.tdNumeric}`}>{formatCount(row.neverUsedUsers)}</td>
+            <td className={styles.td}>
+              <div className={styles.scoreCell}>
+                <div className={styles.scoreTrack}>
+                  <div
+                    className={styles.scoreBar}
+                    style={{
+                      width: `${Math.max(0, Math.min(100, row.adoptionRatePct))}%`,
+                      backgroundColor: scoreColour(row.adoptionRatePct),
+                    }}
+                  />
+                </div>
+                <Text size={200} weight="semibold" className={styles.scoreValue}>
+                  {formatPct(row.adoptionRatePct)}
+                </Text>
+              </div>
+            </td>
+            <td className={styles.td}>
+              <ScoreBar score={row.averageAdoptionScore} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** Shared table styling for the two user lists, so they look and behave identically. */
+export function useAdoptionTableStyles() {
+  return useStyles();
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/global.d.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/global.d.ts
@@ -26,6 +26,8 @@ declare global {
     o365AnalyticsProfilingStatusAPI: string;
     /** Base endpoint for the lite in-app Reports API (enabled areas + weekly usage charts). */
     o365AnalyticsReportsAPI: string;
+    /** Base endpoint for the Copilot licence-adoption API (summary, user lists, CSV exports). */
+    o365AnalyticsCopilotAdoptionAPI: string;
     /** Endpoint for the system-health ("is it working?") API. */
     o365AnalyticsHealthAPI: string;
   }

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/CopilotAdoptionPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/CopilotAdoptionPage.tsx
@@ -1,0 +1,673 @@
+import { useEffect, useState } from 'react';
+import {
+  makeStyles,
+  tokens,
+  Title3,
+  Body1,
+  Text,
+  Card,
+  Select,
+  Tab,
+  TabList,
+  MessageBar,
+  MessageBarBody,
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  type SelectTabEventHandler,
+} from '@fluentui/react-components';
+import {
+  fetchAdoptionAvailability,
+  fetchAdoptionFilters,
+  fetchAdoptionSql,
+  fetchAdoptionSummary,
+} from '../api/copilotAdoptionApi';
+import type {
+  AdoptionFilterOptions,
+  CopilotAdoptionAvailability,
+  CopilotAdoptionSummary,
+} from '../types/copilotAdoption';
+import Spinner from '../components/Spinner';
+import SqlPopover from '../components/SqlPopover';
+import TimeSeriesChart from '../components/charts/TimeSeriesChart';
+import CategoryBarChart from '../components/charts/CategoryBarChart';
+import AdoptionFunnel from '../components/copilotAdoption/AdoptionFunnel';
+import LicensedUsersPanel from '../components/copilotAdoption/LicensedUsersPanel';
+import OpportunitiesPanel from '../components/copilotAdoption/OpportunitiesPanel';
+import { SegmentTable } from '../components/copilotAdoption/adoptionShared';
+import { KpiGrid, formatCount, formatDate, formatPct } from '../components/copilotAdoption/KpiGrid';
+import type { KpiDefinition } from '../components/copilotAdoption/KpiGrid';
+
+const WINDOW_OPTIONS = [
+  { value: 7, label: 'Last 7 days' },
+  { value: 28, label: 'Last 28 days' },
+  { value: 90, label: 'Last 90 days' },
+  { value: 180, label: 'Last 180 days' },
+];
+
+type AdoptionTab = 'overview' | 'licensed' | 'opportunities' | 'method';
+
+const useStyles = makeStyles({
+  header: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  controls: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+  },
+  intro: {
+    marginTop: '8px',
+    maxWidth: '780px',
+  },
+  subTabs: {
+    marginTop: '16px',
+  },
+  stack: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    marginTop: '16px',
+  },
+  twoUp: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+    gap: '16px',
+  },
+  cardHead: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  cardBody: {
+    marginTop: '10px',
+  },
+  method: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    color: tokens.colorNeutralForeground2,
+    maxWidth: '860px',
+  },
+  skuTable: {
+    width: '100%',
+    borderCollapse: 'collapse',
+  },
+  skuCell: {
+    padding: '6px 10px',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: tokens.colorNeutralStroke3,
+    textAlign: 'left',
+  },
+});
+
+/**
+ * The Copilot Adoption area.
+ *
+ * Answers the two questions that decide Copilot spend: which licensed users are not getting value
+ * from their seat (as a graded score, not a yes/no), and which unlicensed heavy Microsoft 365 users
+ * have the strongest case for one. Both lists export to CSV so they can be handed to department
+ * leads or attached to a licence request.
+ *
+ * Deliberately built for an executive reader: every headline number has its definition on the page,
+ * the segment breakdowns show absolute counts next to percentages, and the "How these numbers are
+ * calculated" tab spells out the formula and the exact SKUs that were counted as Copilot seats -
+ * because the first question anyone asks about a number like this is "where did that come from?".
+ */
+export default function CopilotAdoptionPage() {
+  const styles = useStyles();
+
+  const [availability, setAvailability] = useState<CopilotAdoptionAvailability | null>(null);
+  const [availabilityError, setAvailabilityError] = useState<string | null>(null);
+  const [windowDays, setWindowDays] = useState(28);
+  const [tab, setTab] = useState<AdoptionTab>('overview');
+
+  const [summary, setSummary] = useState<CopilotAdoptionSummary | null>(null);
+  const [summaryLoading, setSummaryLoading] = useState(true);
+  const [summaryError, setSummaryError] = useState<string | null>(null);
+  const [filterOptions, setFilterOptions] = useState<AdoptionFilterOptions | null>(null);
+  const [sql, setSql] = useState<Record<string, string> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAdoptionAvailability()
+      .then((a) => {
+        if (!cancelled) setAvailability(a);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setAvailabilityError(e instanceof Error ? e.message : 'Failed to check Copilot adoption availability.');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!availability?.available) {
+      setSummaryLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setSummaryLoading(true);
+    setSummaryError(null);
+
+    fetchAdoptionSummary(windowDays)
+      .then((s) => {
+        if (!cancelled) setSummary(s);
+      })
+      .catch((e) => {
+        if (!cancelled) setSummaryError(e instanceof Error ? e.message : 'Failed to load the adoption summary.');
+      })
+      .finally(() => {
+        if (!cancelled) setSummaryLoading(false);
+      });
+
+    // The filter lists and the SQL come from the same cached analysis, so these are cheap follow-ups
+    // rather than extra work. Their failure is not worth surfacing - the page works without them.
+    fetchAdoptionFilters(windowDays)
+      .then((f) => {
+        if (!cancelled) setFilterOptions(f);
+      })
+      .catch(() => undefined);
+
+    fetchAdoptionSql(windowDays)
+      .then((s) => {
+        if (!cancelled) setSql(s);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [availability, windowDays]);
+
+  const onTabSelect: SelectTabEventHandler = (_e, data) => setTab(data.value as AdoptionTab);
+
+  return (
+    <div>
+      <div className={styles.header}>
+        <div>
+          <Title3>Copilot Adoption</Title3>
+          <Body1 block className={styles.intro}>
+            Who is paying for a Microsoft 365 Copilot licence they are not using, and who would benefit from one
+            they do not have. Both lists export to CSV with full user metadata, so they can be handed to a
+            department lead or attached to a licence request.
+          </Body1>
+        </div>
+        <div className={styles.controls}>
+          <Text size={200} className={styles.muted}>
+            Period
+          </Text>
+          <Select
+            value={String(windowDays)}
+            onChange={(_e, d) => setWindowDays(Number(d.value))}
+            aria-label="Reporting period"
+          >
+            {WINDOW_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+
+      {availabilityError && (
+        <MessageBar intent="error" style={{ marginTop: '16px' }}>
+          <MessageBarBody>{availabilityError}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {availability && !availability.available && (
+        <MessageBar intent="info" style={{ marginTop: '16px' }}>
+          <MessageBarBody>
+            Copilot adoption reporting is not available on this deployment.
+            <ul style={{ margin: '6px 0 0 0', paddingInlineStart: '20px' }}>
+              {availability.messages.map((m) => (
+                <li key={m}>{m}</li>
+              ))}
+            </ul>
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      {availability?.available && (
+        <>
+          {availability.messages.length > 0 && (
+            <MessageBar intent="warning" style={{ marginTop: '16px' }}>
+              <MessageBarBody>
+                <ul style={{ margin: 0, paddingInlineStart: '20px' }}>
+                  {availability.messages.map((m) => (
+                    <li key={m}>{m}</li>
+                  ))}
+                </ul>
+              </MessageBarBody>
+            </MessageBar>
+          )}
+
+          <div className={styles.subTabs}>
+            <TabList selectedValue={tab} onTabSelect={onTabSelect}>
+              <Tab value="overview">Overview</Tab>
+              <Tab value="licensed">Licensed users</Tab>
+              <Tab value="opportunities">Licence opportunities</Tab>
+              <Tab value="method">How this is calculated</Tab>
+            </TabList>
+          </div>
+
+          {summaryLoading && (
+            <div style={{ textAlign: 'center', padding: '32px' }}>
+              <Spinner size={80} label="Analysing Copilot adoption..." />
+            </div>
+          )}
+
+          {summaryError && (
+            <MessageBar intent="error" style={{ marginTop: '16px' }}>
+              <MessageBarBody>{summaryError}</MessageBarBody>
+            </MessageBar>
+          )}
+
+          {!summaryLoading && summary && (
+            <div className={styles.stack}>
+              {summary.warnings.length > 0 && (
+                <MessageBar intent="warning">
+                  <MessageBarBody>
+                    <ul style={{ margin: 0, paddingInlineStart: '20px' }}>
+                      {summary.warnings.map((w) => (
+                        <li key={w}>{w}</li>
+                      ))}
+                    </ul>
+                  </MessageBarBody>
+                </MessageBar>
+              )}
+
+              {tab === 'overview' && (
+                <OverviewTab summary={summary} sql={sql} />
+              )}
+
+              {tab === 'licensed' && (
+                <LicensedUsersPanel windowDays={windowDays} filterOptions={filterOptions} />
+              )}
+
+              {tab === 'opportunities' && (
+                <OpportunitiesPanel windowDays={windowDays} filterOptions={filterOptions} />
+              )}
+
+              {tab === 'method' && <MethodTab summary={summary} />}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** The executive view: headline figures, the funnel, and where the gaps are. */
+function OverviewTab({ summary, sql }: { summary: CopilotAdoptionSummary; sql: Record<string, string> | null }) {
+  const styles = useStyles();
+  const kpis = buildKpis(summary);
+
+  return (
+    <>
+      <KpiGrid items={kpis} />
+
+      <Card>
+        <div className={styles.cardHead}>
+          <div>
+            <Text weight="semibold" size={400}>
+              Adoption funnel
+            </Text>
+            <Text size={200} block className={styles.muted}>
+              Every stage is a subset of the one above it. The biggest drop is where the effort should go.
+            </Text>
+          </div>
+          {sql?.licensedUsers && <SqlPopover sql={sql.licensedUsers} title="SQL behind these figures" />}
+        </div>
+        <div className={styles.cardBody}>
+          <AdoptionFunnel stages={summary.funnel} />
+        </div>
+      </Card>
+
+      <div className={styles.twoUp}>
+        <Card>
+          <Text weight="semibold" size={400}>
+            Engagement distribution
+          </Text>
+          <Text size={200} block className={styles.muted}>
+            Licensed users by engagement band. "Never used" and "Dormant" together are the reclaimable seats.
+          </Text>
+          <div className={styles.cardBody}>
+            <CategoryBarChart categories={summary.bandBreakdown} valueLabel="Users" />
+          </div>
+        </Card>
+
+        <Card>
+          <div className={styles.cardHead}>
+            <div>
+              <Text weight="semibold" size={400}>
+                Where Copilot is used
+              </Text>
+              <Text size={200} block className={styles.muted}>
+                Interactions by app across licensed users. Often the fastest way to spot an unused surface.
+              </Text>
+            </div>
+            {sql?.usageByApp && <SqlPopover sql={sql.usageByApp} title="SQL behind this chart" />}
+          </div>
+          <div className={styles.cardBody}>
+            {summary.usageByApp.length > 0 ? (
+              <CategoryBarChart categories={summary.usageByApp} valueLabel="Interactions" />
+            ) : (
+              <Text className={styles.muted}>
+                No per-app breakdown is available. This needs the Copilot audit import.
+              </Text>
+            )}
+          </div>
+        </Card>
+      </div>
+
+      {summary.weeklyTrend.length > 0 && (
+        <Card>
+          <div className={styles.cardHead}>
+            <div>
+              <Text weight="semibold" size={400}>
+                Weekly active licensed users
+              </Text>
+              <Text size={200} block className={styles.muted}>
+                A single adoption rate cannot show whether an enablement programme is working. This can.
+                {summary.coworkDetected && ' The second line tracks Microsoft 365 Copilot Cowork adoption.'}
+              </Text>
+            </div>
+            {sql?.weeklyTrend && <SqlPopover sql={sql.weeklyTrend} title="SQL behind this chart" />}
+          </div>
+          <div className={styles.cardBody}>
+            <TimeSeriesChart series={summary.weeklyTrend} valueLabel="Users" />
+          </div>
+        </Card>
+      )}
+
+      <Card>
+        <Text weight="semibold" size={400}>
+          Adoption by department
+        </Text>
+        <Text size={200} block className={styles.muted}>
+          Lowest adoption first - the running order for an enablement plan. Departments with fewer than{' '}
+          {summary.options.minSeatsPerSegment} seats are omitted because the percentage would not be meaningful.
+        </Text>
+        <div className={styles.cardBody}>
+          <SegmentTable rows={summary.adoptionByDepartment} segmentLabel="Department" />
+        </div>
+      </Card>
+
+      {summary.adoptionByCountry.length > 0 && (
+        <Card>
+          <Text weight="semibold" size={400}>
+            Adoption by country
+          </Text>
+          <Text size={200} block className={styles.muted}>
+            For organisations that run enablement regionally.
+          </Text>
+          <div className={styles.cardBody}>
+            <SegmentTable rows={summary.adoptionByCountry} segmentLabel="Country" />
+          </div>
+        </Card>
+      )}
+
+      {summary.opportunityByDepartment.length > 0 && (
+        <Card>
+          <div className={styles.cardHead}>
+            <div>
+              <Text weight="semibold" size={400}>
+                Where the unmet demand is
+              </Text>
+              <Text size={200} block className={styles.muted}>
+                Departments with the most recommended licence candidates. Pair this with the department adoption
+                table above: a department with unused seats and strong candidates can often be rebalanced at no cost.
+              </Text>
+            </div>
+            {sql?.licenceOpportunities && <SqlPopover sql={sql.licenceOpportunities} title="SQL behind this chart" />}
+          </div>
+          <div className={styles.cardBody}>
+            <CategoryBarChart categories={summary.opportunityByDepartment} valueLabel="Candidates" />
+          </div>
+        </Card>
+      )}
+    </>
+  );
+}
+
+/**
+ * The methodology tab.
+ *
+ * Not optional decoration: the first question asked about any adoption figure is "how did you get
+ * that?", and a report used to justify licence spend has to be able to answer it without someone
+ * reading the source code.
+ */
+function MethodTab({ summary }: { summary: CopilotAdoptionSummary }) {
+  const styles = useStyles();
+  const o = summary.options;
+
+  return (
+    <Card>
+      <Accordion multiple collapsible defaultOpenItems={['score']}>
+        <AccordionItem value="score">
+          <AccordionHeader>How the engagement score is calculated</AccordionHeader>
+          <AccordionPanel>
+            <div className={styles.method}>
+              <Text>
+                Each licensed user gets a score out of 100 built from three components, because "did they use
+                Copilot?" is almost never a yes/no question. Someone who opened it twice and someone who lives in
+                it produce the same "active user" count and need opposite responses.
+              </Text>
+              <Text>
+                <strong>Frequency ({formatPct(o.frequencyWeight * 100)} of the score).</strong> Days used in the
+                period, against a target of {formatPct(o.frequencyTargetRatio * 100)} of the available working
+                days (assuming {o.workingDaysPerWeek} working days a week). Working days rather than calendar days
+                - otherwise a genuinely daily user would top out at about 71%.
+              </Text>
+              <Text>
+                <strong>Depth ({formatPct(o.depthWeight * 100)}).</strong> Interactions per active day, against a
+                target of {o.depthTargetInteractionsPerActiveDay} per day. Separates "opened it once that day" from
+                "worked with it that day".
+              </Text>
+              <Text>
+                <strong>Breadth ({formatPct(o.breadthWeight * 100)}).</strong> How many Copilot surfaces (Teams,
+                Word, Outlook, Copilot Chat and so on) they use, against a target of {o.breadthTargetApps}. Users
+                who only ever use one surface are the cheapest group to move.
+              </Text>
+              <Text>
+                <strong>Bands.</strong> Champion at {o.championScore}+, Established at {o.establishedScore}+,
+                Developing at {o.developingScore}+, Trialling below that. Users with no activity in the period are
+                split into <em>Dormant</em> (used Copilot within the last {o.historyDays} days but not in this
+                period) and <em>Never used</em> - the distinction matters, because one needs a conversation and the
+                other needs onboarding or the seat back.
+              </Text>
+            </div>
+          </AccordionPanel>
+        </AccordionItem>
+
+        <AccordionItem value="opportunity">
+          <AccordionHeader>How licence candidates are ranked</AccordionHeader>
+          <AccordionPanel>
+            <div className={styles.method}>
+              <Text>
+                Unlicensed users are scored out of 100 on four weighted signals, with the weighting set so that
+                evidence beats inference.
+              </Text>
+              <Text>
+                <strong>Already using Copilot Chat without a licence</strong> carries the most weight. It is the
+                only signal that proves demand for Copilot itself rather than inferring it from general activity,
+                and it is invisible in Microsoft's own reports, which cover licensed users only.
+              </Text>
+              <Text>
+                <strong>Teams collaboration</strong>, <strong>email volume</strong> and{' '}
+                <strong>document work</strong> make up the rest. They identify heavy knowledge workers who would
+                benefit but have never had the chance to try it. Anyone scoring{' '}
+                {o.opportunityRecommendScore} or above is marked as recommended.
+              </Text>
+              <Text>
+                Disabled accounts are excluded from the candidate list. They are, however, kept in the licensed
+                user list - a disabled account still holding a Copilot seat is the clearest reclaim there is.
+              </Text>
+            </div>
+          </AccordionPanel>
+        </AccordionItem>
+
+        <AccordionItem value="sources">
+          <AccordionHeader>Where the data comes from</AccordionHeader>
+          <AccordionPanel>
+            <div className={styles.method}>
+              <Text>
+                <strong>Copilot audit log:</strong>{' '}
+                {summary.dataSources.auditAvailable ? 'available' : 'no data for this period'}. Covers every user,
+                including unlicensed Copilot Chat use, and matches the selected period exactly.
+              </Text>
+              <Text>
+                <strong>Microsoft Copilot usage report:</strong>{' '}
+                {summary.dataSources.copilotUsageReportAvailable
+                  ? `snapshot of ${formatDate(summary.dataSources.copilotUsageReportDate)}`
+                  : 'not imported'}
+                . Licensed users only, and unavailable entirely when the tenant conceals user information.
+              </Text>
+              <Text>
+                <strong>Microsoft 365 usage reports:</strong>{' '}
+                {summary.dataSources.m365UsageReportsAvailable
+                  ? `snapshot of ${formatDate(summary.dataSources.m365UsageReportDate)}`
+                  : 'not imported'}
+                . Used to find heavy Microsoft 365 users who do not hold a Copilot licence.
+              </Text>
+              <Text className={styles.muted}>
+                Analysis generated {formatDate(summary.generatedUtc)} covering{' '}
+                {formatDate(summary.fromUtc)} to {formatDate(summary.toUtc)}.
+              </Text>
+            </div>
+          </AccordionPanel>
+        </AccordionItem>
+
+        <AccordionItem value="skus">
+          <AccordionHeader>Which licences were counted as Copilot seats</AccordionHeader>
+          <AccordionPanel>
+            <div className={styles.method}>
+              <Text>
+                Microsoft ships Copilot-branded SKUs that are not a Microsoft 365 Copilot seat (Copilot Studio,
+                Copilot for Sales), and ships new seat SKUs regularly. Everything the tool found is listed below so
+                the licensed population can be checked rather than taken on trust.
+              </Text>
+              <table className={styles.skuTable}>
+                <thead>
+                  <tr>
+                    <th className={styles.skuCell}>Product</th>
+                    <th className={styles.skuCell}>SKU</th>
+                    <th className={styles.skuCell}>Users</th>
+                    <th className={styles.skuCell}>Counted as a Copilot seat</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.seatLicenceTypes.map((licence) => (
+                    <tr key={licence.id}>
+                      <td className={styles.skuCell}>{licence.name}</td>
+                      <td className={styles.skuCell}>
+                        <Text size={200} className={styles.muted}>
+                          {licence.skuPartNumber}
+                        </Text>
+                      </td>
+                      <td className={styles.skuCell}>{formatCount(licence.assignedUsers)}</td>
+                      <td className={styles.skuCell}>{licence.isCopilotSeat ? 'Yes' : 'No'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </Card>
+  );
+}
+
+/**
+ * The headline figures, in the order an executive reads them: how many seats, how many are working,
+ * how many are wasted, and what the unmet demand is.
+ */
+function buildKpis(summary: CopilotAdoptionSummary): KpiDefinition[] {
+  const items: KpiDefinition[] = [
+    {
+      key: 'licensed',
+      label: 'Copilot licences',
+      value: formatCount(summary.licensedUsers),
+      hint: `${summary.seatLicenceTypes.filter((l) => l.isCopilotSeat).length} seat SKU(s) counted`,
+    },
+    {
+      key: 'adoption',
+      label: 'Adoption rate',
+      value: formatPct(summary.adoptionRatePct),
+      hint: `${formatCount(summary.activeUsers)} used Copilot in this period`,
+      tone: summary.adoptionRatePct >= 70 ? 'good' : summary.adoptionRatePct >= 40 ? 'warning' : 'critical',
+    },
+    {
+      key: 'habit',
+      label: 'Habitual users',
+      value: formatPct(summary.habitRatePct),
+      hint: `${formatCount(summary.habitualUsers)} have made Copilot part of the working week`,
+      tone: summary.habitRatePct >= 50 ? 'good' : summary.habitRatePct >= 25 ? 'warning' : 'critical',
+    },
+    {
+      key: 'reclaim',
+      label: 'Reclaimable seats',
+      value: formatCount(summary.reclaimableSeats),
+      hint: `${formatCount(summary.neverUsedUsers)} never used, ${formatCount(summary.dormantUsers)} dormant`,
+      tone: summary.reclaimableSeats > 0 ? 'critical' : 'good',
+    },
+    {
+      key: 'score',
+      label: 'Average engagement',
+      value: Math.round(summary.averageAdoptionScore),
+      hint: `Median ${Math.round(summary.medianAdoptionScore)} of 100`,
+    },
+  ];
+
+  // Cowork is only claimed as a metric when Cowork was actually seen: on a tenant that has not been
+  // enabled for it, "0% Cowork adoption" reads as a failure rather than as "not available here".
+  if (summary.coworkDetected) {
+    items.push({
+      key: 'cowork',
+      label: 'Cowork adoption',
+      value: formatPct(summary.coworkAdoptionPct),
+      hint: `${formatCount(summary.coworkUsers)} licensed users, ${formatCount(
+        summary.coworkInteractions,
+      )} interactions`,
+      tone: 'opportunity',
+    });
+  }
+
+  if (summary.unlicensedActiveUsers > 0) {
+    items.push({
+      key: 'unlicensed',
+      label: 'Using Copilot unlicensed',
+      value: formatCount(summary.unlicensedActiveUsers),
+      hint: 'Proven demand - already using Copilot Chat with no seat',
+      tone: 'opportunity',
+    });
+  }
+
+  items.push({
+    key: 'candidates',
+    label: 'Recommended for a licence',
+    value: formatCount(summary.recommendedForLicence),
+    hint: 'Heavy Microsoft 365 users with a strong business case',
+    tone: 'opportunity',
+  });
+
+  return items;
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/copilotAdoption.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/copilotAdoption.ts
@@ -1,0 +1,238 @@
+// Mirrors Common/Entities/CopilotAdoption/CopilotAdoptionModels.cs (returned by api/CopilotAdoption).
+//
+// The chart shapes (AdoptionSeries / AdoptionCategory) are deliberately identical to the Reports
+// area's ReportSeries / ReportCategory so the existing TimeSeriesChart and CategoryBarChart
+// components render them with no new charting code.
+
+import type { ReportCategory, ReportSeries } from './reports';
+
+/** Which parts of the adoption tool this deployment can show. */
+export interface CopilotAdoptionAvailability {
+  available: boolean;
+  copilotAuditImportEnabled: boolean;
+  copilotUsageReportImportEnabled: boolean;
+  userMetadataImportEnabled: boolean;
+  m365UsageReportImportEnabled: boolean;
+  messages: string[];
+}
+
+/** A licence type and whether the tool counted it as a Microsoft 365 Copilot seat. */
+export interface LicenceTypeClassification {
+  id: number;
+  name: string;
+  skuPartNumber: string;
+  assignedUsers: number;
+  isCopilotSeat: boolean;
+}
+
+/**
+ * How embedded Copilot is in a licensed user's working week. Numeric values match the C#
+ * AdoptionBand enum, worst first, so a distribution reads left to right as a maturity curve.
+ */
+export enum AdoptionBand {
+  NeverUsed = 0,
+  Dormant = 1,
+  Trialling = 2,
+  Developing = 3,
+  Established = 4,
+  Champion = 5,
+}
+
+/** Which imports supplied the data, so no headline number is quoted without its caveats. */
+export interface AdoptionDataSources {
+  auditAvailable: boolean;
+  copilotUsageReportAvailable: boolean;
+  m365UsageReportsAvailable: boolean;
+  userMetadataAvailable: boolean;
+  copilotUsageReportDate: string | null;
+  m365UsageReportDate: string | null;
+  copilotUsageReportObfuscated: boolean;
+}
+
+/** Adoption for one slice of the organisation (a department, a country). */
+export interface AdoptionSegmentRow {
+  segment: string;
+  licensedUsers: number;
+  activeUsers: number;
+  habitualUsers: number;
+  neverUsedUsers: number;
+  adoptionRatePct: number;
+  averageAdoptionScore: number;
+}
+
+/** Every threshold and weight the adoption maths used, echoed back so a figure can be traced to its rule. */
+export interface CopilotAdoptionOptions {
+  windowDays: number;
+  historyDays: number;
+  workingDaysPerWeek: number;
+  frequencyTargetRatio: number;
+  depthTargetInteractionsPerActiveDay: number;
+  breadthTargetApps: number;
+  frequencyWeight: number;
+  depthWeight: number;
+  breadthWeight: number;
+  championScore: number;
+  establishedScore: number;
+  developingScore: number;
+  opportunityRecommendScore: number;
+  minSeatsPerSegment: number;
+}
+
+/** The executive view. */
+export interface CopilotAdoptionSummary {
+  generatedUtc: string;
+  windowDays: number;
+  fromUtc: string;
+  toUtc: string;
+  dataSources: AdoptionDataSources;
+  seatLicenceTypes: LicenceTypeClassification[];
+
+  licensedUsers: number;
+  activeUsers: number;
+  neverUsedUsers: number;
+  dormantUsers: number;
+  adoptionRatePct: number;
+  habitualUsers: number;
+  habitRatePct: number;
+  reclaimableSeats: number;
+  averageAdoptionScore: number;
+  medianAdoptionScore: number;
+  totalInteractions: number;
+
+  coworkUsers: number;
+  coworkAdoptionPct: number;
+  coworkInteractions: number;
+  coworkDetected: boolean;
+
+  unlicensedActiveUsers: number;
+  recommendedForLicence: number;
+
+  funnel: ReportCategory[];
+  bandBreakdown: ReportCategory[];
+  adoptionByDepartment: AdoptionSegmentRow[];
+  adoptionByCountry: AdoptionSegmentRow[];
+  usageByApp: ReportCategory[];
+  opportunityByDepartment: ReportCategory[];
+  weeklyTrend: ReportSeries[];
+
+  options: CopilotAdoptionOptions;
+  warnings: string[];
+}
+
+/** One licensed user with the adoption maths applied. */
+export interface LicensedUserAdoptionRow {
+  userId: number;
+  userPrincipalName: string;
+  mail: string | null;
+  department: string | null;
+  jobTitle: string | null;
+  country: string | null;
+  officeLocation: string | null;
+  companyName: string | null;
+  manager: string | null;
+  accountEnabled: boolean | null;
+  seatLicences: string | null;
+
+  interactions: number;
+  activeDays: number;
+  expectedActiveDays: number;
+  appsUsed: number;
+  agentsUsed: number;
+  coworkInteractions: number;
+  usedCowork: boolean;
+
+  firstInteractionUtc: string | null;
+  lastInteractionUtc: string | null;
+  daysSinceLastUse: number | null;
+
+  reportPrompts: number | null;
+  reportActiveDays: number | null;
+  reportLastActivityUtc: string | null;
+
+  adoptionScore: number;
+  frequencyScore: number;
+  depthScore: number;
+  breadthScore: number;
+  band: AdoptionBand;
+  bandName: string;
+  signalSource: string;
+  recommendedAction: string;
+}
+
+/** An unlicensed user ranked as a candidate for a Copilot seat. */
+export interface LicenceOpportunityRow {
+  userId: number;
+  userPrincipalName: string;
+  mail: string | null;
+  department: string | null;
+  jobTitle: string | null;
+  country: string | null;
+  officeLocation: string | null;
+  companyName: string | null;
+  manager: string | null;
+
+  unlicensedCopilotInteractions: number;
+  unlicensedCopilotActiveDays: number;
+  lastCopilotInteractionUtc: string | null;
+
+  teamsMessages: number;
+  teamsMeetings: number;
+  emailsSent: number;
+  emailsRead: number;
+  filesViewedOrEdited: number;
+  lastM365ActivityUtc: string | null;
+
+  opportunityScore: number;
+  copilotDemandScore: number;
+  collaborationScore: number;
+  emailScore: number;
+  documentScore: number;
+  recommended: boolean;
+  rationale: string;
+}
+
+export interface LicensedUserPage {
+  total: number;
+  skip: number;
+  take: number;
+  rows: LicensedUserAdoptionRow[];
+  warnings: string[];
+}
+
+export interface LicenceOpportunityPage {
+  total: number;
+  skip: number;
+  take: number;
+  rows: LicenceOpportunityRow[];
+  warnings: string[];
+}
+
+/** Distinct values for the filter drop-downs, derived from the loaded analysis. */
+export interface AdoptionFilterOptions {
+  departments: string[];
+  countries: string[];
+  bands: { value: number; name: string }[];
+}
+
+/** Filter/sort state for the licensed-user list. */
+export interface LicensedUserFilters {
+  search: string;
+  bands: AdoptionBand[];
+  department: string;
+  country: string;
+  coworkOnly: boolean;
+  disabledOnly: boolean;
+  sortBy: string;
+  sortDesc: boolean;
+}
+
+/** Filter/sort state for the licence-opportunity list. */
+export interface OpportunityFilters {
+  search: string;
+  department: string;
+  country: string;
+  recommendedOnly: boolean;
+  existingCopilotUsersOnly: boolean;
+  sortBy: string;
+  sortDesc: boolean;
+}

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -141,20 +141,52 @@
   <PropertyGroup>
     <!-- File with mtime of last successful npm install -->
     <NpmInstallStampFile>Scripts/admin-app/node_modules/.install-stamp</NpmInstallStampFile>
+    <!-- Vite always emits index.html, so it is the marker for "the SPA bundle is up to date". -->
+    <SpaBuildOutputFile>Scripts/admin-app/build/index.html</SpaBuildOutputFile>
   </PropertyGroup>
-  <Target Name="NpmInstall" BeforeTargets="BeforeBuild" Inputs="Scripts\admin-app\package.json" Outputs="$(NpmInstallStampFile)">
+  <ItemGroup>
+    <!--
+      Every input that can change the SPA bundle.
+
+      package.json on its own is NOT enough, and used to be the only input: it changes only when a
+      dependency changes, so on any machine that had built once, editing a page or component left the
+      npm build skipped and the previously-built bundle served unchanged. A newly added admin page
+      simply never appeared, with nothing in the build output to say why.
+    -->
+    <SpaSourceFile Include="$(SpaRoot)src\**\*" />
+    <SpaSourceFile Include="$(SpaRoot)public\**\*" />
+    <SpaSourceFile Include="$(SpaRoot)index.html" />
+    <SpaSourceFile Include="$(SpaRoot)vite.config.ts" />
+    <SpaSourceFile Include="$(SpaRoot)tsconfig.json" />
+    <SpaSourceFile Include="$(SpaRoot)package.json" />
+  </ItemGroup>
+  <!-- Dependencies only. Re-runs when the manifest or the lock file changes. -->
+  <Target Name="NpmInstall" Inputs="$(SpaRoot)package.json;$(SpaRoot)package-lock.json" Outputs="$(NpmInstallStampFile)">
     <!-- Ensure Node.js is installed -->
     <Exec Command="node --version" ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
     </Exec>
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
-    <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
-    <Message Importance="high" Text="Thus: $(SpaRoot)" />
+    <Message Importance="high" Text="Restoring admin-app dependencies using 'npm'. This may take several minutes..." />
     <Exec Command="npm install" WorkingDirectory="$(SpaRoot)" />
-    <Exec Command="npm run build" WorkingDirectory="$(SpaRoot)" />
     <Touch Files="$(NpmInstallStampFile)" AlwaysCreate="true" />
+  </Target>
+  <!-- The bundle itself. Re-runs whenever any SPA source file is newer than the emitted index.html. -->
+  <Target Name="NpmBuildSpa" DependsOnTargets="NpmInstall" Inputs="@(SpaSourceFile)" Outputs="$(SpaBuildOutputFile)">
+    <Message Importance="high" Text="Building the admin SPA with 'npm run build'..." />
+    <Exec Command="npm run build" WorkingDirectory="$(SpaRoot)" />
+  </Target>
+  <!--
+    Registering the built assets as Content has to happen on EVERY build, not only when the bundle was
+    rebuilt. It used to live inside the incremental target, so a skipped npm build also meant the
+    bundle was never copied to the build output or into the publish package.
+
+    It cannot be a plain top-level ItemGroup either: on a first build those files do not exist yet at
+    project-evaluation time, which is why it was inside a target to begin with.
+  -->
+  <Target Name="IncludeSpaBuildOutput" BeforeTargets="BeforeBuild" DependsOnTargets="NpmBuildSpa">
     <ItemGroup>
-      <Content Include="Scripts\admin-app\build\**">
+      <Content Include="$(SpaRoot)build\**" Exclude="@(Content)">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
     </ItemGroup>

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -181,6 +181,7 @@
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\AccountController.cs" />
     <Compile Include="Controllers\BaseAPIController.cs" />
+    <Compile Include="Controllers\CopilotAdoptionAPIController.cs" />
     <Compile Include="Controllers\ImportConfigController.cs" />
     <Compile Include="Controllers\InstallLogAPIController.cs" />
     <Compile Include="Controllers\ProfilingStatusAPIController.cs" />


### PR DESCRIPTION
Adds a **Copilot Adoption** area to the web app: a licence-decision tool built on data the product already imports. No schema changes, no migrations, no config-schema change.

Milestone: **Copilot licence adoption tool** (#12). First cut — expect review comments.

## Why

Two questions decide Copilot spend, and neither is answerable today:

1. **Who holds a Copilot licence and isn't getting value from it?** Microsoft's report gives "active users", which is a yes/no. Someone who opened Copilot once and someone who lives in it produce the same count and need opposite responses (reclaim the seat vs. recruit them as an advocate).
2. **Who's a heavy Microsoft 365 user without a licence?** Including — the part nothing else can see — people **already using Copilot Chat with no seat**. Microsoft's reports APIs exclude unlicensed users entirely; our audit-log import doesn't.

## Architecture

| Layer | Location | Responsibility |
|---|---|---|
| Analysis engine | `Common/Entities/CopilotAdoption/` | SKU classification, scoring, SQL builders, CSV, orchestration |
| API | `Web/Controllers/CopilotAdoptionAPIController.cs` | Caching, filtering, paging, CSV responses |
| UI | `Web/Scripts/admin-app/src/{pages,components/copilotAdoption}` | Overview / Licensed users / Opportunities / methodology |

**The engine deliberately lives in `Common.Entities`, not the web project.** The stated requirement was that this be reusable for automated reports later; `CopilotAdoptionService.AnalyseAsync()` returns the complete scored dataset and has no web dependency, so a web-job can call it unchanged. It also means every rule is unit-testable without a controller.

### Files

**`CopilotLicenceClassifier.cs`** — decides which `license_types` rows are a Microsoft 365 Copilot *seat*. Ordered rules: exclusion list → SKU part-number prefix → conservative display-name fallback. Prefix matching (not an exact list) because a SKU newer than the shipped licensing CSV has **no display name** — the importer stores the part number as the name — so an exact-list classifier would silently miss a customer's newest and most expensive seats. Copilot Studio / Copilot for Sales / Sales Copilot are explicitly excluded; counting them would inflate the denominator and understate adoption, which is the failure mode that matters when the number is used to argue about spend. The classification for **every** licence type is returned to the UI and can be overridden per request, so a misclassified SKU is a visible, correctable fact rather than a wrong headline.

**`CopilotAdoptionScoring.cs`** — all the maths, as pure functions. Engagement = frequency (50%) + depth (30%) + breadth (20%), each capped at its target:

- *Frequency*: active days vs. 60% of **working** days in the window. Calendar days would cap a genuinely daily user at ~71%.
- *Depth*: interactions per active day vs. 5. Separates "opened it" from "worked with it".
- *Breadth*: distinct surfaces vs. 3. Single-surface users are the cheapest group to move.

Bands: Champion 75+, Established 50+, Developing 25+, Trialling >0. Zero-activity users are split **before** thresholds into `Dormant` (used it within `HistoryDays`) and `NeverUsed`. Every threshold and weight is in `CopilotAdoptionOptions` and echoed back in the API response, so a figure can be traced to the rule that produced it.

Opportunity scoring weights unlicensed Copilot Chat use at 35 vs. 25/20/20 for Teams/email/documents — evidence over inference.

**`CopilotAdoptionSql.cs`** — every query, as strings (testable, and shown in the existing SQL popover).

**`CsvSerialiser.cs`** — RFC 4180, UTF-8 **with BOM**, formula-injection defused, culture-invariant.

**`CopilotAdoptionExports.cs`** — filter/sort/page + the two CSV column schemas.

## Performance (target: ~200k-user tenant)

- Licensed population from `user_license_type_lookups` filtered by `license_type_id` — index-only seek on the leading key of `IX_license_type_id_user_id`, **not** a scan of `users`.
- Copilot audit history read **once** over a bounded range; the window-vs-history split is `CASE` inside a single aggregate rather than two joins. This is the most expensive join in the product.
- M365 figures from **one** resolved snapshot date per workload → equality seek on `IX_date` (per `IndexUsageReportSnapshots`), not a range scan.
- Unlicensed candidates driven **from the activity tables**, anti-joined against the licensed set. Driving from `dbo.users` would scan every account to discard the ~majority with no activity.
- `OPTION (RECOMPILE)` throughout; the `copilot_chats`→`audit_events` join is left **un-hinted**, per the measurements recorded on `ReportsAPIController.CopilotAuditNaturalJoin` (a forced MERGE join degraded to a flat 73,857-read full scan at every window).
- Analysis runs once per (window, licence selection) and is cached for 10 min; the cached value is the `Task`, so concurrent first-hits share one execution rather than each starting a full audit scan.
- Licensed users are scored **in memory** (capped at 50k, warns if hit) so the scoring rules have exactly one implementation. Copilot seats are bought individually, so this is far below any real tenant. Unlicensed candidates can't be — that population is the whole directory — so they're ranked in SQL by an expression generated from the *same* options object, then re-scored in C# before display.

**No schema change.** `Migrations/`, `Create DB.sql` and `CONFIG_VERSION` are untouched — verify with `git diff origin/dev --stat -- src/AnalyticsEngine/Common/Entities/Migrations src/AnalyticsEngine/Common/Entities/Resources`.

## Correctness details worth a look

- **Per-user audit fallback.** If the audit import is healthy overall but has nothing for a given user while Microsoft's report shows them active, the report wins for that user. Without this, a lagging or partly-failed import puts actively-working people on a list of seats to take away. The source used is recorded per row (`signalSource`) and exported.
- **Cowork is not reported as "0%" when undetected.** On a tenant not enabled for Cowork, `coworkDetected: false` suppresses the metric — "0% Cowork adoption" reads as a failure and would be quoted as one.
- **Disabled accounts** are excluded from candidates (can't use a licence) but **kept** in the licensed list — a disabled account holding a seat is the clearest reclaim there is. The `disabledOnly` filter treats `null` (not imported) as *not* disabled.
- **Segments below 5 seats are dropped** from the department/country charts; "0% of 2 seats" at the top of an executive chart invites the wrong call. Absolute counts are shown alongside every percentage.
- **Empty licence list** yields `IN (-1)`, not `IN ()` — a tenant with no Copilot licences gets an empty report, not a 500. That's a legitimate use ("should we buy Copilot?"), and the opportunity side still works.
- **Sorting always tie-breaks on UPN** so paging can't duplicate or drop a user between a page and an export.

## Tests

**62 new tests, all passing.** Pure tests cover SKU classification, scoring/banding, opportunity ranking, CSV escaping/Unicode/injection/culture, filtering, sorting, paging, summary assembly and controller parameter handling.

`CopilotAdoptionSqlIntegrationTests` runs the **real SQL** against a throwaway database (`ScratchDatabase`, same pattern as the migration tests) via `Database.SqlQuery<T>`, so DTO materialisation is exercised too. That was worth doing — it caught three defects nothing else would have:

| Defect | Impact if shipped |
|---|---|
| `Read` used as an unbracketed alias | `Incorrect syntax near the keyword 'Read'` — the entire opportunities list 500s |
| Ranking expression referenced CTEs omitted when a source is unavailable | `The multi-part identifier "teams.Messages" could not be bound` on any audit-only deployment |
| Per-user audit gap classified active users as `NeverUsed` | Active people listed as seats to reclaim |

A Greek-alphabet round-trip test guards the Unicode requirement end-to-end (a `varchar` anywhere on the path would mangle it in a document about to go to an executive).

```
Total tests: 62   Passed: 62
```

### Pre-existing failures, not from this PR

`MigrationSnapshotTests.LatestMigrationSnapshot_IsUpToDateWithTheEntityModel` fails, which cascades into `EntityTests` (`AutomaticDataLossException`). Verified by stashing this branch and running it against pristine `origin/dev` — it fails identically there. The pending op is `DropForeignKey("dbo.copilot_interactions", ...)`, from the AI-interaction-history entities already on `dev` (issue #271). This PR adds no entities and no migrations.

## Reviewer hotspots

1. **`CopilotLicenceClassifier` prefix/exclusion lists** — the highest-consequence judgement here. A missed seat SKU understates the denominator.
2. **The weights and thresholds in `CopilotAdoptionOptions`** — defensible defaults, but they're opinions. Worth a second view given the audience.
3. **`MaxLicensedUsersScored = 50000`** — in-memory scoring cap. I believe it's comfortably above any real Copilot seat count; if you disagree the scoring would need to move into SQL, which costs the single-implementation guarantee.
4. **`CopilotAdoptionSql.LicenceOpportunitiesSql`** — the only query whose cost is bounded by activity rather than by seats. Ranking is TOP 5,000.
5. **Cowork detection** — `app_host = 'cowork'` OR a `Copilot.M365Copilot.Cowork*` agent id. Please sanity-check against real payload shapes.

## Not in this PR

- Scheduled/emailed reports. The engine is shaped for it (`AnalyseAsync` → complete dataset, no web deps) but no job is wired up.
- Seat cost input, so "reclaimable seats" can't be shown as a currency figure. Deliberate: it needs a config-schema change and a `CONFIG_VERSION` bump.
- Wiki documentation — happy to write it once the shape is agreed.
- No benchmark table: this PR adds no indexes and no schema changes, so the *Prove every schema change improves performance* gate doesn't apply. The query shapes follow the patterns already measured for the Reports area.
