### PR TITLE
Copilot adoption: make the numbers on the coloured charts readable

### DIFF
--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/CombinedViews.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/CombinedViews.tsx
@@ -9,6 +9,42 @@ import { useAdoptionTableStyles } from './adoptionShared';
 /** Heaviest cohort darkest, so the shape of the power law reads left to right. */
 const COHORT_COLOUR = ['#0b3d6b', '#1f6cb0', '#5b9bd5', '#c7dbef'];
 
+/** Ends of the heat-table colour ramp, as the fraction of the hue mixed onto the page background. */
+const RAMP_MIN_ALPHA = 0.12;
+const RAMP_MAX_ALPHA = 0.65;
+
+/** `#rrggbb` to an sRGB triple. */
+function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.replace('#', ''), 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+/**
+ * Mixes `hex` into the (white) page background at `alpha`, returning a solid sRGB triple.
+ *
+ * Heat ramps are built this way instead of with CSS `opacity` because opacity is applied to the
+ * whole element - including the number printed on it - so the low end of the ramp fades the value
+ * out of legibility.
+ */
+function blendOnWhite(hex: string, alpha: number): [number, number, number] {
+  return hexToRgb(hex).map((channel) => Math.round(255 + alpha * (channel - 255))) as [number, number, number];
+}
+
+/**
+ * White or near-black text, whichever has more contrast on the given fill.
+ *
+ * The crossover is where WCAG contrast against white equals contrast against Fluent's light-theme
+ * body colour (#242424), which lands at a relative luminance of ~0.218.
+ */
+function readableForeground(r: number, g: number, b: number): string {
+  const toLinear = (channel: number) => {
+    const s = channel / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const luminance = 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+  return luminance < 0.218 ? '#ffffff' : tokens.colorNeutralForeground1;
+}
+
 const useStyles = makeStyles({
   bar: {
     display: 'flex',
@@ -22,7 +58,6 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    color: '#ffffff',
     fontSize: '12px',
     fontVariantNumeric: 'tabular-nums',
     minWidth: '2px',
@@ -50,12 +85,7 @@ const useStyles = makeStyles({
     width: '16px',
     height: '16px',
     borderRadius: '3px',
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    color: '#ffffff',
-    fontSize: '10px',
-    fontWeight: 700,
+    display: 'inline-block',
     flexShrink: 0,
   },
   muted: {
@@ -94,18 +124,27 @@ export function ConcentrationBar({ bands }: { bands: AdoptionConcentrationBand[]
   return (
     <div>
       <div className={styles.bar}>
-        {bands.map((b, i) => (
-          <div
-            key={b.label}
-            className={styles.slice}
-            style={{ width: `${Math.max(0.5, b.sharePct)}%`, backgroundColor: COHORT_COLOUR[i % COHORT_COLOUR.length] }}
-            title={`${b.label}: ${formatCount(b.users)} users, ${formatCount(b.interactions)} interactions (${formatPct(
-              b.sharePct,
-            )} of all activity), ${b.interactionsPerUser} each`}
-          >
-            {b.sharePct >= 8 ? `${i + 1}. ${formatPct(b.sharePct)}` : ''}
-          </div>
-        ))}
+        {bands.map((b, i) => {
+          const colour = COHORT_COLOUR[i % COHORT_COLOUR.length];
+          return (
+            <div
+              key={b.label}
+              className={styles.slice}
+              style={{
+                width: `${Math.max(0.5, b.sharePct)}%`,
+                backgroundColor: colour,
+                // The ramp runs from near-black to very pale, so a fixed white label is unreadable on
+                // the last step or two. Pick the label colour from the fill's luminance instead.
+                color: readableForeground(...hexToRgb(colour)),
+              }}
+              title={`${b.label}: ${formatCount(b.users)} users, ${formatCount(b.interactions)} interactions (${formatPct(
+                b.sharePct,
+              )} of all activity), ${b.interactionsPerUser} each`}
+            >
+              {b.sharePct >= 8 ? formatPct(b.sharePct) : ''}
+            </div>
+          );
+        })}
       </div>
 
       <div className={styles.legend}>
@@ -115,9 +154,7 @@ export function ConcentrationBar({ bands }: { bands: AdoptionConcentrationBand[]
               className={styles.swatch}
               style={{ backgroundColor: COHORT_COLOUR[i % COHORT_COLOUR.length] }}
               aria-hidden="true"
-            >
-              {i + 1}
-            </span>
+            />
             <Text size={200}>
               <strong>{b.label}</strong>{' '}
               <span className={styles.muted}>
@@ -155,8 +192,25 @@ export function CombinedSegmentTable({ rows }: { rows: AdoptionCombinedSegmentRo
 
   // Conditional shading rather than a bar: this table is read by scanning for the outliers, and a
   // colour ramp finds them faster than eight columns of numbers.
-  const shade = (value: number, max: number, hue: string) =>
-    value <= 0 ? undefined : { backgroundColor: hue, opacity: 0.15 + 0.85 * (value / max) };
+  //
+  // The ramp is baked into a solid background colour rather than applied with `opacity`. Element
+  // opacity fades the digits along with the fill, so the palest cells became unreadable while the
+  // darkest ones were left with dark text on a dark fill.
+  //
+  // It also stops at RAMP_MAX_ALPHA rather than running to a solid fill. Past roughly two thirds
+  // strength these hues stop clearing WCAG AA 4.5:1 against the body text, and flipping the label to
+  // white does not help - the flip point is itself the lowest-contrast spot on the whole ramp
+  // (~3.9:1). Capping keeps one text colour, stays legible end to end, and still separates the
+  // outliers plainly (contrast runs 13:1 at the pale end to ~4.9:1 at the strong end).
+  const shade = (value: number, max: number, hue: string) => {
+    if (value <= 0) return undefined;
+    const alpha = RAMP_MIN_ALPHA + (RAMP_MAX_ALPHA - RAMP_MIN_ALPHA) * (value / max);
+    const [r, g, b] = blendOnWhite(hue, alpha);
+    return {
+      backgroundColor: `rgb(${r}, ${g}, ${b})`,
+      color: tokens.colorNeutralForeground1,
+    };
+  };
 
   return (
     <table className={table.table}>


### PR DESCRIPTION
## Problem

Three legibility defects on the Copilot adoption page, all in `components/copilotAdoption/CombinedViews.tsx`.

**1. Heat cells fade their own digits.** `CombinedSegmentTable`'s `shade()` returned `{ backgroundColor: hue, opacity: 0.15 + 0.85 * (value / max) }`. CSS `opacity` applies to the **whole element, including the text**, so the low end of the ramp faded the number out along with the fill, and the high end left the default dark text on a near-solid `#0f6cbd` / `#a4373a`. Both ends were hard to read; only the middle was fine.

**2. `ConcentrationBar` slice labels are hardcoded white.** The `slice` class set `color: '#ffffff'` for all four cohorts, but the ramp ends at `#c7dbef`. White on that is **1.5:1** — effectively invisible.

**3. The `1.` / `2.` / `3.` / `4.` prefixes read as part of the percentage.** `1. 31.5%` scans as a single malformed number rather than "slice 1, 31.5%".

## Changes

- `shade()` now blends the hue onto the page background to a **solid** colour (`blendOnWhite`) so the digits stay fully opaque, and sets the text colour explicitly.
- The ramp is capped at `RAMP_MAX_ALPHA = 0.65` instead of running to a solid fill. Past roughly two-thirds strength these hues no longer clear WCAG AA 4.5:1 against the body text, and flipping the label to white does **not** rescue it — the flip point is itself the lowest-contrast spot on the whole ramp (~3.9:1, worse than either end). Capping keeps a single text colour and stays legible end to end.
- New `readableForeground(r, g, b)` picks white or `colorNeutralForeground1` by WCAG relative luminance. The threshold (0.218) is where contrast against white equals contrast against Fluent's light-theme body colour `#242424`. Applied to the `ConcentrationBar` slices, whose hues are fixed and span nearly the full luminance range.
- Removed the ordinal prefix from the slice labels and the matching digits from the legend swatches (the swatch is now a plain colour chip). The legend already runs in bar order with ordinal labels — "Top 10%", "Next 15%" — so the mapping survives.

The app is light-theme only (`webLightTheme` in `main.tsx`), so blending against white is correct rather than an assumption.

## Measured contrast

Heat ramp, dark text, after the change:

| value / max | Blue `#0f6cbd` | Red `#a4373a` |
|---|---|---|
| 0.05 | 13.1:1 | 12.9:1 |
| 0.40 | 8.5:1 | 8.0:1 |
| 0.80 | 5.5:1 | 5.4:1 |
| 1.00 | 5.0:1 | **4.9:1** |

Worst case 4.87:1, comfortably over AA for 12px text. Before the change the flip point sat at 3.92:1 and the pale end was faded on top of that.

Concentration bar slices, after the change:

| Cohort | Fill | Label | Contrast |
|---|---|---|---|
| 1 | `#0b3d6b` | white | 11.1:1 |
| 2 | `#1f6cb0` | white | 5.5:1 |
| 3 | `#5b9bd5` | `#242424` | 5.2:1 |
| 4 | `#c7dbef` | `#242424` | 11.0:1 (was **1.5:1** white) |

## Verification

- `npm run build` (`tsc --noEmit && vite build`) passes.
- Contrast figures computed with the WCAG relative-luminance formula over the exact colours the components now emit.
- Rendered the two components with the real values from the reported screenshots and checked the output visually.

## Scope

- Presentation only — no data, API or type changes.
- `adoptionShared.tsx`'s other coloured elements (`ScoreBar`, `BandBadge`, `rateColour`) were checked and are unaffected: they colour bars and badges with no text sitting on the ramp, and the badges already use `colorNeutralForegroundOnBrand` on dark band colours.
- `shade()` was the only `opacity`-based heat ramp in the portal.
