### PR TITLE
Stop the --initdb child duplicating every log line in the install log

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel/Program.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Program.cs
@@ -40,19 +40,15 @@ namespace App.ControlPanel
                     catch (FormatException)
                     {
                         InstallerLogs.AddToWindowsEventLog("Couldn't convert init param from base64; assuming the connection-string was sent in clear-text.");
-                        Console.Out.WriteLine("Couldn't convert init param from base64; assuming the connection-string was sent in clear-text.");
                         initInfo = new DatabaseUpgradeInfo() { ConnectionString = secondArgfullArgsString };
                     }
 
-                    // Attempt to upgrade/verify the DB is on the correct migration. Mirror every
-                    // log line to stdout so the parent installer process (which captures stdout)
-                    // can echo schema-upgrade progress live into the install log, instead of the
-                    // operator having to dig through Windows Event Viewer.
-                    DatabaseUpgrader.CheckDbUpgraded(initInfo, msg =>
-                    {
-                        InstallerLogs.AddToWindowsEventLog(msg);
-                        try { Console.Out.WriteLine(msg); } catch { /* no console attached — ignore */ }
-                    });
+                    // Attempt to upgrade/verify the DB is on the correct migration. Every log line is
+                    // mirrored to stdout so the parent installer process (which captures stdout) can echo
+                    // schema-upgrade progress live into the install log, instead of the operator having to
+                    // dig through Windows Event Viewer. AddToWindowsEventLog already writes to stdout, so
+                    // do NOT add a Console.Write here as well - that duplicated every line in the log.
+                    DatabaseUpgrader.CheckDbUpgraded(initInfo, msg => InstallerLogs.AddToWindowsEventLog(msg));
                     return;
                 }
                 else if (args.Contains(InstallerConstants.PARAM_REGISTERCONFIG))


### PR DESCRIPTION
Fixes the duplicated log lines reported in #327.

## Problem

`InstallerLogs.AddToWindowsEventLog` writes the message to **stdout** before it writes to the Windows event log:

```csharp
public static void AddToWindowsEventLog(string msg, bool isError)
{
    var buildLabel = Common.Entities.BuildConstants.BuildLabel;
    Console.WriteLine(msg);          // stdout write #1
    try { ... eventLog.WriteEntry(...) ...
```

The `--initdb` branch in `App.ControlPanel/Program.cs` then wrote it again:

```csharp
DatabaseUpgrader.CheckDbUpgraded(initInfo, msg =>
{
    InstallerLogs.AddToWindowsEventLog(msg);
    try { Console.Out.WriteLine(msg); } catch { /* no console attached — ignore */ }
});
```

The parent installer captures the child's stdout (`SqlInstallerTasks.SendMsgToInstaller` → `proc.OutputDataReceived`) and echoes each line as `[child] ...`, so every `DatabaseUpgrader` message landed in the install log twice.

Migration output (`DB SCHEMA: Applying '...'`) was unaffected because the migration classes call `Console.WriteLine` directly and never go through the `DatabaseUpgrader` callback — which is why only a subset of lines looked duplicated and the pattern appeared arbitrary.

## Changes

`App.ControlPanel/Program.cs` only:

- Dropped the redundant `Console.Out.WriteLine(msg)` from the `--initdb` `CheckDbUpgraded` callback, collapsing it to an expression-bodied lambda.
- Dropped the same redundant `Console.Out.WriteLine` from the adjacent `FormatException` handler (`"Couldn't convert init param from base64..."`), which had the identical double-write.
- Reworded the comment to record *why* there is no `Console.Write` here, so the next reader doesn't reintroduce it.

## What this deliberately does not change

`InstallerLogs.AddToWindowsEventLog` keeps its `Console.WriteLine`. Removing it there would be the tempting "cleaner" fix, but other call sites depend on it for stdout mirroring — notably the `PARAM_REGISTERCONFIG` error paths in the same file, whose output the parent surfaces as the `Last output: ...` text on a failed child run. Removing it would silently blind the parent to child errors, which is worse than the bug being fixed.

The method name remaining misleading (it writes to two sinks) is called out in #327 as a follow-up; renaming it is a wider change than this fix warrants.

## Verification

- Searched the solution for any other `AddToWindowsEventLog(...)` immediately followed by a `Console.*` write — the two in `Program.cs` were the only instances, and both are fixed here.
- `App.ControlPanel.WinForms.csproj` builds clean (Debug) → `AnalyticsInstaller.exe`.

## Risk

Very low. Log-emission only; no behavioural, schema, config-schema or dependency changes. `CONFIG_VERSION` unchanged (no installer config schema change). Worst case is a line that should be echoed to the parent is not — mitigated by the fact that the single remaining write is the one that was already there before the duplicate was introduced.

## Reviewer hotspot

The only judgement call is keeping `Console.WriteLine` inside `AddToWindowsEventLog` rather than moving it to the call sites. If you'd prefer the console write hoisted out of the event-log helper, that's a mechanical follow-up across its call sites — but it should be its own PR, since it changes what every caller emits.
