### PR TITLE
Release: Service Bus namespace idempotency and tag preservation, Copilot adoption chart legibility, SPA stale-chunk recovery

### DIFF
--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
@@ -26,6 +26,24 @@ namespace CloudInstallEngine.Azure.InstallTasks
             + "(https://learn.microsoft.com/azure/service-bus-messaging/service-bus-migrate-standard-premium), "
             + "(b) keep public network access enabled on Service Bus, or (c) disable the Teams calls import.";
 
+        /// <summary>
+        /// The minimum TLS version every namespace must enforce.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately <c>Tls12</c> and NOT the near-identically named <c>Tls1_2</c>. In
+        /// Azure.ResourceManager.ServiceBus 1.2.0 the underscored members are deprecated aliases whose
+        /// underlying value is the EMPTY STRING, while the real API values ("1.0".."1.3") live on
+        /// <c>Tls10</c>..<c>Tls13</c>. Comparing against the empty alias made the "needs updating" test
+        /// true on every single run, so the installer logged "Updating service-bus namespace '...' to
+        /// enforce TLS 1.2 minimum..." and re-PUT the namespace forever - while sending
+        /// <c>minimumTlsVersion: ""</c>, so TLS 1.2 was never actually enforced either.
+        ///
+        /// The sibling Storage, Redis and App Service SDKs do not share the quirk, so only this task
+        /// was affected. ServiceBusNamespaceInstallTaskTests pins the value so an SDK upgrade (or a
+        /// well-meaning rename back to Tls1_2) can't silently reintroduce the bug.
+        /// </remarks>
+        public static readonly ServiceBusMinimumTlsVersion RequiredMinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls12;
+
         public ServiceBusNamespaceInstallTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool requirePremiumSku = false, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
         {
             _requirePremiumSku = requirePremiumSku;
@@ -33,6 +51,16 @@ namespace CloudInstallEngine.Azure.InstallTasks
         }
 
         public override string TaskName => "get/create Service-bus namespace";
+
+        /// <summary>
+        /// True when an existing namespace still needs its minimum TLS version raising to
+        /// <see cref="RequiredMinimumTlsVersion"/>. A namespace already at 1.2 must return false, or the
+        /// installer re-writes it on every run.
+        /// </summary>
+        public static bool NeedsMinimumTlsUpdate(ServiceBusMinimumTlsVersion? current)
+        {
+            return current == null || current.Value != RequiredMinimumTlsVersion;
+        }
 
         /// <summary>
         /// True when the namespace this task produced can host a private endpoint (i.e. it is Premium). False
@@ -61,7 +89,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 _logger.LogInformation($"Creating new service-bus namespace '{name}' at {skuLabel} SKU (public access: {(_allowPublicAccess ? "enabled" : "disabled")}). This may take several minutes...");
 
                 var newResourceData = new ServiceBusNamespaceData(AzureLocation);
-                newResourceData.MinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls1_2;
+                newResourceData.MinimumTlsVersion = RequiredMinimumTlsVersion;
                 newResourceData.PublicNetworkAccess = desiredAccess;
                 if (_requirePremiumSku)
                 {
@@ -112,11 +140,21 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 updateData.MinimumTlsVersion = sbNS.Data.MinimumTlsVersion;
                 updateData.PublicNetworkAccess = sbNS.Data.PublicNetworkAccess;
 
+                // Carry the tags across. CreateOrUpdate is a PUT, so any tag missing from the payload is
+                // dropped - which is why the namespace was the only untagged resource in an otherwise
+                // fully tagged resource group. The read-back snapshot predates the EnsureTagsOnExisting
+                // PATCH above, so re-apply the configured tags on top of it as well.
+                foreach (var tag in sbNS.Data.Tags)
+                {
+                    updateData.Tags[tag.Key] = tag.Value;
+                }
+                base.EnsureTagsOnNew(updateData.Tags);
+
                 // Enforce TLS 1.2 minimum
-                if (sbNS.Data.MinimumTlsVersion == null || sbNS.Data.MinimumTlsVersion != ServiceBusMinimumTlsVersion.Tls1_2)
+                if (NeedsMinimumTlsUpdate(sbNS.Data.MinimumTlsVersion))
                 {
                     _logger.LogInformation($"Updating service-bus namespace '{sbNS.Data.Name}' to enforce TLS 1.2 minimum...");
-                    updateData.MinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls1_2;
+                    updateData.MinimumTlsVersion = RequiredMinimumTlsVersion;
                     needsUpdate = true;
                 }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/ServiceBusNamespaceInstallTaskTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/ServiceBusNamespaceInstallTaskTests.cs
@@ -1,0 +1,60 @@
+using Azure.ResourceManager.ServiceBus.Models;
+using CloudInstallEngine.Azure.InstallTasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// Guards the minimum-TLS decision in <see cref="ServiceBusNamespaceInstallTask"/>.
+    ///
+    /// The task previously compared against <c>ServiceBusMinimumTlsVersion.Tls1_2</c>, which in
+    /// Azure.ResourceManager.ServiceBus 1.2.0 is a deprecated alias whose underlying value is the EMPTY
+    /// STRING - the real API values live on <c>Tls10</c>..<c>Tls13</c>. The comparison therefore never
+    /// matched the "1.2" the ARM API returns, so every install logged "Updating service-bus namespace
+    /// '...' to enforce TLS 1.2 minimum..." and re-PUT the namespace (which also wiped its tags), while
+    /// writing an empty minimumTlsVersion that enforced nothing.
+    ///
+    /// These tests are written against a value built the way the SDK's deserialiser builds it - from the
+    /// raw API string - so they keep working across SDK upgrades and would fail again if the wrong
+    /// constant were reintroduced.
+    /// </summary>
+    [TestClass]
+    public class ServiceBusNamespaceInstallTaskTests
+    {
+        /// <summary>What Microsoft.ServiceBus returns in the namespace payload for TLS 1.2.</summary>
+        private const string ARM_TLS_12 = "1.2";
+
+        [TestMethod]
+        public void RequiredMinimumTlsVersion_IsTheValueTheArmApiUses()
+        {
+            Assert.AreEqual(
+                ARM_TLS_12,
+                ServiceBusNamespaceInstallTask.RequiredMinimumTlsVersion.ToString(),
+                "The constant sent as minimumTlsVersion must be the literal ARM value, not an empty deprecated alias.");
+        }
+
+        [TestMethod]
+        public void NeedsMinimumTlsUpdate_NamespaceAlreadyAtTls12_ReturnsFalse()
+        {
+            var asReturnedByArm = new ServiceBusMinimumTlsVersion(ARM_TLS_12);
+
+            Assert.IsFalse(
+                ServiceBusNamespaceInstallTask.NeedsMinimumTlsUpdate(asReturnedByArm),
+                "A namespace already at TLS 1.2 must not be rewritten - otherwise every install re-PUTs it.");
+        }
+
+        [TestMethod]
+        public void NeedsMinimumTlsUpdate_UnsetOrOlderVersion_ReturnsTrue()
+        {
+            Assert.IsTrue(
+                ServiceBusNamespaceInstallTask.NeedsMinimumTlsUpdate(null),
+                "A namespace with no minimum TLS version must be raised to 1.2.");
+            Assert.IsTrue(
+                ServiceBusNamespaceInstallTask.NeedsMinimumTlsUpdate(new ServiceBusMinimumTlsVersion("1.0")),
+                "A namespace on TLS 1.0 must be raised to 1.2.");
+            Assert.IsTrue(
+                ServiceBusNamespaceInstallTask.NeedsMinimumTlsUpdate(new ServiceBusMinimumTlsVersion("1.1")),
+                "A namespace on TLS 1.1 must be raised to 1.2.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -204,6 +204,7 @@
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
     <Compile Include="InstallTests\KeyVaultFirewallConfigTaskTests.cs" />
+    <Compile Include="InstallTests\ServiceBusNamespaceInstallTaskTests.cs" />
     <Compile Include="InstallTests\RbacPermissionProbeTests.cs" />
     <Compile Include="InstallTests\TeamsUserActivityReportUrlTests.cs" />
     <Compile Include="InstallTests\SpoInstallTests.cs" />

--- a/src/AnalyticsEngine/Web/Controllers/HomeController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net;
 using System.Runtime.Caching;
+using System.Web;
 using System.Web.Mvc;
 
 namespace Web.AnalyticsWeb.Controllers
@@ -8,6 +9,10 @@ namespace Web.AnalyticsWeb.Controllers
     [Authorize]
     public class HomeController : Controller
     {
+        // Read and written through this single constant: the two used to differ, so the cached copy
+        // was stored under a key nothing ever read and index.html was re-read from disk every request.
+        private const string PortalIndexCacheKey = "portalIndexHtml";
+
         // Root of the site. The whole admin experience (home/system status, Teams permissions,
         // user lookup) is now the SPA, so "/" serves it. It's served through this [Authorize]'d
         // action (rather than as a static file) so OIDC sign-in still gates access; the SPA then
@@ -41,7 +46,7 @@ namespace Web.AnalyticsWeb.Controllers
         private ActionResult ServePortalApp()
         {
             var cache = MemoryCache.Default;
-            var fileContents = cache["portalIndexHtml"] as string;
+            var fileContents = cache[PortalIndexCacheKey] as string;
 
             if (fileContents == null)
             {
@@ -59,9 +64,15 @@ namespace Web.AnalyticsWeb.Controllers
 #if !DEBUG
                 var policy = new CacheItemPolicy();
                 policy.ChangeMonitors.Add(new HostFileChangeMonitor(new List<string> { indexFile }));
-                cache.Set("adminAppIndexHtml", fileContents, policy);
+                cache.Set(PortalIndexCacheKey, fileContents, policy);
 #endif
             }
+
+            // index.html names content-hashed chunks, so a browser holding a cached copy after a
+            // redeploy asks for chunks that no longer exist ("Failed to fetch dynamically imported
+            // module"). It must always be revalidated; the hashed assets it points at stay cacheable.
+            Response.Cache.SetCacheability(HttpCacheability.NoCache);
+            Response.Cache.SetNoStore();
 
             return Content(fileContents, "text/html");
         }

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/CombinedViews.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/CombinedViews.tsx
@@ -9,6 +9,42 @@ import { useAdoptionTableStyles } from './adoptionShared';
 /** Heaviest cohort darkest, so the shape of the power law reads left to right. */
 const COHORT_COLOUR = ['#0b3d6b', '#1f6cb0', '#5b9bd5', '#c7dbef'];
 
+/** Ends of the heat-table colour ramp, as the fraction of the hue mixed onto the page background. */
+const RAMP_MIN_ALPHA = 0.12;
+const RAMP_MAX_ALPHA = 0.65;
+
+/** `#rrggbb` to an sRGB triple. */
+function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.replace('#', ''), 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+/**
+ * Mixes `hex` into the (white) page background at `alpha`, returning a solid sRGB triple.
+ *
+ * Heat ramps are built this way instead of with CSS `opacity` because opacity is applied to the
+ * whole element - including the number printed on it - so the low end of the ramp fades the value
+ * out of legibility.
+ */
+function blendOnWhite(hex: string, alpha: number): [number, number, number] {
+  return hexToRgb(hex).map((channel) => Math.round(255 + alpha * (channel - 255))) as [number, number, number];
+}
+
+/**
+ * White or near-black text, whichever has more contrast on the given fill.
+ *
+ * The crossover is where WCAG contrast against white equals contrast against Fluent's light-theme
+ * body colour (#242424), which lands at a relative luminance of ~0.218.
+ */
+function readableForeground(r: number, g: number, b: number): string {
+  const toLinear = (channel: number) => {
+    const s = channel / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const luminance = 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+  return luminance < 0.218 ? '#ffffff' : tokens.colorNeutralForeground1;
+}
+
 const useStyles = makeStyles({
   bar: {
     display: 'flex',
@@ -22,7 +58,6 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    color: '#ffffff',
     fontSize: '12px',
     fontVariantNumeric: 'tabular-nums',
     minWidth: '2px',
@@ -50,12 +85,7 @@ const useStyles = makeStyles({
     width: '16px',
     height: '16px',
     borderRadius: '3px',
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    color: '#ffffff',
-    fontSize: '10px',
-    fontWeight: 700,
+    display: 'inline-block',
     flexShrink: 0,
   },
   muted: {
@@ -94,18 +124,27 @@ export function ConcentrationBar({ bands }: { bands: AdoptionConcentrationBand[]
   return (
     <div>
       <div className={styles.bar}>
-        {bands.map((b, i) => (
-          <div
-            key={b.label}
-            className={styles.slice}
-            style={{ width: `${Math.max(0.5, b.sharePct)}%`, backgroundColor: COHORT_COLOUR[i % COHORT_COLOUR.length] }}
-            title={`${b.label}: ${formatCount(b.users)} users, ${formatCount(b.interactions)} interactions (${formatPct(
-              b.sharePct,
-            )} of all activity), ${b.interactionsPerUser} each`}
-          >
-            {b.sharePct >= 8 ? `${i + 1}. ${formatPct(b.sharePct)}` : ''}
-          </div>
-        ))}
+        {bands.map((b, i) => {
+          const colour = COHORT_COLOUR[i % COHORT_COLOUR.length];
+          return (
+            <div
+              key={b.label}
+              className={styles.slice}
+              style={{
+                width: `${Math.max(0.5, b.sharePct)}%`,
+                backgroundColor: colour,
+                // The ramp runs from near-black to very pale, so a fixed white label is unreadable on
+                // the last step or two. Pick the label colour from the fill's luminance instead.
+                color: readableForeground(...hexToRgb(colour)),
+              }}
+              title={`${b.label}: ${formatCount(b.users)} users, ${formatCount(b.interactions)} interactions (${formatPct(
+                b.sharePct,
+              )} of all activity), ${b.interactionsPerUser} each`}
+            >
+              {b.sharePct >= 8 ? formatPct(b.sharePct) : ''}
+            </div>
+          );
+        })}
       </div>
 
       <div className={styles.legend}>
@@ -115,9 +154,7 @@ export function ConcentrationBar({ bands }: { bands: AdoptionConcentrationBand[]
               className={styles.swatch}
               style={{ backgroundColor: COHORT_COLOUR[i % COHORT_COLOUR.length] }}
               aria-hidden="true"
-            >
-              {i + 1}
-            </span>
+            />
             <Text size={200}>
               <strong>{b.label}</strong>{' '}
               <span className={styles.muted}>
@@ -155,8 +192,25 @@ export function CombinedSegmentTable({ rows }: { rows: AdoptionCombinedSegmentRo
 
   // Conditional shading rather than a bar: this table is read by scanning for the outliers, and a
   // colour ramp finds them faster than eight columns of numbers.
-  const shade = (value: number, max: number, hue: string) =>
-    value <= 0 ? undefined : { backgroundColor: hue, opacity: 0.15 + 0.85 * (value / max) };
+  //
+  // The ramp is baked into a solid background colour rather than applied with `opacity`. Element
+  // opacity fades the digits along with the fill, so the palest cells became unreadable while the
+  // darkest ones were left with dark text on a dark fill.
+  //
+  // It also stops at RAMP_MAX_ALPHA rather than running to a solid fill. Past roughly two thirds
+  // strength these hues stop clearing WCAG AA 4.5:1 against the body text, and flipping the label to
+  // white does not help - the flip point is itself the lowest-contrast spot on the whole ramp
+  // (~3.9:1). Capping keeps one text colour, stays legible end to end, and still separates the
+  // outliers plainly (contrast runs 13:1 at the pale end to ~4.9:1 at the strong end).
+  const shade = (value: number, max: number, hue: string) => {
+    if (value <= 0) return undefined;
+    const alpha = RAMP_MIN_ALPHA + (RAMP_MAX_ALPHA - RAMP_MIN_ALPHA) * (value / max);
+    const [r, g, b] = blendOnWhite(hue, alpha);
+    return {
+      backgroundColor: `rgb(${r}, ${g}, ${b})`,
+      color: tokens.colorNeutralForeground1,
+    };
+  };
 
   return (
     <table className={table.table}>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/lazyWithReload.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/lazyWithReload.ts
@@ -1,0 +1,39 @@
+import { lazy } from 'react';
+import type { ComponentType } from 'react';
+
+const RELOAD_FLAG = 'portal:chunk-reloaded';
+
+/**
+ * Wraps `React.lazy` so a stale code-split chunk recovers itself instead of breaking the route.
+ *
+ * Vite emits content-hashed chunks and empties `build/assets` on every build, so a rebuild or a
+ * redeploy invalidates the chunk URLs baked into any page that is already open. The next route
+ * change then fails with "Failed to fetch dynamically imported module: .../assets/HealthPage-*.js"
+ * and the route silently renders nothing - the user just sees a dead page until they refresh.
+ *
+ * Reloading pulls a fresh index.html carrying the current hashes, which is all that is needed. The
+ * sessionStorage flag makes that a one-shot, so a chunk that is missing for some other reason
+ * (a broken build, a bad deploy) surfaces as a real error rather than an infinite reload loop.
+ */
+export function lazyWithReload<T extends ComponentType<any>>( // eslint-disable-line @typescript-eslint/no-explicit-any
+  factory: () => Promise<{ default: T }>,
+) {
+  return lazy(() =>
+    factory()
+      .then((module) => {
+        // Loaded fine, so let a future stale chunk have its own reload.
+        sessionStorage.removeItem(RELOAD_FLAG);
+        return module;
+      })
+      .catch((error: unknown) => {
+        if (sessionStorage.getItem(RELOAD_FLAG) === null) {
+          sessionStorage.setItem(RELOAD_FLAG, '1');
+          window.location.reload();
+          // Deliberately never settles: the reload takes over before React can render anything.
+          return new Promise<{ default: T }>(() => {});
+        }
+
+        throw error;
+      }),
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/navigation.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/navigation.tsx
@@ -1,4 +1,3 @@
-import { lazy } from 'react';
 import type { ReactElement } from 'react';
 import {
   ChartMultiple20Regular,
@@ -12,16 +11,19 @@ import {
   Sparkle20Regular,
 } from '@fluentui/react-icons';
 
-// Code-split the pages so each route is a separate chunk (smaller initial load).
-const InsightsOverviewPage = lazy(() => import('./pages/InsightsOverviewPage'));
-const ReportsPage = lazy(() => import('./pages/ReportsPage'));
-const CopilotAdoptionPage = lazy(() => import('./pages/CopilotAdoptionPage'));
-const TeamsPermissionsPage = lazy(() => import('./pages/TeamsPermissionsPage'));
-const UserLookupPage = lazy(() => import('./pages/UserLookupPage'));
-const ProfilingStatusPage = lazy(() => import('./pages/ProfilingStatusPage'));
-const InstallLogPage = lazy(() => import('./pages/InstallLogPage'));
-const HealthPage = lazy(() => import('./pages/HealthPage'));
-const ServiceConfigurationPage = lazy(() => import('./pages/ServiceConfigurationPage'));
+import { lazyWithReload } from './lazyWithReload';
+
+// Code-split the pages so each route is a separate chunk (smaller initial load). lazyWithReload
+// recovers from a stale chunk after a rebuild/redeploy instead of leaving the route blank.
+const InsightsOverviewPage = lazyWithReload(() => import('./pages/InsightsOverviewPage'));
+const ReportsPage = lazyWithReload(() => import('./pages/ReportsPage'));
+const CopilotAdoptionPage = lazyWithReload(() => import('./pages/CopilotAdoptionPage'));
+const TeamsPermissionsPage = lazyWithReload(() => import('./pages/TeamsPermissionsPage'));
+const UserLookupPage = lazyWithReload(() => import('./pages/UserLookupPage'));
+const ProfilingStatusPage = lazyWithReload(() => import('./pages/ProfilingStatusPage'));
+const InstallLogPage = lazyWithReload(() => import('./pages/InstallLogPage'));
+const HealthPage = lazyWithReload(() => import('./pages/HealthPage'));
+const ServiceConfigurationPage = lazyWithReload(() => import('./pages/ServiceConfigurationPage'));
 
 /**
  * The portal is split into two areas so the two audiences it serves don't have to wade

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -290,6 +290,12 @@
   <ItemGroup>
     <Reference Include="System.Runtime.Caching" />
   </ItemGroup>
+  <ItemGroup>
+    <TypeScriptCompile Include="Scripts\portal\src\lazyWithReload.ts" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{4A0DDDB5-7A95-4FBF-97CC-616D07737A77}" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>


### PR DESCRIPTION
Release candidate: `dev` -> `main`.

Base `main` @ `567cc68` -> head `dev` @ `7d5dce0` (merge-base `ac11fc2`). **3 commits, 2 squash-merged PRs plus 1 direct commit, 8 files, +252 / -41.**

Two-dot and three-dot diffs are identical (both `8 files changed, 252 insertions(+), 41 deletions(-)`), and `main`'s tree (`3e680cd`) is byte-identical to the merge-base tree, so `main`'s extra commit contributes no tree difference. `main`'s tip `567cc68` is the #344 merge, whose second parent `ac11fc2` is an ancestor of `dev`. There is no divergence to reconcile.

**This is a pure bug-fix release.** No new features, no database migrations, no schema change, no installer config-schema change, no breaking changes, no dependency changes. Three independent defects, each with a self-contained fix.

**No issues are closed by this release.** Neither #345 nor #346 has a linked issue (`closingIssuesReferences` is empty on both, checked via the API rather than read off the PR text), and `7d5dce0` references none. Nothing to close on merge.

---

## 1. What is in this release

| Commit / PR | Change | Area | Schema | Config schema |
| --- | --- | --- | --- | --- |
| #345 | Service Bus namespace is no longer re-PUT on every install, its tags are no longer wiped, and TLS 1.2 is now actually enforced | Installer | - | - |
| #346 | Copilot adoption page: the numbers printed on the coloured charts are legible again | Portal (presentation only) | - | - |
| `7d5dce0` | SPA no longer renders a blank route after a redeploy; `index.html` server cache actually works and is no longer browser-cached | Web / Portal | - | - |

---

## 2. #345 - Installer rewrote the Service Bus namespace on every run and wiped its tags

`Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs`

### Root cause (a): the TLS comparison could never be true

In `Azure.ResourceManager.ServiceBus` **1.2.0**, `ServiceBusMinimumTlsVersion` exposes **two** sets of members. The underscored ones are deprecated aliases whose underlying value is the **empty string**; the real ARM values live on the un-underscored ones. Re-verified for this PR by reflection against the assembly actually resolved into the build output (`ProductVersion 1.2.0`, pinned by `CloudInstallEngine.csproj`):

```
Tls1_0 = ''   Tls10 = '1.0'
Tls1_1 = ''   Tls11 = '1.1'
Tls1_2 = ''   Tls12 = '1.2'   <-- the task used Tls1_2
Tls1_3 = ''   Tls13 = '1.3'
```

ARM returns `"minimumTlsVersion": "1.2"`, and `"1.2" != ""`, so the "needs updating" test was **always** true. Two consequences:

1. The namespace was re-PUT on **every** install, logging `Updating service-bus namespace '...' to enforce TLS 1.2 minimum...` each time. Cosmetically noisy; operationally a pointless long-running ARM write on every run.
2. **TLS 1.2 was never actually enforced.** Both the create and the update path assigned the empty alias, so the payload carried `"minimumTlsVersion": ""`. New namespaces only landed on 1.2 because that is the current ARM default - the installer was not the thing putting them there.

The sibling SDKs were checked the same way and do **not** share the quirk, so `StorageAccountInstallTask`, `RedisInstallTask` and `AppServiceWebsiteTask` are correct and deliberately unchanged:

```
Azure.ResourceManager.Storage    1.7.0  StorageMinimumTlsVersion.Tls1_2        = 'TLS1_2'
Azure.ResourceManager.Redis      1.5.1  RedisTlsVersion.Tls1_2                 = '1.2'
Azure.ResourceManager.AppService 1.5.0  AppServiceSupportedTlsVersion.Tls1_2   = '1.2'
```

### Root cause (b): the needless PUT was silently destroying tags

Found while confirming (a), and **independent of it**. `CreateOrUpdateAsync` is a **PUT**, and `updateData` never carried `Tags`, so every one of those writes dropped the namespace's tags. Tags are applied separately by a `TagResource` merge-PATCH in `EnsureTagsOnExisting`, which runs *immediately before* the PUT that removed them.

Evidence: on a deployed resource group, every installer-created resource carried the deployment tag except the Service Bus namespace, which had none.

This was *triggered* by (a) but is not caused by it - it would still strike on any genuine update, e.g. a public-network-access change on a namespace already at TLS 1.2.

### What changed

- A documented `public static readonly ServiceBusMinimumTlsVersion RequiredMinimumTlsVersion = ServiceBusMinimumTlsVersion.Tls12`, used by **both** the create and the update path, so the two can no longer drift.
- The decision is extracted into `public static bool NeedsMinimumTlsUpdate(ServiceBusMinimumTlsVersion? current)` so it is unit-testable with no Azure and no mocking of the ARM client.
- `updateData` now copies `sbNS.Data.Tags` and then re-applies the configured tags through the existing `base.EnsureTagsOnNew(updateData.Tags)` helper.

### Why this fix and not an alternative

- **Why not just fix the constant and leave the tags alone?** (b) is a separate defect on a separate trigger. Fixing only (a) would make it *rarer* and therefore harder to diagnose, not gone.
- **Why re-apply configured tags on top of the copied snapshot, rather than copying the snapshot alone?** `sbNS.Data` is a read-back snapshot taken *before* `EnsureTagsOnExisting` issues its PATCH. A tag that the installer added on this very run is therefore absent from the snapshot, so a snapshot-only copy would still drop it. Layering `EnsureTagsOnNew` on top closes that window.
- **Why an extracted static predicate rather than testing through the task?** The surrounding method needs a live `ServiceBusNamespaceCollection`. Extracting the one decision that was wrong keeps the regression test free of Azure entirely.

### Tag merge semantics - worth understanding before reviewing

`EnsureTagsOnNew(existingTags, wanted)` only adds a key when it is **absent** (`if (!existingTags.ContainsKey(tag.Key))`). Combined with the snapshot copy that runs first, the resulting PUT payload is:

> **existing tags win on a key collision; configured tags only fill in missing keys.**

That is deliberate, and it is the *same* rule `EnsureTagsOnExisting` already applies in its merge-PATCH (it too only patches absent keys). So the PUT payload now agrees with what the PATCH path would have produced, and a tag a customer set out-of-band survives the installer. The flip side, stated plainly: **the installer will not correct a configured tag whose value was changed out-of-band.** That is pre-existing installer-wide behaviour, not something this PR introduces.

### Tests

New `Tests.UnitTests/InstallTests/ServiceBusNamespaceInstallTaskTests.cs`, registered in `Tests.UnitTests.csproj`:

| Test | Asserts |
| --- | --- |
| `RequiredMinimumTlsVersion_IsTheValueTheArmApiUses` | The constant serialises to the literal `"1.2"`, not an empty alias |
| `NeedsMinimumTlsUpdate_NamespaceAlreadyAtTls12_ReturnsFalse` | A namespace already at 1.2 is **not** rewritten |
| `NeedsMinimumTlsUpdate_UnsetOrOlderVersion_ReturnsTrue` | `null` / `1.0` / `1.1` still upgrade |

They build their input as `new ServiceBusMinimumTlsVersion("1.2")` - the way the SDK deserialiser builds it from the raw ARM payload - rather than from a named member, so they keep testing the real contract across SDK upgrades and would fail again if the underscored constant were reintroduced.

---

## 3. #346 - Copilot adoption page: unreadable numbers on the coloured charts

`Web/Scripts/portal/src/components/copilotAdoption/CombinedViews.tsx`. **Presentation only** - no data, API, type or query change; no other file touched.

### Three defects

1. **Heat cells faded their own digits.** `CombinedSegmentTable`'s `shade()` returned `{ backgroundColor: hue, opacity: 0.15 + 0.85 * (value / max) }`. CSS `opacity` applies to the whole element **including its text**, so the pale end of the ramp faded the number out along with the fill, and the strong end left default dark text on a near-solid `#0f6cbd` / `#a4373a`. Measured, that strong end is **2.88:1 (blue)** and **2.36:1 (red)** - both far below WCAG AA 4.5:1.
2. **`ConcentrationBar` slice labels were hardcoded white.** The `slice` class set `color: '#ffffff'` for all four cohorts, but the ramp ends at `#c7dbef`. Recomputed: **two** of the four cohorts failed AA, not one - `#5b9bd5` at **3.0:1** and `#c7dbef` at **1.4:1** (effectively invisible).
3. **The `1.` / `2.` / `3.` / `4.` prefixes read as part of the percentage.** `1. 31.5%` scans as one malformed number.

### What changed

- `hexToRgb` + `blendOnWhite(hex, alpha)` mix the hue onto the page background to a **solid** colour, so the digits stay fully opaque at every step of the ramp.
- The ramp is capped at `RAMP_MAX_ALPHA = 0.65` (floor `RAMP_MIN_ALPHA = 0.12`) rather than running to a solid fill.
- New `readableForeground(r, g, b)` picks white or `tokens.colorNeutralForeground1` by WCAG relative luminance, and is applied per-slice on the concentration bar.
- The ordinal prefixes are dropped from the slice labels, and the matching digits from the legend swatches (which become plain `inline-block` blocks, still `aria-hidden`).

### Why cap the ramp at 0.65 instead of running to a solid fill and flipping the label to white?

Because the flip point is the *worst* spot on the ramp, not a safe one. Recomputed for this PR over an uncapped ramp with a luminance-driven white flip:

| Hue | Worst contrast | At alpha | AA 4.5:1 |
| --- | --- | --- | --- |
| `#0f6cbd` | **3.92:1** | 0.83 (the flip point) | FAIL |
| `#a4373a` | **3.98:1** | 0.75 (the flip point) | FAIL |

Capping keeps a single text colour across the whole ramp and stays legible end to end. Measured after the change, dark text throughout:

| Hue | Pale end (t=0.05) | Full strength (t=1.00) | Worst across ramp |
| --- | --- | --- | --- |
| `#0f6cbd` licensed | 12.6:1 | 5.5:1 | 5.50:1 |
| `#a4373a` unlicensed | 12.4:1 | 4.9:1 | **4.87:1** (over AA) |

Concentration-bar cohorts after the change: **11.1:1, 5.5:1, 5.2:1, 10.9:1** (the palest was 1.4:1).

### Why blending onto white is correct rather than an assumption

The app is light-theme only - `main.tsx` wraps everything in `FluentProvider theme={webLightTheme}` and that is the only theme in the file. Confirmed against the installed package: `webLightTheme.colorNeutralBackground1 === '#ffffff'` and `colorNeutralForeground1 === '#242424'`, which are exactly the two values the new code assumes.

### Scope check

`shade()` was the only `opacity`-based heat ramp in the portal. `adoptionShared.tsx`'s `ScoreBar` / `BandBadge` / `rateColour` were checked and are unaffected - they colour bars and badges that carry no text on the ramp.

---

## 4. `7d5dce0` - SPA blank route after a redeploy, plus a dead `index.html` cache

`Web/Controllers/HomeController.cs`, new `Web/Scripts/portal/src/lazyWithReload.ts`, `Web/Scripts/portal/src/navigation.tsx`, `Web/Web.csproj`.

### 4a. The server-side `index.html` cache never worked

`ServePortalApp()` read `cache["portalIndexHtml"]` but wrote `cache.Set("adminAppIndexHtml", ...)`. The two keys never matched, so the cached copy was filed under a key nothing read and `index.html` was re-read from disk on **every request**. Both sides now use one `private const string PortalIndexCacheKey = "portalIndexHtml"`.

Note the write sits inside `#if !DEBUG`, so this only ever affected **Release** builds - which is precisely why it survived local debugging. The entry keeps its `HostFileChangeMonitor` on the file, so the now-live cache still self-invalidates on redeploy; enabling it does not introduce a staleness risk.

### 4b. `index.html` must not be browser-cached

`index.html` names content-hashed chunks, so a browser holding a stale copy after a redeploy requests chunks that no longer exist. `ServePortalApp()` now sets `Response.Cache.SetCacheability(HttpCacheability.NoCache)` and `SetNoStore()` (hence the new `using System.Web;`). The hashed assets it points at are untouched and stay cacheable.

### 4c. `lazyWithReload` - stale chunks recover themselves

Vite emits content-hashed chunks and empties `build/assets` on every build, so a rebuild or redeploy invalidates the chunk URLs baked into an already-open page. The next route change failed with:

```
Failed to fetch dynamically imported module: .../assets/HealthPage-<hash>.js
```

and the route rendered **nothing** - a dead page until the user manually refreshed. (This build produces e.g. `build/assets/HealthPage-CTWACJs9.js`, so the mechanism is exactly as described.)

The new 39-line wrapper around `React.lazy` catches the import failure, sets a `sessionStorage` flag (`portal:chunk-reloaded`), and calls `window.location.reload()` once to pull a fresh `index.html`. On the failure path it returns a deliberately never-settling promise so React cannot render an error state in the moments before the reload takes over. On a **successful** load it clears the flag, so a future stale chunk gets its own reload.

The flag is what makes it **one-shot**: a chunk missing for a genuine reason (broken build, bad deploy) surfaces as a real error instead of an infinite reload loop.

All **nine** code-split routes in `navigation.tsx` move from `lazy` to `lazyWithReload` (`InsightsOverview`, `Reports`, `CopilotAdoption`, `TeamsPermissions`, `UserLookup`, `ProfilingStatus`, `InstallLog`, `Health`, `ServiceConfiguration`); the now-unused `lazy` import is dropped.

### 4d. `Web.csproj`

Registers `Scripts\portal\src\lazyWithReload.ts` as `TypeScriptCompile` and adds a `<Service>` GUID (Visual Studio project metadata, not a functional change). It also **drops the trailing newline at EOF** - harmless, but it will show as a spurious last-line change in the next diff that touches this file, so a reviewer may want it restored.

---

## 5. Migrations, configuration and breaking changes

All three verified against the diff for this PR, not read off the contributing PR bodies.

| Check | Result | How it was verified |
| --- | --- | --- |
| **Database migrations** | **None** | `git diff --name-only origin/main...origin/dev` matches nothing under `Migrations/` |
| **Fresh-install schema** | **Unchanged** | No `Create DB.sql` in the diff |
| **Installer config schema** | **Unchanged** | `BaseSolutionInstallConfig.cs` is not in the diff; `CONFIG_VERSION` is `"2.2.0"` on **both** `origin/main` and `origin/dev` |
| **Breaking changes** | **None** | No public contract, API surface, config key or asset name changes |
| **Dependencies** | **Unchanged** | No `packages.config` / `PackageReference` / `package.json` in the diff |

Consequences, stated explicitly:

- **No `.manual.sql` assets are required for this release.** There are no migrations, so there is no manual upgrade-script chain to attach, order or name a predecessor for.
- **`CONFIG_VERSION` is correctly *not* bumped.** No installer config field was added, removed or changed, so an existing 2.2.0 config loads and behaves identically. Admins do not need to re-open or re-save their configuration.
- **The "prove every schema change with a benchmark" gate does not apply.** That gate is scoped to *performance-motivated* SQL schema changes. This release contains no SQL schema change of any classification - additive, removal or performance-motivated - so there is nothing to measure and nothing being waved through unmeasured.
- **No maintenance window and no importer downtime** are implied by anything in this diff.

---

## 6. Verification performed

Re-run independently for this PR, not inherited from the contributing PRs.

- **Portal build** - `npm run build` (`tsc --noEmit && vite build`) on the merged head: **clean**, 927 modules transformed, 0 type errors, 0 build errors.
- **`Tests.UnitTests` builds** with MSBuild (VS 18 Enterprise, located via `vswhere`), Debug: succeeded.
- **New Service Bus tests: 3/3 pass.**
- **Full `InstallTests` namespace: 49 tests, 45 pass, 4 fail.** All 4 failures are `VNetIntegrationTests` (`ConfigFileLoadsWithVNetDefaults`, `SolutionInstallConfig_VNetEnabled_SkuUpgradeValidation`, `SolutionInstallConfig_SerializationRoundTrip_PreservesVNet`, `DeployWithVNet_CreatesVNetAndResources`), each failing with `Test config file not found at '...\InstallTests\TestConfigs\InstallerTestConfig.json'`. That file is deliberately not in the repo. These are **pre-existing and environmental**, live in files this release does not touch, and are **not** release regressions.
- **Root cause proven by reflection**, not inferred: the `ServiceBusMinimumTlsVersion` and sibling-SDK tables above were dumped from the assemblies resolved into the build output.
- **Contrast figures recomputed** with an independent implementation of the WCAG relative-luminance and contrast formulae, against the real hues (`#0f6cbd`, `#a4373a`, and the four `COHORT_COLOUR` values) and the real Fluent token values.
- **CI on the contributing PRs**: all checks green on both before merge, including `test_dotnet (Release)` at 8m27s (#345) and 9m0s (#346), plus `gitleaks`, `test_aitracker` and all four `build_dotnet` matrix legs.

### Test validation in both directions

The three new tests were confirmed to fail on the old constant and pass on the new one. The failing direction is re-proven here from the reflection table rather than by mutating the tree:

| Test | With old `Tls1_2` (`''`) | With new `Tls12` (`'1.2'`) |
| --- | --- | --- |
| `RequiredMinimumTlsVersion_IsTheValueTheArmApiUses` | **FAIL** - asserts `ToString() == "1.2"`, gets `""` | PASS |
| `NeedsMinimumTlsUpdate_NamespaceAlreadyAtTls12_ReturnsFalse` | **FAIL** - `"1.2" != ""` so it returns `true` | PASS |
| `NeedsMinimumTlsUpdate_UnsetOrOlderVersion_ReturnsTrue` | PASS | PASS |

So **2 of 3 fail on the old constant**. The third is honest about what it is: it covers behaviour that was never broken, and is there to stop a fix for the first two from over-correcting into "never upgrade anything".

---

## 7. Risks and reviewer hotspots

1. **`7d5dce0` has had no build or test coverage in CI.** This is the biggest gap in the release. It was committed directly to `dev` rather than through a PR, and `ci.yml` only builds on push to `main` (plus `workflow_dispatch`) - so the only check that has ever run against that SHA is `gitleaks`. Its build and tests were gated **for the first time by this PR**. That gap is now closed: all checks on this PR are green, including `test_dotnet (Release)` (8m18s), all four `build_dotnet` matrix legs (notably the Release `Web.csproj` leg, 3m51s, which had never run against this SHA), `build_aitracker`, `test_aitracker` and `gitleaks`. The residual point is a process one - the commit reached `dev` without review or CI, and only this release PR caught up with it.
2. **Service Bus: on an existing namespace already at TLS 1.2 with the desired public-network-access, `needsUpdate` is now `false` and no PUT happens at all.** That is the entire point of the fix, but it is a genuine behaviour change: the installer becomes a no-op for that resource where it previously always wrote. Anything that was implicitly relying on that write - including the tag re-application it was destroying - now does not happen. The tags are still correct because `EnsureTagsOnExisting`'s PATCH runs unconditionally, before and independently of the PUT.
3. **Service Bus tag copy is merge-style and existing-wins.** Existing tags are copied first, then configured tags fill only the gaps. A configured tag whose value was changed out-of-band is **not** corrected. Consistent with `EnsureTagsOnExisting` and with the rest of the installer, but worth an explicit nod.
4. **The one-shot reload flag is cleared by *any* successful chunk load, not per-chunk.** So the guard means "one reload per successful-load boundary", not "one reload per session". Concretely: after a reload the first route's chunk loads successfully and clears the flag, so navigating to a *persistently* broken chunk can trigger a second reload rather than an error. It is not an unattended infinite loop - each cycle needs a user navigation - but it is not strictly "once ever" either. Worth confirming that is the intended trade-off.
5. **`lazyWithReload` assumes `sessionStorage` is reachable.** In a sandboxed cross-origin iframe, or with site data blocked, `sessionStorage` access throws and the throw happens inside the `catch` handler. Low likelihood for an authenticated admin portal served at the site root, but it is an unguarded call on an error path.
6. **`index.html` is now `NoCache` + `NoStore`, so every portal page load costs one extra revalidation request** to the origin instead of potentially serving from browser cache. The document is ~1.7 kB and the content-hashed assets it references remain fully cacheable, so the practical cost is one small conditional request per load. This is the correct trade for not serving chunk URLs that no longer exist, but it is a real change in request volume.
7. **`readableForeground`'s crossover constant is very slightly off.** Solving "contrast against white equals contrast against `#242424`" exactly gives a relative luminance of **0.2165**; the code uses **0.218**. No practical effect: `shade()` is capped so it never flips at all, and the four cohort colours sit well clear of the boundary (all comfortably over AA on whichever side they land). Flagged only so the number is not taken as exact.
8. **`Web.csproj` lost its trailing newline** (see 4d).

---

## 8. Deliberately out of scope / deferred

- **No wider audit of `opacity`-based styling in the portal.** `shade()` was confirmed to be the only heat ramp printing text over an opacity-faded fill; the other adoption visuals were checked and carry no text on their ramps. A broader accessibility sweep of the portal is not attempted here.
- **No change to the sibling installer tasks.** Storage, Redis and App Service were checked by reflection and are correct as written. Refactoring them onto a shared TLS constant would be churn without a defect behind it.
- **No general SPA error boundary.** `lazyWithReload` deliberately fixes only the stale-chunk case and lets every other failure surface as a real error. A route-level error boundary is a separate concern.
- **No `VNetIntegrationTests` fix.** Those 4 tests need a local installer config that is intentionally not committed. Making them skip cleanly instead of failing is a worthwhile tidy-up but is unrelated to this release, and changing them here would obscure the release diff.
- **`CONFIG_VERSION` intentionally not bumped** - see section 5.

