### PR TITLE
Make the retention guard prove tables are purged, not merely mentioned

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
@@ -7,11 +7,13 @@ using Common.Entities.Entities.WebTraffic;
 using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Tests.UnitTests
@@ -107,9 +109,9 @@ namespace Tests.UnitTests
 
         /// <summary>
         /// Inventory guard, also from issue #286: fail when a Copilot usage-report table exists in the
-        /// entity model but is not accounted for in the cleanup script. Adding a table to a growing
-        /// feature and forgetting to age it is precisely how the Teams add-on tables became expensive
-        /// enough to need deprecating, and nothing else in the build notices.
+        /// entity model but is not aged by the cleanup script. Adding a table to a growing feature and
+        /// forgetting to age it is precisely how the Teams add-on tables became expensive enough to
+        /// need deprecating, and nothing else in the build notices.
         /// <para>
         /// The table list is derived from the EF model by reflection, NOT hard-coded, because a
         /// hard-coded list cannot fail for the case the issue actually cares about - somebody adding a
@@ -117,27 +119,31 @@ namespace Tests.UnitTests
         /// matters.
         /// </para>
         /// <para>
-        /// "Accounted for" means named in the script. Deleting it is the usual answer; deliberately not
-        /// ageing it is acceptable too, provided the script says so by name - the existing
-        /// <c>copilot_interaction_user_watermarks</c> note is the precedent. What must not happen is a
-        /// new table appearing and nobody deciding either way.
+        /// Two subtleties, both of which an earlier version of this test got wrong:
+        /// </para>
+        /// <para>
+        /// It looks for the actual batched <c>DELETE</c>, not merely the table name. A plain substring
+        /// search over the whole file is satisfied by any passing mention in a comment, so removing the
+        /// delete while leaving the surrounding prose - which names all three tables - would have kept
+        /// this green.
+        /// </para>
+        /// <para>
+        /// It matches on word boundaries. <c>copilot_user</c> is a substring of
+        /// <c>copilot_user_count_log</c>, so a future table with a prefix name would have been "found"
+        /// inside a longer one and slipped through the very guard meant to catch it. Underscore is a
+        /// regex word character, so <c>\bcopilot_user\b</c> correctly does not match inside
+        /// <c>copilot_user_count_log</c>.
+        /// </para>
+        /// <para>
+        /// A table that genuinely must not be aged can opt out with a <c>RETENTION-EXEMPT:</c> line
+        /// naming it, which keeps the decision explicit and reviewable rather than silent.
         /// </para>
         /// </summary>
         [TestMethod]
         public void CleanupScript_AccountsForEveryCopilotUsageReportTable()
         {
             var cleanupScript = File.ReadAllText(GetCleanOldDataSqlPath());
-
-            // Every [Table]-mapped Copilot entity declared alongside the usage-report classes.
-            var usageReportNamespace = typeof(CopilotUsageUserActivityLog).Namespace;
-            var copilotTables = typeof(CopilotUsageUserActivityLog).Assembly
-                .GetTypes()
-                .Where(t => t.Namespace == usageReportNamespace)
-                .Select(t => t.GetCustomAttribute<TableAttribute>())
-                .Where(a => a != null && a.Name.StartsWith("copilot_", StringComparison.OrdinalIgnoreCase))
-                .Select(a => a.Name)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            var copilotTables = DiscoverCopilotUsageReportTables();
 
             // A reflection-driven test that discovers nothing passes vacuously, which would be worse
             // than no test at all. Pin the floor at the three tables that exist today.
@@ -148,14 +154,54 @@ namespace Tests.UnitTests
 
             foreach (var table in copilotTables)
             {
-                StringAssert.Contains(
+                var purged = Regex.IsMatch(
                     cleanupScript,
-                    table,
-                    $"'{table}' is a Copilot usage-report table in the entity model but is never " +
-                    "mentioned in Clean Old Data Data.sql, so it grows forever (issue #286). Either " +
-                    "add a retention delete for it, or - if it genuinely must not be aged - name it in " +
-                    "a comment explaining why, as copilot_interaction_user_watermarks does.");
+                    @"delete\s+top\s*\(\s*@copilotBatch\s*\)\s+from\s+" + Regex.Escape(table) + @"\b",
+                    RegexOptions.IgnoreCase);
+
+                var exempt = Regex.IsMatch(
+                    cleanupScript,
+                    @"RETENTION-EXEMPT:\s*" + Regex.Escape(table) + @"\b",
+                    RegexOptions.IgnoreCase);
+
+                Assert.IsTrue(purged || exempt,
+                    $"'{table}' is a Copilot usage-report table in the entity model, but Clean Old Data " +
+                    "Data.sql neither purges it nor declares it exempt, so it grows forever (issue #286). " +
+                    $"Either add 'delete top (@copilotBatch) from {table} where ...' inside a batch loop, " +
+                    $"or - if it genuinely must not be aged - add a comment line 'RETENTION-EXEMPT: {table}' " +
+                    "explaining why, as copilot_interaction_user_watermarks is excluded on purpose.");
             }
+        }
+
+        /// <summary>
+        /// Every <c>[Table]</c>-mapped Copilot entity declared alongside the usage-report classes.
+        /// <para>
+        /// <see cref="Assembly.GetTypes"/> throws <see cref="ReflectionTypeLoadException"/> if any type
+        /// in the assembly fails to load, which would error this test rather than fail it cleanly. The
+        /// partial results it carries are enough for an inventory check, so use them.
+        /// </para>
+        /// </summary>
+        private static List<string> DiscoverCopilotUsageReportTables()
+        {
+            var usageReportNamespace = typeof(CopilotUsageUserActivityLog).Namespace;
+
+            Type[] types;
+            try
+            {
+                types = typeof(CopilotUsageUserActivityLog).Assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t != null).ToArray();
+            }
+
+            return types
+                .Where(t => t.Namespace == usageReportNamespace)
+                .Select(t => t.GetCustomAttribute<TableAttribute>())
+                .Where(a => a != null && a.Name.StartsWith("copilot_", StringComparison.OrdinalIgnoreCase))
+                .Select(a => a.Name)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DataCleanupTests.cs
@@ -154,17 +154,12 @@ namespace Tests.UnitTests
 
             foreach (var table in copilotTables)
             {
-                var purged = Regex.IsMatch(
-                    cleanupScript,
-                    @"delete\s+top\s*\(\s*@copilotBatch\s*\)\s+from\s+" + Regex.Escape(table) + @"\b",
-                    RegexOptions.IgnoreCase);
-
                 var exempt = Regex.IsMatch(
                     cleanupScript,
                     @"RETENTION-EXEMPT:\s*" + Regex.Escape(table) + @"\b",
                     RegexOptions.IgnoreCase);
 
-                Assert.IsTrue(purged || exempt,
+                Assert.IsTrue(IsPurgedInBatches(cleanupScript, table) || exempt,
                     $"'{table}' is a Copilot usage-report table in the entity model, but Clean Old Data " +
                     "Data.sql neither purges it nor declares it exempt, so it grows forever (issue #286). " +
                     $"Either add 'delete top (@copilotBatch) from {table} where ...' inside a batch loop, " +
@@ -205,14 +200,17 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// The three usage-report tables that exist today are the fast-growing ones, so they must not
-        /// merely be aged - they must be aged in BATCHES. Kept separate from the inventory guard above
-        /// because it is a stronger claim about a known set rather than a claim about every future table.
+        /// The three usage-report tables that exist today are the fast-growing ones. This pins them by
+        /// name, which the reflection-driven guard above deliberately does not: if the namespace or the
+        /// <c>[Table]</c> attributes move, discovery could quietly stop finding them and only the
+        /// <c>&gt;= 3</c> floor would notice. Both tests use the same <see cref="IsPurgedInBatches"/>
+        /// matcher, so there is one definition of what counts as batched.
         /// </summary>
         [TestMethod]
         public void CleanupScript_BatchesTheCopilotUsageReportDeletes()
         {
             var cleanupScript = File.ReadAllText(GetCleanOldDataSqlPath());
+            var discovered = DiscoverCopilotUsageReportTables();
 
             var mustBeBatched = new[]
             {
@@ -223,15 +221,43 @@ namespace Tests.UnitTests
 
             foreach (var table in mustBeBatched)
             {
-                StringAssert.Contains(
-                    cleanupScript,
-                    "delete top (@copilotBatch) from " + table,
+                Assert.IsTrue(
+                    discovered.Contains(table, StringComparer.OrdinalIgnoreCase),
+                    $"'{table}' was not discovered by reflection over the usage-report namespace, so the " +
+                    "inventory guard is no longer covering it. Check that its [Table] attribute and " +
+                    "namespace still match what DiscoverCopilotUsageReportTables looks for.");
+
+                Assert.IsTrue(
+                    IsPurgedInBatches(cleanupScript, table),
                     $"'{table}' has no batched retention delete in Clean Old Data Data.sql (issue #286). " +
                     "The batch size must come from @copilotBatch rather than a literal, because the loop " +
                     "exits by comparing @@ROWCOUNT against that same variable - a literal that drifts " +
                     "from it would stop the purge after a single pass.");
             }
         }
+
+        /// <summary>
+        /// Whether <paramref name="cleanupScript"/> deletes <paramref name="table"/> in batches driven by
+        /// <c>@copilotBatch</c>.
+        /// <para>
+        /// Tolerates the SQL spellings a future edit might reasonably use - an optional <c>dbo.</c>
+        /// qualifier and optional square brackets around either part - because bracket-quoting is the
+        /// house style elsewhere in this very script (<c>[sessions]</c>, <c>[date]</c>,
+        /// <c>[event_meta_general]</c>) and <c>dbo.</c> appears in every <c>OBJECT_ID</c> guard. A guard
+        /// that reports correct, batched code as "grows forever" gets weakened rather than trusted.
+        /// </para>
+        /// <para>
+        /// The <c>\b</c> sits immediately after the table name and before the optional closing bracket,
+        /// so <c>copilot_user</c> still does not match inside <c>copilot_user_count_log</c> - underscore
+        /// is a regex word character, which is what makes that work.
+        /// </para>
+        /// </summary>
+        private static bool IsPurgedInBatches(string cleanupScript, string table) =>
+            Regex.IsMatch(
+                cleanupScript,
+                @"delete\s+top\s*\(\s*@copilotBatch\s*\)\s+from\s+(?:\[?dbo\]?\s*\.\s*)?\[?"
+                    + Regex.Escape(table) + @"\b\]?",
+                RegexOptions.IgnoreCase);
 
         // Resolves to <repoRoot>\src\Clean Old Data Data.sql relative to this source file (Tests.UnitTests\DataCleanupTests.cs).
         private static string GetCleanOldDataSqlPath([CallerFilePath] string thisFilePath = "")


### PR DESCRIPTION
An independent review of #320 found two blind spots in the inventory guard added for #286. Both let the guard pass in exactly the situation it exists to catch, so it was providing false assurance rather than none.

## 1. A substring match let a prefix-named table slip through

The guard used `StringAssert.Contains(cleanupScript, table)` — a raw substring search over the whole file.

`copilot_user` is a substring of `copilot_user_count_log`, which the script already names. So a future table called `copilot_user` would have been "found" inside the longer name and passed **with no delete of its own**. Same for `copilot_usage` and `copilot_usage_report`.

That is precisely the case the guard was written for: somebody adds a fourth usage-report table and forgets to age it.

Now matched on a word boundary. Underscore is a regex word character, so `\bcopilot_user\b` correctly does **not** match inside `copilot_user_count_log` — verified against the .NET regex engine rather than assumed:

```
raw substring  'copilot_user'           : True    <-- false pass
word-boundary  'copilot_user'           : False
word-boundary  'copilot_user_count_log' : True    <-- real table still matches
```

## 2. A bare comment satisfied it

Because the search covered comments too, and the surrounding prose names all three tables, **deleting the actual `DELETE` while leaving the comments would have kept the test green**.

The guard now looks for the batched delete itself:

```
delete\s+top\s*\(\s*@copilotBatch\s*\)\s+from\s+<table>\b
```

so it proves the table is *aged*, not merely *discussed*. A table that genuinely must not be aged opts out with an explicit `RETENTION-EXEMPT: <table>` line, keeping that decision visible and reviewable instead of implicit in whatever prose happens to mention the name.

## Both failure modes reproduced

| Scenario | Old guard | New guard |
|---|---|---|
| Removed the `copilot_user_count_log` delete, left every comment intact | would pass | **fails**, naming the table |
| Added a `[Table("copilot_user")]` entity (prefix of an existing table) with no cleanup rule | would pass | **fails** |

Both were rebuilt from scratch before trusting the result — an earlier attempt at this kind of check ran against a stale assembly and reported a false pass.

## Also hardened

`Assembly.GetTypes()` was uncaught, so a `ReflectionTypeLoadException` would have *errored* the test rather than failing it cleanly. It now falls back to the partial `Types` the exception carries, which is sufficient for an inventory check.

Discovery is extracted into `DiscoverCopilotUsageReportTables()` so both tests share one definition of what counts as a usage-report table.

## Verification

Test-only change; no production code touched. `DataCleanupTests` 5/5, `ReportsAPIControllerTests` 16/16.
