### PR TITLE
Make the activity-report phase fail per-report, and stop strict paging breaking install verification

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -717,7 +717,22 @@ namespace App.ControlPanel.Engine
 
             // 4 days should give us some data
             const int DAYS_BACK_CHECK = 3;
-            await teamsUserUsageLoader.PopulateLoadedReportPagesFromGraph(DAYS_BACK_CHECK);
+
+            // The daily loaders use strict paging (see AbstractDailyActivityLoader), so a Graph failure
+            // here throws rather than yielding an empty report. That is deliberate for the importer - a
+            // failed download must never be recorded as a successful empty day - but this is the INSTALL
+            // VERIFIER, whose whole job is to report problems rather than propagate them. Catch it and
+            // report, matching the Teams-report check above.
+            try
+            {
+                await teamsUserUsageLoader.PopulateLoadedReportPagesFromGraph(DAYS_BACK_CHECK);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"ERROR: Got error trying to read the Teams user usage report from Graph: '{ex.Message}'");
+                _logger.LogError("Important: ensure the runtime account has the Reports.Read.All application permission granted and admin-consented, and that this is a global-cloud tenant.");
+                return;
+            }
 
             bool? validEmailFound = null;
             foreach (var reportPage in teamsUserUsageLoader.LoadedReportPages.Values)

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphPagingFailureTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphPagingFailureTests.cs
@@ -233,9 +233,9 @@ namespace Tests.UnitTests
         {
             // A missed duplicate hits the unique index and fails the batch, so the safe fallback when we
             // cannot work out a window is the old unbounded behaviour.
-            Assert.AreEqual(DateTime.MinValue, CopilotInteractionHistoryImporter.DedupWindowStart(new DateTime[0]));
-            Assert.AreEqual(DateTime.MinValue, CopilotInteractionHistoryImporter.DedupWindowStart(null));
-            Assert.AreEqual(DateTime.MinValue, CopilotInteractionHistoryImporter.DedupWindowStart(new[] { default(DateTime) }));
+            Assert.AreEqual(CopilotInteractionHistoryImporter.UnboundedDedupWindowStart, CopilotInteractionHistoryImporter.DedupWindowStart(new DateTime[0]));
+            Assert.AreEqual(CopilotInteractionHistoryImporter.UnboundedDedupWindowStart, CopilotInteractionHistoryImporter.DedupWindowStart(null));
+            Assert.AreEqual(CopilotInteractionHistoryImporter.UnboundedDedupWindowStart, CopilotInteractionHistoryImporter.DedupWindowStart(new[] { default(DateTime) }));
         }
 
         /// <summary>
@@ -249,20 +249,43 @@ namespace Tests.UnitTests
         {
             var real = new DateTime(2026, 8, 20, 9, 0, 0, DateTimeKind.Utc);
 
-            Assert.AreEqual(DateTime.MinValue,
+            Assert.AreEqual(CopilotInteractionHistoryImporter.UnboundedDedupWindowStart,
                 CopilotInteractionHistoryImporter.DedupWindowStart(new[] { real, default(DateTime), real.AddHours(3) }),
                 "A single unusable timestamp must widen the window to everything, not be skipped.");
 
-            Assert.AreEqual(DateTime.MinValue,
+            Assert.AreEqual(CopilotInteractionHistoryImporter.UnboundedDedupWindowStart,
                 CopilotInteractionHistoryImporter.DedupWindowStart(new[] { default(DateTime), real }),
                 "Order must not matter.");
         }
 
+        /// <summary>
+        /// The fail-open sentinel must be a value SQL Server can accept as a parameter against
+        /// <c>created_utc</c>, which is a <c>datetime</c> (floor 1753-01-01). Returning
+        /// <see cref="DateTime.MinValue"/> risked a SqlDateTime overflow - the guard failing CLOSED by
+        /// throwing, in precisely the case it exists to handle.
+        /// </summary>
         [TestMethod]
-        public void DedupWindowStart_NearDateTimeMinValue_DoesNotThrow()
+        public void UnboundedDedupWindowStart_IsWithinSqlServerDatetimeRange()
+        {
+            var sentinel = CopilotInteractionHistoryImporter.UnboundedDedupWindowStart;
+
+            Assert.IsTrue(sentinel >= System.Data.SqlTypes.SqlDateTime.MinValue.Value,
+                "The sentinel must be >= SQL Server's datetime floor or it cannot be passed as a parameter.");
+            Assert.IsTrue(sentinel <= System.Data.SqlTypes.SqlDateTime.MaxValue.Value);
+            Assert.IsTrue(sentinel < new DateTime(2000, 1, 1),
+                "It must still be early enough to be an effective 'no lower bound'.");
+        }
+
+        [TestMethod]
+        public void DedupWindowStart_NearTheDatetimeFloor_DoesNotUnderflow()
         {
             var start = CopilotInteractionHistoryImporter.DedupWindowStart(new[] { DateTime.MinValue.AddDays(1) });
-            Assert.AreEqual(DateTime.MinValue, start);
+            Assert.AreEqual(CopilotInteractionHistoryImporter.UnboundedDedupWindowStart, start);
+
+            // A real timestamp just above the floor must not be pushed below it by the margin.
+            var justAboveFloor = CopilotInteractionHistoryImporter.UnboundedDedupWindowStart.AddDays(1);
+            Assert.AreEqual(CopilotInteractionHistoryImporter.UnboundedDedupWindowStart,
+                CopilotInteractionHistoryImporter.DedupWindowStart(new[] { justAboveFloor }));
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/CopilotInteractionHistoryImporter.cs
@@ -202,7 +202,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
             catch (Exception ex)
             {
                 _logger.LogError(ex, $"Copilot interaction history import failed: {ex.Message}");
-                runLog.Error = Truncate(ex.Message, 1000);
+                runLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
             }
 
             return await FinishRunAsync(runLog, sw);
@@ -844,6 +844,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
         /// The timestamp-only core of <see cref="DedupWindowStart(List{UserLoadResult})"/>, separated so it
         /// can be unit tested without building loader results.
         /// </summary>
+        /// <summary>
+        /// The "no bound" sentinel for the de-duplication window.
+        ///
+        /// Deliberately NOT <see cref="DateTime.MinValue"/>. <c>copilot_interactions.created_utc</c> is a
+        /// SQL Server <c>datetime</c> (EF6 <c>c.DateTime()</c>), whose floor is 1753-01-01; passing
+        /// 0001-01-01 as a parameter against that column risks a <c>SqlDateTime</c> overflow. That would
+        /// turn this guard - whose entire purpose is to FAIL OPEN when the window cannot be computed - into
+        /// one that fails closed by throwing, in exactly the situation it exists for. No Copilot
+        /// interaction can predate 1753, so this is equivalent in meaning and safe as a parameter.
+        /// </summary>
+        internal static readonly DateTime UnboundedDedupWindowStart = new DateTime(1753, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         internal static DateTime DedupWindowStart(IEnumerable<DateTime> createdUtcs)
         {
             var oldest = DateTime.MaxValue;
@@ -854,11 +866,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
                     // A default timestamp means we cannot place that row in time. Skipping it would compute
                     // a window that EXCLUDES the stored row it duplicates - a missed duplicate, which hits
                     // the unique index and fails the batch. So any default makes the whole window fall
-                    // open. (Unreachable today: InteractionStatsExtractor drops interactions with no
-                    // createdDateTime before they get here. This guard is written to fail open so that
-                    // stays true if that ever changes.)
+                    // open. Reachable in practice: Graph returning "0001-01-01T00:00:00Z" deserialises to a
+                    // non-null DateTime that IS default, so the null check in InteractionStatsExtractor
+                    // does not cover this.
                     if (created == default(DateTime))
-                        return DateTime.MinValue;
+                        return UnboundedDedupWindowStart;
 
                     if (created < oldest)
                         oldest = created;
@@ -867,12 +879,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
 
             // No timestamps at all - fall back to reading everything rather than risking a missed duplicate.
             if (oldest == DateTime.MaxValue)
-                return DateTime.MinValue;
+                return UnboundedDedupWindowStart;
 
-            // Guard the subtraction: a bad timestamp near DateTime.MinValue would otherwise throw.
-            return oldest > DateTime.MinValue.AddDays(DedupLookbackMarginDays)
-                ? oldest.AddDays(-DedupLookbackMarginDays)
-                : DateTime.MinValue;
+            // Guard the subtraction, and never return a value below the datetime floor.
+            if (oldest <= UnboundedDedupWindowStart.AddDays(DedupLookbackMarginDays))
+                return UnboundedDedupWindowStart;
+
+            return oldest.AddDays(-DedupLookbackMarginDays);
         }
 
         private async Task<HashSet<string>> LoadExistingInteractionKeysAsync(AnalyticsEntitiesContext db, List<int> sessionIds, DateTime fromUtc)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/GraphPilotGroupMemberResolver.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Copilot/InteractionHistory/GraphPilotGroupMemberResolver.cs
@@ -292,7 +292,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHisto
                 }
                 catch (Exception ex)
                 {
-                    budget.Stop($"group discovery failed ({ex.GetType().Name}: {ex.Message}).");
+                    budget.Stop($"group discovery failed ({ex.GetType().Name}: {GraphHttpException.DescribeForStorage(ex)}).");
                     break;
                 }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -403,48 +403,75 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
                 _logger.LogInformation($"Reading all activity reports from {daysBackMax} days back...");
 
-                // Parallel-load all, each one with own DB context
+                // Parallel-load all, each one with own DB context.
+                //
+                // Each report is run through RunReportSafely so ONE failing report cannot discard the work
+                // of the others: whatever downloaded successfully is still saved. Failures are collected and
+                // decide whether this phase is allowed to stamp itself complete below.
                 var importTasks = new List<Task>();
+                var failedReports = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+                async Task RunReportSafely(string reportName, Func<Task> work)
+                {
+                    try
+                    {
+                        await work();
+                    }
+                    catch (GraphHttpException ex)
+                    {
+                        failedReports.Add($"{reportName} (HTTP {(int)ex.StatusCode} {ex.StatusCode})");
+                        _logger.LogError(ex, $"{reportName} failed with HTTP {(int)ex.StatusCode} ({ex.StatusCode}): {ex.Message} " +
+                            "The other activity reports are unaffected and any data already downloaded has been saved. " +
+                            "This phase will NOT be recorded as complete, so it retries on the next cycle. " +
+                            "A 401/403 here almost always means the Reports.Read.All application permission is missing or not admin-consented.");
+                    }
+                    catch (Exception ex)
+                    {
+                        failedReports.Add($"{reportName} ({ex.GetType().Name})");
+                        _logger.LogError(ex, $"{reportName} failed: {ex.Message}. The other activity reports are unaffected; " +
+                            "this phase will NOT be recorded as complete, so it retries on the next cycle.");
+                    }
+                }
 
                 var lookupIdCache = new ConcurrentLookupDbIdsCache();
 
                 // Daily imports
                 var teamsUserUsageLoader = new TeamsUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserUsageLoader, daysBackMax, "Teams user activity", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("Teams user activity", () => LoadAndSaveDailyImportReport(teamsUserUsageLoader, daysBackMax, "Teams user activity", _logger, lookupIdCache, lastImportedDate)));
 
                 var teamsUserDeviceLoader = new TeamsUserDeviceLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(teamsUserDeviceLoader, daysBackMax, "Teams user device", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("Teams user device", () => LoadAndSaveDailyImportReport(teamsUserDeviceLoader, daysBackMax, "Teams user device", _logger, lookupIdCache, lastImportedDate)));
 
                 var outlookLoader = new OutlookUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(outlookLoader, daysBackMax, "Outlook activity", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("Outlook activity", () => LoadAndSaveDailyImportReport(outlookLoader, daysBackMax, "Outlook activity", _logger, lookupIdCache, lastImportedDate)));
 
                 var oneDriveUsageLoader = new OneDriveUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUsageLoader, daysBackMax, "OneDrive usage", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("OneDrive usage", () => LoadAndSaveDailyImportReport(oneDriveUsageLoader, daysBackMax, "OneDrive usage", _logger, lookupIdCache, lastImportedDate)));
 
                 var oneDriveUserActivityLoader = new OneDriveUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(oneDriveUserActivityLoader, daysBackMax, "OneDrive activity", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("OneDrive activity", () => LoadAndSaveDailyImportReport(oneDriveUserActivityLoader, daysBackMax, "OneDrive activity", _logger, lookupIdCache, lastImportedDate)));
 
                 var sharePointUserActivityLoader = new SharePointUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(sharePointUserActivityLoader, daysBackMax, "SharePoint user activity", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("SharePoint user activity", () => LoadAndSaveDailyImportReport(sharePointUserActivityLoader, daysBackMax, "SharePoint user activity", _logger, lookupIdCache, lastImportedDate)));
 
                 var yammerUserActivityLoader = new YammerUserUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerUserActivityLoader, daysBackMax, "Yammer user activity", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("Yammer user activity", () => LoadAndSaveDailyImportReport(yammerUserActivityLoader, daysBackMax, "Yammer user activity", _logger, lookupIdCache, lastImportedDate)));
 
                 var yammerGroupsActivityLoader = new YammerGroupUsageLoader(client, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerGroupsActivityLoader, daysBackMax, "Yammer group activity", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("Yammer group activity", () => LoadAndSaveDailyImportReport(yammerGroupsActivityLoader, daysBackMax, "Yammer group activity", _logger, lookupIdCache, lastImportedDate)));
 
                 var yammerDeviceActivityLoader = new YammerDeviceUsageLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(yammerDeviceActivityLoader, daysBackMax, "Yammer device activity", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("Yammer device activity", () => LoadAndSaveDailyImportReport(yammerDeviceActivityLoader, daysBackMax, "Yammer device activity", _logger, lookupIdCache, lastImportedDate)));
 
                 var userPlatActivityLoader = new AppPlatformUserActivityLoader(client, userGroupsCache, userGroupsFilterModel, _logger);
-                importTasks.Add(LoadAndSaveDailyImportReport(userPlatActivityLoader, daysBackMax, "Apps & platform activity", _logger, lookupIdCache, lastImportedDate));
+                importTasks.Add(RunReportSafely("Apps & platform activity", () => LoadAndSaveDailyImportReport(userPlatActivityLoader, daysBackMax, "Apps & platform activity", _logger, lookupIdCache, lastImportedDate)));
 
                 // Weekly imports
                 using (var db = new AnalyticsEntitiesContext())
                 {
                     var sharePointSitesWeeklyUsageReportLoader = new SharePointSitesWeeklyUsageReportLoader(db, client, _logger, new GraphSPSiteIdToUrlCache(_graphClient, db, _logger));
 
-                    importTasks.Add(sharePointSitesWeeklyUsageReportLoader.LoadAndSaveLastWeeksReportsIfRefreshOnDay(System.DayOfWeek.Sunday));
+                    importTasks.Add(RunReportSafely("SharePoint sites weekly usage", () => sharePointSitesWeeklyUsageReportLoader.LoadAndSaveLastWeeksReportsIfRefreshOnDay(System.DayOfWeek.Sunday)));
                     await Task.WhenAll(importTasks);
                 }
 
@@ -458,7 +485,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     }
                 }
 
-                // Remember last import date so the next cycle within the throttle window is skipped.
+                // Remember last import date so the next cycle within the throttle window is skipped - but
+                // ONLY when every report actually completed. The timestamp is the proof that the phase
+                // finished, so stamping it after a failure is what used to make a broken import look
+                // healthy and idle for 24 hours (issue #285). Anything that downloaded successfully has
+                // already been saved above, so a retry next cycle is cheap and picks up only what is missing.
+                if (failedReports.Count > 0)
+                {
+                    _logger.LogError($"Activity reports did NOT fully import - {failedReports.Count} of {importTasks.Count} report(s) failed: " +
+                        string.Join(", ", failedReports.OrderBy(r => r)) + ". " +
+                        "Everything that did download has been saved. This phase has NOT been marked complete and will retry on the next cycle. " +
+                        "If this repeats, check the runtime account has the Reports.Read.All application permission granted and admin-consented.");
+                    return false;
+                }
+
                 if (lastImportedStore != null)
                 {
                     await lastImportedStore.SaveDT();

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -421,7 +421,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     {
                         failedReports.Add($"{reportName} (HTTP {(int)ex.StatusCode} {ex.StatusCode})");
                         _logger.LogError(ex, $"{reportName} failed with HTTP {(int)ex.StatusCode} ({ex.StatusCode}): {ex.Message} " +
-                            "The other activity reports are unaffected and any data already downloaded has been saved. " +
+                            "The other activity reports are unaffected and keep whatever they downloaded; this report saved nothing at all. " +
                             "This phase will NOT be recorded as complete, so it retries on the next cycle. " +
                             "A 401/403 here almost always means the Reports.Read.All application permission is missing or not admin-consented.");
                     }
@@ -494,7 +494,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 {
                     _logger.LogError($"Activity reports did NOT fully import - {failedReports.Count} of {importTasks.Count} report(s) failed: " +
                         string.Join(", ", failedReports.OrderBy(r => r)) + ". " +
-                        "Everything that did download has been saved. This phase has NOT been marked complete and will retry on the next cycle. " +
+                        "Reports that succeeded have been saved; each failed report saved nothing. This phase has NOT been marked complete and will retry on the next cycle - " +
+                        "note that until it succeeds the once-a-day throttle stays disarmed, so the phase re-runs every cycle and re-downloads the full window. " +
                         "If this repeats, check the runtime account has the Reports.Read.All application permission granted and admin-consented.");
                     return false;
                 }


### PR DESCRIPTION
Two consequences of #309''s strict-paging change that need handling before the release goes out. Both were found by reviewing the blast radius of that change rather than by a test failing.

## 1. Strict paging broke install verification

`SolutionInstallVerifier` calls `PopulateLoadedReportPagesFromGraph` to check the tenant''s usage-report anonymisation setting. That call sat **outside any try/catch**:

- **Before #309:** a 403 yielded an empty report, and verification logged *"WARNING: Unable to verify usage report anonymization settings"* and carried on to report success.
- **After #309:** it throws, so a permissions problem would abort the entire install-verification run.

That inverts the verifier''s purpose — it exists to *report* problems, not propagate them. The call is now wrapped and reports in exactly the style of the `ReadTeamsUserActivityReportAsync` check immediately above it (log the error, name the likely cause, return), so a missing `Reports.Read.All` grant produces a clear message instead of an aborted run.

## 2. The activity-report phase was all-or-nothing

Throwing out of `Task.WhenAll` meant one failing report discarded the other ten reports'' work for that cycle. Worse, a permanently failing workload could have starved every other report indefinitely — each cycle would abort at the same place.

Each report now runs through a `RunReportSafely` wrapper, so:

- a failure is **isolated** — everything that downloaded successfully is still saved;
- the failure is logged with its **HTTP status** and the likely cause;
- the collected failures decide whether the phase may stamp itself complete.

### The #285 property still holds — and now holds more precisely

The "last imported" timestamp is still only written when **every** report actually completed, so a broken import cannot look healthy and idle for 24 hours. What changes is the cost of a partial failure: it now costs only the failing report, not the whole cycle, and the log names which reports failed and why.

```
Activity reports did NOT fully import - 1 of 11 report(s) failed: Yammer user activity (HTTP 403 Forbidden).
Everything that did download has been saved. This phase has NOT been marked complete and will retry on the
next cycle. If this repeats, check the runtime account has the Reports.Read.All application permission
granted and admin-consented.
```

## Why this matters for the release

#309 fixed a genuine "broken import looks healthy" bug, but it made the failure mode coarser than it needed to be. This keeps the fix and removes both regressions it introduced. Without it, the release would ship a change that can abort install verification on a misconfigured tenant — precisely the tenant most likely to be running it.

## Testing

30/30 pass locally (`GraphPagingFailureTests`, `OutlookUserActivityLoaderTests`, `ImportCadenceTests`). The strict-paging behaviour itself is covered by `DailyActivityLoader_ForbiddenFromGraph_Throws_InsteadOfRecordingAnEmptyDay` from #309; this PR changes only how that exception is handled by the two callers.

No schema change, no config-schema change, no migration.

## Reviewer hotspots

1. **`RunReportSafely` is a local function capturing `failedReports`** (a `ConcurrentBag`), used across eleven parallel tasks — concurrent-safe by type.
2. **The phase now returns `false` on partial failure**, where it previously either returned `true` or threw. Callers treat `false` as "did not run/complete", which is the intended meaning.

Follow-up from #309, which was itself follow-up from the release critique of #283.


---

# Added after the third release critique

The critique cleared the two fixes above ("I found nothing in it that I'd ask to be changed before merge") but found three further items, now included in this PR.

## Two persisted paths still wrote Graph URLs — #309 missed them

`GraphPilotGroupMemberResolver.cs:295` persisted `ex.Message` into the budget stop reason, which flows `budget.Reason` → `PilotGroupResolution.IncompleteReason` → `runLog.Error` → the `copilot_interaction_import_log.error` column and the Health page. For a Graph failure that stored the **full request URL — including the customer's pilot group name** in the `$filter`.

Its three sibling catch blocks in the same class (lines 210, 256, 349) all use `ex.GetType().Name` only, so this was an oversight rather than a decision. `CopilotInteractionHistoryImporter`'s top-level catch-all had the same shape. Both now route through `GraphHttpException.DescribeForStorage`.

## The fail-open sentinel could fail closed

`DedupWindowStart` returned `DateTime.MinValue` (0001-01-01) when it couldn't compute a window. But `copilot_interactions.created_utc` is a SQL Server **`datetime`**, whose floor is **1753-01-01** — so passing that as a parameter risks a `SqlDateTime` overflow. The guard whose entire purpose is to **fail open** could therefore have **failed closed by throwing**, in precisely the situation it exists for.

Replaced with an explicit `UnboundedDedupWindowStart` of 1753-01-01, and the margin subtraction can no longer push a value below it. New test asserts the sentinel sits inside `SqlDateTime`'s range.

**#309's "unreachable today" claim was also wrong.** A Graph payload carrying `"0001-01-01T00:00:00Z"` deserialises to a **non-null** `DateTime` that *is* `default`, so the null check in `InteractionStatsExtractor` does not cover it. The guard can genuinely fire — which makes the overflow hardening load-bearing rather than theoretical.

## Log accuracy

A failing report saves **nothing at all** — not even days that downloaded before the failure, because `PopulateLoadedReportPagesFromGraph` throws before `SaveLoadedReportsToSql` is reached. So *"any data already downloaded has been saved"* was misleading during triage. Both messages now say so precisely, and the phase-level message states that the once-a-day throttle stays disarmed until the failure clears.

## Known, accepted, and filed separately

The critique's remaining finding is that while any one report is failing, the withheld stamp means `lastSuccessfulImport == null`, which disables the finalized-date skip list — so the phase re-runs each cycle and re-downloads the full window. It downgraded this from a blocker to "name it in the admin notes and file a follow-up", because after this PR it is **efficiency only**: no data loss, no other subsystem affected, no starvation. The correct fix (per-report stamping or a partial-completion watermark) is too large for a release PR. Now noted in the log message, in PR #283's admin-facing risk list, and filed as its own issue.

## Testing

53/53 pass locally (`GraphPagingFailureTests`, `CopilotInteractionHistoryTests`, `OutlookUserActivityLoaderTests`).
