### PR TITLE
Release critique follow-ups: the same #285 hole in the legacy daily reports, a fail-closed dedup guard, and three doc errors

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Migrations/202607231700001_CoverCopilotAccessedResourceDedup.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202607231700001_CoverCopilotAccessedResourceDedup.cs
@@ -9,6 +9,18 @@ namespace Common.Entities.Migrations
     /// resource_site_url_id, resource_type_id, sensitivity_label_id)</c> -&gt;
     /// <c>IX_copilot_event_accessed_resources_dedup</c>.
     ///
+    /// SUPERSEDED (comment only - the SQL below is frozen and still correct as the step it was):
+    /// <see cref="WidenCopilotAccessedResourceDedupIndex"/> later rebuilds this index with
+    /// <c>action_id</c> and <c>list_item_unique_id_id</c> added as key columns, because treating those two
+    /// as payload rather than identity dropped distinct actions and could fabricate action / list-item
+    /// pairings (issue #287). The "five resolved lookup foreign keys" described below is therefore the
+    /// tuple as it stood at THIS migration, not as the merge uses it today.
+    ///
+    /// Note for anyone upgrading from a build older than this migration: both run, so the index is created
+    /// here with six key columns and then immediately dropped and rebuilt with eight. That doubled build is
+    /// unavoidable without editing shipped migrations; sites already on current stable only pay for the
+    /// rebuild.
+    ///
     /// Why: the shared Copilot merge (<c>common_upsert_copilot_agents.sql</c>) de-duplicates the accessed-resource
     /// junction with a keyed anti-join that compares the full resolved tuple for a chat:
     /// <code>

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608210700001_WidenCopilotAccessedResourceDedupIndex.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608210700001_WidenCopilotAccessedResourceDedupIndex.cs
@@ -4,10 +4,14 @@ namespace Common.Entities.Migrations
     using System.Data.Entity.Migrations;
 
     /// <summary>
-    /// Widens <c>IX_copilot_event_accessed_resources_dedup</c> from five key columns to seven, adding
+    /// Widens <c>IX_copilot_event_accessed_resources_dedup</c> from six key columns to eight, adding
     /// <c>action_id</c> and <c>list_item_unique_id_id</c> -&gt;
     /// <c>copilot_event_accessed_resources(copilot_chat_id, resource_id_id, resource_name_id,
     /// resource_site_url_id, resource_type_id, sensitivity_label_id, action_id, list_item_unique_id_id)</c>.
+    ///
+    /// (Two counts are in play and are easy to conflate: the merge's de-duplication <b>tuple</b> goes from
+    /// five resource columns to seven, and the <b>index</b> goes from six key columns to eight, because it
+    /// carries <c>copilot_chat_id</c> as its leading correlation key in addition to the tuple.)
     ///
     /// Why: issue #287. The Copilot merge (<c>common_upsert_copilot_agents.sql</c>) resolved accessed
     /// resources by grouping on the five-column resource tuple and then picking the two extra columns with
@@ -20,8 +24,9 @@ namespace Common.Entities.Migrations
     /// independently over the group, so the surviving row could pair an <c>action_id</c> from one source
     /// row with a <c>list_item_unique_id_id</c> from another - a combination that never occurred.</description></item>
     /// </list>
-    /// The merge now takes the whole seven-column tuple as the row identity, so this index has to carry the
-    /// same seven columns as KEY columns for the de-dup existence check to keep seeking it.
+    /// The merge now takes the whole seven-column tuple as the row identity, so this index has to carry all
+    /// seven of those columns as KEY columns alongside <c>copilot_chat_id</c> - eight in total - for the
+    /// de-dup existence check to keep seeking it.
     ///
     /// The previous justification for leaving them out - that <c>list_item_unique_id_id</c> would breach the
     /// 1700-byte index-key limit - was simply incorrect: both columns are <c>int</c> foreign keys, so this

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608210700002_IndexCopilotInteractionKeywordsByKeyword.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608210700002_IndexCopilotInteractionKeywordsByKeyword.cs
@@ -45,9 +45,10 @@ namespace Common.Entities.Migrations
     /// existence check finally has a seekable path instead of scanning the whole link index once per
     /// candidate. The bulk sweep is honestly a smaller win - when EVERY keyword is a candidate, scanning
     /// the link index once is the right plan either way, so the read count is unchanged (11,281 vs 11,256)
-    /// and the ~1.8x time saving comes from the scan arriving already ordered by <c>keyword_id</c>. Both
-    /// are improvements and neither regresses, so the index is kept - but the headline number belongs to
-    /// the per-user purge, not the nightly sweep.
+    /// and the plan operator stays Hash Match on both sides. The ~1.8x time saving there is reproducible
+    /// but NOT explained by the index: a hash join takes no benefit from input ordering, so treat the bulk
+    /// figure as incidental rather than as the reason for this migration. Both are improvements and
+    /// neither regresses, so the index is kept - but the headline number belongs to the per-user purge.
     ///
     /// This migration changes only the SQL schema, not the EF entity model snapshot (its <c>.resx</c> Target
     /// is byte-identical to the previous migration's).

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphPagingFailureTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphPagingFailureTests.cs
@@ -1,3 +1,4 @@
+using Common.Entities.Config;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
@@ -8,9 +9,12 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.Graph;
 using WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHistory;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace Tests.UnitTests
 {
@@ -234,6 +238,26 @@ namespace Tests.UnitTests
             Assert.AreEqual(DateTime.MinValue, CopilotInteractionHistoryImporter.DedupWindowStart(new[] { default(DateTime) }));
         }
 
+        /// <summary>
+        /// The dangerous case, and the one the original guard got wrong: a batch that mixes one unusable
+        /// timestamp with normal ones. Skipping the default would compute a window that EXCLUDES the stored
+        /// row it duplicates - a missed duplicate, a unique-index violation, and a failed batch. Any default
+        /// must therefore make the whole window fall open.
+        /// </summary>
+        [TestMethod]
+        public void DedupWindowStart_MixedDefaultAndRealTimestamps_FallsOpen()
+        {
+            var real = new DateTime(2026, 8, 20, 9, 0, 0, DateTimeKind.Utc);
+
+            Assert.AreEqual(DateTime.MinValue,
+                CopilotInteractionHistoryImporter.DedupWindowStart(new[] { real, default(DateTime), real.AddHours(3) }),
+                "A single unusable timestamp must widen the window to everything, not be skipped.");
+
+            Assert.AreEqual(DateTime.MinValue,
+                CopilotInteractionHistoryImporter.DedupWindowStart(new[] { default(DateTime), real }),
+                "Order must not matter.");
+        }
+
         [TestMethod]
         public void DedupWindowStart_NearDateTimeMinValue_DoesNotThrow()
         {
@@ -244,10 +268,71 @@ namespace Tests.UnitTests
         [TestMethod]
         public void DedupLookbackMargin_IsGenerousEnoughToBeSafe()
         {
-            // The margin exists purely so the bound can never cause a MISS. Shrinking it below a couple of
-            // days would start to matter for a tenant whose importer has been stopped over a weekend.
-            Assert.IsTrue(CopilotInteractionHistoryImporter.DedupLookbackMarginDays >= 2,
-                "A margin under two days risks missing a duplicate after a weekend outage.");
+            // The window is anchored to the BATCH's oldest timestamp, not to wall-clock, so outage length is
+            // irrelevant. The margin absorbs timestamp re-statement by Graph and SQL Server's datetime
+            // rounding (up to 3.33 ms) - milliseconds of real risk. Any value of a day or more is ample;
+            // this guards against someone reducing it to zero and removing the safety entirely.
+            Assert.IsTrue(CopilotInteractionHistoryImporter.DedupLookbackMarginDays >= 1,
+                "The margin must stay non-trivial: it is what absorbs timestamp re-statement and datetime rounding at the window boundary.");
+        }
+
+        #endregion
+
+        #region Issue #285 follow-up - the legacy daily activity reports had the same hole
+
+        /// <summary>
+        /// The daily usage-report loaders (SharePoint / Teams / OneDrive / Yammer / Exchange) had exactly
+        /// the bug #285 described for the Copilot reports: a 403 returned an empty day, which was recorded
+        /// as a successfully loaded empty day, after which the whole activity-report phase stamped itself
+        /// complete for 24 hours. They now use strict paging, so the failure propagates and the phase is
+        /// retried on the next cycle.
+        /// </summary>
+        [TestMethod]
+        public async Task DailyActivityLoader_ForbiddenFromGraph_Throws_InsteadOfRecordingAnEmptyDay()
+        {
+            using (var handler = new StubHandler(HttpStatusCode.Forbidden, Forbidden))
+            using (var client = new ManualGraphCallClient(handler, NullLogger.Instance))
+            {
+                var loader = new OutlookUserActivityLoader(client, new NoUsersHaveGroupsUserGroupsCache(NullLogger.Instance),
+                    new UserGroupsFilterModel(string.Empty), NullLogger.Instance);
+
+                var ex = await Assert.ThrowsExceptionAsync<GraphHttpException>(
+                    () => loader.PopulateLoadedReportPagesFromGraph(1));
+
+                Assert.AreEqual(HttpStatusCode.Forbidden, ex.StatusCode);
+                Assert.AreEqual(0, loader.LoadedReportPages.Count,
+                    "A day that failed to download must NOT be recorded as a loaded (empty) day.");
+            }
+        }
+
+        #endregion
+
+        #region Issue #285 follow-up - what gets PERSISTED must not carry the URL
+
+        [TestMethod]
+        public void SummaryWithoutUrl_OmitsTheUrlButKeepsStatusAndErrorCode()
+        {
+            var ex = new GraphHttpException(HttpStatusCode.Forbidden,
+                "https://graph.microsoft.com/v1.0/users/someone@contoso.com/messages", Forbidden, null);
+
+            StringAssert.Contains(ex.Message, "someone@contoso.com", "The full message keeps the URL - it is written to logs, which already record it.");
+
+            var stored = ex.SummaryWithoutUrl;
+            Assert.IsFalse(stored.Contains("someone@contoso.com"), "The persisted summary must not carry a user principal name.");
+            Assert.IsFalse(stored.Contains("graph.microsoft.com"), "The persisted summary must not carry the URL at all.");
+            StringAssert.Contains(stored, "403");
+            StringAssert.Contains(stored, "Authorization_RequestDenied");
+        }
+
+        [TestMethod]
+        public void DescribeForStorage_FallsBackToTheMessageForOrdinaryExceptions()
+        {
+            Assert.AreEqual("boom", GraphHttpException.DescribeForStorage(new InvalidOperationException("boom")));
+            Assert.IsNull(GraphHttpException.DescribeForStorage(null));
+
+            var graphEx = new GraphHttpException(HttpStatusCode.InternalServerError, "https://graph.microsoft.com/x", ServerError, null);
+            Assert.AreEqual(graphEx.SummaryWithoutUrl, GraphHttpException.DescribeForStorage(graphEx),
+                "A Graph HTTP failure must be stored in its URL-free form.");
         }
 
         #endregion

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
@@ -74,9 +74,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
         ///
         /// The margin exists so the bound can never cause a MISS, which would be far worse than a slow read:
         /// a missed duplicate hits the unique index on (session_id, graph_interaction_id) and fails the
-        /// batch. Seven days is enormous relative to the real risk - the importer works forward from a
-        /// per-user watermark, so an incoming interaction is re-presented with the same timestamp it was
-        /// first seen with - and still bounds the read to a fixed window instead of "everything, forever".
+        /// batch.
+        ///
+        /// Note what the margin is NOT protecting against. The window is anchored to the BATCH's own oldest
+        /// timestamp, not to wall-clock, so the length of any importer outage is irrelevant - a stored row
+        /// that duplicates a batch row carries the same <c>createdDateTime</c> as that batch row, which is
+        /// by construction >= the batch minimum. What the margin actually absorbs is narrower: Graph
+        /// re-stating a timestamp slightly differently between reads, <c>datetime</c> rounding in SQL
+        /// Server (up to 3.33 ms), and clock/precision differences on the boundary. Seven days is far more
+        /// than any of those need, and still bounds the read to a fixed window instead of "everything,
+        /// forever" - so it is cheap insurance, not a load-bearing outage guard.
         /// </summary>
         internal const int DedupLookbackMarginDays = 7;
 
@@ -844,13 +851,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             {
                 foreach (var created in createdUtcs)
                 {
-                    if (created != default(DateTime) && created < oldest)
+                    // A default timestamp means we cannot place that row in time. Skipping it would compute
+                    // a window that EXCLUDES the stored row it duplicates - a missed duplicate, which hits
+                    // the unique index and fails the batch. So any default makes the whole window fall
+                    // open. (Unreachable today: InteractionStatsExtractor drops interactions with no
+                    // createdDateTime before they get here. This guard is written to fail open so that
+                    // stays true if that ever changes.)
+                    if (created == default(DateTime))
+                        return DateTime.MinValue;
+
+                    if (created < oldest)
                         oldest = created;
                 }
             }
 
-            // No usable timestamps (shouldn't happen - created_utc is required) - fall back to reading
-            // everything rather than risking a missed duplicate.
+            // No timestamps at all - fall back to reading everything rather than risking a missed duplicate.
             if (oldest == DateTime.MaxValue)
                 return DateTime.MinValue;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphHttpException.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphHttpException.cs
@@ -51,6 +51,39 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// </summary>
         public string GraphErrorCode { get; }
 
+        /// <summary>
+        /// The status and Graph error code with the URL deliberately omitted, for anywhere the text is
+        /// PERSISTED rather than logged.
+        ///
+        /// <see cref="Exception.Message"/> embeds the failing URL, which is the right call for a log line -
+        /// and <c>ManualGraphCallClient</c> has already logged it at error level anyway. But this type is
+        /// now thrown for every Graph call, and some request paths identify a person
+        /// (<c>/users/{upn}/messages</c> in the sent-email loader). Anything writing to a database column,
+        /// a job summary or another durable store should use this instead, so a user principal name does
+        /// not end up somewhere it was never meant to be retained.
+        /// </summary>
+        public string SummaryWithoutUrl
+        {
+            get
+            {
+                var status = $"{(int)StatusCode} ({StatusCode})";
+                return string.IsNullOrEmpty(GraphErrorCode)
+                    ? $"Graph returned {status}."
+                    : $"Graph returned {status} with error code '{GraphErrorCode}'.";
+            }
+        }
+
+        /// <summary>
+        /// The text to persist for an exception: the URL-free summary when it is a Graph HTTP failure,
+        /// otherwise the exception's own message. Use this anywhere the result is written to a database
+        /// column or other durable store rather than to a log.
+        /// </summary>
+        public static string DescribeForStorage(Exception ex)
+        {
+            if (ex == null) return null;
+            return ex is GraphHttpException graphEx ? graphEx.SummaryWithoutUrl : ex.Message;
+        }
+
         private static string BuildMessage(HttpStatusCode statusCode, string url, string responseBody)
         {
             var code = ExtractGraphErrorCode(responseBody);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -198,10 +198,26 @@ SELECT CAST(CASE WHEN EXISTS (
         /// data with no HTTP, and so the date-skipping in <see cref="PopulateLoadedReportPagesFromGraph"/> can be
         /// verified without hitting Graph.
         /// </summary>
+        /// <remarks>
+        /// Uses STRICT paging. These reports have exactly the problem issue #285 described for the Copilot
+        /// reports: a 403 from a missing <c>Reports.Read.All</c> grant, or a 5xx mid-paging, used to return
+        /// the pages gathered so far without throwing - so a failed day was recorded as a successfully
+        /// loaded EMPTY day, and the whole activity-report phase then stamped itself as complete for 24
+        /// hours. A broken import looked healthy and idle.
+        ///
+        /// Throwing restores the contract the phase is already written around: see
+        /// <c>GraphImporter.GetAndSaveActivityReportsMultiThreaded</c>, which deletes the "last imported"
+        /// timestamp BEFORE loading and only re-saves it after every loader has completed, precisely so
+        /// that "if this phase fails after a partial save, the next cycle must re-import". The exception
+        /// propagates out of the <c>Task.WhenAll</c>, the timestamp is never re-saved, and the phase is
+        /// retried next cycle with the real HTTP status recorded in Application Insights.
+        ///
+        /// A genuinely empty day (Graph returns 200 with no rows) is unaffected and still loads as empty.
+        /// </remarks>
         protected virtual Task<List<TUserActivityUserDetail>> LoadReportPageForDateFromGraph(DateTime date)
         {
             var requestUrl = $"{ReportGraphURL}(date={date.ToString("yyyy-MM-dd")})?$format=application/json";
-            return _client.LoadAllPagesWithThrottleRetries<TUserActivityUserDetail>(requestUrl, Telemetry);
+            return _client.LoadAllPagesWithThrottleRetries<TUserActivityUserDetail>(requestUrl, Telemetry, throwOnHttpError: true);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageUserDetailLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageUserDetailLoader.cs
@@ -99,7 +99,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
                 // Tolerated, not a failure - see CopilotUserCountReportLoader for the full reasoning. The
                 // report endpoint doesn't exist in this cloud, so there is nothing to retry; record why.
                 importLog.RowsRead = 0;
-                importLog.Error = Truncate($"Report not available: {ex.Message}", 1000);
+                importLog.Error = Truncate($"Report not available: {GraphHttpException.DescribeForStorage(ex)}", 1000);
                 await SaveImportLog(db, importLog);
 
                 _logger.LogWarning($"Copilot per-user report {request} is not available on this tenant: {ex.Message} " +
@@ -108,7 +108,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             }
             catch (Exception ex)
             {
-                importLog.Error = Truncate(ex.Message, 1000);
+                importLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
                 await SaveImportLog(db, importLog);
                 throw;
             }
@@ -169,7 +169,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             {
                 // Persistence failures must reach the Health page too, and must be written on a FRESH context:
                 // the one that just failed a SaveChanges can be left with entities in a broken state.
-                importLog.Error = Truncate(ex.Message, 1000);
+                importLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
                 await SaveImportLogOnNewContext(importLog);
                 throw;
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUserCountReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUserCountReportLoader.cs
@@ -104,7 +104,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
                 // completed run for cadence purposes - but the reason is recorded on the import log so the
                 // Health page shows why the table is empty instead of implying the tenant has no licences.
                 importLog.RowsRead = 0;
-                importLog.Error = Truncate($"Report not available: {ex.Message}", 1000);
+                importLog.Error = Truncate($"Report not available: {GraphHttpException.DescribeForStorage(ex)}", 1000);
                 await SaveImportLog(db, importLog);
 
                 _logger.LogWarning($"Copilot aggregate report {request} is not available on this tenant: {ex.Message} " +
@@ -113,7 +113,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             }
             catch (Exception ex)
             {
-                importLog.Error = Truncate(ex.Message, 1000);
+                importLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
                 await SaveImportLog(db, importLog);
                 throw;
             }
@@ -163,7 +163,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             {
                 // Persistence failures must reach the Health page too, and must be written on a FRESH context:
                 // the one that just failed a SaveChanges can be left with entities in a broken state.
-                importLog.Error = Truncate(ex.Message, 1000);
+                importLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
                 using (var freshDb = new AnalyticsEntitiesContext())
                 {
                     await SaveImportLog(freshDb, importLog);


### PR DESCRIPTION
Acts on the second adversarial critique of the `dev` → `main` release (run at `56da5d6`, after #307 landed). The critique found **no blockers** — this PR clears the items it did find that are worth fixing before the release goes out.

**No schema change.** Every migration's `Up_Sql` is untouched and byte-verified as still appearing verbatim in its `.manual.sql`; `git diff` on `*.manual.sql` is empty. The upgrade path is unaffected.

---

## Correctness

### The legacy daily activity reports had exactly the #285 bug

`AbstractDailyActivityLoader.LoadReportPageForDateFromGraph` — which serves **all** the SharePoint / Teams / OneDrive / Yammer / Exchange daily usage reports — still used lenient paging. A 403 from a missing `Reports.Read.All` grant, or a 5xx mid-paging, returned the pages gathered so far without throwing, so:

1. the failed day was added to `LoadedReportPages` as a **successfully loaded empty day**;
2. every loader therefore "completed";
3. `GetAndSaveActivityReportsMultiThreaded` re-saved its "last imported" timestamp;
4. the whole activity-report phase went quiet for **24 hours**.

A broken import looked healthy and idle — the same misleading-symptom class as #285, on a much older code path. #307 fixed only the Copilot reports.

The fix is a one-line opt-in to strict paging, and it **restores a contract the phase is already written around**. Its own comment says it best:

> The timestamp is both the once-a-day throttle and the proof that every loader completed. Clear it before any batched writes: if this phase fails after a partial save, the next cycle must re-import rather than trusting the old marker.

That design only works if a loader can actually fail. The exception now propagates out of `Task.WhenAll`, the timestamp is never re-saved, and the real HTTP status reaches Application Insights. A genuinely empty day (HTTP 200, no rows) is unaffected.

**Behaviour change worth reviewing:** one failing report type now aborts that cycle's activity phase instead of importing the rest. That is the pre-existing design intent, and everything is retried next cycle, but it is a real change to a long-standing path. The existing `OutlookUserActivityLoaderTests` (including the finalized-date skip logic) still pass unchanged.

### `DedupWindowStart` failed closed where it should fail open

It **skipped** `default(DateTime)` when computing the batch minimum. A batch mixing one unusable timestamp with real ones would compute a window that **excludes** the stored row it duplicates → missed duplicate → unique-index violation on `(session_id, graph_interaction_id)` → failed batch.

**Unreachable today** — `InteractionStatsExtractor` returns `null` when `CreatedDateTime == null` (line 116), so such a stat never reaches the pipeline. But the guard was written in the unsafe direction and the test only covered the *all*-default case, which happens to fall open by a different route. Any default now widens the window to everything, and the mixed case is tested.

---

## Privacy

`GraphHttpException.BuildMessage` embeds the failing URL, and both Copilot loaders persist `ex.Message` into `copilot_usage_report_import_log.error`.

That is right for a log line — and `ManualGraphCallClient` already logs the URL at error level, so there is no net new *log* exposure. But #307 made this type the one thrown for **every** Graph call, and some request paths identify a person (`/users/{upn}/messages` in the sent-email loader). Persisting a UPN into a database column is a different thing from logging it.

Adds `SummaryWithoutUrl` (status + Graph error code, no URL) and `DescribeForStorage(Exception)`, and routes all six persisting call sites through it. Full detail is still available in logs and on the exception.

---

## Documentation accuracy

| Fix | Detail |
|---|---|
| **`WidenCopilotAccessedResourceDedupIndex`** | Said it widens the index *"from five key columns to seven"*. It is **six → eight**; the *tuple* is five → seven. The two differ because the index also carries `copilot_chat_id` as its leading correlation key. The rest of the file was already right (`6-key`/`8-key` in the benchmark rows), which is exactly how the summary line slipped through. Now states both counts and why they differ. |
| **`IndexCopilotInteractionKeywordsByKeyword`** | Attributed the bulk-sweep gain to *"the scan arriving already ordered by `keyword_id`"* — but the recorded plan is **Hash Match on both sides**, and a hash join takes no benefit from input ordering. The 1.8x is real and reproducible, but the stated mechanism cannot be the cause. Now reported as **incidental**, with the per-user purge (82x fewer reads, Scan → Seek) as the actual justification. |
| **`CoverCopilotAccessedResourceDedup`** | Shipped and its SQL is frozen, but it still described the five-column tuple as current with no pointer to the migration that supersedes it. Adds a SUPERSEDED note (**comment only**) and records that a site upgrading from *before* it builds this index twice — six keys, then dropped and rebuilt with eight. Anyone on current stable pays only for the rebuild. |

---

## Testing

`GraphPagingFailureTests` grows from 11 to 18. New:

- `DedupWindowStart_MixedDefaultAndRealTimestamps_FallsOpen` — the case that was missing, both orderings.
- `DailyActivityLoader_ForbiddenFromGraph_Throws_InsteadOfRecordingAnEmptyDay` — asserts the failure propagates **and** that no empty day is recorded.
- `SummaryWithoutUrl_OmitsTheUrlButKeepsStatusAndErrorCode` — asserts a synthetic UPN survives in `Message` (logs) but never in the persisted summary.
- `DescribeForStorage_FallsBackToTheMessageForOrdinaryExceptions`.
- `DedupLookbackMargin_IsGenerousEnoughToBeSafe` rewritten — the old assertion justified the margin as protection against "a weekend outage", which is **wrong**: the window is anchored to the batch's own oldest timestamp, not wall-clock, so outage length is irrelevant. A wrong rationale enshrined in an assertion is how someone later changes the constant for the wrong reason. The margin's real job is absorbing timestamp re-statement and `datetime` rounding.

**Run:** 25/25 pass locally (`GraphPagingFailureTests`, `OutlookUserActivityLoaderTests`, `UrlFullUrlMigrationPipelineTests`), including the full migration replay.

## Reviewer hotspots

1. **The strict-paging change to `AbstractDailyActivityLoader`** is the only behavioural change here, and it touches every legacy daily report. Worth confirming you want fail-fast-and-retry over import-what-we-can.
2. **`CoverCopilotAccessedResourceDedup` is a shipped migration.** Only its XML doc comment changed; `Up_Sql` / `Down_Sql` are byte-identical, so no customer database is affected.

Addresses findings B1, B9, B10, B11, B12, B13 and the #296 wording from the second release critique. All benchmark data referenced is synthetic.
