### PR TITLE
Reports: surface Copilot prompt key phrases, sentiment and languages in the Copilot tab (#312)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ReportsAPIControllerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ReportsAPIControllerTests.cs
@@ -242,6 +242,77 @@ namespace Tests.UnitTests
             }
         }
 
+        #region Copilot prompt insight charts (issue #312)
+
+        [TestMethod]
+        public void KeyPhrasesQuery_AggregatesAndCapsInSql()
+        {
+            // copilot_interaction_keywords is ~10 rows per scored prompt, so a million prompts is ~10M
+            // rows. This MUST be a SQL-side TOP N aggregate - fetching rows to count them client-side
+            // would pull the whole link table into the web app.
+            var sql = ReportsAPIController.BuildCopilotKeyPhrasesQuery(top: 40);
+
+            StringAssert.Contains(sql, "TOP 40");
+            StringAssert.Contains(sql, "GROUP BY");
+            StringAssert.Contains(sql, "COUNT_BIG(*)");
+            StringAssert.Contains(sql, "dbo.copilot_interaction_keywords");
+            StringAssert.Contains(sql, "dbo.keywords");
+            StringAssert.Contains(sql, "OPTION (RECOMPILE)");
+
+            // Bounded by the reporting window, not the whole table.
+            StringAssert.Contains(sql, "i.created_utc >= @from");
+        }
+
+        [TestMethod]
+        public void SentimentQuery_ExcludesUnscoredPrompts()
+        {
+            // An unscored prompt is not a neutral prompt. Counting NULL as 0 would drag the average
+            // towards neutral in proportion to how much of the data was never scored.
+            var sql = ReportsAPIController.BuildCopilotSentimentQuery();
+
+            StringAssert.Contains(sql, "AVG(i.sentiment_score)");
+            StringAssert.Contains(sql, "i.sentiment_score IS NOT NULL");
+            StringAssert.Contains(sql, "i.created_utc >= @from");
+            StringAssert.Contains(sql, "OPTION (RECOMPILE)");
+        }
+
+        [TestMethod]
+        public void LanguagesQuery_IsBoundedAndIgnoresUndetected()
+        {
+            var sql = ReportsAPIController.BuildCopilotLanguagesQuery(top: 8);
+
+            StringAssert.Contains(sql, "TOP 8");
+            StringAssert.Contains(sql, "dbo.languages");
+            StringAssert.Contains(sql, "i.language_id IS NOT NULL");
+            StringAssert.Contains(sql, "i.created_utc >= @from");
+            StringAssert.Contains(sql, "OPTION (RECOMPILE)");
+        }
+
+        [TestMethod]
+        public void PromptInsightQueries_ReadInteractionHistoryNotTheAuditLog()
+        {
+            // These three are the ONLY Copilot charts sourced from the opt-in Graph interaction-history
+            // import. The rest of the tab reads copilot_chats/audit_events. Mixing them up would silently
+            // report on a different population.
+            var queries = new[]
+            {
+                ReportsAPIController.BuildCopilotKeyPhrasesQuery(),
+                ReportsAPIController.BuildCopilotSentimentQuery(),
+                ReportsAPIController.BuildCopilotLanguagesQuery(),
+            };
+
+            foreach (var sql in queries)
+            {
+                StringAssert.Contains(sql, "dbo.copilot_interactions");
+                Assert.IsFalse(sql.Contains("copilot_chats"),
+                    "Prompt insight charts must not read the audit-log Copilot tables.");
+                Assert.IsFalse(sql.Contains("audit_events"),
+                    "Prompt insight charts must not read the audit-log Copilot tables.");
+            }
+        }
+
+        #endregion
+
         [TestMethod]
         public void QueryTimeoutDetection_RecognizesNestedTimeout()
         {

--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -245,7 +245,7 @@ namespace Web.AnalyticsWeb.Controllers
                 "GROUP BY ISNULL(c.app_host, '(unknown)') ORDER BY Value DESC\r\n" +
                 "OPTION (RECOMPILE);";
 
-            return new List<Task<ReportChart>>
+            var charts = new List<Task<ReportChart>>
             {
                 RunTimeSeriesAsync("copilot-interactions", "Copilot interactions per week",
                     "Total Microsoft 365 Copilot interactions each week.", "Interactions", "Interactions", interactions, from, weekSpine),
@@ -254,6 +254,110 @@ namespace Web.AnalyticsWeb.Controllers
                 RunCategoryAsync("copilot-hosts", "Interactions by app",
                     "Where Copilot is being used across the window (top apps).", "Interactions", hosts, from),
             };
+
+            // The prompt-insight charts are driven by Azure AI Language enrichment of the Copilot
+            // interaction-history import. Without a cognitive configuration those columns are never
+            // populated, so the charts would be three permanently empty panels - don't offer them at all.
+            if (IsCognitiveEnabled())
+                charts.AddRange(CopilotPromptInsightCharts(from, weekSpine));
+
+            return charts;
+        }
+
+        /// <summary>
+        /// True when the app has a usable Azure AI Language (cognitive) configuration. Never throws:
+        /// a report page must not fail because configuration could not be read, and the safe answer is
+        /// "don't show the cognitive charts".
+        /// </summary>
+        private static bool IsCognitiveEnabled()
+        {
+            try
+            {
+                return new AppConfig().IsValidCognitiveConfig;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Charts over the cognitive enrichment of Copilot prompt history: extracted key phrases,
+        /// sentiment and detected language. Only added when cognitive services are configured.
+        /// </summary>
+        /// <remarks>
+        /// These read <c>copilot_interactions</c> (the opt-in Graph AI interaction-history import), NOT
+        /// <c>copilot_chats</c> (the audit-log import that backs the rest of this tab). Both can be
+        /// enabled independently, so all three carry an explicit "no data" warning rather than rendering
+        /// an empty panel that looks broken.
+        ///
+        /// Scale note: at ten key phrases per scored prompt a million prompts is ~10M rows in
+        /// <c>copilot_interaction_keywords</c>, so the phrase query is a SQL-side TOP N aggregate and
+        /// never a client-side count. It is bounded by <c>created_utc</c> on the interaction, which is
+        /// also what <c>IX_copilot_interactions_dedup_window</c> leads on after the session id.
+        /// </remarks>
+        private static List<Task<ReportChart>> CopilotPromptInsightCharts(DateTime from, List<DateTime> weekSpine)
+        {
+            const string NoDataWarning =
+                "No cognitive data in this period. This needs the Copilot AI interaction-history import "
+                + "enabled with cognitive enrichment turned on, and at least one import cycle to have run.";
+
+            var phrases = BuildCopilotKeyPhrasesQuery();
+            var sentiment = BuildCopilotSentimentQuery();
+            var languages = BuildCopilotLanguagesQuery();
+
+            return new List<Task<ReportChart>>
+            {
+                RunCategoryAsync("copilot-key-phrases", "Most common prompt phrases",
+                    "Key phrases extracted from Copilot prompts by Azure AI Language, sized by how often they appear.",
+                    "Mentions", phrases, from, chartType: "wordcloud", emptyWarning: NoDataWarning),
+                RunTimeSeriesAsync("copilot-sentiment", "Prompt sentiment over time",
+                    "Average sentiment of Copilot prompts each week, from -1 (negative) to +1 (positive). Weeks with no scored prompts are left as gaps, not zero.",
+                    "Sentiment", "Average sentiment", sentiment, from, weekSpine, missingValue: null),
+                RunCategoryAsync("copilot-languages", "Prompt languages",
+                    "Languages detected in Copilot prompts across the window.",
+                    "Prompts", languages, from, emptyWarning: NoDataWarning),
+            };
+        }
+
+        /// <summary>Top extracted key phrases in the window. TOP N in SQL - the link table is large.</summary>
+        internal static string BuildCopilotKeyPhrasesQuery(int top = 40)
+        {
+            return
+                $"SELECT TOP {top} k.[name] AS Label, CAST(COUNT_BIG(*) AS float) AS Value\r\n" +
+                "FROM dbo.copilot_interaction_keywords AS ck\r\n" +
+                "INNER JOIN dbo.keywords AS k ON k.id = ck.keyword_id\r\n" +
+                "INNER JOIN dbo.copilot_interactions AS i ON i.id = ck.interaction_id\r\n" +
+                "WHERE i.created_utc >= @from\r\n" +
+                "GROUP BY k.[name] ORDER BY Value DESC\r\n" +
+                "OPTION (RECOMPILE);";
+        }
+
+        /// <summary>
+        /// Weekly mean prompt sentiment. Rows with no score are excluded rather than counted as zero -
+        /// zero is "neutral", which is a real and different answer from "not scored".
+        /// </summary>
+        internal static string BuildCopilotSentimentQuery()
+        {
+            var wb = WeekBucket("i.created_utc");
+            return
+                $"SELECT {wb} AS WeekStart, AVG(i.sentiment_score) AS Value\r\n" +
+                "FROM dbo.copilot_interactions AS i\r\n" +
+                "WHERE i.created_utc >= @from AND i.sentiment_score IS NOT NULL\r\n" +
+                $"GROUP BY {wb} ORDER BY WeekStart\r\n" +
+                "OPTION (RECOMPILE);";
+        }
+
+        /// <summary>Detected prompt languages in the window.</summary>
+        internal static string BuildCopilotLanguagesQuery(int top = 8)
+        {
+            return
+                $"SELECT TOP {top} l.[name] AS Label, CAST(COUNT_BIG(*) AS float) AS Value\r\n" +
+                "FROM dbo.copilot_interactions AS i\r\n" +
+                "INNER JOIN dbo.languages AS l ON l.id = i.language_id\r\n" +
+                "WHERE i.created_utc >= @from AND i.language_id IS NOT NULL\r\n" +
+                "GROUP BY l.[name] ORDER BY Value DESC\r\n" +
+                "OPTION (RECOMPILE);";
         }
 
         internal static string BuildCopilotUsersQuery(DateTime from, DateTime? today = null)
@@ -512,9 +616,16 @@ namespace Web.AnalyticsWeb.Controllers
 
         #region Query runners
 
-        /// <summary>Runs a single-series weekly query and gap-fills missing weeks with zero.</summary>
+        /// <summary>
+        /// Runs a single-series weekly query and gap-fills missing weeks with <paramref name="missingValue"/>
+        /// (zero by default, since most of these charts count events and "no rows" really is "nothing
+        /// happened"). Pass null for averages, where a week with no rows means "not measured" rather than
+        /// zero - drawing an unscored week as 0 sentiment would read as "neutral", which is a different
+        /// and wrong answer.
+        /// </summary>
         private static async Task<ReportChart> RunTimeSeriesAsync(string key, string title, string description,
-            string valueLabel, string seriesName, string body, DateTime from, List<DateTime> weekSpine)
+            string valueLabel, string seriesName, string body, DateTime from, List<DateTime> weekSpine,
+            double? missingValue = 0)
         {
             var chart = new ReportChart
             {
@@ -531,7 +642,7 @@ namespace Web.AnalyticsWeb.Controllers
                 var rows = await QueryWeeksAsync(body, from);
                 chart.Series = new List<ReportSeries>
                 {
-                    new ReportSeries { Name = seriesName, Points = FillWeeks(weekSpine, rows) },
+                    new ReportSeries { Name = seriesName, Points = FillWeeks(weekSpine, rows, missingValue) },
                 };
             }
             catch (Exception ex)
@@ -785,14 +896,14 @@ namespace Web.AnalyticsWeb.Controllers
 
         /// <summary>Runs a categorical (bar) query - label + value rows, already ordered by the query.</summary>
         private static async Task<ReportChart> RunCategoryAsync(string key, string title, string description,
-            string valueLabel, string body, DateTime from)
+            string valueLabel, string body, DateTime from, string chartType = "bar", string emptyWarning = null)
         {
             var chart = new ReportChart
             {
                 Key = key,
                 Title = title,
                 Description = description,
-                Type = "bar",
+                Type = chartType,
                 ValueLabel = valueLabel,
                 Sql = DisplaySql(body, from),
             };
@@ -808,6 +919,11 @@ namespace Web.AnalyticsWeb.Controllers
                     chart.Categories = rows
                         .Select(r => new ReportCategory { Label = r.Label, Value = r.Value })
                         .ToList();
+
+                    // "Nothing came back" is ambiguous for the cognitive charts - the import may simply be
+                    // off - so let the caller explain it rather than leaving an empty panel.
+                    if (chart.Categories.Count == 0 && !string.IsNullOrEmpty(emptyWarning))
+                        chart.Warning = emptyWarning;
                 }
             }
             catch (Exception ex)

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/WordCloud.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/WordCloud.tsx
@@ -1,0 +1,94 @@
+import { makeStyles, tokens, Text } from '@fluentui/react-components';
+import type { ReportCategory } from '../../types/reports';
+import { formatValue, seriesColor } from './chartCommon';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    justifyContent: 'center',
+    gap: '4px 14px',
+    width: '100%',
+    padding: '18px 8px',
+    lineHeight: '1.5',
+  },
+  word: {
+    cursor: 'default',
+    whiteSpace: 'nowrap',
+    transition: 'opacity 120ms ease',
+    ':hover': {
+      opacity: 0.65,
+    },
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '24px 0',
+    textAlign: 'center',
+  },
+});
+
+/** Smallest and largest rendered font size, in pixels. */
+const MIN_FONT = 12;
+const MAX_FONT = 40;
+
+type WordCloudProps = {
+  categories: ReportCategory[];
+  /** Unit shown in the tooltip, e.g. "Mentions". */
+  valueLabel: string;
+};
+
+/**
+ * A dependency-free word cloud for "top N phrases" data.
+ *
+ * Deliberately a simple flow layout rather than a packed/spiral cloud: the point is to convey
+ * relative frequency at a glance, and a flow layout stays readable, reflows on narrow screens and
+ * needs no layout library. Font size carries the value; colour is from the shared palette purely to
+ * make the cloud legible, and does NOT encode anything.
+ *
+ * Scaling is by square root of the value, not linearly. Phrase frequencies are heavily long-tailed -
+ * one dominant phrase would otherwise flatten everything else to the minimum size and the cloud would
+ * convey nothing.
+ */
+export default function WordCloud({ categories, valueLabel }: WordCloudProps) {
+  const styles = useStyles();
+
+  if (categories.length === 0) {
+    return <div className={styles.empty}>No data for this period.</div>;
+  }
+
+  const values = categories.map((c) => c.value);
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+
+  // sqrt scaling, guarding the degenerate case where every phrase has the same count (max === min),
+  // which would otherwise divide by zero and render nothing.
+  const spread = Math.sqrt(max) - Math.sqrt(min);
+  const fontFor = (v: number) => {
+    if (spread <= 0) return (MIN_FONT + MAX_FONT) / 2;
+    const t = (Math.sqrt(v) - Math.sqrt(min)) / spread;
+    return MIN_FONT + t * (MAX_FONT - MIN_FONT);
+  };
+
+  // Largest first reads better than the SQL order and keeps the visual weight at the top.
+  const ordered = [...categories].sort((a, b) => b.value - a.value);
+
+  return (
+    <div className={styles.root}>
+      {ordered.map((c, i) => (
+        <Text
+          key={c.label}
+          className={styles.word}
+          title={`${c.label}: ${formatValue(c.value)} ${valueLabel}`}
+          style={{
+            fontSize: `${fontFor(c.value).toFixed(1)}px`,
+            color: seriesColor(i),
+            fontWeight: c.value >= max * 0.6 ? 600 : 400,
+          }}
+        >
+          {c.label}
+        </Text>
+      ))}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
@@ -22,6 +22,7 @@ import Spinner from '../components/Spinner';
 import SqlPopover from '../components/SqlPopover';
 import TimeSeriesChart from '../components/charts/TimeSeriesChart';
 import CategoryBarChart from '../components/charts/CategoryBarChart';
+import WordCloud from '../components/charts/WordCloud';
 
 /** The report areas in display order, with the enabled-flag they map to and their friendly copy. */
 const AREA_DEFS: { flag: keyof ReportAreas; key: ReportAreaKey; label: string; blurb: string }[] = [
@@ -380,6 +381,8 @@ function ReportAreaView({
                   <TimeSeriesChart series={chart.series} valueLabel={chart.valueLabel} />
                 ) : chart.type === 'bar' && chart.categories ? (
                   <CategoryBarChart categories={chart.categories} valueLabel={chart.valueLabel} />
+                ) : chart.type === 'wordcloud' && chart.categories ? (
+                  <WordCloud categories={chart.categories} valueLabel={chart.valueLabel} />
                 ) : (
                   <Text className={styles.muted}>No data for this period.</Text>
                 )}

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
@@ -30,9 +30,9 @@ export interface ReportCategory {
   value: number;
 }
 
-export type ReportChartType = 'timeseries' | 'bar';
+export type ReportChartType = 'timeseries' | 'bar' | 'wordcloud';
 
-/** A single chart: a weekly `timeseries` (series set) or a `bar` chart (categories set). */
+/** A single chart: a weekly `timeseries` (series set), or a `bar` / `wordcloud` (categories set). */
 export interface ReportChart {
   key: string;
   title: string;


### PR DESCRIPTION
Closes the gap raised in #312: the Copilot AI interaction-history import extracts key phrases, a sentiment score and a detected language for every scored prompt, but **nothing in the product ever read them back**. They were written by the importer and deleted by the retention jobs — that was the entire lifecycle.

So an admin who enabled cognitive enrichment paid for Azure AI Language calls, accepted prompt text leaving the tenant, stored the results, and had no way to see any of it. That is a poor trade to offer, and it made the enrichment toggle hard to justify.

## What this adds

Three charts on the **existing** `Copilot` sub-tab in Reports (`AREA_DEFS` already had it):

| Chart | Type | Source |
|---|---|---|
| **Most common prompt phrases** | word cloud (new type) | `copilot_interaction_keywords` → `keywords` |
| **Prompt sentiment over time** | weekly line | `copilot_interactions.sentiment_score` |
| **Prompt languages** | bar | `copilot_interactions.language_id` → `languages` |

All three respect the existing 1/3/6-month period selector and appear in the existing "SQL behind this chart" popover like every other chart.

## Gating: cognitive services only

Added only when `AppConfig.IsValidCognitiveConfig` is true. Without a cognitive configuration those columns are never populated, so the alternative is three permanently empty panels.

**Enabled is necessary but not sufficient** — cognitive services can be configured at the Azure level while the Copilot interaction-history import itself is off. So rather than rendering an empty panel that looks broken, the two category charts carry an explicit warning naming what has to be turned on:

> No cognitive data in this period. This needs the Copilot AI interaction-history import enabled with cognitive enrichment turned on, and at least one import cycle to have run.

`IsCognitiveEnabled()` never throws — a report page must not fail because configuration could not be read, and the safe answer is "don't show the cognitive charts".

## Sentiment gap-fills with null, not zero

`RunTimeSeriesAsync` always filled missing weeks with **zero**. That is correct for charts that count events — no rows really does mean nothing happened — but **wrong for an average**. A week where nothing was scored would have been drawn as `0`, i.e. *neutral*, which is a real and different answer from *not measured*, and would have made quiet weeks look like unhappy ones.

The fill value is now a parameter (`missingValue`, defaulting to `0`), so **every existing caller keeps its current behaviour** and only sentiment opts into null. The `ReportTimePoint.Value` type was already `double?` and the front end already draws null as a gap — this just uses the capability that was there.

The SQL excludes unscored rows too (`sentiment_score IS NOT NULL`) rather than averaging NULLs as zero.

## The word cloud

A new `wordcloud` chart type, reusing the existing `categories` payload (label + value) so the backend contract is unchanged.

Rendered by a new **dependency-free** component, matching the existing hand-rolled `CategoryBarChart` / `TimeSeriesChart` — no charting library was added.

- **Square-root font scaling.** Phrase frequencies are heavily long-tailed; linear scaling would flatten everything below the top phrase to the minimum size and the cloud would convey nothing.
- Deliberately a **flow layout**, not a packed/spiral cloud — it stays readable, reflows on narrow screens and needs no layout library.
- Colour is from the shared palette purely for legibility and **encodes nothing**; size carries the value.
- Guards the degenerate case where every phrase has the same count (which would otherwise divide by zero).

## Scale

`copilot_interaction_keywords` holds ~10 rows per scored prompt, so a million prompts is ~10M rows. All three queries are **SQL-side aggregates with `TOP N`**, bounded by the reporting window — none fetch rows to count client-side. Pinned by a test, because this is the kind of thing that quietly regresses.

No new index is added. The phrase query joins the link table to `copilot_interactions` and bounds on `created_utc`; if this proves slow on a large tenant, any index must come with the measured before/after the release gate requires — I have not shipped one on speculation.

## Testing

- **4 new backend tests**: TOP N + `GROUP BY` present, sentiment excludes unscored rows, languages bounded, and a guard that all three read `copilot_interactions` (the opt-in Graph import) and **never** `copilot_chats` / `audit_events` — mixing those up would silently report on a different population.
- 15/15 `ReportsAPIControllerTests` pass.
- `tsc --noEmit` clean and the SPA bundle builds.
- **All three queries executed against a real database** with this release's schema to confirm the table and column names resolve — SQL string errors are not caught by compilation or by the assertions above.

## Reviewer hotspots

1. **The `missingValue` default.** I kept `0` so no existing chart changes. Worth a look that sentiment is genuinely the only average in here.
2. **Word-cloud disclosure.** A key phrase can amount to a whole short prompt, so this is more disclosive than the aggregate counts elsewhere on the page. It sits behind the same `[Authorize]` as the rest of Reports; if that is not enough, it should be gated further.
3. **No index added** — see Scale above.

Closes #312.
