### PR TITLE
Copilot interaction history: make UserGroupsFilter an optional narrowing, not a precondition

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -220,11 +220,6 @@ namespace Common.Entities.Config
                 && interactionBackOffHours >= 0
                 ? interactionBackOffHours
                 : DefaultCopilotInteractionHistoryEmptyUserBackOffHours;
-
-            // Guard rail: refuse to run tenant-wide unless an admin has explicitly said so. Without this
-            // an empty UserGroupsFilter would silently mean "every user in the tenant".
-            this.CopilotInteractionHistoryAllowUnscoped = bool.TryParse(ConfigurationManager.AppSettings.Get("CopilotInteractionHistoryAllowUnscoped"), out var interactionAllowUnscoped)
-                && interactionAllowUnscoped;
         }
 
         /// <summary>
@@ -534,14 +529,6 @@ namespace Common.Entities.Config
         /// <c>CopilotInteractionHistoryEmptyUserBackOffHours</c>.
         /// </summary>
         public int CopilotInteractionHistoryEmptyUserBackOffHours { get; set; } = DefaultCopilotInteractionHistoryEmptyUserBackOffHours;
-
-        /// <summary>
-        /// Permits the interaction-history import to run with no <see cref="UserGroupsFilter"/> set, i.e.
-        /// against every user in the database. Off by default and intentionally awkward to turn on: at the
-        /// ~200k-user design target an unscoped run is 200k Graph calls per cycle. Override with
-        /// <c>CopilotInteractionHistoryAllowUnscoped</c>.
-        /// </summary>
-        public bool CopilotInteractionHistoryAllowUnscoped { get; set; } = false;
 
         #endregion
     }

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotInteractionHistoryTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotInteractionHistoryTests.cs
@@ -333,35 +333,30 @@ namespace Tests.UnitTests
         #region Cost controls
 
         [TestMethod]
-        public void Import_RefusesToRunWithoutAGroupScope()
+        public void Import_DoesNotRequireAGroupScope()
         {
+            // UserGroupsFilter is an optional narrowing, not a precondition. The controls that decide whether
+            // this import runs at all are the workload toggle and the AiEnterpriseInteraction.Read.All
+            // permission - to stop it, turn the workload off or withhold the permission. Requiring a group
+            // filter as well meant an admin who wanted tenant-wide history had to opt in twice.
             var logger = AnalyticsLogger.ConsoleOnlyTracer();
-            var settings = new AppConfig { CopilotInteractionHistoryAllowUnscoped = false };
+            var importer = NewImporter(logger, new AppConfig(), new UserGroupsFilterModel(string.Empty));
 
-            var importer = NewImporter(logger, settings, new UserGroupsFilterModel(string.Empty));
-
-            // An empty filter would mean "every user in the tenant", i.e. one Graph call each. At the
-            // ~200k-user design target that is 200k calls per cycle, so it must be refused outright.
-            Assert.IsFalse(importer.ValidateScopeConfiguration());
+            Assert.IsNotNull(importer,
+                "An empty UserGroupsFilter is a valid configuration - every enabled user is eligible, still " +
+                "bounded by CopilotInteractionHistoryMaxUsersPerCycle.");
         }
 
         [TestMethod]
-        public void Import_RunsUnscopedOnlyWhenExplicitlyAllowed()
+        public void PerCycleCap_IsTheBrakeThatBoundsAnUnnarrowedRun()
         {
-            var logger = AnalyticsLogger.ConsoleOnlyTracer();
-            var settings = new AppConfig { CopilotInteractionHistoryAllowUnscoped = true };
+            // With the group filter now optional, this cap is what stops an unnarrowed run costing one Graph
+            // call per user in the directory. A zero or negative setting must fall back to the default rather
+            // than being read as "no limit".
+            Assert.AreEqual(500, AppConfig.DefaultCopilotInteractionHistoryMaxUsersPerCycle);
 
-            var importer = NewImporter(logger, settings, new UserGroupsFilterModel(string.Empty));
-            Assert.IsTrue(importer.ValidateScopeConfiguration());
-        }
-
-        [TestMethod]
-        public void Import_AcceptsAConfiguredGroupScope()
-        {
-            var logger = AnalyticsLogger.ConsoleOnlyTracer();
-            var importer = NewImporter(logger, new AppConfig(), new UserGroupsFilterModel("Copilot Pilot*"));
-
-            Assert.IsTrue(importer.ValidateScopeConfiguration());
+            var configured = new AppConfig { CopilotInteractionHistoryMaxUsersPerCycle = 250 };
+            Assert.AreEqual(250, configured.CopilotInteractionHistoryMaxUsersPerCycle);
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
@@ -21,17 +21,22 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
     /// <para>
     /// <b>Cost model.</b> <c>getAllEnterpriseInteractions</c> has no tenant-wide or delta form, so this
     /// import costs at least one HTTP call for every user it looks at. At the product's ~200k-user design
-    /// target that would be 200k calls per cycle, which is why the import is off by default and why four
-    /// independent brakes apply, in this order:
+    /// target that would be 200k calls per cycle if it were unbounded, which is why the import is off by
+    /// default and why these brakes apply, in this order:
     /// <list type="number">
-    /// <item>the <c>CopilotInteractionHistory</c> feature toggle (off by default);</item>
-    /// <item>the <c>UserGroupsFilter</c> scope, which must be set - an unscoped run is refused unless
-    /// <c>CopilotInteractionHistoryAllowUnscoped</c> is explicitly turned on;</item>
+    /// <item>the <c>CopilotInteractionHistory</c> feature toggle (off by default), and the
+    /// <c>AiEnterpriseInteraction.Read.All</c> application permission, which the installer does not grant.
+    /// Those two are the real controls: to stop this import, turn the workload off or withhold the
+    /// permission;</item>
+    /// <item><c>UserGroupsFilter</c>, an <b>optional</b> narrowing to one or more Entra ID groups. Recommended
+    /// for a pilot, but not required - without it every enabled user is eligible, still subject to the
+    /// ceiling below;</item>
     /// <item><c>CopilotInteractionHistoryMaxUsersPerCycle</c>, a hard per-cycle ceiling. Users are taken
     /// least-recently-run first, so a scope bigger than the cap is still covered - just round-robin over
     /// several cycles rather than all at once;</item>
     /// <item>a per-user back-off list, so users who return nothing (almost always because they have no
-    /// <c>M365_COPILOT_BUSINESS_CHAT</c> service plan) stop consuming the budget.</item>
+    /// <c>M365_COPILOT_BUSINESS_CHAT</c> service plan) stop consuming the budget;</item>
+    /// <item>the cadence gate (<c>CopilotInteractionHistoryIntervalHours</c>, daily by default).</item>
     /// </list>
     /// On top of that the import is incremental: each user has a watermark, so a steady-state cycle only asks
     /// for interactions created since the last successful run.
@@ -101,15 +106,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
 
         /// <summary>
         /// Runs one import cycle. Returns the run log that was persisted, or null when the import declined to
-        /// run at all (missing permission, or an unscoped configuration).
+        /// run at all (missing permission).
         /// </summary>
         public async Task<CopilotInteractionImportLog> ImportAsync()
         {
             _logger.LogInformation("Starting Copilot AI interaction history import...");
             var sw = Stopwatch.StartNew();
-
-            if (!ValidateScopeConfiguration())
-                return null;
 
             if (!await _sourceLoader.HasInteractionReadAccessAsync())
             {
@@ -125,31 +127,39 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
 
             try
             {
-                var scopedUsers = await ResolveScopedUsersAsync();
-                runLog.UsersInScope = scopedUsers.Count;
+                var due = await SelectDueUsersAsync(runLog);
 
-                if (scopedUsers.Count == 0)
+                if (runLog.UsersInScope == 0)
                 {
-                    _logger.LogWarning(
-                        $"No users matched the UserGroupsFilter ('{_settings.UserGroupsFilter}') for the Copilot " +
-                        "interaction history import, so there is nothing to do. Check the group name(s) - the filter " +
-                        "matches Entra ID group display names and supports * wildcards.");
+                    if (_userGroupsFilter.Patterns.Count > 0)
+                    {
+                        _logger.LogWarning(
+                            $"No users matched the UserGroupsFilter ('{_settings.UserGroupsFilter}') for the Copilot " +
+                            "interaction history import, so there is nothing to do. Check the group name(s) - the filter " +
+                            "matches Entra ID group display names and supports * wildcards.");
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "The Copilot interaction history import found no enabled users to look at, so there is " +
+                            "nothing to do.");
+                    }
                     return await FinishRunAsync(runLog, sw);
                 }
 
-                var due = await SelectDueUsersAsync(scopedUsers, runLog);
                 if (due.Count == 0)
                 {
                     _logger.LogInformation(
-                        $"Copilot interaction history: all {scopedUsers.Count} in-scope user(s) are inside their " +
+                        $"Copilot interaction history: all {runLog.UsersInScope} in-scope user(s) are inside their " +
                         "back-off window, so no Graph calls were made this cycle.");
                     return await FinishRunAsync(runLog, sw);
                 }
 
                 _logger.LogInformation(
-                    $"Copilot interaction history: {scopedUsers.Count} user(s) in scope, calling Graph for {due.Count} " +
-                    $"of them this cycle (cap {_settings.CopilotInteractionHistoryMaxUsersPerCycle}, least-recently-run " +
-                    $"first). Cognitive enrichment is {(_cognitiveEnricher.IsEnabled ? "enabled" : "disabled")}.");
+                    $"Copilot interaction history: {runLog.UsersInScope} user(s) in scope" +
+                    $"{(_userGroupsFilter.Patterns.Count > 0 ? $" (narrowed by UserGroupsFilter '{_settings.UserGroupsFilter}')" : " (no UserGroupsFilter set - every enabled user is eligible)")}, " +
+                    $"calling Graph for {due.Count} of them this cycle (cap {_settings.CopilotInteractionHistoryMaxUsersPerCycle}, " +
+                    $"least-recently-run first). Cognitive enrichment is {(_cognitiveEnricher.IsEnabled ? "enabled" : "disabled")}.");
 
                 for (int i = 0; i < due.Count; i += _userChunkSize)
                 {
@@ -170,79 +180,73 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
 
         #region Scope and scheduling
 
+
         /// <summary>
-        /// Refuses to run against an unbounded user set. Without this, an operator who ticks the box but
-        /// leaves <c>UserGroupsFilter</c> empty would silently start one Graph call per user in the tenant.
+        /// Picks the users to call Graph for this cycle: optionally narrowed by <c>UserGroupsFilter</c>, with
+        /// backed-off users dropped, ordered least-recently-run first, and capped.
         /// </summary>
-        internal bool ValidateScopeConfiguration()
+        /// <remarks>
+        /// <para>
+        /// <c>UserGroupsFilter</c> is an <b>optional narrowing</b>, not a precondition. With it set, only that
+        /// group's members are eligible; without it, every enabled user is. The controls that decide whether
+        /// this import runs at all are the workload toggle and the <c>AiEnterpriseInteraction.Read.All</c>
+        /// permission - not the filter.
+        /// </para>
+        /// <para>
+        /// Ordering by last run (nulls first) is what makes the cap safe: a scope bigger than the cap is still
+        /// covered, just spread over consecutive cycles, and never-imported users are always preferred over
+        /// ones already up to date.
+        /// </para>
+        /// <para>
+        /// The two paths are deliberately different. Narrowed, the member list is small, so users are fetched
+        /// by UPN in chunks and ordered in memory. Unnarrowed - now the default - the whole selection is done
+        /// in SQL: joined to the watermarks, back-off filtered, ordered and <c>TOP</c>-capped, so the cycle
+        /// materialises at most <c>CopilotInteractionHistoryMaxUsersPerCycle</c> users no matter how large the
+        /// directory is. Pulling 200,000 users back to filter them in memory would otherwise become the normal
+        /// case rather than the exception.
+        /// </para>
+        /// </remarks>
+        private async Task<List<UserImportState>> SelectDueUsersAsync(CopilotInteractionImportLog runLog)
         {
+            var now = DateTime.UtcNow;
+            var cap = _settings.CopilotInteractionHistoryMaxUsersPerCycle > 0
+                ? _settings.CopilotInteractionHistoryMaxUsersPerCycle
+                : AppConfig.DefaultCopilotInteractionHistoryMaxUsersPerCycle;
+
             if (_userGroupsFilter.Patterns.Count > 0)
-                return true;
+                return await SelectDueUsersInGroupsAsync(runLog, now, cap);
 
-            if (_settings.CopilotInteractionHistoryAllowUnscoped)
-            {
-                _logger.LogWarning(
-                    "Copilot interaction history is running UNSCOPED (no UserGroupsFilter) because " +
-                    "CopilotInteractionHistoryAllowUnscoped is true. This costs one Graph call per user in the " +
-                    $"database, limited to {_settings.CopilotInteractionHistoryMaxUsersPerCycle} per cycle. " +
-                    "Setting UserGroupsFilter to a pilot group is strongly recommended.");
-                return true;
-            }
-
-            _logger.LogWarning(
-                "Skipping the Copilot interaction history import: no UserGroupsFilter is configured. This import " +
-                "makes one Microsoft Graph call per user, so it must be pointed at a pilot group. Set the " +
-                "UserGroupsFilter app setting to one or more Entra ID group display names (';'-separated, '*' " +
-                "wildcards allowed), or set CopilotInteractionHistoryAllowUnscoped=true to accept the cost of " +
-                "scanning every user.");
-            return false;
+            return await SelectDueUsersAcrossDirectoryAsync(runLog, now, cap);
         }
 
         /// <summary>
-        /// Users eligible for the import: enabled accounts with a usable identifier that are members of a
-        /// group matching the filter.
+        /// Narrowed path: resolve the group's members from Graph, then fetch just those users.
         /// </summary>
         /// <remarks>
-        /// Resolution is deliberately group-first - list the pilot group's members, then intersect with the
-        /// users table - rather than asking "is this user in the group?" for every user in the database.
-        /// The latter is one Graph call per tenant user, which at the ~200k-user design target would spend
-        /// 200,000 calls just working out who to import, before reading a single interaction.
+        /// Resolution is deliberately group-first - list the group's members, then look those up in the users
+        /// table - rather than asking "is this user in the group?" for every user in the database. The latter
+        /// is one Graph call per tenant user, which at the ~200k-user design target would spend 200,000 calls
+        /// just working out who to import, before reading a single interaction.
         /// </remarks>
-        private async Task<List<Common.Entities.User>> ResolveScopedUsersAsync()
+        private async Task<List<UserImportState>> SelectDueUsersInGroupsAsync(
+            CopilotInteractionImportLog runLog, DateTime now, int cap)
         {
-            if (_userGroupsFilter.Patterns.Count == 0)
-            {
-                // Only reachable when the operator explicitly opted in to an unscoped run, which is the one
-                // case where we genuinely do want every enabled user.
-                using (var db = _dbContextFactory())
-                {
-                    return await db.users
-                        .Where(u => u.UserPrincipalName != null && u.UserPrincipalName != ""
-                                    && (u.AccountEnabled == null || u.AccountEnabled == true))
-                        .ToListAsync();
-                }
-            }
-
             if (_pilotGroupResolver == null)
             {
                 _logger.LogWarning(
-                    "A UserGroupsFilter is configured but no pilot-group resolver is available, so membership can't " +
-                    "be checked. Skipping the Copilot interaction history import rather than risk scanning every user.");
-                return new List<Common.Entities.User>();
+                    "A UserGroupsFilter is configured but no group resolver is available, so membership can't be " +
+                    "checked. Skipping this cycle rather than silently widening the scope to every user.");
+                return new List<UserImportState>();
             }
 
             var memberUpns = await _pilotGroupResolver.GetMemberUpnsAsync(_userGroupsFilter);
             if (memberUpns.Count == 0)
-                return new List<Common.Entities.User>();
+            {
+                runLog.UsersInScope = 0;
+                return new List<UserImportState>();
+            }
 
-            // Query BY the pilot members rather than loading the directory and filtering in memory. The old
-            // shape materialised every enabled user - ~200,000 tracked entities at the design baseline - just
-            // to keep the handful in a pilot group, every cycle. Chunked to stay inside SQL Server's
-            // 2100-parameter limit.
-            //
-            // Disabled accounts are still excluded here: they can't generate new Copilot interactions, so
-            // calling Graph for them would spend the per-cycle budget on guaranteed-empty results.
-            var inScope = new List<Common.Entities.User>();
+            var candidates = new List<UserImportState>();
             using (var db = _dbContextFactory())
             {
                 foreach (var upnChunk in ChunkStrings(memberUpns.ToList()))
@@ -250,65 +254,76 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
                     var rows = await db.users
                         .Where(u => upnChunk.Contains(u.UserPrincipalName)
                                     && (u.AccountEnabled == null || u.AccountEnabled == true))
-                        .ToListAsync();
-
-                    inScope.AddRange(rows);
-                }
-            }
-
-            _logger.LogInformation(
-                $"Copilot interaction history: the pilot group(s) have {memberUpns.Count} member(s), of which " +
-                $"{inScope.Count} are enabled users present in the analytics database.");
-
-            return inScope;
-        }
-
-        /// <summary>
-        /// Picks which in-scope users to actually call Graph for this cycle: drops those still inside a
-        /// back-off window, then takes the least-recently-run first up to the cap.
-        /// </summary>
-        /// <remarks>
-        /// Ordering by last run (nulls first) is what makes the cap safe. A pilot group larger than the cap
-        /// still gets fully covered, just spread over consecutive cycles, and never-imported users are always
-        /// preferred over ones already up to date.
-        /// </remarks>
-        private async Task<List<UserImportState>> SelectDueUsersAsync(List<Common.Entities.User> scopedUsers, CopilotInteractionImportLog runLog)
-        {
-            var now = DateTime.UtcNow;
-            var userIds = scopedUsers.Select(u => u.ID).ToList();
-
-            var watermarksByUserId = new Dictionary<int, CopilotInteractionUserWatermark>();
-            using (var db = _dbContextFactory())
-            {
-                foreach (var idChunk in ChunkIds(userIds))
-                {
-                    var rows = await db.CopilotInteractionUserWatermarks
-                        .Where(w => idChunk.Contains(w.UserId))
+                        .GroupJoin(
+                            db.CopilotInteractionUserWatermarks,
+                            u => u.ID,
+                            w => w.UserId,
+                            (u, ws) => new { User = u, Watermark = ws.FirstOrDefault() })
                         .ToListAsync();
 
                     foreach (var row in rows)
-                        watermarksByUserId[row.UserId] = row;
+                        candidates.Add(new UserImportState { User = row.User, Watermark = row.Watermark });
                 }
             }
 
-            var due = new List<UserImportState>();
-            foreach (var user in scopedUsers)
-            {
-                watermarksByUserId.TryGetValue(user.ID, out var watermark);
+            runLog.UsersInScope = candidates.Count;
 
-                if (watermark?.SkipUntilUtc != null && watermark.SkipUntilUtc.Value > now)
+            var due = new List<UserImportState>(candidates.Count);
+            foreach (var candidate in candidates)
+            {
+                if (candidate.Watermark?.SkipUntilUtc != null && candidate.Watermark.SkipUntilUtc.Value > now)
                 {
                     runLog.UsersSkipped++;
                     continue;
                 }
-
-                due.Add(new UserImportState { User = user, Watermark = watermark });
+                due.Add(candidate);
             }
 
             return due
                 .OrderBy(d => d.Watermark?.LastRunUtc ?? DateTime.MinValue)
-                .Take(_settings.CopilotInteractionHistoryMaxUsersPerCycle)
+                .Take(cap)
                 .ToList();
+        }
+
+        /// <summary>
+        /// Unnarrowed path: every enabled user is eligible, but the selection happens in SQL so only the
+        /// capped number of users is ever materialised.
+        /// </summary>
+        private async Task<List<UserImportState>> SelectDueUsersAcrossDirectoryAsync(
+            CopilotInteractionImportLog runLog, DateTime now, int cap)
+        {
+            using (var db = _dbContextFactory())
+            {
+                var eligible = db.users
+                    .Where(u => u.UserPrincipalName != null && u.UserPrincipalName != ""
+                                && (u.AccountEnabled == null || u.AccountEnabled == true));
+
+                // Reported for the run log so an operator can see the ratio of scope to per-cycle budget.
+                // One COUNT per cycle (daily by default) against the Graph calls that follow it.
+                runLog.UsersInScope = await eligible.CountAsync();
+
+                if (runLog.UsersInScope == 0)
+                    return new List<UserImportState>();
+
+                // Back-off, ordering and the cap all resolve server-side: SQL Server sorts NULL LastRunUtc
+                // first ascending, which is exactly the "never imported goes first" rule.
+                var rows = await eligible
+                    .GroupJoin(
+                        db.CopilotInteractionUserWatermarks,
+                        u => u.ID,
+                        w => w.UserId,
+                        (u, ws) => new { User = u, Watermark = ws.FirstOrDefault() })
+                    .Where(x => x.Watermark == null
+                                || x.Watermark.SkipUntilUtc == null
+                                || x.Watermark.SkipUntilUtc <= now)
+                    .OrderBy(x => x.Watermark.LastRunUtc)
+                    .Take(cap)
+                    .ToListAsync();
+
+                return rows
+                    .Select(r => new UserImportState { User = r.User, Watermark = r.Watermark })
+                    .ToList();
+            }
         }
 
         #endregion

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/readme.md
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/readme.md
@@ -55,28 +55,39 @@ Copilot responses are never scored: they are model output rather than a signal a
 longer than prompts (so they would dominate the per-character cognitive bill), and the question this feature
 answers is "what were our people asking for, and how did they feel about it".
 
-## The cost problem, and the four brakes
+## The cost problem, and the brakes
 
 `getAllEnterpriseInteractions` has **no tenant-wide form and no delta form**. It is one HTTP call per user.
 At this product's stated design target of ~200,000 users that would be 200,000 Graph calls per import cycle,
 which is a non-starter as an always-on import.
 
-Four independent brakes apply, in order:
+These brakes apply, in order:
 
-1. **The feature toggle.** `ImportTaskSettings.CopilotInteractionHistory`, off by default.
-2. **Group scope.** `UserGroupsFilter` must be set - the import **refuses to run** without it unless
-   `CopilotInteractionHistoryAllowUnscoped=true` is set explicitly. Scope is resolved **group-first**: the
-   matching Entra ID groups are listed once and their members paged, then intersected with the users table.
-   The obvious alternative - asking "is this user in the pilot group?" for each user - is one Graph call per
-   *tenant* user, so it would spend 200,000 calls just deciding who to import. Group-first is
-   O(groups + pilot members) instead, and it also pages membership properly rather than reading only the
-   first page of a user's `memberOf`.
+1. **The feature toggle and the permission.** `ImportTaskSettings.CopilotInteractionHistory` is off by
+   default, and the import needs `AiEnterpriseInteraction.Read.All`, which the installer does not grant.
+   **These two are the real controls: to stop this import, turn the workload off or withhold the
+   permission.**
+2. **Group scope — optional.** `UserGroupsFilter` narrows the import to one or more Entra ID groups.
+   Recommended for a pilot, but **not required**; without it every enabled user is eligible, still bounded by
+   the ceiling below. When it *is* set, scope is resolved **group-first**: the matching groups are listed once
+   and their members paged, then looked up in the users table. The obvious alternative - asking "is this user
+   in the group?" for each user - is one Graph call per *tenant* user, so it would spend 200,000 calls just
+   deciding who to import. Group-first is O(groups + members) instead, and it pages membership properly rather
+   than reading only the first page of a user's `memberOf`.
 3. **A per-cycle ceiling.** `CopilotInteractionHistoryMaxUsersPerCycle` (default 500). Users are taken
-   least-recently-run first, so a pilot group larger than the cap is still fully covered - just round-robin
-   over consecutive cycles.
+   least-recently-run first, so a scope larger than the cap is still fully covered - just round-robin over
+   consecutive cycles. **With the group filter optional, this is the brake that bounds an unnarrowed run.**
 4. **A per-user back-off.** Users who return nothing twice in a row (almost always because they lack the
    `M365_COPILOT_BUSINESS_CHAT` service plan) are skipped for `CopilotInteractionHistoryEmptyUserBackOffHours`
    (default 72). The back-off always expires, so a newly-licensed user is picked up again.
+
+### How the user selection scales without a filter
+
+Because running unnarrowed is a normal configuration rather than an escape hatch, the unnarrowed path does the
+whole selection **in SQL** - joined to the watermarks, back-off filtered, ordered least-recently-run first and
+`TOP`-capped - so a cycle materialises at most `CopilotInteractionHistoryMaxUsersPerCycle` users however large
+the directory is. Only the narrowed path fetches users by UPN in chunks, which is safe because a group's
+membership is small by definition.
 
 On top of that the import is **incremental**: each user has a watermark, so a steady-state cycle only asks for
 interactions created since the last successful run. The whole section is additionally cadence-gated by
@@ -142,8 +153,7 @@ Data is only returned for users licensed with the **`M365_COPILOT_BUSINESS_CHAT`
 | Setting | Default | Purpose |
 |---|---|---|
 | `ImportJobSettings` -> `CopilotInteractionHistory` | off | Master toggle (installer checkbox) |
-| `UserGroupsFilter` | none | Entra ID group display names, `;`-separated, `*` wildcards. **Required.** |
-| `CopilotInteractionHistoryAllowUnscoped` | `false` | Permits running with no group filter. Understand the cost first. |
+| `UserGroupsFilter` | none | Entra ID group display names, `;`-separated, `*` wildcards. **Optional** - narrows the import; without it every enabled user is eligible. |
 | `CopilotInteractionHistoryMaxUsersPerCycle` | `500` | Hard ceiling on Graph calls per cycle |
 | `CopilotInteractionHistoryIntervalHours` | `24` | Minimum gap between runs; 0 = every cycle |
 | `CopilotInteractionHistoryMaxDaysBackOnFirstRun` | `30` | Backfill window for a newly in-scope user |


### PR DESCRIPTION
## The change

`UserGroupsFilter` was a **precondition**: the interaction-history import refused to run without it unless `CopilotInteractionHistoryAllowUnscoped=true` was also set. That made an admin who legitimately wanted tenant-wide history opt in twice, and it conflated "narrow the scope" with "is this allowed to run".

The controls that decide whether this import runs at all are:

1. the **workload toggle** (`ImportTaskSettings.CopilotInteractionHistory`, off by default), and
2. the **`AiEnterpriseInteraction.Read.All` application permission**, which the installer does not grant and which needs explicit admin consent.

To stop the import, turn the workload off or withhold the permission. `UserGroupsFilter` is now simply an **optional narrowing**: set it to run against a pilot group, leave it empty to cover every enabled user.

`CopilotInteractionHistoryAllowUnscoped` is **removed** — it no longer means anything.

## Config impact: none

`CopilotInteractionHistoryAllowUnscoped` was an **AppSetting bound onto `AppConfig`**, not a persisted property on `BaseSolutionInstallConfig` / `SolutionInstallConfig` / `TargetSolutionConfig` / `ImportTaskSettings`. It is therefore *not* part of the installer's saved config schema, and **`CONFIG_VERSION` stays at 2.1.0**.

A leftover `CopilotInteractionHistoryAllowUnscoped` app setting in an existing `App.config` is simply ignored.

## The part that needed real work: unnarrowed is now the normal path

Removing the gate is three lines. The consequence is not.

Previously the code loaded **every enabled user** into memory and filtered in C#, which was acceptable only because that path was an explicitly-opted-into rarity. Making the filter optional promotes it to a normal configuration — so at the 200k-user design baseline the old shape would have materialised ~200,000 tracked EF entities *every cycle*, then thrown almost all of them away to pick 500.

The selection now happens **in SQL** for the unnarrowed path:

```csharp
eligible
  .GroupJoin(db.CopilotInteractionUserWatermarks, u => u.ID, w => w.UserId,
             (u, ws) => new { User = u, Watermark = ws.FirstOrDefault() })
  .Where(x => x.Watermark == null
              || x.Watermark.SkipUntilUtc == null
              || x.Watermark.SkipUntilUtc <= now)
  .OrderBy(x => x.Watermark.LastRunUtc)
  .Take(cap)
```

Back-off filtering, least-recently-run ordering and the cap all resolve server-side, so **a cycle materialises at most `CopilotInteractionHistoryMaxUsersPerCycle` users however large the directory is**. SQL Server sorts `NULL LastRunUtc` first on an ascending sort, which is exactly the existing "never-imported users go first" rule — so round-robin coverage is preserved without special-casing.

The **narrowed** path is deliberately left as a chunked fetch by UPN with in-memory ordering: a group's membership is small by definition, and group-first resolution avoids the one-Graph-call-per-tenant-user trap. The two paths are now separate methods (`SelectDueUsersInGroupsAsync` / `SelectDueUsersAcrossDirectoryAsync`) with the reasoning recorded on each.

`runLog.UsersInScope` for the unnarrowed path is a single `COUNT` per cycle — once per day by default, against the Graph calls that follow it.

## What still bounds the cost

With the filter optional, the ceiling carries more weight, so it is worth being explicit about what remains:

| Brake | Effect |
| --- | --- |
| Workload toggle | Off by default |
| `AiEnterpriseInteraction.Read.All` | Not granted by the installer; needs admin consent |
| `CopilotInteractionHistoryMaxUsersPerCycle` | **500 by default** — the hard per-cycle Graph-call ceiling, and now the primary brake on an unnarrowed run. A zero/negative value falls back to the default rather than meaning "unlimited" |
| Per-user back-off | Users returning nothing twice are parked for 72h |
| Cadence gate | Daily by default |
| Watermarks | Steady-state cycles only ask for interactions since the last successful run |

An unnarrowed run on a 200,000-user tenant is therefore 500 Graph calls per day working round-robin through the directory — not 200,000 per cycle.

## Verification

- Full solution builds (Debug).
- **148/148 pass** across the interaction-history, adoption, settings and config suites.
- `AllowUnscoped` is gone from the entire tree (source, tests and docs) — verified by search.

## Files

| File | Change |
| --- | --- |
| `CopilotInteractionHistoryImporter.cs` | `ValidateScopeConfiguration` and `ResolveScopedUsersAsync` removed; selection split into the narrowed and unnarrowed paths; class doc rewritten |
| `Common/Entities/Config/AppConfig.cs` | `CopilotInteractionHistoryAllowUnscoped` property and its AppSetting binding removed |
| `Tests.UnitTests/CopilotInteractionHistoryTests.cs` | The two tests asserting the refusal replaced with ones asserting an empty filter is valid and that the per-cycle cap is the brake |
| `InteractionHistory/readme.md` | "The cost problem, and the four brakes" reworked; new section on how selection scales without a filter; config table updated |
