### PR TITLE
Hold StackExchange.Redis at 2.x - 3.x breaks the Azure Redis auth extension

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel/App.Template.config
+++ b/src/AnalyticsEngine/App.ControlPanel/App.Template.config
@@ -222,15 +222,11 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Hashing" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="StackExchange.Redis" publicKeyToken="c219ff1ca8c2ce46" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -670,7 +670,7 @@
       <Version>13.0.4</Version>
     </PackageReference>
     <PackageReference Include="StackExchange.Redis">
-      <Version>3.1.31</Version>
+      <Version>2.13.17</Version>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.PerformanceCounter">
       <Version>10.0.11</Version>

--- a/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
+++ b/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
@@ -233,7 +233,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Hashing" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -246,10 +246,6 @@
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="StackExchange.Redis" publicKeyToken="c219ff1ca8c2ce46" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/AnalyticsEngine/Web/Web.Template.config
+++ b/src/AnalyticsEngine/Web/Web.Template.config
@@ -58,7 +58,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Hashing" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -271,10 +271,6 @@
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Bcl.Cryptography" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="StackExchange.Redis" publicKeyToken="c219ff1ca8c2ce46" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
@@ -149,10 +149,6 @@
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="StackExchange.Redis" publicKeyToken="c219ff1ca8c2ce46" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.2" newVersion="10.0.0.2" />
 			</dependentAssembly>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
@@ -237,10 +237,6 @@
 				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="StackExchange.Redis" publicKeyToken="c219ff1ca8c2ce46" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.2" newVersion="10.0.0.2" />
 			</dependentAssembly>


### PR DESCRIPTION
Fixes a regression I introduced in #341.

## What broke

`Microsoft.Azure.StackExchangeRedis` 3.3.1 — the extension this solution uses for **Entra ID / RBAC authentication to Azure Cache for Redis** — is compiled against `StackExchange.Redis` **2.10.1**, and its assembly binds to:

```
StackExchange.Redis, Version=2.0.0.0
```

#341 bumped `StackExchange.Redis` to 3.1.31, which ships assembly version **3.0.0.0**. The extension would have been calling across a major version boundary, held together only by the binding redirect that bump required.

There is no 3.x-compatible release of the Azure extension, and **2.13.17 is the latest 2.x** — so the solution was already current on the compatible major. The bump gained nothing and risked breaking Redis auth at runtime.

## Changes

* `StackExchange.Redis` 3.1.31 → **2.13.17**.
* Removes the `StackExchange.Redis` → 3.0.0.0 binding redirect from all five `.Template.config` files; with 2.x there is no longer a version conflict to redirect.
* Corrects the `System.IO.Hashing` redirects: a clean restore resolves **10.0.0.3**, whereas the incremental build #341 was validated against had produced 10.0.0.5.

## Verification

Rebuilt from a **wiped `obj`/`bin`** rather than incrementally, which is how the `System.IO.Hashing` drift surfaced:

* Debug and Release both build with **zero warnings and zero errors**
* every binding redirect matches its shipped assembly version
* offline test suites pass (157 tests)

## Lesson for the earlier change

#341 validated the Redis bump on *compile + tests*, which passed — the mismatch only shows up as a runtime binding across the Azure extension. The check that would have caught it is the one applied to the other majors in that PR: verify what the dependent assembly actually *binds to*, not just that the new version compiles. `Microsoft.Azure.StackExchangeRedis` was a direct reference sitting right next to `StackExchange.Redis` in the same csproj and I did not check the pairing.
