### PR TITLE
Copilot interaction history: close the wildcard and group-discovery holes in the call brake (#297)

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Config/UserGroupsFilterModel.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/UserGroupsFilterModel.cs
@@ -29,6 +29,18 @@ namespace Common.Entities.Config
         }
 
         /// <summary>
+        /// True when the filter would match every group, i.e. at least one pattern is nothing but
+        /// wildcards ("*", "**"). Such a filter is not a narrowing at all.
+        /// </summary>
+        /// <remarks>
+        /// Worth asking separately because "match everything" and "match these groups" have very
+        /// different costs for a caller that resolves patterns against a directory. Expanding '*' means
+        /// enumerating every group and every group's membership only to conclude "everyone", which a
+        /// caller can nearly always answer far more cheaply by not filtering at all (issue #297).
+        /// </remarks>
+        public bool MatchesEverything => Patterns.Any(p => p.Trim('*').Length == 0);
+
+        /// <summary>
         /// Checks if the given group name matches any filter pattern (supports * wildcard).
         /// </summary>
         public bool Matches(string groupName)

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotInteractionHistoryTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotInteractionHistoryTests.cs
@@ -470,8 +470,8 @@ namespace Tests.UnitTests
             var members = await resolver.GetMemberUpnsAsync(filter);
 
             Assert.AreEqual(1, resolver.CallCount, "Scope must be resolved with a single group-side lookup.");
-            Assert.AreEqual(2, members.Count);
-            Assert.IsTrue(members.Contains("PILOT1@CONTOSO.COM"),
+            Assert.AreEqual(2, members.MemberUpns.Count);
+            Assert.IsTrue(members.MemberUpns.Contains("PILOT1@CONTOSO.COM"),
                 "Membership matching must be case-insensitive to line up with SQL Server's collation.");
         }
 
@@ -483,8 +483,50 @@ namespace Tests.UnitTests
                 AnalyticsLogger.ConsoleOnlyTracer());
 
             // No filter means no pilot group; it must never be read as "everyone".
-            var members = await resolver.GetMemberUpnsAsync(new UserGroupsFilterModel(string.Empty));
-            Assert.AreEqual(0, members.Count);
+            var resolution = await resolver.GetMemberUpnsAsync(new UserGroupsFilterModel(string.Empty));
+            Assert.AreEqual(0, resolution.MemberUpns.Count);
+            Assert.IsFalse(resolution.IsIncomplete, "An empty filter is a complete answer, not a failure.");
+        }
+
+        [TestMethod]
+        public async Task PilotGroupResolver_RefusesAMatchAllFilterWithoutCallingGraph()
+        {
+            // '*' matches every group. Expanding it would page the whole directory and every group's
+            // membership only to conclude "everyone" - millions of calls on a large tenant (issue #297).
+            // The resolver must refuse it outright rather than start enumerating. No HTTP handler is
+            // usable here, so any Graph call at all would throw rather than return.
+            var resolver = new GraphPilotGroupMemberResolver(
+                new ManualGraphCallClient(new System.Net.Http.HttpClientHandler(), AnalyticsLogger.ConsoleOnlyTracer()),
+                AnalyticsLogger.ConsoleOnlyTracer());
+
+            foreach (var matchAll in new[] { "*", "**", " * " })
+            {
+                var resolution = await resolver.GetMemberUpnsAsync(new UserGroupsFilterModel(matchAll));
+
+                Assert.AreEqual(0, resolution.MemberUpns.Count, $"'{matchAll}' must not resolve to a scope.");
+                Assert.IsTrue(resolution.IsIncomplete,
+                    $"'{matchAll}' must be reported as unusable, not as a legitimate empty pilot group.");
+                StringAssert.Contains(resolution.IncompleteReason, "every group",
+                    "The reason must tell the admin why their filter was refused.");
+            }
+        }
+
+        [TestMethod]
+        public void MatchesEverything_OnlyTrueForPurelyWildcardPatterns()
+        {
+            // The distinction that decides whether the importer enumerates the directory, so it is worth
+            // pinning down. A '*' anywhere else is a genuine narrowing and must still be honoured.
+            Assert.IsTrue(new UserGroupsFilterModel("*").MatchesEverything);
+            Assert.IsTrue(new UserGroupsFilterModel("**").MatchesEverything);
+            Assert.IsTrue(new UserGroupsFilterModel("Copilot Pilot;*").MatchesEverything,
+                "Patterns are OR'd, so one match-all pattern makes the whole filter match everything.");
+
+            Assert.IsFalse(new UserGroupsFilterModel("Copilot*").MatchesEverything);
+            Assert.IsFalse(new UserGroupsFilterModel("*Pilot").MatchesEverything);
+            Assert.IsFalse(new UserGroupsFilterModel("*Pilot*").MatchesEverything);
+            Assert.IsFalse(new UserGroupsFilterModel("Copilot Pilot").MatchesEverything);
+            Assert.IsFalse(new UserGroupsFilterModel(string.Empty).MatchesEverything,
+                "No filter is 'unscoped', which the importer handles separately - not 'matches everything'.");
         }
 
         #endregion
@@ -595,10 +637,13 @@ namespace Tests.UnitTests
 
             public int CallCount { get; private set; }
 
-            public Task<HashSet<string>> GetMemberUpnsAsync(UserGroupsFilterModel filter)
+            /// <summary>Set to make the fake report a truncated / failed scope resolution.</summary>
+            public string IncompleteReason { get; set; }
+
+            public Task<PilotGroupResolution> GetMemberUpnsAsync(UserGroupsFilterModel filter)
             {
                 CallCount++;
-                return Task.FromResult(_members);
+                return Task.FromResult(new PilotGroupResolution(_members, IncompleteReason));
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
@@ -131,7 +131,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
 
                 if (runLog.UsersInScope == 0)
                 {
-                    if (_userGroupsFilter.Patterns.Count > 0)
+                    if (!string.IsNullOrEmpty(runLog.Error))
+                    {
+                        // Already reported as a failure by the scope resolver - don't follow it with a
+                        // reassuring "nothing to do", which is what made this case easy to miss.
+                    }
+                    else if (_userGroupsFilter.Patterns.Count > 0)
                     {
                         _logger.LogWarning(
                             $"No users matched the UserGroupsFilter ('{_settings.UserGroupsFilter}') for the Copilot " +
@@ -214,7 +219,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
                 : AppConfig.DefaultCopilotInteractionHistoryMaxUsersPerCycle;
 
             if (_userGroupsFilter.Patterns.Count > 0)
-                return await SelectDueUsersInGroupsAsync(runLog, now, cap);
+            {
+                // A filter of '*' matches every group, so it narrows nothing - but resolving it the group-first
+                // way would enumerate the entire directory and every group's membership just to arrive back at
+                // "everyone". Take the unnarrowed path instead, which reaches the same scope in one capped SQL
+                // query (issue #297).
+                if (_userGroupsFilter.MatchesEverything)
+                {
+                    _logger.LogWarning(
+                        $"Copilot interaction history: UserGroupsFilter ('{_settings.UserGroupsFilter}') matches every " +
+                        "group, so it is not narrowing anything. Treating this cycle as unscoped - every enabled user " +
+                        "is eligible, capped per cycle as usual. Name the pilot group(s) to actually narrow the import, " +
+                        "or clear the filter to make the intent explicit.");
+                }
+                else
+                {
+                    return await SelectDueUsersInGroupsAsync(runLog, now, cap);
+                }
+            }
 
             return await SelectDueUsersAcrossDirectoryAsync(runLog, now, cap);
         }
@@ -239,7 +261,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
                 return new List<UserImportState>();
             }
 
-            var memberUpns = await _pilotGroupResolver.GetMemberUpnsAsync(_userGroupsFilter);
+            var resolution = await _pilotGroupResolver.GetMemberUpnsAsync(_userGroupsFilter);
+
+            // An incomplete resolution is the import failing to do its job, not a quiet no-op. Recorded on
+            // the run log so it surfaces on the health page rather than only in a log line nobody reads
+            // (issue #297) - a pilot group sitting past the discovery cap used to look exactly like an
+            // idle, healthy import.
+            if (resolution.IsIncomplete)
+            {
+                var message = "Copilot interaction history: the pilot scope could not be resolved in full - "
+                    + resolution.IncompleteReason;
+                _logger.LogError(message);
+                runLog.Error = Truncate(message, 1000);
+            }
+
+            var memberUpns = resolution.MemberUpns;
             if (memberUpns.Count == 0)
             {
                 runLog.UsersInScope = 0;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/GraphPilotGroupMemberResolver.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/GraphPilotGroupMemberResolver.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHistory
@@ -13,16 +14,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>Why this exists rather than reusing <see cref="User.UserGroupsCache"/>.</b> That cache answers
+    /// <b>Why this exists rather than reusing the per-user groups cache.</b> That cache answers
     /// "which groups is this user in?", one Graph call per user. Asking it about every user in the database
     /// to find a pilot group would cost one call per tenant user - at the ~200k-user design target that is
     /// 200,000 Graph calls spent *deciding who to import*, before a single interaction is read. It would
     /// defeat the entire point of scoping the feature.
     /// </para>
     /// <para>
-    /// Going group-first inverts the cost: enumerate groups once, keep the ones whose display name matches
-    /// the filter, then page their members. That is O(groups + pilot members) instead of O(tenant users),
-    /// so a 50-person pilot costs roughly a handful of calls no matter how large the tenant is.
+    /// Going group-first inverts the cost: find the matching groups, then page their members. That is
+    /// O(matched groups + pilot members) instead of O(tenant users), so a 50-person pilot costs a handful
+    /// of calls no matter how large the tenant is.
     /// </para>
     /// <para>
     /// It also fixes a correctness problem: the per-user cache reads only the first page of a user's
@@ -33,23 +34,59 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
     public interface IPilotGroupMemberResolver
     {
         /// <summary>
-        /// Member UPNs of every group whose display name matches <paramref name="filter"/>. Returns an empty
-        /// set when nothing matches. Comparison is case-insensitive so it lines up with SQL Server's default
-        /// collation when the results are matched against the users table.
+        /// Member UPNs of every group matching <paramref name="filter"/>, plus whether the answer is
+        /// complete. Comparison is case-insensitive so it lines up with SQL Server's default collation
+        /// when the results are matched against the users table.
         /// </summary>
-        Task<HashSet<string>> GetMemberUpnsAsync(UserGroupsFilterModel filter);
+        Task<PilotGroupResolution> GetMemberUpnsAsync(UserGroupsFilterModel filter);
     }
 
     /// <summary>Microsoft Graph implementation of <see cref="IPilotGroupMemberResolver"/>.</summary>
+    /// <remarks>
+    /// <para>
+    /// Patterns are resolved by the cheapest route that can answer them (issue #297):
+    /// </para>
+    /// <list type="number">
+    /// <item><description>
+    /// A pattern that is a GUID is a group <b>object id</b> - fetched directly, one call, no ambiguity.
+    /// This is the form to prefer: display names are not unique in Entra ID and can be renamed.
+    /// </description></item>
+    /// <item><description>
+    /// A pattern with no <c>*</c> is an <b>exact display name</b> - resolved server-side with
+    /// <c>$filter=displayName eq '...'</c>, one call, regardless of directory size.
+    /// </description></item>
+    /// <item><description>
+    /// Only a pattern that genuinely contains a <c>*</c> needs the directory enumerating, because Graph
+    /// cannot express the product's wildcard syntax as a server-side filter.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// That ordering matters at scale. Enumeration was previously the *only* path, so an exactly-named
+    /// pilot group on a 200k-user tenant paged the entire group list to find one group - and if the
+    /// directory held more groups than the page cap allowed, the group could sit past the cap and never
+    /// be found at all, which surfaced as a silent no-op.
+    /// </para>
+    /// <para>
+    /// Every call, of every kind, is drawn from one shared budget. Group discovery and member paging used
+    /// to be capped separately, so the caps multiplied: ~50 group pages x ~999 groups x 50 member pages
+    /// each is a worst case in the millions of calls. A single total budget cannot be multiplied out.
+    /// </para>
+    /// </remarks>
     public class GraphPilotGroupMemberResolver : IPilotGroupMemberResolver
     {
         /// <summary>Graph's maximum page size for directory objects.</summary>
         private const int GraphPageSize = 999;
 
         /// <summary>
-        /// Safety cap on group pages. Filtering happens client-side on display name (so that the '*'
-        /// wildcards the rest of the product uses keep working), which means the group list is enumerated;
-        /// this bounds that on a very large directory.
+        /// Total Graph calls this resolver may make in one cycle, shared across group discovery and member
+        /// paging. One budget rather than per-stage caps, so no combination of them can multiply out.
+        /// Generous for any realistic pilot: an exactly-named group of 5,000 members costs about 7 calls.
+        /// </summary>
+        private const int MaxTotalGraphCalls = 200;
+
+        /// <summary>
+        /// Safety cap on group pages when a wildcard pattern forces enumeration. Only reached by wildcards;
+        /// exact names and object ids never enumerate.
         /// </summary>
         private const int MaxGroupPages = 50;
 
@@ -65,36 +102,170 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             _logger = logger;
         }
 
-        public async Task<HashSet<string>> GetMemberUpnsAsync(UserGroupsFilterModel filter)
+        public async Task<PilotGroupResolution> GetMemberUpnsAsync(UserGroupsFilterModel filter)
         {
             var upns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             if (filter == null || filter.Patterns.Count == 0)
-                return upns;
+                return new PilotGroupResolution(upns);
 
-            var groups = await LoadMatchingGroupsAsync(filter);
+            // A match-all filter ('*') is not a narrowing, and the caller is expected to have taken the
+            // unnarrowed path instead of paying for a directory enumeration that concludes "everyone".
+            // Refused rather than honoured so it can never become an expensive silent default.
+            if (filter.MatchesEverything)
+            {
+                return new PilotGroupResolution(upns,
+                    "UserGroupsFilter matches every group ('*'), which is not a pilot scope. Remove the filter " +
+                    "to import across the directory, or name the pilot group(s).");
+            }
+
+            var budget = new CallBudget(MaxTotalGraphCalls);
+            var groups = await LoadMatchingGroupsAsync(filter, budget);
+
             if (groups.Count == 0)
             {
+                if (budget.Exhausted)
+                {
+                    return new PilotGroupResolution(upns, budget.Reason);
+                }
+
                 _logger.LogWarning(
                     $"Copilot interaction history: no Entra ID group matched UserGroupsFilter " +
                     $"('{string.Join(";", filter.Patterns)}'). The filter matches group *display names* and " +
-                    "supports '*' wildcards.");
-                return upns;
+                    "supports '*' wildcards; a group object id can be used instead and is matched exactly.");
+                return new PilotGroupResolution(upns);
             }
 
             foreach (var group in groups)
             {
+                if (budget.Exhausted)
+                    break;
+
                 var before = upns.Count;
-                await AddGroupMembersAsync(group, upns);
+                await AddGroupMembersAsync(group, upns, budget);
                 _logger.LogInformation(
                     $"Copilot interaction history: group '{group.DisplayName}' contributed {upns.Count - before} member(s) to the pilot scope.");
             }
 
-            return upns;
+            return new PilotGroupResolution(upns, budget.Reason);
         }
 
-        private async Task<List<GraphGroup>> LoadMatchingGroupsAsync(UserGroupsFilterModel filter)
+        private async Task<List<GraphGroup>> LoadMatchingGroupsAsync(UserGroupsFilterModel filter, CallBudget budget)
+        {
+            // Keyed by object id: the same group can be named by an id and by a display name, and two
+            // wildcard patterns can both match it.
+            var matched = new Dictionary<string, GraphGroup>(StringComparer.OrdinalIgnoreCase);
+            var wildcardPatterns = new List<string>();
+
+            foreach (var pattern in filter.Patterns)
+            {
+                if (budget.Exhausted)
+                    return matched.Values.ToList();
+
+                if (pattern.Contains("*"))
+                {
+                    wildcardPatterns.Add(pattern);
+                }
+                else if (Guid.TryParse(pattern, out var groupId))
+                {
+                    var group = await LoadGroupByIdAsync(groupId, budget);
+                    if (group != null)
+                        matched[group.Id] = group;
+                }
+                else
+                {
+                    foreach (var group in await LoadGroupsByExactNameAsync(pattern, budget))
+                        matched[group.Id] = group;
+                }
+            }
+
+            if (wildcardPatterns.Count > 0 && !budget.Exhausted)
+            {
+                foreach (var group in await EnumerateGroupsAsync(wildcardPatterns, budget))
+                    matched[group.Id] = group;
+            }
+
+            return matched.Values.ToList();
+        }
+
+        /// <summary>Direct lookup by object id - one call, exact, and immune to a group being renamed.</summary>
+        private async Task<GraphGroup> LoadGroupByIdAsync(Guid groupId, CallBudget budget)
+        {
+            var url = $"https://graph.microsoft.com/v1.0/groups/{groupId}?$select=id,displayName";
+            try
+            {
+                budget.Spend();
+                var group = await _httpClient.GetAsyncWithThrottleRetries<GraphGroup>(url);
+                if (group == null || string.IsNullOrEmpty(group.Id))
+                {
+                    _logger.LogWarning(
+                        $"Copilot interaction history: no Entra ID group with object id '{groupId}' was found.");
+                    return null;
+                }
+                return group;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    $"Copilot interaction history: could not read the group with object id '{groupId}' " +
+                    $"({ex.GetType().Name}). Check the id is a group, and that the runtime identity can read it.");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Exact display-name lookup, server-side. One call whatever the directory size, so this never
+        /// depends on a group appearing before the enumeration cap.
+        /// </summary>
+        private async Task<List<GraphGroup>> LoadGroupsByExactNameAsync(string displayName, CallBudget budget)
+        {
+            // OData string literals escape a single quote by doubling it. Without this a group named
+            // "Bob's pilot" would produce a malformed filter and a 400.
+            var literal = displayName.Replace("'", "''");
+            var url = "https://graph.microsoft.com/v1.0/groups" +
+                      $"?$filter=displayName eq '{Uri.EscapeDataString(literal)}'" +
+                      $"&$select=id,displayName&$top={GraphPageSize}";
+
+            try
+            {
+                budget.Spend();
+                var page = await _httpClient.GetAsyncWithThrottleRetries<PageableGraphResponse<GraphGroup>>(url);
+                var results = page?.PageResults?.Where(g => !string.IsNullOrEmpty(g.Id)).ToList()
+                    ?? new List<GraphGroup>();
+
+                if (results.Count == 0)
+                {
+                    _logger.LogWarning(
+                        $"Copilot interaction history: no Entra ID group is named '{displayName}'. The match is " +
+                        "on the group's display name and is exact unless the pattern contains '*'.");
+                }
+                else if (results.Count > 1)
+                {
+                    // Display names are not unique in Entra ID. Say so rather than quietly taking them all.
+                    _logger.LogWarning(
+                        $"Copilot interaction history: {results.Count} Entra ID groups are named '{displayName}'. " +
+                        "All of them are being treated as pilot groups - use the group's object id instead to " +
+                        "select exactly one.");
+                }
+
+                return results;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    $"Copilot interaction history: could not look up the group named '{displayName}' " +
+                    $"({ex.GetType().Name}).");
+                return new List<GraphGroup>();
+            }
+        }
+
+        /// <summary>
+        /// The fallback for genuine wildcard patterns: page the directory and match client-side, because
+        /// Graph has no server-side equivalent of the product's '*' syntax.
+        /// </summary>
+        private async Task<List<GraphGroup>> EnumerateGroupsAsync(List<string> wildcardPatterns, CallBudget budget)
         {
             var matched = new List<GraphGroup>();
+            var matcher = new UserGroupsFilterModel(string.Join(";", wildcardPatterns));
             var url = $"https://graph.microsoft.com/v1.0/groups?$select=id,displayName&$top={GraphPageSize}";
             var pages = 0;
 
@@ -102,20 +273,39 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             {
                 if (++pages > MaxGroupPages)
                 {
-                    _logger.LogWarning(
-                        $"Copilot interaction history: stopped enumerating Entra ID groups after {MaxGroupPages} pages. " +
-                        "If the pilot group wasn't found, narrow UserGroupsFilter or raise this limit.");
+                    budget.Stop(
+                        $"group discovery stopped after {MaxGroupPages} pages while expanding the wildcard " +
+                        $"pattern(s) '{string.Join(";", wildcardPatterns)}'. Groups beyond that point were not " +
+                        "considered, so the pilot scope may be incomplete. Name the group exactly, or use its " +
+                        "object id, to resolve it without enumerating the directory.");
                     break;
                 }
 
-                var page = await _httpClient.GetAsyncWithThrottleRetries<PageableGraphResponse<GraphGroup>>(url);
+                if (budget.Exhausted)
+                    break;
+
+                PageableGraphResponse<GraphGroup> page;
+                try
+                {
+                    budget.Spend();
+                    page = await _httpClient.GetAsyncWithThrottleRetries<PageableGraphResponse<GraphGroup>>(url);
+                }
+                catch (Exception ex)
+                {
+                    budget.Stop($"group discovery failed ({ex.GetType().Name}: {ex.Message}).");
+                    break;
+                }
+
                 if (page?.PageResults == null)
                     break;
 
                 foreach (var group in page.PageResults)
                 {
-                    if (!string.IsNullOrEmpty(group.DisplayName) && filter.Matches(group.DisplayName))
+                    if (!string.IsNullOrEmpty(group.Id) && !string.IsNullOrEmpty(group.DisplayName)
+                        && matcher.Matches(group.DisplayName))
+                    {
                         matched.Add(group);
+                    }
                 }
 
                 url = page.OdataNextLink;
@@ -124,7 +314,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             return matched;
         }
 
-        private async Task AddGroupMembersAsync(GraphGroup group, HashSet<string> upns)
+        private async Task AddGroupMembersAsync(GraphGroup group, HashSet<string> upns, CallBudget budget)
         {
             // Restrict to user members: a group can also contain nested groups, devices and service
             // principals, none of which have Copilot interaction history.
@@ -136,23 +326,28 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             {
                 if (++pages > MaxMemberPagesPerGroup)
                 {
-                    _logger.LogWarning(
-                        $"Copilot interaction history: stopped reading members of '{group.DisplayName}' after " +
-                        $"{MaxMemberPagesPerGroup} pages. This group looks too large to be a pilot group.");
+                    budget.Stop(
+                        $"reading members of '{group.DisplayName}' stopped after {MaxMemberPagesPerGroup} pages. " +
+                        "This group looks too large to be a pilot group.");
                     return;
                 }
+
+                if (budget.Exhausted)
+                    return;
 
                 PageableGraphResponse<GraphGroupMember> page;
                 try
                 {
+                    budget.Spend();
                     page = await _httpClient.GetAsyncWithThrottleRetries<PageableGraphResponse<GraphGroupMember>>(url);
                 }
                 catch (Exception ex)
                 {
-                    // A group we can't read shouldn't abort the whole import; the others still resolve.
-                    _logger.LogWarning(
-                        $"Copilot interaction history: could not read members of group '{group.DisplayName}' " +
-                        $"({ex.GetType().Name}). Skipping that group for this cycle.");
+                    // A group we can't read shouldn't abort the whole import; the others still resolve. It
+                    // does make the scope incomplete, though, so it is recorded rather than swallowed.
+                    budget.Stop(
+                        $"members of group '{group.DisplayName}' could not be read ({ex.GetType().Name}), so that " +
+                        "group contributed nobody to the pilot scope.");
                     return;
                 }
 
@@ -166,6 +361,42 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
                 }
 
                 url = page.OdataNextLink;
+            }
+        }
+
+        /// <summary>
+        /// One shared allowance for every Graph call made while resolving the scope, plus the reason
+        /// resolution stopped early. Separate per-stage caps multiply together; a single total cannot.
+        /// </summary>
+        private class CallBudget
+        {
+            private int _remaining;
+
+            public CallBudget(int total)
+            {
+                _remaining = total;
+            }
+
+            /// <summary>Why resolution stopped early, or null while it is still complete.</summary>
+            public string Reason { get; private set; }
+
+            public bool Exhausted => Reason != null;
+
+            public void Spend()
+            {
+                if (--_remaining < 0)
+                {
+                    Stop($"the resolver's budget of {MaxTotalGraphCalls} Graph calls for working out the pilot " +
+                         "scope was used up. Narrow UserGroupsFilter to the pilot group(s), or use group " +
+                         "object ids, so the scope resolves in a handful of calls.");
+                }
+            }
+
+            /// <summary>Records the first reason resolution stopped; later ones are consequences of it.</summary>
+            public void Stop(string reason)
+            {
+                if (Reason == null)
+                    Reason = reason;
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/PilotGroupResolution.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/PilotGroupResolution.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHistory
+{
+    /// <summary>
+    /// The outcome of resolving <c>UserGroupsFilter</c> to a set of pilot member UPNs.
+    /// </summary>
+    /// <remarks>
+    /// Carries a completeness flag as well as the members because "no members" and "we gave up looking"
+    /// are very different things and used to be indistinguishable (issue #297). An empty set from a
+    /// mistyped group name is a configuration problem the admin should fix; an empty set because group
+    /// discovery hit its safety cap is the importer failing to do its job, and silently reporting the
+    /// second as the first meant a pilot group sitting past the cap looked like an idle, healthy import.
+    /// </remarks>
+    public class PilotGroupResolution
+    {
+        public PilotGroupResolution(HashSet<string> memberUpns, string incompleteReason = null)
+        {
+            MemberUpns = memberUpns ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            IncompleteReason = incompleteReason;
+        }
+
+        /// <summary>Member UPNs of every matched group. Empty when nothing matched.</summary>
+        public HashSet<string> MemberUpns { get; }
+
+        /// <summary>
+        /// Why the resolved scope may be missing members, or null when it is known to be complete.
+        /// </summary>
+        public string IncompleteReason { get; }
+
+        /// <summary>
+        /// True when a cap or an error stopped resolution early, so <see cref="MemberUpns"/> may be a
+        /// subset of the configured scope. The import should report this rather than treat the result
+        /// as authoritative.
+        /// </summary>
+        public bool IsIncomplete => !string.IsNullOrEmpty(IncompleteReason);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Graph\Copilot\InteractionHistory\IAiInteractionSourceLoader.cs" />
     <Compile Include="Graph\Copilot\InteractionHistory\InteractionCognitiveEnricher.cs" />
     <Compile Include="Graph\Copilot\InteractionHistory\InteractionStatsExtractor.cs" />
+    <Compile Include="Graph\Copilot\InteractionHistory\PilotGroupResolution.cs" />
     <Compile Include="Graph\Email\DeltaTokenStores.cs" />
     <Compile Include="Graph\Email\GraphSentEmailSourceLoader.cs" />
     <Compile Include="Graph\Email\ISentEmailSentimentScorer.cs" />


### PR DESCRIPTION
Closes #297

## Problem

The pilot-group scope is the main brake stopping this import making **one Graph call per tenant user**. Three separate things weakened it - and the third made the other two hard to notice.

### 1. A wildcard silently authorised a directory-wide enumeration

Scope was decided by `if (_userGroupsFilter.Patterns.Count > 0)`. Any non-empty pattern counted as "scoped" - including the documented `*` wildcard, which matches **every group**.

The per-cycle user ceiling is applied only *after* every matching group's members have been enumerated, so it does not bound the resolver. Worst case was roughly `50 group pages x 999 groups x 50 member pages` - **millions of Graph calls before a single interaction was read**, which is precisely the cost this feature's design exists to avoid.

### 2. An exact group name still paged the entire directory

Display-name matching was client-side, so resolving even one exactly-named group meant enumerating every group in the tenant, capped at `MaxGroupPages = 50` (~49,950 groups).

A 200,000-user tenant with Teams routinely has more groups than that. The pilot group could therefore sit **past the cap**, never be found, and the import would no-op - while looking perfectly healthy.

### 3. Truncation was indistinguishable from an empty group

`GetMemberUpnsAsync` returned a bare `HashSet<string>`. "This group has no members", "your group name is a typo" and "we gave up enumerating" all came back as an empty set. The one that means *the importer is broken* was reported identically to the two that mean *your config is wrong*.

## Change

### Match-all filters take the unnarrowed path

`UserGroupsFilterModel` gains `MatchesEverything` - true only when a pattern is nothing but wildcards (`*`, `**`).

Since #298 made `UserGroupsFilter` an optional narrowing, an unnarrowed cycle already does the right thing: the whole selection happens in SQL, `TOP`-capped, so at most `CopilotInteractionHistoryMaxUsersPerCycle` users materialise however large the directory is.

So a match-all filter now takes **that** path. Same resulting scope, reached with one capped SQL query instead of asking Graph to enumerate the entire directory to conclude "everyone". The admin is warned their filter isn't narrowing anything.

The resolver **also refuses** a match-all filter outright, rather than relying on the caller to have made the right choice - so it can never become an expensive silent default via a future caller.

`*` anywhere else (`Copilot*`, `*Pilot*`) is a genuine narrowing and is still honoured.

### Patterns are routed by the cheapest form that can answer them

| Pattern | Route | Cost |
|---|---|---|
| GUID | `GET /groups/{id}` - direct object-id lookup | 1 call, exact, survives a rename |
| No `*` | `GET /groups?$filter=displayName eq '...'` - **server-side** | 1 call, independent of directory size |
| Contains `*` | enumerate and match client-side | only route that needs paging |

Graph has no server-side equivalent of the product's `*` syntax, so enumeration remains the fallback - but it is now the *exception* rather than the only path. An exactly-named pilot group can no longer be hidden behind the page cap.

Two smaller correctness fixes fall out of the server-side lookup:

- **OData quote escaping** - a group named `Bob's pilot` produced a malformed filter and a 400. Single quotes are now doubled.
- **Duplicate display names** - display names are not unique in Entra ID. Multiple matches are reported with a nudge toward object ids, rather than quietly treating them all as pilot groups.

### One shared call budget

Group discovery and member paging were capped separately, so the real ceiling was their **product**. A single `CallBudget` of 200 calls now covers every call of every kind. A total cannot be multiplied out.

200 is generous for any realistic pilot: an exactly-named group of 5,000 members costs about 7 calls.

### Truncation is reported as a failure

`GetMemberUpnsAsync` now returns `PilotGroupResolution` - the members plus `IncompleteReason`, the reason resolution stopped early (budget exhausted, discovery cap hit, a group unreadable).

The importer writes that to `runLog.Error`, so it surfaces on the health page rather than only in a log line nobody reads. The reassuring "no users matched ... so there is nothing to do" warning is suppressed when a failure has already been reported, since that message is exactly what made this case easy to miss.

Partial scopes are still processed - the members found *are* genuinely in the group, so importing them beats importing nobody - but the run is no longer reported as clean.

## Acceptance criteria

- [x] A wildcard pattern cannot silently authorise a directory-wide enumeration - refused by the resolver, and downgraded to the capped SQL path by the importer.
- [x] An exact group name resolves without paging the whole directory - one server-side `$filter` call.
- [x] Hitting the discovery cap is reported as a failure, not as "no members" - `PilotGroupResolution.IncompleteReason` -> `runLog.Error`.
- [x] Group object ids are preferred - supported directly, and recommended in the log message on ambiguous names.

## Tests

Three new tests, plus the existing ones updated for the richer return type:

- `PilotGroupResolver_RefusesAMatchAllFilterWithoutCallingGraph` - covers `*`, `**` and `" * "`, and asserts the refusal carries a reason. The resolver has no usable HTTP handler in this test, so *any* Graph call would throw rather than return - the test fails if the refusal is ever removed.
- `MatchesEverything_OnlyTrueForPurelyWildcardPatterns` - pins the distinction that decides whether the directory gets enumerated, including that `Copilot*`, `*Pilot` and `*Pilot*` are **not** match-all, and that an empty filter is "unscoped" rather than "matches everything".
- `PilotGroupResolver_ReturnsNothingForAnEmptyFilter` - now also asserts the empty answer is *complete*, not a failure.

31/31 interaction-history and pilot-group tests pass. Full suite: 878 passed, 13 failed - all 13 are pre-existing environment failures needing real Azure/Graph/Cognitive credentials or a local `InstallerTestConfig.json`, and none of them reference the resolver or filter (verified by searching for every consumer of the changed interface).

## Reviewer notes

- **No schema change, no migration, no config-schema change, no `CONFIG_VERSION` bump.** `UserGroupsFilter` is an existing persisted setting whose *meaning* is unchanged - `*` still means "match every group"; it is now satisfied by a cheaper route.
- **Behaviour change worth flagging:** a tenant that set `UserGroupsFilter = *` and relied on it as a scope was already importing everyone; they will now get a warning saying so, and the same scope resolved far more cheaply.
- `PilotGroupResolution` is a new file - registered in the `.csproj`.
- The `MaxTotalGraphCalls = 200` budget is the load-bearing number; reviewers who think it is too tight should note that only wildcard patterns can approach it.
