### PR TITLE
Fix fractional y-axis labels, and correct the sentiment scale in the chart description

### DIFF
--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -312,7 +312,7 @@ namespace Web.AnalyticsWeb.Controllers
                     "Key phrases extracted from Copilot prompts by Azure AI Language, sized by how often they appear.",
                     "Mentions", phrases, from, chartType: "wordcloud", emptyWarning: NoDataWarning),
                 RunTimeSeriesAsync("copilot-sentiment", "Prompt sentiment over time",
-                    "Average sentiment of Copilot prompts each week, from -1 (negative) to +1 (positive). Weeks with no scored prompts are left as gaps, not zero.",
+                    "Average positive-sentiment confidence of Copilot prompts each week, from 0.0 (negative) through 0.5 (neutral) to 1.0 (positive). Weeks with no scored prompts are left as gaps, not zero.",
                     "Sentiment", "Average sentiment", sentiment, from, weekSpine, missingValue: null),
                 RunCategoryAsync("copilot-languages", "Prompt languages",
                     "Languages detected in Copilot prompts across the window.",
@@ -335,7 +335,9 @@ namespace Web.AnalyticsWeb.Controllers
 
         /// <summary>
         /// Weekly mean prompt sentiment. Rows with no score are excluded rather than counted as zero -
-        /// zero is "neutral", which is a real and different answer from "not scored".
+        /// the score is a positive-sentiment CONFIDENCE (0.0-1.0, matching the sent-email import), so 0
+        /// means "confidently negative", not "not scored". Averaging NULLs in as zero would drag every
+        /// week towards negative in proportion to how much of the data was never enriched.
         /// </summary>
         internal static string BuildCopilotSentimentQuery()
         {

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/chartCommon.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/components/charts/chartCommon.ts
@@ -21,13 +21,22 @@ export function seriesColor(i: number): string {
   return CHART_PALETTE[i % CHART_PALETTE.length];
 }
 
-/** Compact number for axis labels: 1234 -> "1.2k", 2_500_000 -> "2.5M". */
+/**
+ * Compact number for axis labels: 1234 -> "1.2k", 2_500_000 -> "2.5M".
+ *
+ * Small fractional values keep their decimals. Rounding them to whole numbers turned a sentiment
+ * axis of 0, 0.2, 0.4, 0.6, 0.8, 1 into "0, 0, 0, 1, 1, 1" - six labels, four of them duplicates and
+ * none of them true. Integer inputs are unaffected, so the counting charts render exactly as before.
+ */
 export function formatCompact(n: number): string {
   const abs = Math.abs(n);
   if (abs >= 1e9) return `${trim(n / 1e9)}B`;
   if (abs >= 1e6) return `${trim(n / 1e6)}M`;
   if (abs >= 1e3) return `${trim(n / 1e3)}k`;
-  return String(Math.round(n));
+  if (Number.isInteger(n)) return String(n);
+
+  // Enough precision to keep neighbouring ticks distinct without a wall of digits.
+  return Number(n.toFixed(2)).toString();
 }
 
 function trim(n: number): string {
@@ -35,9 +44,9 @@ function trim(n: number): string {
   return n.toFixed(1).replace(/\.0$/, '');
 }
 
-/** Full number for tooltips (e.g. "1,234"; fractional values keep up to one decimal). */
+/** Full number for tooltips (e.g. "1,234"; fractional values keep up to two decimals). */
 export function formatValue(n: number): string {
-  const rounded = Number.isInteger(n) ? n : Math.round(n * 10) / 10;
+  const rounded = Number.isInteger(n) ? n : Math.round(n * 100) / 100;
   return rounded.toLocaleString();
 }
 


### PR DESCRIPTION
Two problems with the prompt-sentiment chart added in #313, both visible in the screenshot that prompted this.

## The y axis read "1, 1, 0, 0, 0, 0"

`formatCompact` rounded everything below 1000 to a whole number:

```ts
return String(Math.round(n));
```

That is correct for the charts it was written for — they all **count** things, so ticks are naturally integers. It is wrong for an **average**. A sentiment axis of `0, 0.2, 0.4, 0.6, 0.8, 1` collapsed to six labels, four of them duplicates and none of them true.

Fractional values now keep up to two decimals. **Integers are formatted exactly as before**, so every existing chart is byte-identical — this only affects axes that were already rendering wrongly.

Tooltips got the same fix: they rounded to one decimal, so a sentiment of 0.87 was reported as 0.9.

## The description was factually wrong

It claimed sentiment runs **from -1 to +1**. It does not. `sentiment_score` is the positive-sentiment **confidence** from Azure AI Language, **0.0–1.0** — `InteractionCognitiveEnricher` stores `doc.DocumentSentiment.ConfidenceScores.Positive`, matching the sent-email import so the two are directly comparable. The entity doc says so explicitly; I had the scale wrong in the user-facing text.

Now described as **0.0 (negative) → 0.5 (neutral) → 1.0 (positive)**.

That correction also sharpens *why* the query excludes unscored prompts, which I had justified imprecisely. On a 0–1 confidence scale, `0` means "confidently negative" — not "not scored". Averaging NULLs in as zero would drag every week towards negative in proportion to how much of the data was never enriched. The code was already right; the reasoning attached to it now is too.

## What I deliberately did not do

My first attempt at this also added negative-axis support to `TimeSeriesChart` (tracking a data minimum, a `niceScale` helper, plotting against a span rather than a max). Since the score is bounded 0–1, no chart in the product can go negative, so that was unused generality in a component every report depends on. I reverted it — `TimeSeriesChart.tsx` is untouched by this PR.

## Testing

- 15/15 `ReportsAPIControllerTests` pass.
- `tsc --noEmit` clean, SPA bundle builds.
- Change is limited to `chartCommon.ts` (2 formatters) and one chart description string.

Follow-up to #313.
