### PR TITLE
Correct the last copy of the disproven 800,000 rows/day figure

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
@@ -35,8 +35,11 @@ namespace Tests.UnitTests
 
         /// <summary>
         /// Issue #286 asked for the Copilot usage-report tables to gain a retention bound AND for the
-        /// delete to be batched, because at the 200,000-user baseline the table gains roughly 800,000
-        /// rows a day and the first purge after enabling the import can be tens of millions of rows.
+        /// delete to be batched. The per-user detail report is requested for a single period
+        /// (<c>CopilotReportRequest.DefaultRefreshPeriod</c>, "D28"), so the table gains about one row
+        /// per licensed user per day - roughly 200,000 a day at the 200,000-user baseline, or ~6 million
+        /// over the one-month retention window. The first purge after enabling the import has to clear
+        /// everything accumulated since then, which can be far more.
         /// <para>
         /// This asserts the outcome rather than merely running the script: rows older than the cutoff
         /// go, rows inside it stay. Before the batching change the script deleted these in one


### PR DESCRIPTION
The release-readiness gate's final finding on #283, and the only thing standing between it and a GO.

`#320` corrected the disproven "800,000 rows a day" figure in `Clean Old Data Data.sql`, but left an identical copy of it in the XML doc comment of `Cleanup_PurgesOldCopilotUsageReportRows_AndKeepsRecentOnes` - the test that exists to enforce that very behaviour, in a file the same commit had already edited.

This is the same paired-artifact drift the gate has now caught three times in this release: a claim corrected in one place and left standing in another.

## The correct figure

`GraphImporter` passes `CopilotReportRequest.DefaultRefreshPeriod` (`"D28"`) to `CopilotUsageUserDetailLoader.LoadAndSaveAsync`, i.e. a **single** period. The entity is keyed `(date, user_id, report_period_days)`, which is what made "users x 4 report periods" look plausible - the key supports four, the importer requests one.

So `copilot_usage_user_activity_log` gains about one row per licensed user per day: roughly **200,000/day** at the 200,000-user baseline, ~6 million over the one-month retention window. The case for batching is unchanged; the number supporting it was 4x too large.

## Swept rather than spot-fixed

Rather than fix only the instance that was reported, I searched the whole tree for every figure published during this release:

| Searched | Result |
|---|---|
| `800,000`, `users x 4`, `4 report periods` | none remain |
| Superseded fast-biased timings (`2,023` / `2,542` / `3,155` ms, and the `1,969` / `3,049` / `1,451` / `9,225` ms loop-join pairs) | none remain in `src/` |
| The phrase `medians of five` | none remain |
| Corrected values present where expected | `1,923 ms` in `ReportsAPIController`, `200,000 a day` in both the cleanup script and the test |

The only `tens of millions` hit is a pre-existing, unrelated comment in `IndexAuditEventsTimeStamp` about `audit_events`.

Documentation only - no behaviour change. `DataCleanupTests` passes 5/5 locally.
