### PR TITLE
Tests.FakeDataGen: Copilot prompt history + the new audit tables, and a stronger upgrade rehearsal

### DIFF
--- a/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotActivityGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotActivityGenerator.cs
@@ -17,6 +17,15 @@ namespace Tests.FakeDataGen.Copilot
         private readonly CopilotLicenseManager _licenseManager;
         private readonly CopilotUserManager _userManager;
         private readonly CopilotResourceGenerator _resourceGenerator;
+        private readonly CopilotEventDetailGenerator _detailGenerator;
+
+        /// <summary>
+        /// The last few conversation ids seen per user, so consecutive interactions can share a thread rather
+        /// than every interaction being its own conversation. <c>thread_id</c> exists to group interactions,
+        /// so generating a unique one per row would make it useless for exactly the reports it is for.
+        /// </summary>
+        private readonly System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>> _recentThreadsByUser
+            = new System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<string>>();
 
         public CopilotActivityGenerator(string connectionString)
         {
@@ -24,6 +33,7 @@ namespace Tests.FakeDataGen.Copilot
             _licenseManager = new CopilotLicenseManager();
             _userManager = new CopilotUserManager(_random, _licenseManager);
             _resourceGenerator = new CopilotResourceGenerator(_random);
+            _detailGenerator = new CopilotEventDetailGenerator(_random);
         }
 
         /// <summary>
@@ -170,7 +180,15 @@ namespace Tests.FakeDataGen.Copilot
                 EventID = eventId,
                 AuditEvent = auditEvent,
                 AppHost = CopilotActivityGeneratorConfig.AppHosts[_random.Next(CopilotActivityGeneratorConfig.AppHosts.Length)],
-                CopilotCreditEstimateTotal = _random.Next(1, 50)
+                CopilotCreditEstimateTotal = _random.Next(1, 50),
+
+                // Fields the importer parses but used to discard. Generating them keeps any report built
+                // over them honest - an empty column looks the same as a working report on no data.
+                ThreadId = NextThreadId(user.ID),
+                ClientRegion = CopilotActivityGeneratorConfig.ClientRegions[
+                    _random.Next(CopilotActivityGeneratorConfig.ClientRegions.Length)],
+                CopilotLogVersion = CopilotActivityGeneratorConfig.CopilotLogVersions[
+                    _random.Next(CopilotActivityGeneratorConfig.CopilotLogVersions.Length)]
             };
 
             // Add agent if requested
@@ -188,6 +206,13 @@ namespace Tests.FakeDataGen.Copilot
 
             db.CopilotChats.Add(copilotChat);
 
+            // Detail tables that hang off the same audit record: both messages, every context, the models
+            // that answered and the plugins that grounded it.
+            _detailGenerator.AddMessages(db, copilotChat);
+            _detailGenerator.AddContexts(db, copilotChat);
+            _detailGenerator.AddAIModels(db, copilotChat);
+            _detailGenerator.AddSystemPlugins(db, copilotChat);
+
             // Randomly decide if this is a file, meeting, or chat-only event
             int eventType = _random.Next(3);
 
@@ -204,6 +229,36 @@ namespace Tests.FakeDataGen.Copilot
             // Otherwise it's chat-only (no additional metadata)
 
             return copilotChat;
+        }
+
+        /// <summary>
+        /// Picks a conversation id for this user: usually continues a recent conversation, sometimes starts a
+        /// new one. A fresh id per interaction would make <c>thread_id</c> useless for the grouping it exists
+        /// to support.
+        /// </summary>
+        private string NextThreadId(int userId)
+        {
+            if (!_recentThreadsByUser.TryGetValue(userId, out var recent))
+            {
+                recent = new System.Collections.Generic.List<string>();
+                _recentThreadsByUser[userId] = recent;
+            }
+
+            // 60% continue an existing conversation, so threads have several turns.
+            if (recent.Count > 0 && _random.Next(100) < 60)
+            {
+                return recent[_random.Next(recent.Count)];
+            }
+
+            var threadId = $"19:copilot_{Guid.NewGuid():N}@thread.v2";
+            recent.Add(threadId);
+
+            // Only the last few conversations stay "open" - otherwise every user accumulates every thread
+            // they have ever had and the distribution flattens out.
+            if (recent.Count > 5)
+                recent.RemoveAt(0);
+
+            return threadId;
         }
 
         private void CreateMeetingEvent(AnalyticsEntitiesContext db, CopilotChat copilotChat, User user)

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotActivityGeneratorConfig.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotActivityGeneratorConfig.cs
@@ -26,6 +26,51 @@ namespace Tests.FakeDataGen.Copilot
 
         public static readonly string[] ResourceTypes = { "File", "Email", "WebPage", "ListItem", "Message" };
 
+        /// <summary>
+        /// What Copilot did with an accessed resource (audit schema field <c>Action</c>).
+        /// </summary>
+        public static readonly string[] AccessedResourceActions = { "Read", "Preview", "Reference", "Write" };
+
+        /// <summary>User region on the audit record (<c>ClientRegion</c>).</summary>
+        public static readonly string[] ClientRegions = { "US", "GB", "DE", "FR", "JP", "AU", "BR" };
+
+        /// <summary>
+        /// Copilot audit-log schema versions (<c>CopilotLogVersion</c>). Several are generated on purpose:
+        /// the field exists so payload-shape changes are visible, which is only testable with a mix.
+        /// </summary>
+        public static readonly string[] CopilotLogVersions = { "1.0", "1.1", "2.0" };
+
+        /// <summary>
+        /// Interaction context types (<c>Contexts[].Type</c>) - where the user was when they used Copilot.
+        /// </summary>
+        public static readonly string[] ContextTypes = { "docx", "xlsx", "pptx", "TeamsMeeting", "TeamsChannel", "TeamsChat", "OneNote" };
+
+        /// <summary>
+        /// AI models as (name, provider, version). The dimension de-duplicates on the whole tuple, so the
+        /// same model at two versions must produce two rows - generated here so that behaviour is exercised.
+        /// </summary>
+        public static readonly (string Name, string Provider, string Version)[] AIModels =
+        {
+            ("gpt-4o", "OpenAI", "2024-08-06"),
+            ("gpt-4o", "OpenAI", "2024-11-20"),
+            ("gpt-4.1", "OpenAI", "2025-04-14"),
+            ("DEEP_LEO", "Microsoft", "1.2"),
+            ("phi-4", "Microsoft", "2024-12-12"),
+        };
+
+        /// <summary>
+        /// AI system plugins as (plugin id, name, version) - the connectors that ground an answer.
+        /// Same tuple de-duplication as the models, so a version bump is a new row, not a rewrite.
+        /// </summary>
+        public static readonly (string PluginId, string Name, string Version)[] AISystemPlugins =
+        {
+            ("BingWebSearch", "BuiltIn", "1.0"),
+            ("SharePointGrounding", "BuiltIn", "2.1"),
+            ("SharePointGrounding", "BuiltIn", "2.2"),
+            ("GraphConnector.ServiceNow", "Connector", "1.0"),
+            ("GraphConnector.Confluence", "Connector", "3.4"),
+        };
+
         // File extensions for document generation
         public static readonly string[] FileExtensions = { "docx", "xlsx", "pptx", "pdf", "txt" };
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotEventDetailGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotEventDetailGenerator.cs
@@ -1,0 +1,208 @@
+using Common.Entities;
+using Common.Entities.Entities.AuditLog;
+using System;
+using System.Linq;
+
+namespace Tests.FakeDataGen.Copilot
+{
+    /// <summary>
+    /// Fills the Copilot audit detail tables that the importer parses out of a single audit record but that
+    /// live alongside <c>copilot_chats</c>: messages, interaction contexts, AI models and AI system plugins.
+    /// </summary>
+    /// <remarks>
+    /// These tables were added when the importer stopped discarding fields it had already parsed. Generating
+    /// activity without them leaves every one of them empty, so any report built over them looks correct
+    /// against an empty set and breaks on real data.
+    /// <para>
+    /// Two details are modelled rather than randomised, because they are what the schema exists to express:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><b>Both messages.</b> An interaction produces a prompt row AND a response row.
+    /// <c>is_prompt</c> would be a constant if only responses were generated, and <c>size</c> on the prompt is
+    /// the only record of the interaction's input volume.</description></item>
+    /// <item><description><b>Tuple-keyed dimensions.</b> Models and plugins de-duplicate on the whole
+    /// (name/id, provider, version) tuple, so the same model at two versions is deliberately generated to
+    /// produce two dimension rows rather than silently reusing one.</description></item>
+    /// </list>
+    /// </remarks>
+    public class CopilotEventDetailGenerator
+    {
+        private readonly Random _random;
+
+        public CopilotEventDetailGenerator(Random random)
+        {
+            _random = random;
+        }
+
+        /// <summary>
+        /// Adds the prompt and response message rows for an interaction.
+        /// </summary>
+        public void AddMessages(AnalyticsEntitiesContext db, CopilotChat chat)
+        {
+            // Prompts are short, responses are long - so a report on average message size by is_prompt has a
+            // real difference to show rather than two identical bars.
+            db.CopilotMessages.Add(new CopilotMessage
+            {
+                ChatId = chat.EventID,
+                RelatedChat = chat,
+                MessageId = Guid.NewGuid().ToString(),
+                IsPrompt = true,
+                Size = 40 + _random.Next(1200)
+            });
+
+            db.CopilotMessages.Add(new CopilotMessage
+            {
+                ChatId = chat.EventID,
+                RelatedChat = chat,
+                MessageId = Guid.NewGuid().ToString(),
+                IsPrompt = false,
+                // Microsoft does not populate Size for every host, so leave it null sometimes - a report
+                // that assumes it is always present should fail here, not in production.
+                Size = _random.Next(100) < 85 ? 500 + _random.Next(9500) : (long?)null
+            });
+        }
+
+        /// <summary>
+        /// Adds the interaction's contexts - where the user was when they used Copilot.
+        /// </summary>
+        /// <remarks>
+        /// More than one context per interaction is generated on purpose. The importer's file/meeting
+        /// resolution only acts on the FIRST file or meeting context, so <c>copilot_event_files</c> /
+        /// <c>copilot_event_meetings</c> hold at most one; this table is the only place the rest survive, and
+        /// it is only worth having if the data can actually have several.
+        /// </remarks>
+        public void AddContexts(AnalyticsEntitiesContext db, CopilotChat chat)
+        {
+            int contextCount = _random.Next(100) < 30 ? 2 + _random.Next(2) : 1;
+
+            for (int i = 0; i < contextCount; i++)
+            {
+                var typeName = CopilotActivityGeneratorConfig.ContextTypes[
+                    _random.Next(CopilotActivityGeneratorConfig.ContextTypes.Length)];
+
+                bool isTeams = typeName.StartsWith("Teams", StringComparison.OrdinalIgnoreCase);
+
+                db.CopilotEventContexts.Add(new CopilotEventContext
+                {
+                    ChatId = chat.EventID,
+                    RelatedChat = chat,
+                    ContextType = GetOrCreateContextType(db, typeName),
+                    ContextRef = isTeams
+                        ? $"19:meeting_{Guid.NewGuid():N}@thread.v2"
+                        : $"https://contoso.sharepoint.com/sites/Finance/Shared%20Documents/Καλημέρα%20κόσμε_{_random.Next(1000)}.{typeName}",
+                    ContainerId = isTeams
+                        ? $"19:{Guid.NewGuid():N}@thread.tacv2"
+                        : $"contoso.sharepoint.com,{Guid.NewGuid()},{Guid.NewGuid()}"
+                });
+            }
+        }
+
+        /// <summary>
+        /// Links the interaction to the AI model(s) that produced the answer.
+        /// </summary>
+        public void AddAIModels(AnalyticsEntitiesContext db, CopilotChat chat)
+        {
+            int modelCount = _random.Next(100) < 20 ? 2 : 1;
+            var used = new System.Collections.Generic.HashSet<int>();
+
+            for (int i = 0; i < modelCount; i++)
+            {
+                int index = _random.Next(CopilotActivityGeneratorConfig.AIModels.Length);
+                if (!used.Add(index))
+                    continue;
+
+                var spec = CopilotActivityGeneratorConfig.AIModels[index];
+                db.CopilotEventAIModels.Add(new CopilotEventAIModel
+                {
+                    ChatId = chat.EventID,
+                    RelatedChat = chat,
+                    AIModel = GetOrCreateAIModel(db, spec.Name, spec.Provider, spec.Version)
+                });
+            }
+        }
+
+        /// <summary>
+        /// Links the interaction to the system plugins / connectors that grounded it. Plenty of interactions
+        /// use none, which is the case a report needs to handle.
+        /// </summary>
+        public void AddSystemPlugins(AnalyticsEntitiesContext db, CopilotChat chat)
+        {
+            if (_random.Next(100) < 45)
+                return;
+
+            int pluginCount = _random.Next(100) < 25 ? 2 : 1;
+            var used = new System.Collections.Generic.HashSet<int>();
+
+            for (int i = 0; i < pluginCount; i++)
+            {
+                int index = _random.Next(CopilotActivityGeneratorConfig.AISystemPlugins.Length);
+                if (!used.Add(index))
+                    continue;
+
+                var spec = CopilotActivityGeneratorConfig.AISystemPlugins[index];
+                db.CopilotEventAISystemPlugins.Add(new CopilotEventAISystemPlugin
+                {
+                    ChatId = chat.EventID,
+                    RelatedChat = chat,
+                    AISystemPlugin = GetOrCreateSystemPlugin(db, spec.PluginId, spec.Name, spec.Version)
+                });
+            }
+        }
+
+        #region Dimension resolution
+
+        private CopilotContextType GetOrCreateContextType(AnalyticsEntitiesContext db, string name)
+        {
+            var existing = db.CopilotContextTypes.Local.FirstOrDefault(t => t.Name == name)
+                ?? db.CopilotContextTypes.FirstOrDefault(t => t.Name == name);
+
+            if (existing == null)
+            {
+                existing = new CopilotContextType { Name = name };
+                db.CopilotContextTypes.Add(existing);
+            }
+
+            return existing;
+        }
+
+        /// <summary>
+        /// Resolved on the whole (name, provider, version) tuple, matching the importer: the version is part
+        /// of a model's identity for AI-transparency reporting, so matching on name alone would collapse two
+        /// genuinely different models into one dimension row.
+        /// </summary>
+        private CopilotAIModel GetOrCreateAIModel(AnalyticsEntitiesContext db, string name, string provider, string version)
+        {
+            var existing = db.CopilotAIModels.Local
+                    .FirstOrDefault(m => m.Name == name && m.ProviderName == provider && m.Version == version)
+                ?? db.CopilotAIModels
+                    .FirstOrDefault(m => m.Name == name && m.ProviderName == provider && m.Version == version);
+
+            if (existing == null)
+            {
+                existing = new CopilotAIModel { Name = name, ProviderName = provider, Version = version };
+                db.CopilotAIModels.Add(existing);
+            }
+
+            return existing;
+        }
+
+        /// <summary>Same tuple rule as the models - a plugin upgrade is a new row, not a rewrite.</summary>
+        private CopilotAISystemPlugin GetOrCreateSystemPlugin(AnalyticsEntitiesContext db, string pluginId, string name, string version)
+        {
+            var existing = db.CopilotAISystemPlugins.Local
+                    .FirstOrDefault(p => p.PluginId == pluginId && p.Name == name && p.Version == version)
+                ?? db.CopilotAISystemPlugins
+                    .FirstOrDefault(p => p.PluginId == pluginId && p.Name == name && p.Version == version);
+
+            if (existing == null)
+            {
+                existing = new CopilotAISystemPlugin { PluginId = pluginId, Name = name, Version = version };
+                db.CopilotAISystemPlugins.Add(existing);
+            }
+
+            return existing;
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotInteractionHistoryGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotInteractionHistoryGenerator.cs
@@ -1,0 +1,640 @@
+using Common.Entities;
+using Common.Entities.Entities.Copilot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tests.FakeDataGen.Generation;
+
+namespace Tests.FakeDataGen.Copilot
+{
+    /// <summary>
+    /// Generates fake Copilot AI interaction history - the per-turn "prompt history" tables the
+    /// interaction-history import fills - so reports can be built and measured without a real tenant.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The point of this generator is report shape, so it produces the structure real reporting depends on
+    /// rather than uniform noise:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><b>Real turns.</b> Every user prompt is followed by an <c>aiResponse</c> sharing its
+    /// <c>request_id</c>, which is what makes turn counts and prompt-to-response ratios meaningful. The
+    /// response carries <c>response_latency_ms</c>; the prompt does not - matching what the importer
+    /// stores.</description></item>
+    /// <item><description><b>Prompt-only enrichment.</b> Sentiment, language and key phrases are set on
+    /// <c>userPrompt</c> rows only. Copilot responses are never scored by the importer, so a report that
+    /// averaged sentiment across all rows would look right here and be wrong in production.</description></item>
+    /// <item><description><b>Shared threads.</b> A small share of sessions belong to two users with the same
+    /// <c>session_ref</c> - a Teams meeting Copilot session appears in more than one participant's history.
+    /// That is why the sessions table is unique on (user, ref) rather than ref alone, and it is exactly the
+    /// case a per-user report can get wrong.</description></item>
+    /// <item><description><b>Skew.</b> App class, device and locale are weighted, and turns per session vary,
+    /// so "top N" style reports have something to rank.</description></item>
+    /// </list>
+    /// <para>
+    /// Locales and key phrases deliberately include Greek. Any column holding customer text must survive the
+    /// full Unicode range, and generating only ASCII here would hide a truncation or collation bug until a
+    /// customer found it.
+    /// </para>
+    /// <para>
+    /// All generated content is synthetic. No prompt or response text is produced or stored - the real import
+    /// stores only counts, so this generates only counts.
+    /// </para>
+    /// </remarks>
+    public class CopilotInteractionHistoryGenerator
+    {
+        private readonly string _connectionString;
+        private readonly Random _random = new Random();
+        private readonly CopilotLicenseManager _licenseManager;
+        private readonly CopilotUserManager _userManager;
+
+        /// <summary>Sessions per context. EF6 slows down as the change tracker grows, so it is recycled.</summary>
+        private const int SessionsPerBatch = 200;
+
+        public CopilotInteractionHistoryGenerator(string connectionString)
+        {
+            _connectionString = connectionString;
+            _licenseManager = new CopilotLicenseManager();
+            _userManager = new CopilotUserManager(_random, _licenseManager);
+        }
+
+        #region Weighted catalogues
+
+        // Weighted so reports have something to rank. BizChat dominates on a real tenant.
+        private static readonly (string Name, int Weight)[] AppClasses =
+        {
+            ("IPM.SkypeTeams.Message.Copilot.BizChat", 45),
+            ("IPM.SkypeTeams.Message.Copilot.Teams", 15),
+            ("IPM.SkypeTeams.Message.Copilot.Word", 12),
+            ("IPM.SkypeTeams.Message.Copilot.Outlook", 12),
+            ("IPM.SkypeTeams.Message.Copilot.Excel", 8),
+            ("IPM.SkypeTeams.Message.Copilot.PowerPoint", 5),
+            ("IPM.SkypeTeams.Message.Copilot.Loop", 3),
+        };
+
+        private static readonly (string Name, int Weight)[] Devices =
+        {
+            ("desktop", 55),
+            ("web", 30),
+            ("mobile", 15),
+        };
+
+        // el-GR is here on purpose: non-Latin script must survive the round trip.
+        private static readonly (string Name, int Weight)[] Locales =
+        {
+            ("en-us", 55),
+            ("en-gb", 15),
+            ("fr-fr", 8),
+            ("de-de", 7),
+            ("es-es", 5),
+            ("el-gr", 5),
+            ("ja-jp", 5),
+        };
+
+        private static readonly (string Locale, string Language)[] LanguageByLocale =
+        {
+            ("en-us", "English"),
+            ("en-gb", "English"),
+            ("fr-fr", "French"),
+            ("de-de", "German"),
+            ("es-es", "Spanish"),
+            ("el-gr", "Greek"),
+            ("ja-jp", "Japanese"),
+        };
+
+        private const string ConversationTypeBizChat = "bizchat";
+        private const string ConversationTypeAppChat = "appchat";
+        private const string InteractionTypePrompt = "userPrompt";
+        private const string InteractionTypeResponse = "aiResponse";
+
+        /// <summary>
+        /// Topical phrases of the kind Azure AI Language extracts - never prompt text. The Greek entries make
+        /// sure a non-ASCII key phrase survives insertion, indexing and reporting.
+        /// </summary>
+        private static readonly string[] KeyPhrases =
+        {
+            "quarterly sales forecast", "customer churn analysis", "meeting summary", "expense policy",
+            "onboarding checklist", "budget variance", "project timeline", "risk register",
+            "security incident report", "supplier contract", "travel booking", "performance review",
+            "product roadmap", "release notes", "training plan", "headcount planning",
+            "invoice reconciliation", "market research", "sprint retrospective", "data retention policy",
+            "Καλημέρα κόσμε", "ετήσιος προϋπολογισμός", "ανάλυση πωλήσεων",
+        };
+
+        #endregion
+
+        /// <summary>
+        /// Generates interaction history and the per-user watermarks / import-log rows that go with it.
+        /// </summary>
+        /// <param name="userCount">Users to spread the history across (existing users are reused).</param>
+        /// <param name="sessionsPerUser">Average conversations per user.</param>
+        /// <param name="turnsPerSession">Average prompt+response turns per conversation. Each turn is 2 rows.</param>
+        /// <param name="daysBack">Window the history is spread over.</param>
+        /// <param name="cognitivePercentage">Share of prompts carrying sentiment / language / key phrases.</param>
+        /// <param name="sharedThreadPercentage">Share of sessions also present in a second user's history.</param>
+        /// <param name="windowEndUtc">Optional shared window end, so several generators can align.</param>
+        public void GenerateInteractionHistory(
+            int userCount = 250,
+            int sessionsPerUser = 8,
+            int turnsPerSession = 6,
+            int daysBack = 90,
+            int cognitivePercentage = 70,
+            int sharedThreadPercentage = 5,
+            DateTime? windowEndUtc = null)
+        {
+            if (userCount < 1) throw new ArgumentOutOfRangeException(nameof(userCount));
+            if (sessionsPerUser < 1) throw new ArgumentOutOfRangeException(nameof(sessionsPerUser));
+            if (turnsPerSession < 1) throw new ArgumentOutOfRangeException(nameof(turnsPerSession));
+            if (daysBack < 1) throw new ArgumentOutOfRangeException(nameof(daysBack));
+            if (cognitivePercentage < 0 || cognitivePercentage > 100) throw new ArgumentOutOfRangeException(nameof(cognitivePercentage));
+            if (sharedThreadPercentage < 0 || sharedThreadPercentage > 100) throw new ArgumentOutOfRangeException(nameof(sharedThreadPercentage));
+
+            var windowEnd = windowEndUtc ?? DateTime.UtcNow;
+            var runStarted = DateTime.UtcNow;
+
+            Console.WriteLine("Generating Copilot AI interaction history...");
+            Console.WriteLine($"- {userCount} user(s), ~{sessionsPerUser} session(s) each, ~{turnsPerSession} turn(s) per session");
+            Console.WriteLine($"- Spread across the last {daysBack} day(s)");
+            Console.WriteLine($"- {cognitivePercentage}% of prompts will carry sentiment / language / key phrases");
+            Console.WriteLine($"- {sharedThreadPercentage}% of sessions will be shared with a second user");
+            Console.WriteLine($"- Estimated rows: ~{(long)userCount * sessionsPerUser * turnsPerSession * 2:N0} interactions");
+            Console.WriteLine();
+
+            List<int> userIds;
+            Lookups lookups;
+
+            using (var db = new AnalyticsEntitiesContext(_connectionString, true, false))
+            {
+                _licenseManager.EnsureLicensesExist(db);
+
+                var users = db.users.OrderBy(u => u.ID).Take(userCount).ToList();
+                if (users.Count == 0)
+                {
+                    Console.WriteLine($"No users found in database. Creating {userCount} test users...");
+                    users = _userManager.CreateTestUsers(db, userCount, 100);
+                }
+                else
+                {
+                    Console.WriteLine($"Found {users.Count} existing user(s) to attribute history to.");
+                }
+
+                userIds = users.Select(u => u.ID).ToList();
+                lookups = EnsureLookups(db);
+            }
+
+            if (userIds.Count == 0)
+            {
+                Console.WriteLine("No users available - nothing generated.");
+                return;
+            }
+
+            var plan = BuildSessionPlan(userIds, sessionsPerUser, sharedThreadPercentage);
+            Console.WriteLine($"Planned {plan.Count:N0} session(s) across {userIds.Count:N0} user(s).");
+
+            var stats = new GenerationStats();
+            var newestInteractionByUser = new Dictionary<int, DateTime>();
+
+            for (int offset = 0; offset < plan.Count; offset += SessionsPerBatch)
+            {
+                var batch = plan.GetRange(offset, Math.Min(SessionsPerBatch, plan.Count - offset));
+                WriteSessionBatch(batch, lookups, turnsPerSession, daysBack, cognitivePercentage,
+                    windowEnd, stats, newestInteractionByUser);
+
+                Console.WriteLine($"  {Math.Min(offset + SessionsPerBatch, plan.Count):N0}/{plan.Count:N0} session(s), " +
+                    $"{stats.Interactions:N0} interaction(s) written...");
+            }
+
+            WriteWatermarks(newestInteractionByUser, userIds, windowEnd);
+            WriteImportLog(runStarted, userIds.Count, newestInteractionByUser.Count, stats);
+
+            Console.WriteLine();
+            Console.WriteLine("Copilot interaction history generation complete:");
+            Console.WriteLine($"  Sessions:      {stats.Sessions:N0}");
+            Console.WriteLine($"  Interactions:  {stats.Interactions:N0} ({stats.Prompts:N0} prompt(s), {stats.Responses:N0} response(s))");
+            Console.WriteLine($"  Key phrases:   {stats.KeyPhraseLinks:N0} link(s)");
+            Console.WriteLine($"  Scored prompts:{stats.ScoredPrompts,8:N0}");
+        }
+
+        #region Lookups
+
+        private Lookups EnsureLookups(AnalyticsEntitiesContext db)
+        {
+            var lookups = new Lookups
+            {
+                InteractionTypes = EnsureNamed(db, db.CopilotInteractionTypes,
+                    new[] { InteractionTypePrompt, InteractionTypeResponse }),
+                AppClasses = EnsureNamed(db, db.CopilotInteractionAppClasses, AppClasses.Select(a => a.Name)),
+                ConversationTypes = EnsureNamed(db, db.CopilotInteractionConversationTypes,
+                    new[] { ConversationTypeBizChat, ConversationTypeAppChat }),
+                Locales = EnsureNamed(db, db.CopilotInteractionLocales, Locales.Select(l => l.Name)),
+                Devices = EnsureNamed(db, db.CopilotInteractionDevices, Devices.Select(d => d.Name)),
+                Languages = EnsureNamed(db, db.Languages, LanguageByLocale.Select(l => l.Language).Distinct()),
+                KeyPhrases = EnsureNamed(db, db.KeyWords, KeyPhrases),
+            };
+
+            return lookups;
+        }
+
+        /// <summary>
+        /// Resolves a name-keyed lookup table, inserting anything missing. Matches the importer's behaviour,
+        /// including reusing the shared <c>languages</c> and <c>keywords</c> tables rather than duplicating them.
+        /// </summary>
+        private static Dictionary<string, int> EnsureNamed<T>(
+            AnalyticsEntitiesContext db,
+            System.Data.Entity.DbSet<T> set,
+            IEnumerable<string> names) where T : Common.Entities.AbstractEFEntityWithName, new()
+        {
+            var wanted = names.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            var existing = set.Where(x => wanted.Contains(x.Name)).ToList();
+
+            var byName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var row in existing)
+            {
+                if (!string.IsNullOrEmpty(row.Name))
+                    byName[row.Name] = row.ID;
+            }
+
+            var added = new List<T>();
+            foreach (var name in wanted)
+            {
+                if (byName.ContainsKey(name))
+                    continue;
+
+                var entity = new T { Name = name };
+                set.Add(entity);
+                added.Add(entity);
+            }
+
+            if (added.Count > 0)
+            {
+                db.SaveChanges();
+                foreach (var entity in added)
+                    byName[entity.Name] = entity.ID;
+            }
+
+            return byName;
+        }
+
+        #endregion
+
+        #region Session planning and writing
+
+        /// <summary>
+        /// Decides who owns which conversation before anything is written, so shared threads can be planned
+        /// rather than discovered.
+        /// </summary>
+        private List<PlannedSession> BuildSessionPlan(List<int> userIds, int sessionsPerUser, int sharedThreadPercentage)
+        {
+            var plan = new List<PlannedSession>(userIds.Count * sessionsPerUser);
+
+            foreach (var userId in userIds)
+            {
+                // Vary the count so "most active users" reports have a real distribution to rank.
+                int sessions = Math.Max(1, (int)Math.Round(sessionsPerUser * (0.4 + _random.NextDouble() * 1.6)));
+
+                for (int i = 0; i < sessions; i++)
+                {
+                    var sessionRef = $"session-{Guid.NewGuid():N}";
+                    plan.Add(new PlannedSession { UserId = userId, SessionRef = sessionRef });
+
+                    // A shared thread is the SAME session_ref owned by a second user - a meeting Copilot
+                    // session showing up in another participant's history.
+                    if (userIds.Count > 1 && _random.Next(100) < sharedThreadPercentage)
+                    {
+                        int otherUserId;
+                        do { otherUserId = userIds[_random.Next(userIds.Count)]; }
+                        while (otherUserId == userId);
+
+                        plan.Add(new PlannedSession { UserId = otherUserId, SessionRef = sessionRef });
+                    }
+                }
+            }
+
+            return plan;
+        }
+
+        private void WriteSessionBatch(
+            List<PlannedSession> batch,
+            Lookups lookups,
+            int turnsPerSession,
+            int daysBack,
+            int cognitivePercentage,
+            DateTime windowEnd,
+            GenerationStats stats,
+            Dictionary<int, DateTime> newestInteractionByUser)
+        {
+            // A fresh context per batch: EF6's change tracker makes inserts progressively slower as it grows,
+            // and recycling is cheaper than fighting it.
+            using (var db = new AnalyticsEntitiesContext(_connectionString, true, false))
+            {
+                db.Configuration.AutoDetectChangesEnabled = false;
+                try
+                {
+                    var sessions = new List<CopilotInteractionSession>(batch.Count);
+                    foreach (var planned in batch)
+                    {
+                        var session = new CopilotInteractionSession
+                        {
+                            SessionRef = planned.SessionRef,
+                            UserId = planned.UserId
+                        };
+                        db.CopilotInteractionSessions.Add(session);
+                        sessions.Add(session);
+                    }
+
+                    db.ChangeTracker.DetectChanges();
+                    db.SaveChanges();
+                    stats.Sessions += sessions.Count;
+
+                    var keyPhraseLinks = new List<CopilotInteractionKeyword>();
+
+                    for (int i = 0; i < sessions.Count; i++)
+                    {
+                        WriteSessionInteractions(db, sessions[i], lookups, turnsPerSession, daysBack,
+                            cognitivePercentage, windowEnd, stats, newestInteractionByUser, keyPhraseLinks);
+                    }
+
+                    db.ChangeTracker.DetectChanges();
+                    db.SaveChanges();
+
+                    // Key-phrase links need the interaction ids, so they are a second pass.
+                    foreach (var link in keyPhraseLinks)
+                        db.CopilotInteractionKeywords.Add(link);
+
+                    if (keyPhraseLinks.Count > 0)
+                    {
+                        db.ChangeTracker.DetectChanges();
+                        db.SaveChanges();
+                        stats.KeyPhraseLinks += keyPhraseLinks.Count;
+                    }
+                }
+                finally
+                {
+                    db.Configuration.AutoDetectChangesEnabled = true;
+                }
+            }
+        }
+
+        private void WriteSessionInteractions(
+            AnalyticsEntitiesContext db,
+            CopilotInteractionSession session,
+            Lookups lookups,
+            int turnsPerSession,
+            int daysBack,
+            int cognitivePercentage,
+            DateTime windowEnd,
+            GenerationStats stats,
+            Dictionary<int, DateTime> newestInteractionByUser,
+            List<CopilotInteractionKeyword> keyPhraseLinks)
+        {
+            int turns = Math.Max(1, (int)Math.Round(turnsPerSession * (0.3 + _random.NextDouble() * 1.7)));
+
+            // A conversation happens in one sitting: pick a start, then walk forward.
+            var conversationStart = ActivityTimestampGenerator.Next(_random, daysBack, windowEnd);
+
+            // Properties that belong to the conversation, not the turn.
+            var appClass = WeightedPick(AppClasses);
+            var locale = WeightedPick(Locales);
+            var device = WeightedPick(Devices);
+            var conversationType = appClass.Contains("BizChat") ? ConversationTypeBizChat : ConversationTypeAppChat;
+            var languageName = LanguageByLocale.First(l => l.Locale == locale).Language;
+
+            var cursor = conversationStart;
+
+            for (int turn = 0; turn < turns; turn++)
+            {
+                var requestId = $"request-{Guid.NewGuid():N}";
+                bool scored = _random.Next(100) < cognitivePercentage;
+
+                // ---- The user prompt -------------------------------------------------------------
+                int promptChars = 25 + _random.Next(375);
+                var prompt = new CopilotInteraction
+                {
+                    GraphInteractionId = $"interaction-{Guid.NewGuid():N}",
+                    SessionId = session.ID,
+                    UserId = session.UserId,
+                    RequestId = requestId,
+                    InteractionTypeId = lookups.InteractionTypes[InteractionTypePrompt],
+                    AppClassId = lookups.AppClasses[appClass],
+                    ConversationTypeId = lookups.ConversationTypes[conversationType],
+                    LocaleId = lookups.Locales[locale],
+                    DeviceId = lookups.Devices[device],
+                    CreatedUtc = cursor,
+                    BodyCharCount = promptChars,
+                    BodyWordCount = Math.Max(1, promptChars / 6),
+                    AttachmentCount = _random.Next(100) < 12 ? 1 + _random.Next(2) : 0,
+                    LinkCount = _random.Next(100) < 18 ? 1 + _random.Next(3) : 0,
+                    MentionCount = _random.Next(100) < 8 ? 1 : 0,
+                    ContextCount = _random.Next(100) < 35 ? 1 + _random.Next(4) : 0,
+
+                    // Latency belongs to the response, never the prompt - see the entity remarks.
+                    ResponseLatencyMs = null,
+
+                    // Enrichment is prompt-only: the importer never scores Copilot's own output.
+                    SentimentScore = scored ? Math.Round(_random.NextDouble(), 4) : (double?)null,
+                    LanguageId = scored ? lookups.Languages[languageName] : (int?)null,
+                };
+                db.CopilotInteractions.Add(prompt);
+                stats.Prompts++;
+                stats.Interactions++;
+                if (scored) stats.ScoredPrompts++;
+
+                // ---- Copilot's response ----------------------------------------------------------
+                // Mostly quick, with a long tail so latency percentile reports have something to show.
+                int latencyMs = _random.Next(100) < 90
+                    ? 500 + _random.Next(4500)
+                    : 5000 + _random.Next(25000);
+
+                var responseAt = cursor.AddMilliseconds(latencyMs);
+                int responseChars = 200 + _random.Next(3800);
+
+                var response = new CopilotInteraction
+                {
+                    GraphInteractionId = $"interaction-{Guid.NewGuid():N}",
+                    SessionId = session.ID,
+                    UserId = session.UserId,
+                    RequestId = requestId,
+                    InteractionTypeId = lookups.InteractionTypes[InteractionTypeResponse],
+                    AppClassId = lookups.AppClasses[appClass],
+                    ConversationTypeId = lookups.ConversationTypes[conversationType],
+                    LocaleId = lookups.Locales[locale],
+                    DeviceId = lookups.Devices[device],
+                    CreatedUtc = responseAt,
+                    BodyCharCount = responseChars,
+                    BodyWordCount = Math.Max(1, responseChars / 6),
+                    AttachmentCount = 0,
+                    LinkCount = _random.Next(100) < 45 ? 1 + _random.Next(5) : 0,
+                    MentionCount = 0,
+                    ContextCount = 0,
+                    ResponseLatencyMs = latencyMs,
+                    SentimentScore = null,
+                    LanguageId = null,
+                };
+                db.CopilotInteractions.Add(response);
+                stats.Responses++;
+                stats.Interactions++;
+
+                if (scored)
+                {
+                    foreach (var phrase in PickKeyPhrases(locale))
+                    {
+                        keyPhraseLinks.Add(new CopilotInteractionKeyword
+                        {
+                            Interaction = prompt,
+                            KeyWordId = lookups.KeyPhrases[phrase]
+                        });
+                    }
+                }
+
+                TrackNewest(newestInteractionByUser, session.UserId, responseAt);
+
+                // Thinking time before the next prompt in the same conversation.
+                cursor = responseAt.AddSeconds(15 + _random.Next(240));
+            }
+        }
+
+        /// <summary>Greek conversations get Greek key phrases, so non-ASCII reaches the keywords table.</summary>
+        private IEnumerable<string> PickKeyPhrases(string locale)
+        {
+            bool greek = locale == "el-gr";
+            var pool = greek
+                ? KeyPhrases.Where(p => p.Any(c => c > 0x374)).ToArray()
+                : KeyPhrases.Where(p => p.All(c => c < 0x374)).ToArray();
+
+            if (pool.Length == 0)
+                pool = KeyPhrases;
+
+            int wanted = 1 + _random.Next(3);
+            return pool.OrderBy(_ => _random.Next()).Take(Math.Min(wanted, pool.Length)).ToList();
+        }
+
+        private static void TrackNewest(Dictionary<int, DateTime> newest, int userId, DateTime candidate)
+        {
+            if (!newest.TryGetValue(userId, out var current) || candidate > current)
+                newest[userId] = candidate;
+        }
+
+        #endregion
+
+        #region Watermarks and import log
+
+        /// <summary>
+        /// Writes the per-user import state. Without it the tables look like data that arrived from nowhere,
+        /// and anything reading the watermarks (or a re-run of the real importer) sees every user as new.
+        /// </summary>
+        private void WriteWatermarks(Dictionary<int, DateTime> newestInteractionByUser, List<int> userIds, DateTime windowEnd)
+        {
+            using (var db = new AnalyticsEntitiesContext(_connectionString, true, false))
+            {
+                db.Configuration.AutoDetectChangesEnabled = false;
+                try
+                {
+                    var existing = db.CopilotInteractionUserWatermarks
+                        .Where(w => userIds.Contains(w.UserId))
+                        .ToDictionary(w => w.UserId, w => w);
+
+                    foreach (var userId in userIds)
+                    {
+                        bool hasData = newestInteractionByUser.TryGetValue(userId, out var newest);
+
+                        if (!existing.TryGetValue(userId, out var watermark))
+                        {
+                            watermark = new CopilotInteractionUserWatermark { UserId = userId };
+                            db.CopilotInteractionUserWatermarks.Add(watermark);
+                        }
+
+                        watermark.LastRunUtc = windowEnd;
+                        watermark.LastError = null;
+
+                        if (hasData)
+                        {
+                            watermark.LastInteractionUtc = newest;
+                            watermark.ConsecutiveEmptyOrFailed = 0;
+                            watermark.SkipUntilUtc = null;
+                        }
+                        else
+                        {
+                            // A user with no history looks exactly like an unlicensed one to the importer,
+                            // so give them the same back-off state the real thing would.
+                            watermark.ConsecutiveEmptyOrFailed = 2;
+                            watermark.SkipUntilUtc = windowEnd.AddHours(72);
+                        }
+                    }
+
+                    db.ChangeTracker.DetectChanges();
+                    db.SaveChanges();
+                }
+                finally
+                {
+                    db.Configuration.AutoDetectChangesEnabled = true;
+                }
+            }
+        }
+
+        private void WriteImportLog(DateTime runStarted, int usersInScope, int usersWithData, GenerationStats stats)
+        {
+            using (var db = new AnalyticsEntitiesContext(_connectionString, true, false))
+            {
+                db.CopilotInteractionImportLogs.Add(new CopilotInteractionImportLog
+                {
+                    RunStartedUtc = runStarted,
+                    RunFinishedUtc = DateTime.UtcNow,
+                    UsersInScope = usersInScope,
+                    UsersScanned = usersWithData,
+                    UsersSkipped = Math.Max(0, usersInScope - usersWithData),
+                    UsersFailed = 0,
+                    InteractionsRead = stats.Interactions,
+                    InteractionsSaved = stats.Interactions,
+                    CognitiveDocsScored = stats.ScoredPrompts,
+                    Error = null
+                });
+
+                db.SaveChanges();
+            }
+        }
+
+        #endregion
+
+        private string WeightedPick((string Name, int Weight)[] options)
+        {
+            int total = options.Sum(o => o.Weight);
+            int roll = _random.Next(total);
+
+            foreach (var option in options)
+            {
+                roll -= option.Weight;
+                if (roll < 0)
+                    return option.Name;
+            }
+
+            return options[options.Length - 1].Name;
+        }
+
+        private class PlannedSession
+        {
+            public int UserId { get; set; }
+            public string SessionRef { get; set; }
+        }
+
+        private class Lookups
+        {
+            public Dictionary<string, int> InteractionTypes { get; set; }
+            public Dictionary<string, int> AppClasses { get; set; }
+            public Dictionary<string, int> ConversationTypes { get; set; }
+            public Dictionary<string, int> Locales { get; set; }
+            public Dictionary<string, int> Devices { get; set; }
+            public Dictionary<string, int> Languages { get; set; }
+            public Dictionary<string, int> KeyPhrases { get; set; }
+        }
+
+        private class GenerationStats
+        {
+            public int Sessions;
+            public int Interactions;
+            public int Prompts;
+            public int Responses;
+            public int ScoredPrompts;
+            public int KeyPhraseLinks;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotResourceGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Copilot/CopilotResourceGenerator.cs
@@ -1,4 +1,4 @@
-using Common.Entities;
+﻿using Common.Entities;
 using Common.Entities.Entities.AuditLog;
 using System;
 using System.Linq;
@@ -53,6 +53,45 @@ namespace Tests.FakeDataGen.Copilot
             }
         }
 
+        /// <summary>
+        /// Sets the action Copilot performed and the SharePoint list item id behind the resource.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="listItemSourceId"/> is deliberately the SAME lookup row as the resource id most of
+        /// the time. The audit payload very often repeats the resource Id verbatim as listItemUniqueId, and
+        /// both columns are dimensioned against <c>copilot_event_accessed_resource_ids</c> precisely so the
+        /// two de-duplicate against each other instead of storing the string twice on the largest Copilot
+        /// table. Generating a distinct value every time would hide that, and would inflate the dimension in
+        /// a way real data does not.
+        /// </remarks>
+        private void AddActionAndListItem(AnalyticsEntitiesContext db, CopilotEventAccessedResource resource, bool sharePointBacked)
+        {
+            resource.Action = GetOrCreateAccessedResourceAction(db,
+                CopilotActivityGeneratorConfig.AccessedResourceActions[
+                    _random.Next(CopilotActivityGeneratorConfig.AccessedResourceActions.Length)]);
+
+            if (!sharePointBacked)
+                return;
+
+            resource.ListItemUniqueId = _random.Next(100) < 80
+                ? resource.ResourceId
+                : GetOrCreateAccessedResourceId(db, Guid.NewGuid().ToString().ToUpperInvariant());
+        }
+
+        private CopilotAccessedResourceAction GetOrCreateAccessedResourceAction(AnalyticsEntitiesContext db, string name)
+        {
+            var action = db.CopilotAccessedResourceActions.Local.FirstOrDefault(a => a.Name == name)
+                ?? db.CopilotAccessedResourceActions.FirstOrDefault(a => a.Name == name);
+
+            if (action == null)
+            {
+                action = new CopilotAccessedResourceAction { Name = name };
+                db.CopilotAccessedResourceActions.Add(action);
+            }
+
+            return action;
+        }
+
         private void AddSharePointResource(AnalyticsEntitiesContext db, CopilotEventAccessedResource resource)
         {
             // SharePoint/OneDrive document
@@ -65,6 +104,7 @@ namespace Tests.FakeDataGen.Copilot
             resource.ResourceName = GetOrCreateAccessedResourceName(db, docName);
             resource.ResourceSiteUrl = GetOrCreateAccessedResourceSiteUrl(db, siteUrl);
             resource.ResourceType = GetOrCreateAccessedResourceType(db, "File");
+            AddActionAndListItem(db, resource, sharePointBacked: true);
         }
 
         private void AddOutlookResource(AnalyticsEntitiesContext db, CopilotEventAccessedResource resource)
@@ -79,13 +119,14 @@ namespace Tests.FakeDataGen.Copilot
             resource.ResourceName = GetOrCreateAccessedResourceName(db, attachmentName);
             resource.ResourceSiteUrl = GetOrCreateAccessedResourceSiteUrl(db, "https://outlook.office365.com/owa");
             resource.ResourceType = GetOrCreateAccessedResourceType(db, "Email");
+            AddActionAndListItem(db, resource, sharePointBacked: false);
         }
 
         private void AddWebPageResource(AnalyticsEntitiesContext db, CopilotEventAccessedResource resource)
         {
             // Web page or other resource
             string webUrl = CopilotActivityGeneratorConfig.ResourceSiteUrls[_random.Next(CopilotActivityGeneratorConfig.ResourceSiteUrls.Length)];
-            string resourceName = webUrl.Contains("accuweather") ? "Weather Forecast - S�o Tom�" : "Email Message";
+            string resourceName = webUrl.Contains("accuweather") ? "Weather Forecast - São Tomé" : "Email Message";
 
             resource.ResourceId = GetOrCreateAccessedResourceId(db, webUrl);
             resource.ResourceName = GetOrCreateAccessedResourceName(db, resourceName);

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
@@ -30,6 +30,8 @@ namespace Tests.FakeDataGen
                 ctx => RunOffice365ActivityGenerator(ctx.RequireConnectionString())),
             new MenuItem("Generate combined profiling data (O365 + Copilot)", MenuCategory.DataGeneration,
                 ctx => RunCombinedActivityGenerator(ctx.RequireConnectionString())),
+            new MenuItem("Generate fake Copilot prompt history (AI interaction history)", MenuCategory.DataGeneration,
+                ctx => RunCopilotInteractionHistoryGenerator(ctx.RequireConnectionString())),
 
             // Stress tests
             new MenuItem("ActivityAPI import stress test", MenuCategory.StressTest,
@@ -318,6 +320,40 @@ namespace Tests.FakeDataGen
 
             Console.WriteLine();
             Console.WriteLine("Copilot activity generation completed successfully!");
+        }
+
+        /// <summary>
+        /// Generates the per-turn Copilot "prompt history" tables so interaction reports can be built and
+        /// measured without a real tenant. No prompt text is generated or stored - the real import keeps only
+        /// counts, so this does too.
+        /// </summary>
+        private static void RunCopilotInteractionHistoryGenerator(string connectionString)
+        {
+            Console.WriteLine("===========================================");
+            Console.WriteLine("  Generate Fake Copilot Prompt History");
+            Console.WriteLine("===========================================");
+            Console.WriteLine();
+
+            if (!ConfirmDatabaseSafeToWrite(connectionString))
+            {
+                Console.WriteLine("Operation cancelled by user.");
+                return;
+            }
+
+            int userCount = PromptInt("How many users should have history?", 250, 1, int.MaxValue);
+            int sessionsPerUser = PromptInt("Average conversations per user", 8, 1, 10000);
+            int turnsPerSession = PromptInt("Average turns per conversation (each turn = a prompt + a response)", 6, 1, 10000);
+            int daysBack = PromptInt("How many days back should history be spread across?", 90, 1, 3650);
+            int cognitivePercent = PromptInt("Percentage of prompts with sentiment / language / key phrases (0-100)", 70, 0, 100);
+            int sharedPercent = PromptInt("Percentage of conversations shared with a second user (0-100)", 5, 0, 100);
+
+            Console.WriteLine();
+            var generator = new CopilotInteractionHistoryGenerator(connectionString);
+            generator.GenerateInteractionHistory(userCount, sessionsPerUser, turnsPerSession, daysBack,
+                cognitivePercent, sharedPercent);
+
+            Console.WriteLine();
+            Console.WriteLine("Copilot prompt history generation completed successfully!");
         }
 
         private static void RunOffice365ActivityGenerator(string connectionString)

--- a/src/AnalyticsEngine/Tests.FakeDataGen/README.md
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/README.md
@@ -116,6 +116,36 @@ entire generated data set in the EF change tracker.
 the source data before compiling, or clear/rebuild previously compiled fake-data
 weeks before re-running the weekly procedure.
 
+### Copilot prompt history (AI interaction history)
+
+`CopilotInteractionHistoryGenerator` fills the per-turn interaction-history tables that the
+Graph `getAllEnterpriseInteractions` import writes, so **interaction reports can be built and
+measured without a real tenant**. It writes sessions, interactions, the five lookups, key-phrase
+links, per-user watermarks and an import-log row.
+
+It generates report *shape*, not uniform noise:
+
+- **Real turns.** Every `userPrompt` is followed by an `aiResponse` sharing its `request_id`, which is
+  what makes turn counts and prompt-to-response ratios meaningful. `response_latency_ms` is set on the
+  response only - never the prompt - matching what the importer stores. Latency has a deliberate long
+  tail so percentile reports have something to show.
+- **Prompt-only enrichment.** Sentiment, language and key phrases land on `userPrompt` rows only,
+  because the importer never scores Copilot's own output. A report that averaged sentiment across all
+  rows would look correct against uniform data and be wrong in production.
+- **Shared threads.** A configurable share of conversations exist under the same `session_ref` for two
+  users - a Teams meeting Copilot session in more than one participant's history. That is why the
+  sessions table is unique on (user, ref) rather than ref alone.
+- **Skew.** App class, device and locale are weighted and turns-per-conversation varies, so "top N"
+  reports have something to rank.
+- **Unicode.** Locales and key phrases include Greek, so a truncation or collation bug surfaces here
+  rather than in a customer tenant.
+
+**No prompt or response text is generated or stored.** The real import keeps only counts, so this keeps
+only counts; the sole free text is topical key phrases of the kind Azure AI Language returns.
+
+Prompts for users, conversations per user, turns per conversation, window, enrichment percentage and
+shared-thread percentage. Roughly `users x conversations x turns x 2` interaction rows.
+
 ### Combined profiling data
 
 The combined option prompts once for the event count, shared user count, and date

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Copilot\CopilotActivityGenerator.cs" />
+    <Compile Include="Copilot\CopilotEventDetailGenerator.cs" />
     <Compile Include="Copilot\CopilotInteractionHistoryGenerator.cs" />
     <Compile Include="Copilot\CopilotActivityGeneratorConfig.cs" />
     <Compile Include="Copilot\CopilotLicenseManager.cs" />

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Copilot\CopilotActivityGenerator.cs" />
+    <Compile Include="Copilot\CopilotInteractionHistoryGenerator.cs" />
     <Compile Include="Copilot\CopilotActivityGeneratorConfig.cs" />
     <Compile Include="Copilot\CopilotLicenseManager.cs" />
     <Compile Include="Copilot\CopilotResourceGenerator.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/UpgradeFromStableTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UpgradeFromStableTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.Migrations;
 using System.Data.SqlClient;
+using System.Linq;
 using Common.Entities.Migrations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -77,15 +78,56 @@ namespace Tests.UnitTests
                 Assert.AreEqual(GreekUrl, ScalarString(connectionString, "SELECT TOP 1 full_url FROM dbo.urls"),
                     "Non-ASCII URL did not survive the upgrade intact.");
 
-                // 5. The new tables this release adds exist.
-                foreach (var table in new[] { "copilot_usage_report_import_log", "copilot_usage_user_activity_log", "copilot_user_count_log" })
+                // 5. The upgrade actually reached the newest migration in the assembly.
+                //
+                //    Deliberately compared against the migrator's own list rather than a hard-coded id: a
+                //    literal here would silently stop covering the newest migration the moment one is added,
+                //    which is exactly when this test matters most.
+                var newestAvailable = NewMigrator(connectionString).GetLocalMigrations().Last();
+                Assert.AreEqual(newestAvailable, LatestApplied(connectionString),
+                    "Upgrade did not reach the newest migration in the assembly.");
+
+                // 6. The new tables this release adds exist - the usage-report tables, the Copilot audit
+                //    tables that were previously parsed and dropped, and the interaction-history tables.
+                var expectedTables = new[]
+                {
+                    // Graph Copilot usage reports
+                    "copilot_usage_report_import_log", "copilot_usage_user_activity_log", "copilot_user_count_log",
+                    // Copilot audit fields that used to be discarded
+                    "copilot_event_accessed_resource_actions", "copilot_ai_system_plugins",
+                    "copilot_event_context_types", "copilot_event_ai_system_plugins", "copilot_event_contexts",
+                    // Copilot AI interaction history
+                    "copilot_interactions", "copilot_interaction_sessions", "copilot_interaction_keywords",
+                    "copilot_interaction_user_watermarks", "copilot_interaction_import_log",
+                    "copilot_interaction_app_classes", "copilot_interaction_conversation_types",
+                    "copilot_interaction_types", "copilot_interaction_locales", "copilot_interaction_devices",
+                };
+
+                foreach (var table in expectedTables)
                 {
                     Assert.AreEqual(1L, ScalarLong(connectionString,
                         "SELECT COUNT_BIG(*) FROM sys.tables WHERE name = '" + table + "'"),
                         "Expected new table " + table + " after upgrade.");
                 }
 
-                // 6. DeprecateTeamsAddons drops its tables only when they were empty.
+                // 7. Columns added to existing tables landed too. A migration that creates its new tables but
+                //    silently skips an AddColumn leaves the importer writing to a column that isn't there.
+                foreach (var column in new[]
+                {
+                    "copilot_chats.thread_id", "copilot_chats.client_region", "copilot_chats.copilot_log_version",
+                    "copilot_event_messages.size", "copilot_event_messages.is_prompt",
+                    "copilot_event_accessed_resources.action_id",
+                    "copilot_event_accessed_resources.list_item_unique_id_id",
+                    "copilot_ai_models.version",
+                })
+                {
+                    var parts = column.Split('.');
+                    Assert.AreEqual(1L, ScalarLong(connectionString,
+                        "SELECT COUNT_BIG(*) FROM sys.columns WHERE object_id = OBJECT_ID('dbo." + parts[0] + "') AND name = '" + parts[1] + "'"),
+                        "Expected new column " + column + " after upgrade.");
+                }
+
+                // 8. DeprecateTeamsAddons drops its tables only when they were empty.
                 var addonTableCount = ScalarLong(connectionString,
                     "SELECT COUNT_BIG(*) FROM sys.tables WHERE name IN ('teams_addons','teams_addons_log','teams_addons_user_installed_log')");
 


### PR DESCRIPTION
Adds a `Tests.FakeDataGen` generator for Copilot **prompt history** — the per-turn AI interaction-history tables — so interaction reports can be built and measured without a real tenant.

Menu option 4 under DATA GENERATION: *"Generate fake Copilot prompt history (AI interaction history)"*.

## What it fills

All ten interaction-history tables: sessions, interactions, the five lookups (interaction type, app class, conversation type, locale, device), key-phrase links into the shared `keywords` table, per-user watermarks, and an import-log row.

The watermarks and import log matter more than they look. Without them the tables read as data that arrived from nowhere, and a subsequent run of the *real* importer would treat every user as never-seen and re-backfill them.

## It generates report shape, not uniform noise

This is the part worth reviewing, because uniform random data would let a broken report look correct.

| Property | Why it is modelled this way |
| --- | --- |
| **Real turns** — every `userPrompt` is followed by an `aiResponse` sharing its `request_id` | `requestId` pairing is the whole point of this feed. Without it, turn counts and prompt-to-response ratios have nothing to compute from |
| **`response_latency_ms` on responses only** | Matches the entity contract exactly ("only ever set on `aiResponse` rows"). Latency has a deliberate long tail (90% under 5 s, the rest up to 30 s) so percentile reports have something to show |
| **Sentiment / language / key phrases on prompts only** | The importer never scores Copilot's own output. A report that averaged sentiment across *all* rows would look right against uniform data and be wrong in production |
| **Shared threads** | A configurable share of conversations exist under the same `session_ref` for two users — a Teams meeting Copilot session in more than one participant's history. This is why the sessions table is unique on `(user_id, session_ref)` and not on `session_ref` alone, and it is the case per-user reporting most easily gets wrong |
| **Weighted skew** | App class (BizChat dominant), device and locale are weighted, and turns-per-conversation varies, so "top N" and "most active user" reports have a real distribution to rank rather than a flat one |
| **Conversation-level coherence** | App class, locale, device and conversation type belong to the conversation, not the turn, and turns walk forward in time with realistic thinking gaps |

## Privacy

**No prompt or response text is generated or stored.** The real import reduces each body to counts and discards it, so this generates only counts. The sole free text is topical key phrases of the kind Azure AI Language returns (`"quarterly sales forecast"`), never prompt text.

## Unicode

Locales and key phrases deliberately include Greek (`el-gr`, `Καλημέρα κόσμε`, `ετήσιος προϋπολογισμός`, `ανάλυση πωλήσεων`). Generating only ASCII would hide a truncation or collation bug until a customer hit it.

## Verified against LocalDB

Ran at 20 users / 3 conversations / 3 turns and checked the result in SQL rather than trusting the console output:

| Check | Result |
| --- | --- |
| Broken turn pairs (a `request_id` without exactly 2 rows) | **0** |
| Latency set on a prompt, or missing from a response | **0** |
| Sentiment or language set on a response | **0** |
| Shared threads (one `session_ref`, two users) | 7 |
| Watermark rows | 20 (one per user) |
| Import-log rows | 1 |
| Key-phrase links | 337 |

Distributions came out as intended — BizChat 222 interactions vs Loop 6; latency min 504 ms / avg 3,914 ms / max 29,573 ms.

Greek round-trip confirmed at the byte level: `Καλημέρα κόσμε` stored as 14 characters / **28 bytes** in `nvarchar`, raw UTF-16 showing `0x03xx` codepoints and no `?` substitution.

## Note on how it was verified

Launching the freshly-built `Tests.FakeDataGen.exe` from the repo path fails with *"Access is denied"* in this environment (a security policy on new binaries, not a code problem — the same thing blocked an unrelated throwaway tool earlier). The generator was therefore driven directly through its public API to verify it, and the results above come from querying the database afterwards. The menu wiring itself is unexercised by that route and is worth a manual run.

## Performance

Sessions are written in batches of 200 on a recycled `AnalyticsEntitiesContext`, with `AutoDetectChangesEnabled` disabled and one explicit `DetectChanges()` before each save — EF6 otherwise runs change detection on every `Add`, making bulk inserts quadratic. Row counts scale as `users x conversations x turns x 2`.


---

## Added after review: the Copilot audit tables, and a stronger upgrade rehearsal

### The activity generator now fills the new Copilot audit tables

`CopilotActivityGenerator` never populated anything the "persist parsed-but-dropped audit fields" work added, so five tables and nine columns were empty and any report over them looked correct against an empty set.

Now generated: **both** message rows per interaction (`is_prompt` would otherwise be a constant, and `size` on the prompt is the only record of input volume), **every** interaction context rather than just the one the file/meeting resolution keeps, the AI models that answered, the system plugins that grounded it, the action performed against each accessed resource, and `thread_id` / `client_region` / `copilot_log_version` on the chat.

Two behaviours are exercised rather than assumed:

- **Tuple-keyed dimensions.** Models and plugins de-duplicate on the whole (name/id, provider, version) tuple, so the catalogue deliberately contains the same model *and* the same plugin at two versions.
- **Shared resource-id dimension.** `list_item_unique_id_id` mostly reuses the resource id's own lookup row, as the real payload does, so the de-duplication that column exists for is actually hit.

Verified against LocalDB at 300 events: 600 messages (300 prompts / 300 responses, 541 with `size`), 432 contexts across 7 types, 346 model links, 194 plugin links, 118 resources with an action, 60 with a list-item id — and **300 chats sharing only 152 distinct `thread_id`s**, so conversation grouping genuinely groups.

### Pre-existing Unicode corruption repaired

`CopilotResourceGenerator` contained `"Weather Forecast - S\uFFFDo Tom\uFFFD"` — "São Tomé" stored as two **U+FFFD replacement characters** from a lossy save, with the file carrying **no UTF-8 BOM**. That is precisely how non-ASCII gets lost in a .NET Framework project. Restored, and the file now has a BOM.

### The from-stable upgrade rehearsal now proves the target schema

`UpgradeFromStableTests` built a database at stable, upgraded it and checked data survival — but never asserted **which** migration it landed on, and checked only three of the new tables. It would have passed if the upgrade stopped short.

It now asserts the upgrade reaches the **newest migration in the assembly** (read from the migrator, not hard-coded, so it cannot go stale), that **all 18 tables** this release adds exist, and that **all 8 columns** added to existing tables landed — a migration that creates its tables but skips an `AddColumn` otherwise leaves the importer writing to a column that is not there.

Both upgrade tests pass against the current migration chain, from stable `202608131055001_IndexReportDateQueries` through to `202608200600001_AddCopilotInteractionHistory`.