### PR TITLE
Multi-model review fixes: 4 blockers, dedup correctness + 5.7x speedup, Graph paging order, and 7 more

### DIFF
--- a/infra/TelemetryService/drift/README.md
+++ b/infra/TelemetryService/drift/README.md
@@ -109,6 +109,14 @@ node filter-what-if.mjs what-if.json drift-ignore.json
 node --test          # the filter's own tests
 ```
 
-`what-if.json` contains subscription and resource-group identifiers. Do not commit it or paste it
-into an issue — the filter's summary output is deliberately trimmed to the provider-relative
-resource id for the same reason.
+`what-if.json` contains subscription and resource-group identifiers, and — because the check runs with
+`--result-format FullResourcePayloads` — full resource payloads including app settings. Do not commit
+it or paste it into an issue.
+
+The job summary is safe to publish: `shortenResourceId` trims every reported id to its
+provider-relative part, and **string values are redacted**, leaving only the property path, the change
+type, and the value's type/size. Booleans and numbers are published because they cannot carry a
+secret and they are usually the finding itself (`alwaysOn: false -> true`). Without that redaction a
+drifted app-settings resource would print the Application Insights connection string — instrumentation
+key included — into a world-readable summary on a public repository. There are regression tests for
+both behaviours.

--- a/infra/TelemetryService/drift/filter-what-if.mjs
+++ b/infra/TelemetryService/drift/filter-what-if.mjs
@@ -174,6 +174,19 @@ export function evaluate(whatIf, ignoreRules) {
   return { drift, suppressed, informational };
 }
 
+/**
+ * Renders a property value for the job summary.
+ *
+ * The summary is written to $GITHUB_STEP_SUMMARY, which on a public repository is world-readable,
+ * and what-if runs with --result-format FullResourcePayloads. Deployed values therefore routinely
+ * include things that must never be published: the Application Insights connection string (which
+ * embeds the instrumentation key), the Cosmos endpoint, tenant and client ids, address prefixes.
+ *
+ * So values are redacted by default. Booleans and numbers are published because they cannot carry a
+ * secret and they are what make a drift report actionable - the two defects that motivated this
+ * feature were `alwaysOn: false` (a boolean) and an emptied array. For everything else the type and
+ * size are enough to identify the change; the actual value is read from the Azure portal.
+ */
 function format(value) {
   if (value === undefined) {
     return '_(absent)_';
@@ -181,9 +194,16 @@ function format(value) {
   if (value === null) {
     return '`null`';
   }
-  const text = typeof value === 'object' ? JSON.stringify(value) : String(value);
-  const trimmed = text.length > 120 ? `${text.slice(0, 117)}...` : text;
-  return `\`${trimmed.replace(/\|/g, '\\|')}\``;
+  if (typeof value === 'boolean' || typeof value === 'number') {
+    return `\`${value}\``;
+  }
+  if (Array.isArray(value)) {
+    return `_(array, ${value.length} item${value.length === 1 ? '' : 's'} - redacted)_`;
+  }
+  if (typeof value === 'object') {
+    return `_(object, ${Object.keys(value).length} propert${Object.keys(value).length === 1 ? 'y' : 'ies'} - redacted)_`;
+  }
+  return `_(${typeof value}, ${String(value).length} chars - redacted)_`;
 }
 
 /**
@@ -207,6 +227,9 @@ export function buildSummary({ drift, suppressed, informational }) {
       '',
       'The template is the source of truth. Either redeploy it, or update the template if the',
       'deployed value is the one you actually want.',
+      '',
+      'String values are redacted - this summary is world-readable on a public repository. Read the',
+      'actual values from the Azure portal or `az deployment group what-if` run locally.',
       '',
     );
 

--- a/infra/TelemetryService/drift/filter-what-if.test.mjs
+++ b/infra/TelemetryService/drift/filter-what-if.test.mjs
@@ -291,6 +291,76 @@ describe('summary output', () => {
     assert.match(summary, /alwaysOn/);
   });
 
+  test('publishes boolean values, because they cannot carry a secret and they are the finding', () => {
+    const summary = buildSummary(evaluate({
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: SITE,
+          delta: [{ path: 'properties.siteConfig.alwaysOn', propertyChangeType: 'Modify', before: false, after: true }],
+        },
+      ],
+    }, shippedRules));
+
+    assert.match(summary, /`false`/);
+    assert.match(summary, /`true`/);
+  });
+
+  test('REDACTS string values - what-if returns full resource payloads', () => {
+    // Regression guard. FullResourcePayloads includes app settings, so an unredacted summary would
+    // publish the Application Insights connection string (instrumentation key and all) to anyone.
+    const connectionString =
+      'InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://example.invalid/';
+
+    const summary = buildSummary(evaluate({
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: APPSETTINGS,
+          delta: [{
+            path: 'properties.APPLICATIONINSIGHTS_CONNECTION_STRING',
+            propertyChangeType: 'Modify',
+            before: connectionString,
+            after: 'InstrumentationKey=11111111-1111-1111-1111-111111111111;IngestionEndpoint=https://example.invalid/',
+          }],
+        },
+      ],
+    }, shippedRules));
+
+    assert.doesNotMatch(summary, /InstrumentationKey/,
+      'a connection string must never reach the job summary');
+    assert.doesNotMatch(summary, /IngestionEndpoint/);
+    assert.match(summary, /APPLICATIONINSIGHTS_CONNECTION_STRING/,
+      'the property path is still reported, so the drift is actionable');
+    assert.match(summary, /redacted/);
+  });
+
+  test('redacts array and object values but reports their size', () => {
+    const summary = buildSummary(evaluate({
+      status: 'Succeeded',
+      changes: [
+        {
+          changeType: 'Modify',
+          resourceId: AUTHSETTINGS,
+          delta: [{
+            path: 'properties.identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedApplications',
+            propertyChangeType: 'Array',
+            before: [],
+            after: ['11111111-1111-1111-1111-111111111111'],
+          }],
+        },
+      ],
+    }, shippedRules));
+
+    assert.doesNotMatch(summary, /11111111-1111-1111-1111-111111111111/,
+      'a client id must not be published');
+    assert.match(summary, /allowedApplications/);
+    assert.match(summary, /0 items/);
+    assert.match(summary, /1 item\b/);
+  });
+
   test('shortenResourceId keeps only the provider-relative part', () => {
     assert.equal(shortenResourceId(SITE), 'Microsoft.Web/sites/app-contoso-telemetry');
   });

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionModels.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionModels.cs
@@ -629,6 +629,14 @@ namespace Common.Entities.CopilotAdoption
         [JsonProperty("copilotUsageReportDate")]
         public DateTime? CopilotUsageReportDate { get; set; }
 
+        /// <summary>
+        /// Which Graph report period (7 / 28 / 90 / 180) the snapshot above was read from; 0 when the
+        /// imported rows predate the period being recorded. Pinned because the usage-report table holds one
+        /// row per (date, user, period), so a date-only snapshot duplicates every user.
+        /// </summary>
+        [JsonProperty("copilotUsageReportPeriodDays")]
+        public int CopilotUsageReportPeriodDays { get; set; }
+
         /// <summary>The snapshot date the Microsoft 365 workload figures came from.</summary>
         [JsonProperty("m365UsageReportDate")]
         public DateTime? M365UsageReportDate { get; set; }

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
@@ -139,6 +139,19 @@ namespace Common.Entities.CopilotAdoption
                 new SqlParameter("@settled", settled));
             summary.DataSources.CopilotUsageReportAvailable = summary.DataSources.CopilotUsageReportDate.HasValue;
 
+            if (summary.DataSources.CopilotUsageReportDate.HasValue)
+            {
+                // Pin the report period as well as the date. Without this the snapshot join fans every
+                // licensed user out across D7/D28/D90/D180 - see LatestCopilotReportPeriodSql.
+                summary.DataSources.CopilotUsageReportPeriodDays = await SafeScalarAsync(
+                    CopilotAdoptionSql.LatestCopilotReportPeriodSql,
+                    summary.Warnings,
+                    "Copilot usage-report snapshot period",
+                    cancellationToken,
+                    new SqlParameter("@copilotReportDate", summary.DataSources.CopilotUsageReportDate.Value),
+                    new SqlParameter("@windowDays", _options.WindowDays));
+            }
+
             summary.DataSources.M365UsageReportDate = await SafeDateAsync(
                 CopilotAdoptionSql.LatestM365ReportDateSql,
                 summary.Warnings,
@@ -246,6 +259,7 @@ namespace Common.Entities.CopilotAdoption
             if (includeReport)
             {
                 parameters["@copilotReportDate"] = summary.DataSources.CopilotUsageReportDate.Value;
+                parameters["@copilotReportPeriodDays"] = summary.DataSources.CopilotUsageReportPeriodDays;
             }
 
             analysis.Sql["licensedUsers"] = CopilotAdoptionSql.ForDisplay(detailSql, parameters);
@@ -369,7 +383,11 @@ namespace Common.Entities.CopilotAdoption
         {
             var summary = analysis.Summary;
 
-            if (summary.DataSources.AuditAvailable && seatIds.Count > 0)
+            // Deliberately not gated on seatIds.Count: the "should we buy Copilot?" case has no seat SKUs at
+            // all, and that is exactly when this count matters most. UnlicensedActiveUsersSql renders an
+            // empty id list as IN (-1), so every active user correctly counts as unlicensed. Requiring seats
+            // here reported a flat zero while the candidate list below simultaneously showed real users.
+            if (summary.DataSources.AuditAvailable)
             {
                 var unlicensedSql = CopilotAdoptionSql.UnlicensedActiveUsersSql(seatIds);
                 analysis.Sql["unlicensedActiveUsers"] = CopilotAdoptionSql.ForDisplay(
@@ -565,6 +583,14 @@ namespace Common.Entities.CopilotAdoption
             try
             {
                 return await query();
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is not a query failure and must not be degraded into a warning. The analysis
+                // is cached as a shared Task, so swallowing this would let an aborted run complete as a
+                // "successful" empty result and be served to every other caller until the entry expires.
+                // Letting it propagate faults the task, which the cache then evicts.
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
@@ -81,6 +81,29 @@ namespace Common.Entities.CopilotAdoption
             "WHERE r.[date] <= @settled;";
 
         /// <summary>
+        /// The report period to read for a given snapshot date, chosen as the one closest to the analysis
+        /// window.
+        /// </summary>
+        /// <remarks>
+        /// <c>copilot_usage_user_activity_log</c> is unique on <c>(date, user_id, report_period_days)</c>:
+        /// Graph publishes D7, D28, D90 and D180, and a user has a separate row per period on the same date
+        /// with different prompt and active-day counts. Selecting a snapshot by date alone therefore returns
+        /// several rows per user, and joining that to <c>users</c> multiplies every licensed user by the
+        /// number of stored periods - inflating adoption counts (which can then exceed the licensed
+        /// population) and burning the row cap on duplicates. The period has to be pinned as well.
+        /// Returns 0 when the column is NULL for every row on that date, which is how reports imported
+        /// before the period was recorded are handled.
+        /// </remarks>
+        public const string LatestCopilotReportPeriodSql =
+            "SELECT TOP (1) ISNULL(r.report_period_days, 0) AS Value\r\n" +
+            "FROM dbo.copilot_usage_user_activity_log AS r\r\n" +
+            "WHERE r.[date] = @copilotReportDate\r\n" +
+            "GROUP BY r.report_period_days\r\n" +
+            "ORDER BY CASE WHEN r.report_period_days IS NULL THEN 1 ELSE 0 END,\r\n" +
+            "         ABS(ISNULL(r.report_period_days, 0) - @windowDays),\r\n" +
+            "         ISNULL(r.report_period_days, 0);";
+
+        /// <summary>
         /// The most recent settled Microsoft 365 usage-report snapshot. Teams is used as the reference
         /// workload because every tenant that imports usage reports at all imports Teams, and mixing
         /// snapshot dates across workloads would compare a user's Monday against someone else's Friday.
@@ -191,7 +214,12 @@ namespace Common.Entities.CopilotAdoption
                     "           " + ReportLastActivityExpression() + " AS ReportLastActivityUtc,\r\n" +
                     "           r.agent_last_activity_date AS ReportAgentLastActivityUtc\r\n" +
                     "    FROM dbo.copilot_usage_user_activity_log AS r\r\n" +
+                    // Both the date AND the period are pinned: the table holds one row per
+                    // (date, user, period), so filtering on date alone returns D7/D28/D90/D180 rows for the
+                    // same user and fans every licensed user out by the number of stored periods.
                     "    WHERE r.[date] = @copilotReportDate\r\n" +
+                    "      AND ((@copilotReportPeriodDays > 0 AND r.report_period_days = @copilotReportPeriodDays)\r\n" +
+                    "           OR (@copilotReportPeriodDays = 0 AND r.report_period_days IS NULL))\r\n" +
                     ")";
             }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSqlIntegrationTests.cs
@@ -187,6 +187,7 @@ namespace Tests.UnitTests
                     new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
                     new SqlParameter("@historyFrom", DateTime.UtcNow.Date.AddDays(-365)),
                     new SqlParameter("@copilotReportDate", snapshot),
+                    new SqlParameter("@copilotReportPeriodDays", 28),
                     new SqlParameter("@maxRows", 1000));
 
                 Assert.AreEqual(1, rows.Count);
@@ -198,6 +199,70 @@ namespace Tests.UnitTests
                     "Teams, Word and the collapsed chat surface are inside the window; Excel is not.");
                 Assert.AreEqual(inWindow, row.ReportLastActivityUtc,
                     "The last-activity date is the latest across every per-app column.");
+            }
+        }
+
+        [TestMethod]
+        public void LicensedUsersQuery_PinsTheReportPeriodSoUsersAreNotDuplicated()
+        {
+            // Regression guard. copilot_usage_user_activity_log holds one row per
+            // (date, user_id, report_period_days), and Graph publishes D7/D28/D90/D180 - so a snapshot
+            // selected by date alone returns several rows for the same user. Joined to dbo.users that
+            // multiplies every licensed user by the number of stored periods, which inflated adoption
+            // counts past the licensed population and burned the row cap on duplicates.
+            using (var db = ScratchDatabase.Create("CopilotAdoptPeriod"))
+            {
+                CreateUserTables(db);
+                CreateCopilotTables(db);
+                CreateCopilotReportTable(db);
+
+                var snapshot = DateTime.UtcNow.Date.AddDays(-3);
+                var inWindow = DateTime.UtcNow.Date.AddDays(-5);
+
+                db.Execute(
+                    $@"INSERT INTO dbo.license_types (id, name, sku_id)
+                           VALUES (1, N'Microsoft Copilot for Microsoft 365', N'Microsoft_365_Copilot');
+                       INSERT INTO dbo.users (id, user_name, account_enabled) VALUES (1, N'period@contoso.com', 1);
+                       INSERT INTO dbo.user_license_type_lookups (id, user_id, license_type_id) VALUES (1, 1, 1);
+
+                       -- The SAME user and date, published for two different periods.
+                       INSERT INTO dbo.copilot_usage_user_activity_log
+                           (id, [date], user_id, last_activity_date, report_period_days,
+                            prompts_all_apps, active_usage_days,
+                            teams_last_activity_date, word_last_activity_date, excel_last_activity_date,
+                            chat_last_activity_date)
+                       VALUES
+                           (1, '{snapshot:yyyy-MM-dd}', 1, '{inWindow:yyyy-MM-dd}', 7,
+                            11, 3,
+                            '{inWindow:yyyy-MM-dd}', NULL, NULL, NULL),
+                           (2, '{snapshot:yyyy-MM-dd}', 1, '{inWindow:yyyy-MM-dd}', 28,
+                            47, 12,
+                            '{inWindow:yyyy-MM-dd}', NULL, NULL, NULL);");
+
+                var sql = CopilotAdoptionSql.LicensedUsersSql(new[] { 1 }, new int[0], includeCopilotReport: true);
+
+                var d28 = Query<LicensedUserUsageRow>(
+                    db, sql,
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@historyFrom", DateTime.UtcNow.Date.AddDays(-365)),
+                    new SqlParameter("@copilotReportDate", snapshot),
+                    new SqlParameter("@copilotReportPeriodDays", 28),
+                    new SqlParameter("@maxRows", 1000));
+
+                Assert.AreEqual(1, d28.Count, "One licensed user must produce exactly one row, not one per period.");
+                Assert.AreEqual(47, d28[0].ReportPrompts, "The pinned D28 figures must be the ones returned.");
+
+                // Asking for the other period returns that period's numbers for the same single user.
+                var d7 = Query<LicensedUserUsageRow>(
+                    db, sql,
+                    new SqlParameter("@from", DateTime.UtcNow.Date.AddDays(-28)),
+                    new SqlParameter("@historyFrom", DateTime.UtcNow.Date.AddDays(-365)),
+                    new SqlParameter("@copilotReportDate", snapshot),
+                    new SqlParameter("@copilotReportPeriodDays", 7),
+                    new SqlParameter("@maxRows", 1000));
+
+                Assert.AreEqual(1, d7.Count);
+                Assert.AreEqual(11, d7[0].ReportPrompts);
             }
         }
 

--- a/src/AnalyticsEngine/Web/Controllers/CopilotAdoptionAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/CopilotAdoptionAPIController.cs
@@ -363,6 +363,21 @@ namespace Web.AnalyticsWeb.Controllers
         /// starting their own scan of the Copilot audit history. A failed analysis is evicted so the
         /// next request retries rather than serving a cached error for ten minutes.
         /// </summary>
+        /// <remarks>
+        /// Two details are load-bearing.
+        /// <para>
+        /// The work is wrapped in a <see cref="Lazy{T}"/> and only the winner of
+        /// <c>AddOrGetExisting</c> is evaluated. Starting the task first and then racing to insert it does
+        /// not share anything: a C# async method runs eagerly, so the loser has already issued its queries
+        /// and "abandoning" it only discards the result. Two concurrent first hits meant two full scans of
+        /// the audit history - and the SPA loads summary, filters and SQL concurrently on a cold page.
+        /// </para>
+        /// <para>
+        /// The shared execution deliberately does NOT take the caller's <see cref="CancellationToken"/>.
+        /// The token is bound to one HTTP request, so an admin navigating away would cancel the analysis
+        /// that every other waiter is awaiting.
+        /// </para>
+        /// </remarks>
         private static Task<CopilotAdoptionAnalysis> GetAnalysisAsync(
             int windowDays,
             string seatLicenceTypeIds,
@@ -373,26 +388,30 @@ namespace Web.AnalyticsWeb.Controllers
             var cacheKey = CacheKeyPrefix + window + "::"
                            + (overrideIds.Count == 0 ? "auto" : string.Join(",", overrideIds.OrderBy(i => i)));
 
-            var existing = MemoryCache.Default.Get(cacheKey) as Task<CopilotAdoptionAnalysis>;
-            if (existing != null && !existing.IsFaulted && !existing.IsCanceled)
+            var existing = MemoryCache.Default.Get(cacheKey) as Lazy<Task<CopilotAdoptionAnalysis>>;
+            if (existing != null && !IsDead(existing))
             {
-                return existing;
+                return existing.Value;
             }
 
-            var options = CopilotAdoptionOptions.Default;
-            options.WindowDays = window;
+            var candidate = new Lazy<Task<CopilotAdoptionAnalysis>>(() =>
+            {
+                var options = CopilotAdoptionOptions.Default;
+                options.WindowDays = window;
 
-            var service = new CopilotAdoptionService(options);
-            var task = service.AnalyseAsync(overrideIds.Count == 0 ? null : overrideIds, cancellationToken);
+                var service = new CopilotAdoptionService(options);
+                return service.AnalyseAsync(overrideIds.Count == 0 ? null : overrideIds, CancellationToken.None);
+            }, LazyThreadSafetyMode.ExecutionAndPublication);
 
-            // AddOrGetExisting is atomic, so if another request got there first we use its task and
-            // abandon ours rather than running the analysis twice.
+            // AddOrGetExisting is atomic. Because the Lazy has not been evaluated yet, the loser costs
+            // nothing at all - no query is issued for it.
             var winner = MemoryCache.Default.AddOrGetExisting(
-                cacheKey, task, DateTimeOffset.UtcNow.AddMinutes(CacheMinutes)) as Task<CopilotAdoptionAnalysis>;
+                cacheKey, candidate, DateTimeOffset.UtcNow.AddMinutes(CacheMinutes)) as Lazy<Task<CopilotAdoptionAnalysis>>;
 
-            var effective = winner ?? task;
+            var effective = winner ?? candidate;
+            var task = effective.Value;
 
-            effective.ContinueWith(
+            task.ContinueWith(
                 completed =>
                 {
                     if (completed.IsFaulted || completed.IsCanceled)
@@ -402,7 +421,17 @@ namespace Web.AnalyticsWeb.Controllers
                 },
                 TaskContinuationOptions.ExecuteSynchronously);
 
-            return effective;
+            return task;
+        }
+
+        /// <summary>A cached entry whose analysis already failed must not be served again.</summary>
+        private static bool IsDead(Lazy<Task<CopilotAdoptionAnalysis>> entry)
+        {
+            if (!entry.IsValueCreated)
+                return false;
+
+            var task = entry.Value;
+            return task.IsFaulted || task.IsCanceled;
         }
 
         #endregion

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
@@ -210,21 +210,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
         /// </remarks>
         private async Task<List<Common.Entities.User>> ResolveScopedUsersAsync()
         {
-            List<Common.Entities.User> candidates;
-            using (var db = _dbContextFactory())
-            {
-                // Disabled accounts can't generate new Copilot interactions, so calling Graph for them would
-                // spend the per-cycle budget on guaranteed-empty results.
-                candidates = await db.users
-                    .Where(u => u.UserPrincipalName != null && u.UserPrincipalName != ""
-                                && (u.AccountEnabled == null || u.AccountEnabled == true))
-                    .ToListAsync();
-            }
-
             if (_userGroupsFilter.Patterns.Count == 0)
             {
-                // Only reachable when the operator explicitly opted in to an unscoped run.
-                return candidates;
+                // Only reachable when the operator explicitly opted in to an unscoped run, which is the one
+                // case where we genuinely do want every enabled user.
+                using (var db = _dbContextFactory())
+                {
+                    return await db.users
+                        .Where(u => u.UserPrincipalName != null && u.UserPrincipalName != ""
+                                    && (u.AccountEnabled == null || u.AccountEnabled == true))
+                        .ToListAsync();
+                }
             }
 
             if (_pilotGroupResolver == null)
@@ -239,13 +235,25 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             if (memberUpns.Count == 0)
                 return new List<Common.Entities.User>();
 
-            // memberUpns is an OrdinalIgnoreCase set, so no ToLower() per user here - that would allocate a
-            // string per candidate for no benefit and is an anti-pattern at this scale.
+            // Query BY the pilot members rather than loading the directory and filtering in memory. The old
+            // shape materialised every enabled user - ~200,000 tracked entities at the design baseline - just
+            // to keep the handful in a pilot group, every cycle. Chunked to stay inside SQL Server's
+            // 2100-parameter limit.
+            //
+            // Disabled accounts are still excluded here: they can't generate new Copilot interactions, so
+            // calling Graph for them would spend the per-cycle budget on guaranteed-empty results.
             var inScope = new List<Common.Entities.User>();
-            foreach (var user in candidates)
+            using (var db = _dbContextFactory())
             {
-                if (memberUpns.Contains(user.UserPrincipalName))
-                    inScope.Add(user);
+                foreach (var upnChunk in ChunkStrings(memberUpns.ToList()))
+                {
+                    var rows = await db.users
+                        .Where(u => upnChunk.Contains(u.UserPrincipalName)
+                                    && (u.AccountEnabled == null || u.AccountEnabled == true))
+                        .ToListAsync();
+
+                    inScope.AddRange(rows);
+                }
             }
 
             _logger.LogInformation(
@@ -350,46 +358,98 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
         }
 
         /// <summary>
-        /// Strips interactions we already hold, matching on (session ref, Graph interaction id) - the same
+        /// Strips interactions we already hold, matching on (session, Graph interaction id) - the same
         /// key as the unique index that ultimately protects against duplicates.
         /// </summary>
+        /// <remarks>
+        /// Keyed on the database <c>session_id</c>, not on the raw Graph <c>sessionId</c> string. Two
+        /// reasons, one correctness and one performance:
+        /// <list type="number">
+        /// <item><description>
+        /// <c>copilot_interaction_sessions</c> is unique on <c>(user_id, session_ref)</c> because a Copilot
+        /// thread can be shared - a Teams meeting session appears in more than one participant's history.
+        /// Filtering on <c>session_ref</c> alone therefore matches *other* users' rows, so a second pilot
+        /// user's genuinely-new interactions would be discarded as "already imported". The read is complete,
+        /// so the watermark still advances and the under-count is permanent.
+        /// </description></item>
+        /// <item><description>
+        /// <c>session_id</c> is the leading column of the <c>(session_id, graph_interaction_id)</c> unique
+        /// index, which covers this query. Filtering through the <c>Session.SessionRef</c> navigation instead
+        /// forces a join and an nvarchar(450) predicate. Measured at synthetic scale (50k sessions / 2.25M
+        /// interactions): 2,408 logical reads and 486 ms via the navigation, against 1,323 reads and 85 ms
+        /// keyed on <c>session_id</c> - 1.8x the reads and 5.7x the time for the same result.
+        /// </description></item>
+        /// </list>
+        /// </remarks>
         private async Task RemoveAlreadyImportedAsync(AnalyticsEntitiesContext db, List<UserLoadResult> withData)
         {
-            var sessionRefs = new HashSet<string>(StringComparer.Ordinal);
+            // The (user, session ref) pairs this batch actually touches.
+            var refsByUser = new Dictionary<int, HashSet<string>>();
             foreach (var result in withData)
+            {
+                var userId = result.State.User.ID;
                 foreach (var s in result.Stats)
-                    if (!string.IsNullOrEmpty(s.SessionRef))
-                        sessionRefs.Add(Truncate(s.SessionRef, 450));
+                {
+                    if (string.IsNullOrEmpty(s.SessionRef))
+                        continue;
 
-            if (sessionRefs.Count == 0)
+                    if (!refsByUser.TryGetValue(userId, out var refs))
+                    {
+                        refs = new HashSet<string>(StringComparer.Ordinal);
+                        refsByUser[userId] = refs;
+                    }
+                    refs.Add(Truncate(s.SessionRef, 450));
+                }
+            }
+
+            if (refsByUser.Count == 0)
                 return;
 
-            // One batched query per IN-clause chunk, not one per interaction.
-            var existing = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var refChunk in ChunkStrings(sessionRefs.ToList()))
+            var allRefs = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var refs in refsByUser.Values)
+                allRefs.UnionWith(refs);
+
+            // Resolve each user's OWN session rows. The user-id predicate is what keeps a shared thread
+            // belonging to another pilot user out of the result.
+            var userIds = refsByUser.Keys.ToList();
+            var sessionIdByUserAndRef = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var refChunk in ChunkStrings(allRefs.ToList()))
             {
-                var rows = await db.CopilotInteractions
-                    .Where(i => refChunk.Contains(i.Session.SessionRef))
-                    .Select(i => new { i.Session.SessionRef, i.GraphInteractionId })
+                var rows = await db.CopilotInteractionSessions
+                    .Where(x => refChunk.Contains(x.SessionRef) && userIds.Contains(x.UserId))
+                    .Select(x => new { x.ID, x.UserId, x.SessionRef })
                     .ToListAsync();
 
                 foreach (var row in rows)
-                    existing.Add(row.SessionRef + "|" + row.GraphInteractionId);
+                {
+                    if (refsByUser.TryGetValue(row.UserId, out var wanted) && wanted.Contains(row.SessionRef))
+                        sessionIdByUserAndRef[SessionKey(row.UserId, row.SessionRef)] = row.ID;
+                }
             }
 
+            if (sessionIdByUserAndRef.Count == 0)
+                return;
+
+            var existing = await LoadExistingInteractionKeysAsync(db, sessionIdByUserAndRef.Values.Distinct().ToList());
             if (existing.Count == 0)
                 return;
 
             foreach (var result in withData)
             {
+                var userId = result.State.User.ID;
                 var keep = new List<InteractionStats>(result.Stats.Count);
                 var keptBodies = result.PromptBodies != null ? new List<string>(result.Stats.Count) : null;
 
                 for (int i = 0; i < result.Stats.Count; i++)
                 {
                     var s = result.Stats[i];
-                    if (existing.Contains(Truncate(s.SessionRef, 450) + "|" + s.GraphInteractionId))
+
+                    if (!string.IsNullOrEmpty(s.SessionRef)
+                        && sessionIdByUserAndRef.TryGetValue(SessionKey(userId, Truncate(s.SessionRef, 450)), out var sessionId)
+                        && existing.Contains(InteractionKey(sessionId, s.GraphInteractionId)))
+                    {
                         continue;
+                    }
 
                     keep.Add(s);
                     // Bodies are index-aligned with Stats, so they must be filtered in lock-step.
@@ -539,56 +599,73 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             var newInteractions = new List<CopilotInteraction>();
             var keyPhrasesByInteraction = new Dictionary<CopilotInteraction, List<string>>();
 
-            foreach (var result in withData)
+            // EF6 calls DetectChanges on every DbSet.Add by default, and DetectChanges walks the entire
+            // change tracker - so adding N entities costs O(N^2) entity examinations. A full chunk can carry
+            // 25 users x 50 pages x 100 interactions, where that quadratic term dominates the whole save.
+            // Detection is instead done once, explicitly, immediately before SaveChanges.
+            //
+            // Scoped to this loop only: the lookup/session resolution above and SaveKeyPhrasesAsync below
+            // both add and save their own entities, and they rely on automatic detection.
+            var autoDetectWasEnabled = db.Configuration.AutoDetectChangesEnabled;
+            db.Configuration.AutoDetectChangesEnabled = false;
+            try
             {
-                foreach (var s in result.Stats)
+                foreach (var result in withData)
                 {
-                    if (!sessionIds.TryGetValue(SessionKey(result.State.User.ID, s.SessionRef), out var sessionId))
-                        continue;
-
-                    // The watermark overlap intentionally re-fetches a few seconds of interactions, so
-                    // already-imported rows are expected here and are simply dropped.
-                    if (existingKeys.Contains(InteractionKey(sessionId, s.GraphInteractionId)))
-                        continue;
-
-                    var interaction = new CopilotInteraction
+                    foreach (var s in result.Stats)
                     {
-                        GraphInteractionId = Truncate(s.GraphInteractionId, 200),
-                        SessionId = sessionId,
-                        UserId = result.State.User.ID,
-                        RequestId = Truncate(s.RequestId, 200),
-                        InteractionTypeId = lookups.InteractionTypes.Resolve(s.InteractionType),
-                        AppClassId = lookups.AppClasses.Resolve(s.AppClass),
-                        ConversationTypeId = lookups.ConversationTypes.Resolve(s.ConversationType),
-                        LocaleId = lookups.Locales.Resolve(s.Locale),
-                        DeviceId = lookups.Devices.Resolve(s.Device),
-                        CreatedUtc = s.CreatedUtc,
-                        BodyCharCount = s.BodyCharCount,
-                        BodyWordCount = s.BodyWordCount,
-                        AttachmentCount = s.AttachmentCount,
-                        LinkCount = s.LinkCount,
-                        MentionCount = s.MentionCount,
-                        ContextCount = s.ContextCount,
-                        ResponseLatencyMs = s.ResponseLatencyMs,
-                        SentimentScore = s.SentimentScore,
-                        LanguageId = lookups.Languages.Resolve(s.LanguageName),
-                    };
+                        if (!sessionIds.TryGetValue(SessionKey(result.State.User.ID, s.SessionRef), out var sessionId))
+                            continue;
 
-                    newInteractions.Add(interaction);
-                    db.CopilotInteractions.Add(interaction);
+                        // The watermark overlap intentionally re-fetches a few seconds of interactions, so
+                        // already-imported rows are expected here and are simply dropped.
+                        if (existingKeys.Contains(InteractionKey(sessionId, s.GraphInteractionId)))
+                            continue;
 
-                    if (s.KeyPhrases != null && s.KeyPhrases.Count > 0)
-                        keyPhrasesByInteraction[interaction] = s.KeyPhrases;
+                        var interaction = new CopilotInteraction
+                        {
+                            GraphInteractionId = Truncate(s.GraphInteractionId, 200),
+                            SessionId = sessionId,
+                            UserId = result.State.User.ID,
+                            RequestId = Truncate(s.RequestId, 200),
+                            InteractionTypeId = lookups.InteractionTypes.Resolve(s.InteractionType),
+                            AppClassId = lookups.AppClasses.Resolve(s.AppClass),
+                            ConversationTypeId = lookups.ConversationTypes.Resolve(s.ConversationType),
+                            LocaleId = lookups.Locales.Resolve(s.Locale),
+                            DeviceId = lookups.Devices.Resolve(s.Device),
+                            CreatedUtc = s.CreatedUtc,
+                            BodyCharCount = s.BodyCharCount,
+                            BodyWordCount = s.BodyWordCount,
+                            AttachmentCount = s.AttachmentCount,
+                            LinkCount = s.LinkCount,
+                            MentionCount = s.MentionCount,
+                            ContextCount = s.ContextCount,
+                            ResponseLatencyMs = s.ResponseLatencyMs,
+                            SentimentScore = s.SentimentScore,
+                            LanguageId = lookups.Languages.Resolve(s.LanguageName),
+                        };
 
-                    // Guard against the same interaction appearing twice inside one batch.
-                    existingKeys.Add(InteractionKey(sessionId, s.GraphInteractionId));
+                        newInteractions.Add(interaction);
+                        db.CopilotInteractions.Add(interaction);
+
+                        if (s.KeyPhrases != null && s.KeyPhrases.Count > 0)
+                            keyPhrasesByInteraction[interaction] = s.KeyPhrases;
+
+                        // Guard against the same interaction appearing twice inside one batch.
+                        existingKeys.Add(InteractionKey(sessionId, s.GraphInteractionId));
+                    }
                 }
+
+                if (newInteractions.Count == 0)
+                    return 0;
+
+                db.ChangeTracker.DetectChanges();
+                await db.SaveChangesAsync();
             }
-
-            if (newInteractions.Count == 0)
-                return 0;
-
-            await db.SaveChangesAsync();
+            finally
+            {
+                db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
+            }
 
             await SaveKeyPhrasesAsync(db, keyPhrasesByInteraction);
 
@@ -707,23 +784,36 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             var allPhrases = keyPhrasesByInteraction.Values.SelectMany(p => p);
             var keywordIds = await LookupTable<KeyWord>.BuildAsync(db, db.KeyWords, allPhrases);
 
-            foreach (var entry in keyPhrasesByInteraction)
+            // Same reason as SaveChunkAsync: EF6 runs DetectChanges on every Add, so this loop is O(N^2)
+            // in the number of link rows - and there are up to ten key phrases per scored prompt, on top of
+            // the interactions already tracked from the same save.
+            var autoDetectWasEnabled = db.Configuration.AutoDetectChangesEnabled;
+            db.Configuration.AutoDetectChangesEnabled = false;
+            try
             {
-                foreach (var phrase in entry.Value)
+                foreach (var entry in keyPhrasesByInteraction)
                 {
-                    var keywordId = keywordIds.Resolve(phrase);
-                    if (keywordId == null)
-                        continue;
-
-                    db.CopilotInteractionKeywords.Add(new CopilotInteractionKeyword
+                    foreach (var phrase in entry.Value)
                     {
-                        InteractionId = entry.Key.ID,
-                        KeyWordId = keywordId.Value
-                    });
-                }
-            }
+                        var keywordId = keywordIds.Resolve(phrase);
+                        if (keywordId == null)
+                            continue;
 
-            await db.SaveChangesAsync();
+                        db.CopilotInteractionKeywords.Add(new CopilotInteractionKeyword
+                        {
+                            InteractionId = entry.Key.ID,
+                            KeyWordId = keywordId.Value
+                        });
+                    }
+                }
+
+                db.ChangeTracker.DetectChanges();
+                await db.SaveChangesAsync();
+            }
+            finally
+            {
+                db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
+            }
         }
 
         /// <summary>
@@ -768,10 +858,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
                         // A retryable failure, or a partially-read window. Record it but leave the watermark
                         // alone so the same window is retried in full next cycle - advancing it here would
                         // silently skip whatever we failed to read.
+                        //
+                        // Deliberately does NOT touch ConsecutiveEmptyOrFailed or apply the back-off. That
+                        // back-off exists to stop us re-asking users who have no Copilot licence, and it lasts
+                        // CopilotInteractionHistoryEmptyUserBackOffHours (72h by default). Counting a transient
+                        // Graph failure towards it means a brief 5xx or throttling blip - which hits every user
+                        // in the cycle, not one - parks the entire active pilot group for three days, which is
+                        // the opposite of "retried in full next cycle". A user that fails every cycle simply
+                        // gets retried daily; the per-cycle ceiling and least-recently-run ordering already
+                        // bound what that can cost.
                         runLog.UsersFailed++;
                         watermark.LastError = Truncate(result.Error, 500);
-                        watermark.ConsecutiveEmptyOrFailed++;
-                        ApplyBackOff(watermark, now);
                         continue;
                     }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/GraphAiInteractionSourceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/GraphAiInteractionSourceLoader.cs
@@ -259,6 +259,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
         /// always sent even for an open-ended catch-up; <paramref name="toUtc"/> is simply "now" in that case.
         /// <c>sessionId</c> and <c>requestId</c> are not filterable, which is why incremental loading has to
         /// key off the timestamp.
+        /// <para>
+        /// <c>$orderby=createdDateTime asc</c> is required, not cosmetic. When a user's window exceeds the
+        /// per-cycle page cap the read is truncated and the watermark advances to the newest interaction
+        /// actually received, on the assumption that everything older has been seen. That assumption only
+        /// holds if pages arrive oldest-first. Graph does not document a default order and history feeds
+        /// commonly return newest-first, in which case a truncated first-run backfill would read the newest
+        /// N interactions, push the watermark to almost-now, and permanently skip every older unread
+        /// interaction in the window - silent data loss that looks like a clean resume.
+        /// </para>
         /// </remarks>
         internal static string BuildInteractionsUrl(string userKey, DateTime fromUtc, DateTime toUtc)
         {
@@ -270,6 +279,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             sb.Append("/interactionHistory/getAllEnterpriseInteractions");
             sb.Append("?$filter=");
             sb.Append(Uri.EscapeDataString(filter));
+            sb.Append("&$orderby=");
+            sb.Append(Uri.EscapeDataString("createdDateTime asc"));
             sb.Append("&$top=");
             sb.Append(GraphPageSize.ToString(CultureInfo.InvariantCulture));
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/InteractionCognitiveEnricher.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/InteractionCognitiveEnricher.cs
@@ -236,9 +236,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
 
         private void LogCognitiveFailure(Exception ex, string operation, int docCount)
         {
-            // Warning, not Error: cognitive enrichment is optional and the import continues without it. The
-            // exception detail is included so a misconfigured endpoint is still diagnosable, but the prompt
-            // text never is - RequestFailedException messages from Azure AI Language do not echo the document.
+            // Warning, not Error: cognitive enrichment is optional and the import continues without it.
+            //
+            // Only RequestFailedException detail is logged. Azure AI Language's own service errors are
+            // status/code pairs that never echo the document, but an arbitrary exception message can:
+            // a serialisation or argument failure routinely quotes the offending value, which here is the
+            // user's literal Copilot prompt. Logging ex.Message on the general path would write prompt text
+            // into Application Insights in clear - the one thing this feature must never do - so unexpected
+            // exceptions are reduced to their type name.
             if (ex is RequestFailedException rfe)
             {
                 _logger.LogWarning($"Copilot interaction {operation} failed for {docCount} prompt(s) " +
@@ -246,7 +251,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             }
             else
             {
-                _logger.LogWarning($"Copilot interaction {operation} failed for {docCount} prompt(s): {ex.Message}. Continuing without scores for this batch.");
+                _logger.LogWarning($"Copilot interaction {operation} failed for {docCount} prompt(s) " +
+                    $"({ex.GetType().Name}). Continuing without scores for this batch. " +
+                    "The exception message is withheld because it can contain prompt text.");
             }
         }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -218,6 +218,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     // Cadence-gated like the other non-fresh Graph sections, but for a different reason: this
                     // one costs a Graph call per in-scope user, so running it every cycle would be expensive
                     // even for a modest pilot group. Defaults to daily.
+                    //
+                    // Uses the bool overload deliberately. ImportAsync returns null when it declined to run
+                    // (no UserGroupsFilter, or the app registration has no AiEnterpriseInteraction.Read.All
+                    // consent) and sets Error on the run log when it caught one. Reporting those as success
+                    // would stamp the daily gate on a cycle that imported nothing, so enabling the feature
+                    // before admin consent is granted would silently do nothing for another 24 hours.
                     await RunGraphSectionIfDueAsync(CopilotInteractionHistoryLastImportedKey, _settings.CopilotInteractionHistoryIntervalHours, "Copilot interaction history import", async () =>
                     {
                         var interactionImporter = new CopilotInteractionHistoryImporter(
@@ -228,7 +234,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                             new GraphPilotGroupMemberResolver(httpClient, _logger),
                             userGroupsFilter);
 
-                        await interactionImporter.ImportAsync();
+                        var interactionLog = await interactionImporter.ImportAsync();
+                        return interactionLog != null && string.IsNullOrEmpty(interactionLog.Error);
                     });
                 }
                 else


### PR DESCRIPTION
Fixes from a four-model review of the parts of this release that had not been reviewed (#288, #289, #291, #292), plus a synthetic-scale benchmark of the interaction-history dedup path.

Reviewers: **Claude Opus 4.8, GPT-5.6 Sol, Gemini 3.1 Pro, Grok 4.6**, run independently on the same scope. Every finding was verified against the code before being acted on; two did not survive that check and were dropped.

### Everything in this PR

| # | Fix | Severity | Found by | Area |
| --- | --- | --- | --- | --- |
| 1 | Report snapshot pinned to one period, so licensed users are no longer duplicated per D7/D28/D90/D180 | **Blocker** | Sol | #292 |
| 2 | Drift job summary redacts string values (was publishing the App Insights connection string) | **Blocker** | Sol | #289 |
| 3 | Cadence gate no longer stamps itself on a no-op or failed import | **Blocker** | Grok | #291 |
| 4 | Transient Graph errors no longer trigger the 72h unlicensed back-off | **Blocker** | Gemini | #291 |
| 5 | Dedup re-keyed to per-user `session_id`: stops dropping a shared thread's rows, and 1.8x fewer reads / 5.7x faster | High | Opus + benchmark | #291 |
| 6 | `$orderby=createdDateTime asc` so page-cap resume cannot silently skip history | High | Opus, Sol, Grok | #291 |
| 7 | Adoption analysis cached as `Lazy<Task>` with `CancellationToken.None`; `SafeAsync` rethrows cancellation | High | Opus, Sol, Grok | #292 |
| 8 | Pilot users queried by UPN in chunks instead of materialising ~200k tracked entities per cycle | Medium | Opus, Sol, Grok | #291 |
| 9 | EF6 `AutoDetectChangesEnabled` disabled around the `Add` loops (they were O(N^2)) | Medium | Sol | #291 |
| 10 | Cognitive failures no longer log raw `ex.Message`, which can quote prompt text | Medium | Gemini | #291 |
| 11 | `UnlicensedActiveUsers` no longer suppressed when the tenant holds no Copilot seats | Medium | Sol | #292 |

Fixes 1-4 are release blockers; 5-11 are correctness and scale fixes in the same files. Nothing here changes the database schema, so **there is no new migration and no config-schema change**.

---

## 1. Blockers

### 1.1 Adoption figures inflated up to 4× (#292)

`ReportSnapshot` selected Microsoft's per-user snapshot with `WHERE r.[date] = @copilotReportDate` and no period filter, then `LEFT JOIN ReportSnapshot ON report.user_id = u.id`.

`copilot_usage_user_activity_log` is unique on **(date, user_id, report_period_days)** and the importer stores D7/D28/D90/D180 — the period is in the key precisely because "D7 and D28 describe the same user and date with different prompt counts". So the join returned one row *per period per user*:

- adoption counts could exceed the licensed population outright;
- `TOP (50000) ORDER BY u.id` covered only ~25,000 unique users at two periods;
- the licensed-user table showed duplicate rows.

**Fix:** `@copilotReportPeriodDays` is now pinned alongside the date and chosen as the stored period closest to the analysis window (`LatestCopilotReportPeriodSql`). Rows imported before the period was recorded (`report_period_days IS NULL`) are handled explicitly rather than silently excluded.

New regression test `LicensedUsersQuery_PinsTheReportPeriodSoUsersAreNotDuplicated` seeds D7 *and* D28 for one user/date and asserts exactly one row comes back, with that period's numbers.

### 1.2 The drift check leaked configuration values into a public job summary (#289)

My own bug from #289. `buildSummary` rendered raw `before`/`after` values into `$GITHUB_STEP_SUMMARY`, which is **world-readable on a public repository**, and the check runs with `--result-format FullResourcePayloads`. A drifted `Microsoft.Web/sites/config` would therefore have printed the Application Insights connection string — instrumentation key included — along with the Cosmos endpoint and client/tenant ids.

I had tested that resource *ids* were trimmed and never that *values* were. They weren't.

**Fix:** values are redacted by default, leaving the property path, change type, and the value's type/size. Booleans and numbers are still published — they cannot carry a secret and they are usually the finding itself (`alwaysOn: false → true`). Two regression tests: one asserts a connection string never reaches the summary while the property path still does, one asserts array contents (client ids) are replaced by a count.

### 1.3 Cadence gate stamped itself on a no-op or failed run (#291)

Copilot usage reports use the `Func<Task<bool>>` overload of `RunGraphSectionIfDueAsync`, whose whole purpose is "returning false records the section as not done, so the cadence gate lets it retry next cycle". Interaction history used the `Func<Task>` overload, which **always returns true**.

`ImportAsync` returns `null` when it declines to run (no `UserGroupsFilter`; no `AiEnterpriseInteraction.Read.All` consent) and sets `Error` when it caught one. All of that was discarded. Enabling the feature before granting admin consent — the single most likely sequence — silently did nothing for another 24 hours.

**Fix:** use the bool overload and report `log != null && string.IsNullOrEmpty(log.Error)`.

### 1.4 Transient Graph errors triggered the 72-hour unlicensed back-off (#291)

The error branch's comment says the window is "retried in full next cycle", but the code incremented `ConsecutiveEmptyOrFailed` and applied the back-off — which is what *prevents* the next cycle. That back-off exists for users with no Copilot service plan and lasts 72h by default.

A brief Graph 5xx or throttling episode hits every user in the cycle, not one. Two such cycles parked the **entire active pilot group** for three days.

**Fix:** transient errors record `LastError` and leave the watermark alone, but no longer count toward the back-off. A user that fails every cycle is simply retried daily; the per-cycle ceiling and least-recently-run ordering already bound that cost.

---

## 2. Dedup: one change fixing a correctness bug and a measured 5.7× slowdown (#291)

`RemoveAlreadyImportedAsync` filtered existing interactions through the `i.Session.SessionRef` navigation and keyed the result on `sessionRef + "|" + graphInteractionId`.

**Correctness:** `copilot_interaction_sessions` is unique on `(user_id, session_ref)` because a Copilot thread can be *shared* — a Teams meeting session appears in more than one participant's history. Filtering on `session_ref` alone matched **other users' rows**, so a second pilot user's genuinely-new interactions were discarded as "already imported". The read is complete, so the watermark still advanced and the under-count was permanent.

**Performance:** measured on a synthetic replica (50,000 sessions / 2,250,000 interactions, medians of 5, `OPTION (RECOMPILE)`, cold run discarded, all data synthetic):

| Dedup query shape | Logical reads | Elapsed |
| --- | --- | --- |
| via `Session.SessionRef` navigation (before) | 2,408 | 486 ms |
| keyed on `session_id` (after) | **1,323** | **85 ms** |

1.8× fewer reads and 5.7× faster for the same result, because `session_id` is the leading column of the `(session_id, graph_interaction_id)` unique index, which covers the query.

**Fix:** resolve each user's own `session_id` first (user-id predicate included), then key on `(session_id, graph_interaction_id)` — the table's actual unique constraint.

### The index #291 shipped is correct — now measured

#291 shipped schema changes with no benchmark, which the repo's release gate forbids. Same rig, before = primary keys only:

| Query | Before | After (as shipped) |
| --- | --- | --- |
| `session_id` seek, narrow (250 sessions) | 48,328 reads | **1,323 reads / 85 ms** (36×) |
| `session_id` seek, wide (1,000 sessions) | 48,328 reads | **4,713 reads / 355 ms** (10×) |

Seek, not scan. **The index shape is proven good and needs no change.**

One result worth recording: the obvious "just add a date bound to stop re-reading old turns" would have made it **worse** — `created_utc >=` against the shipped index took wide-1000 from 4,713 to **16,687 reads (3.5× worse)**, because `created_utc` isn't in that index. That is the repo's documented `INCLUDE` lesson repeating itself, and it is why bounding the dedup window is filed as an issue with measurements rather than patched blind here.

---

## 3. Other fixes

| Area | Fix |
| --- | --- |
| **#291 paging** | `$orderby=createdDateTime asc` added. Truncation advances the watermark to the newest interaction read, which is only a valid cursor if pages are oldest-first; Graph documents no default order and history feeds commonly return newest-first. Without it, a heavy user's first-run 30-day backfill could read the newest 5,000, push the watermark to almost-now, and permanently skip the rest — silent loss that looks like a clean resume. **Flagged independently by three of the four reviewers.** |
| **#291 scale** | `ResolveScopedUsersAsync` queried the directory and filtered in memory — ~200,000 tracked EF entities every cycle to select a 50-person pilot. Now queries *by* pilot UPNs in ≤1000-parameter chunks. The full scan remains only for the explicitly opted-in unscoped mode. |
| **#291 saves** | EF6 runs `DetectChanges` on every `Add`, making the `Add` loops O(N²) in tracked entities. `AutoDetectChangesEnabled` is now disabled around both loops with one explicit `DetectChanges()` before `SaveChanges`, restored in `finally`. Scoped narrowly: lookup/session resolution still relies on automatic detection. |
| **#291 privacy** | `LogCognitiveFailure`'s `else` branch logged raw `ex.Message`. The comment justified this for `RequestFailedException` only — but a serialisation or argument failure routinely quotes the offending value, which here is the user's literal prompt. Unexpected exceptions are now reduced to their type name. |
| **#292 cache** | The analysis `Task` was started *before* `AddOrGetExisting` (so two concurrent first-hits both ran a full audit scan — the SPA loads three endpoints concurrently on a cold page) and carried the **first caller's** `CancellationToken`. Worse, `SafeAsync` caught `OperationCanceledException` and degraded it to a warning, so an aborted run completed as a *successful empty* analysis and was served to everyone for 10 minutes. Now a `Lazy<Task<…>>` is cached so the loser costs nothing, the shared work uses `CancellationToken.None`, and `SafeAsync` rethrows cancellation so the entry is evicted. |
| **#292 correctness** | `UnlicensedActiveUsers` was gated on `seatIds.Count > 0`, so the "should we buy Copilot?" case — no seats at all, which is exactly when the number matters — always reported zero while the candidate list below showed real users. |

---

## 4. Findings that did not survive verification

- **"`audit_events` scan reads 1.8 billion rows" (Gemini, critical).** The join drives from the much smaller `copilot_chats` on `au.id` (the PK), and the code carries a comment recording a prior measurement of that exact join in the Reports area. Not reproducible without a scale `audit_events`; not treated as a blocker.
- **"Key phrases contradict the no-prompt-text guarantee" (Sol, critical).** Accurate as an observation but not a defect: storing key phrases is a documented, deliberate design decision, and retention already deletes orphaned keywords because "an extracted key phrase can amount to a whole short prompt". It is a **claim-accuracy** problem, not a code one — the release notes must not say "no prompt text is persisted" without qualifying it. Raised separately.

Reviewers also disagreed usefully: Grok cleared the back-off logic after checking watermark advancement, while Gemini caught that the same branch increments the back-off counter. Both were looking at the same `if`.

---

## 5. Verification

- Full solution builds (Debug).
- **95/95 pass** across the adoption, interaction-history, migration-pipeline and migration-cleanup suites against a dropped-and-replayed LocalDB — the 94 that existed plus the new period-pinning regression test.
- **33/33 pass** for the drift filter, including the two new redaction regression tests.

## 6. Deferred to issues

Filed rather than fixed here, because each needs its own measurement or a schema migration. All four carry their measurements so they can be picked up cold:

| Issue | Finding |
| --- | --- |
| #294 | **Dedup is unbounded in time** — re-reads every interaction ever recorded for each touched session, every cycle (measured: 252,000 rows for 50 long-lived threads). Needs an index change, not just a `WHERE` clause — see the 3.5x regression measured above. |
| #295 | **Weekly trend scans the same six-month range twice** (active-user and Cowork series are separate passes over `copilot_chats` joined to `audit_events`). |
| #296 | **`copilot_interaction_keywords` has no index leading on `keyword_id`**, which the orphan-keyword cleanup probes, so it scans the link table. |
| #297 | **A `*` wildcard is accepted as a pilot "scope"**, and group discovery caps at ~49,950 groups — the mandatory scope brake can miss the group on a large tenant. |

## 7. Not code — for the release notes

Two things this PR deliberately does not change, but which the customer-facing notes must get right:

- **"No prompt text is persisted" needs qualifying.** Extracted key phrases *are* verbatim prompt substrings; the feature's own readme acknowledges one "can amount to a whole short prompt". The design is deliberate and retention already deletes orphaned keywords, but the blanket claim is misleading as written.
- **#285 is still open and now matters more.** Graph paging failures are recorded as successful empty imports, so a missing consent grant looks identical to "no Copilot licences". This release ships two Graph-paging importers, and fixes 3 and 4 above make the *cadence* honest without making the *outcome* honest — admins still need to be told how to tell "no data" from "not working".
