### PR TITLE
Web portal: recover from an expired session instead of failing with an opaque 'Failed to fetch'

### DIFF
--- a/src/AnalyticsEngine/Web/App_Start/Startup.Auth.cs
+++ b/src/AnalyticsEngine/Web/App_Start/Startup.Auth.cs
@@ -2,16 +2,27 @@
 using Common.Entities.Models;
 using Common.Entities.Redis;
 using Common.Entities.Redis.Auth;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OpenIdConnect;
 using Owin;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace Web.AnalyticsWeb
 {
     public partial class Startup
     {
+        /// <summary>
+        /// Response header set on the 401 that replaces the sign-in redirect for API calls, so the SPA can tell
+        /// "your session has expired, re-authenticate" apart from an authenticated-but-unauthorised 401 (e.g.
+        /// SiteTokenAPI reporting that it has no Graph refresh token for this session).
+        /// </summary>
+        public const string SessionExpiredHeader = "X-Auth-Session-Expired";
+
         public void ConfigureAuth(IAppBuilder app)
         {
             var config = new AppConfig();
@@ -41,8 +52,40 @@ namespace Web.AnalyticsWeb
                     {
                         ValidateIssuer = true
                     },
+                    // Stops the cancelled API challenges below leaving orphan nonce cookies behind.
+                    CookieManager = new ApiSafeCookieManager(app.GetDefaultCookieManager()),
                     Notifications = new OpenIdConnectAuthenticationNotifications()
                     {
+                        // An expired session must not turn an API call into a sign-in redirect.
+                        //
+                        // The OIDC middleware runs in Active mode, so it converts the 401 from an [Authorize]'d
+                        // controller into a 302 to login.microsoftonline.com. A top-level navigation handles that
+                        // fine, but the SPA's fetch() follows the redirect cross-origin, the login page carries no
+                        // CORS headers, and the call rejects with an opaque "TypeError: Failed to fetch" - so the
+                        // portal just breaks with no hint that the user simply needs to sign in again.
+                        //
+                        // For API requests we therefore suppress the redirect and leave the plain 401 in place.
+                        RedirectToIdentityProvider = context =>
+                        {
+                            if (context.ProtocolMessage.RequestType == OpenIdConnectRequestType.Authentication
+                                && IsApiRequest(context.OwinContext.Request))
+                            {
+                                context.HandleResponse();
+                                context.OwinContext.Response.StatusCode = 401;
+
+                                // Only flag it as an expired session when there is genuinely no signed-in user.
+                                // A 401 raised by a controller while the user IS signed in (SiteTokenAPI having
+                                // no Graph refresh token) must not bounce them through a pointless sign-in.
+                                var signedIn = context.OwinContext.Authentication?.User?.Identity?.IsAuthenticated == true;
+                                if (!signedIn)
+                                {
+                                    context.OwinContext.Response.Headers[SessionExpiredHeader] = "true";
+                                }
+                            }
+
+                            return Task.CompletedTask;
+                        },
+
                         // When AAD redirects back with an auth code, redeem it for tokens and stash
                         // the refresh token in the (encrypted, httpOnly) auth cookie so the SPA can
                         // get a Graph token via SiteTokenAPI without Redis. When Redis IS configured
@@ -71,6 +114,96 @@ namespace Web.AnalyticsWeb
                         }
                     }
                 });
+        }
+
+        /// <summary>
+        /// True for calls the SPA makes with fetch/XHR rather than a top-level navigation. Those must get a
+        /// status code they can act on, not a redirect to the identity provider they cannot follow.
+        /// </summary>
+        private static bool IsApiRequest(IOwinRequest request)
+        {
+            if (request == null) return false;
+
+            // The portal's apiFetch always sends this and a browser navigation never does, so it is the one
+            // unambiguous signal that a script is waiting for a status code.
+            if (string.Equals(request.Headers["X-Requested-With"], "XMLHttpRequest",
+                    System.StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // Otherwise fall back to the path - but NOT for a top-level navigation. The Copilot adoption CSV
+            // and workbook exports are plain <a href> links to [Authorize]'d /api routes, and they must still
+            // redirect to sign-in: the browser IS navigating, so it can follow the redirect and then deliver
+            // the download. Answering those with a bare 401 would just show the user a blank error page.
+            if (IsDocumentNavigation(request)) return false;
+
+            return request.Path.StartsWithSegments(new PathString("/api"));
+        }
+
+        /// <summary>
+        /// True when the browser is navigating the top-level document (a link, address bar or form post)
+        /// rather than making a background request.
+        /// </summary>
+        /// <remarks>
+        /// Uses the Fetch Metadata request headers, which every current browser sends. On a browser old
+        /// enough to omit them this returns false and the <c>/api</c> path rule applies as before.
+        /// </remarks>
+        private static bool IsDocumentNavigation(IOwinRequest request)
+        {
+            return string.Equals(request.Headers["Sec-Fetch-Mode"], "navigate",
+                       System.StringComparison.OrdinalIgnoreCase)
+                || string.Equals(request.Headers["Sec-Fetch-Dest"], "document",
+                       System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Cookie manager for the OIDC middleware that suppresses response cookies on API requests.
+        /// </summary>
+        /// <remarks>
+        /// Katana writes the OIDC nonce cookie in <c>AddNonceToMessage</c>, which runs BEFORE the
+        /// <c>RedirectToIdentityProvider</c> notification - so <c>HandleResponse()</c> cancels the redirect but
+        /// cannot un-write the cookie. Without this, every suppressed API challenge would leave an orphan
+        /// <c>OpenIdConnect.nonce.*</c> cookie behind that nothing ever consumes (they live ~15 minutes).
+        /// A page firing several parallel API calls would drop several per attempt, and because the auth cookie
+        /// on this site already carries the Graph refresh token, the accumulated Cookie header can grow past
+        /// IIS/proxy limits - turning a recoverable "please sign in again" into a 400 Request Too Large that
+        /// the user cannot get out of without clearing cookies.
+        ///
+        /// The only cookie the middleware writes on a challenge is that nonce, and for API requests the
+        /// challenge is cancelled, so dropping the write is exactly right. Reads and deletes are untouched, and
+        /// so is every non-API request - the sign-in redirect and its callback are top-level navigations, which
+        /// still get a real nonce and validate it normally.
+        ///
+        /// It decorates the host's own manager rather than constructing one: Katana does
+        /// <c>Options.CookieManager ??= app.GetDefaultCookieManager()</c>, and under
+        /// <c>Microsoft.Owin.Host.SystemWeb</c> that default integrates with System.Web's cookie collection.
+        /// Hard-coding a replacement would quietly change behaviour on the successful sign-in path.
+        /// </remarks>
+        private sealed class ApiSafeCookieManager : ICookieManager
+        {
+            private readonly ICookieManager _inner;
+
+            public ApiSafeCookieManager(ICookieManager inner)
+            {
+                _inner = inner ?? new CookieManager();
+            }
+
+            public string GetRequestCookie(IOwinContext context, string key)
+                => _inner.GetRequestCookie(context, key);
+
+            public void AppendResponseCookie(IOwinContext context, string key, string value, CookieOptions options)
+            {
+                if (IsApiRequest(context?.Request))
+                {
+                    return;
+                }
+
+                _inner.AppendResponseCookie(context, key, value, options);
+            }
+
+            public void DeleteCookie(IOwinContext context, string key, CookieOptions options)
+                => _inner.DeleteCookie(context, key, options);
         }
     }
 }

--- a/src/AnalyticsEngine/Web/Models/AuthTeamRequest.cs
+++ b/src/AnalyticsEngine/Web/Models/AuthTeamRequest.cs
@@ -11,8 +11,5 @@ namespace Web.AnalyticsWeb.Models
 
         [JsonProperty("teamIdsToDeauth")]
         public List<string> TeamIdsToDeauth { get; set; }
-
-        [JsonProperty("token")]
-        public string Token { get; set; }
     }
 }

--- a/src/AnalyticsEngine/Web/Scripts/portal/README.md
+++ b/src/AnalyticsEngine/Web/Scripts/portal/README.md
@@ -56,6 +56,38 @@ longer resolves (`AADSTS5000224`), so it could not sign anyone in — it only re
 failure with an opaque popup error, while adding `@azure/msal-browser` to the initial bundle for
 every page. The Teams permissions page now explains what to do instead when no token is available.
 
+### Expired sessions
+
+Every call to the site's own API goes through `apiFetch` (`src/api/http.ts`) rather than raw
+`fetch`. That exists because of how an expired session used to surface: the OIDC middleware runs
+in Active mode, so it turns the 401 from an `[Authorize]`'d controller into a **302 to
+login.microsoftonline.com**. A top-level navigation follows that happily, but `fetch` follows it
+cross-origin, the login page carries no CORS headers, and the call rejects with an opaque
+`TypeError: Failed to fetch`. Leave the portal open long enough — or let the App Service recycle,
+so the new instance can't decrypt the old auth cookie — and every page started failing with a
+network-looking error that was really just "please sign in again".
+
+`Startup.ConfigureAuth` now suppresses that redirect for API requests (matched by the `/api` path
+or the `X-Requested-With: XMLHttpRequest` header `apiFetch` always sends) and returns a plain
+`401` carrying `X-Auth-Session-Expired: true`. `apiFetch` watches for that header and
+re-authenticates with a full-page navigation, which is the only thing that can complete the OIDC
+round-trip — and normally completes silently, because the user's Entra session outlives the
+site's. The current hash route is stashed first and restored by `restoreRouteAfterReauth()` in
+`main.tsx`, so the user lands back where they were, and a `sessionStorage` flag makes it one-shot
+so a session that can't be re-established fails loudly instead of looping.
+
+The header matters: a bare 401 is **not** enough to conclude the session is gone. `SiteTokenAPI`
+returns 401 to mean "you are signed in, but I have no Graph refresh token for you" — the server
+only sets the header when there is genuinely no authenticated user, so that case still shows the
+Teams page's specific message instead of bouncing through a pointless sign-in.
+
+Graph access tokens are fetched at the point of use (`src/auth/siteToken.ts`), never cached on a
+page, because they only last about an hour and the pages that need them are ones an admin leaves
+open. They are used for the SPA's **direct** calls to `graph.microsoft.com` (the Teams page's
+profile and joined-teams lookups). The Teams authorisation save does **not** send one:
+`TeamsAuthAPIController.Put` authorises each Team with the refresh token it already holds in the
+auth cookie, so a token in the request body would be ignored.
+
 ## Backend APIs used
 
 | Window var | Endpoint | Purpose |
@@ -77,8 +109,8 @@ npm run dev      # Vite dev server (http://localhost:5173)
 ```
 
 When running the Vite dev server in isolation the backend APIs are not available, so the
-Home and User Lookup pages will report an API error and the Teams page falls back to
-client-side MSAL sign-in - that is expected outside the ASP.NET host.
+Home and User Lookup pages will report an API error and the Teams page reports that no Graph
+token could be obtained - that is expected outside the ASP.NET host.
 
 ## Production build
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/copilotAdoptionApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/copilotAdoptionApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type {
   AdoptionFilterOptions,
   CopilotAdoptionAvailability,
@@ -12,9 +13,8 @@ const baseUrl = (): string =>
   window.o365AnalyticsCopilotAdoptionAPI ?? `${window.location.origin}/api/CopilotAdoption`;
 
 async function getJson<T>(path: string, what: string): Promise<T> {
-  const response = await fetch(`${baseUrl()}${path}`, {
+  const response = await apiFetch(`${baseUrl()}${path}`, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/healthApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/healthApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type {
   HealthSummary,
   DataOverviewSection,
@@ -11,9 +12,8 @@ const baseUrl = (): string => window.o365AnalyticsHealthAPI ?? `${window.locatio
 
 /** GETs a Health sub-section and parses JSON, throwing a friendly error on a non-200. */
 async function getSection<T>(path: string, label: string): Promise<T> {
-  const response = await fetch(`${baseUrl()}/${path}`, {
+  const response = await apiFetch(`${baseUrl()}/${path}`, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/http.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/http.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared fetch wrapper for the portal's calls to the site's own `[Authorize]`'d API.
+ *
+ * Why this exists: the site signs the admin in with a server-side OIDC redirect and keeps the
+ * session in an encrypted auth cookie. When that session ends - it expires, or the App Service
+ * recycles and the new instance can't decrypt the old cookie - the next API call is no longer
+ * authenticated. The OIDC middleware runs in Active mode, so it answers with a 302 to
+ * login.microsoftonline.com; `fetch` follows that cross-origin, the login page carries no CORS
+ * headers, and the call rejects with an opaque `TypeError: Failed to fetch`. Leave the portal open
+ * long enough and every page starts failing with a network-looking error that is really just
+ * "please sign in again", and nothing recovers until the user reloads by hand.
+ *
+ * `Startup.ConfigureAuth` now suppresses that redirect for API requests and returns a plain 401
+ * with the `X-Auth-Session-Expired` header instead. This helper watches for it and re-authenticates
+ * with a full-page navigation, which is the one thing that CAN complete the OIDC round-trip - and
+ * usually completes silently, because the user's Entra session normally outlives the site's.
+ *
+ * The header matters: a bare 401 is NOT enough to conclude the session is gone. `SiteTokenAPI`
+ * returns 401 to mean "you are signed in, but I have no Graph refresh token for you", and the Teams
+ * page shows a specific message for that. Only the header-flagged 401 triggers a sign-in.
+ */
+
+/** Set by the server on the 401 that replaces the sign-in redirect. Keep in step with `Startup.SessionExpiredHeader`. */
+const SESSION_EXPIRED_HEADER = 'X-Auth-Session-Expired';
+
+/** One-shot guard, so a session that cannot be re-established fails loudly instead of looping. */
+const REAUTH_FLAG = 'portal:reauth-attempted';
+
+/** Where the user was, so re-authenticating doesn't dump them back on the default page. */
+const RETURN_ROUTE_KEY = 'portal:return-route';
+
+/**
+ * Set once this document starts navigating to sign-in.
+ *
+ * Pages fire several API calls in parallel, so a request that was already in flight can complete
+ * *after* re-authentication has begun - a long-running query, or one served by an instance that
+ * could still read the cookie. Without this, that late success would clear the one-shot flag below
+ * before the document unloaded, re-arming the bounce and defeating the loop guard. Module state is
+ * the right scope: it dies with the document, so the freshly loaded page starts clean.
+ */
+let reauthNavigationStarted = false;
+
+/**
+ * Handed to every caller once the sign-in navigation has begun. It deliberately never settles: the
+ * document is on its way out, so no caller should render an error - or anything else - over a page
+ * that is being replaced.
+ */
+const NEVER_SETTLES: Promise<Response> = new Promise<Response>(() => {});
+
+/** Thrown when the session has expired and re-authenticating has already been tried once. */
+export class SessionExpiredError extends Error {
+  constructor() {
+    super('Your session has expired. Reload the page to sign in again.');
+    this.name = 'SessionExpiredError';
+  }
+}
+
+/**
+ * Restores the route the user was on before an expired session bounced them through sign-in.
+ * Called once from the app entry point, before the router reads the URL.
+ *
+ * The SPA uses HashRouter, so the route lives in the fragment and never reaches the server - the
+ * OIDC round-trip always lands back on the default page. Stashing it is the only way to return the
+ * user to where they were.
+ */
+export function restoreRouteAfterReauth(): void {
+  const saved = sessionStorage.getItem(RETURN_ROUTE_KEY);
+  sessionStorage.removeItem(RETURN_ROUTE_KEY);
+
+  if (saved && saved !== window.location.hash) {
+    window.location.hash = saved;
+  }
+}
+
+function reauthenticate(): void {
+  reauthNavigationStarted = true;
+  sessionStorage.setItem(REAUTH_FLAG, '1');
+
+  if (window.location.hash) {
+    sessionStorage.setItem(RETURN_ROUTE_KEY, window.location.hash);
+  }
+
+  // A full-page navigation, not a fetch: only a top-level request can follow the redirect to Entra
+  // and back. '/' is [Authorize]'d, so it triggers the sign-in the failed API call could not.
+  window.location.assign('/');
+}
+
+/**
+ * `fetch` for the site's own API. Always sends the auth cookie, marks the call as an XHR so the
+ * server answers with 401 rather than a sign-in redirect, and transparently re-authenticates a
+ * session that has expired.
+ *
+ * On an expired session the returned promise deliberately never settles - the page is navigating
+ * away, so callers must not render an error for a request that is being retried by the sign-in.
+ */
+export async function apiFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const response = await fetch(input, {
+    credentials: 'same-origin',
+    ...init,
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest',
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (response.status === 401 && response.headers.get(SESSION_EXPIRED_HEADER)) {
+    // A sibling request may already have started the navigation - pages fire several calls at once.
+    if (reauthNavigationStarted) {
+      return NEVER_SETTLES;
+    }
+
+    if (sessionStorage.getItem(REAUTH_FLAG) === null) {
+      reauthenticate();
+      return NEVER_SETTLES;
+    }
+
+    // This document came back FROM a sign-in and the session is still gone, so signing in again
+    // would only loop. Surface it so the user sees a real error instead of a blank page.
+    throw new SessionExpiredError();
+  }
+
+  // A response that got through means the session is healthy, so let a later expiry have its own
+  // sign-in attempt. Skipped once we're navigating away, so a late in-flight success can't re-arm
+  // the guard for the document that is already on its way to sign-in.
+  if (!reauthNavigationStarted) {
+    sessionStorage.removeItem(REAUTH_FLAG);
+  }
+
+  return response;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/installLogApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/installLogApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { InstallLogEntry } from '../types/installLog';
 
 const baseUrl = (): string =>
@@ -5,9 +6,8 @@ const baseUrl = (): string =>
 
 /** Fetch the install log (config history from sys_configs), newest first. */
 export async function fetchInstallLog(): Promise<InstallLogEntry[]> {
-  const response = await fetch(baseUrl(), {
+  const response = await apiFetch(baseUrl(), {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/profilingStatusApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/profilingStatusApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { ProfilingStatus, TraceLogPage } from '../types/profilingStatus';
 
 const baseUrl = (): string =>
@@ -5,9 +6,8 @@ const baseUrl = (): string =>
 
 /** Fetch profiling data-freshness (earliest/latest dates for the profiling & source tables). */
 export async function fetchProfilingStatus(): Promise<ProfilingStatus> {
-  const response = await fetch(baseUrl(), {
+  const response = await apiFetch(baseUrl(), {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 
@@ -21,9 +21,8 @@ export async function fetchProfilingStatus(): Promise<ProfilingStatus> {
 /** Fetch a page of profiling.TraceLogs (newest first). Page is zero-based. */
 export async function fetchTraceLogs(page: number, pageSize: number): Promise<TraceLogPage> {
   const url = `${baseUrl()}/tracelogs?page=${encodeURIComponent(page)}&pageSize=${encodeURIComponent(pageSize)}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/reportsApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/reportsApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { ReportAreaData, ReportAreaKey, ReportAreas } from '../types/reports';
 
 const baseUrl = (): string =>
@@ -5,9 +6,8 @@ const baseUrl = (): string =>
 
 /** Which report areas are enabled for this deployment (drives the visible sub-tabs). */
 export async function fetchReportAreas(): Promise<ReportAreas> {
-  const response = await fetch(`${baseUrl()}/areas`, {
+  const response = await apiFetch(`${baseUrl()}/areas`, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 
@@ -34,9 +34,8 @@ export async function fetchReportArea(
   if (options?.agentName) params.set('agentName', options.agentName);
 
   const url = `${baseUrl()}/${area}?${params.toString()}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/systemStatusApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/systemStatusApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { SystemStatus } from '../types/systemStatus';
 
 const baseUrl = (): string =>
@@ -5,9 +6,8 @@ const baseUrl = (): string =>
 
 /** Fetch the system status (counts + configuration) shown on the Home page. */
 export async function fetchSystemStatus(): Promise<SystemStatus> {
-  const response = await fetch(baseUrl(), {
+  const response = await apiFetch(baseUrl(), {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/updateCheckApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/updateCheckApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { UpdateCheck } from '../types/updateCheck';
 
 const baseUrl = (): string => window.o365AnalyticsUpdateCheckAPI ?? `${window.location.origin}/api/UpdateCheck`;
@@ -9,9 +10,8 @@ const baseUrl = (): string => window.o365AnalyticsUpdateCheckAPI ?? `${window.lo
  * briefly, so repeated presses don't burn GitHub's anonymous rate limit (which the installer shares).
  */
 export async function fetchUpdateCheck(): Promise<UpdateCheck> {
-  const response = await fetch(baseUrl(), {
+  const response = await apiFetch(baseUrl(), {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/userLookupApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/userLookupApi.ts
@@ -1,12 +1,12 @@
+import { apiFetch } from './http';
 import type { UserDataSummary, UserDataDetailResponse } from '../types/userData';
 
 const baseUrl = (): string =>
   window.o365AnalyticsUserLookupAPI ?? `${window.location.origin}/api/UserDataLookup`;
 
 async function getJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/auth/siteToken.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/auth/siteToken.ts
@@ -1,0 +1,43 @@
+import { apiFetch } from '../api/http';
+import type { GraphAccessToken } from '../types/graphToken';
+
+/**
+ * Gets a Microsoft Graph access token for the signed-in admin from `POST api/SiteTokenAPI`.
+ *
+ * Used for the SPA's **direct** calls to `graph.microsoft.com` (the Teams page's profile and
+ * joined-teams lookups). It is deliberately NOT used for the Teams authorisation save: that goes to
+ * this site's own API, and `TeamsAuthAPIController.Put` authorises each Team with the refresh token
+ * it already holds in the auth cookie, so a token in the request body would simply be ignored.
+ *
+ * Always asks the server for a fresh token rather than caching one on the page. Graph access tokens
+ * last roughly an hour, so a token minted when a page mounted can easily be dead by the time the
+ * admin acts on it. The server mints a new one from the long-lived refresh token on every call, so
+ * fetching at the point of use is both correct and cheap.
+ *
+ * Returns `null` when the site is signed in but has no Graph refresh token for this session (the
+ * caller shows a "sign out and back in" message). A genuinely expired *site* session is handled by
+ * {@link apiFetch}, which re-authenticates instead of returning.
+ */
+export async function fetchGraphToken(): Promise<GraphAccessToken | null> {
+  // Undefined when the SPA runs outside ASP.NET (the Vite dev server), where there is no token API.
+  if (!window.o365AnalyticsTokenAPI) {
+    console.error("Couldn't get server-side OAuth token from website: no token endpoint configured.");
+    return null;
+  }
+
+  const response = await apiFetch(window.o365AnalyticsTokenAPI, { method: 'POST' }).catch((error: unknown) => {
+    console.error("Couldn't get server-side OAuth token from website.");
+    console.error(error);
+    return null;
+  });
+
+  if (!response || !response.ok) {
+    return null;
+  }
+
+  return response.json().catch((error: unknown) => {
+    console.error('Error deserialising server-side OAuth token:');
+    console.error(error);
+    return null;
+  }) as Promise<GraphAccessToken | null>;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/teams/TeamList.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/teams/TeamList.tsx
@@ -12,6 +12,7 @@ import { TeamAuthStatusResponse, TeamAuthStatus, AuthTokenResponse } from '../..
 import ConfirmSelection from './ConfirmSelection';
 import type { Team } from '@microsoft/microsoft-graph-types';
 import toast from '../toast';
+import { apiFetch } from '../../api/http';
 
 type TeamListProps = {
   teamsList: Array<Team>;
@@ -192,9 +193,8 @@ export default class TeamList extends React.Component<TeamListProps, TeamListSta
 
     // Is the ASP.Net API defined? If we're debugging from the react app only, it won't be.
     if (window.o365AnalyticsAuthAPI) {
-      const response = await fetch(window.o365AnalyticsAuthAPI, {
+      const response = await apiFetch(window.o365AnalyticsAuthAPI, {
         method: 'POST',
-        credentials: 'same-origin',
         headers: {
           'Content-Type': 'application/json',
           Accept: 'application/json',
@@ -234,15 +234,15 @@ export default class TeamList extends React.Component<TeamListProps, TeamListSta
   async authSelectedTeams() {
     this.setState({ isBusy: true });
 
+    // No Graph token is sent: the server authorises each Team with the refresh token it holds in
+    // the auth cookie (see TeamsAuthAPIController.Put), so a token in the body would be ignored.
     const body = {
       teamIdsToAuth: this.state.teamIdsToAuth,
       teamIdsToDeauth: this.state.teamIdsToDeauth,
-      token: window.o365AnalyticsTeamsToken.accessToken,
     };
 
-    fetch(window.o365AnalyticsAuthAPI, {
+    return apiFetch(window.o365AnalyticsAuthAPI, {
       method: 'PUT',
-      credentials: 'same-origin',
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/global.d.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/global.d.ts
@@ -1,11 +1,7 @@
-import type { GraphAccessToken } from './types/graphToken';
-
 // Runtime configuration injected by the host page (index.html / the ASP.NET site).
 // Centralised here so individual components don't each re-declare the Window shape.
 declare global {
   interface Window {
-    /** Graph token for the signed-in admin, stashed for the Teams auth PUT call. */
-    o365AnalyticsTeamsToken: GraphAccessToken;
     /** POST endpoint that returns the server-side delegated OAuth token. */
     o365AnalyticsTokenAPI: string;
     /** Endpoint for getting/setting Teams deep-analytics authorisation. */

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/main.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/main.tsx
@@ -3,12 +3,17 @@ import { createRoot } from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 import { FluentProvider, webLightTheme } from '@fluentui/react-components';
 import App from './App';
+import { restoreRouteAfterReauth } from './api/http';
 import './index.css';
 
 const container = document.getElementById('root');
 if (!container) {
   throw new Error('Root container #root not found');
 }
+
+// If an expired session sent the user through sign-in, put them back on the page they were on.
+// Must run before HashRouter reads the URL.
+restoreRouteAfterReauth();
 
 createRoot(container).render(
   <StrictMode>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/TeamsPermissionsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/TeamsPermissionsPage.tsx
@@ -4,6 +4,7 @@ import TeamList from '../components/teams/TeamList';
 import Spinner from '../components/Spinner';
 import { GraphResponse } from '../types/GraphResponse';
 import { fetchMsGraph, GRAPH_ENDPOINTS } from '../auth/graph';
+import { fetchGraphToken } from '../auth/siteToken';
 import type { GraphAccessToken } from '../types/graphToken';
 import type { User, Team } from '@microsoft/microsoft-graph-types';
 
@@ -14,7 +15,6 @@ type TeamsPermissionsState = {
   noToken: boolean;
   joinedTeams: Array<Team> | null;
   graphProfile: User | null;
-  serverSideToken: GraphAccessToken | null;
 };
 
 /**
@@ -27,6 +27,9 @@ type TeamsPermissionsState = {
  * There used to be a second, client-side MSAL sign-in path for when that call failed. It was
  * removed: it was pinned to a hard-coded app registration that no longer resolves, so it could
  * not sign anyone in - it only replaced a clear failure with an opaque one.
+ *
+ * Tokens are fetched at the point of use rather than cached on the page, because a Graph access
+ * token only lasts about an hour and this page is one an admin leaves open.
  */
 export default class TeamsPermissionsPage extends React.Component<{}, TeamsPermissionsState> {
   constructor(props: {}) {
@@ -37,14 +40,10 @@ export default class TeamsPermissionsPage extends React.Component<{}, TeamsPermi
       noToken: false,
       joinedTeams: null,
       graphProfile: null,
-      serverSideToken: null,
     };
   }
 
   async loadTeamsData(tokenResponse: GraphAccessToken) {
-    // Save token for API call
-    window.o365AnalyticsTeamsToken = tokenResponse;
-
     // Get profile
     const graphProfile: User = await fetchMsGraph(GRAPH_ENDPOINTS.ME, tokenResponse.accessToken).catch(() => {
       this.setState({ error: 'Unable to fetch Graph profile.' });
@@ -61,29 +60,13 @@ export default class TeamsPermissionsPage extends React.Component<{}, TeamsPermi
   // React events
   async componentDidMount() {
     // Ask the site for a Graph token for the signed-in admin.
-    const serverSideTokenResponse = await fetch(window.o365AnalyticsTokenAPI, {
-      method: 'POST',
-      credentials: 'same-origin',
-    }).catch((error) => {
-      // Expected when running the SPA outside ASP.NET (e.g. the Vite dev server).
-      console.error("Couldn't get server-side OAuth token from website.");
-      console.error(error);
-    });
-
-    let serverSideToken: GraphAccessToken | null = null;
-    if (serverSideTokenResponse && serverSideTokenResponse.ok) {
-      serverSideToken = await serverSideTokenResponse.json().catch((error: unknown) => {
-        console.error('Error deserialising server-side OAuth token:');
-        console.error(error);
-      });
-    }
+    const serverSideToken = await fetchGraphToken();
 
     if (!serverSideToken) {
       this.setState({ loading: false, noToken: true });
       return;
     }
 
-    this.setState({ serverSideToken });
     return this.loadTeamsData(serverSideToken);
   }
 


### PR DESCRIPTION
## Scope

Makes the portal recover from an expired site session instead of failing with an opaque network error, and stops caching a short-lived Graph token on a long-lived page.

Addresses #350.

## Problem

Admins sign in via a server-side OIDC redirect; the session lives in an encrypted OWIN auth cookie. When that session ends the next API call is unauthenticated, and two things combined to make that fail badly:

1. The OIDC middleware runs in **Active** mode, so it converts the `401` from an `[Authorize]`'d controller into a **`302` to `login.microsoftonline.com`**.
2. The SPA called its API with plain `fetch(..., { credentials: 'same-origin' })`. `fetch` follows redirects, so it followed that `302` cross-origin; the Entra login page carries no CORS headers, so the call rejected with `TypeError: Failed to fetch`.

None of the 12 `fetch` calls in `src/api/*.ts` handled this — they only checked `response.ok`, which never ran. So a recoverable "please sign in again" surfaced as a permanent, network-looking error that only a manual reload fixed.

The session can end from cookie expiry **or** from an App Service instance recycle, where the new instance can't decrypt a cookie encrypted with the previous instance's machine key. The latter is why this felt random rather than time-based.

There was a second-order effect: because the middleware turned *any* `401` into a redirect, the `401` that `SiteTokenAPIController` raises to mean "no Graph refresh token for this session" also never reached the SPA — the Teams page's `noToken` message was unreachable.

## Changes

### Server — `Web/App_Start/Startup.Auth.cs`

**`RedirectToIdentityProvider` notification.** For API requests, suppresses the sign-in redirect via `HandleResponse()` and leaves a plain `401`. It sets `X-Auth-Session-Expired: true` **only** when there is genuinely no authenticated user, so `SiteTokenAPI`'s deliberate `401` stays distinguishable and keeps its own message instead of bouncing the admin through a pointless sign-in.

**`ApiSafeCookieManager`.** Suppressing the redirect is not sufficient on its own. In Katana 4.2.3, `ApplyResponseChallengeAsync` calls `AddNonceToMessage()` — which writes an `OpenIdConnect.nonce.*` cookie — **before** invoking the notification:

```csharp
if (Options.ProtocolValidator.RequireNonce) { AddNonceToMessage(openIdConnectMessage); }
...
await Options.Notifications.RedirectToIdentityProvider(notification);
if (!notification.HandledResponse) { ... Response.Redirect(redirectUri); }
```

So `HandleResponse()` cancels the redirect but cannot un-write the cookie. Every suppressed challenge would leave an orphan nonce cookie that nothing ever consumes (~15 min lifetime). A page firing several parallel API calls drops several per attempt, and because this site's auth cookie already carries the Graph refresh token, the accumulated `Cookie` header can grow past IIS/proxy limits — turning a recoverable session expiry into a `400 Request Too Large` that the user can only escape by clearing cookies.

A decorating `ICookieManager` drops those writes for API requests only; reads, deletes and all non-API requests are untouched. It **wraps `app.GetDefaultCookieManager()`** rather than constructing a manager, because Katana does `Options.CookieManager ??= app.GetDefaultCookieManager()` and `Microsoft.Owin.Host.SystemWeb` registers a System.Web-integrated manager there — hard-coding a replacement would quietly alter the successful sign-in path.

**Request classification.** `IsApiRequest` prefers `X-Requested-With: XMLHttpRequest` and explicitly **excludes top-level document navigations** (`Sec-Fetch-Mode: navigate` / `Sec-Fetch-Dest: document`) before falling back to the `/api` path rule. This matters: the Copilot adoption CSV and workbook exports are plain `<a href>` links to `[Authorize]`'d `/api/CopilotAdoption/**` routes (`LicensedUsersPanel.tsx:304`, `OpportunitiesPanel.tsx:268`, `CopilotAdoptionPage.tsx:299`). The browser *is* navigating there, so those must still redirect to sign-in and then deliver the download rather than land on a bare `401`.

### Portal — `Web/Scripts/portal/`

**`src/api/http.ts` (new).** `apiFetch` wraps every call to the site's own API: sends `X-Requested-With`, and on the header-flagged `401` re-authenticates with a full-page navigation — the only thing that can complete the OIDC round-trip, and normally silent because the Entra session outlives the site's. The hash route is stashed and restored by `restoreRouteAfterReauth()` in `main.tsx` (HashRouter means the route never reaches the server, so the OIDC round-trip would otherwise always dump the admin on the default page). A `sessionStorage` flag makes it one-shot; a module-level flag stops a late in-flight success re-arming that guard for a document already navigating away; concurrent siblings get a never-settling promise so they can't render errors over a page being replaced.

**Graph tokens at point of use — `src/auth/siteToken.ts` (new).** `fetchGraphToken()` mints a fresh token per call instead of caching one on the page in `window.o365AnalyticsTeamsToken` (global removed). Tokens last ~1h and the Teams page is one admins leave open. These are for the SPA's **direct** `graph.microsoft.com` calls.

**Dead token field removed.** `TeamsAuthAPIController.Put` never read `authTeamData.Token` — it authorises each Team from the refresh token in the auth cookie. The field is removed from the request body and from `AuthTeamRequest`.

## Review history

This went through three rounds of adversarial review. Five defects were found; **three were introduced by a previous round's fix**, which is why the loop ran to a clean round:

| Round | Defect | Consequence if shipped |
| --- | --- | --- |
| 1 | `HandleResponse()` can't prevent the nonce cookie | Orphan cookies accumulate → `400 Request Too Large`, unrecoverable without clearing cookies |
| 1 | Minting a Graph token at submit time gated the Teams Save on a token the server ignores | **Would have blocked a Save that previously succeeded** — breaking the page the change was meant to help |
| 1 | A late in-flight success cleared the one-shot re-auth guard | Guard re-armed, repeated sign-in bounces |
| 2 | Hard-coded `new CookieManager()` replaced the host's `SystemWebCookieManager` | Silent change to the successful sign-in path |
| 2 | `/api` path rule caught `<a href>` export links | **Regression**: expired session + click Export → blank `401` instead of sign-in + download |

Round 3 returned clean.

## Testing

- `npm run build` (includes `tsc --noEmit`) — clean.
- `Web.csproj` — builds clean.
- **Bundle check**: entry chunk unchanged at **397.43 kB** before and after (verified by building `dev` and this branch and comparing). The shared async chunk is just renamed `Spinner-*` → `http-*` and grows 0.8 kB, which is the new module.

Not covered by automated tests: the portal has no test runner (`lint` is `tsc --noEmit`), and the OWIN pipeline behaviour needs a hosted request. The session-expiry and export paths are the two worth exercising manually — see below.

## Schema / config effects

- **No database migration.**
- **No installer config-schema change** — no persisted property added, so `CONFIG_VERSION` is unchanged.
- Web-app only; importers and installer untouched.

## Reviewer hotspots

1. **`IsApiRequest` ordering** (`Startup.Auth.cs`) — it decides both whether to suppress the redirect *and* whether to drop the nonce cookie. The two must agree for a given request; a disagreement either way is a bug (orphan cookie, or a real sign-in losing its nonce).
2. **The `X-Auth-Session-Expired` discriminator** — the whole design rests on `Authentication.User.Identity.IsAuthenticated` telling "session gone" apart from "signed in but no Graph token". This holds because the cookie middleware is registered first and authenticates before controllers run; it would stop holding if another host auth (Windows auth, App Service Easy Auth) ever supplied a principal.
3. **Export links** — worth manually confirming that, with an expired session, clicking *Export CSV* still signs in and delivers the file rather than showing a bare 401.

## Manual verification suggested

1. Sign in, leave a tab open, invalidate the session (recycle the App Service or clear the auth cookie), then use the portal → expect a silent re-auth landing back on the same page, not `Failed to fetch`.
2. Same expired state, click **Export CSV** / **Export workbook** → expect sign-in then the download.
3. Confirm no `OpenIdConnect.nonce.*` cookies accumulate in devtools after several expired API calls.
