### PR TITLE
Add a retention bound to the Copilot usage-report tables (#286)

### DIFF
--- a/src/Clean Data By User StoredProc.sql
+++ b/src/Clean Data By User StoredProc.sql
@@ -182,6 +182,15 @@ BEGIN
     IF OBJECT_ID('dbo.copilot_interaction_user_watermarks', 'U') IS NOT NULL
         DELETE FROM copilot_interaction_user_watermarks WHERE user_id = @UserId;
 
+    -- Copilot usage reports (optional import) - issue #286.
+    --
+    -- Microsoft's own per-user Copilot figures. Deleted explicitly for the same reason as the
+    -- interaction history above: this is per-user usage data, so a request to purge a user has to take
+    -- it with them. copilot_user_count_log is deliberately NOT touched - it is a tenant-level count per
+    -- app and date with no user dimension, so there is nothing user-identifying in it to remove.
+    IF OBJECT_ID('dbo.copilot_usage_user_activity_log', 'U') IS NOT NULL
+        DELETE FROM copilot_usage_user_activity_log WHERE user_id = @UserId;
+
     -- An extracted key phrase can amount to a whole short prompt, so purging a user must not leave their
     -- phrases behind. Only phrases now referenced by nothing are removed - the keywords table is shared
     -- with Teams channel analysis, so both referencing tables are checked.

--- a/src/Clean Old Data Data.sql
+++ b/src/Clean Old Data Data.sql
@@ -126,6 +126,28 @@ if OBJECT_ID('dbo.copilot_interaction_keywords', 'U') is not null
 -- each user's whole backfill window - one Graph call per user, which is the exact cost this feature
 -- is designed to avoid.
 
+
+-- Copilot usage reports (optional import) - issue #286.
+--
+-- These are Microsoft's own per-user Copilot figures, one row per (date, user, report period). The
+-- import refreshes them daily and keeps every historical snapshot, so the table grows by roughly
+-- (licensed users x report periods) rows per day forever. On a large tenant that is the
+-- fastest-growing table this feature adds, and it had no retention bound at all - which is how the
+-- deprecated Teams add-on tables got so expensive.
+--
+-- Bounded on [date] (the report's own snapshot date), matching how every other daily log here is aged.
+-- Guarded with OBJECT_ID because the tables only exist once the AddCopilotUsageReports migration has
+-- run, and this script is also used against older databases.
+if OBJECT_ID('dbo.copilot_usage_user_activity_log', 'U') is not null
+	delete from copilot_usage_user_activity_log where [date] < @archiveDateMax
+
+if OBJECT_ID('dbo.copilot_user_count_log', 'U') is not null
+	delete from copilot_user_count_log where report_date < @archiveDateMax
+
+-- The per-run diagnostics log, aged like the interaction-history one above.
+if OBJECT_ID('dbo.copilot_usage_report_import_log', 'U') is not null
+	delete from copilot_usage_report_import_log where imported_utc < @archiveDateMax
+
 -- commit/rollback
 --rollback transaction archive
 


### PR DESCRIPTION
Closes #286

## Problem

The Copilot usage-report import writes Microsoft's own per-user Copilot figures into three tables. None of them were referenced by either retention script, so **they grew without bound**:

| Table | Grain | Growth |
|---|---|---|
| `copilot_usage_user_activity_log` | one row per (date, user, report period) | licensed users x report periods, **per day, forever** |
| `copilot_user_count_log` | tenant-level count per app and date | small, but unbounded |
| `copilot_usage_report_import_log` | one row per import run | small, but unbounded |

The import refreshes daily and keeps every historical snapshot, so on a large tenant `copilot_usage_user_activity_log` is the fastest-growing table this feature adds. This is precisely how the deprecated Teams add-on tables became expensive - noted in the comment so the next table doesn't repeat it.

Two separate gaps, because this repo has two independent retention paths:

- **`Clean Old Data Data.sql`** - the age-based purge every other daily log is already bounded by.
- **`Clean Data By User StoredProc.sql`** - the per-user purge used to honour a delete request for an individual.

The second is the more serious of the two: this is **per-user usage data**, so a request to purge a user was leaving their Copilot usage rows behind.

## Change

**Age-based purge** - all three tables bounded by `@archiveDateMax`, each on its own date column:

- `copilot_usage_user_activity_log` -> `[date]` (the report's own snapshot date)
- `copilot_user_count_log` -> `report_date`
- `copilot_usage_report_import_log` -> `imported_utc`

Column names differ per table and are easy to get wrong; each was checked against the migration rather than assumed.

**Per-user purge** - `copilot_usage_user_activity_log` deleted by `user_id`, alongside the interaction-history tables already handled there.

`copilot_user_count_log` is **deliberately not** in the per-user script: it is a tenant-level count per app and date with no user dimension, so there is nothing user-identifying to remove. Stated in the comment so it doesn't look like an oversight to the next reader.

## Safety

Every statement is wrapped in `IF OBJECT_ID('dbo.<table>', 'U') IS NOT NULL`. These tables only exist once the `AddCopilotUsageReports` migration has run, and both scripts are also run against older databases that predate it - matching the existing guarded deletes for the interaction-history tables.

## Verification

All four statements were executed against a migrated database and completed successfully, confirming every table and column name resolves. No schema change, no migration, no config change - these are operator-run maintenance scripts.

## Admin impact

Anyone already running the Copilot usage-report import has been accumulating unbounded rows. After this, the next run of the age-based purge will remove everything older than the retention window, which **may delete a large number of rows on its first run** - worth doing in a maintenance window on a big tenant. Called out in the release notes.
