### PR TITLE
Stable release: blob checkpoint RBAC for hardened storage accounts, and portal recovery from expired sessions

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/ResourceSecurityInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/ResourceSecurityInstallJob.cs
@@ -14,6 +14,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
     {
         private readonly RoleAssignmentTask _appInsightsReaderRoleTask;
         private readonly RoleAssignmentTask _storageBlobDataContributorRoleTask;
+        private readonly RoleAssignmentTask _storageTableDataContributorRoleTask;
         private readonly RoleAssignmentTask _redisCacheContributorRoleTask;
         private readonly RoleAssignmentTask _cognitiveServicesUserRoleTask;
         private readonly RoleAssignmentTask _serviceBusDataOwnerRoleTask;
@@ -41,6 +42,22 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
             _storageBlobDataContributorRoleTask = new RoleAssignmentTask(storageBlobContributorConfig, logger, Location, tagDic);
             this.AddTask(_storageBlobDataContributorRoleTask);
+
+            // Assign "Storage Table Data Contributor" to the runtime account for Table data-plane access.
+            // The audit-import blob checkpoint (ProcessedBlobStoreFactory / AzureTableProcessedBlobStore) lives in
+            // Azure Table storage. Accounts hardened with allowSharedKeyAccess = false - increasingly the default
+            // under enterprise governance policy - reject the connection-string client with
+            // "403 KeyBasedAuthenticationNotPermitted", so the importer falls back to RBAC via ClientSecretCredential.
+            // "Storage Blob Data Contributor" above does NOT cover the Table service, so without this role the
+            // fallback fails too and the checkpoint silently degrades to non-durable in-memory.
+            var storageTableContributorConfig = TaskConfig.GetConfigForPropAndVal(RoleAssignmentTask.CONFIG_KEY_ROLE_NAME, "Storage Table Data Contributor")
+                .AddSetting(RoleAssignmentTask.CONFIG_KEY_CLIENT_ID, config.RuntimeAccountOffice365.ClientId)
+                .AddSetting(RoleAssignmentTask.CONFIG_KEY_CLIENT_SECRET, config.RuntimeAccountOffice365.Secret)
+                .AddSetting(RoleAssignmentTask.CONFIG_KEY_TENANT_ID, config.RuntimeAccountOffice365.DirectoryId)
+                .AddSetting(RoleAssignmentTask.CONFIG_KEY_PRINCIPAL_TYPE, "ServicePrincipal");
+
+            _storageTableDataContributorRoleTask = new RoleAssignmentTask(storageTableContributorConfig, logger, Location, tagDic);
+            this.AddTask(_storageTableDataContributorRoleTask);
 
             // Assign Redis Cache Contributor role to the runtime account for RBAC-based Redis access (when keys are disabled)
             var redisCacheContributorConfig = TaskConfig.GetConfigForPropAndVal(RoleAssignmentTask.CONFIG_KEY_ROLE_NAME, "Redis Cache Contributor")
@@ -89,6 +106,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
         public RoleAssignmentResource AppInsightsReaderRole => GetTaskResult<RoleAssignmentResource>(_appInsightsReaderRoleTask);
         public RoleAssignmentResource StorageBlobDataContributorRole => GetTaskResult<RoleAssignmentResource>(_storageBlobDataContributorRoleTask);
+        public RoleAssignmentResource StorageTableDataContributorRole => GetTaskResult<RoleAssignmentResource>(_storageTableDataContributorRoleTask);
         public RoleAssignmentResource RedisCacheContributorRole => GetTaskResult<RoleAssignmentResource>(_redisCacheContributorRoleTask);
         public RoleAssignmentResource CognitiveServicesUserRole =>
             _cognitiveServicesUserRoleTask == null ? null : GetTaskResult<RoleAssignmentResource>(_cognitiveServicesUserRoleTask);

--- a/src/AnalyticsEngine/Tests.UnitTests/CheckpointTableClientFactoryTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CheckpointTableClientFactoryTests.cs
@@ -1,0 +1,131 @@
+using Azure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Covers how the audit blob checkpoint decides between shared-key and RBAC/Entra ID authentication for its
+    /// Azure Table store. Storage accounts with allowSharedKeyAccess = false return
+    /// "403 KeyBasedAuthenticationNotPermitted", which must route the importer to the runtime service principal
+    /// rather than degrading to the non-durable in-memory checkpoint.
+    /// </summary>
+    [TestClass]
+    public class CheckpointTableClientFactoryTests
+    {
+        // Obviously-fake, low-entropy account/key; never a real connection string.
+        private const string SharedKeyConnStr =
+            "DefaultEndpointsProtocol=https;AccountName=contosoanalytics;AccountKey=FAKEFAKEFAKEFAKEFAKEFAKE==;EndpointSuffix=core.windows.net";
+
+        [TestMethod]
+        public void GetTableEndpoint_ComposesFromAccountNameAndSuffix()
+        {
+            Assert.AreEqual(new Uri("https://contosoanalytics.table.core.windows.net"),
+                CheckpointTableClientFactory.GetTableEndpoint(SharedKeyConnStr));
+        }
+
+        /// <summary>Sovereign clouds use a different endpoint suffix, so it must never be hard-coded.</summary>
+        [TestMethod]
+        public void GetTableEndpoint_HonoursSovereignCloudSuffix()
+        {
+            var connStr = "DefaultEndpointsProtocol=https;AccountName=contosoanalytics;AccountKey=abc==;EndpointSuffix=core.usgovcloudapi.net";
+
+            Assert.AreEqual(new Uri("https://contosoanalytics.table.core.usgovcloudapi.net"),
+                CheckpointTableClientFactory.GetTableEndpoint(connStr));
+        }
+
+        /// <summary>An explicit TableEndpoint wins over the composed one (custom/private DNS).</summary>
+        [TestMethod]
+        public void GetTableEndpoint_PrefersExplicitTableEndpoint()
+        {
+            var connStr = "DefaultEndpointsProtocol=https;AccountName=contosoanalytics;AccountKey=abc==;" +
+                          "TableEndpoint=https://contosoanalytics.privatelink.table.core.windows.net/;EndpointSuffix=core.windows.net";
+
+            Assert.AreEqual(new Uri("https://contosoanalytics.privatelink.table.core.windows.net/"),
+                CheckpointTableClientFactory.GetTableEndpoint(connStr));
+        }
+
+        [TestMethod]
+        public void GetTableEndpoint_NoAccountName_ReturnsNull()
+        {
+            Assert.IsNull(CheckpointTableClientFactory.GetTableEndpoint("DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net"));
+            Assert.IsNull(CheckpointTableClientFactory.GetTableEndpoint(null));
+            Assert.IsNull(CheckpointTableClientFactory.GetTableEndpoint(string.Empty));
+        }
+
+        /// <summary>
+        /// An account key is base64 and routinely ends in '=' padding, so parsing must split on the FIRST '='
+        /// only - otherwise the key is silently truncated and shared-key auth breaks.
+        /// </summary>
+        [TestMethod]
+        public void HasAccountKey_DetectsBase64PaddedKey()
+        {
+            Assert.IsTrue(CheckpointTableClientFactory.HasAccountKey(SharedKeyConnStr));
+            Assert.IsTrue(CheckpointTableClientFactory.HasAccountKey("AccountName=contosoanalytics;AccountKey=YWJj=="));
+        }
+
+        /// <summary>An RBAC-only connection string names the account but carries no key.</summary>
+        [TestMethod]
+        public void HasAccountKey_FalseWhenAbsentOrBlank()
+        {
+            Assert.IsFalse(CheckpointTableClientFactory.HasAccountKey("DefaultEndpointsProtocol=https;AccountName=contosoanalytics;EndpointSuffix=core.windows.net"));
+            Assert.IsFalse(CheckpointTableClientFactory.HasAccountKey("AccountName=contosoanalytics;AccountKey="));
+            Assert.IsFalse(CheckpointTableClientFactory.HasAccountKey(null));
+        }
+
+        [TestMethod]
+        public void IsDevelopmentStorage_DetectsEmulator()
+        {
+            Assert.IsTrue(CheckpointTableClientFactory.IsDevelopmentStorage("UseDevelopmentStorage=true"));
+            Assert.IsFalse(CheckpointTableClientFactory.IsDevelopmentStorage(SharedKeyConnStr));
+        }
+
+        /// <summary>This is the exact error a storage account with allowSharedKeyAccess = false returns.</summary>
+        [TestMethod]
+        public void IsKeyAuthDisabled_TrueForKeyBasedAuthenticationNotPermitted()
+        {
+            Assert.IsTrue(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(403, "Key based authentication is not permitted on this storage account.", "KeyBasedAuthenticationNotPermitted", null)));
+            Assert.IsTrue(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(403, "Auth type disabled", "AuthenticationTypeDisabled", null)));
+        }
+
+        /// <summary>
+        /// A firewall / private-endpoint block also surfaces as 403, but retrying with a token would not help,
+        /// so it must NOT be treated as "key auth disabled".
+        /// </summary>
+        [TestMethod]
+        public void IsKeyAuthDisabled_FalseForOtherFailures()
+        {
+            Assert.IsFalse(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(403, "This request is not authorized to perform this operation.", "AuthorizationFailure", null)));
+            Assert.IsFalse(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(403, "Permission mismatch", "AuthorizationPermissionMismatch", null)));
+            Assert.IsFalse(CheckpointTableClientFactory.IsKeyAuthDisabled(
+                new RequestFailedException(404, "Not found", "ResourceNotFound", null)));
+            Assert.IsFalse(CheckpointTableClientFactory.IsKeyAuthDisabled(null));
+        }
+
+        /// <summary>
+        /// With no key AND no service principal there is nothing to authenticate with, so the store must throw
+        /// (letting ProcessedBlobStoreFactory fall back to in-memory) rather than hang or return a dead client.
+        /// </summary>
+        [TestMethod]
+        public void CreateAndEnsureTable_NoKeyAndNoServicePrincipal_Throws()
+        {
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                CheckpointTableClientFactory.CreateAndEnsureTable(
+                    "DefaultEndpointsProtocol=https;AccountName=contosoanalytics;EndpointSuffix=core.windows.net",
+                    "AuditImporterProcessedBlobs", null, null, null, null));
+        }
+
+        [TestMethod]
+        public void CreateAndEnsureTable_EmptyConnectionString_Throws()
+        {
+            Assert.ThrowsException<ArgumentException>(() =>
+                CheckpointTableClientFactory.CreateAndEnsureTable(string.Empty, "AuditImporterProcessedBlobs",
+                    "00000000-0000-0000-0000-000000000000", "client", "secret", null));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="PreInstallAdvisorTests.cs" />
     <Compile Include="ImportCadenceTests.cs" />
     <Compile Include="AppInsightsAuthTests.cs" />
+    <Compile Include="CheckpointTableClientFactoryTests.cs" />
     <Compile Include="CopilotAuditLogContentSchemaTests.cs" />
     <Compile Include="CopilotEventManagerAccessedResourcesTests.cs" />
     <Compile Include="CopilotEventManagerEdgeCaseTests.cs" />

--- a/src/AnalyticsEngine/Web/App_Start/Startup.Auth.cs
+++ b/src/AnalyticsEngine/Web/App_Start/Startup.Auth.cs
@@ -2,16 +2,27 @@
 using Common.Entities.Models;
 using Common.Entities.Redis;
 using Common.Entities.Redis.Auth;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OpenIdConnect;
 using Owin;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace Web.AnalyticsWeb
 {
     public partial class Startup
     {
+        /// <summary>
+        /// Response header set on the 401 that replaces the sign-in redirect for API calls, so the SPA can tell
+        /// "your session has expired, re-authenticate" apart from an authenticated-but-unauthorised 401 (e.g.
+        /// SiteTokenAPI reporting that it has no Graph refresh token for this session).
+        /// </summary>
+        public const string SessionExpiredHeader = "X-Auth-Session-Expired";
+
         public void ConfigureAuth(IAppBuilder app)
         {
             var config = new AppConfig();
@@ -41,8 +52,40 @@ namespace Web.AnalyticsWeb
                     {
                         ValidateIssuer = true
                     },
+                    // Stops the cancelled API challenges below leaving orphan nonce cookies behind.
+                    CookieManager = new ApiSafeCookieManager(app.GetDefaultCookieManager()),
                     Notifications = new OpenIdConnectAuthenticationNotifications()
                     {
+                        // An expired session must not turn an API call into a sign-in redirect.
+                        //
+                        // The OIDC middleware runs in Active mode, so it converts the 401 from an [Authorize]'d
+                        // controller into a 302 to login.microsoftonline.com. A top-level navigation handles that
+                        // fine, but the SPA's fetch() follows the redirect cross-origin, the login page carries no
+                        // CORS headers, and the call rejects with an opaque "TypeError: Failed to fetch" - so the
+                        // portal just breaks with no hint that the user simply needs to sign in again.
+                        //
+                        // For API requests we therefore suppress the redirect and leave the plain 401 in place.
+                        RedirectToIdentityProvider = context =>
+                        {
+                            if (context.ProtocolMessage.RequestType == OpenIdConnectRequestType.Authentication
+                                && IsApiRequest(context.OwinContext.Request))
+                            {
+                                context.HandleResponse();
+                                context.OwinContext.Response.StatusCode = 401;
+
+                                // Only flag it as an expired session when there is genuinely no signed-in user.
+                                // A 401 raised by a controller while the user IS signed in (SiteTokenAPI having
+                                // no Graph refresh token) must not bounce them through a pointless sign-in.
+                                var signedIn = context.OwinContext.Authentication?.User?.Identity?.IsAuthenticated == true;
+                                if (!signedIn)
+                                {
+                                    context.OwinContext.Response.Headers[SessionExpiredHeader] = "true";
+                                }
+                            }
+
+                            return Task.CompletedTask;
+                        },
+
                         // When AAD redirects back with an auth code, redeem it for tokens and stash
                         // the refresh token in the (encrypted, httpOnly) auth cookie so the SPA can
                         // get a Graph token via SiteTokenAPI without Redis. When Redis IS configured
@@ -71,6 +114,96 @@ namespace Web.AnalyticsWeb
                         }
                     }
                 });
+        }
+
+        /// <summary>
+        /// True for calls the SPA makes with fetch/XHR rather than a top-level navigation. Those must get a
+        /// status code they can act on, not a redirect to the identity provider they cannot follow.
+        /// </summary>
+        private static bool IsApiRequest(IOwinRequest request)
+        {
+            if (request == null) return false;
+
+            // The portal's apiFetch always sends this and a browser navigation never does, so it is the one
+            // unambiguous signal that a script is waiting for a status code.
+            if (string.Equals(request.Headers["X-Requested-With"], "XMLHttpRequest",
+                    System.StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // Otherwise fall back to the path - but NOT for a top-level navigation. The Copilot adoption CSV
+            // and workbook exports are plain <a href> links to [Authorize]'d /api routes, and they must still
+            // redirect to sign-in: the browser IS navigating, so it can follow the redirect and then deliver
+            // the download. Answering those with a bare 401 would just show the user a blank error page.
+            if (IsDocumentNavigation(request)) return false;
+
+            return request.Path.StartsWithSegments(new PathString("/api"));
+        }
+
+        /// <summary>
+        /// True when the browser is navigating the top-level document (a link, address bar or form post)
+        /// rather than making a background request.
+        /// </summary>
+        /// <remarks>
+        /// Uses the Fetch Metadata request headers, which every current browser sends. On a browser old
+        /// enough to omit them this returns false and the <c>/api</c> path rule applies as before.
+        /// </remarks>
+        private static bool IsDocumentNavigation(IOwinRequest request)
+        {
+            return string.Equals(request.Headers["Sec-Fetch-Mode"], "navigate",
+                       System.StringComparison.OrdinalIgnoreCase)
+                || string.Equals(request.Headers["Sec-Fetch-Dest"], "document",
+                       System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Cookie manager for the OIDC middleware that suppresses response cookies on API requests.
+        /// </summary>
+        /// <remarks>
+        /// Katana writes the OIDC nonce cookie in <c>AddNonceToMessage</c>, which runs BEFORE the
+        /// <c>RedirectToIdentityProvider</c> notification - so <c>HandleResponse()</c> cancels the redirect but
+        /// cannot un-write the cookie. Without this, every suppressed API challenge would leave an orphan
+        /// <c>OpenIdConnect.nonce.*</c> cookie behind that nothing ever consumes (they live ~15 minutes).
+        /// A page firing several parallel API calls would drop several per attempt, and because the auth cookie
+        /// on this site already carries the Graph refresh token, the accumulated Cookie header can grow past
+        /// IIS/proxy limits - turning a recoverable "please sign in again" into a 400 Request Too Large that
+        /// the user cannot get out of without clearing cookies.
+        ///
+        /// The only cookie the middleware writes on a challenge is that nonce, and for API requests the
+        /// challenge is cancelled, so dropping the write is exactly right. Reads and deletes are untouched, and
+        /// so is every non-API request - the sign-in redirect and its callback are top-level navigations, which
+        /// still get a real nonce and validate it normally.
+        ///
+        /// It decorates the host's own manager rather than constructing one: Katana does
+        /// <c>Options.CookieManager ??= app.GetDefaultCookieManager()</c>, and under
+        /// <c>Microsoft.Owin.Host.SystemWeb</c> that default integrates with System.Web's cookie collection.
+        /// Hard-coding a replacement would quietly change behaviour on the successful sign-in path.
+        /// </remarks>
+        private sealed class ApiSafeCookieManager : ICookieManager
+        {
+            private readonly ICookieManager _inner;
+
+            public ApiSafeCookieManager(ICookieManager inner)
+            {
+                _inner = inner ?? new CookieManager();
+            }
+
+            public string GetRequestCookie(IOwinContext context, string key)
+                => _inner.GetRequestCookie(context, key);
+
+            public void AppendResponseCookie(IOwinContext context, string key, string value, CookieOptions options)
+            {
+                if (IsApiRequest(context?.Request))
+                {
+                    return;
+                }
+
+                _inner.AppendResponseCookie(context, key, value, options);
+            }
+
+            public void DeleteCookie(IOwinContext context, string key, CookieOptions options)
+                => _inner.DeleteCookie(context, key, options);
         }
     }
 }

--- a/src/AnalyticsEngine/Web/Models/AuthTeamRequest.cs
+++ b/src/AnalyticsEngine/Web/Models/AuthTeamRequest.cs
@@ -11,8 +11,5 @@ namespace Web.AnalyticsWeb.Models
 
         [JsonProperty("teamIdsToDeauth")]
         public List<string> TeamIdsToDeauth { get; set; }
-
-        [JsonProperty("token")]
-        public string Token { get; set; }
     }
 }

--- a/src/AnalyticsEngine/Web/Scripts/portal/README.md
+++ b/src/AnalyticsEngine/Web/Scripts/portal/README.md
@@ -56,6 +56,38 @@ longer resolves (`AADSTS5000224`), so it could not sign anyone in — it only re
 failure with an opaque popup error, while adding `@azure/msal-browser` to the initial bundle for
 every page. The Teams permissions page now explains what to do instead when no token is available.
 
+### Expired sessions
+
+Every call to the site's own API goes through `apiFetch` (`src/api/http.ts`) rather than raw
+`fetch`. That exists because of how an expired session used to surface: the OIDC middleware runs
+in Active mode, so it turns the 401 from an `[Authorize]`'d controller into a **302 to
+login.microsoftonline.com**. A top-level navigation follows that happily, but `fetch` follows it
+cross-origin, the login page carries no CORS headers, and the call rejects with an opaque
+`TypeError: Failed to fetch`. Leave the portal open long enough — or let the App Service recycle,
+so the new instance can't decrypt the old auth cookie — and every page started failing with a
+network-looking error that was really just "please sign in again".
+
+`Startup.ConfigureAuth` now suppresses that redirect for API requests (matched by the `/api` path
+or the `X-Requested-With: XMLHttpRequest` header `apiFetch` always sends) and returns a plain
+`401` carrying `X-Auth-Session-Expired: true`. `apiFetch` watches for that header and
+re-authenticates with a full-page navigation, which is the only thing that can complete the OIDC
+round-trip — and normally completes silently, because the user's Entra session outlives the
+site's. The current hash route is stashed first and restored by `restoreRouteAfterReauth()` in
+`main.tsx`, so the user lands back where they were, and a `sessionStorage` flag makes it one-shot
+so a session that can't be re-established fails loudly instead of looping.
+
+The header matters: a bare 401 is **not** enough to conclude the session is gone. `SiteTokenAPI`
+returns 401 to mean "you are signed in, but I have no Graph refresh token for you" — the server
+only sets the header when there is genuinely no authenticated user, so that case still shows the
+Teams page's specific message instead of bouncing through a pointless sign-in.
+
+Graph access tokens are fetched at the point of use (`src/auth/siteToken.ts`), never cached on a
+page, because they only last about an hour and the pages that need them are ones an admin leaves
+open. They are used for the SPA's **direct** calls to `graph.microsoft.com` (the Teams page's
+profile and joined-teams lookups). The Teams authorisation save does **not** send one:
+`TeamsAuthAPIController.Put` authorises each Team with the refresh token it already holds in the
+auth cookie, so a token in the request body would be ignored.
+
 ## Backend APIs used
 
 | Window var | Endpoint | Purpose |
@@ -77,8 +109,8 @@ npm run dev      # Vite dev server (http://localhost:5173)
 ```
 
 When running the Vite dev server in isolation the backend APIs are not available, so the
-Home and User Lookup pages will report an API error and the Teams page falls back to
-client-side MSAL sign-in - that is expected outside the ASP.NET host.
+Home and User Lookup pages will report an API error and the Teams page reports that no Graph
+token could be obtained - that is expected outside the ASP.NET host.
 
 ## Production build
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/copilotAdoptionApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/copilotAdoptionApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type {
   AdoptionFilterOptions,
   CopilotAdoptionAvailability,
@@ -12,9 +13,8 @@ const baseUrl = (): string =>
   window.o365AnalyticsCopilotAdoptionAPI ?? `${window.location.origin}/api/CopilotAdoption`;
 
 async function getJson<T>(path: string, what: string): Promise<T> {
-  const response = await fetch(`${baseUrl()}${path}`, {
+  const response = await apiFetch(`${baseUrl()}${path}`, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/healthApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/healthApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type {
   HealthSummary,
   DataOverviewSection,
@@ -11,9 +12,8 @@ const baseUrl = (): string => window.o365AnalyticsHealthAPI ?? `${window.locatio
 
 /** GETs a Health sub-section and parses JSON, throwing a friendly error on a non-200. */
 async function getSection<T>(path: string, label: string): Promise<T> {
-  const response = await fetch(`${baseUrl()}/${path}`, {
+  const response = await apiFetch(`${baseUrl()}/${path}`, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/http.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/http.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared fetch wrapper for the portal's calls to the site's own `[Authorize]`'d API.
+ *
+ * Why this exists: the site signs the admin in with a server-side OIDC redirect and keeps the
+ * session in an encrypted auth cookie. When that session ends - it expires, or the App Service
+ * recycles and the new instance can't decrypt the old cookie - the next API call is no longer
+ * authenticated. The OIDC middleware runs in Active mode, so it answers with a 302 to
+ * login.microsoftonline.com; `fetch` follows that cross-origin, the login page carries no CORS
+ * headers, and the call rejects with an opaque `TypeError: Failed to fetch`. Leave the portal open
+ * long enough and every page starts failing with a network-looking error that is really just
+ * "please sign in again", and nothing recovers until the user reloads by hand.
+ *
+ * `Startup.ConfigureAuth` now suppresses that redirect for API requests and returns a plain 401
+ * with the `X-Auth-Session-Expired` header instead. This helper watches for it and re-authenticates
+ * with a full-page navigation, which is the one thing that CAN complete the OIDC round-trip - and
+ * usually completes silently, because the user's Entra session normally outlives the site's.
+ *
+ * The header matters: a bare 401 is NOT enough to conclude the session is gone. `SiteTokenAPI`
+ * returns 401 to mean "you are signed in, but I have no Graph refresh token for you", and the Teams
+ * page shows a specific message for that. Only the header-flagged 401 triggers a sign-in.
+ */
+
+/** Set by the server on the 401 that replaces the sign-in redirect. Keep in step with `Startup.SessionExpiredHeader`. */
+const SESSION_EXPIRED_HEADER = 'X-Auth-Session-Expired';
+
+/** One-shot guard, so a session that cannot be re-established fails loudly instead of looping. */
+const REAUTH_FLAG = 'portal:reauth-attempted';
+
+/** Where the user was, so re-authenticating doesn't dump them back on the default page. */
+const RETURN_ROUTE_KEY = 'portal:return-route';
+
+/**
+ * Set once this document starts navigating to sign-in.
+ *
+ * Pages fire several API calls in parallel, so a request that was already in flight can complete
+ * *after* re-authentication has begun - a long-running query, or one served by an instance that
+ * could still read the cookie. Without this, that late success would clear the one-shot flag below
+ * before the document unloaded, re-arming the bounce and defeating the loop guard. Module state is
+ * the right scope: it dies with the document, so the freshly loaded page starts clean.
+ */
+let reauthNavigationStarted = false;
+
+/**
+ * Handed to every caller once the sign-in navigation has begun. It deliberately never settles: the
+ * document is on its way out, so no caller should render an error - or anything else - over a page
+ * that is being replaced.
+ */
+const NEVER_SETTLES: Promise<Response> = new Promise<Response>(() => {});
+
+/** Thrown when the session has expired and re-authenticating has already been tried once. */
+export class SessionExpiredError extends Error {
+  constructor() {
+    super('Your session has expired. Reload the page to sign in again.');
+    this.name = 'SessionExpiredError';
+  }
+}
+
+/**
+ * Restores the route the user was on before an expired session bounced them through sign-in.
+ * Called once from the app entry point, before the router reads the URL.
+ *
+ * The SPA uses HashRouter, so the route lives in the fragment and never reaches the server - the
+ * OIDC round-trip always lands back on the default page. Stashing it is the only way to return the
+ * user to where they were.
+ */
+export function restoreRouteAfterReauth(): void {
+  const saved = sessionStorage.getItem(RETURN_ROUTE_KEY);
+  sessionStorage.removeItem(RETURN_ROUTE_KEY);
+
+  if (saved && saved !== window.location.hash) {
+    window.location.hash = saved;
+  }
+}
+
+function reauthenticate(): void {
+  reauthNavigationStarted = true;
+  sessionStorage.setItem(REAUTH_FLAG, '1');
+
+  if (window.location.hash) {
+    sessionStorage.setItem(RETURN_ROUTE_KEY, window.location.hash);
+  }
+
+  // A full-page navigation, not a fetch: only a top-level request can follow the redirect to Entra
+  // and back. '/' is [Authorize]'d, so it triggers the sign-in the failed API call could not.
+  window.location.assign('/');
+}
+
+/**
+ * `fetch` for the site's own API. Always sends the auth cookie, marks the call as an XHR so the
+ * server answers with 401 rather than a sign-in redirect, and transparently re-authenticates a
+ * session that has expired.
+ *
+ * On an expired session the returned promise deliberately never settles - the page is navigating
+ * away, so callers must not render an error for a request that is being retried by the sign-in.
+ */
+export async function apiFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const response = await fetch(input, {
+    credentials: 'same-origin',
+    ...init,
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest',
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (response.status === 401 && response.headers.get(SESSION_EXPIRED_HEADER)) {
+    // A sibling request may already have started the navigation - pages fire several calls at once.
+    if (reauthNavigationStarted) {
+      return NEVER_SETTLES;
+    }
+
+    if (sessionStorage.getItem(REAUTH_FLAG) === null) {
+      reauthenticate();
+      return NEVER_SETTLES;
+    }
+
+    // This document came back FROM a sign-in and the session is still gone, so signing in again
+    // would only loop. Surface it so the user sees a real error instead of a blank page.
+    throw new SessionExpiredError();
+  }
+
+  // A response that got through means the session is healthy, so let a later expiry have its own
+  // sign-in attempt. Skipped once we're navigating away, so a late in-flight success can't re-arm
+  // the guard for the document that is already on its way to sign-in.
+  if (!reauthNavigationStarted) {
+    sessionStorage.removeItem(REAUTH_FLAG);
+  }
+
+  return response;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/installLogApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/installLogApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { InstallLogEntry } from '../types/installLog';
 
 const baseUrl = (): string =>
@@ -5,9 +6,8 @@ const baseUrl = (): string =>
 
 /** Fetch the install log (config history from sys_configs), newest first. */
 export async function fetchInstallLog(): Promise<InstallLogEntry[]> {
-  const response = await fetch(baseUrl(), {
+  const response = await apiFetch(baseUrl(), {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/profilingStatusApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/profilingStatusApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { ProfilingStatus, TraceLogPage } from '../types/profilingStatus';
 
 const baseUrl = (): string =>
@@ -5,9 +6,8 @@ const baseUrl = (): string =>
 
 /** Fetch profiling data-freshness (earliest/latest dates for the profiling & source tables). */
 export async function fetchProfilingStatus(): Promise<ProfilingStatus> {
-  const response = await fetch(baseUrl(), {
+  const response = await apiFetch(baseUrl(), {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 
@@ -21,9 +21,8 @@ export async function fetchProfilingStatus(): Promise<ProfilingStatus> {
 /** Fetch a page of profiling.TraceLogs (newest first). Page is zero-based. */
 export async function fetchTraceLogs(page: number, pageSize: number): Promise<TraceLogPage> {
   const url = `${baseUrl()}/tracelogs?page=${encodeURIComponent(page)}&pageSize=${encodeURIComponent(pageSize)}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/reportsApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/reportsApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { ReportAreaData, ReportAreaKey, ReportAreas } from '../types/reports';
 
 const baseUrl = (): string =>
@@ -5,9 +6,8 @@ const baseUrl = (): string =>
 
 /** Which report areas are enabled for this deployment (drives the visible sub-tabs). */
 export async function fetchReportAreas(): Promise<ReportAreas> {
-  const response = await fetch(`${baseUrl()}/areas`, {
+  const response = await apiFetch(`${baseUrl()}/areas`, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 
@@ -34,9 +34,8 @@ export async function fetchReportArea(
   if (options?.agentName) params.set('agentName', options.agentName);
 
   const url = `${baseUrl()}/${area}?${params.toString()}`;
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/systemStatusApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/systemStatusApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { SystemStatus } from '../types/systemStatus';
 
 const baseUrl = (): string =>
@@ -5,9 +6,8 @@ const baseUrl = (): string =>
 
 /** Fetch the system status (counts + configuration) shown on the Home page. */
 export async function fetchSystemStatus(): Promise<SystemStatus> {
-  const response = await fetch(baseUrl(), {
+  const response = await apiFetch(baseUrl(), {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/updateCheckApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/updateCheckApi.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './http';
 import type { UpdateCheck } from '../types/updateCheck';
 
 const baseUrl = (): string => window.o365AnalyticsUpdateCheckAPI ?? `${window.location.origin}/api/UpdateCheck`;
@@ -9,9 +10,8 @@ const baseUrl = (): string => window.o365AnalyticsUpdateCheckAPI ?? `${window.lo
  * briefly, so repeated presses don't burn GitHub's anonymous rate limit (which the installer shares).
  */
 export async function fetchUpdateCheck(): Promise<UpdateCheck> {
-  const response = await fetch(baseUrl(), {
+  const response = await apiFetch(baseUrl(), {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/userLookupApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/userLookupApi.ts
@@ -1,12 +1,12 @@
+import { apiFetch } from './http';
 import type { UserDataSummary, UserDataDetailResponse } from '../types/userData';
 
 const baseUrl = (): string =>
   window.o365AnalyticsUserLookupAPI ?? `${window.location.origin}/api/UserDataLookup`;
 
 async function getJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: 'GET',
-    credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/auth/siteToken.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/auth/siteToken.ts
@@ -1,0 +1,43 @@
+import { apiFetch } from '../api/http';
+import type { GraphAccessToken } from '../types/graphToken';
+
+/**
+ * Gets a Microsoft Graph access token for the signed-in admin from `POST api/SiteTokenAPI`.
+ *
+ * Used for the SPA's **direct** calls to `graph.microsoft.com` (the Teams page's profile and
+ * joined-teams lookups). It is deliberately NOT used for the Teams authorisation save: that goes to
+ * this site's own API, and `TeamsAuthAPIController.Put` authorises each Team with the refresh token
+ * it already holds in the auth cookie, so a token in the request body would simply be ignored.
+ *
+ * Always asks the server for a fresh token rather than caching one on the page. Graph access tokens
+ * last roughly an hour, so a token minted when a page mounted can easily be dead by the time the
+ * admin acts on it. The server mints a new one from the long-lived refresh token on every call, so
+ * fetching at the point of use is both correct and cheap.
+ *
+ * Returns `null` when the site is signed in but has no Graph refresh token for this session (the
+ * caller shows a "sign out and back in" message). A genuinely expired *site* session is handled by
+ * {@link apiFetch}, which re-authenticates instead of returning.
+ */
+export async function fetchGraphToken(): Promise<GraphAccessToken | null> {
+  // Undefined when the SPA runs outside ASP.NET (the Vite dev server), where there is no token API.
+  if (!window.o365AnalyticsTokenAPI) {
+    console.error("Couldn't get server-side OAuth token from website: no token endpoint configured.");
+    return null;
+  }
+
+  const response = await apiFetch(window.o365AnalyticsTokenAPI, { method: 'POST' }).catch((error: unknown) => {
+    console.error("Couldn't get server-side OAuth token from website.");
+    console.error(error);
+    return null;
+  });
+
+  if (!response || !response.ok) {
+    return null;
+  }
+
+  return response.json().catch((error: unknown) => {
+    console.error('Error deserialising server-side OAuth token:');
+    console.error(error);
+    return null;
+  }) as Promise<GraphAccessToken | null>;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/teams/TeamList.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/teams/TeamList.tsx
@@ -12,6 +12,7 @@ import { TeamAuthStatusResponse, TeamAuthStatus, AuthTokenResponse } from '../..
 import ConfirmSelection from './ConfirmSelection';
 import type { Team } from '@microsoft/microsoft-graph-types';
 import toast from '../toast';
+import { apiFetch } from '../../api/http';
 
 type TeamListProps = {
   teamsList: Array<Team>;
@@ -192,9 +193,8 @@ export default class TeamList extends React.Component<TeamListProps, TeamListSta
 
     // Is the ASP.Net API defined? If we're debugging from the react app only, it won't be.
     if (window.o365AnalyticsAuthAPI) {
-      const response = await fetch(window.o365AnalyticsAuthAPI, {
+      const response = await apiFetch(window.o365AnalyticsAuthAPI, {
         method: 'POST',
-        credentials: 'same-origin',
         headers: {
           'Content-Type': 'application/json',
           Accept: 'application/json',
@@ -234,15 +234,15 @@ export default class TeamList extends React.Component<TeamListProps, TeamListSta
   async authSelectedTeams() {
     this.setState({ isBusy: true });
 
+    // No Graph token is sent: the server authorises each Team with the refresh token it holds in
+    // the auth cookie (see TeamsAuthAPIController.Put), so a token in the body would be ignored.
     const body = {
       teamIdsToAuth: this.state.teamIdsToAuth,
       teamIdsToDeauth: this.state.teamIdsToDeauth,
-      token: window.o365AnalyticsTeamsToken.accessToken,
     };
 
-    fetch(window.o365AnalyticsAuthAPI, {
+    return apiFetch(window.o365AnalyticsAuthAPI, {
       method: 'PUT',
-      credentials: 'same-origin',
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/global.d.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/global.d.ts
@@ -1,11 +1,7 @@
-import type { GraphAccessToken } from './types/graphToken';
-
 // Runtime configuration injected by the host page (index.html / the ASP.NET site).
 // Centralised here so individual components don't each re-declare the Window shape.
 declare global {
   interface Window {
-    /** Graph token for the signed-in admin, stashed for the Teams auth PUT call. */
-    o365AnalyticsTeamsToken: GraphAccessToken;
     /** POST endpoint that returns the server-side delegated OAuth token. */
     o365AnalyticsTokenAPI: string;
     /** Endpoint for getting/setting Teams deep-analytics authorisation. */

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/main.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/main.tsx
@@ -3,12 +3,17 @@ import { createRoot } from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 import { FluentProvider, webLightTheme } from '@fluentui/react-components';
 import App from './App';
+import { restoreRouteAfterReauth } from './api/http';
 import './index.css';
 
 const container = document.getElementById('root');
 if (!container) {
   throw new Error('Root container #root not found');
 }
+
+// If an expired session sent the user through sign-in, put them back on the page they were on.
+// Must run before HashRouter reads the URL.
+restoreRouteAfterReauth();
 
 createRoot(container).render(
   <StrictMode>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/TeamsPermissionsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/TeamsPermissionsPage.tsx
@@ -4,6 +4,7 @@ import TeamList from '../components/teams/TeamList';
 import Spinner from '../components/Spinner';
 import { GraphResponse } from '../types/GraphResponse';
 import { fetchMsGraph, GRAPH_ENDPOINTS } from '../auth/graph';
+import { fetchGraphToken } from '../auth/siteToken';
 import type { GraphAccessToken } from '../types/graphToken';
 import type { User, Team } from '@microsoft/microsoft-graph-types';
 
@@ -14,7 +15,6 @@ type TeamsPermissionsState = {
   noToken: boolean;
   joinedTeams: Array<Team> | null;
   graphProfile: User | null;
-  serverSideToken: GraphAccessToken | null;
 };
 
 /**
@@ -27,6 +27,9 @@ type TeamsPermissionsState = {
  * There used to be a second, client-side MSAL sign-in path for when that call failed. It was
  * removed: it was pinned to a hard-coded app registration that no longer resolves, so it could
  * not sign anyone in - it only replaced a clear failure with an opaque one.
+ *
+ * Tokens are fetched at the point of use rather than cached on the page, because a Graph access
+ * token only lasts about an hour and this page is one an admin leaves open.
  */
 export default class TeamsPermissionsPage extends React.Component<{}, TeamsPermissionsState> {
   constructor(props: {}) {
@@ -37,14 +40,10 @@ export default class TeamsPermissionsPage extends React.Component<{}, TeamsPermi
       noToken: false,
       joinedTeams: null,
       graphProfile: null,
-      serverSideToken: null,
     };
   }
 
   async loadTeamsData(tokenResponse: GraphAccessToken) {
-    // Save token for API call
-    window.o365AnalyticsTeamsToken = tokenResponse;
-
     // Get profile
     const graphProfile: User = await fetchMsGraph(GRAPH_ENDPOINTS.ME, tokenResponse.accessToken).catch(() => {
       this.setState({ error: 'Unable to fetch Graph profile.' });
@@ -61,29 +60,13 @@ export default class TeamsPermissionsPage extends React.Component<{}, TeamsPermi
   // React events
   async componentDidMount() {
     // Ask the site for a Graph token for the signed-in admin.
-    const serverSideTokenResponse = await fetch(window.o365AnalyticsTokenAPI, {
-      method: 'POST',
-      credentials: 'same-origin',
-    }).catch((error) => {
-      // Expected when running the SPA outside ASP.NET (e.g. the Vite dev server).
-      console.error("Couldn't get server-side OAuth token from website.");
-      console.error(error);
-    });
-
-    let serverSideToken: GraphAccessToken | null = null;
-    if (serverSideTokenResponse && serverSideTokenResponse.ok) {
-      serverSideToken = await serverSideTokenResponse.json().catch((error: unknown) => {
-        console.error('Error deserialising server-side OAuth token:');
-        console.error(error);
-      });
-    }
+    const serverSideToken = await fetchGraphToken();
 
     if (!serverSideToken) {
       this.setState({ loading: false, noToken: true });
       return;
     }
 
-    this.setState({ serverSideToken });
     return this.loadTeamsData(serverSideToken);
   }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/AzureTableProcessedBlobStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/AzureTableProcessedBlobStore.cs
@@ -27,12 +27,27 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
         private readonly TimeSpan _retention;
         private readonly ILogger _logger;
 
-        public AzureTableProcessedBlobStore(string storageConnectionString, TimeSpan retention, ILogger logger, string tableName = DefaultTableName)
+        /// <summary>
+        /// Connects with shared key when the account allows it, otherwise with the runtime service principal
+        /// (see <see cref="CheckpointTableClientFactory"/>). Throws if neither works, so the factory falls back
+        /// to the in-memory store.
+        /// </summary>
+        public AzureTableProcessedBlobStore(string storageConnectionString, TimeSpan retention, ILogger logger,
+            string tenantId = null, string clientId = null, string clientSecret = null, string tableName = DefaultTableName)
+            : this(CheckpointTableClientFactory.CreateAndEnsureTable(storageConnectionString, tableName, tenantId, clientId, clientSecret, logger),
+                   retention, logger)
+        {
+        }
+
+        /// <summary>
+        /// Takes an already-authenticated client whose table is known to exist. Used by the connection-string
+        /// constructor and directly by tests.
+        /// </summary>
+        public AzureTableProcessedBlobStore(TableClient table, TimeSpan retention, ILogger logger)
         {
             _retention = retention > TimeSpan.Zero ? retention : TimeSpan.FromDays(8);
             _logger = logger;
-            _table = new TableClient(storageConnectionString, tableName);
-            _table.CreateIfNotExists(); // throws if the connection string is unusable -> factory falls back.
+            _table = table ?? throw new ArgumentNullException(nameof(table));
         }
 
         public async Task<ISet<string>> GetProcessedBlobIdsAsync()

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/CheckpointTableClientFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/CheckpointTableClientFactory.cs
@@ -1,0 +1,170 @@
+using Azure;
+using Azure.Data.Tables;
+using Azure.Identity;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
+{
+    /// <summary>
+    /// Builds the <see cref="TableClient"/> behind <see cref="AzureTableProcessedBlobStore"/> so the blob
+    /// checkpoint works against both classic shared-key storage accounts and accounts that have shared-key
+    /// access disabled (<c>allowSharedKeyAccess = false</c>) and therefore require RBAC / Entra ID tokens.
+    /// </summary>
+    /// <remarks>
+    /// A storage account hardened with <c>allowSharedKeyAccess = false</c> - increasingly the default under
+    /// enterprise governance policy and the Azure security baseline - rejects a connection-string (shared key)
+    /// client with <c>403 KeyBasedAuthenticationNotPermitted</c>. Per the repo convention for Entra ID fallbacks
+    /// (see Azure AI Language, Redis and Service Bus) we authenticate with a <see cref="ClientSecretCredential"/>
+    /// built from the runtime service principal - never <c>DefaultAzureCredential</c> or managed identity - so
+    /// behaviour is identical in the web job, the installer tests and unit tests.
+    /// <para>
+    /// Data-plane RBAC on the Table service needs the <b>Storage Table Data Contributor</b> role;
+    /// <c>Storage Blob Data Contributor</c> does NOT cover Table storage. The installer assigns it in
+    /// <c>ResourceSecurityInstallJob</c>.
+    /// </para>
+    /// </remarks>
+    public static class CheckpointTableClientFactory
+    {
+        /// <summary>Error codes a storage account returns when shared-key (account key) auth is switched off.</summary>
+        private static readonly HashSet<string> KeyAuthDisabledCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "KeyBasedAuthenticationNotPermitted",
+            "AuthenticationTypeDisabled",
+        };
+
+        /// <summary>
+        /// Builds a <see cref="TableClient"/> for <paramref name="tableName"/> and ensures the table exists.
+        /// Shared key is preferred when the connection string carries an <c>AccountKey</c>; if the account
+        /// rejects it because key auth is disabled, the call is retried with the runtime service principal.
+        /// Throws when no usable authentication is available, so the caller can fall back to the in-memory store.
+        /// </summary>
+        public static TableClient CreateAndEnsureTable(string storageConnectionString, string tableName,
+            string tenantId, string clientId, string clientSecret, ILogger logger)
+        {
+            if (string.IsNullOrWhiteSpace(storageConnectionString))
+                throw new ArgumentException("A storage connection string is required.", nameof(storageConnectionString));
+
+            // Azurite / the storage emulator has no Entra ID identity at all, so there is nothing to fall back to.
+            if (IsDevelopmentStorage(storageConnectionString))
+                return CreateFromConnectionString(storageConnectionString, tableName);
+
+            var endpoint = GetTableEndpoint(storageConnectionString);
+            var canUseRbac = endpoint != null
+                && !string.IsNullOrWhiteSpace(tenantId)
+                && !string.IsNullOrWhiteSpace(clientId)
+                && !string.IsNullOrWhiteSpace(clientSecret);
+
+            if (HasAccountKey(storageConnectionString))
+            {
+                try
+                {
+                    return CreateFromConnectionString(storageConnectionString, tableName);
+                }
+                catch (RequestFailedException ex) when (IsKeyAuthDisabled(ex) && canUseRbac)
+                {
+                    logger?.LogInformation($"Blob checkpoint: shared-key access is disabled on the storage account ({ex.ErrorCode}); " +
+                        "retrying with RBAC/Entra ID using the runtime service principal.");
+                }
+            }
+
+            if (!canUseRbac)
+            {
+                throw new InvalidOperationException(BuildNoRbacMessage(endpoint, storageConnectionString));
+            }
+
+            var rbacClient = new TableClient(endpoint, tableName, new ClientSecretCredential(tenantId, clientId, clientSecret));
+            rbacClient.CreateIfNotExists();
+            return rbacClient;
+        }
+
+        /// <summary>True when the storage account rejected the request because account-key auth is turned off.</summary>
+        public static bool IsKeyAuthDisabled(RequestFailedException ex)
+        {
+            if (ex == null) return false;
+            if (ex.Status != 401 && ex.Status != 403) return false;
+            return ex.ErrorCode != null && KeyAuthDisabledCodes.Contains(ex.ErrorCode);
+        }
+
+        /// <summary>True when the connection string carries a usable shared key.</summary>
+        public static bool HasAccountKey(string storageConnectionString)
+        {
+            var parts = Parse(storageConnectionString);
+            return parts.TryGetValue("AccountKey", out var key) && !string.IsNullOrWhiteSpace(key);
+        }
+
+        /// <summary>True for the local storage emulator, which has no Entra ID identity.</summary>
+        public static bool IsDevelopmentStorage(string storageConnectionString)
+        {
+            var parts = Parse(storageConnectionString);
+            return parts.TryGetValue("UseDevelopmentStorage", out var v)
+                && bool.TryParse(v, out var useDev) && useDev;
+        }
+
+        /// <summary>
+        /// Resolves the Table service endpoint a token-authenticated client must target. Prefers an explicit
+        /// <c>TableEndpoint</c>, otherwise composes it from <c>AccountName</c> + <c>EndpointSuffix</c> (which
+        /// differs in sovereign clouds). Returns <c>null</c> when the connection string names no account.
+        /// </summary>
+        public static Uri GetTableEndpoint(string storageConnectionString)
+        {
+            var parts = Parse(storageConnectionString);
+
+            if (parts.TryGetValue("TableEndpoint", out var explicitEndpoint) && !string.IsNullOrWhiteSpace(explicitEndpoint))
+                return Uri.TryCreate(explicitEndpoint.Trim(), UriKind.Absolute, out var explicitUri) ? explicitUri : null;
+
+            if (!parts.TryGetValue("AccountName", out var account) || string.IsNullOrWhiteSpace(account))
+                return null;
+
+            var suffix = parts.TryGetValue("EndpointSuffix", out var s) && !string.IsNullOrWhiteSpace(s)
+                ? s.Trim() : "core.windows.net";
+            var scheme = parts.TryGetValue("DefaultEndpointsProtocol", out var p) && !string.IsNullOrWhiteSpace(p)
+                ? p.Trim() : "https";
+
+            return Uri.TryCreate($"{scheme}://{account.Trim()}.table.{suffix}", UriKind.Absolute, out var uri) ? uri : null;
+        }
+
+        private static TableClient CreateFromConnectionString(string storageConnectionString, string tableName)
+        {
+            var client = new TableClient(storageConnectionString, tableName);
+            client.CreateIfNotExists();
+            return client;
+        }
+
+        private static string BuildNoRbacMessage(Uri endpoint, string storageConnectionString)
+        {
+            if (!HasAccountKey(storageConnectionString) && endpoint == null)
+                return "The storage connection string contains neither an AccountKey nor an AccountName/TableEndpoint, " +
+                       "so neither shared-key nor RBAC authentication can be used for the blob checkpoint table.";
+
+            return "Shared-key access is unavailable on the storage account and the runtime service principal " +
+                   "(tenant id / client id / client secret) is not configured, so the blob checkpoint table cannot " +
+                   "be authenticated. Configure the runtime account, or re-enable shared-key access on the account.";
+        }
+
+        /// <summary>
+        /// Splits a storage connection string into its key/value parts. Only the FIRST '=' is treated as the
+        /// separator because an <c>AccountKey</c> is base64 and routinely ends in '=' padding.
+        /// </summary>
+        private static IDictionary<string, string> Parse(string storageConnectionString)
+        {
+            var parts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(storageConnectionString)) return parts;
+
+            foreach (var segment in storageConnectionString.Split(';'))
+            {
+                if (string.IsNullOrWhiteSpace(segment)) continue;
+
+                var separator = segment.IndexOf('=');
+                if (separator <= 0) continue;
+
+                var key = segment.Substring(0, separator).Trim();
+                var value = segment.Substring(separator + 1).Trim();
+                if (key.Length > 0 && !parts.ContainsKey(key)) parts[key] = value;
+            }
+
+            return parts;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/ProcessedBlobStoreFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/ProcessedBlobStoreFactory.cs
@@ -26,7 +26,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
             {
                 try
                 {
-                    var store = new AzureTableProcessedBlobStore(storageConn, retention, logger);
+                    var store = new AzureTableProcessedBlobStore(storageConn, retention, logger,
+                        config.TenantGUID == Guid.Empty ? null : config.TenantGUID.ToString(), config.ClientID, config.ClientSecret);
                     logger?.LogInformation("Blob checkpoint: durable Azure Table store initialised (processed blobs persist across restarts).");
                     (logger as AnalyticsLogger)?.TrackHealthCheck(HealthComponent.BlobCheckpoint, HealthStatus.Healthy,
                         "Durable Azure Table checkpoint active.");
@@ -44,8 +45,11 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
                         detail += " -> " + inner.Message;
                     logger?.LogError(ex, $"Blob checkpoint: could not initialise the Azure Table store ({ex.GetType().Name}: {detail}); " +
                         "falling back to in-memory (dedupes across cycles but only for the life of this process - lost on restart/redeploy). " +
-                        "Check the Storage connection string is valid and the account's Table service is reachable: " +
-                        "shared-key access enabled, and storage firewall / private endpoint / selected-networks not blocking the importer.");
+                        "Check the Storage connection string is valid and the account's Table service is reachable: storage firewall / " +
+                        "private endpoint / selected-networks not blocking the importer. If the account has shared-key access disabled " +
+                        "(allowSharedKeyAccess = false, giving '403 KeyBasedAuthenticationNotPermitted'), the importer authenticates with the " +
+                        "runtime service principal instead - that account needs the 'Storage Table Data Contributor' role on the storage " +
+                        "account ('Storage Blob Data Contributor' does NOT cover the Table service).");
                     // Surface the degraded (non-durable) checkpoint on the Health page instead of only in the log.
                     (logger as AnalyticsLogger)?.TrackHealthCheck(HealthComponent.BlobCheckpoint, HealthStatus.Degraded,
                         $"Azure Table init failed ({ex.GetType().Name}); using non-durable in-memory checkpoint (lost on restart). See importer error log.");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ActivityAPI\ActivityImporter.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\AzureTableProcessedBlobStore.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\BlobCommitTracker.cs" />
+    <Compile Include="ActivityAPI\BlobCheckpoint\CheckpointTableClientFactory.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\InMemoryProcessedBlobStore.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\IProcessedBlobStore.cs" />
     <Compile Include="ActivityAPI\BlobCheckpoint\ProcessedBlobStoreFactory.cs" />


### PR DESCRIPTION
Release candidate: `dev` -> `main`.

Base `main` @ `1a2e160` -> head `dev` @ `f1c1ab6`. **2 commits, 2 squash-merged PRs, 24 files, +719 / -62.**

`dev` is a clean fast-forward descendant of `main`: the two-dot and three-dot diffs are identical (both `24 files changed, 719 insertions(+), 62 deletions(-)`) and `git log origin/main..origin/dev` contains no merge commits. There is no divergence to reconcile and nothing was hand-resolved.

**The baseline is genuine this cycle.** `origin/main` @ `1a2e16067a6a348326c8f0c28b12e893a211c1dd` is the target commit of the **published** stable release **1807** (`isDraft: false`, `isPrerelease: false`, verified via `gh release view 1807`). Admins upgrading from current stable really are coming from this exact tree, so the upgrade notes below apply as written.

**This is a pure bug-fix release.** No new features, no database migrations, no fresh-install schema change, no installer config-schema change, no breaking changes, no dependency changes. Two independent defects, each self-contained, in two disjoint subsystems (audit importer / web portal). They do not interact: there is no file, type or call path shared between them.

**Issue handling - read before merging.** #348 and #350 are **both still open** (checked with `gh api`, not read off the PR text), and `closingIssuesReferences` is **empty on both** #349 and #351 - the contributing PRs correctly used `Addresses #N`, which is inert on a `dev`-targeted PR. The repo convention is for the release PR to carry the closing keyword; **this body deliberately does not**, at the request of the release owner. Consequence, stated plainly: **merging this PR will close nothing automatically.** #348 and #350 must be closed by hand afterwards, each with a comment naming the build number.

---

## 1. What is in this release

| Commit / PR | Change | Area | Schema | Config schema |
| --- | --- | --- | --- | --- |
| `1ff4840` / #349 | Audit blob checkpoint authenticates the Azure Table with RBAC when the storage account has shared-key access disabled; the installer assigns the matching Table data-plane role | Importer + Installer | - | - |
| `f1c1ab6` / #351 | Portal recovers from an expired session instead of failing with an opaque `TypeError: Failed to fetch`; Graph tokens are fetched at point of use rather than cached on the page | Web / Portal | - | - |

Both were reviewed and merged into `dev` through their own PRs, with all required checks green (see section 6).

---

## 2. #349 - Blob checkpoint silently became non-durable on a hardened storage account

Files: `WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/{CheckpointTableClientFactory.cs (new), AzureTableProcessedBlobStore.cs, ProcessedBlobStoreFactory.cs}`, `App.ControlPanel.Engine/InstallerTasks/ResourceSecurityInstallJob.cs`, `Tests.UnitTests/CheckpointTableClientFactoryTests.cs (new)`.

### Root cause

`AzureTableProcessedBlobStore` built its client from a shared-key connection string and created the table in the constructor:

```csharp
_table = new TableClient(storageConnectionString, tableName);
_table.CreateIfNotExists(); // throws if the connection string is unusable -> factory falls back.
```

On a storage account with `allowSharedKeyAccess = false` that throws on **every** importer cycle:

```
Azure.RequestFailedException at Azure.Data.Tables.TableClient.CreateIfNotExists
Status: 403 (Key based authentication is not permitted on this storage account.)
ErrorCode: KeyBasedAuthenticationNotPermitted
```

`ProcessedBlobStoreFactory` catches that and falls back to `InMemoryProcessedBlobStore`. That fallback is the trap: **imports keep working, so nothing looks broken**, but the checkpoint is now held only in process memory. Every WebJob restart, redeploy, scale event or idle recycle loses it and the importer re-downloads and re-processes every audit blob in the `DaysBeforeNowToDownload` window (default 7 days). The condition never self-heals, because the next cycle takes exactly the same failing path.

The only signal was `BlobCheckpoint = Degraded` on the Health page plus one error line per start, and that line actively misdirected: it told the operator to check that shared-key access was **enabled**, which on a governed account is the one thing they cannot do and should not want to.

Disabling shared key is the Azure security baseline (`Storage accounts should prevent shared key access`) and is commonly applied - and **re-applied** - automatically by enterprise governance policy, including to accounts the installer itself created with shared key enabled. So re-enabling the key is not a durable workaround; the deployment would regress the next time policy remediated it.

This was the **last shared-key storage client in the solution** - Redis, Service Bus, Azure AI Language and App Insights were already RBAC-first.

### The second half of the defect: the role did not exist

Switching to a token credential alone would not have fixed anything. `ResourceSecurityInstallJob` assigned only `Storage Blob Data Contributor`, and **that role does not cover the Table service**. The RBAC path would have failed with:

```
Status: 403 (This request is not authorized to perform this operation using this permission.)
ErrorCode: AuthorizationPermissionMismatch
```

and the checkpoint would have degraded to in-memory exactly as before, just with a different error code. Both halves had to ship together, and they did.

### What changed

**`CheckpointTableClientFactory` (new, 170 lines, static).** Builds the checkpoint `TableClient` and ensures the table exists.

- **Shared key is still tried first**, whenever the connection string carries a non-blank `AccountKey`. This is what makes the change a no-op for every install that is not affected: if the key works, the RBAC code never executes.
- On a `401`/`403` whose `ErrorCode` is `KeyBasedAuthenticationNotPermitted` or `AuthenticationTypeDisabled`, it retries with `ClientSecretCredential` built from the runtime service principal. This follows the repo's stated Entra ID convention (`src/AnalyticsEngine/.github/copilot-instructions.md`: use `ClientSecretCredential` with the runtime account from config, *not* `DefaultAzureCredential` or managed identity), so behaviour is identical in the web job, installer tests and unit tests.
- The retry is guarded by `&& canUseRbac` in the exception filter, so when no service principal is configured the original `RequestFailedException` propagates untouched rather than being swallowed and re-thrown as something less diagnosable.
- **Endpoint resolution** prefers an explicit `TableEndpoint`, else composes `{DefaultEndpointsProtocol}://{AccountName}.table.{EndpointSuffix}` with `EndpointSuffix` defaulting to `core.windows.net`. Sovereign clouds and private-DNS/private-endpoint names therefore work instead of being hard-coded to commercial Azure.
- **Connection-string parsing splits on the first `=` only**, because an `AccountKey` is base64 and routinely ends in `=` padding; a naive `Split('=')` truncates the key and breaks shared-key auth for everyone. Duplicate keys are first-wins.
- `UseDevelopmentStorage=true` short-circuits to the connection-string path - the emulator has no Entra ID identity to fall back to.
- **Other 403s are deliberately NOT retried.** `AuthorizationFailure` (storage firewall / selected networks / private endpoint) and `AuthorizationPermissionMismatch` propagate unchanged, so a networking or RBAC-grant fault is never silently re-reported as an auth-mode fault. This is asserted by a test, not just by intent.
- When neither auth method is available it throws `InvalidOperationException` with a message naming which half is missing, so the caller still falls back to in-memory rather than handing back a dead client.

**`AzureTableProcessedBlobStore`.** The connection-string constructor now takes optional `tenantId` / `clientId` / `clientSecret` and delegates construction to the factory via a `this(...)` chain; a second constructor accepts a pre-built `TableClient` (null-guarded) for tests. **Read/write/purge logic is completely untouched** - the diff here is constructor-only.

**`ProcessedBlobStoreFactory`.** Passes the runtime credentials through, mapping an unset tenant to `null` (`config.TenantGUID == Guid.Empty ? null : config.TenantGUID.ToString()`) so a blank GUID cannot masquerade as a configured tenant. The fallback log line was rewritten: it no longer tells operators to enable shared key, and instead names the `403 KeyBasedAuthenticationNotPermitted` case and the exact role required.

**`ResourceSecurityInstallJob`.** Adds a `Storage Table Data Contributor` role assignment for the runtime account, alongside the existing Blob role, plus a `StorageTableDataContributorRole` result property.

### Why this approach rather than the alternatives

- **Why not just document "re-enable shared key"?** Because policy re-applies the hardening. The workaround would silently expire.
- **Why not `DefaultAzureCredential`?** It is explicitly against the convention in this repo, and its probe order makes behaviour differ between the WebJob, a developer machine and CI - which is precisely the class of bug that is impossible to reproduce.
- **Why try shared key first rather than RBAC first?** It keeps the change a strict no-op for existing healthy installs. RBAC-first would have made every deployment depend on a role assignment that older installs do not yet have.
- **Why a separate static factory rather than branching inside the store?** The decision logic (endpoint composition, key detection, error-code classification) is then testable with no Azure, no network and no mocking - which is what the 11 new tests exercise.

### Tests

`Tests.UnitTests/CheckpointTableClientFactoryTests.cs` - **11 tests**, registered in `Tests.UnitTests.csproj`. Coverage: endpoint composition, sovereign-cloud suffix, explicit `TableEndpoint` precedence, missing `AccountName`, base64-padded `AccountKey` detection, absent/blank key, emulator detection, both "key auth disabled" error codes, the four error shapes that must **not** be treated as key-auth-disabled (`AuthorizationFailure`, `AuthorizationPermissionMismatch`, a 404, and `null`), and both no-auth-available failure modes (`InvalidOperationException` / `ArgumentException`).

Test data is synthetic per the repo policy: account `contosoanalytics`, an obviously-fake low-entropy key, zeroed GUID.

Independently re-run for this PR: **11/11 pass** (see section 6).

---

## 3. #351 - An expired portal session surfaced as an opaque network error and never recovered

Files: `Web/App_Start/Startup.Auth.cs`, `Web/Models/AuthTeamRequest.cs`, `Web/Scripts/portal/src/api/http.ts (new)`, `Web/Scripts/portal/src/auth/siteToken.ts (new)`, the eight `src/api/*.ts` clients, `components/teams/TeamList.tsx`, `pages/TeamsPermissionsPage.tsx`, `global.d.ts`, `main.tsx`, `README.md`.

### Root cause

Admins sign in through a server-side OIDC redirect; the session lives in an encrypted OWIN auth cookie. Two things combined to make its expiry fail badly:

1. The OIDC middleware runs in **Active** mode, so it converts the `401` from an `[Authorize]`'d controller into a **`302` to `login.microsoftonline.com`**.
2. The SPA called its own API with plain `fetch(..., { credentials: 'same-origin' })`. `fetch` follows redirects, so it followed that `302` cross-origin; the Entra sign-in page carries no CORS headers; the call rejected with:

```
TypeError: Failed to fetch
```

Every affected call site only checked `response.ok`, which never ran because the promise rejected first. So a recoverable "please sign in again" presented as a permanent, network-looking failure that only a manual reload cleared.

**Why it felt random rather than time-based:** the session ends either from cookie expiry *or* from an App Service instance recycle, where the new instance cannot decrypt a cookie encrypted under the previous instance's machine key. The second cause is uncorrelated with how long the admin has been signed in.

There was a second-order effect worth noting: because the middleware turned *any* `401` into a redirect, the `401` that `SiteTokenAPIController` raises to mean "signed in, but I hold no Graph refresh token for this session" also never reached the SPA, making the Teams page's `noToken` message unreachable.

### What changed - server (`Startup.Auth.cs`)

**`RedirectToIdentityProvider` notification.** When `context.ProtocolMessage.RequestType == OpenIdConnectRequestType.Authentication` **and** the request is classified as an API request, it calls `HandleResponse()` to cancel the redirect and leaves a plain `401`. It sets the new `X-Auth-Session-Expired: true` header **only** when `context.OwinContext.Authentication?.User?.Identity?.IsAuthenticated != true` - i.e. only when there is genuinely nobody signed in. That is what keeps `SiteTokenAPI`'s deliberate `401` distinguishable, so it keeps showing its own message instead of bouncing the admin through a pointless sign-in. The header name is exposed as `public const string Startup.SessionExpiredHeader`.

**`ApiSafeCookieManager` - and why suppressing the redirect was not enough on its own.** In Katana 4.2.3, `ApplyResponseChallengeAsync` calls `AddNonceToMessage()` - which writes an `OpenIdConnect.nonce.*` cookie - **before** it invokes the notification. `HandleResponse()` therefore cancels the redirect but cannot un-write the cookie. Left alone, every suppressed API challenge would drop an orphan nonce cookie (~15 min lifetime) that nothing ever consumes. A page firing several parallel API calls drops several per attempt, and because this site's auth cookie already carries the Graph refresh token, the accumulated `Cookie` header can grow past IIS/proxy header limits - converting a recoverable session expiry into a `400 Request Too Large` that the user can only escape by clearing cookies. The decorator drops **response cookie writes only, on API requests only**; `GetRequestCookie` and `DeleteCookie` delegate untouched.

Crucially it **wraps `app.GetDefaultCookieManager()`** rather than constructing a manager: Katana does `Options.CookieManager ??= app.GetDefaultCookieManager()`, and under `Microsoft.Owin.Host.SystemWeb` that default is a System.Web-integrated manager. Hard-coding a replacement would have quietly altered the successful sign-in path. (An earlier review round did exactly that and it was caught - see below.)

**Request classification (`IsApiRequest`).** In order: (1) `X-Requested-With: XMLHttpRequest` -> API; (2) a top-level document navigation (`Sec-Fetch-Mode: navigate` or `Sec-Fetch-Dest: document`) -> **not** API; (3) otherwise, path prefix `/api`.

Step (2) exists for a concrete regression: the Copilot adoption CSV and workbook exports are plain `<a href>` links to `[Authorize]`'d `/api/CopilotAdoption/**` routes. The browser genuinely *is* navigating, so those must still redirect to sign-in and then deliver the download; answering them with a bare `401` would land the admin on a blank error page.

### What changed - portal

**`src/api/http.ts` (new).** `apiFetch` always sends `X-Requested-With: XMLHttpRequest` and `credentials: 'same-origin'`. On a `401` carrying the header it re-authenticates with a **full-page navigation** to `/` (the only thing that can complete the OIDC round-trip, and normally silent because the Entra session outlives the site's). Supporting machinery, all deliberate:

- The hash route is stashed in `sessionStorage` and restored by `restoreRouteAfterReauth()`, called from `main.tsx` **before** `createRoot`. `HashRouter` means the route never reaches the server, so without this the round-trip always dumps the admin on the default page.
- A `sessionStorage` flag (`portal:reauth-attempted`) makes re-auth **one-shot**: a session that cannot be re-established throws `SessionExpiredError` instead of looping through sign-in.
- A module-level `reauthNavigationStarted` flag stops a late in-flight success from clearing that guard for a document already navigating away (module scope is correct here - it dies with the document).
- Concurrent siblings receive a deliberately never-settling promise, so they cannot render an error over a page that is being replaced.

**`src/auth/siteToken.ts` (new).** `fetchGraphToken()` mints a fresh Graph token per call instead of caching one in `window.o365AnalyticsTeamsToken` (global removed from `global.d.ts`). Graph access tokens last about an hour and the Teams page is one admins leave open. These tokens are only for the SPA's **direct** `graph.microsoft.com` calls.

**Dead field removed.** `AuthTeamRequest.Token` is gone from the model and the request body. Verified against the controller rather than the PR prose: `TeamsAuthAPIController.Put` never reads `authTeamData.Token` (`git grep authTeamData.Token` returns nothing on `dev`); it authorises each Team from the refresh token it already holds via `base.GetCachedUserAccessTokenAsync()`. The removal is therefore safe and not a contract change anyone was relying on.

**Call-site migration - counted from the diff, not the PR text.** On `main` there were **15** raw `fetch(` calls under `Web/Scripts/portal/src`, of which **13** targeted the site's own `[Authorize]`'d API (10 in `src/api/*.ts`, 2 in `TeamList.tsx`, 1 in `TeamsPermissionsPage.tsx`). **All 13 now go through `apiFetch`.** Exactly **3** raw `fetch(` calls remain on `dev`, all correctly excluded:

| Remaining raw `fetch` | Why it is excluded |
| --- | --- |
| `api/http.ts:97` | The wrapper itself |
| `api/systemStatusApi.ts:26` | The Graph call-records webhook validation probe - it POSTs to a configured webhook URL, not to an `[Authorize]`'d portal API |
| `auth/graph.ts:9` | Direct calls to `graph.microsoft.com`, which use a bearer token and have nothing to do with the site session |

(For the record, #351's prose says "12 fetch calls in `src/api/*.ts`"; the verified figures are 10 in `src/api/*.ts` and 13 site-API call sites overall. The code is right; only the prose count was loose.)

One incidental improvement: `TeamList.authSelectedTeams` previously fired `fetch(...)` without returning or awaiting it; it is now `return apiFetch(...)`, so the caller can actually observe the save.

### Review history (from #351, retained because it explains the shape of the fix)

Three rounds of adversarial review; five defects, **three of them introduced by a previous round's fix** - which is why the loop ran until a round came back clean.

| Round | Defect | Consequence if shipped |
| --- | --- | --- |
| 1 | `HandleResponse()` cannot prevent the nonce cookie | Orphan cookies accumulate -> `400 Request Too Large`, unrecoverable without clearing cookies |
| 1 | Minting a Graph token at submit time gated the Teams Save on a token the server ignores | Would have **blocked a Save that previously succeeded** |
| 1 | A late in-flight success cleared the one-shot re-auth guard | Guard re-armed; repeated sign-in bounces |
| 2 | Hard-coded `new CookieManager()` replaced the host's System.Web manager | Silent change to the successful sign-in path |
| 2 | `/api` path rule caught `<a href>` export links | **Regression**: expired session + Export -> blank `401` instead of sign-in + download |

---

## 4. Migrations, configuration and breaking changes

All verified against the `origin/main`..`origin/dev` diff for **this** PR, not read off the contributing PR bodies.

| Check | Result | How it was verified |
| --- | --- | --- |
| **Database migrations** | **None** | `git diff --name-only origin/main origin/dev` matches nothing under `Migrations/` |
| **Fresh-install schema** | **Unchanged** | No `Create DB.sql` in the diff |
| **Installer config schema** | **Unchanged** | `BaseSolutionInstallConfig.cs` is not in the diff; `CONFIG_VERSION` is `"2.2.0"` on **both** `origin/main` and `origin/dev` |
| **Breaking changes** | **None** | No public API/contract, config key, endpoint or asset-name change. The one removed field (`AuthTeamRequest.Token`) was never read by its controller |
| **Dependencies** | **Unchanged** | No `packages.config`, `PackageReference`, `package.json` or lockfile in the diff. `Azure.Identity` and `Azure.Data.Tables` were **already** referenced by `WebJob.Office365ActivityImporter.Engine.csproj` on `main`; the only csproj edits are two `<Compile Include>` registrations |

Consequences, stated explicitly so nothing is left implicit:

- **No `.manual.sql` assets are required for this release.** There are no migrations, so there is no manual upgrade-script chain to attach, no run order to state and no predecessor migration to name. This is the normally-forgotten release step, and here it genuinely does not apply.
- **`CONFIG_VERSION` is correctly NOT bumped.** No installer config property was added, removed or changed, so an existing 2.2.0 config file loads and behaves identically. **Admins do not need to re-open or re-save their configuration.**
- **The "prove every schema change with a benchmark" gate does not apply.** That gate is scoped to *performance-motivated* SQL schema changes. This release contains no SQL schema change of any classification - additive, removal or performance-motivated - so there is nothing to measure and nothing being waved through unmeasured.
- **No maintenance window, and no importer downtime**, is implied by anything in this diff.

---

## 5. Upgrade / operational notes

### 5a. The one that matters: the new Azure role assignment (#349)

The installer now assigns **`Storage Table Data Contributor`** to the runtime service principal, at **resource-group scope**. Verified from source rather than from the PR text: `RoleAssignmentTask` derives from `InstallTaskInAzResourceGroup<RoleAssignmentResource>` and computes `var scope = Container.Id`, i.e. the resource group container.

**Does an existing deployment need the installer re-run? It depends on the storage account, and the distinction is sharp:**

| Deployment | Needs installer re-run? | If not re-run |
| --- | --- | --- |
| Storage account **allows** shared key (the default, and most installs) | **No.** Nothing changes | Shared key is tried first and succeeds; the RBAC code never executes. The role assignment is simply unused |
| Storage account has `allowSharedKeyAccess = false` | **Yes** | The importer will still degrade to the non-durable in-memory checkpoint. The new code will now correctly *attempt* RBAC, but without the role that attempt fails with `403 AuthorizationPermissionMismatch`, and the fallback behaves exactly as it did before the fix |

So for the affected population, **shipping the binaries alone does not fix the bug** - the role assignment is a hard prerequisite. The alternative to a full installer run is to grant `Storage Table Data Contributor` to the runtime app registration on the storage account (or its resource group) by hand; that is sufficient and takes effect on the importer's next cycle without a redeploy.

The role assignment is **additive and idempotent**: `RoleAssignmentTask` enumerates existing assignments and returns early when one already matches the same principal and role definition, so re-running the installer does not duplicate it. No downtime, and nothing is revoked - `Storage Blob Data Contributor` is unchanged.

**How an admin confirms the fix landed:** the Health page should report `BlobCheckpoint` as **Healthy** rather than **Degraded**, and the importer log should carry `Blob checkpoint: durable Azure Table store initialised` instead of the fallback error. On an account with shared key disabled, expect one informational line per start noting that shared-key access is disabled and RBAC is being used - that is the healthy path, not a warning.

### 5b. Portal session fix (#351)

**No admin action of any kind.** No configuration, no role, no DNS, no App Service setting. The fix is entirely in the shipped `Website.zip` and takes effect as soon as the site is redeployed and the browser picks up the new `index.html`.

Two operational notes worth knowing:

- Admins with the portal open across the upgrade will be served the new bundle on their next full load; until then they keep the old behaviour. Nothing breaks either way.
- The fix reduces, but does not eliminate, sign-in interruptions: a genuinely expired Entra session still shows the Microsoft sign-in page. What changes is that it is now a sign-in rather than `TypeError: Failed to fetch`, and the admin is returned to the page they were on.

---

## 6. Verification performed

Re-run independently for this PR against the merged head `f1c1ab6`, not inherited from the contributing PRs. (The local checkout was byte-identical to `origin/dev` at the time of building.)

- **`Tests.UnitTests` builds** with MSBuild (VS 18 Enterprise, located via `vswhere`), Debug: **succeeded**, together with `App.ControlPanel.Engine` and `Web`.
- **New checkpoint tests: 11/11 pass** (`vstest.console.exe` 18.9.0, `/Tests:CheckpointTableClientFactoryTests`, 0.46s). Every one of the 11 listed in section 2 passed by name.
- **Portal build clean.** The `Web` build runs `tsc --noEmit && vite build`: **929 modules transformed, 0 type errors, 0 build errors**.
- **Bundle claim reproduced independently.** #351 asserted the entry chunk was unchanged at 397.43 kB; the local build emits `build/assets/index-*.js` at exactly **397.43 kB**, with the shared async chunk now named `http-*` (200.05 kB) - consistent with the module being renamed into the shared chunk rather than added to the entry bundle.
- **Migration / config / dependency claims** re-derived from the diff by path matching and by diffing `CONFIG_VERSION` across both branches (section 4), not taken from PR prose.
- **Role scope proven from source** (`InstallTaskInAzResourceGroup`, `scope = Container.Id`), not assumed from the PR text.
- **Issue states checked via `gh api`** - #348 and #350 both `state: open`, `closed_at: null`; `closingIssuesReferences` empty on both #349 and #351.
- **CI on the contributing PRs**: all checks green on both before merge - `test_dotnet (Release)` 8m34s (#349) and 8m51s (#351), all four `build_dotnet` Release matrix legs (including the `Web.csproj` leg at 3m7s / 2m52s), `build_aitracker`, `test_aitracker`, `setup_tests` and `gitleaks`.

### What is NOT covered by automated tests

Stated plainly, because it is the weakest part of the release:

- **The OWIN pipeline behaviour in #351 has no automated coverage at all.** `IsApiRequest`, the `RedirectToIdentityProvider` suppression and `ApiSafeCookieManager` are all private/nested and need a hosted request to exercise. The portal has no test runner either (`lint` is `tsc --noEmit`), so `apiFetch`'s re-auth state machine is likewise unverified except by type-checking and by review.
- **The RBAC path in #349 is tested at the decision level, not end-to-end.** The 11 tests prove endpoint composition, key detection and error-code classification; they do not prove that a real `ClientSecretCredential` succeeds against a real hardened storage account. That requires an account with `allowSharedKeyAccess = false` and the role assigned.

Suggested manual verification before or shortly after promoting the build:

1. Sign in, leave a tab open, invalidate the session (recycle the App Service, or clear the auth cookie), then use the portal -> expect a silent re-auth landing back on the **same page**, not `Failed to fetch`.
2. In that same expired state, click **Export CSV** / **Export workbook** -> expect sign-in followed by the download, **not** a bare `401`. This is the classification path that regressed once during review.
3. Confirm no `OpenIdConnect.nonce.*` cookies accumulate in devtools after several expired API calls.
4. On a storage account with `allowSharedKeyAccess = false`, with the role assigned, confirm Health reports `BlobCheckpoint = Healthy` and the durable-store log line appears.

---

## 7. Risks and reviewer hotspots

1. **`ApiSafeCookieManager` and its blast radius on the successful sign-in path.** This is the highest-leverage thing to review. Two properties make it safe, and both should be confirmed rather than assumed: (a) it is set **only** on `OpenIdConnectAuthenticationOptions.CookieManager`, so the cookie-authentication middleware that writes the actual session cookie is untouched; (b) it suppresses **only** `AppendResponseCookie`, and only when `IsApiRequest` is true - reads and deletes always delegate. A real sign-in is a top-level navigation, so it is never classified as an API request and still gets a real nonce to validate. The failure mode if this reasoning is wrong is severe and non-obvious: sign-in would break with a nonce-validation error rather than an auth error.
2. **`IsApiRequest` must agree with itself across two call sites.** The same predicate decides *both* whether to suppress the redirect *and* whether to drop the nonce cookie. They must agree for a given request; a disagreement in either direction is a bug (an orphan cookie, or a genuine sign-in losing its nonce). Worth checking that no future caller reorders the checks.
3. **Export links depend entirely on the Fetch Metadata headers.** The `<a href>` CSV/workbook exports stay correct only because `Sec-Fetch-Mode`/`Sec-Fetch-Dest` mark them as navigations. **Residual gap:** on a browser old enough to omit those headers, `IsDocumentNavigation` returns false and the `/api` path rule applies, so an expired-session export click would get a bare `401` instead of a sign-in. Current browsers all send them, so this is a small and knowingly-accepted tail - but it is a real behavioural dependency on a client-supplied header, and it is the exact path that regressed during review.
4. **Deliberate non-retry of other 403s in the checkpoint factory.** `IsKeyAuthDisabled` retries on exactly two error codes and requires status 401/403. This is correct - retrying a firewall/private-endpoint `AuthorizationFailure` with a token would just produce a second, more confusing failure - but it does mean a storage account that ever returns a *different* code for disabled key auth would silently fall back to in-memory again. The classification is the single point of failure for the whole fix and deserves a second pair of eyes.
5. **Shared-key-first ordering is what preserves existing behaviour.** Confirm the ordering is not "tidied" later into RBAC-first: that would make every existing install depend on a role assignment it may not have, converting a no-op release into a breaking one.
6. **`AzureTableProcessedBlobStore`'s public constructor signature changed shape.** `tableName` moved from the 4th positional parameter to the 7th, behind three new optional credential parameters. Any caller passing `tableName` positionally would now silently bind it to `tenantId`. There is exactly one caller in the tree (`ProcessedBlobStoreFactory`, verified by grep) and it does not pass `tableName`, so nothing is broken today - but it is a public constructor on a public class, and the failure mode is silent rather than a compile error.
7. **`http.ts` calls `sessionStorage` unguarded.** `getItem`/`setItem`/`removeItem` are called on the error path with no `try`/`catch`. In a sandboxed cross-origin iframe or with site data blocked, that access throws and the throw happens *inside* the expired-session handler. Low likelihood for an authenticated admin portal at the site root, and identical in kind to the note raised against `lazyWithReload` in the previous release - but still an unguarded call on a recovery path.
8. **`apiFetch` spreads caller headers after its own.** `{ 'X-Requested-With': 'XMLHttpRequest', ...(init.headers ?? {}) }` means a caller could override `X-Requested-With` and desynchronise the client from the server's classification. No current caller does; worth a convention note.
9. **The never-settling promise is intentional but unusual.** On an expired session `apiFetch` returns a promise that never resolves or rejects. That is deliberate (the document is being replaced), but any caller with a `finally` that clears a spinner or releases a lock will never run it. Correct while the navigation always follows; it would become a hang if a future change made re-auth conditional.
10. **The `X-Auth-Session-Expired` discriminator rests on one assumption:** that `Authentication.User.Identity.IsAuthenticated` reliably distinguishes "session gone" from "signed in but no Graph token". That holds because the cookie middleware is registered first and authenticates before controllers run. It would stop holding if another host authentication (Windows auth, App Service Easy Auth) ever supplied a principal.
11. **The header name is duplicated, not shared.** `Startup.SessionExpiredHeader` (C#) and `SESSION_EXPIRED_HEADER` (TypeScript) are independent string literals with only a comment tying them together. Nothing fails at build time if one changes; the symptom would be a silent return of the original `Failed to fetch` behaviour.
12. **No merge-conflict or hand-resolution risk in this PR.** `dev` fast-forwards from `main` and the two changes touch disjoint files, so there is no reconciliation for a reviewer to re-check.

---

## 8. Deliberately out of scope / deferred

- **Installer *Test Configuration* still has no Table data-plane reachability check.** A missing `Storage Table Data Contributor` role is still discovered only from the importer log or the Health page, never at install time. Same class of gap as #329, and the main reason 5a has to be read carefully rather than being caught automatically.
- **No broader RBAC-first configuration rework.** #349 makes the checkpoint the last shared-key client to gain an RBAC fallback, but the wider "prefer RBAC everywhere" change remains tracked in #154.
- **No end-to-end/integration test for either fix.** Both would need real infrastructure (a hardened storage account; a hosted OWIN request). Noted in section 6 rather than papered over.
- **No portal test runner introduced.** Adding one is worthwhile but is a separate change and would swamp this release diff.
- **The two remaining non-portal-API `fetch` calls are intentionally left raw** (`auth/graph.ts`, the webhook probe). Routing them through `apiFetch` would attach session-expiry semantics to calls that have nothing to do with the site session.
- **Issue closure is deliberately manual** - see the note at the top. No closing keyword is present in this body by request.