### PR TITLE
Stop GitHub API rate limiting breaking CI and real installs (#302)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,3 +183,8 @@ jobs:
           vstestLocation: C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\Extensions\\TestPlatform\\vstest.console.exe
         env:
           Configuration: ${{ matrix.configuration }}
+          # DownloadLatestReleaseZipsHaveContent calls the GitHub REST API. Anonymous requests are limited
+          # to 60/hour per IP and Actions runners share outbound addresses, so the budget is often already
+          # spent and the API answers 403 - failing the required check for reasons unrelated to the change.
+          # The built-in token raises it to 5,000/hour. Read-only public metadata; no extra permission needed.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/SoftwarePackageDownloadTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/SoftwarePackageDownloadTasks.cs
@@ -27,7 +27,66 @@ namespace App.ControlPanel.Engine.InstallerTasks
             var client = new HttpClient();
             client.DefaultRequestHeaders.Add("User-Agent", "AnalyticsEngine-Installer");
             client.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+
+            // Anonymous GitHub API requests are limited to 60 per hour PER IP. That is shared by everyone
+            // behind the same outbound address - a CI runner pool, or an entire office behind one NAT - so
+            // the budget is routinely already spent by the time we ask, and the API answers 403.
+            // A token raises the limit to 5,000/hour for whoever supplies one. The installer normally has
+            // none (and must keep working without one), but CI does.
+            var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN")
+                ?? Environment.GetEnvironmentVariable("GH_TOKEN");
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                client.DefaultRequestHeaders.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.Trim());
+            }
+
             return client;
+        }
+
+        /// <summary>
+        /// Turns a failed GitHub API response into something an admin can act on.
+        /// </summary>
+        /// <remarks>
+        /// A rate-limited response is a bare <c>403 Forbidden</c>, which reads like a permissions problem and
+        /// sends people looking for a credential that was never needed. GitHub distinguishes the two in the
+        /// headers: on a rate limit <c>x-ratelimit-remaining</c> is 0 and <c>x-ratelimit-reset</c> carries the
+        /// unix time it frees up. Say which one it is, and when it will work again.
+        /// </remarks>
+        private static string DescribeFailedRelease(HttpResponseMessage response, string apiUrl)
+        {
+            var remaining = FirstHeader(response, "x-ratelimit-remaining");
+            var isRateLimited = (int)response.StatusCode == 429
+                || (response.StatusCode == System.Net.HttpStatusCode.Forbidden && remaining == "0");
+
+            if (!isRateLimited)
+            {
+                return $"Failed to fetch latest release from GitHub ({response.StatusCode}). URL: {apiUrl}";
+            }
+
+            var resetText = "shortly";
+            if (long.TryParse(FirstHeader(response, "x-ratelimit-reset"), out var resetUnix))
+            {
+                resetText = new DateTimeOffset(DateTimeOffset.FromUnixTimeSeconds(resetUnix).UtcDateTime)
+                    .ToString("u") + " (UTC)";
+            }
+
+            return "GitHub rejected the request because its API rate limit has been reached, not because of a "
+                + $"permissions problem. The limit resets at {resetText}. "
+                + "Anonymous requests are limited to 60 per hour per public IP address, which is shared by "
+                + "everyone on your network, so a busy office or VPN can exhaust it. "
+                + "Either wait for the reset and retry, set a GITHUB_TOKEN environment variable to a token "
+                + "with public read access, or download the release ZIPs manually and install from local "
+                + $"files instead. URL: {apiUrl}";
+        }
+
+        private static string FirstHeader(HttpResponseMessage response, string name)
+        {
+            if (response.Headers.TryGetValues(name, out var values))
+            {
+                return values.FirstOrDefault();
+            }
+            return null;
         }
 
         public override async Task<LocalStorageInstallSourceInfo> ExecuteTaskReturnResult(object contextArg)
@@ -41,7 +100,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
             var response = await _httpClient.GetAsync(apiUrl);
             if (!response.IsSuccessStatusCode)
             {
-                throw new UnexpectedInstallException($"Failed to fetch latest release from GitHub ({response.StatusCode}). URL: {apiUrl}");
+                throw new UnexpectedInstallException(DescribeFailedRelease(response, apiUrl));
             }
 
             var json = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
Closes #302

## Problem

`SoftwarePackageDownloadTasks` asks the GitHub REST API for the latest release so the installer can download the deployment ZIPs. It was an anonymous request.

**Anonymous GitHub API requests are limited to 60 per hour, per public IP address** - and that budget is shared by everyone behind the same outbound address. Two distinct victims:

1. **CI.** `DownloadLatestReleaseZipsHaveContent` runs on GitHub-hosted runners, which share a pool of outbound addresses with every other Actions customer. The 60/hour is frequently already spent before our job starts, so the required check fails for reasons that have nothing to do with the change under test. This flake was diagnosed off two real CI failures in this release.
2. **Real installs.** An admin running the installer from a corporate network sits behind a NAT shared with the whole office or VPN. Same exhaustion, but during a customer's deployment.

The failure mode made it much worse: a rate-limited GitHub response is a bare **`403 Forbidden`**. That reads like a *permissions* problem, so an admin goes looking for a credential the installer never needed and does not have - exactly the class of misleading error this project's release notes are supposed to explain away.

## Change

**1. Send a token when one is available.** `CreateHttpClient()` now reads `GITHUB_TOKEN`, falling back to `GH_TOKEN`, and sends it as a bearer token. A token raises the limit to 5,000/hour.

The installer normally has neither variable set and **must keep working without one** - this is public release metadata, so no credential is required. The token is strictly an optional escape hatch, not a new prerequisite. Nothing to configure for existing installs.

**2. Tell the admin which failure it actually is.** New `DescribeFailedRelease()` distinguishes a rate limit from a real permissions error using the headers GitHub already sends: a rate-limited reply has `x-ratelimit-remaining: 0` (or HTTP 429), and `x-ratelimit-reset` carries the unix time the budget frees up.

On a rate limit the admin now gets: that it is **not** a permissions problem, the **exact UTC time it will work again**, why a shared IP causes it, and three ways forward - wait and retry, set `GITHUB_TOKEN`, or download the ZIPs manually and install from local files. Any other failure keeps the original status-code message.

**3. Give CI the token it already has.** `tests.yml` passes the built-in `secrets.GITHUB_TOKEN` to the test step. This is a read-only call for public release metadata, so it needs **no additional workflow permission** - the default token is sufficient.

## Reviewer notes

- No schema change, no migration, no config-schema change, no `CONFIG_VERSION` bump.
- Behaviour is unchanged on the success path and when no token is present.
- The token is read from the environment only - never persisted, never logged, and not added to the installer's saved config.
- Should stop `DownloadLatestReleaseZipsHaveContent` flaking on unrelated PRs once merged.
