### PR TITLE
Installer: stop rewriting the Service Bus namespace on every run (and wiping its tags)

### DIFF
--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
@@ -26,6 +26,24 @@ namespace CloudInstallEngine.Azure.InstallTasks
             + "(https://learn.microsoft.com/azure/service-bus-messaging/service-bus-migrate-standard-premium), "
             + "(b) keep public network access enabled on Service Bus, or (c) disable the Teams calls import.";
 
+        /// <summary>
+        /// The minimum TLS version every namespace must enforce.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately <c>Tls12</c> and NOT the near-identically named <c>Tls1_2</c>. In
+        /// Azure.ResourceManager.ServiceBus 1.2.0 the underscored members are deprecated aliases whose
+        /// underlying value is the EMPTY STRING, while the real API values ("1.0".."1.3") live on
+        /// <c>Tls10</c>..<c>Tls13</c>. Comparing against the empty alias made the "needs updating" test
+        /// true on every single run, so the installer logged "Updating service-bus namespace '...' to
+        /// enforce TLS 1.2 minimum..." and re-PUT the namespace forever - while sending
+        /// <c>minimumTlsVersion: ""</c>, so TLS 1.2 was never actually enforced either.
+        ///
+        /// The sibling Storage, Redis and App Service SDKs do not share the quirk, so only this task
+        /// was affected. ServiceBusNamespaceInstallTaskTests pins the value so an SDK upgrade (or a
+        /// well-meaning rename back to Tls1_2) can't silently reintroduce the bug.
+        /// </remarks>
+        public static readonly ServiceBusMinimumTlsVersion RequiredMinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls12;
+
         public ServiceBusNamespaceInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool requirePremiumSku = false, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
             _requirePremiumSku = requirePremiumSku;
@@ -33,6 +51,16 @@ namespace CloudInstallEngine.Azure.InstallTasks
         }
 
         public override string TaskName => "get/create Service-bus namespace";
+
+        /// <summary>
+        /// True when an existing namespace still needs its minimum TLS version raising to
+        /// <see cref="RequiredMinimumTlsVersion"/>. A namespace already at 1.2 must return false, or the
+        /// installer re-writes it on every run.
+        /// </summary>
+        public static bool NeedsMinimumTlsUpdate(ServiceBusMinimumTlsVersion? current)
+        {
+            return current == null || current.Value != RequiredMinimumTlsVersion;
+        }
 
         /// <summary>
         /// True when the namespace this task produced can host a private endpoint (i.e. it is Premium). False
@@ -61,7 +89,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 _logger.LogInformation($"Creating new service-bus namespace '{name}' at {skuLabel} SKU (public access: {(_allowPublicAccess ? "enabled" : "disabled")}). This may take several minutes...");
 
                 var newResourceData = new ServiceBusNamespaceData(AzureLocation);
-                newResourceData.MinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls1_2;
+                newResourceData.MinimumTlsVersion = RequiredMinimumTlsVersion;
                 newResourceData.PublicNetworkAccess = desiredAccess;
                 if (_requirePremiumSku)
                 {
@@ -112,11 +140,21 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 updateData.MinimumTlsVersion = sbNS.Data.MinimumTlsVersion;
                 updateData.PublicNetworkAccess = sbNS.Data.PublicNetworkAccess;
 
+                // Carry the tags across. CreateOrUpdate is a PUT, so any tag missing from the payload is
+                // dropped - which is why the namespace was the only untagged resource in an otherwise
+                // fully tagged resource group. The read-back snapshot predates the EnsureTagsOnExisting
+                // PATCH above, so re-apply the configured tags on top of it as well.
+                foreach (var tag in sbNS.Data.Tags)
+                {
+                    updateData.Tags[tag.Key] = tag.Value;
+                }
+                base.EnsureTagsOnNew(updateData.Tags);
+
                 // Enforce TLS 1.2 minimum
-                if (sbNS.Data.MinimumTlsVersion == null || sbNS.Data.MinimumTlsVersion != ServiceBusMinimumTlsVersion.Tls1_2)
+                if (NeedsMinimumTlsUpdate(sbNS.Data.MinimumTlsVersion))
                 {
                     _logger.LogInformation($"Updating service-bus namespace '{sbNS.Data.Name}' to enforce TLS 1.2 minimum...");
-                    updateData.MinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls1_2;
+                    updateData.MinimumTlsVersion = RequiredMinimumTlsVersion;
                     needsUpdate = true;
                 }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/ServiceBusNamespaceInstallTaskTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/ServiceBusNamespaceInstallTaskTests.cs
@@ -1,0 +1,60 @@
+using Azure.ResourceManager.ServiceBus.Models;
+using CloudInstallEngine.Azure.InstallTasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// Guards the minimum-TLS decision in <see cref="ServiceBusNamespaceInstallTask"/>.
+    ///
+    /// The task previously compared against <c>ServiceBusMinimumTlsVersion.Tls1_2</c>, which in
+    /// Azure.ResourceManager.ServiceBus 1.2.0 is a deprecated alias whose underlying value is the EMPTY
+    /// STRING - the real API values live on <c>Tls10</c>..<c>Tls13</c>. The comparison therefore never
+    /// matched the "1.2" the ARM API returns, so every install logged "Updating service-bus namespace
+    /// '...' to enforce TLS 1.2 minimum..." and re-PUT the namespace (which also wiped its tags), while
+    /// writing an empty minimumTlsVersion that enforced nothing.
+    ///
+    /// These tests are written against a value built the way the SDK's deserialiser builds it - from the
+    /// raw API string - so they keep working across SDK upgrades and would fail again if the wrong
+    /// constant were reintroduced.
+    /// </summary>
+    [TestClass]
+    public class ServiceBusNamespaceInstallTaskTests
+    {
+        /// <summary>What Microsoft.ServiceBus returns in the namespace payload for TLS 1.2.</summary>
+        private const string ARM_TLS_12 = "1.2";
+
+        [TestMethod]
+        public void RequiredMinimumTlsVersion_IsTheValueTheArmApiUses()
+        {
+            Assert.AreEqual(
+                ARM_TLS_12,
+                ServiceBusNamespaceInstallTask.RequiredMinimumTlsVersion.ToString(),
+                "The constant sent as minimumTlsVersion must be the literal ARM value, not an empty deprecated alias.");
+        }
+
+        [TestMethod]
+        public void NeedsMinimumTlsUpdate_NamespaceAlreadyAtTls12_ReturnsFalse()
+        {
+            var asReturnedByArm = new ServiceBusMinimumTlsVersion(ARM_TLS_12);
+
+            Assert.IsFalse(
+                ServiceBusNamespaceInstallTask.NeedsMinimumTlsUpdate(asReturnedByArm),
+                "A namespace already at TLS 1.2 must not be rewritten - otherwise every install re-PUTs it.");
+        }
+
+        [TestMethod]
+        public void NeedsMinimumTlsUpdate_UnsetOrOlderVersion_ReturnsTrue()
+        {
+            Assert.IsTrue(
+                ServiceBusNamespaceInstallTask.NeedsMinimumTlsUpdate(null),
+                "A namespace with no minimum TLS version must be raised to 1.2.");
+            Assert.IsTrue(
+                ServiceBusNamespaceInstallTask.NeedsMinimumTlsUpdate(new ServiceBusMinimumTlsVersion("1.0")),
+                "A namespace on TLS 1.0 must be raised to 1.2.");
+            Assert.IsTrue(
+                ServiceBusNamespaceInstallTask.NeedsMinimumTlsUpdate(new ServiceBusMinimumTlsVersion("1.1")),
+                "A namespace on TLS 1.1 must be raised to 1.2.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -204,6 +204,7 @@
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
     <Compile Include="InstallTests\KeyVaultFirewallConfigTaskTests.cs" />
+    <Compile Include="InstallTests\ServiceBusNamespaceInstallTaskTests.cs" />
     <Compile Include="InstallTests\RbacPermissionProbeTests.cs" />
     <Compile Include="InstallTests\TeamsUserActivityReportUrlTests.cs" />
     <Compile Include="InstallTests\SpoInstallTests.cs" />


### PR DESCRIPTION
## Problem

Every installer run logs this, on a namespace that is **already** at TLS 1.2:

```
Updating service-bus namespace 'xxx' to enforce TLS 1.2 minimum...
```

`ServiceBusMinimumTlsVersion` in `Azure.ResourceManager.ServiceBus` 1.2.0 carries **two** sets of members. The underscored ones are deprecated aliases whose underlying value is the **empty string**; the real API values live on the un-underscored ones:

```
Tls1_0 = ''   Tls10 = '1.0'
Tls1_1 = ''   Tls11 = '1.1'
Tls1_2 = ''   Tls12 = '1.2'   <-- the task used Tls1_2
Tls1_3 = ''   Tls13 = '1.3'
```

(Dumped by reflection against the pinned package version. `StorageMinimumTlsVersion` (`'TLS1_2'`), `RedisTlsVersion` (`'1.2'`) and `AppServiceSupportedTlsVersion` (`'1.2'`) do **not** share the quirk, so `StorageAccountInstallTask`, `RedisInstallTask` and `AppServiceWebsiteTask` were checked and are correct — no change needed there.)

ARM returns `"minimumTlsVersion": "1.2"`, and `"1.2" != ""`, so `NeedsMinimumTlsUpdate` was always true. Two consequences:

1. **The namespace is re-PUT on every install**, with a spurious log line each time.
2. **TLS 1.2 was never actually enforced.** Both the create path and the update path assigned the empty alias, so the payload carried `"minimumTlsVersion": ""`. New namespaces only end up at 1.2 because that is the current ARM default — the installer was not setting it.

### Second bug, found while confirming the first

`CreateOrUpdateAsync` is a **PUT**, and `updateData` never carried `Tags`, so each of those needless writes **wiped the namespace's tags**. Tags are applied separately via a `TagResource` merge-PATCH in `EnsureTagsOnExisting`, which runs immediately *before* the PUT that removes them.

Observed on a deployed resource group: every installer-created resource carries the deployment's tag except the Service Bus namespace, which has none.

| Resource type | Tags |
|---|---|
| `Microsoft.Cache/redisEnterprise` | present |
| `Microsoft.KeyVault/vaults` | present |
| `Microsoft.Sql/servers` | present |
| `Microsoft.Storage/storageAccounts` | present |
| `Microsoft.Web/sites`, `Microsoft.Web/serverFarms` | present |
| `Microsoft.Network/virtualNetworks` | present |
| `microsoft.insights/components` | present |
| **`Microsoft.ServiceBus/namespaces`** | **none** |

This is triggered by, but independent of, bug 1 — it would still strike on any genuine update (e.g. a public-network-access change).

## Changes

`Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs`:

- New `public static readonly ServiceBusMinimumTlsVersion RequiredMinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls12`, used by both the create and update paths. The `<remarks>` explain why it must not be `Tls1_2`, since the two names are a one-character difference and the wrong one looks more idiomatic.
- Extracted `public static bool NeedsMinimumTlsUpdate(ServiceBusMinimumTlsVersion?)` so the decision is unit-testable without Azure.
- `updateData` now copies `sbNS.Data.Tags` and then re-applies the configured tags via the existing `EnsureTagsOnNew` helper (the read-back snapshot predates the tag PATCH, so copying the snapshot alone would still drop a freshly added tag).

`Tests.UnitTests/InstallTests/ServiceBusNamespaceInstallTaskTests.cs` (new, registered in the csproj):

- `RequiredMinimumTlsVersion_IsTheValueTheArmApiUses` — pins the serialised constant to `"1.2"`.
- `NeedsMinimumTlsUpdate_NamespaceAlreadyAtTls12_ReturnsFalse` — the reported bug.
- `NeedsMinimumTlsUpdate_UnsetOrOlderVersion_ReturnsTrue` — null / 1.0 / 1.1 still upgrade.

The tests build their input with `new ServiceBusMinimumTlsVersion("1.2")`, i.e. the way the SDK deserialiser builds it from the raw ARM payload, so they stay valid across SDK upgrades rather than just re-asserting whichever constant the code happens to use.

## Verification

- Confirmed the live namespace really is at `minimumTlsVersion: "1.2"` (ARM GET **and** the list call the task uses, at the SDK's api-version) while the task still reported it as needing an update.
- Enum values dumped by reflection from the four pinned SDK packages.
- Full solution builds, 0 errors / 0 warnings.
- New tests **fail** on the old constant (2 of 3; the third covers behaviour that was never broken) and pass after the fix.
- Rest of `InstallTests` unaffected: 48 passed. The 4 `VNetIntegrationTests` failures are pre-existing and environmental — they require a local `InstallTests/TestConfigs/InstallerTestConfig.json` that is not in the repo.

## Risk / reviewer notes

- **No config-schema change**, so no `CONFIG_VERSION` bump. No database migration.
- Behaviour change worth a second look: on an existing namespace already at TLS 1.2 with the desired public-network-access, `needsUpdate` is now `false` and **no PUT happens at all**. That is the point of the fix, but it does mean the namespace is no longer implicitly rewritten each run.
- The tag copy is deliberately merge-style (existing ∪ configured) rather than replacing with the configured set, so tags added out-of-band by the customer survive.
- Namespaces created by an affected build are almost certainly already at TLS 1.2 via the ARM default; the first run after this change will set it explicitly if not, and restore the missing tags.
