### PR TITLE
Portal: check for updates against the latest GitHub release

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="IndexReportDateQueriesMigrationTests.cs" />
     <Compile Include="MigrationSnapshotTests.cs" />
     <Compile Include="UpgradeFromStableTests.cs" />
+    <Compile Include="UpdateCheckBuildVersionTests.cs" />
     <Compile Include="ScratchDatabase.cs" />
     <Compile Include="StressHarness\ActivityApiDbStressRunner.cs" />
     <Compile Include="StressHarness\ActivityApiDbStressTests.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/UpdateCheckBuildVersionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UpdateCheckBuildVersionTests.cs
@@ -1,0 +1,87 @@
+extern alias AnalyticsWeb;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BuildVersion = AnalyticsWeb::Web.AnalyticsWeb.Models.UpdateCheck.BuildVersion;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The portal's "check for updates" comparison. This is the only logic in the feature that can be
+    /// silently wrong - a bad compare either nags every admin to upgrade to the build they already run,
+    /// or quietly never tells them a release exists - so it is covered directly.
+    /// </summary>
+    [TestClass]
+    public class UpdateCheckBuildVersionTests
+    {
+        [TestMethod]
+        public void DevBuildIsRecognised()
+        {
+            Assert.IsTrue(BuildVersion.IsDevBuild("DEV_BUILD"));
+            Assert.IsTrue(BuildVersion.IsDevBuild("dev_build"), "Comparison should be case-insensitive.");
+            Assert.IsTrue(BuildVersion.IsDevBuild("  DEV_BUILD  "), "Surrounding whitespace shouldn't matter.");
+            Assert.IsTrue(BuildVersion.IsDevBuild(null));
+            Assert.IsTrue(BuildVersion.IsDevBuild(""));
+
+            Assert.IsFalse(BuildVersion.IsDevBuild("Build 1796"));
+        }
+
+        [TestMethod]
+        public void ParsesTheBuildNumberFromBothRealFormats()
+        {
+            // What the release pipeline writes into BuildConstants.BuildLabel...
+            Assert.AreEqual(1796, BuildVersion.TryParseBuildNumber("Build 1796"));
+
+            // ...and what GitHub carries as a release tag_name.
+            Assert.AreEqual(1756, BuildVersion.TryParseBuildNumber("1756"));
+
+            // Tolerated hand-written variations.
+            Assert.AreEqual(1756, BuildVersion.TryParseBuildNumber("v1756"));
+            Assert.AreEqual(1756, BuildVersion.TryParseBuildNumber("Stable build 1756"));
+        }
+
+        [TestMethod]
+        public void ReturnsNullWhenThereIsNoBuildNumber()
+        {
+            Assert.IsNull(BuildVersion.TryParseBuildNumber("DEV_BUILD"));
+            Assert.IsNull(BuildVersion.TryParseBuildNumber(null));
+            Assert.IsNull(BuildVersion.TryParseBuildNumber(""));
+            Assert.IsNull(BuildVersion.TryParseBuildNumber("   "));
+            Assert.IsNull(BuildVersion.TryParseBuildNumber("no digits here"));
+
+            // Larger than int.MaxValue - not a build number we produced, so don't guess.
+            Assert.IsNull(BuildVersion.TryParseBuildNumber("99999999999999999999"));
+        }
+
+        [TestMethod]
+        public void UpdateIsOnlyOfferedWhenTheReleaseIsGenuinelyNewer()
+        {
+            Assert.IsTrue(BuildVersion.IsUpdateAvailable(1756, 1796), "A higher release build is an update.");
+
+            Assert.IsFalse(BuildVersion.IsUpdateAvailable(1796, 1796), "Same build is not an update.");
+            Assert.IsFalse(BuildVersion.IsUpdateAvailable(1796, 1756),
+                "Running ahead of the published release (e.g. a pre-release build) must not offer a downgrade.");
+        }
+
+        [TestMethod]
+        public void UnknownVersionsNeverOfferAnUpdate()
+        {
+            // Never nag on a guess: if either side is unknown, say nothing.
+            Assert.IsFalse(BuildVersion.IsUpdateAvailable(null, 1796));
+            Assert.IsFalse(BuildVersion.IsUpdateAvailable(1756, null));
+            Assert.IsFalse(BuildVersion.IsUpdateAvailable(null, null));
+        }
+
+        [TestMethod]
+        public void ADevBuildNeverOffersAnUpdate()
+        {
+            // End to end over the two helpers: a locally-compiled build has no number, so however new the
+            // published release is, the portal must not claim an update is available.
+            var current = BuildVersion.TryParseBuildNumber(BuildVersion.DevBuildLabel);
+            var latest = BuildVersion.TryParseBuildNumber("1796");
+
+            Assert.IsNull(current);
+            Assert.AreEqual(1796, latest);
+            Assert.IsFalse(BuildVersion.IsUpdateAvailable(current, latest));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Controllers/UpdateCheckAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/UpdateCheckAPIController.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using System.Web.Http;
+using Web.AnalyticsWeb.Models.UpdateCheck;
+
+namespace Web.AnalyticsWeb.Controllers
+{
+    /// <summary>
+    /// "Is there a newer release than the build we're running?" for the portal's Administration area.
+    /// </summary>
+    /// <remarks>
+    /// Read-only and on demand - nothing here polls GitHub in the background, so a deployment that never
+    /// opens the page never makes an outbound call. The result is cached briefly server-side to protect
+    /// GitHub's anonymous rate limit, which the installer also depends on.
+    /// </remarks>
+    [Authorize]
+    [RoutePrefix("api/UpdateCheck")]
+    public class UpdateCheckAPIController : ApiController
+    {
+        // GET: api/UpdateCheck
+        [HttpGet]
+        [Route("")]
+        public async Task<IHttpActionResult> Get()
+        {
+            // Failures are reported inside the model (CheckError) rather than as an HTTP error, so the
+            // page can always show which build is running even when GitHub is unreachable.
+            return Ok(await UpdateChecker.CheckAsync());
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Models/UpdateCheck/BuildVersion.cs
+++ b/src/AnalyticsEngine/Web/Models/UpdateCheck/BuildVersion.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Web.AnalyticsWeb.Models.UpdateCheck
+{
+    /// <summary>
+    /// Parses and compares the two different shapes this product expresses its version in.
+    /// </summary>
+    /// <remarks>
+    /// There are exactly two, and they do not match each other:
+    /// <list type="bullet">
+    /// <item>
+    /// The running build is <see cref="Common.Entities.BuildConstants.BuildLabel"/>, which the release
+    /// pipeline rewrites from <c>"DEV_BUILD"</c> to <c>"Build 1796"</c> (see the sed step in
+    /// <c>.github/workflows/ci.yml</c>). A locally-compiled build keeps <c>"DEV_BUILD"</c>.
+    /// </item>
+    /// <item>
+    /// A published release's <c>tag_name</c> on GitHub is the bare build number, e.g. <c>"1756"</c>
+    /// (its <c>name</c> is "Stable build 1756").
+    /// </item>
+    /// </list>
+    /// So the comparison is an integer compare of the build number pulled out of each. This is pure
+    /// string/number logic with no IO, deliberately separated so it can be tested directly.
+    /// </remarks>
+    public static class BuildVersion
+    {
+        /// <summary>The label a build that was not produced by the release pipeline carries.</summary>
+        public const string DevBuildLabel = "DEV_BUILD";
+
+        // The first run of digits in the string. Both shapes above are covered by this, and it stays
+        // tolerant of a tag someone writes by hand as "v1756" or "Build 1756".
+        private static readonly Regex _firstNumber = new Regex(@"\d+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// True when <paramref name="buildLabel"/> is a local/developer build rather than a released one.
+        /// Such a build has no build number, so it can never be compared against a release.
+        /// </summary>
+        public static bool IsDevBuild(string buildLabel)
+        {
+            return string.IsNullOrWhiteSpace(buildLabel)
+                || buildLabel.Trim().Equals(DevBuildLabel, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Extracts the build number from a build label or a release tag, or null when there isn't one.
+        /// </summary>
+        public static int? TryParseBuildNumber(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || IsDevBuild(value))
+            {
+                return null;
+            }
+
+            var match = _firstNumber.Match(value);
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            // A build number that doesn't fit in an int is not a build number we produced.
+            return int.TryParse(match.Value, out var number) ? (int?)number : null;
+        }
+
+        /// <summary>
+        /// True only when both versions are known AND the released one is genuinely higher. Anything
+        /// unknown returns false: we would rather say nothing than tell an admin to upgrade on a guess.
+        /// </summary>
+        public static bool IsUpdateAvailable(int? currentBuild, int? latestBuild)
+        {
+            return currentBuild.HasValue && latestBuild.HasValue && latestBuild.Value > currentBuild.Value;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Models/UpdateCheck/UpdateCheckApiModel.cs
+++ b/src/AnalyticsEngine/Web/Models/UpdateCheck/UpdateCheckApiModel.cs
@@ -1,0 +1,61 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Web.AnalyticsWeb.Models.UpdateCheck
+{
+    /// <summary>
+    /// Result of an "is there a newer release than the build we're running?" check, returned by
+    /// <c>api/UpdateCheck</c>.
+    /// </summary>
+    /// <remarks>
+    /// Every failure mode is reported in <see cref="CheckError"/> rather than as an HTTP error, so the
+    /// portal can always render the build it is running even when GitHub is unreachable - which is the
+    /// normal case on a locked-down deployment with no outbound internet.
+    /// </remarks>
+    public class UpdateCheckApiModel
+    {
+        /// <summary>The label of the running build, e.g. "Build 1796" (or "DEV_BUILD" locally).</summary>
+        [JsonProperty("currentBuildLabel")]
+        public string CurrentBuildLabel { get; set; }
+
+        /// <summary>The running build number, or null for a local build with no number.</summary>
+        [JsonProperty("currentBuild")]
+        public int? CurrentBuild { get; set; }
+
+        /// <summary>True when this is a locally-compiled build, so no comparison is possible.</summary>
+        [JsonProperty("isDevBuild")]
+        public bool IsDevBuild { get; set; }
+
+        /// <summary>Build number of the latest published stable release, or null if it couldn't be read.</summary>
+        [JsonProperty("latestBuild")]
+        public int? LatestBuild { get; set; }
+
+        /// <summary>Release title, e.g. "Stable build 1756".</summary>
+        [JsonProperty("latestReleaseName")]
+        public string LatestReleaseName { get; set; }
+
+        /// <summary>Link to the release page, for the admin to read the notes and download from.</summary>
+        [JsonProperty("latestReleaseUrl")]
+        public string LatestReleaseUrl { get; set; }
+
+        /// <summary>When the latest release was published.</summary>
+        [JsonProperty("latestPublishedUtc")]
+        public DateTime? LatestPublishedUtc { get; set; }
+
+        /// <summary>True only when both build numbers are known and the released one is higher.</summary>
+        [JsonProperty("updateAvailable")]
+        public bool UpdateAvailable { get; set; }
+
+        /// <summary>Why the check couldn't be completed, phrased for an admin. Null on success.</summary>
+        [JsonProperty("checkError")]
+        public string CheckError { get; set; }
+
+        /// <summary>
+        /// When the GitHub result being reported was actually fetched. The result is cached briefly, so
+        /// this can be older than the moment the admin pressed the button - showing it avoids implying a
+        /// live call happened when it didn't.
+        /// </summary>
+        [JsonProperty("checkedAtUtc")]
+        public DateTime CheckedAtUtc { get; set; }
+    }
+}

--- a/src/AnalyticsEngine/Web/Models/UpdateCheck/UpdateChecker.cs
+++ b/src/AnalyticsEngine/Web/Models/UpdateCheck/UpdateChecker.cs
@@ -1,0 +1,239 @@
+using App.ControlPanel.Engine.Models;
+using Common.Entities;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.Caching;
+using System.Threading.Tasks;
+
+namespace Web.AnalyticsWeb.Models.UpdateCheck
+{
+    /// <summary>
+    /// Answers "is there a newer release than the build we're running?" by comparing
+    /// <see cref="BuildConstants.BuildLabel"/> against the latest published release on GitHub.
+    /// </summary>
+    /// <remarks>
+    /// Read-only and best-effort. It never throws at the caller: a deployment with no outbound internet
+    /// (very common - private endpoints, locked-down egress) must still be able to open the page and see
+    /// which build it is on, with an explanation of why the remote half is missing.
+    /// </remarks>
+    public static class UpdateChecker
+    {
+        /// <summary>
+        /// GitHub's <c>releases/latest</c> deliberately excludes drafts and pre-releases, so this only ever
+        /// compares against a published stable release - which is exactly what we want to offer an admin.
+        /// </summary>
+        private static readonly string _apiUrl =
+            $"https://api.github.com/repos/{SoftwareReleaseConfig.GITHUB_REPO_OWNER}/{SoftwareReleaseConfig.GITHUB_REPO_NAME}/releases/latest";
+
+        private const string CacheKey = "UpdateCheck::LatestRelease";
+
+        /// <summary>
+        /// How long a GitHub answer is reused. Anonymous GitHub API calls are limited to 60/hour per public
+        /// IP, shared by everything behind the same outbound address. Releases appear every few weeks, so
+        /// caching costs the admin nothing and stops a handful of impatient clicks burning the budget for
+        /// the whole tenant (including the installer, which needs the same API to download a release).
+        /// </summary>
+        private static readonly TimeSpan _cacheFor = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// Short by design: this runs while an admin waits on a button press, and on a deployment with
+        /// blocked egress the connection typically hangs rather than refusing, so an untimed call would
+        /// leave the page spinning until IIS gave up.
+        /// </summary>
+        private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(10);
+
+        private static readonly HttpClient _httpClient = CreateHttpClient();
+
+        private static HttpClient CreateHttpClient()
+        {
+            var client = new HttpClient { Timeout = _timeout };
+            // GitHub rejects requests with no User-Agent outright.
+            client.DefaultRequestHeaders.Add("User-Agent", "Microsoft365-Analytics-Insights-Portal");
+            client.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+            return client;
+        }
+
+        /// <summary>
+        /// Compares the running build against the latest published release. Never throws.
+        /// </summary>
+        public static async Task<UpdateCheckApiModel> CheckAsync()
+        {
+            var currentLabel = BuildConstants.BuildLabel;
+            var result = new UpdateCheckApiModel
+            {
+                CurrentBuildLabel = currentLabel,
+                IsDevBuild = BuildVersion.IsDevBuild(currentLabel),
+                CurrentBuild = BuildVersion.TryParseBuildNumber(currentLabel),
+                CheckedAtUtc = DateTime.UtcNow,
+            };
+
+            var latest = await GetLatestReleaseAsync();
+
+            result.CheckedAtUtc = latest.FetchedAtUtc;
+            if (latest.Error != null)
+            {
+                result.CheckError = latest.Error;
+                return result;
+            }
+
+            result.LatestBuild = latest.Build;
+            result.LatestReleaseName = latest.Name;
+            result.LatestReleaseUrl = latest.Url;
+            result.LatestPublishedUtc = latest.PublishedUtc;
+
+            if (result.IsDevBuild)
+            {
+                result.CheckError = "This is a locally-compiled build (DEV_BUILD), so it has no build number to "
+                    + "compare. The latest published release is shown for reference.";
+                return result;
+            }
+
+            if (!result.CurrentBuild.HasValue)
+            {
+                result.CheckError = $"Couldn't read a build number out of this build's label ('{currentLabel}'), "
+                    + "so it can't be compared. The latest published release is shown for reference.";
+                return result;
+            }
+
+            if (!result.LatestBuild.HasValue)
+            {
+                result.CheckError = "Couldn't read a build number from the latest GitHub release, so the two "
+                    + "can't be compared. Open the release page to check manually.";
+                return result;
+            }
+
+            result.UpdateAvailable = BuildVersion.IsUpdateAvailable(result.CurrentBuild, result.LatestBuild);
+            return result;
+        }
+
+        private class LatestRelease
+        {
+            public int? Build { get; set; }
+            public string Name { get; set; }
+            public string Url { get; set; }
+            public DateTime? PublishedUtc { get; set; }
+            public string Error { get; set; }
+            public DateTime FetchedAtUtc { get; set; }
+        }
+
+        private static async Task<LatestRelease> GetLatestReleaseAsync()
+        {
+            if (MemoryCache.Default[CacheKey] is LatestRelease cached)
+            {
+                return cached;
+            }
+
+            var fetched = await FetchLatestReleaseAsync();
+
+            // Cache failures too, for the same window. A blocked-egress deployment would otherwise pay the
+            // full timeout on every click, and a rate-limited one would keep asking while still limited.
+            MemoryCache.Default.Set(CacheKey, fetched, DateTimeOffset.UtcNow.Add(_cacheFor));
+            return fetched;
+        }
+
+        private static async Task<LatestRelease> FetchLatestReleaseAsync()
+        {
+            var result = new LatestRelease { FetchedAtUtc = DateTime.UtcNow };
+
+            try
+            {
+                using (var response = await _httpClient.GetAsync(_apiUrl))
+                {
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        result.Error = DescribeFailure(response);
+                        return result;
+                    }
+
+                    var release = JObject.Parse(await response.Content.ReadAsStringAsync());
+                    result.Build = BuildVersion.TryParseBuildNumber(release["tag_name"]?.ToString());
+                    result.Name = release["name"]?.ToString();
+                    result.Url = release["html_url"]?.ToString();
+
+                    if (DateTime.TryParse(release["published_at"]?.ToString(), null,
+                        System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal,
+                        out var published))
+                    {
+                        result.PublishedUtc = published;
+                    }
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // HttpClient surfaces its own timeout as a cancellation, which reads like the user cancelled.
+                result.Error = $"Timed out after {_timeout.TotalSeconds:0}s contacting github.com. If this web app "
+                    + "has no outbound internet access (for example a private-endpoint deployment with restricted "
+                    + "egress), update checks can't work from here - check the release page manually instead.";
+            }
+            catch (HttpRequestException ex)
+            {
+                result.Error = $"Couldn't reach github.com to check for updates: {InnerMostMessage(ex)}. This is "
+                    + "expected if the web app has no outbound internet access; check the release page manually.";
+            }
+            catch (Exception ex)
+            {
+                result.Error = $"Update check failed: {InnerMostMessage(ex)}";
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Turns a failed GitHub response into something an admin can act on.
+        /// </summary>
+        /// <remarks>
+        /// A rate-limited response is a bare <c>403 Forbidden</c>, which reads like a permissions problem and
+        /// sends people hunting for a credential that was never needed. GitHub distinguishes the two in the
+        /// headers: on a rate limit <c>x-ratelimit-remaining</c> is 0 and <c>x-ratelimit-reset</c> carries the
+        /// unix time it frees up. Mirrors the installer's handling in
+        /// <c>LatestStableSoftwarePackageDownloadTask</c>.
+        /// </remarks>
+        private static string DescribeFailure(HttpResponseMessage response)
+        {
+            var remaining = FirstHeader(response, "x-ratelimit-remaining");
+            var isRateLimited = (int)response.StatusCode == 429
+                || (response.StatusCode == HttpStatusCode.Forbidden && remaining == "0");
+
+            if (isRateLimited)
+            {
+                var resetText = "shortly";
+                if (long.TryParse(FirstHeader(response, "x-ratelimit-reset"), out var resetUnix))
+                {
+                    resetText = DateTimeOffset.FromUnixTimeSeconds(resetUnix).UtcDateTime.ToString("u");
+                }
+
+                return "GitHub rejected the request because its API rate limit has been reached, not because of a "
+                    + $"permissions problem. The limit resets at {resetText}. Anonymous requests are limited to 60 "
+                    + "per hour per public IP address, which is shared by everything behind your outbound address. "
+                    + "Try again after the reset.";
+            }
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return "GitHub returned 404 for the releases endpoint. If this deployment sits behind a proxy that "
+                    + "intercepts HTTPS, it may be returning its own response rather than GitHub's.";
+            }
+
+            return $"GitHub returned {(int)response.StatusCode} ({response.StatusCode}) when asked for the latest release.";
+        }
+
+        private static string FirstHeader(HttpResponseMessage response, string name)
+        {
+            return response.Headers.TryGetValues(name, out var values)
+                ? System.Linq.Enumerable.FirstOrDefault(values)
+                : null;
+        }
+
+        /// <summary>The useful message is usually on the inner-most exception, not the wrapper.</summary>
+        private static string InnerMostMessage(Exception ex)
+        {
+            while (ex.InnerException != null)
+            {
+                ex = ex.InnerException;
+            }
+            return ex.Message;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/index.html
+++ b/src/AnalyticsEngine/Web/Scripts/portal/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#0f6cbd" />
 
-  <title>Microsoft 365 Advanced Analytics - Admin</title>
+  <title>Microsoft 365 Advanced Analytics</title>
 
   <!--
     Runtime configuration injected for the SPA. The API URLs are derived from the current
@@ -31,6 +31,7 @@
     window.o365AnalyticsReportsAPI = baseUrl + "api/Reports";
     window.o365AnalyticsCopilotAdoptionAPI = baseUrl + "api/CopilotAdoption";
     window.o365AnalyticsHealthAPI = baseUrl + "api/Health";
+    window.o365AnalyticsUpdateCheckAPI = baseUrl + "api/UpdateCheck";
   </script>
 </head>
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/updateCheckApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/updateCheckApi.ts
@@ -1,0 +1,23 @@
+import type { UpdateCheck } from '../types/updateCheck';
+
+const baseUrl = (): string => window.o365AnalyticsUpdateCheckAPI ?? `${window.location.origin}/api/UpdateCheck`;
+
+/**
+ * Asks the server to compare the running build against the latest published GitHub release.
+ *
+ * Only called when the admin presses the button - nothing polls. The server caches GitHub's answer
+ * briefly, so repeated presses don't burn GitHub's anonymous rate limit (which the installer shares).
+ */
+export async function fetchUpdateCheck(): Promise<UpdateCheck> {
+  const response = await fetch(baseUrl(), {
+    method: 'GET',
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Couldn't check for updates (${response.status}).`);
+  }
+
+  return response.json() as Promise<UpdateCheck>;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/global.d.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/global.d.ts
@@ -30,6 +30,8 @@ declare global {
     o365AnalyticsCopilotAdoptionAPI: string;
     /** Endpoint for the system-health ("is it working?") API. */
     o365AnalyticsHealthAPI: string;
+    /** Endpoint for the "is there a newer release?" check. */
+    o365AnalyticsUpdateCheckAPI: string;
   }
 }
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/ServiceConfigurationPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/ServiceConfigurationPage.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   Body1,
   Button,
+  Link,
   Table,
   TableBody,
   TableRow,
@@ -20,8 +21,10 @@ import {
 } from '@fluentui/react-components';
 import { fetchSystemStatus, testWebhook } from '../api/systemStatusApi';
 import { fetchHealthConfig } from '../api/healthApi';
+import { fetchUpdateCheck } from '../api/updateCheckApi';
 import type { SystemStatus } from '../types/systemStatus';
 import type { ConfigSection } from '../types/health';
+import type { UpdateCheck } from '../types/updateCheck';
 import { formatUtc } from '../components/health/healthShared';
 import Spinner from '../components/Spinner';
 
@@ -47,6 +50,16 @@ const useStyles = makeStyles({
     flexWrap: 'wrap',
     gap: '6px',
     marginTop: '4px',
+  },
+  updateRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+    flexWrap: 'wrap',
+    marginTop: '8px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
   },
 });
 
@@ -92,6 +105,121 @@ function WebhookSubscriptionBadge({ status }: { status: SystemStatus }) {
     default:
       return <Text>Not applicable - Teams calls import is disabled</Text>;
   }
+}
+
+/**
+ * The "check for updates" card. Deliberately on demand: nothing is fetched until the admin presses
+ * the button, so a deployment that never opens this page never makes an outbound call to GitHub -
+ * which matters because plenty of these deployments have no outbound internet at all.
+ */
+function UpdateCheckCard({ styles }: { styles: ReturnType<typeof useStyles> }) {
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<UpdateCheck | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  const onCheck = async () => {
+    setChecking(true);
+    setFailure(null);
+    try {
+      setResult(await fetchUpdateCheck());
+    } catch (e) {
+      setFailure(e instanceof Error ? e.message : 'Update check failed.');
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader header={<Subtitle2>Software updates</Subtitle2>} />
+      <Body1>
+        Compares the build this site is running against the latest published release on GitHub. Nothing is
+        sent to GitHub until you press the button.
+      </Body1>
+
+      <div className={styles.updateRow}>
+        <Button appearance="primary" onClick={onCheck} disabled={checking}>
+          {checking ? 'Checking...' : 'Check for updates'}
+        </Button>
+        {result && (
+          <Text size={200} className={styles.muted}>
+            Checked {formatUtc(result.checkedAtUtc)}
+          </Text>
+        )}
+      </div>
+
+      {failure && (
+        <MessageBar intent="error">
+          <MessageBarBody>{failure}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {result && (
+        <>
+          <Table aria-label="Update check" size="small">
+            <TableBody>
+              <TableRow>
+                <TableCell className={styles.label}>This site is running</TableCell>
+                <TableCell className={styles.value}>{result.currentBuildLabel ?? 'Unknown'}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell className={styles.label}>Latest published release</TableCell>
+                <TableCell className={styles.value}>
+                  {result.latestReleaseName ?? (result.latestBuild != null ? `Build ${result.latestBuild}` : 'Unknown')}
+                  {result.latestPublishedUtc && (
+                    <Text size={200} block className={styles.muted}>
+                      Published {formatUtc(result.latestPublishedUtc)}
+                    </Text>
+                  )}
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+
+          {result.updateAvailable ? (
+            <MessageBar intent="warning">
+              <MessageBarBody>
+                <strong>An update is available.</strong> This site is on build {result.currentBuild}; build{' '}
+                {result.latestBuild} has been released.{' '}
+                {result.latestReleaseUrl && (
+                  <Link href={result.latestReleaseUrl} target="_blank" rel="noreferrer">
+                    Open the release notes and downloads
+                  </Link>
+                )}
+                . Read the release notes before upgrading - they call out any database migrations and
+                configuration changes.
+              </MessageBarBody>
+            </MessageBar>
+          ) : result.checkError ? (
+            <MessageBar intent="info">
+              <MessageBarBody>
+                {result.checkError}{' '}
+                {result.latestReleaseUrl && (
+                  <Link href={result.latestReleaseUrl} target="_blank" rel="noreferrer">
+                    Open the latest release
+                  </Link>
+                )}
+              </MessageBarBody>
+            </MessageBar>
+          ) : (
+            <MessageBar intent="success">
+              <MessageBarBody>
+                This site is up to date - no newer release has been published.
+                {result.latestReleaseUrl && (
+                  <>
+                    {' '}
+                    <Link href={result.latestReleaseUrl} target="_blank" rel="noreferrer">
+                      View the current release
+                    </Link>
+                  </>
+                )}
+              </MessageBarBody>
+            </MessageBar>
+          )}
+        </>
+      )}
+    </Card>
+  );
 }
 
 /**
@@ -181,6 +309,8 @@ export default function ServiceConfigurationPage() {
       <Title3 block>Service configuration{status.buildLabel ? ` - ${status.buildLabel}` : ''}</Title3>
 
       <div className={styles.cards}>
+        <UpdateCheckCard styles={styles} />
+
         <Card>
           <CardHeader header={<Subtitle2>Azure resources</Subtitle2>} />
           <Body1>These are the resources this deployment is configured to use:</Body1>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/types/updateCheck.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/types/updateCheck.ts
@@ -1,0 +1,21 @@
+// Mirrors Web/Models/UpdateCheck/UpdateCheckApiModel.cs (returned by api/UpdateCheck).
+
+export interface UpdateCheck {
+  /** Label of the running build, e.g. "Build 1796" (or "DEV_BUILD" locally). */
+  currentBuildLabel: string | null;
+  /** Running build number, or null for a local build with no number. */
+  currentBuild: number | null;
+  /** True when this is a locally-compiled build, so no comparison is possible. */
+  isDevBuild: boolean;
+  /** Build number of the latest published stable release, or null if it couldn't be read. */
+  latestBuild: number | null;
+  latestReleaseName: string | null;
+  latestReleaseUrl: string | null;
+  latestPublishedUtc: string | null;
+  /** True only when both build numbers are known and the released one is higher. */
+  updateAvailable: boolean;
+  /** Why the check couldn't be completed, phrased for an admin. Null on success. */
+  checkError: string | null;
+  /** When the GitHub result being reported was actually fetched (it is cached briefly). */
+  checkedAtUtc: string;
+}

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Controllers\HealthAPIController.cs" />
     <Compile Include="Controllers\SystemStatusAPIController.cs" />
     <Compile Include="Controllers\TeamsAuthAPIController.cs" />
+    <Compile Include="Controllers\UpdateCheckAPIController.cs" />
     <Compile Include="Controllers\UserDataLookupAPIController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
@@ -236,6 +237,9 @@
     <Compile Include="Models\Health\HealthModels.cs" />
     <Compile Include="Models\Health\HealthService.cs" />
     <Compile Include="Models\SystemStatusApiModel.cs" />
+    <Compile Include="Models\UpdateCheck\BuildVersion.cs" />
+    <Compile Include="Models\UpdateCheck\UpdateCheckApiModel.cs" />
+    <Compile Include="Models\UpdateCheck\UpdateChecker.cs" />
     <Compile Include="Models\TeamAuthStatusResponse.cs" />
     <Compile Include="Models\UserDataLookupModels.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Adds a **Check for updates** card to **Administration → Service configuration**. Admins previously had no way to tell whether the build they are running is current, short of watching the repo.

## How the comparison works

The product expresses its version in two shapes that don't match each other, so this is the part worth reviewing carefully:

| Source | Shape | Example |
| --- | --- | --- |
| Running build | `BuildConstants.BuildLabel`, rewritten by the release pipeline's `sed` step in `ci.yml` | `Build 1796` (`DEV_BUILD` locally) |
| Published release | GitHub `tag_name` (its `name` is "Stable build 1756") | `1756` |

So it is an integer compare of the build number pulled out of each. That logic lives in `BuildVersion` with **no IO**, so it is directly testable — getting it wrong either nags every admin to install the build they already run, or silently never tells them a release exists.

**An unknown version on either side never offers an update.** A `DEV_BUILD`, an unparsable label, or an unreadable tag all resolve to "can't compare" with an explanation, never to "upgrade". Better to say nothing than to advise on a guess.

## Deliberate design choices

- **On demand only.** Nothing polls. A deployment that never opens the page never makes an outbound call to GitHub.
- **Uses `releases/latest`**, which GitHub defines as excluding drafts and pre-releases — so it only ever offers a *published stable* release. (Confirmed against the repo: the current draft is correctly not returned.)
- **Server-side cached for 10 minutes.** Anonymous GitHub API calls are capped at 60/hour per public IP, and **the installer needs that same budget** to download a release. A few impatient clicks shouldn't spend it.
- **10s timeout, and failures are cached too.** On a deployment with blocked egress the connection *hangs* rather than refuses, so an untimed call would leave the page spinning and every subsequent click would pay the full timeout again.
- **Failures come back in the payload, not as an HTTP error**, so the page still shows which build is running when GitHub is unreachable — the normal case for a private-endpoint deployment with restricted egress.
- **A 403 rate-limit is explained as a rate limit.** GitHub returns a bare `403` for this, which reads like a permissions problem and sends people hunting for a credential that was never needed; the reset time is read from `x-ratelimit-reset`. This mirrors the installer's existing handling in `LatestStableSoftwarePackageDownloadTask`.

## Files

| File | Purpose |
| --- | --- |
| `Web/Models/UpdateCheck/BuildVersion.cs` | Pure parse/compare. No IO. |
| `Web/Models/UpdateCheck/UpdateChecker.cs` | GitHub call, caching, error mapping. Never throws. |
| `Web/Models/UpdateCheck/UpdateCheckApiModel.cs` | Response shape. |
| `Web/Controllers/UpdateCheckAPIController.cs` | `GET api/UpdateCheck`, `[Authorize]`. |
| `portal/src/pages/ServiceConfigurationPage.tsx` | The card. |
| `portal/index.html`, `src/global.d.ts` | Registers `o365AnalyticsUpdateCheckAPI` alongside the other API globals. |

Placed on Service configuration because that page already answers "what is this deployment, and is its schema current" — "is its *software* current" belongs with it rather than as a new nav item for a single button.

## Testing

`UpdateCheckBuildVersionTests` — 6 tests, all passing locally via `vstest.console`:

- both real formats parse (`Build 1796`, `1756`), plus tolerated hand-written variants (`v1756`, `Stable build 1756`)
- `DEV_BUILD` recognised (case/whitespace insensitive), and never offers an update
- no-digits, empty, null and `> int.MaxValue` all return null rather than guessing
- **running *ahead* of the published release does not offer a downgrade** — this matters for anyone on a pre-release build
- unknown on either side never offers an update

**All four UI states were rendered end-to-end in headless Edge** against a stubbed API (synthetic data), driving the actual button click over CDP:

| State | Result |
| --- | --- |
| Update available | "An update is available… build 1800 has been released", with a verified real `<a href>` to the release page |
| Up to date | "This site is up to date — no newer release has been published" |
| Offline / timeout | Latest shown as "Unknown" plus the egress explanation; build still displayed |
| `DEV_BUILD` | Explains it can't be compared, still links to the latest release for reference |

`Web.csproj` and `Tests.UnitTests.csproj` both build clean (they use explicit `<Compile>` items, so the new files are registered).

## Risk

Low and self-contained. One new read-only `[Authorize]` endpoint; no schema, migration, config-schema (`CONFIG_VERSION` unchanged) or dependency changes. The one new behaviour is an outbound HTTPS call to `api.github.com`, which only happens when an admin presses the button, and which fails safe.

## Unrelated finding, raised separately

While verifying the rendered page I noticed `portal/index.html` hard-codes an Entra **client ID and tenant authority** that nothing substitutes at build or deploy time. That looks like both a data-hygiene problem for a public repo and a functional bug in the client-side MSAL fallback for every deployment that isn't that tenant. Not touched here — flagged for a separate issue.
