### PR TITLE
Installer: DNS-check the Azure Managed Redis hostname, not just the classic one

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -3,6 +3,8 @@ using App.ControlPanel.Engine.Models;
 using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.KeyVault;
+using Azure.ResourceManager.Redis;
+using Azure.ResourceManager.RedisEnterprise;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Sql;
 using CloudInstallEngine.Azure;
@@ -89,7 +91,7 @@ namespace App.ControlPanel.Engine
             // DNS resolution checks for the configured Azure resource hostnames. Catches the
             // "The remote name could not be resolved" class of failure (broken/limited DNS on the
             // installer host) up-front instead of letting it abort an install part-way through.
-            await VerifyResourceDnsResolution();
+            await VerifyResourceDnsResolution(testRg);
 
             // Key Vault data-plane reachability with the installer account (the exact call that failed
             // mid-install). Only runs when the vault already exists and installer credentials are present.
@@ -432,7 +434,7 @@ namespace App.ControlPanel.Engine
         /// installer host - the cause of "The remote name could not be resolved: '&lt;x&gt;.vault.azure.net'"
         /// install failures - are caught up-front rather than mid-install. Logs only; never throws.
         /// </summary>
-        async Task VerifyResourceDnsResolution()
+        async Task VerifyResourceDnsResolution(ResourceGroupResource testRg)
         {
             _logger.LogInformation("Checking DNS resolution for configured Azure resource hostnames...");
 
@@ -446,7 +448,7 @@ namespace App.ControlPanel.Engine
                     $"Installation will fail until DNS / network / proxy connectivity is fixed on this machine.");
             }
 
-            var targets = BuildResourceDnsTargets(Config);
+            var targets = BuildResourceDnsTargets(Config, TryGetRedisHostNameFromArm(testRg));
             if (targets.Count == 0)
             {
                 _logger.LogInformation("No named Azure resources configured to DNS-check.");
@@ -483,9 +485,17 @@ namespace App.ControlPanel.Engine
                 else if (privateOnly)
                 {
                     // Public access disabled: the host must be on the VNet to resolve the private endpoint IP.
-                    _logger.LogError(
-                        $"DNS check: could not resolve {target.Label} {failureDescription}.{hint} " +
-                        PrivateNetworkGuidance.BuildVmOnVNetGuidance($"reaching the {target.Label}", Config.NetworkConfig?.VNetName));
+                    var message = $"DNS check: could not resolve {target.Label} {failureDescription}.{hint} " +
+                        PrivateNetworkGuidance.BuildVmOnVNetGuidance($"reaching the {target.Label}", Config.NetworkConfig?.VNetName);
+
+                    if (target.PrivateNetworkResolutionFailureIsWarning)
+                    {
+                        _logger.LogWarning(message);
+                    }
+                    else
+                    {
+                        _logger.LogError(message);
+                    }
                 }
                 else
                 {
@@ -507,7 +517,7 @@ namespace App.ControlPanel.Engine
         /// enabled and has a name configured. Pure string logic so it is unit-testable without any network
         /// access.
         /// </summary>
-        public static List<ResourceDnsTarget> BuildResourceDnsTargets(SolutionInstallConfig config)
+        public static List<ResourceDnsTarget> BuildResourceDnsTargets(SolutionInstallConfig config, string redisHostNameFromArm = null)
         {
             var targets = new List<ResourceDnsTarget>();
             if (config == null) return targets;
@@ -528,7 +538,7 @@ namespace App.ControlPanel.Engine
             Add("Storage account (table)", config.StorageAccountName, DNS_SUFFIX_STORAGE_TABLE);
             Add("App Service", config.AppServiceWebAppName, DNS_SUFFIX_APP_SERVICE);
 
-            var redisTarget = BuildRedisDnsTarget(config.RedisName, config.AzureLocationName);
+            var redisTarget = BuildRedisDnsTarget(config.RedisName, config.AzureLocationName, redisHostNameFromArm);
             if (redisTarget != null)
             {
                 targets.Add(redisTarget);
@@ -547,19 +557,27 @@ namespace App.ControlPanel.Engine
         }
 
         /// <summary>
-        /// Build the Redis DNS target. The installer provisions Azure Managed Redis
-        /// (<c>&lt;name&gt;.&lt;region&gt;.redis.azure.net</c>) but reuses a pre-existing legacy classic cache
-        /// (<c>&lt;name&gt;.redis.cache.windows.net</c>) when one already exists under the same name, and the
-        /// saved config does not record which kind was deployed. Both are therefore offered as candidates and
-        /// the check passes if either resolves - otherwise a perfectly healthy Managed Redis is reported as a
-        /// hard ERROR because the classic name genuinely does not exist in DNS (see issue #325).
+        /// Build the Redis DNS target. When ARM has reported the deployed cache hostname, use that exact
+        /// hostname: it is the same value the installer writes into the runtime Redis connection string and
+        /// avoids reconstructing a name from suffix guesses. Before the cache exists, fall back to the two
+        /// possible hostnames for a current Managed Redis deployment and a reused legacy classic cache.
         /// Returns null when no cache name is configured.
         /// </summary>
-        public static ResourceDnsTarget BuildRedisDnsTarget(string redisName, string azureLocationName)
+        public static ResourceDnsTarget BuildRedisDnsTarget(string redisName, string azureLocationName, string hostNameFromArm = null)
         {
             if (string.IsNullOrWhiteSpace(redisName)) return null;
 
             var name = redisName.Trim();
+
+            if (!string.IsNullOrWhiteSpace(hostNameFromArm))
+            {
+                return new ResourceDnsTarget(
+                    "Redis cache",
+                    hostNameFromArm.Trim(),
+                    "The Redis hostname was read from the existing Azure resource.",
+                    privateNetworkResolutionFailureIsWarning: true);
+            }
+
             var candidates = new List<string>();
 
             // Managed Redis first: it is what a current install deploys, so it is the name that should be
@@ -581,7 +599,50 @@ namespace App.ControlPanel.Engine
                 : "No Azure region is configured, so only the legacy classic cache hostname could be checked. " +
                   "Select the Azure region to also check the Azure Managed Redis hostname.";
 
-            return new ResourceDnsTarget("Redis cache", candidates, hint);
+            return new ResourceDnsTarget("Redis cache", candidates, hint, privateNetworkResolutionFailureIsWarning: true);
+        }
+
+        /// <summary>
+        /// If the configured Redis resource already exists, read its actual public hostname from ARM. This
+        /// mirrors <c>RedisInstallTask</c>: a pre-existing classic cache wins over Managed Redis because the
+        /// installer reuses it instead of provisioning a replacement.
+        /// </summary>
+        string TryGetRedisHostNameFromArm(ResourceGroupResource testRg)
+        {
+            if (testRg == null || string.IsNullOrWhiteSpace(Config?.RedisName))
+            {
+                return null;
+            }
+
+            var redisName = Config.RedisName.Trim();
+
+            try
+            {
+                var classic = testRg.GetAllRedis().Where(c => c.Data.Name == redisName).SingleOrDefault();
+                if (!string.IsNullOrWhiteSpace(classic?.Data?.HostName))
+                {
+                    return classic.Data.HostName;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not read classic Redis cache hostname from ARM for '{redisName}': {ex.Message}");
+            }
+
+            try
+            {
+                var managed = testRg.GetRedisEnterpriseClusters().Where(c => c.Data.Name == redisName).SingleOrDefault();
+                if (!string.IsNullOrWhiteSpace(managed?.Data?.HostName))
+                {
+                    return managed.Data.HostName;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not read Azure Managed Redis hostname from ARM for '{redisName}': {ex.Message}");
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -960,7 +1021,20 @@ namespace App.ControlPanel.Engine
         {
         }
 
-        public ResourceDnsTarget(string label, IReadOnlyList<string> fqdns, string failureHint = null)
+        public ResourceDnsTarget(
+            string label,
+            string fqdn,
+            string failureHint,
+            bool privateNetworkResolutionFailureIsWarning)
+            : this(label, new List<string> { fqdn }, failureHint, privateNetworkResolutionFailureIsWarning)
+        {
+        }
+
+        public ResourceDnsTarget(
+            string label,
+            IReadOnlyList<string> fqdns,
+            string failureHint = null,
+            bool privateNetworkResolutionFailureIsWarning = false)
         {
             if (fqdns == null || fqdns.Count == 0)
             {
@@ -970,6 +1044,7 @@ namespace App.ControlPanel.Engine
             Label = label;
             Fqdns = fqdns;
             FailureHint = failureHint;
+            PrivateNetworkResolutionFailureIsWarning = privateNetworkResolutionFailureIsWarning;
         }
 
         /// <summary>Human-readable resource description, e.g. "Key Vault".</summary>
@@ -986,6 +1061,12 @@ namespace App.ControlPanel.Engine
         /// "the resource may not exist yet" wording cannot explain. Null when there is nothing extra to say.
         /// </summary>
         public string FailureHint { get; }
+
+        /// <summary>
+        /// True when failing to resolve this target from outside a private-endpoint deployment is advisory
+        /// rather than proof that installation will fail from that host.
+        /// </summary>
+        public bool PrivateNetworkResolutionFailureIsWarning { get; }
 
         /// <summary>Primary (most likely) public fully-qualified hostname, e.g. "myvault.vault.azure.net".</summary>
         public string Fqdn => Fqdns[0];

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -403,7 +403,18 @@ namespace App.ControlPanel.Engine
         private const string DNS_SUFFIX_STORAGE_BLOB = ".blob.core.windows.net";
         private const string DNS_SUFFIX_STORAGE_TABLE = ".table.core.windows.net";
         private const string DNS_SUFFIX_APP_SERVICE = ".azurewebsites.net";
-        private const string DNS_SUFFIX_REDIS = ".redis.cache.windows.net";
+
+        /// <summary>
+        /// Public DNS suffix for Azure Managed Redis (Redis Enterprise), which the installer provisions
+        /// by default. The full name is region-qualified: <c>&lt;name&gt;.&lt;region&gt;.redis.azure.net</c>.
+        /// </summary>
+        private const string DNS_SUFFIX_REDIS_MANAGED = ".redis.azure.net";
+
+        /// <summary>
+        /// Public DNS suffix for legacy classic Azure Cache for Redis. Only relevant when the installer
+        /// detects and reuses a pre-existing classic cache (see <c>RedisInstallTask</c>).
+        /// </summary>
+        private const string DNS_SUFFIX_REDIS_CLASSIC = ".redis.cache.windows.net";
         private const string DNS_SUFFIX_SERVICE_BUS = ".servicebus.windows.net";
         private const string DNS_SUFFIX_COGNITIVE = ".cognitiveservices.azure.com";
 
@@ -446,23 +457,34 @@ namespace App.ControlPanel.Engine
 
             foreach (var target in targets)
             {
-                var (ok, error) = await TryResolveHost(target.Fqdn);
+                // A target can carry more than one candidate hostname (Redis, where the same configured
+                // name is either Azure Managed Redis or a reused legacy classic cache). Resolving any one
+                // of them proves the resource is reachable, so only report a failure when all of them fail.
+                var (ok, resolvedHost, failureDetail) = await TryResolveAnyHost(target.Fqdns);
                 if (ok)
                 {
-                    _logger.LogInformation($"DNS OK: {target.Label} '{target.Fqdn}' resolved.");
+                    _logger.LogInformation($"DNS OK: {target.Label} '{resolvedHost}' resolved.");
                     continue;
                 }
+
+                // "hostname 'x' (reason)" for a single candidate; "hostname - tried 'x' (reason), 'y' (reason)"
+                // when there are several, so the admin can see every name that was attempted and why each failed.
+                var failureDescription = target.Fqdns.Count == 1
+                    ? $"hostname {failureDetail}"
+                    : $"hostname - tried {failureDetail}";
+
+                var hint = string.IsNullOrEmpty(target.FailureHint) ? string.Empty : " " + target.FailureHint;
 
                 if (!controlOk)
                 {
                     // Root cause already reported above; don't repeat the per-resource guidance.
-                    _logger.LogError($"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}).");
+                    _logger.LogError($"DNS check: could not resolve {target.Label} {failureDescription}.{hint}");
                 }
                 else if (privateOnly)
                 {
                     // Public access disabled: the host must be on the VNet to resolve the private endpoint IP.
                     _logger.LogError(
-                        $"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}). " +
+                        $"DNS check: could not resolve {target.Label} {failureDescription}.{hint} " +
                         PrivateNetworkGuidance.BuildVmOnVNetGuidance($"reaching the {target.Label}", Config.NetworkConfig?.VNetName));
                 }
                 else
@@ -470,7 +492,7 @@ namespace App.ControlPanel.Engine
                     // Public access path: if the resource already exists this is a real DNS / network problem
                     // that will break the install; if it has not been created yet, it is expected.
                     _logger.LogError(
-                        $"DNS check: could not resolve {target.Label} hostname '{target.Fqdn}' ({error}). " +
+                        $"DNS check: could not resolve {target.Label} {failureDescription}.{hint} " +
                         $"If this resource has not been created yet this is expected and can be ignored; " +
                         $"if it already exists, the installer host cannot reach it and data-plane steps " +
                         $"(e.g. Key Vault secret upload) will fail.");
@@ -481,8 +503,9 @@ namespace App.ControlPanel.Engine
         }
 
         /// <summary>
-        /// Build the list of (resource, public-FQDN) DNS targets for every resource that is both enabled
-        /// and has a name configured. Pure string logic so it is unit-testable without any network access.
+        /// Build the list of (resource, public-FQDN candidates) DNS targets for every resource that is both
+        /// enabled and has a name configured. Pure string logic so it is unit-testable without any network
+        /// access.
         /// </summary>
         public static List<ResourceDnsTarget> BuildResourceDnsTargets(SolutionInstallConfig config)
         {
@@ -504,7 +527,13 @@ namespace App.ControlPanel.Engine
             // private endpoint / DNS zone on private deployments - check it resolves too (see #207 / AzurePaaSInstallJob).
             Add("Storage account (table)", config.StorageAccountName, DNS_SUFFIX_STORAGE_TABLE);
             Add("App Service", config.AppServiceWebAppName, DNS_SUFFIX_APP_SERVICE);
-            Add("Redis cache", config.RedisName, DNS_SUFFIX_REDIS);
+
+            var redisTarget = BuildRedisDnsTarget(config.RedisName, config.AzureLocationName);
+            if (redisTarget != null)
+            {
+                targets.Add(redisTarget);
+            }
+
             if (config.ServiceBusEnabled)
             {
                 Add("Service Bus", config.ServiceBusName, DNS_SUFFIX_SERVICE_BUS);
@@ -515,6 +544,82 @@ namespace App.ControlPanel.Engine
             }
 
             return targets;
+        }
+
+        /// <summary>
+        /// Build the Redis DNS target. The installer provisions Azure Managed Redis
+        /// (<c>&lt;name&gt;.&lt;region&gt;.redis.azure.net</c>) but reuses a pre-existing legacy classic cache
+        /// (<c>&lt;name&gt;.redis.cache.windows.net</c>) when one already exists under the same name, and the
+        /// saved config does not record which kind was deployed. Both are therefore offered as candidates and
+        /// the check passes if either resolves - otherwise a perfectly healthy Managed Redis is reported as a
+        /// hard ERROR because the classic name genuinely does not exist in DNS (see issue #325).
+        /// Returns null when no cache name is configured.
+        /// </summary>
+        public static ResourceDnsTarget BuildRedisDnsTarget(string redisName, string azureLocationName)
+        {
+            if (string.IsNullOrWhiteSpace(redisName)) return null;
+
+            var name = redisName.Trim();
+            var candidates = new List<string>();
+
+            // Managed Redis first: it is what a current install deploys, so it is the name that should be
+            // reported when neither resolves. Needs the region, which older configs may not have.
+            var region = NormaliseAzureRegionForDns(azureLocationName);
+            if (region != null)
+            {
+                candidates.Add($"{name}.{region}{DNS_SUFFIX_REDIS_MANAGED}");
+            }
+
+            candidates.Add(name + DNS_SUFFIX_REDIS_CLASSIC);
+
+            // The managed name is region-qualified and the region is taken from this config, not from ARM. An
+            // existing cache that lives in a different region than the config now says would fail both
+            // candidates, so name that possibility rather than leaving the admin to guess.
+            var hint = region != null
+                ? $"The Azure Managed Redis hostname is built from the configured region '{region}'; " +
+                  $"if the cache exists in a different region, correct the region on the Azure tab."
+                : "No Azure region is configured, so only the legacy classic cache hostname could be checked. " +
+                  "Select the Azure region to also check the Azure Managed Redis hostname.";
+
+            return new ResourceDnsTarget("Redis cache", candidates, hint);
+        }
+
+        /// <summary>
+        /// Turn a configured Azure location into the region segment of an Azure Managed Redis FQDN, or null
+        /// when it cannot be one. <c>AzureLocationName</c> normally holds the short name already
+        /// (<c>westeurope</c>), but it is a free-text string on the config: it can hold the display name
+        /// ("West Europe" - same value once spaces are stripped), the installer's "no region selected"
+        /// placeholder, or nothing at all on an older config.
+        /// </summary>
+        static string NormaliseAzureRegionForDns(string azureLocationName)
+        {
+            if (string.IsNullOrWhiteSpace(azureLocationName)) return null;
+
+            var normalised = azureLocationName.Trim().Replace(" ", string.Empty).ToLowerInvariant();
+
+            // Every Azure region short name is lowercase alphanumeric (westeurope, uksouth, eastus2). Anything
+            // else - notably the "---" placeholder - is not a region and must not be baked into a hostname.
+            return System.Text.RegularExpressions.Regex.IsMatch(normalised, "^[a-z0-9]+$") ? normalised : null;
+        }
+
+        /// <summary>
+        /// Resolve the first host name that resolves out of <paramref name="hosts"/>. Returns
+        /// (true, the host that resolved, null) on success, and (false, null, detail) when none resolve -
+        /// where detail lists every candidate tried and why each failed, e.g.
+        /// <c>'a.redis.azure.net' (No such host is known), 'a.redis.cache.windows.net' (No such host is known)</c>.
+        /// Reporting only the last candidate's error would hide, say, a timeout on the name that actually
+        /// matters behind an NXDOMAIN on the legacy fallback. Never throws.
+        /// </summary>
+        static async Task<(bool ok, string resolvedHost, string failureDetail)> TryResolveAnyHost(IReadOnlyList<string> hosts)
+        {
+            var failures = new List<string>();
+            foreach (var host in hosts)
+            {
+                var (ok, error) = await TryResolveHost(host);
+                if (ok) return (true, host, null);
+                failures.Add($"'{host}' ({error})");
+            }
+            return (false, null, string.Join(", ", failures));
         }
 
         /// <summary>
@@ -844,21 +949,45 @@ namespace App.ControlPanel.Engine
     }
 
     /// <summary>
-    /// A configured Azure resource and the public hostname that must resolve for the installer / runtime
+    /// A configured Azure resource and the public hostname(s) that must resolve for the installer / runtime
     /// to reach it. Built by <see cref="SolutionInstallVerifier.BuildResourceDnsTargets"/>.
+    /// Most resources have exactly one candidate; Redis has two because the same configured name is either
+    /// Azure Managed Redis or a reused legacy classic cache, and the config does not record which.
     /// </summary>
     public class ResourceDnsTarget
     {
-        public ResourceDnsTarget(string label, string fqdn)
+        public ResourceDnsTarget(string label, string fqdn) : this(label, new List<string> { fqdn }, null)
         {
+        }
+
+        public ResourceDnsTarget(string label, IReadOnlyList<string> fqdns, string failureHint = null)
+        {
+            if (fqdns == null || fqdns.Count == 0)
+            {
+                throw new ArgumentException("A DNS target needs at least one candidate hostname.", nameof(fqdns));
+            }
+
             Label = label;
-            Fqdn = fqdn;
+            Fqdns = fqdns;
+            FailureHint = failureHint;
         }
 
         /// <summary>Human-readable resource description, e.g. "Key Vault".</summary>
         public string Label { get; }
 
-        /// <summary>Public fully-qualified hostname, e.g. "myvault.vault.azure.net".</summary>
-        public string Fqdn { get; }
+        /// <summary>
+        /// Candidate fully-qualified hostnames, in preference order. The resource is considered reachable
+        /// when any one of them resolves.
+        /// </summary>
+        public IReadOnlyList<string> Fqdns { get; }
+
+        /// <summary>
+        /// Optional resource-specific guidance appended to the failure message, for anything the generic
+        /// "the resource may not exist yet" wording cannot explain. Null when there is nothing extra to say.
+        /// </summary>
+        public string FailureHint { get; }
+
+        /// <summary>Primary (most likely) public fully-qualified hostname, e.g. "myvault.vault.azure.net".</summary>
+        public string Fqdn => Fqdns[0];
     }
 }

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
@@ -27,6 +27,7 @@ namespace App.ControlPanel.Frames
             installSolutionControl1.CancelRequested += InstallSolutionControl1_CancelRequested;
             tabs.Selecting += Tabs_Selecting;
             azureBaseConfigControl1.OnNeedAppRegistrationCredentials = () => GetConfigFromGUI().InstallerAccount;
+            azureBaseConfigControl1.AzureLocationChanged += (s, region) => azureStorageConfigControl1.AzureRegion = region;
             networkingConfigControl1.OnNeedAzureCredentials = () =>
             {
                 var config = GetConfigFromGUI();
@@ -189,6 +190,11 @@ namespace App.ControlPanel.Frames
             azureStorageConfigControl1.SQLServerPassword = config.SQLServerAdminPassword;
             azureStorageConfigControl1.SQLServerUsername = config.SQLServerAdminUsername;
             azureStorageConfigControl1.StorageAccount = config.StorageAccountName;
+            // Take the region from the picker rather than the raw config: the picker rejects a value that is
+            // not a known Azure region (it falls back to its "no region" placeholder), and the preview label
+            // must agree with what the Azure tab actually shows. Set explicitly because SelectedIndexChanged
+            // does not fire when the assignment leaves the selection unchanged.
+            azureStorageConfigControl1.AzureRegion = azureBaseConfigControl1.AzureLocationString;
             azureStorageConfigControl1.RedisName = config.RedisName;
             azureStorageConfigControl1.ServiceBusName = config.ServiceBusName;
             azureStorageConfigControl1.ServiceBusEnabled = config.ServiceBusEnabled;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureBaseConfigControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureBaseConfigControl.cs
@@ -23,9 +23,17 @@ namespace App.ControlPanel.Frames.InstallWizardPages
             InitializeComponent();
             cmbEnvType.Items.Clear();
             cmbEnvType.Items.AddRange(new string[] { PERF_TIER_TESTING, PERF_TIER_PROD });
+            cmbLocation.SelectedIndexChanged += (s, e) => AzureLocationChanged?.Invoke(this, AzureLocationString);
         }
 
         public event EventHandler<bool> LoadingSubscriptionStateChange;
+
+        /// <summary>
+        /// Raised with the newly selected Azure region short name whenever the region picker changes.
+        /// Other wizard pages preview region-qualified hostnames (Azure Managed Redis is
+        /// <c>&lt;name&gt;.&lt;region&gt;.redis.azure.net</c>) and need to stay in step with it.
+        /// </summary>
+        public event EventHandler<string> AzureLocationChanged;
 
         public Func<AppRegistrationCredentials> OnNeedAppRegistrationCredentials;
 

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
@@ -80,7 +80,7 @@
             this.lblRedisName.Name = "lblRedisName";
             this.lblRedisName.Size = new System.Drawing.Size(235, 13);
             this.lblRedisName.TabIndex = 175;
-            this.lblRedisName.Text = "spoinsightsdemocache.redis.cache.windows.net";
+            this.lblRedisName.Text = "spoinsightsdemocache.westeurope.redis.azure.net";
             // 
             // lblServiceBusName
             // 

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs
@@ -1,10 +1,13 @@
-﻿using System;
+﻿using App.ControlPanel.Engine;
+using System;
 using System.Windows.Forms;
 
 namespace App.ControlPanel.Frames.InstallWizard
 {
     public partial class AzureStorageConfigControl : UserControl
     {
+        private string _azureRegion;
+
         public AzureStorageConfigControl()
         {
             InitializeComponent();
@@ -17,6 +20,20 @@ namespace App.ControlPanel.Frames.InstallWizard
         public string StorageAccount { get { return txtStorageAccount.Text; } set { txtStorageAccount.Text = value; } }
         public string RedisName { get { return txtRedisName.Text; } set { txtRedisName.Text = value; } }
         public string ServiceBusName { get { return txtServiceBusName.Text; } set { txtServiceBusName.Text = value; } }
+
+        /// <summary>
+        /// Azure region selected on the base-config page. Azure Managed Redis hostnames are region-qualified
+        /// (<c>&lt;name&gt;.&lt;region&gt;.redis.azure.net</c>), so the preview label cannot be built without it.
+        /// </summary>
+        public string AzureRegion
+        {
+            get { return _azureRegion; }
+            set
+            {
+                _azureRegion = value;
+                UpdateResponsiveUIControls();
+            }
+        }
 
         public bool ServiceBusEnabled
         {
@@ -31,13 +48,34 @@ namespace App.ControlPanel.Frames.InstallWizard
         private void UpdateResponsiveUIControls()
         {
             lblStorageAccountURL.Text = $"https://{txtStorageAccount.Text}.blob.core.windows.net/";
-            lblRedisName.Text = $"{txtRedisName.Text}.redis.cache.windows.net";
+            lblRedisName.Text = BuildRedisHostnamePreview();
             lblServiceBusName.Text = $"{txtServiceBusName.Text}.servicebus.windows.net";
             lblSQLServerName.Text = $"{txtSQLServerName.Text}.database.windows.net";
 
             // Disable SB name fields when Service Bus is disabled
             txtServiceBusName.Enabled = chkServiceBusEnabled.Checked;
             lblServiceBusName.Enabled = chkServiceBusEnabled.Checked;
+        }
+
+        /// <summary>
+        /// The installer provisions Azure Managed Redis, whose FQDN is region-qualified. Showing the legacy
+        /// classic '.redis.cache.windows.net' name here misled admins configuring firewalls and private DNS
+        /// (issue #325). Reuses the verifier's hostname logic so the preview and the Test Configuration DNS
+        /// check can never drift apart.
+        /// </summary>
+        private string BuildRedisHostnamePreview()
+        {
+            var target = SolutionInstallVerifier.BuildRedisDnsTarget(txtRedisName.Text, _azureRegion);
+            if (target == null) return string.Empty;
+
+            // No region picked yet: BuildRedisDnsTarget can only offer the legacy classic name, which is not
+            // what a new install deploys. Say so rather than showing a hostname that will not exist.
+            if (target.Fqdns.Count == 1)
+            {
+                return $"{txtRedisName.Text.Trim()}.<region>.redis.azure.net (select an Azure region to preview)";
+            }
+
+            return target.Fqdn;
         }
 
         private void txtStorageAccount_TextChanged(object sender, EventArgs e)

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -492,9 +492,9 @@ namespace Tests.UnitTests
         [TestMethod]
         public void BuildRedisDnsTargetOffersManagedRedisFirstThenClassic()
         {
-            // The installer provisions Azure Managed Redis, but reuses a pre-existing classic cache of the
-            // same name if one exists - and the saved config does not record which. Both must be offered or
-            // a healthy Managed Redis is reported as a hard ERROR (issue #325).
+            // Before the resource exists in ARM, the verifier cannot know which Redis kind will be present:
+            // the installer provisions Azure Managed Redis, but reuses a pre-existing classic cache of the
+            // same name if one exists. Both must be offered or one healthy cache kind is reported as broken.
             var target = SolutionInstallVerifier.BuildRedisDnsTarget("mycache", "westeurope");
 
             Assert.AreEqual("Redis cache", target.Label);
@@ -502,6 +502,23 @@ namespace Tests.UnitTests
                 new[] { "mycache.westeurope.redis.azure.net", "mycache.redis.cache.windows.net" },
                 target.Fqdns.ToArray());
             Assert.AreEqual("mycache.westeurope.redis.azure.net", target.Fqdn, "Managed Redis must be the primary candidate.");
+            Assert.IsTrue(target.PrivateNetworkResolutionFailureIsWarning,
+                "Redis DNS misses on private-endpoint deployments should be advisory, not hard errors.");
+        }
+
+        [TestMethod]
+        public void BuildRedisDnsTargetUsesArmHostNameWhenKnown()
+        {
+            var target = SolutionInstallVerifier.BuildRedisDnsTarget(
+                "mycache",
+                "westeurope",
+                "mycache.actual.redis.azure.net");
+
+            CollectionAssert.AreEqual(new[] { "mycache.actual.redis.azure.net" }, target.Fqdns.ToArray());
+            Assert.AreEqual("mycache.actual.redis.azure.net", target.Fqdn);
+            StringAssert.Contains(target.FailureHint, "existing Azure resource");
+            Assert.IsTrue(target.PrivateNetworkResolutionFailureIsWarning,
+                "A Redis private-endpoint DNS miss from the installer host is not by itself an install blocker.");
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -392,6 +392,7 @@ namespace Tests.UnitTests
                 StorageAccountName = "mystorage",
                 AppServiceWebAppName = "myapp",
                 RedisName = "mycache",
+                AzureLocationName = "westeurope",
                 ServiceBusName = "mysb",
                 ServiceBusEnabled = true,
                 CognitiveServiceName = "mycog",
@@ -405,7 +406,8 @@ namespace Tests.UnitTests
             CollectionAssert.Contains(fqdns, "mystorage.blob.core.windows.net");
             CollectionAssert.Contains(fqdns, "mystorage.table.core.windows.net");
             CollectionAssert.Contains(fqdns, "myapp.azurewebsites.net");
-            CollectionAssert.Contains(fqdns, "mycache.redis.cache.windows.net");
+            // Azure Managed Redis is what the installer deploys, so it is the primary candidate.
+            CollectionAssert.Contains(fqdns, "mycache.westeurope.redis.azure.net");
             CollectionAssert.Contains(fqdns, "mysb.servicebus.windows.net");
             CollectionAssert.Contains(fqdns, "mycog.cognitiveservices.azure.com");
         }
@@ -476,14 +478,127 @@ namespace Tests.UnitTests
         [TestMethod]
         public void BuildResourceDnsTargetsSingleResourceHasCorrectLabelAndFqdn()
         {
-            var config = new SolutionInstallConfig { RedisName = "mycache" };
+            var config = new SolutionInstallConfig { RedisName = "mycache", AzureLocationName = "westeurope" };
 
             var targets = SolutionInstallVerifier.BuildResourceDnsTargets(config);
 
             Assert.AreEqual(1, targets.Count);
             Assert.AreEqual("Redis cache", targets.Single().Label);
-            Assert.AreEqual("mycache.redis.cache.windows.net", targets.Single().Fqdn);
+            Assert.AreEqual("mycache.westeurope.redis.azure.net", targets.Single().Fqdn);
         }
+
+        #region Redis DNS candidates (issue #325)
+
+        [TestMethod]
+        public void BuildRedisDnsTargetOffersManagedRedisFirstThenClassic()
+        {
+            // The installer provisions Azure Managed Redis, but reuses a pre-existing classic cache of the
+            // same name if one exists - and the saved config does not record which. Both must be offered or
+            // a healthy Managed Redis is reported as a hard ERROR (issue #325).
+            var target = SolutionInstallVerifier.BuildRedisDnsTarget("mycache", "westeurope");
+
+            Assert.AreEqual("Redis cache", target.Label);
+            CollectionAssert.AreEqual(
+                new[] { "mycache.westeurope.redis.azure.net", "mycache.redis.cache.windows.net" },
+                target.Fqdns.ToArray());
+            Assert.AreEqual("mycache.westeurope.redis.azure.net", target.Fqdn, "Managed Redis must be the primary candidate.");
+        }
+
+        [TestMethod]
+        public void BuildRedisDnsTargetFallsBackToClassicOnlyWhenRegionMissing()
+        {
+            // An older saved config may have no region. Guessing one would produce a hostname that can never
+            // resolve, so only the region-free classic name is offered.
+            foreach (var noRegion in new[] { null, "", "   " })
+            {
+                var target = SolutionInstallVerifier.BuildRedisDnsTarget("mycache", noRegion);
+                CollectionAssert.AreEqual(new[] { "mycache.redis.cache.windows.net" }, target.Fqdns.ToArray(),
+                    $"Region '{noRegion ?? "<null>"}' should fall back to classic only.");
+            }
+        }
+
+        [TestMethod]
+        public void BuildRedisDnsTargetIgnoresNoRegionSelectedPlaceholder()
+        {
+            // The region combo stores "---" when nothing is picked; that must never be baked into a hostname.
+            var target = SolutionInstallVerifier.BuildRedisDnsTarget("mycache", "---");
+
+            CollectionAssert.AreEqual(new[] { "mycache.redis.cache.windows.net" }, target.Fqdns.ToArray());
+        }
+
+        [TestMethod]
+        public void BuildRedisDnsTargetNormalisesDisplayNameRegions()
+        {
+            // AzureLocationName is free text on the config: a display name ("West Europe") is the short name
+            // once spaces are stripped and case is normalised.
+            var target = SolutionInstallVerifier.BuildRedisDnsTarget("mycache", " West Europe ");
+
+            Assert.AreEqual("mycache.westeurope.redis.azure.net", target.Fqdn);
+        }
+
+        [TestMethod]
+        public void BuildRedisDnsTargetTrimsNameAndReturnsNullWhenUnnamed()
+        {
+            Assert.AreEqual("mycache.uksouth.redis.azure.net",
+                SolutionInstallVerifier.BuildRedisDnsTarget("  mycache  ", "uksouth").Fqdn);
+
+            Assert.IsNull(SolutionInstallVerifier.BuildRedisDnsTarget(null, "uksouth"));
+            Assert.IsNull(SolutionInstallVerifier.BuildRedisDnsTarget("   ", "uksouth"));
+        }
+
+        [TestMethod]
+        public void BuildResourceDnsTargetsExcludesRedisWhenUnnamedEvenWithRegion()
+        {
+            var config = new SolutionInstallConfig { AzureLocationName = "westeurope", KeyVaultName = "myvault" };
+
+            CollectionAssert.DoesNotContain(
+                SolutionInstallVerifier.BuildResourceDnsTargets(config).Select(t => t.Label).ToList(),
+                "Redis cache");
+        }
+
+        [TestMethod]
+        public void ResourceDnsTargetRejectsEmptyCandidateList()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new ResourceDnsTarget("Redis cache", new List<string>()));
+            Assert.ThrowsException<ArgumentException>(() => new ResourceDnsTarget("Redis cache", (List<string>)null));
+        }
+
+        [TestMethod]
+        public void BuildRedisDnsTargetProducesManagedCandidateForEveryOfferedAzureRegion()
+        {
+            // The region picker is populated straight from AzurePublicCloudEnumerator, so every value it can
+            // produce must survive normalisation. If a future Azure.Core adds a region short name containing
+            // a character the normaliser rejects, that region would silently lose its Managed Redis candidate
+            // and the #325 false ERROR would come back for those customers only - exactly the kind of
+            // regression that never gets noticed in testing.
+            var regions = AzurePublicCloudEnumerator.GetAzureLocations();
+
+            Assert.IsTrue(regions.Count > 0, "No Azure regions enumerated - the picker would be empty.");
+
+            foreach (var region in regions)
+            {
+                var target = SolutionInstallVerifier.BuildRedisDnsTarget("mycache", region.Name);
+
+                Assert.AreEqual(2, target.Fqdns.Count,
+                    $"Region '{region.Name}' produced no Azure Managed Redis candidate.");
+                Assert.AreEqual($"mycache.{region.Name.ToLowerInvariant().Replace(" ", string.Empty)}.redis.azure.net",
+                    target.Fqdn, $"Wrong Managed Redis FQDN for region '{region.Name}'.");
+            }
+        }
+
+        [TestMethod]
+        public void BuildRedisDnsTargetAlwaysExplainsWhichRegionWasAssumed()
+        {
+            // The managed FQDN is region-qualified from config, not from ARM, so a cache that lives in a
+            // different region fails both candidates. The hint has to say so or the admin has nothing to go on.
+            var withRegion = SolutionInstallVerifier.BuildRedisDnsTarget("mycache", "westeurope");
+            StringAssert.Contains(withRegion.FailureHint, "westeurope");
+
+            var withoutRegion = SolutionInstallVerifier.BuildRedisDnsTarget("mycache", null);
+            StringAssert.Contains(withoutRegion.FailureHint, "No Azure region is configured");
+        }
+
+        #endregion
 
         [TestMethod]
         public void TransportFailureDetectorDetectsDnsAggregateException()


### PR DESCRIPTION
Fixes the Test Configuration DNS check reporting a hard `ERROR` for healthy Azure Managed Redis deployments.

## Problem

`SolutionInstallVerifier` previously checked Redis by reconstructing the legacy classic Azure Cache for Redis hostname (`<name>.redis.cache.windows.net`). Current installs provision Azure Managed Redis, whose ARM-reported hostname is region-qualified (`<name>.<region>.redis.azure.net`), so diagnostics could report a red DNS failure while the runtime still connected successfully using the ARM `RedisInstallResult.HostName`.

## Changes

- Rebased onto current `origin/dev`.
- Redis DNS checks now read the existing Redis resource hostname from ARM when the resource group is available:
  - classic `Microsoft.Cache/Redis` is checked first, matching `RedisInstallTask`'s reuse-classic precedence;
  - otherwise Managed Redis `Microsoft.Cache/redisEnterprise` is checked and its `Data.HostName` is used;
  - only the pre-create/no-ARM-result path falls back to candidate hostnames.
- Kept the pre-create fallback candidates for fresh installs: Managed Redis first, classic second, so both new Managed Redis and reused classic deployments remain diagnosable.
- Redis DNS misses on private-endpoint-only deployments are now warnings, not hard errors, because a host outside the VNet cannot prove the cache is broken merely by failing to resolve the private endpoint path.
- Updated the Redis hostname preview on the Azure storage page to share the verifier's Redis hostname logic and track the selected Azure region.
- Added/updated unit coverage for ARM-provided Redis hostnames, Managed/classic candidate ordering, no-region fallback, region normalisation, and private-endpoint warning severity.

## Validation

- `MSBuild.exe "O365 Advanced Analytics Engine.sln" /p:Configuration=Debug /m:2` — passed.
- Targeted `InstallEngineTests` — 50/50 passed.
- Full `Tests.UnitTests` run under the machine-wide vstest lock — 1468 passed, 12 failed due local/environment prerequisites outside this change: the four known VNet fixture-copy failures, placeholder/no live tenant credentials for live Graph/Redis/Cognitive tests, malformed local Service Bus placeholder config, and the opt-in stress test requiring `STRESS_RUN=1`.
- Multi-model code review: claude-opus-4.8, gpt-5.6-sol, and grok-4.6 all reported no significant issues after the ARM-hostname/private-endpoint update.

## Risk / scope

- Diagnostics/UI only; no runtime Redis connection-string behavior change.
- No EF migration and no database schema change.
- No persisted installer config property was added/removed/renamed, so no `CONFIG_VERSION` bump was needed.
- Reviewer hotspot: `TryGetRedisHostNameFromArm` intentionally mirrors install precedence by checking classic Redis before Managed Redis.

Addresses #325
