### PR TITLE
Installer: handle new-tenant Graph Reports readiness

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -9,6 +9,8 @@ using CloudInstallEngine.Azure;
 using DataUtils;
 using DataUtils.Http;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -673,6 +675,7 @@ namespace App.ControlPanel.Engine
         // "'D7'" produces period=''D7'', which Graph's OData parser rejects ("Syntax error at
         // position 13 in 'period=''D7'''"). See issue #133.
         internal const string TeamsUserActivityReportPeriod = "D7";
+        internal const string GraphReportsUnknownTenantErrorCode = "UnknownTenantId";
 
         /// <summary>
         /// Reads the Teams user-activity usage report via the typed Graph SDK - the exact call the
@@ -694,6 +697,69 @@ namespace App.ControlPanel.Engine
             }
         }
 
+        /// <summary>
+        /// Graph Reports wraps service-specific errors inside the outer Graph error message. For
+        /// example, the outer code can be "UnknownError" while its JSON message contains the real
+        /// "UnknownTenantId" code. Recognize both shapes without treating unrelated text as a match.
+        /// </summary>
+        internal static bool IsGraphReportsUnknownTenant(Exception ex)
+        {
+            if (ex == null)
+            {
+                return false;
+            }
+
+            if (ex is Microsoft.Graph.Models.ODataErrors.ODataError oDataError)
+            {
+                if (string.Equals(oDataError.Error?.Code, GraphReportsUnknownTenantErrorCode, StringComparison.OrdinalIgnoreCase)
+                    || JsonErrorPayloadContainsCode(oDataError.Error?.Message, GraphReportsUnknownTenantErrorCode))
+                {
+                    return true;
+                }
+            }
+
+            return JsonErrorPayloadContainsCode(ex.Message, GraphReportsUnknownTenantErrorCode);
+        }
+
+        private static bool JsonErrorPayloadContainsCode(string payload, string expectedCode, int remainingNestedMessages = 2)
+        {
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return false;
+            }
+
+            try
+            {
+                var error = JObject.Parse(payload)["error"];
+                if (error == null)
+                {
+                    return false;
+                }
+
+                if (string.Equals(error["code"]?.Value<string>(), expectedCode, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                var nestedMessage = error["message"]?.Value<string>();
+                return remainingNestedMessages > 0
+                    && JsonErrorPayloadContainsCode(nestedMessage, expectedCode, remainingNestedMessages - 1);
+            }
+            catch (JsonReaderException)
+            {
+                return false;
+            }
+        }
+
+        private void LogGraphReportsUnknownTenant()
+        {
+            _logger.LogWarning(
+                $"Microsoft Graph Reports does not recognize this tenant ('{GraphReportsUnknownTenantErrorCode}'), so usage-report access could not be verified. " +
+                "For a newly created tenant, the Microsoft 365 reporting service can take time to onboard it and start generating reports. " +
+                "Retry after usage reports are available in the Microsoft 365 admin center. If the tenant is not new or this persists, contact Microsoft support. " +
+                "This response is not a Reports.Read.All permission denial.");
+        }
+
         async Task VerifyUserActivityImport(Microsoft.Graph.GraphServiceClient graphClient, TeamsUserUsageLoader teamsUserUsageLoader)
         {
             _logger.LogInformation("Verifying Graph API for user activity import...");
@@ -703,6 +769,11 @@ namespace App.ControlPanel.Engine
             try
             {
                 await ReadTeamsUserActivityReportAsync(graphClient);
+            }
+            catch (Exception ex) when (IsGraphReportsUnknownTenant(ex))
+            {
+                LogGraphReportsUnknownTenant();
+                return;
             }
             catch (Exception ex)
             {
@@ -726,6 +797,11 @@ namespace App.ControlPanel.Engine
             try
             {
                 await teamsUserUsageLoader.PopulateLoadedReportPagesFromGraph(DAYS_BACK_CHECK);
+            }
+            catch (Exception ex) when (IsGraphReportsUnknownTenant(ex))
+            {
+                LogGraphReportsUnknownTenant();
+                return;
             }
             catch (Exception ex)
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/TeamsUserActivityReportUrlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/TeamsUserActivityReportUrlTests.cs
@@ -26,7 +26,10 @@ namespace Tests.UnitTests.InstallTests
             // Arrange: a Graph client whose transport captures the SDK-composed request URI and
             // returns an empty CSV report (200). This exercises the real Kiota URL composition -
             // where the bug lives - with no network call and no credentials.
-            var handler = new UriCapturingHandler("Report Refresh Date,User Principal Name\r\n");
+            var handler = new GraphReportResponseHandler(
+                HttpStatusCode.OK,
+                "Report Refresh Date,User Principal Name\r\n",
+                "application/octet-stream");
             var httpClient = new HttpClient(handler);
             var graphClient = new GraphServiceClient(httpClient, new BearerTokenAuthenticationProvider("test-token"));
 
@@ -43,17 +46,71 @@ namespace Tests.UnitTests.InstallTests
                 $"Period must not be double-quoted (issue #133). Actual URL: {url}");
         }
 
-        /// <summary>
-        /// Test transport that records the outgoing request URI and returns a stubbed 200 CSV
-        /// response, so the typed report call completes without hitting Microsoft Graph.
-        /// </summary>
-        private sealed class UriCapturingHandler : HttpMessageHandler
+        [TestMethod]
+        public async Task ReadTeamsUserActivityReport_RecognizesNestedUnknownTenantError()
         {
-            private readonly string _csvBody;
+            var responseBody =
+                "{\"error\":{\"code\":\"UnknownError\",\"message\":\"{\\\"error\\\":{\\\"code\\\":\\\"UnknownTenantId\\\",\\\"message\\\":\\\"We do not recognize this tenant ID 00000000-0000-0000-0000-000000000000.\\\"}}\"}}";
+            var handler = new GraphReportResponseHandler(HttpStatusCode.NotFound, responseBody, "application/json");
+            var graphClient = new GraphServiceClient(
+                new HttpClient(handler),
+                new BearerTokenAuthenticationProvider("test-token"));
 
-            public UriCapturingHandler(string csvBody)
+            var exception = await CaptureReportExceptionAsync(graphClient);
+
+            Assert.IsTrue(
+                SolutionInstallVerifier.IsGraphReportsUnknownTenant(exception),
+                $"Expected the nested Graph Reports error code to be recognized. Exception: {exception}");
+        }
+
+        [TestMethod]
+        public async Task ReadTeamsUserActivityReport_DoesNotClassifyPermissionFailureAsUnknownTenant()
+        {
+            var responseBody =
+                "{\"error\":{\"code\":\"Authorization_RequestDenied\",\"message\":\"Insufficient privileges to complete the operation.\"}}";
+            var handler = new GraphReportResponseHandler(HttpStatusCode.Forbidden, responseBody, "application/json");
+            var graphClient = new GraphServiceClient(
+                new HttpClient(handler),
+                new BearerTokenAuthenticationProvider("test-token"));
+
+            var exception = await CaptureReportExceptionAsync(graphClient);
+
+            Assert.IsFalse(
+                SolutionInstallVerifier.IsGraphReportsUnknownTenant(exception),
+                "A genuine authorization failure must retain the installer's permissions error.");
+        }
+
+        private static async Task<Exception> CaptureReportExceptionAsync(GraphServiceClient graphClient)
+        {
+            Exception exception = null;
+            try
             {
-                _csvBody = csvBody;
+                await SolutionInstallVerifier.ReadTeamsUserActivityReportAsync(graphClient);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            Assert.IsNotNull(exception, "Expected the stubbed Graph error response to throw.");
+            return exception;
+        }
+
+        /// <summary>
+        /// Test transport that records the outgoing request URI and returns a stubbed Graph response,
+        /// so the typed report call completes without hitting Microsoft Graph.
+        /// </summary>
+        private sealed class GraphReportResponseHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _statusCode;
+            private readonly string _body;
+            private readonly string _mediaType;
+
+            public GraphReportResponseHandler(HttpStatusCode statusCode, string body, string mediaType)
+            {
+                _statusCode = statusCode;
+                _body = body;
+                _mediaType = mediaType;
             }
 
             public Uri CapturedUri { get; private set; }
@@ -61,9 +118,9 @@ namespace Tests.UnitTests.InstallTests
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 CapturedUri = request.RequestUri;
-                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                var response = new HttpResponseMessage(_statusCode)
                 {
-                    Content = new StringContent(_csvBody, Encoding.UTF8, "application/octet-stream"),
+                    Content = new StringContent(_body, Encoding.UTF8, _mediaType),
                     RequestMessage = request,
                 };
                 return Task.FromResult(response);


### PR DESCRIPTION
## Summary

- Treat Microsoft Graph Reports `UnknownTenantId` as a non-fatal tenant-readiness condition during **Test Configuration**.
- Replace the misleading runtime-account/permissions error with an actionable warning for newly created tenants whose reporting backend is not yet onboarded.
- Preserve the existing error path for genuine authentication, authorization, and other Graph failures.
- Avoid logging the raw `UnknownTenantId` payload, which contains the tenant GUID.

## Root cause

The Graph usage-report request can return HTTP 404 with an outer `UnknownError` whose message contains a second JSON error with code `UnknownTenantId`. This is specific to the Microsoft 365 Reports service: ordinary Graph requests can already succeed while a newly created tenant is still being onboarded by the reporting backend.

`SolutionInstallVerifier.VerifyUserActivityImport` previously caught every exception from the report probe and emitted the same credentials/permissions guidance. That incorrectly characterized this service-readiness response as a `Reports.Read.All` denial.

## Implementation

- Add structured recognition for direct and nested `UnknownTenantId` error codes, including the Graph SDK's wrapped `ODataError` shape.
- Bound nested-message parsing and require an exact error-code match rather than searching arbitrary exception text.
- Apply the readiness warning to both the aggregate report probe and the daily report/anonymization probe.
- Tell operators to retry after usage reports appear in the Microsoft 365 admin center and to contact Microsoft support if the condition persists on an established tenant.

## Tests

- Release build of `Tests.UnitTests` with Visual Studio MSBuild.
- Targeted `TeamsUserActivityReportUrlTests`: 3 passed, covering successful report access, nested `UnknownTenantId`, and a genuine permission failure.
- Release build of `App.ControlPanel.WinForms` produced `AnalyticsInstaller.exe` successfully.

## Schema and configuration

- No database migration.
- No installer configuration-schema change.
- No deployment-template change.

## Risk and reviewer focus

The special case is intentionally narrow: only an exact `UnknownTenantId` code in the typed Graph error or structured nested JSON becomes a warning. `401`, `403`, malformed payloads, and unrelated Graph errors retain the existing error behavior.

Addresses #316