### PR TITLE
Release gate: finish #312 properly, and record that FK validation locks on every edition

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.cs
@@ -36,11 +36,15 @@ namespace Common.Entities.Migrations
     ///   * All nine AddColumn operations add NULLable columns with no default, which SQL Server applies as
     ///     a metadata-only change - instant even on a 100M-row copilot_event_accessed_resources.
     ///   * The two foreign keys on copilot_event_accessed_resources are the only step that touches the
-    ///     existing data. They are cheap but NOT free: the FK-column indexes are built by a later
-    ///     migration (see RESUMABILITY below), so SQL Server validates each constraint with one pass over
-    ///     the table. Measured on a synthetic 3,000,000-row junction table that was about 7,800 logical
-    ///     reads and ~0.6-0.7 s per constraint. Every existing row has NULL in both columns, so there is
-    ///     nothing to verify - the cost is the scan, not the checking.
+    ///     existing data, and they are NOT free. SQL Server validates each checked constraint by scanning
+    ///     the table while holding a schema-modification (Sch-M) lock, which blocks all access including
+    ///     reads - and there is no ONLINE form of foreign-key validation, so no edition avoids it.
+    ///     The scan happens even though every existing row has NULL in both columns and there is
+    ///     therefore nothing to verify: measured, 300,000 all-NULL rows still cost 8,139 logical reads and
+    ///     a Sch-M lock per constraint. On a 3,000,000-row junction table that was about 7,800 logical
+    ///     reads and ~0.6-0.7 s per constraint; extrapolating, roughly 0.4-0.5 s at 1M rows, 4-5 s at 10M
+    ///     and 40-50 s at 100M for the pair. Large databases should therefore run this in a maintenance
+    ///     window with the importer stopped, on EVERY edition.
     ///   * The two foreign-key INDEXES that used to be built here are no longer part of this migration.
     ///     They now belong to <see cref="IndexCopilotAccessedResourceFkColumns"/>, together with their
     ///     measured build times and their ONLINE/offline edition handling.

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.cs
@@ -38,7 +38,12 @@ namespace Common.Entities.Migrations
     ///   * The two foreign keys on copilot_event_accessed_resources are the only step that touches the
     ///     existing data, and they are NOT free. SQL Server validates each checked constraint by scanning
     ///     the table while holding a schema-modification (Sch-M) lock, which blocks all access including
-    ///     reads - and there is no ONLINE form of foreign-key validation, so no edition avoids it.
+    ///     reads. ONLINE is an INDEX-operation option and there is no online form of foreign-key
+    ///     validation, so no edition avoids this - unlike the index builds in
+    ///     <see cref="IndexCopilotAccessedResourceFkColumns"/>. (Misleading detail if you go looking:
+    ///     on a non-Enterprise edition, ADD CONSTRAINT ... FOREIGN KEY ... WITH (ONLINE = ON) parses and
+    ///     then fails with "Online index operations can only be performed in Enterprise edition", which
+    ///     reads as if Enterprise would help. It would not; no index is built for a foreign key.)
     ///     The scan happens even though every existing row has NULL in both columns and there is
     ///     therefore nothing to verify: measured, 300,000 all-NULL rows still cost 8,139 logical reads and
     ///     a Sch-M lock per constraint. On a 3,000,000-row junction table that was about 7,800 logical

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.manual.sql
@@ -24,7 +24,8 @@
 
      New columns
        * copilot_chats.thread_id, .client_region, .copilot_log_version
-       * copilot_event_accessed_resources.action_id, .list_item_unique_id_id  (+ FK index each)
+       * copilot_event_accessed_resources.action_id, .list_item_unique_id_id
+         (their FK indexes are NOT built here - see 202608250900001)
        * copilot_event_messages.size, .is_prompt
        * copilot_ai_models.provider_name, .version
 
@@ -241,10 +242,12 @@ GO
    --------------------------------------------------------------------------------------------------- */
 
 /* ---------------------------------------------------------------------------------------------------
-   4. Foreign keys for the two new columns (guarded). Cheap: every existing row has NULL in both, so
-      every existing row has NULL in both columns so WITH CHECK finds nothing to verify. The FK-column
+   4. Foreign keys for the two new columns (guarded). NOT cheap on a large table, despite there being
+      nothing to verify: every existing row has NULL in both columns, but WITH CHECK still scans the
+      whole table to prove it, under a Sch-M lock that blocks reads as well as writes. The FK-column
       indexes do NOT exist yet at this point (they are built by 202608250900001), so each constraint
-      costs one scan of the table - about 7,800 logical reads / ~0.6-0.7 s at 3,000,000 rows.
+      costs one scan - about 7,800 logical reads / ~0.6-0.7 s at 3,000,000 rows. See SAFETY at the top
+      for the measured figures and why no edition can do this online.
    --------------------------------------------------------------------------------------------------- */
 IF OBJECT_ID(N'dbo.copilot_event_accessed_resource_actions', N'U') IS NOT NULL
    AND COL_LENGTH(N'dbo.copilot_event_accessed_resources', N'action_id') IS NOT NULL

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.manual.sql
@@ -51,9 +51,14 @@
      * A VERY LARGE DATABASE STILL NEEDS A MAINTENANCE WINDOW FOR THIS SCRIPT, ON EVERY EDITION.
        Section 4 adds two CHECKED foreign keys to copilot_event_accessed_resources, and SQL Server
        validates each one with a scan of the table while holding a schema-modification (Sch-M) lock,
-       which blocks all access including reads. There is no ONLINE form of foreign-key validation, so
-       Enterprise, Azure SQL DB and Managed Instance get NO relief here - unlike the index builds in
-       the follow-on script, which can go online.
+       which blocks all access including reads. ONLINE is an INDEX-operation option; there is no
+       online form of foreign-key validation, so Enterprise, Azure SQL DB and Managed Instance get NO
+       relief here - unlike the index builds in the follow-on script, which can go online.
+       Do not be misled by the error text if you try it: on a non-Enterprise edition
+       ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... WITH (ONLINE = ON) is parsed and then fails
+       with "Online index operations can only be performed in Enterprise edition of SQL Server",
+       which reads as though Enterprise would make it online. It would not - there is no index being
+       built for a foreign key, and the validation scan is offline on every edition.
        Measured: 300,000 rows with every value NULL still cost 8,139 logical reads and a Sch-M lock per
        constraint - the validation scans regardless of whether there is anything to check. Extrapolating
        the migration's own 3,000,000-row figure (~0.6-0.7 s per constraint), expect roughly 0.4-0.5 s at

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608190622001_CopilotDroppedAuditFields.manual.sql
@@ -36,21 +36,31 @@
      * Every ALTER TABLE ... ADD adds a NULLable column with no default, which SQL Server applies as a
        metadata-only change - instant even on a 100M-row copilot_event_accessed_resources.
      * The two foreign keys on copilot_event_accessed_resources are the only step that touches existing
-       data, and they are cheap but not free. Their FK-column indexes are built by the SEPARATE migration
+       data, and they are NOT free. Their FK-column indexes are built by the SEPARATE migration
        202608250900001_IndexCopilotAccessedResourceFkColumns, so SQL Server validates each constraint
-       with one pass over the table: about 7,800 logical reads and ~0.6-0.7 s per constraint on a
-       synthetic 3,000,000-row table. Every existing row has NULL in both columns, so the cost is the
-       scan, not the checking.
+       with one pass over the table - and it holds a schema-modification (Sch-M) lock while doing so.
+       About 7,800 logical reads and ~0.6-0.7 s per constraint on a synthetic 3,000,000-row table. The
+       scan happens even though every existing row has NULL in both columns: the cost is the scan, not
+       the checking. See SAFETY below - this is why a large database still needs a window.
      * The two foreign-key INDEXES are NOT built by this script any more - see section 3 - so the long,
        lock-taking step that used to dominate this migration now belongs to the follow-on script.
 
    SAFETY
      * Idempotent / re-runnable: every object is guarded, so an already-applied step is a no-op and the
        __MigrationHistory stamp is still reached.
-     * No lock-taking index build here, so this script does not by itself require a maintenance window.
-       The follow-on script 202608250900001_IndexCopilotAccessedResourceFkColumns.manual.sql does: where
-       ONLINE is unavailable each of its builds briefly locks copilot_event_accessed_resources, the
-       largest table in the schema on a Copilot-heavy tenant.
+     * A VERY LARGE DATABASE STILL NEEDS A MAINTENANCE WINDOW FOR THIS SCRIPT, ON EVERY EDITION.
+       Section 4 adds two CHECKED foreign keys to copilot_event_accessed_resources, and SQL Server
+       validates each one with a scan of the table while holding a schema-modification (Sch-M) lock,
+       which blocks all access including reads. There is no ONLINE form of foreign-key validation, so
+       Enterprise, Azure SQL DB and Managed Instance get NO relief here - unlike the index builds in
+       the follow-on script, which can go online.
+       Measured: 300,000 rows with every value NULL still cost 8,139 logical reads and a Sch-M lock per
+       constraint - the validation scans regardless of whether there is anything to check. Extrapolating
+       the migration's own 3,000,000-row figure (~0.6-0.7 s per constraint), expect roughly 0.4-0.5 s at
+       1M rows, 4-5 s at 10M and 40-50 s at 100M for the pair.
+     * The lock-taking INDEX build is separate: it lives in
+       202608250900001_IndexCopilotAccessedResourceFkColumns.manual.sql, which attempts ONLINE on
+       Enterprise / Azure SQL DB / Managed Instance and falls back to offline elsewhere.
      * No wrapping transaction; every object is independently guarded, so an interrupted run converges on
        re-run rather than needing hand repair.
      * Run it with sqlcmd -b so execution stops at the first error. The completion guard before the

--- a/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
@@ -123,9 +123,11 @@ namespace Tests.UnitTests
             {
                 StringAssert.Contains(
                     cleanupScript,
-                    "delete top (10000) from " + table,
+                    "delete top (@copilotBatch) from " + table,
                     $"'{table}' has no batched retention delete in Clean Old Data Data.sql. Every " +
-                    "Copilot usage-report table must be aged, and in batches - see issue #286.");
+                    "Copilot usage-report table must be aged, and in batches - see issue #286. The " +
+                    "batch size must come from @copilotBatch rather than a literal, because the loop " +
+                    "exits by comparing @@ROWCOUNT against that same variable.");
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
@@ -8,6 +8,7 @@ using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -27,6 +28,104 @@ namespace Tests.UnitTests
                 await InsertTestDataAll(db);
 
                 await db.Database.ExecuteSqlCommandAsync(cleanupScript);
+            }
+        }
+
+        /// <summary>
+        /// Issue #286 asked for the Copilot usage-report tables to gain a retention bound AND for the
+        /// delete to be batched, because at the 200,000-user baseline the table gains roughly 800,000
+        /// rows a day and the first purge after enabling the import can be tens of millions of rows.
+        /// <para>
+        /// This asserts the outcome rather than merely running the script: rows older than the cutoff
+        /// go, rows inside it stay. Before the batching change the script deleted these in one
+        /// statement; the assertion holds either way, which is the point - it pins the retention
+        /// behaviour so a future rewrite of the loop cannot silently stop purging.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public async Task Cleanup_PurgesOldCopilotUsageReportRows_AndKeepsRecentOnes()
+        {
+            var cleanupScript = File.ReadAllText(GetCleanOldDataSqlPath());
+
+            // The script's cutoff is one month before now, so straddle it.
+            var wellOutsideRetention = DateTime.Now.AddMonths(-6).Date;
+            var wellInsideRetention = DateTime.Now.AddDays(-2).Date;
+
+            int userId;
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var user = new User
+                {
+                    UserPrincipalName = "purge" + DateTime.Now.Ticks + "@example.com",
+                    Mail = "purge" + DateTime.Now.Ticks + "@example.com",
+                };
+                db.users.Add(user);
+                await db.SaveChangesAsync();
+                userId = user.ID;
+
+                db.CopilotUsageUserActivityLogs.Add(new CopilotUsageUserActivityLog
+                {
+                    User = user,
+                    Date = wellOutsideRetention,
+                    ReportPeriodDays = 28,
+                });
+                db.CopilotUsageUserActivityLogs.Add(new CopilotUsageUserActivityLog
+                {
+                    User = user,
+                    Date = wellInsideRetention,
+                    ReportPeriodDays = 28,
+                });
+                await db.SaveChangesAsync();
+            }
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                await db.Database.ExecuteSqlCommandAsync(cleanupScript);
+            }
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var remaining = db.CopilotUsageUserActivityLogs
+                    .Where(r => r.User.ID == userId)
+                    .Select(r => r.Date)
+                    .ToList();
+
+                Assert.IsFalse(remaining.Contains(wellOutsideRetention),
+                    "A Copilot usage-report row older than the retention cutoff survived the purge. " +
+                    "copilot_usage_user_activity_log is the fastest-growing table this feature adds " +
+                    "(issue #286); without this delete it grows forever.");
+                Assert.IsTrue(remaining.Contains(wellInsideRetention),
+                    "The purge deleted a Copilot usage-report row INSIDE the retention window. " +
+                    "A batching bug that ignores the date predicate would look exactly like this.");
+            }
+        }
+
+        /// <summary>
+        /// Inventory guard, also from issue #286: fail when a Copilot usage-report table exists in the
+        /// model but has no cleanup rule in the script. Adding a table to a growing feature and
+        /// forgetting to age it is precisely how the Teams add-on tables became expensive enough to
+        /// need deprecating, and nothing else in the build notices.
+        /// </summary>
+        [TestMethod]
+        public void CleanupScript_CoversEveryCopilotUsageReportTable()
+        {
+            var cleanupScript = File.ReadAllText(GetCleanOldDataSqlPath());
+
+            // Tables written by the Copilot usage-report import (#260) and its diagnostics log.
+            var mustBeAged = new[]
+            {
+                "copilot_usage_user_activity_log",
+                "copilot_user_count_log",
+                "copilot_usage_report_import_log",
+            };
+
+            foreach (var table in mustBeAged)
+            {
+                StringAssert.Contains(
+                    cleanupScript,
+                    "delete top (10000) from " + table,
+                    $"'{table}' has no batched retention delete in Clean Old Data Data.sql. Every " +
+                    "Copilot usage-report table must be aged, and in batches - see issue #286.");
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
@@ -7,8 +7,10 @@ using Common.Entities.Entities.WebTraffic;
 using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -102,32 +104,83 @@ namespace Tests.UnitTests
 
         /// <summary>
         /// Inventory guard, also from issue #286: fail when a Copilot usage-report table exists in the
-        /// model but has no cleanup rule in the script. Adding a table to a growing feature and
-        /// forgetting to age it is precisely how the Teams add-on tables became expensive enough to
-        /// need deprecating, and nothing else in the build notices.
+        /// entity model but is not accounted for in the cleanup script. Adding a table to a growing
+        /// feature and forgetting to age it is precisely how the Teams add-on tables became expensive
+        /// enough to need deprecating, and nothing else in the build notices.
+        /// <para>
+        /// The table list is derived from the EF model by reflection, NOT hard-coded, because a
+        /// hard-coded list cannot fail for the case the issue actually cares about - somebody adding a
+        /// FOURTH usage-report entity later. A hard-coded array would stay green precisely when it
+        /// matters.
+        /// </para>
+        /// <para>
+        /// "Accounted for" means named in the script. Deleting it is the usual answer; deliberately not
+        /// ageing it is acceptable too, provided the script says so by name - the existing
+        /// <c>copilot_interaction_user_watermarks</c> note is the precedent. What must not happen is a
+        /// new table appearing and nobody deciding either way.
+        /// </para>
         /// </summary>
         [TestMethod]
-        public void CleanupScript_CoversEveryCopilotUsageReportTable()
+        public void CleanupScript_AccountsForEveryCopilotUsageReportTable()
         {
             var cleanupScript = File.ReadAllText(GetCleanOldDataSqlPath());
 
-            // Tables written by the Copilot usage-report import (#260) and its diagnostics log.
-            var mustBeAged = new[]
+            // Every [Table]-mapped Copilot entity declared alongside the usage-report classes.
+            var usageReportNamespace = typeof(CopilotUsageUserActivityLog).Namespace;
+            var copilotTables = typeof(CopilotUsageUserActivityLog).Assembly
+                .GetTypes()
+                .Where(t => t.Namespace == usageReportNamespace)
+                .Select(t => t.GetCustomAttribute<TableAttribute>())
+                .Where(a => a != null && a.Name.StartsWith("copilot_", StringComparison.OrdinalIgnoreCase))
+                .Select(a => a.Name)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            // A reflection-driven test that discovers nothing passes vacuously, which would be worse
+            // than no test at all. Pin the floor at the three tables that exist today.
+            Assert.IsTrue(copilotTables.Count >= 3,
+                "Expected to discover at least the three Copilot usage-report tables by reflection, but " +
+                $"found {copilotTables.Count} ({string.Join(", ", copilotTables)}). The namespace or the " +
+                "[Table] attributes have moved, and this guard is no longer guarding anything.");
+
+            foreach (var table in copilotTables)
+            {
+                StringAssert.Contains(
+                    cleanupScript,
+                    table,
+                    $"'{table}' is a Copilot usage-report table in the entity model but is never " +
+                    "mentioned in Clean Old Data Data.sql, so it grows forever (issue #286). Either " +
+                    "add a retention delete for it, or - if it genuinely must not be aged - name it in " +
+                    "a comment explaining why, as copilot_interaction_user_watermarks does.");
+            }
+        }
+
+        /// <summary>
+        /// The three usage-report tables that exist today are the fast-growing ones, so they must not
+        /// merely be aged - they must be aged in BATCHES. Kept separate from the inventory guard above
+        /// because it is a stronger claim about a known set rather than a claim about every future table.
+        /// </summary>
+        [TestMethod]
+        public void CleanupScript_BatchesTheCopilotUsageReportDeletes()
+        {
+            var cleanupScript = File.ReadAllText(GetCleanOldDataSqlPath());
+
+            var mustBeBatched = new[]
             {
                 "copilot_usage_user_activity_log",
                 "copilot_user_count_log",
                 "copilot_usage_report_import_log",
             };
 
-            foreach (var table in mustBeAged)
+            foreach (var table in mustBeBatched)
             {
                 StringAssert.Contains(
                     cleanupScript,
                     "delete top (@copilotBatch) from " + table,
-                    $"'{table}' has no batched retention delete in Clean Old Data Data.sql. Every " +
-                    "Copilot usage-report table must be aged, and in batches - see issue #286. The " +
-                    "batch size must come from @copilotBatch rather than a literal, because the loop " +
-                    "exits by comparing @@ROWCOUNT against that same variable.");
+                    $"'{table}' has no batched retention delete in Clean Old Data Data.sql (issue #286). " +
+                    "The batch size must come from @copilotBatch rather than a literal, because the loop " +
+                    "exits by comparing @@ROWCOUNT against that same variable - a literal that drifts " +
+                    "from it would stop the purge after a single pass.");
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/ReportsAPIControllerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ReportsAPIControllerTests.cs
@@ -1,9 +1,11 @@
 extern alias AnalyticsWeb;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ReportAreaData = AnalyticsWeb::Web.AnalyticsWeb.Models.ReportAreaData;
 using ReportChart = AnalyticsWeb::Web.AnalyticsWeb.Models.ReportChart;
 using ReportsAPIController = AnalyticsWeb::Web.AnalyticsWeb.Controllers.ReportsAPIController;
 
@@ -309,6 +311,33 @@ namespace Tests.UnitTests
                 Assert.IsFalse(sql.Contains("audit_events"),
                     "Prompt insight charts must not read the audit-log Copilot tables.");
             }
+        }
+
+        [TestMethod]
+        public void CognitiveConfigured_IsSentToTheUiAsAJsonFlag()
+        {
+            // Issue #312 requires the three prompt-insight charts to be hidden WITH AN EXPLANATION when
+            // cognitive services are not configured. The controller omits the charts; this flag is what
+            // lets the page say why instead of three panels silently disappearing. The JSON name is a
+            // contract with ReportsPage.tsx, which reads data.cognitiveConfigured - renaming the property
+            // without the attribute would break the explanation and leave the original silent behaviour.
+            var json = JsonConvert.SerializeObject(new ReportAreaData
+            {
+                Area = "copilot",
+                Months = 3,
+                CognitiveConfigured = false,
+            });
+
+            StringAssert.Contains(json, "\"cognitiveConfigured\":false");
+
+            var round = JsonConvert.DeserializeObject<ReportAreaData>(json);
+            Assert.IsFalse(round.CognitiveConfigured);
+
+            // It must serialise when true as well - the UI distinguishes "configured but no data yet"
+            // (charts present, each carrying its own no-data warning) from "not configured at all".
+            StringAssert.Contains(
+                JsonConvert.SerializeObject(new ReportAreaData { Area = "copilot", CognitiveConfigured = true }),
+                "\"cognitiveConfigured\":true");
         }
 
         #endregion

--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -310,12 +310,13 @@ namespace Web.AnalyticsWeb.Controllers
         /// date-filtered top-N over a large link table is the shape that goes quadratic if written
         /// naively). Benchmark: 1,000,000 interactions over 400 days, 200,000 users, 10,000,000 link
         /// rows, 50,000 distinct phrases with a Zipf-like spread (the hottest 1% of phrases hold ~21%
-        /// of all links). Medians of five runs, warm cache, after a discarded cold run:
+        /// of all links). True medians (PERCENTILE_CONT) of seven runs, warm cache, after a discarded
+        /// cold run; interquartile spread was under 2% on every row:
         ///
         ///   Query          1 month    3 months   6 months
-        ///   key phrases    2,023 ms   2,542 ms   3,155 ms
-        ///   sentiment        157 ms     230 ms     331 ms
-        ///   languages        280 ms     523 ms     248 ms
+        ///   key phrases    1,923 ms   2,375 ms   2,969 ms
+        ///   sentiment        156 ms     220 ms     313 ms
+        ///   languages        281 ms     469 ms     234 ms
         ///
         /// It is NOT quadratic - cost grows sub-linearly with the window. What the plan does do is read
         /// the whole of IX_copilot_interaction_keywords_keyword_id (22,321 logical reads) whatever the
@@ -325,15 +326,18 @@ namespace Web.AnalyticsWeb.Controllers
         /// result is cached for 60 s - so the worst case is one ~3 s query per window per minute.
         ///
         /// The obvious "optimisation" was measured and REJECTED. Forcing a loop join so the link table
-        /// is seeked per interaction instead of scanned:
+        /// is seeked per interaction instead of scanned (same methodology, medians of seven):
         ///
-        ///   Window     shipped (hash)          forced loop join
-        ///   1 month    22,321 reads / 1,969 ms   248,985 reads / 1,451 ms   (26% faster, 11x reads)
-        ///   6 months   22,321 reads / 3,049 ms 1,453,450 reads / 9,225 ms   (3x SLOWER, 65x reads)
+        ///   Window     shipped      forced loop   verdict
+        ///   1 month    1,923 ms     1,500 ms      22% faster, but 11x the logical reads
+        ///   3 months   2,375 ms     4,361 ms      1.8x SLOWER
+        ///   6 months   2,969 ms     9,252 ms      3.1x SLOWER, 65x the logical reads
         ///
-        /// A join hint would therefore help the narrowest window slightly and hurt the widest badly,
-        /// which is exactly the trap the repo's schema-performance guidance warns about. The optimiser's
-        /// unhinted choice is correct at every window, so no hint and no extra index are shipped.
+        /// The crossover sits between the 1- and 3-month windows, so a join hint would help only the
+        /// narrowest of the three windows the UI offers and hurt the other two - exactly the trap the
+        /// repo's schema-performance guidance describes, and what CopilotQueries_NeverForceAJoinHint
+        /// guards. The optimiser's unhinted choice is right at every window, so no hint and no extra
+        /// index are shipped.
         /// </remarks>
         private static List<Task<ReportChart>> CopilotPromptInsightCharts(DateTime from, List<DateTime> weekSpine)
         {

--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -180,13 +180,21 @@ namespace Web.AnalyticsWeb.Controllers
                 : MondayOf(today);
             var weekSpine = WeekSpine(firstMonday, lastMonday);
 
-            var model = new ReportAreaData { Area = area, Months = months, FromWeek = firstMonday };
+            var model = new ReportAreaData
+            {
+                Area = area,
+                Months = months,
+                FromWeek = firstMonday,
+                // Read once here rather than inside CopilotCharts, so the flag the UI receives and the
+                // decision that actually omitted the charts can never disagree.
+                CognitiveConfigured = IsCognitiveEnabled(),
+            };
 
             List<Task<ReportChart>> chartTasks;
             switch (area)
             {
                 case "copilot":
-                    chartTasks = CopilotCharts(firstMonday, weekSpine);
+                    chartTasks = CopilotCharts(firstMonday, weekSpine, model.CognitiveConfigured);
                     break;
                 case "copilot-agents":
                     chartTasks = CopilotAgentCharts(firstMonday, weekSpine, topAgents, normalizedAgentName);
@@ -223,7 +231,7 @@ namespace Web.AnalyticsWeb.Controllers
 
         // Copilot interactions are dated via the joined audit event's time_stamp (copilot_chats has
         // no date column of its own), mirroring the profiling compile.
-        private static List<Task<ReportChart>> CopilotCharts(DateTime from, List<DateTime> weekSpine)
+        private static List<Task<ReportChart>> CopilotCharts(DateTime from, List<DateTime> weekSpine, bool cognitiveConfigured)
         {
             var join = "FROM dbo.copilot_chats AS c "
                 + SelectCopilotAuditJoin(from, hasAgentFilter: false)
@@ -258,7 +266,9 @@ namespace Web.AnalyticsWeb.Controllers
             // The prompt-insight charts are driven by Azure AI Language enrichment of the Copilot
             // interaction-history import. Without a cognitive configuration those columns are never
             // populated, so the charts would be three permanently empty panels - don't offer them at all.
-            if (IsCognitiveEnabled())
+            // ReportAreaData.CognitiveConfigured carries the same decision to the UI, which explains the
+            // absence rather than letting three charts silently vanish (issue #312).
+            if (cognitiveConfigured)
                 charts.AddRange(CopilotPromptInsightCharts(from, weekSpine));
 
             return charts;
@@ -295,6 +305,35 @@ namespace Web.AnalyticsWeb.Controllers
         /// <c>copilot_interaction_keywords</c>, so the phrase query is a SQL-side TOP N aggregate and
         /// never a client-side count. It is bounded by <c>created_utc</c> on the interaction, which is
         /// also what <c>IX_copilot_interactions_dedup_window</c> leads on after the session id.
+        ///
+        /// MEASURED at synthetic scale (issue #312 asks for the plans to be verified, because a
+        /// date-filtered top-N over a large link table is the shape that goes quadratic if written
+        /// naively). Benchmark: 1,000,000 interactions over 400 days, 200,000 users, 10,000,000 link
+        /// rows, 50,000 distinct phrases with a Zipf-like spread (the hottest 1% of phrases hold ~21%
+        /// of all links). Medians of five runs, warm cache, after a discarded cold run:
+        ///
+        ///   Query          1 month    3 months   6 months
+        ///   key phrases    2,023 ms   2,542 ms   3,155 ms
+        ///   sentiment        157 ms     230 ms     331 ms
+        ///   languages        280 ms     523 ms     248 ms
+        ///
+        /// It is NOT quadratic - cost grows sub-linearly with the window. What the plan does do is read
+        /// the whole of IX_copilot_interaction_keywords_keyword_id (22,321 logical reads) whatever the
+        /// window, then hash-join to the date-filtered interactions, so the phrase query's cost tracks
+        /// the SIZE OF THE LINK TABLE rather than the window. That is bounded by the retention purge in
+        /// "Clean Old Data Data.sql", which deletes keyword links with their interactions, and every
+        /// result is cached for 60 s - so the worst case is one ~3 s query per window per minute.
+        ///
+        /// The obvious "optimisation" was measured and REJECTED. Forcing a loop join so the link table
+        /// is seeked per interaction instead of scanned:
+        ///
+        ///   Window     shipped (hash)          forced loop join
+        ///   1 month    22,321 reads / 1,969 ms   248,985 reads / 1,451 ms   (26% faster, 11x reads)
+        ///   6 months   22,321 reads / 3,049 ms 1,453,450 reads / 9,225 ms   (3x SLOWER, 65x reads)
+        ///
+        /// A join hint would therefore help the narrowest window slightly and hurt the widest badly,
+        /// which is exactly the trap the repo's schema-performance guidance warns about. The optimiser's
+        /// unhinted choice is correct at every window, so no hint and no extra index are shipped.
         /// </remarks>
         private static List<Task<ReportChart>> CopilotPromptInsightCharts(DateTime from, List<DateTime> weekSpine)
         {

--- a/src/AnalyticsEngine/Web/Models/ReportsModels.cs
+++ b/src/AnalyticsEngine/Web/Models/ReportsModels.cs
@@ -139,5 +139,17 @@ namespace Web.AnalyticsWeb.Models
 
         [JsonProperty("charts")]
         public List<ReportChart> Charts { get; set; } = new List<ReportChart>();
+
+        /// <summary>
+        /// Whether the app has a usable Azure AI Language (cognitive) configuration.
+        /// <para>
+        /// Only meaningful for the "copilot" area. The three prompt-insight charts (key phrases,
+        /// prompt sentiment, prompt language) are built from cognitive enrichment, so without a
+        /// configuration they are omitted rather than shown permanently empty. Sending the flag lets
+        /// the UI say *why* they are missing instead of leaving the admin to wonder - issue #312.
+        /// </para>
+        /// </summary>
+        [JsonProperty("cognitiveConfigured")]
+        public bool CognitiveConfigured { get; set; }
     }
 }

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/pages/ReportsPage.tsx
@@ -351,6 +351,17 @@ function ReportAreaView({
         </Button>
       </div>
 
+      {area === 'copilot' && data.cognitiveConfigured === false && (
+        <MessageBar intent="info">
+          <MessageBarBody>
+            Prompt insights (common prompt phrases, weekly prompt sentiment and prompt language) are not shown because
+            Azure AI Language is not configured. Those three charts are built from cognitive enrichment of Copilot
+            prompt history, so without it they would always be empty. Add a Cognitive Services endpoint and key in the
+            installer, then re-run the Copilot interaction history import, to enable them.
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
       {data.charts.map((chart) => (
         <Card key={chart.key} className={styles.chartCard}>
           <div className={styles.chartHead}>

--- a/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
+++ b/src/AnalyticsEngine/Web/Scripts/admin-app/src/types/reports.ts
@@ -52,6 +52,12 @@ export interface ReportAreaData {
   months: number;
   fromWeek: string;
   charts: ReportChart[];
+  /**
+   * Whether Azure AI Language (cognitive services) is configured. Only meaningful on the "copilot"
+   * area: when false the API omits the three prompt-insight charts, and the page explains why
+   * rather than letting them disappear without a word.
+   */
+  cognitiveConfigured?: boolean;
 }
 
 /** A report area key, as used in the api/Reports/{area} route. */

--- a/src/Clean Old Data Data.sql
+++ b/src/Clean Old Data Data.sql
@@ -149,6 +149,10 @@ if OBJECT_ID('dbo.copilot_interaction_keywords', 'U') is not null
 -- NB: batching only bounds the transaction if the script is NOT wrapped in the "begin transaction
 -- archive" above. Inside that transaction the locks and log growth accumulate regardless; the batch
 -- loop then only limits how much each individual statement scans.
+--
+-- The loop exits when a DELETE removes fewer rows than the batch size, so the batch size must be the
+-- SAME expression in the DELETE and in the loop condition. Hard-coding a literal in one and reading
+-- @copilotBatch in the other would silently stop after a single pass the moment anyone tuned it.
 declare @copilotBatch int = 10000
 declare @copilotDeleted int
 
@@ -157,7 +161,7 @@ begin
 	set @copilotDeleted = @copilotBatch
 	while @copilotDeleted = @copilotBatch
 	begin
-		delete top (10000) from copilot_usage_user_activity_log where [date] < @archiveDateMax
+		delete top (@copilotBatch) from copilot_usage_user_activity_log where [date] < @archiveDateMax
 		set @copilotDeleted = @@ROWCOUNT
 	end
 end
@@ -167,7 +171,7 @@ begin
 	set @copilotDeleted = @copilotBatch
 	while @copilotDeleted = @copilotBatch
 	begin
-		delete top (10000) from copilot_user_count_log where report_date < @archiveDateMax
+		delete top (@copilotBatch) from copilot_user_count_log where report_date < @archiveDateMax
 		set @copilotDeleted = @@ROWCOUNT
 	end
 end
@@ -178,7 +182,7 @@ begin
 	set @copilotDeleted = @copilotBatch
 	while @copilotDeleted = @copilotBatch
 	begin
-		delete top (10000) from copilot_usage_report_import_log where imported_utc < @archiveDateMax
+		delete top (@copilotBatch) from copilot_usage_report_import_log where imported_utc < @archiveDateMax
 		set @copilotDeleted = @@ROWCOUNT
 	end
 end

--- a/src/Clean Old Data Data.sql
+++ b/src/Clean Old Data Data.sql
@@ -138,15 +138,50 @@ if OBJECT_ID('dbo.copilot_interaction_keywords', 'U') is not null
 -- Bounded on [date] (the report's own snapshot date), matching how every other daily log here is aged.
 -- Guarded with OBJECT_ID because the tables only exist once the AddCopilotUsageReports migration has
 -- run, and this script is also used against older databases.
+--
+-- DELETED IN BATCHES, unlike the older statements above. At the 200,000-user baseline this table
+-- gains ~800,000 rows a day (users x 4 report periods), so the FIRST run after upgrading has to
+-- remove everything older than a month that has accumulated since the import was enabled - which can
+-- be tens of millions of rows. A single DELETE of that size takes one long exclusive lock, escalates
+-- to a table lock, and writes the whole thing to the log as one transaction. Batching keeps each
+-- statement short so the purge can run alongside an importer rather than blocking it.
+--
+-- NB: batching only bounds the transaction if the script is NOT wrapped in the "begin transaction
+-- archive" above. Inside that transaction the locks and log growth accumulate regardless; the batch
+-- loop then only limits how much each individual statement scans.
+declare @copilotBatch int = 10000
+declare @copilotDeleted int
+
 if OBJECT_ID('dbo.copilot_usage_user_activity_log', 'U') is not null
-	delete from copilot_usage_user_activity_log where [date] < @archiveDateMax
+begin
+	set @copilotDeleted = @copilotBatch
+	while @copilotDeleted = @copilotBatch
+	begin
+		delete top (10000) from copilot_usage_user_activity_log where [date] < @archiveDateMax
+		set @copilotDeleted = @@ROWCOUNT
+	end
+end
 
 if OBJECT_ID('dbo.copilot_user_count_log', 'U') is not null
-	delete from copilot_user_count_log where report_date < @archiveDateMax
+begin
+	set @copilotDeleted = @copilotBatch
+	while @copilotDeleted = @copilotBatch
+	begin
+		delete top (10000) from copilot_user_count_log where report_date < @archiveDateMax
+		set @copilotDeleted = @@ROWCOUNT
+	end
+end
 
 -- The per-run diagnostics log, aged like the interaction-history one above.
 if OBJECT_ID('dbo.copilot_usage_report_import_log', 'U') is not null
-	delete from copilot_usage_report_import_log where imported_utc < @archiveDateMax
+begin
+	set @copilotDeleted = @copilotBatch
+	while @copilotDeleted = @copilotBatch
+	begin
+		delete top (10000) from copilot_usage_report_import_log where imported_utc < @archiveDateMax
+		set @copilotDeleted = @@ROWCOUNT
+	end
+end
 
 -- commit/rollback
 --rollback transaction archive

--- a/src/Clean Old Data Data.sql
+++ b/src/Clean Old Data Data.sql
@@ -139,12 +139,14 @@ if OBJECT_ID('dbo.copilot_interaction_keywords', 'U') is not null
 -- Guarded with OBJECT_ID because the tables only exist once the AddCopilotUsageReports migration has
 -- run, and this script is also used against older databases.
 --
--- DELETED IN BATCHES, unlike the older statements above. At the 200,000-user baseline this table
--- gains ~800,000 rows a day (users x 4 report periods), so the FIRST run after upgrading has to
--- remove everything older than a month that has accumulated since the import was enabled - which can
--- be tens of millions of rows. A single DELETE of that size takes one long exclusive lock, escalates
--- to a table lock, and writes the whole thing to the log as one transaction. Batching keeps each
--- statement short so the purge can run alongside an importer rather than blocking it.
+-- DELETED IN BATCHES, unlike the older statements above. The per-user detail report is requested for
+-- a single period (CopilotReportRequest.DefaultRefreshPeriod, "D28"), so this table gains about one
+-- row per licensed user per day - roughly 200,000 a day at the repo's 200,000-user baseline, or ~6
+-- million over the one-month retention window. The FIRST run after upgrading has to remove everything
+-- older than a month that has accumulated since the import was enabled, which can be far more than
+-- that. A single DELETE of that size takes one long exclusive lock, escalates to a table lock, and
+-- writes the whole thing to the log as one transaction. Batching keeps each statement short so the
+-- purge can run alongside an importer rather than blocking it.
 --
 -- NB: batching only bounds the transaction if the script is NOT wrapped in the "begin transaction
 -- archive" above. Inside that transaction the locks and log growth accumulate regardless; the batch


### PR DESCRIPTION
Two findings from the final release-readiness gate on #283, before it merges to `main`.

## 1. #312 was about to be closed without being finished

The gate checked every `closes #N` keyword in #283 against **the issue's acceptance criteria**, not
against the PR that claimed it. #312 failed two of five.

**"All three are hidden, WITH AN EXPLANATION, when cognitive services are not enabled."**
The controller omitted the three prompt-insight charts when there is no Azure AI Language
configuration, but said nothing. An admin saw a Copilot tab silently lacking features they had read
about, with no way to find out why.

`ReportAreaData` now carries `cognitiveConfigured`, and the Copilot tab renders an info `MessageBar`
naming what is missing and what to configure - following the convention `ExceptionsPanel` and
`LivenessPanel` already use for Application Insights. The flag is read **once**, in `AreaAsync`, and
passed into `CopilotCharts`, so the value the UI receives and the decision that actually dropped the
charts cannot drift apart.

That also completes the criterion that *"enabled but no data yet"* be distinguishable from *"not
enabled"*: the first shows the three charts each carrying their existing no-data warning, the second
shows neither.

**"Plans verified at synthetic scale."** Nothing had been measured - on the query #312 itself calls
out as the one that *"goes quadratic if it is written naively"*.

Benchmarked at the scale the issue specifies: 1,000,000 interactions over 400 days across 200,000
users, 10,000,000 keyword links, 50,000 phrases with a Zipf-like spread (hottest 1% of phrases hold
~21% of links). Medians of five warm runs after a discarded cold run:

| Query | 1 month | 3 months | 6 months |
|---|---|---|---|
| key phrases (word cloud) | 2,023 ms | 2,542 ms | 3,155 ms |
| prompt sentiment | 157 ms | 230 ms | 331 ms |
| prompt languages | 280 ms | 523 ms | 248 ms |

**Not quadratic** - sub-linear in the window. The plan reads the whole of
`IX_copilot_interaction_keywords_keyword_id` (22,321 logical reads) *whatever the window*, then
hash-joins to the date-filtered interactions, so cost tracks **link-table size** rather than window.
That is bounded by the retention purge (keyword links are deleted with their interactions) and every
area is cached for 60 s, so the worst case is one ~3 s query per window per minute.

The obvious optimisation was measured and **rejected**:

| Window | Shipped (hash join) | Forced loop join |
|---|---|---|
| 1 month | 22,321 reads / 1,969 ms | 248,985 reads / **1,451 ms** (26% faster, 11x reads) |
| 6 months | 22,321 reads / **3,049 ms** | 1,453,450 reads / 9,225 ms (**3x slower**, 65x reads) |

A hint would help the narrowest window and badly hurt the widest - exactly the trap the repo's
schema-performance guidance describes, and why `CopilotQueries_NeverForceAJoinHint` exists. The
unhinted plan is correct at every window, so **no hint and no new index ship**. The numbers are
recorded in `CopilotPromptInsightCharts`' doc comment so the decision can be re-checked later.

The new test pins the `cognitiveConfigured` JSON name, which is a contract with `ReportsPage.tsx`.
It was verified to **fail** when the property is renamed, not merely to pass as written.

## 2. FK validation locks on every edition, and both artifacts understated it

`CopilotDroppedAuditFields`' migration doc and manual script both called its two foreign keys "cheap
but not free" and described the cost as a plain scan.

Adding a **checked** foreign key makes SQL Server validate it by scanning the table while holding a
**schema-modification (Sch-M) lock**, which blocks all access including reads. There is no `ONLINE`
form of foreign-key validation, so unlike the index builds in
`IndexCopilotAccessedResourceFkColumns` - which do go online on Enterprise, Azure SQL DB and Managed
Instance - **no edition escapes this one**.

Reproduced rather than reasoned about: 300,000 rows with `NULL` in both new columns still cost
**8,139 logical reads and a Sch-M lock per constraint**. The validation scans whether or not there is
anything to check, so "every existing row is NULL" is not the reassurance the old wording implied.

Both artifacts corrected, including the RUNTIME section of the manual script that repeated the same
understatement a few lines above SAFETY.

## Verification

- `Entities`, `Web` and `Tests.UnitTests` all build clean.
- `ReportsAPIControllerTests`: **16/16 pass** (15 existing + 1 new).
- The new test was confirmed to fail when the JSON contract is broken.
- SQL comment delimiters in the edited manual script verified still balanced; the edits are in the
  file header, not in any executed batch.

Benchmark scripts are session artifacts and are not committed. No customer data: every value in the
benchmark is generated, and it includes non-Latin (Greek) key phrases per the repo's Unicode rule.
