### PR TITLE
Blob checkpoint: authenticate Azure Table with RBAC when shared-key access is disabled

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/ResourceSecurityInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/ResourceSecurityInstallJob.cs
@@ -14,6 +14,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
     {
         private readonly RoleAssignmentTask _appInsightsReaderRoleTask;
         private readonly RoleAssignmentTask _storageBlobDataContributorRoleTask;
+        private readonly RoleAssignmentTask _storageTableDataContributorRoleTask;
         private readonly RoleAssignmentTask _redisCacheContributorRoleTask;
         private readonly RoleAssignmentTask _cognitiveServicesUserRoleTask;
         private readonly RoleAssignmentTask _serviceBusDataOwnerRoleTask;
@@ -41,6 +42,22 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
             _storageBlobDataContributorRoleTask = new RoleAssignmentTask(storageBlobContributorConfig, logger, Location, tagDic);
             this.AddTask(_storageBlobDataContributorRoleTask);
+
+            // Assign "Storage Table Data Contributor" to the runtime account for Table data-plane access.
+            // The audit-import blob checkpoint (ProcessedBlobStoreFactory / AzureTableProcessedBlobStore) lives in
+            // Azure Table storage. Accounts hardened with allowSharedKeyAccess = false - increasingly the default
+            // under enterprise governance policy - reject the connection-string client with
+            // "403 KeyBasedAuthenticationNotPermitted", so the importer falls back to RBAC via ClientSecretCredential.
+            // "Storage Blob Data Contributor" above does NOT cover the Table service, so without this role the
+            // fallback fails too and the checkpoint silently degrades to non-durable in-memory.
+            var storageTableContributorConfig = TaskConfig.GetConfigForPropAndVal(RoleAssignmentTask.CONFIG_KEY_ROLE_NAME, "Storage Table Data Contributor")
+                .AddSetting(RoleAssignmentTask.CONFIG_KEY_CLIENT_ID, config.RuntimeAccountOffice365.ClientId)
+                .AddSetting(RoleAssignmentTask.CONFIG_KEY_CLIENT_SECRET, config.RuntimeAccountOffice365.Secret)
+                .AddSetting(RoleAssignmentTask.CONFIG_KEY_TENANT_ID, config.RuntimeAccountOffice365.DirectoryId)
+                .AddSetting(RoleAssignmentTask.CONFIG_KEY_PRINCIPAL_TYPE, "ServicePrincipal");
+
+            _storageTableDataContributorRoleTask = new RoleAssignmentTask(storageTableContributorConfig, logger, Location, tagDic);
+            this.AddTask(_storageTableDataContributorRoleTask);
 
             // Assign Redis Cache Contributor role to the runtime account for RBAC-based Redis access (when keys are disabled)
             var redisCacheContributorConfig = TaskConfig.GetConfigForPropAndVal(RoleAssignmentTask.CONFIG_KEY_ROLE_NAME, "Redis Cache Contributor")
@@ -89,6 +106,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
         public RoleAssignmentResource AppInsightsReaderRole => GetTaskResult<RoleAssignmentResource>(_appInsightsReaderRoleTask);
         public RoleAssignmentResource StorageBlobDataContributorRole => GetTaskResult<RoleAssignmentResource>(_storageBlobDataContributorRoleTask);
+        public RoleAssignmentResource StorageTableDataContributorRole => GetTaskResult<RoleAssignmentResource>(_storageTableDataContributorRoleTask);
         public RoleAssignmentResource RedisCacheContributorRole => GetTaskResult<RoleAssignmentResource>(_redisCacheContributorRoleTask);
         public RoleAssignmentResource CognitiveServicesUserRole =>
             _cognitiveServicesUserRoleTask == null ? null : GetTaskResult<RoleAssignmentResource>(_cognitiveServicesUserRoleTask);

--- a/src/AnalyticsEngine/Tests.UnitTests/CheckpointTableClientFactoryTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CheckpointTableClientFactoryTests.cs
@@ -1,0 +1,131 @@
+using Azure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Covers how the audit blob checkpoint decides between shared-key and RBAC/Entra ID authentication for its
+    /// Azure Table store. Storage accounts with allowSharedKeyAccess = false return
+    /// "403 KeyBasedAuthenticationNotPermitted", which must route the importer to the runtime service principal
+    /// rather than degrading to the non-durable in-memory checkpoint.
+    /// </summary>
+    [TestClass]
+    public class CheckpointTableClientFactoryTests
+    {
+        // Obviously-fake, low-entropy account/key; never a real connection string.
+        private const string SharedKeyConnStr =
+            "DefaultEndpointsProtocol=https;AccountName=contosoanalytics;AccountKey=FAKEFAKEFAKEFAKEFAKEFAKE==;EndpointSuffix=core.windows.net";
+
+        [TestMethod]
+        public void GetTableEndpoint_ComposesFromAccountNameAndSuffix()
+        {
+            Assert.AreEqual(new Uri("https://contosoanalytics.table.core.windows.net"),
+                CheckpointTableClientFactory.GetTableEndpoint(SharedKeyConnStr));
+        }
+
+        /// <summary>Sovereign clouds use a different endpoint suffix, so it must never be hard-coded.</summary>
+        [TestMethod]
+        public void GetTableEndpoint_HonoursSovereignCloudSuffix()
+        {
+            var connStr = "DefaultEndpointsProtocol=https;AccountName=contosoanalytics;AccountKey=abc==;EndpointSuffix=core.usgovcloudapi.net";
+
+            Assert.AreEqual(new Uri("https://contosoanalytics.table.core.usgovcloudapi.net"),
+                CheckpointTableClientFactory.GetTableEndpoint(connStr));
+        }
+
+        /// <summary>An explicit TableEndpoint wins over the composed one (custom/private DNS).</summary>
+        [TestMethod]
+        public void GetTableEndpoint_PrefersExplicitTableEndpoint()
+        {
+            var connStr = "DefaultEndpointsProtocol=https;AccountName=contosoanalytics;AccountKey=abc==;" +
+                          "TableEndpoint=https://contosoanalytics.privatelink.table.core.windows.net/;EndpointSuffix=core.windows.net";
+
+            Assert.AreEqual(new Uri("https://contosoanalytics.privatelink.table.core.windows.net/"),
+                CheckpointTableClientFactory.GetTableEndpoint(connStr));
+        }
+
+        [TestMethod]
+        public void GetTableEndpoint_NoAccountName_ReturnsNull()
+        {
+            Assert.IsNull(CheckpointTableClientFactory.GetTableEndpoint("DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net"));
+            Assert.IsNull(CheckpointTableClientFactory.GetTableEndpoint(null));
+            Assert.IsNull(CheckpointTableClientFactory.GetTableEndpoint(string.Empty));
+        }
+
+        /// <summary>
+        /// An account key is base64 and routinely ends in '=' padding, so parsing must split on the FIRST '='
+        /// only - otherwise the key is silently truncated and shared-key auth breaks.
+        /// </summary>
+        [TestMethod]
+        public void HasAccountKey_DetectsBase64PaddedKey()
+        {
+            Assert.IsTrue(CheckpointTableClientFactory.HasAccountKey(SharedKeyConnStr));
+            Assert.IsTrue(CheckpointTableClientFactory.HasAccountKey("AccountName=contosoanalytics;AccountKey=YWJj=="));
+        }
+
+        /// <summary>An RBAC-only connection string names the account but carries no key.</summary>
+        [TestMethod]
+        public void HasAccountKey_FalseWhenAbsentOrBlank()
+        {
+            Assert.IsFalse(CheckpointTableClientFactory.HasAccountKey("DefaultEndpointsProtocol=https;AccountName=contosoanalytics;EndpointSuffix=core.windows.net"));
+            Assert.IsFalse(CheckpointTableClientFactory.HasAccountKey("AccountName=contosoanalytics;AccountKey="));
+            Assert.IsFalse(CheckpointTableClientFactory.HasAccountKey(null));
+        }
+
+        [TestMethod]
+        public void IsDevelopmentStorage_DetectsEmulator()
+        {
+            Assert.IsTrue(CheckpointTableClientFactory.IsDevelopmentStorage("UseDevelopmentStorage=true"));
+            Assert.IsFalse(CheckpointTableClientFactory.IsDevelopmentStorage(SharedKeyConnStr));
+        }
+
+        /// <summary>This is the exact error a storage account with allowSharedKeyAccess = false returns.</summary>
+        [TestMethod]
+        public void IsKeyAuthDisabled_TrueForKeyBasedAuthenticationNotPermitted()
+        {
+            Assert.IsTrue(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(403, "Key based authentication is not permitted on this storage account.", "KeyBasedAuthenticationNotPermitted", null)));
+            Assert.IsTrue(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(403, "Auth type disabled", "AuthenticationTypeDisabled", null)));
+        }
+
+        /// <summary>
+        /// A firewall / private-endpoint block also surfaces as 403, but retrying with a token would not help,
+        /// so it must NOT be treated as "key auth disabled".
+        /// </summary>
+        [TestMethod]
+        public void IsKeyAuthDisabled_FalseForOtherFailures()
+        {
+            Assert.IsFalse(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(403, "This request is not authorized to perform this operation.", "AuthorizationFailure", null)));
+            Assert.IsFalse(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(403, "Permission mismatch", "AuthorizationPermissionMismatch", null)));
+            Assert.IsFalse(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(404, "Not found", "ResourceNotFound", null)));
+            Assert.IsFalse(CheckpointTableClientFactory.IsKeyAuthDisabled(null));
+        }
+
+        /// <summary>
+        /// With no key AND no service principal there is nothing to authenticate with, so the store must throw
+        /// (letting ProcessedBlobStoreFactory fall back to in-memory) rather than hang or return a dead client.
+        /// </summary>
+        [TestMethod]
+        public void CreateAndEnsureTable_NoKeyAndNoServicePrincipal_Throws()
+        {
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                CheckpointTableClientFactory.CreateAndEnsureTable(
+                    "DefaultEndpointsProtocol=https;AccountName=contosoanalytics;EndpointSuffix=core.windows.net",
+                    "AuditImporterProcessedBlobs", null, null, null, null));
+        }
+
+        [TestMethod]
+        public void CreateAndEnsureTable_EmptyConnectionString_Throws()
+        {
+            Assert.ThrowsException<ArgumentException>(() =>
+                CheckpointTableClientFactory.CreateAndEnsureTable(string.Empty, "AuditImporterProcessedBlobs",
+                    "00000000-0000-0000-0000-000000000000", "client", "secret", null));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="PreInstallAdvisorTests.cs" />
     <Compile Include="ImportCadenceTests.cs" />
     <Compile Include="AppInsightsAuthTests.cs" />
+    <Compile Include="CheckpointTableClientFactoryTests.cs" />
     <Compile Include="CopilotAuditLogContentSchemaTests.cs" />
     <Compile Include="CopilotEventManagerAccessedResourcesTests.cs" />
     <Compile Include="CopilotEventManagerEdgeCaseTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/AzureTableProcessedBlobStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/AzureTableProcessedBlobStore.cs
@@ -27,12 +27,27 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
         private readonly TimeSpan _retention;
         private readonly ILogger _logger;
 
-        public AzureTableProcessedBlobStore(string storageConnectionString, TimeSpan retention, ILogger logger, string tableName = DefaultTableName)
+        /// <summary>
+        /// Connects with shared key when the account allows it, otherwise with the runtime service principal
+        /// (see <see cref="CheckpointTableClientFactory"/>). Throws if neither works, so the factory falls back
+        /// to the in-memory store.
+        /// </summary>
+        public AzureTableProcessedBlobStore(string storageConnectionString, TimeSpan retention, ILogger logger,
+            string tenantId = null, string clientId = null, string clientSecret = null, string tableName = DefaultTableName)
+            : this(CheckpointTableClientFactory.CreateAndEnsureTable(storageConnectionString, tableName, tenantId, clientId, clientSecret, logger),
+                   retention, logger)
+        {
+        }
+
+        /// <summary>
+        /// Takes an already-authenticated client whose table is known to exist. Used by the connection-string
+        /// constructor and directly by tests.
+        /// </summary>
+        public AzureTableProcessedBlobStore(TableClient table, TimeSpan retention, ILogger logger)
         {
             _retention = retention > TimeSpan.Zero ? retention : TimeSpan.FromDays(8);
             _logger = logger;
-            _table = new TableClient(storageConnectionString, tableName);
-            _table.CreateIfNotExists(); // throws if the connection string is unusable -> factory falls back.
+            _table = table ?? throw new ArgumentNullException(nameof(table));
         }
 
         public async Task<ISet<string>> GetProcessedBlobIdsAsync()

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/CheckpointTableClientFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/CheckpointTableClientFactory.cs
@@ -1,0 +1,170 @@
+using Azure;
+using Azure.Data.Tables;
+using Azure.Identity;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
+{
+    /// <summary>
+    /// Builds the <see cref="TableClient"/> behind <see cref="AzureTableProcessedBlobStore"/> so the blob
+    /// checkpoint works against both classic shared-key storage accounts and accounts that have shared-key
+    /// access disabled (<c>allowSharedKeyAccess = false</c>) and therefore require RBAC / Entra ID tokens.
+    /// </summary>
+    /// <remarks>
+    /// A storage account hardened with <c>allowSharedKeyAccess = false</c> - increasingly the default under
+    /// enterprise governance policy and the Azure security baseline - rejects a connection-string (shared key)
+    /// client with <c>403 KeyBasedAuthenticationNotPermitted</c>. Per the repo convention for Entra ID fallbacks
+    /// (see Azure AI Language, Redis and Service Bus) we authenticate with a <see cref="ClientSecretCredential"/>
+    /// built from the runtime service principal - never <c>DefaultAzureCredential</c> or managed identity - so
+    /// behaviour is identical in the web job, the installer tests and unit tests.
+    /// <para>
+    /// Data-plane RBAC on the Table service needs the <b>Storage Table Data Contributor</b> role;
+    /// <c>Storage Blob Data Contributor</c> does NOT cover Table storage. The installer assigns it in
+    /// <c>ResourceSecurityInstallJob</c>.
+    /// </para>
+    /// </remarks>
+    public static class CheckpointTableClientFactory
+    {
+        /// <summary>Error codes a storage account returns when shared-key (account key) auth is switched off.</summary>
+        private static readonly HashSet<string> KeyAuthDisabledCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "KeyBasedAuthenticationNotPermitted",
+            "AuthenticationTypeDisabled",
+        };
+
+        /// <summary>
+        /// Builds a <see cref="TableClient"/> for <paramref name="tableName"/> and ensures the table exists.
+        /// Shared key is preferred when the connection string carries an <c>AccountKey</c>; if the account
+        /// rejects it because key auth is disabled, the call is retried with the runtime service principal.
+        /// Throws when no usable authentication is available, so the caller can fall back to the in-memory store.
+        /// </summary>
+        public static TableClient CreateAndEnsureTable(string storageConnectionString, string tableName,
+            string tenantId, string clientId, string clientSecret, ILogger logger)
+        {
+            if (string.IsNullOrWhiteSpace(storageConnectionString))
+                throw new ArgumentException("A storage connection string is required.", nameof(storageConnectionString));
+
+            // Azurite / the storage emulator has no Entra ID identity at all, so there is nothing to fall back to.
+            if (IsDevelopmentStorage(storageConnectionString))
+                return CreateFromConnectionString(storageConnectionString, tableName);
+
+            var endpoint = GetTableEndpoint(storageConnectionString);
+            var canUseRbac = endpoint != null
+                && !string.IsNullOrWhiteSpace(tenantId)
+                && !string.IsNullOrWhiteSpace(clientId)
+                && !string.IsNullOrWhiteSpace(clientSecret);
+
+            if (HasAccountKey(storageConnectionString))
+            {
+                try
+                {
+                    return CreateFromConnectionString(storageConnectionString, tableName);
+                }
+                catch (RequestFailedException ex) when (IsKeyAuthDisabled(ex) && canUseRbac)
+                {
+                    logger?.LogInformation($"Blob checkpoint: shared-key access is disabled on the storage account ({ex.ErrorCode}); " +
+                        "retrying with RBAC/Entra ID using the runtime service principal.");
+                }
+            }
+
+            if (!canUseRbac)
+            {
+                throw new InvalidOperationException(BuildNoRbacMessage(endpoint, storageConnectionString));
+            }
+
+            var rbacClient = new TableClient(endpoint, tableName, new ClientSecretCredential(tenantId, clientId, clientSecret));
+            rbacClient.CreateIfNotExists();
+            return rbacClient;
+        }
+
+        /// <summary>True when the storage account rejected the request because account-key auth is turned off.</summary>
+        public static bool IsKeyAuthDisabled(RequestFailedException ex)
+        {
+            if (ex == null) return false;
+            if (ex.Status != 401 && ex.Status != 403) return false;
+            return ex.ErrorCode != null && KeyAuthDisabledCodes.Contains(ex.ErrorCode);
+        }
+
+        /// <summary>True when the connection string carries a usable shared key.</summary>
+        public static bool HasAccountKey(string storageConnectionString)
+        {
+            var parts = Parse(storageConnectionString);
+            return parts.TryGetValue("AccountKey", out var key) && !string.IsNullOrWhiteSpace(key);
+        }
+
+        /// <summary>True for the local storage emulator, which has no Entra ID identity.</summary>
+        public static bool IsDevelopmentStorage(string storageConnectionString)
+        {
+            var parts = Parse(storageConnectionString);
+            return parts.TryGetValue("UseDevelopmentStorage", out var v)
+                && bool.TryParse(v, out var useDev) && useDev;
+        }
+
+        /// <summary>
+        /// Resolves the Table service endpoint a token-authenticated client must target. Prefers an explicit
+        /// <c>TableEndpoint</c>, otherwise composes it from <c>AccountName</c> + <c>EndpointSuffix</c> (which
+        /// differs in sovereign clouds). Returns <c>null</c> when the connection string names no account.
+        /// </summary>
+        public static Uri GetTableEndpoint(string storageConnectionString)
+        {
+            var parts = Parse(storageConnectionString);
+
+            if (parts.TryGetValue("TableEndpoint", out var explicitEndpoint) && !string.IsNullOrWhiteSpace(explicitEndpoint))
+                return Uri.TryCreate(explicitEndpoint.Trim(), UriKind.Absolute, out var explicitUri) ? explicitUri : null;
+
+            if (!parts.TryGetValue("AccountName", out var account) || string.IsNullOrWhiteSpace(account))
+                return null;
+
+            var suffix = parts.TryGetValue("EndpointSuffix", out var s) && !string.IsNullOrWhiteSpace(s)
+                ? s.Trim() : "core.windows.net";
+            var scheme = parts.TryGetValue("DefaultEndpointsProtocol", out var p) && !string.IsNullOrWhiteSpace(p)
+                ? p.Trim() : "https";
+
+            return Uri.TryCreate($"{scheme}://{account.Trim()}.table.{suffix}", UriKind.Absolute, out var uri) ? uri : null;
+        }
+
+        private static TableClient CreateFromConnectionString(string storageConnectionString, string tableName)
+        {
+            var client = new TableClient(storageConnectionString, tableName);
+            client.CreateIfNotExists();
+            return client;
+        }
+
+        private static string BuildNoRbacMessage(Uri endpoint, string storageConnectionString)
+        {
+            if (!HasAccountKey(storageConnectionString) && endpoint == null)
+                return "The storage connection string contains neither an AccountKey nor an AccountName/TableEndpoint, " +
+                       "so neither shared-key nor RBAC authentication can be used for the blob checkpoint table.";
+
+            return "Shared-key access is unavailable on the storage account and the runtime service principal " +
+                   "(tenant id / client id / client secret) is not configured, so the blob checkpoint table cannot " +
+                   "be authenticated. Configure the runtime account, or re-enable shared-key access on the account.";
+        }
+
+        /// <summary>
+        /// Splits a storage connection string into its key/value parts. Only the FIRST '=' is treated as the
+        /// separator because an <c>AccountKey</c> is base64 and routinely ends in '=' padding.
+        /// </summary>
+        private static IDictionary<string, string> Parse(string storageConnectionString)
+        {
+            var parts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(storageConnectionString)) return parts;
+
+            foreach (var segment in storageConnectionString.Split(';'))
+            {
+                if (string.IsNullOrWhiteSpace(segment)) continue;
+
+                var separator = segment.IndexOf('=');
+                if (separator <= 0) continue;
+
+                var key = segment.Substring(0, separator).Trim();
+                var value = segment.Substring(separator + 1).Trim();
+                if (key.Length > 0 && !parts.ContainsKey(key)) parts[key] = value;
+            }
+
+            return parts;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/ProcessedBlobStoreFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/ProcessedBlobStoreFactory.cs
@@ -26,7 +26,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
             {
                 try
                 {
-                    var store = new AzureTableProcessedBlobStore(storageConn, retention, logger);
+                    var store = new AzureTableProcessedBlobStore(storageConn, retention, logger,
+                        config.TenantGUID == Guid.Empty ? null : config.TenantGUID.ToString(), config.ClientID, config.ClientSecret);
                     logger?.LogInformation("Blob checkpoint: durable Azure Table store initialised (processed blobs persist across restarts).");
                     (logger as AnalyticsLogger)?.TrackHealthCheck(HealthComponent.BlobCheckpoint, HealthStatus.Healthy,
                         "Durable Azure Table checkpoint active.");
@@ -44,8 +45,11 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
                         detail += " -> " + inner.Message;
                     logger?.LogError(ex, $"Blob checkpoint: could not initialise the Azure Table store ({ex.GetType().Name}: {detail}); " +
                         "falling back to in-memory (dedupes across cycles but only for the life of this process - lost on restart/redeploy). " +
-                        "Check the Storage connection string is valid and the account's Table service is reachable: " +
-                        "shared-key access enabled, and storage firewall / private endpoint / selected-networks not blocking the importer.");
+                        "Check the Storage connection string is valid and the account's Table service is reachable: storage firewall / " +
+                        "private endpoint / selected-networks not blocking the importer. If the account has shared-key access disabled " +
+                        "(allowSharedKeyAccess = false, giving '403 KeyBasedAuthenticationNotPermitted'), the importer authenticates with the " +
+                        "runtime service principal instead - that account needs the 'Storage Table Data Contributor' role on the storage " +
+                        "account ('Storage Blob Data Contributor' does NOT cover the Table service).");
                     // Surface the degraded (non-durable) checkpoint on the Health page instead of only in the log.
                     (logger as AnalyticsLogger)?.TrackHealthCheck(HealthComponent.BlobCheckpoint, HealthStatus.Degraded,
                         $"Azure Table init failed ({ex.GetType().Name}); using non-durable in-memory checkpoint (lost on restart). See importer error log.");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ActivityAPI\ActivityImporter.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\AzureTableProcessedBlobStore.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\BlobCommitTracker.cs" />
+    <Compile Include="ActivityAPI\BlobCheckpoint\CheckpointTableClientFactory.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\InMemoryProcessedBlobStore.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\IProcessedBlobStore.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\ProcessedBlobStoreFactory.cs" />


### PR DESCRIPTION
## Scope

Fixes the audit blob checkpoint on storage accounts with `allowSharedKeyAccess = false`, and closes the RBAC gap that would have made the fix fail anyway.

Addresses #348.

## Problem

`AzureTableProcessedBlobStore` built its client from a shared-key connection string:

```csharp
_table = new TableClient(storageConnectionString, tableName);
_table.CreateIfNotExists();
```

On an account with `allowSharedKeyAccess = false` this throws on every importer cycle:

```
Azure.RequestFailedException at Azure.Data.Tables.TableClient.CreateIfNotExists
Status: 403 (Key based authentication is not permitted on this storage account.)
ErrorCode: KeyBasedAuthenticationNotPermitted
```

`ProcessedBlobStoreFactory` catches it and falls back to `InMemoryProcessedBlobStore`, so imports keep running and Health reports `BlobCheckpoint = Degraded` — but the checkpoint is then **non-durable**. Every WebJob restart, redeploy or scale event re-downloads and re-processes every audit blob in the lookback window (`DaysBeforeNowToDownload`, default 7 days), and the condition never self-heals.

Disabling shared key is the Azure security baseline recommendation (`Storage accounts should prevent shared key access`) and is commonly applied — and re-applied — automatically by enterprise governance policy, including to accounts the installer created with shared key enabled. Re-enabling it on the account is therefore not a durable workaround.

This was the **last shared-key storage client in the solution**; Redis, Service Bus (#138), Azure AI Language and App Insights were already RBAC-first.

### Second half of the bug

Switching to a token credential alone would not have worked. `ResourceSecurityInstallJob` assigns `Storage Blob Data Contributor`, which does **not** cover the Table service, so the RBAC path would fail with `AuthorizationPermissionMismatch` and the checkpoint would still degrade silently.

## Changes

### `CheckpointTableClientFactory` (new)

Builds the checkpoint `TableClient` and ensures the table exists.

- Prefers shared key when the connection string carries an `AccountKey` (unchanged behaviour for existing installs).
- On `403`/`401` with `KeyBasedAuthenticationNotPermitted` or `AuthenticationTypeDisabled`, retries with `ClientSecretCredential` built from the runtime service principal — per the repo convention for Entra ID fallbacks, never `DefaultAzureCredential` or managed identity, so behaviour is identical in the web job and in tests.
- Resolves the Table endpoint from an explicit `TableEndpoint`, else composes `AccountName` + `EndpointSuffix`, so sovereign clouds and private-DNS endpoints work rather than a hard-coded `core.windows.net`.
- Connection-string parsing splits on the **first** `=` only, because an `AccountKey` is base64 and routinely ends in `=` padding.
- `UseDevelopmentStorage=true` bypasses the RBAC path (the emulator has no Entra ID identity).
- **Other 403s are deliberately not retried with a token.** `AuthorizationFailure` (storage firewall / private endpoint) and `AuthorizationPermissionMismatch` propagate unchanged, so a networking fault is not silently re-reported as an auth fault.
- Throws `InvalidOperationException` when neither auth method is available, so the caller still falls back to in-memory rather than returning a dead client.

### `AzureTableProcessedBlobStore`

Takes the SP credentials and delegates client construction to the factory. A second constructor accepts a pre-built `TableClient` for tests. No change to the store's read/write/purge logic.

### `ResourceSecurityInstallJob`

Assigns **`Storage Table Data Contributor`** to the runtime account at resource-group scope, alongside the existing Blob role.

### `ProcessedBlobStoreFactory`

The fallback log told operators to check that "shared-key access [is] enabled" — now the wrong advice, and the reason this failure reads as a connection-string/networking problem when both are fine. It now names the `403 KeyBasedAuthenticationNotPermitted` case and the required Table role.

## Tests

`CheckpointTableClientFactoryTests` — 11 new tests covering endpoint composition (including sovereign-cloud suffix and explicit `TableEndpoint`), base64-padded `AccountKey` detection, emulator detection, which error codes count as "key auth disabled" (and which explicitly do not), and both no-auth-available failure modes.

```
Total tests: 17   Passed: 17
```

(11 new + the 6 existing `AuditImportFailure*` tests that exercise the checkpoint, re-run to confirm no regression.)

`WebJob.Office365ActivityImporter.Engine`, `App.ControlPanel.Engine` and `Tests.UnitTests` all build clean.

## Schema / config effects

- **No database migration.**
- **No installer config-schema change** — no persisted property added, so `CONFIG_VERSION` is unchanged.
- **New Azure role assignment** performed by the installer (additive, no downtime).

## Upgrade / operational notes

- Existing installs pick up the role assignment on the next installer run.
- An install whose storage account already has shared key disabled will keep degrading to in-memory until the installer is re-run (or the role is assigned by hand), because the role is a prerequisite for the RBAC path.
- Accounts that still allow shared key are entirely unaffected — the key path is tried first and the RBAC code never executes.

## Reviewer hotspots

1. **The retry predicate** in `CheckpointTableClientFactory.IsKeyAuthDisabled` — the deliberate decision to retry on only two error codes, so a firewall/private-endpoint 403 is not mistaken for a key-auth 403.
2. **Endpoint composition** — worth a second pair of eyes on the `EndpointSuffix` / explicit `TableEndpoint` precedence.
3. **The `Parse` split-on-first-`=`** behaviour, which is what keeps a base64 `AccountKey` intact.

## Deferred

- Installer *Test Configuration* has no check for Table data-plane reachability, so a missing role is still only discovered from the importer log (same class of gap as #329).
- Broader RBAC-first config rework tracked in #154.
