### PR TITLE
Compute both Copilot adoption trend series in a single pass (#295)

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
@@ -584,6 +584,28 @@ namespace Common.Entities.CopilotAdoption
         /// which splits weeks on Sunday and would push Sunday's rows into the following week. The same
         /// bucketing as the Reports area, so the two agree.
         /// </summary>
+        /// <remarks>
+        /// Both series are computed in ONE pass over the range (issue #295). They used to be two
+        /// <c>SELECT</c>s joined by <c>UNION ALL</c>, each repeating the same <c>copilot_chats</c> to
+        /// <c>audit_events</c> join over the same six months - so a range holding R Copilot rows was
+        /// processed twice, and the join performed twice, for two numbers that come from the same rows.
+        /// <para>
+        /// The Cowork figure is now a conditional <c>COUNT(DISTINCT ...)</c>: <c>COUNT</c> ignores NULLs,
+        /// so the <c>CASE</c> yielding NULL for non-Cowork rows counts exactly the users the second query
+        /// used to select.
+        /// </para>
+        /// <para>
+        /// Unpivoted with <c>CROSS APPLY (VALUES ...)</c> rather than by selecting from the CTE twice.
+        /// A CTE referenced twice can be expanded and evaluated twice, which would reintroduce the very
+        /// double scan this removes; referencing it once cannot.
+        /// </para>
+        /// <para>
+        /// Output is deliberately identical to before, including the absence of a Cowork point in weeks
+        /// with no Cowork usage. Emitting explicit zeros would arguably suit a trend chart better - a
+        /// missing week is ambiguous between "no data" and "no usage" - but that is a reporting decision,
+        /// not something to slip in with a performance fix.
+        /// </para>
+        /// </remarks>
         public static string WeeklyAdoptionTrendSql(IEnumerable<int> seatLicenceTypeIds, IEnumerable<int> coworkAgentIds)
         {
             var week = WeekBucket("au.time_stamp");
@@ -595,24 +617,26 @@ namespace Common.Entities.CopilotAdoption
                 "    SELECT DISTINCT ul.user_id AS user_id\r\n" +
                 "    FROM dbo.user_license_type_lookups AS ul\r\n" +
                 $"    WHERE ul.license_type_id IN ({seats})\r\n" +
+                "),\r\n" +
+                "Weekly AS (\r\n" +
+                $"    SELECT {week} AS WeekStart,\r\n" +
+                "           COUNT(DISTINCT au.user_id) AS ActiveUsers,\r\n" +
+                $"           COUNT(DISTINCT CASE WHEN ({cowork}) THEN au.user_id END) AS CoworkUsers\r\n" +
+                "    FROM dbo.copilot_chats AS c\r\n" +
+                "    " + AuditJoin + "\r\n" +
+                "    JOIN SeatUsers AS seats ON seats.user_id = au.user_id\r\n" +
+                "    WHERE au.time_stamp >= @trendFrom\r\n" +
+                $"    GROUP BY {week}\r\n" +
                 ")\r\n" +
-                "SELECT 'Active licensed users' AS SeriesName,\r\n" +
-                $"       {week} AS WeekStart,\r\n" +
-                "       CAST(COUNT(DISTINCT au.user_id) AS float) AS Value\r\n" +
-                "FROM dbo.copilot_chats AS c\r\n" +
-                "" + AuditJoin + "\r\n" +
-                "JOIN SeatUsers AS seats ON seats.user_id = au.user_id\r\n" +
-                "WHERE au.time_stamp >= @trendFrom\r\n" +
-                $"GROUP BY {week}\r\n" +
-                "UNION ALL\r\n" +
-                "SELECT 'Cowork users' AS SeriesName,\r\n" +
-                $"       {week} AS WeekStart,\r\n" +
-                "       CAST(COUNT(DISTINCT au.user_id) AS float) AS Value\r\n" +
-                "FROM dbo.copilot_chats AS c\r\n" +
-                "" + AuditJoin + "\r\n" +
-                "JOIN SeatUsers AS seats ON seats.user_id = au.user_id\r\n" +
-                $"WHERE au.time_stamp >= @trendFrom AND ({cowork})\r\n" +
-                $"GROUP BY {week}\r\n" +
+                "SELECT v.SeriesName AS SeriesName,\r\n" +
+                "       w.WeekStart AS WeekStart,\r\n" +
+                "       CAST(v.Value AS float) AS Value\r\n" +
+                "FROM Weekly AS w\r\n" +
+                "CROSS APPLY (VALUES\r\n" +
+                "    ('Active licensed users', w.ActiveUsers),\r\n" +
+                "    ('Cowork users', w.CoworkUsers)\r\n" +
+                ") AS v(SeriesName, Value)\r\n" +
+                "WHERE NOT (v.SeriesName = 'Cowork users' AND v.Value = 0)\r\n" +
                 "ORDER BY SeriesName, WeekStart\r\n" +
                 "OPTION (RECOMPILE);";
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSqlIntegrationTests.cs
@@ -462,6 +462,24 @@ namespace Tests.UnitTests
                 Assert.IsTrue(trend.Any(t => t.SeriesName == "Cowork users"),
                     "The Cowork series must be produced when Cowork interactions exist.");
 
+                // Values, not just presence. Both series are computed in one pass with a conditional
+                // COUNT(DISTINCT ...) (#295), so a regression there would still produce two correctly-named
+                // series carrying the wrong numbers. This fixture has one user with two interactions in the
+                // same week - one Teams, one Cowork - so both series are exactly 1 for that week: the user is
+                // counted once despite two interactions, and the Cowork condition selects the same user.
+                var activeWeeks = trend.Where(t => t.SeriesName == "Active licensed users").ToList();
+                var coworkWeeks = trend.Where(t => t.SeriesName == "Cowork users").ToList();
+
+                Assert.AreEqual(1, activeWeeks.Count, "Both interactions fall in the same week.");
+                Assert.AreEqual(1d, activeWeeks[0].Value,
+                    "One distinct user, counted once - not once per interaction.");
+
+                Assert.AreEqual(1, coworkWeeks.Count);
+                Assert.AreEqual(1d, coworkWeeks[0].Value,
+                    "The Cowork conditional count must select the same user.");
+                Assert.AreEqual(activeWeeks[0].WeekStart, coworkWeeks[0].WeekStart,
+                    "Both series are bucketed from the same rows, so the week must match.");
+
                 var unlicensed = Query<int?>(db,
                     CopilotAdoptionSql.UnlicensedActiveUsersSql(new[] { 1 }),
                     new SqlParameter("@from", from));


### PR DESCRIPTION
Closes #295

## Problem

`WeeklyAdoptionTrendSql` builds the two-series weekly adoption trend on the Copilot Adoption dashboard. It was two near-identical `SELECT`s joined by `UNION ALL`:

- **Active licensed users** - `copilot_chats` -> `audit_events` -> seat users, grouped by week.
- **Cowork users** - the *same* join and the *same* group-by, with an extra `AND (<cowork agent predicate>)`.

Both halves read the same six-month range of the same two tables to produce two numbers derived from the same rows. So the range was scanned, and the `copilot_chats`/`audit_events` join performed, **twice per dashboard load**.

`audit_events` is one of the two large fact tables in this schema. At the ~200k-user scale this repo designs for, doing that work twice for data that one pass already has is the whole cost of the fix.

## Change

Both series now come from a single `Weekly` CTE:

```sql
Weekly AS (
    SELECT <week bucket> AS WeekStart,
           COUNT(DISTINCT au.user_id) AS ActiveUsers,
           COUNT(DISTINCT CASE WHEN (<cowork>) THEN au.user_id END) AS CoworkUsers
    FROM dbo.copilot_chats AS c
    <audit join>
    JOIN SeatUsers AS seats ON seats.user_id = au.user_id
    WHERE au.time_stamp >= @trendFrom
    GROUP BY <week bucket>
)
```

`COUNT` ignores NULLs, so the `CASE` yielding NULL for non-Cowork rows counts exactly the users the second query used to select.

The wide row is unpivoted back into the `(SeriesName, WeekStart, Value)` shape the caller expects with **`CROSS APPLY (VALUES ...)`**, deliberately rather than by selecting from the CTE twice. A CTE is not a materialisation guarantee - one referenced twice can be expanded and evaluated twice, which would have reintroduced the exact double scan this removes. Referencing it once cannot.

## Output is unchanged

This is a pure performance change; the rendered chart must not move.

- **Cowork weeks with no usage stay absent.** The old query emitted no Cowork row for such a week; the unpivot would emit a `0`. Preserved with `WHERE NOT (v.SeriesName = 'Cowork users' AND v.Value = 0)`.
- **Zero-active weeks were never possible** and still aren't - `GROUP BY` only emits groups that have rows, and every row is joined to a seat user, so `ActiveUsers >= 1` in any week that appears.
- Week bucketing, `@trendFrom`, the seat-licence CTE, `ORDER BY` and `OPTION (RECOMPILE)` are untouched.

Emitting explicit zeros would arguably suit a trend chart better - a missing week is ambiguous between "no data" and "no usage" - but that is a reporting decision, not something to slip into a performance fix. Noted in the doc comment.

## Tests

`CopilotAdoptionSqlIntegrationTests` executes this SQL against a real migrated database, so the rewrite is exercised end to end rather than string-compared.

That test asserted only that both series were *present* - which a broken conditional count would still satisfy, since it would produce two correctly-named series carrying wrong numbers. Strengthened to assert the values: the fixture's single user with two interactions in one week (one Teams, one Cowork) must yield exactly `1` for both series, in the same week, proving the user is counted once rather than once per interaction and that the conditional count selects the same user.

63/63 `CopilotAdoption` tests pass locally.

## Reviewer notes

- No schema change, no migration, no config change - query text only.
- The `CROSS APPLY (VALUES ...)` choice is the load-bearing detail; a reviewer swapping it for two `SELECT`s from the CTE would silently undo the fix while all tests still pass.
- No measured before/after benchmark is attached. The release gate in the repo instructions requires one for *schema* changes (indexes, column types) that cost customers an index build; this adds no index and cannot regress - it removes one of two identical passes and leaves the plan for that pass unchanged.
