### PR TITLE
Usage reports: one failing report no longer forces the other ten to re-download

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ReportCompletionStoreTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ReportCompletionStoreTests.cs
@@ -1,0 +1,302 @@
+using Common.Entities.Config;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Per-report completion stamps (issue #311).
+    /// </summary>
+    /// <remarks>
+    /// The phase-level timestamp had to mean two things at once: "don't re-run this once-a-day phase yet" and
+    /// "these stored days are proven complete, so the finalized-date skip list can skip them". Withholding it
+    /// after a failure is right for the first (issue #285) and wrong for the second - it also emptied the skip
+    /// list for the ten reports that had succeeded, so one permanently failing report made all eleven
+    /// re-download their full window every cycle, roughly 10x the intended steady-state Graph volume.
+    /// </remarks>
+    [TestClass]
+    public class ReportCompletionStoreTests
+    {
+        private static readonly string ReportA = GraphImporter.GetReportKey(typeof(TeamsUserUsageLoader));
+        private static readonly string ReportB = GraphImporter.GetReportKey(typeof(OutlookUserActivityLoader));
+
+        /// <summary>
+        /// A GraphImporter wired to a real completion store, so the production decision methods are exercised
+        /// rather than re-implemented in the test.
+        /// </summary>
+        private static GraphImporter NewImporter(IReportCompletionStore store, bool forceImport = false, DataUtils.IClock clock = null)
+        {
+            var settings = new AppConfig { ForceUsageReportsImport = forceImport };
+
+            return new GraphImporter(
+                DataUtils.AnalyticsLogger.ConsoleOnlyTracer(),
+                userGroupsCache: null,
+                graphAppIndentityOAuthContext: null,
+                graphClient: null,
+                settings: settings,
+                activityReportsLastImportedStore: null,
+                lastRunStore: null,
+                sentEmailMailboxSkipList: null,
+                reportCompletionStore: store,
+                clock: clock);
+        }
+
+        #region The store itself
+
+        [TestMethod]
+        public async Task AReportThatHasNeverRunHasNoCompletionStamp()
+        {
+            var store = new InMemoryReportCompletionStore();
+
+            Assert.IsNull(await store.GetLastSuccessAsync(ReportA));
+        }
+
+        [TestMethod]
+        public async Task OneReportSucceedingDoesNotStampAnother()
+        {
+            var store = new InMemoryReportCompletionStore();
+
+            await store.SaveSuccessAsync(ReportA);
+
+            Assert.IsNotNull(await store.GetLastSuccessAsync(ReportA));
+            Assert.IsNull(await store.GetLastSuccessAsync(ReportB),
+                "A report that has not completed must not inherit another report's completion.");
+        }
+
+        [TestMethod]
+        public async Task ClearingOneReportLeavesTheOthersIntact()
+        {
+            var store = new InMemoryReportCompletionStore();
+            await store.SaveSuccessAsync(ReportA);
+            await store.SaveSuccessAsync(ReportB);
+
+            await store.ClearAsync(ReportA);
+
+            Assert.IsNull(await store.GetLastSuccessAsync(ReportA));
+            Assert.IsNotNull(await store.GetLastSuccessAsync(ReportB));
+        }
+
+        [TestMethod]
+        public async Task ReportKeysAreCaseInsensitive()
+        {
+            var store = new InMemoryReportCompletionStore();
+            await store.SaveSuccessAsync(ReportA);
+
+            Assert.IsNotNull(await store.GetLastSuccessAsync(ReportA.ToUpperInvariant()));
+        }
+
+        [TestMethod]
+        public void ConcurrentStampsFromParallelReportsAllLand()
+        {
+            // The reports genuinely run in parallel under Task.WhenAll. The writes must hit the dictionary at
+            // the same moment or this would pass even with a plain Dictionary - hence real threads released
+            // together by a barrier, rather than awaiting already-completed tasks in sequence.
+            //
+            // Dedicated threads, not the thread pool: a barrier needs every participant running at once, and
+            // the pool injects threads roughly one per second beyond its initial burst, which turned this into
+            // a 20-second test.
+            var store = new InMemoryReportCompletionStore();
+            var keys = Enumerable.Range(0, 16).Select(i => $"Report{i}").ToList();
+
+            using (var startLine = new Barrier(keys.Count))
+            {
+                var writers = keys.Select(k => new Thread(() =>
+                {
+                    startLine.SignalAndWait();
+                    store.SaveSuccessAsync(k).GetAwaiter().GetResult();
+                })
+                { IsBackground = true }).ToList();
+
+                writers.ForEach(t => t.Start());
+                foreach (var t in writers)
+                {
+                    Assert.IsTrue(t.Join(TimeSpan.FromSeconds(30)), "Concurrent stamping deadlocked.");
+                }
+            }
+
+            foreach (var key in keys)
+            {
+                Assert.IsNotNull(store.GetLastSuccessAsync(key).GetAwaiter().GetResult(), $"Lost the stamp for {key}.");
+            }
+        }
+
+        [TestMethod]
+        public void ReportKeysComeFromTheLoaderTypeNotTheDisplayLabel()
+        {
+            // Deriving the key from the human-readable label would mean that editing a log message orphaned
+            // every customer's stamp and silently triggered one full re-download.
+            Assert.AreEqual(nameof(TeamsUserUsageLoader), GraphImporter.GetReportKey(typeof(TeamsUserUsageLoader)));
+            Assert.AreNotEqual(
+                GraphImporter.GetReportKey(typeof(TeamsUserUsageLoader)),
+                GraphImporter.GetReportKey(typeof(TeamsUserDeviceLoader)),
+                "Two loaders sharing a key would share one stamp, so one failing would suppress the other's re-import.");
+        }
+
+        [TestMethod]
+        public void RedisKeysAreNamespacedAwayFromThePhaseLevelMarker()
+        {
+            // The phase marker lives at "UserActivityLastImported". A per-report key must not be able to
+            // collide with it, or a report's stamp would disarm the once-a-day throttle (or vice versa).
+            const string phaseKey = "UserActivityLastImported";
+            var fullKey = RedisReportCompletionStore.KeyPrefix + ReportA;
+
+            Assert.IsFalse(fullKey.Equals(phaseKey, StringComparison.OrdinalIgnoreCase));
+        }
+
+        #endregion
+
+        #region ResolveReportSkipListInputAsync - what feeds the finalized-date skip list
+
+        [TestMethod]
+        public async Task AFailingReportNoLongerEmptiesTheSkipListOfTheReportsThatSucceeded()
+        {
+            // The #311 scenario, against the real production method. Report B fails permanently, so the PHASE
+            // marker is withheld (null) - which is correct and must stay that way (#285). Report A succeeded
+            // last cycle and must still skip its finalized days rather than re-downloading the full window.
+            var store = new InMemoryReportCompletionStore();
+            await store.SaveSuccessAsync(ReportA);
+            var importer = NewImporter(store);
+
+            DateTime? withheldPhaseMarker = null;
+
+            Assert.IsNotNull(await importer.ResolveReportSkipListInputAsync(ReportA, withheldPhaseMarker),
+                "The succeeding report must keep its skip list even while another report is broken.");
+
+            Assert.IsNull(await importer.ResolveReportSkipListInputAsync(ReportB, withheldPhaseMarker),
+                "The failing report must still re-import its own full window.");
+        }
+
+        [TestMethod]
+        public async Task TheLegacyPhaseMarkerIsNeverTrustedAsAPerReportCompletion()
+        {
+            // The phase marker is an unversioned Redis key predating the strict-paging fixes (#285 / #310): an
+            // older build could write it after a report had saved a PARTIAL day. Skipping a partially-stored
+            // date loses those rows for good once Graph's ~28-day retention passes, so one extra full download
+            // per report on the first upgraded cycle is the right trade.
+            var store = new InMemoryReportCompletionStore();
+            var importer = NewImporter(store);
+
+            Assert.IsNull(
+                await importer.ResolveReportSkipListInputAsync(ReportA, DateTime.Now.AddHours(-2)),
+                "A report with no stamp of its own must re-import its full window, not inherit the phase marker.");
+        }
+
+        [TestMethod]
+        public async Task WithNoCompletionStoreTheOldPhaseMarkerBehaviourIsUnchanged()
+        {
+            // Callers that supply no store (unit tests, and any embedder) must behave exactly as before.
+            var importer = NewImporter(store: null);
+            var phaseMarker = DateTime.Now.AddHours(-2);
+
+            Assert.AreEqual(phaseMarker, await importer.ResolveReportSkipListInputAsync(ReportA, phaseMarker));
+        }
+
+        [TestMethod]
+        public async Task ClearingBeforeARunMeansACrashMidSaveReImportsThatReportOnly()
+        {
+            // Stamps are cleared before the report runs, so a crash between download and save cannot leave a
+            // stamp claiming a window that was only partly written.
+            var store = new InMemoryReportCompletionStore();
+            await store.SaveSuccessAsync(ReportA);
+            await store.SaveSuccessAsync(ReportB);
+            var importer = NewImporter(store);
+
+            // Report A starts, clears its stamp, then crashes before SaveSuccessAsync.
+            await store.ClearAsync(ReportA);
+
+            Assert.IsNull(await importer.ResolveReportSkipListInputAsync(ReportA, null),
+                "A report that crashed mid-save must re-import its full window.");
+            Assert.IsNotNull(await importer.ResolveReportSkipListInputAsync(ReportB, null),
+                "The crash must not cost any other report its skip list.");
+        }
+
+        #endregion
+
+        #region IsReportDueAsync - the weekly report's independent cadence
+
+        private static readonly TimeSpan OneDay = TimeSpan.FromDays(1);
+
+        [TestMethod]
+        public async Task AReportThatHasNeverSucceededIsDue()
+        {
+            var importer = NewImporter(new InMemoryReportCompletionStore());
+
+            Assert.IsTrue(await importer.IsReportDueAsync(ReportA, OneDay));
+        }
+
+        [TestMethod]
+        public async Task AReportThatSucceededRecentlyIsNotDueEvenWhileAnotherReportRetries()
+        {
+            // The weekly SharePoint sites report pages the WHOLE report from Graph before it checks what is
+            // already stored, so with the phase throttle disarmed by another report's failure it would
+            // re-download in full every cycle - exactly the waste #311 is about.
+            var store = new InMemoryReportCompletionStore();
+            await store.SaveSuccessAsync(ReportA);
+            var importer = NewImporter(store);
+
+            Assert.IsFalse(await importer.IsReportDueAsync(ReportA, OneDay));
+        }
+
+        [TestMethod]
+        public async Task AReportThatSucceededLongerAgoThanTheWindowIsDueAgain()
+        {
+            var store = new StubCompletionStore { LastSuccess = DateTime.Now.AddDays(-2) };
+            var importer = NewImporter(store);
+
+            Assert.IsTrue(await importer.IsReportDueAsync(ReportA, OneDay));
+        }
+
+        [TestMethod]
+        public async Task IsReportDueTreatsALocalStoredTimestampAsAnInstant()
+        {
+            var lastUtc = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+            var lastLocal = lastUtc.ToLocalTime();
+            Assert.AreEqual(DateTimeKind.Local, lastLocal.Kind);
+
+            var store = new StubCompletionStore { LastSuccess = lastLocal };
+
+            Assert.IsFalse(await NewImporter(store, clock: new FixedClock(lastUtc.AddHours(23))).IsReportDueAsync(ReportA, OneDay),
+                "A local-kind stamp less than the window old must not be due.");
+            Assert.IsTrue(await NewImporter(store, clock: new FixedClock(lastUtc.AddHours(25))).IsReportDueAsync(ReportA, OneDay),
+                "A local-kind stamp more than the window old must be due.");
+        }
+
+        [TestMethod]
+        public async Task ForceUsageReportsImportBypassesThePerReportCadence()
+        {
+            var store = new InMemoryReportCompletionStore();
+            await store.SaveSuccessAsync(ReportA);
+            var importer = NewImporter(store, forceImport: true);
+
+            Assert.IsTrue(await importer.IsReportDueAsync(ReportA, OneDay),
+                "ForceUsageReportsImport must bypass the per-report gate as well as the phase gate.");
+        }
+
+        [TestMethod]
+        public async Task WithNoCompletionStoreEveryReportIsAlwaysDue()
+        {
+            var importer = NewImporter(store: null);
+
+            Assert.IsTrue(await importer.IsReportDueAsync(ReportA, OneDay));
+        }
+
+        /// <summary>Lets a completion time be set precisely, without sleeping.</summary>
+        private class StubCompletionStore : IReportCompletionStore
+        {
+            public DateTime? LastSuccess { get; set; }
+
+            public Task<DateTime?> GetLastSuccessAsync(string reportKey) => Task.FromResult(LastSuccess);
+            public Task SaveSuccessAsync(string reportKey) { LastSuccess = DateTime.Now; return Task.CompletedTask; }
+            public Task ClearAsync(string reportKey) { LastSuccess = null; return Task.CompletedTask; }
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -256,6 +256,7 @@
     <Compile Include="AutoThrottleHttpClientTests.cs" />
     <Compile Include="CallsImportTests.cs" />
     <Compile Include="GraphImportTests.cs" />
+    <Compile Include="ReportCompletionStoreTests.cs" />
     <Compile Include="TeamsCrawlTests.cs" />
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -30,6 +30,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         // Two independent markers: one proves the usage-report phase completed (so finalized dates can be
         // skipped safely), the other gates how often the non-fresh Graph sections re-run.
         private readonly ISingleDateStore _activityReportsLastImportedStore;
+        // Per-report completion stamps. The phase marker above cannot answer "is THIS report's stored data
+        // complete?" - withholding it after one report fails also emptied the skip list for the ten that
+        // succeeded, making them re-download their full window every cycle (issue #311).
+        private readonly IReportCompletionStore _reportCompletionStore;
         private readonly IImportLastRunStore _lastRunStore;
 
         private readonly IGraphImportSectionFactory _sectionFactory;
@@ -47,11 +51,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// signature so no call site breaks.
         /// </param>
         public GraphImporter(AnalyticsLogger logger, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null, IImportLastRunStore lastRunStore = null, ISentEmailMailboxSkipList sentEmailMailboxSkipList = null, IClock clock = null)
+            : this(logger, userGroupsCache, graphAppIndentityOAuthContext, graphClient, settings, activityReportsLastImportedStore, lastRunStore, sentEmailMailboxSkipList, reportCompletionStore: null, clock: clock)
+        {
+        }
+
+        public GraphImporter(AnalyticsLogger logger, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings, ISingleDateStore activityReportsLastImportedStore, IImportLastRunStore lastRunStore, ISentEmailMailboxSkipList sentEmailMailboxSkipList, IClock clock, IReportCompletionStore reportCompletionStore)
             : base(logger, settings)
         {
             _clock = clock ?? SystemClock.Instance;
             _graphClient = graphClient;
             _activityReportsLastImportedStore = activityReportsLastImportedStore;
+            _reportCompletionStore = reportCompletionStore;
 
             // Defensive: a per-instance in-memory store still works (just doesn't persist the gate
             // across cycles). Production passes the process-lifetime store hoisted in Program.cs.
@@ -191,6 +201,71 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         }
 
 
+        /// <summary>
+        /// Stable per-report key for <see cref="IReportCompletionStore"/>. Derived from the loader type name
+        /// rather than the human-readable report label, so renaming a log message cannot silently orphan a
+        /// stamp and trigger a full re-download.
+        /// </summary>
+        internal static string GetReportKey(Type loaderType) => loaderType.Name;
+
+        /// <summary>
+        /// The completion date that feeds one report's finalized-date skip list.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately does NOT fall back to the phase-level marker when a per-report stamp is absent. That
+        /// marker is an unversioned Redis key that predates the strict-paging fixes (#285 / #310); an older
+        /// build could write it after a report had saved a partial day, and skipping a partially-stored date
+        /// loses rows permanently once Graph's ~28-day retention passes. One extra full download per report on
+        /// the first upgraded cycle is a bounded, one-off cost.
+        ///
+        /// The phase marker is still used when no per-report store is supplied at all, which keeps existing
+        /// behaviour for those callers.
+        /// </remarks>
+        internal async Task<DateTime?> ResolveReportSkipListInputAsync(string reportKey, DateTime? phaseMarker)
+        {
+            if (_reportCompletionStore == null) return phaseMarker;
+
+            return await _reportCompletionStore.GetLastSuccessAsync(reportKey);
+        }
+
+        /// <summary>
+        /// Whether a report that has no finalized-date skip list of its own is due to run again.
+        /// </summary>
+        internal async Task<bool> IsReportDueAsync(string reportKey, TimeSpan minWait)
+        {
+            if (_reportCompletionStore == null) return true;
+            if (_settings.ForceUsageReportsImport) return true;
+
+            var lastSuccess = await _reportCompletionStore.GetLastSuccessAsync(reportKey);
+            return lastSuccess == null || _clock.UtcNow.Subtract(lastSuccess.Value.ToUniversalTime()) > minWait;
+        }
+
+        private async Task RunWeeklyReportIfDueAsync(SharePointSitesWeeklyUsageReportLoader loader, TimeSpan minWait)
+        {
+            var reportKey = GetReportKey(loader.GetType());
+
+            if (!await IsReportDueAsync(reportKey, minWait))
+            {
+                _logger.LogInformation(
+                    "SharePoint sites weekly usage: skipping - it completed within the last " +
+                    $"{minWait.TotalHours} hours. It has no finalized-date skip list, so re-running it while " +
+                    "another report retries would re-download the whole report for nothing.");
+                return;
+            }
+
+            if (_reportCompletionStore != null)
+            {
+                await _reportCompletionStore.ClearAsync(reportKey);
+            }
+
+            await loader.LoadAndSaveLastWeeksReportsIfRefreshOnDay(System.DayOfWeek.Sunday);
+
+            if (_reportCompletionStore != null)
+            {
+                await _reportCompletionStore.SaveSuccessAsync(reportKey);
+            }
+        }
+
         public async Task<bool> GetAndSaveActivityReportsMultiThreaded(int daysBackMax, ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel)        {
             var MIN_WAIT = TimeSpan.FromDays(1);
 
@@ -313,7 +388,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 {
                     var sharePointSitesWeeklyUsageReportLoader = new SharePointSitesWeeklyUsageReportLoader(db, client, _logger, new GraphSPSiteIdToUrlCache(_graphClient, db, _logger));
 
-                    importTasks.Add(RunReportSafely("SharePoint sites weekly usage", () => sharePointSitesWeeklyUsageReportLoader.LoadAndSaveLastWeeksReportsIfRefreshOnDay(System.DayOfWeek.Sunday)));
+                    importTasks.Add(RunReportSafely("SharePoint sites weekly usage",
+                        () => RunWeeklyReportIfDueAsync(sharePointSitesWeeklyUsageReportLoader, MIN_WAIT)));
                     await Task.WhenAll(importTasks);
                 }
 
@@ -336,8 +412,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 {
                     _logger.LogError($"Activity reports did NOT fully import - {failedReports.Count} of {importTasks.Count} report(s) failed: " +
                         string.Join(", ", failedReports.OrderBy(r => r)) + ". " +
-                        "Reports that succeeded have been saved; each failed report saved nothing. This phase has NOT been marked complete and will retry on the next cycle - " +
-                        "note that until it succeeds the once-a-day throttle stays disarmed, so the phase re-runs every cycle and re-downloads the full window. " +
+                        "Reports that succeeded have been saved AND stamped complete, so on the next cycle they re-import only the most recent " +
+                        "days that Graph can still change - the failed report(s) retry their own full window. This phase has NOT been marked " +
+                        "complete, so the once-a-day throttle stays disarmed and it re-runs every cycle until every report succeeds. " +
                         "If this repeats, check the runtime account has the Reports.Read.All application permission granted and admin-consented.");
                     return false;
                 }
@@ -361,13 +438,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         async Task<int> LoadAndSaveDailyImportReport<TReportDbType, TUserActivityUserDetail, TLookupType, CACHETYPE>
             (AbstractDailyActivityLoader<TReportDbType, TUserActivityUserDetail, TLookupType, CACHETYPE> abstractActivityLoader,
             int daysBackMax, string thingWeAreImporting, ILogger logger, ConcurrentLookupDbIdsCache userEmailToDbIdCache,
-            DateTime? lastSuccessfulImport)
+            DateTime? lastSuccessfulPhaseImport)
             where TReportDbType : AbstractUsageActivityLog, new()
             where TUserActivityUserDetail : AbstractActivityRecord<TLookupType>
             where TLookupType : AbstractEFEntity
             where CACHETYPE : DBLookupCache<TLookupType>
         {
             logger.LogInformation($"Importing {thingWeAreImporting} reports...");
+
+            var reportKey = GetReportKey(abstractActivityLoader.GetType());
+            var lastSuccessfulImport = await ResolveReportSkipListInputAsync(reportKey, lastSuccessfulPhaseImport);
+
+            if (_reportCompletionStore != null)
+            {
+                // Clear before any writes, for the same reason the phase marker is cleared: if this report
+                // fails part-way through its save, the next cycle must re-import rather than trust a stamp
+                // that claims a window it only partly wrote.
+                await _reportCompletionStore.ClearAsync(reportKey);
+            }
 
             // Graph usage data is stable once finalized (~2-3 day latency), so days we already hold and that can no
             // longer change don't need re-downloading or re-writing. Skip them unless a forced full re-import is set.
@@ -413,6 +501,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
             var total = abstractActivityLoader.LoadedReportPages.SelectMany(r => r.Value).Count();
             logger.LogInformation($"Imported {total.ToString("N0")} {thingWeAreImporting} reports.");
+
+            // Only reached when the download AND the save both completed - anything else threw and is caught
+            // by RunReportSafely, leaving this report's stamp cleared so its window is retried next cycle.
+            if (_reportCompletionStore != null)
+            {
+                await _reportCompletionStore.SaveSuccessAsync(reportKey);
+            }
 
             return total;
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ReportCompletionStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ReportCompletionStore.cs
@@ -1,0 +1,133 @@
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine
+{
+    /// <summary>
+    /// Records when each individual usage report last completed successfully.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Separate from the phase-level <see cref="ISingleDateStore"/>, which answers a different question. That
+    /// one timestamp has to mean two things at once: "don't re-run this once-a-day phase yet" AND "these
+    /// stored days are proven complete, so they can be skipped". Withholding it after a failure is correct for
+    /// the first meaning (issue #285 - a broken import must not look complete) but wrong for the second: it
+    /// also emptied the finalized-date skip list for the reports that had succeeded, so one permanently
+    /// failing report made all eleven re-download their full window every cycle (issue #311).
+    /// </para>
+    /// <para>
+    /// A per-report stamp lets those two meanings separate. The phase timestamp keeps its throttling job
+    /// unchanged; the skip list now asks each report when <b>it</b> last completed.
+    /// </para>
+    /// </remarks>
+    public interface IReportCompletionStore
+    {
+        /// <summary>When this report last completed successfully, or null if it never has.</summary>
+        Task<DateTime?> GetLastSuccessAsync(string reportKey);
+
+        /// <summary>Record that this report has just completed successfully.</summary>
+        Task SaveSuccessAsync(string reportKey);
+
+        /// <summary>
+        /// Forget this report's completion. Called before a report runs, so that a crash part-way through its
+        /// save cannot leave a stamp claiming the window is complete.
+        /// </summary>
+        Task ClearAsync(string reportKey);
+    }
+
+    /// <summary>
+    /// In-memory fallback used when Redis is not configured; lives only for the life of the WebJob process.
+    /// Must be constructed ONCE outside the per-cycle loop, exactly like <see cref="InMemorySingleDateStore"/>.
+    /// </summary>
+    public class InMemoryReportCompletionStore : IReportCompletionStore
+    {
+        // Reports run concurrently under Task.WhenAll, so this must be thread-safe.
+        private readonly ConcurrentDictionary<string, DateTime> _lastSuccess =
+            new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+
+        public Task<DateTime?> GetLastSuccessAsync(string reportKey)
+        {
+            return Task.FromResult(_lastSuccess.TryGetValue(reportKey, out var dt) ? dt : (DateTime?)null);
+        }
+
+        public Task SaveSuccessAsync(string reportKey)
+        {
+            _lastSuccess[reportKey] = DateTime.Now;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(string reportKey)
+        {
+            _lastSuccess.TryRemove(reportKey, out _);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Redis-backed <see cref="IReportCompletionStore"/>, so per-report completion survives a WebJob restart
+    /// (which is the whole point - an in-memory stamp would be lost on every restart and the skip list would
+    /// be empty again).
+    /// </summary>
+    public class RedisReportCompletionStore : IReportCompletionStore
+    {
+        /// <summary>
+        /// Prefix for the per-report keys. Deliberately distinct from the phase-level
+        /// <c>UserActivityLastImported</c> key so the two cannot collide.
+        /// </summary>
+        internal const string KeyPrefix = "UserActivityReportLastImported:";
+
+        private readonly ConcurrentDictionary<string, RedisSingleDateLoader> _loaders =
+            new ConcurrentDictionary<string, RedisSingleDateLoader>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly string _redisConnectionString;
+        private readonly string _tenantId;
+        private readonly string _clientId;
+        private readonly string _clientSecret;
+
+        public RedisReportCompletionStore(string redisConnectionString, string tenantId = null, string clientId = null, string clientSecret = null)
+        {
+            _redisConnectionString = redisConnectionString;
+            _tenantId = tenantId;
+            _clientId = clientId;
+            _clientSecret = clientSecret;
+        }
+
+        private RedisSingleDateLoader LoaderFor(string reportKey)
+        {
+            return _loaders.GetOrAdd(reportKey,
+                k => new RedisSingleDateLoader(_redisConnectionString, KeyPrefix + k, _tenantId, _clientId, _clientSecret));
+        }
+
+        public Task<DateTime?> GetLastSuccessAsync(string reportKey) => LoaderFor(reportKey).GetLastDT();
+
+        public Task SaveSuccessAsync(string reportKey) => LoaderFor(reportKey).SaveDT();
+
+        public Task ClearAsync(string reportKey) => LoaderFor(reportKey).DeleteDt();
+    }
+
+    /// <summary>
+    /// Builds the <see cref="IReportCompletionStore"/> for per-report completion stamps: Redis when
+    /// configured (durable across restarts), otherwise in-memory for the life of this process. Mirrors
+    /// <see cref="ActivityReportsLastImportedStoreFactory"/>.
+    /// </summary>
+    public static class ReportCompletionStoreFactory
+    {
+        public static IReportCompletionStore Create(AppConfig config, ILogger logger)
+        {
+            var redisConn = config?.ConnectionStrings?.RedisConnectionString;
+            if (!string.IsNullOrEmpty(redisConn))
+            {
+                return new RedisReportCompletionStore(redisConn, config.TenantGUID.ToString(), config.ClientID, config.ClientSecret);
+            }
+
+            logger?.LogInformation(
+                "No Redis connection string configured - per-report usage-report completion is tracked in memory only, "
+                + "so the finalized-date skip list resets each time the WebJob process restarts.");
+            return new InMemoryReportCompletionStore();
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -266,6 +266,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="RedisSingleDateLoader.cs" />
+    <Compile Include="ReportCompletionStore.cs" />
     <Compile Include="SingleDateStore.cs" />
     <Compile Include="StatsUploader\AnonUsageStatsModelLoader.cs" />
     <Compile Include="StatsUploader\BaseClasses.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -199,6 +199,11 @@ namespace WebJob.Office365ActivityImporter
             // usage-report phase every cycle, even without Redis).
             ISingleDateStore activityReportsLastImportedStore = ActivityReportsLastImportedStoreFactory.Create(configuredSettings, logger);
 
+            // Per-report completion stamps, feeding the finalized-date skip list. Also created ONCE here for
+            // the same reason: the in-memory fallback must survive across cycles or every report re-downloads
+            // its full window every time.
+            IReportCompletionStore reportCompletionStore = ReportCompletionStoreFactory.Create(configuredSettings, logger);
+
             // Cadence-gate store for the non-fresh Graph imports (user metadata, user apps, Teams).
             // Created ONCE here, outside the cycle loop, so the in-memory fallback retains its "last run"
             // timestamps across cycles (mirrors statsDatesLoader above). Redis when configured (gate also
@@ -260,7 +265,7 @@ namespace WebJob.Office365ActivityImporter
             {
                 var importCycleTimer = new JobTimer(logger, Process.GetCurrentProcess().ProcessName);
                 importCycleTimer.Start();
-                var tasks = new ProgramTasks(logger, configuredSettings, activityReportsLastImportedStore, graphLastRunStore, sentEmailMailboxSkipList);
+                var tasks = new ProgramTasks(logger, configuredSettings, activityReportsLastImportedStore, graphLastRunStore, sentEmailMailboxSkipList, reportCompletionStore);
 
                 // Start listening for SB messages & register notifications web-hook with Graph 
                 if (webHookUrl != null && configuredSettings.ImportJobSettings.Calls)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -30,10 +30,18 @@ namespace WebJob.Office365ActivityImporter
         private ManualGraphCallClient _manualGraphCallClient = null;
         private GraphUserGroupsCache _graphUserGroupsCache = null;
         private readonly ISingleDateStore _activityReportsLastImportedStore;
+        // Per-report completion stamps. Like the store above this MUST be process-lifetime: a fresh instance
+        // per cycle would always look "never completed" and empty the finalized-date skip list every run.
+        private readonly IReportCompletionStore _reportCompletionStore;
         private readonly IImportLastRunStore _graphLastRunStore;
         private readonly ISentEmailMailboxSkipList _sentEmailMailboxSkipList;
 
         public ProgramTasks(AnalyticsLogger logger, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null, IImportLastRunStore graphLastRunStore = null, ISentEmailMailboxSkipList sentEmailMailboxSkipList = null)
+            : this(logger, settings, activityReportsLastImportedStore, graphLastRunStore, sentEmailMailboxSkipList, reportCompletionStore: null)
+        {
+        }
+
+        public ProgramTasks(AnalyticsLogger logger, AppConfig settings, ISingleDateStore activityReportsLastImportedStore, IImportLastRunStore graphLastRunStore, ISentEmailMailboxSkipList sentEmailMailboxSkipList, IReportCompletionStore reportCompletionStore)
         {
             _graphAppIndentityOAuthContext = new GraphAppIndentityOAuthContext(logger, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
             _logger = logger;
@@ -41,6 +49,7 @@ namespace WebJob.Office365ActivityImporter
             _activityReportsLastImportedStore = activityReportsLastImportedStore;
             _graphLastRunStore = graphLastRunStore;
             _sentEmailMailboxSkipList = sentEmailMailboxSkipList;
+            _reportCompletionStore = reportCompletionStore;
         }
 
         /// <summary>
@@ -70,7 +79,7 @@ namespace WebJob.Office365ActivityImporter
 
             await InitAuth();
 
-            var graphReader = new GraphImporter(_logger, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings, _activityReportsLastImportedStore, _graphLastRunStore, _sentEmailMailboxSkipList);
+            var graphReader = new GraphImporter(_logger, _graphUserGroupsCache, _graphAppIndentityOAuthContext, _graphClient, _settings, _activityReportsLastImportedStore, _graphLastRunStore, _sentEmailMailboxSkipList, clock: null, reportCompletionStore: _reportCompletionStore);
 
             try
             {


### PR DESCRIPTION
Fixes the "one broken report costs the other reports their skip list" behaviour in #311.

## Problem

`GraphImporter.GetAndSaveActivityReportsMultiThreaded` used one phase-level timestamp for two different jobs:

1. **24-hour phase throttle** — the activity/usage-report phase should not re-run every cycle after a complete success.
2. **finalized-date proof** — `AbstractDailyActivityLoader.GetFinalizedStoredDatesToSkipAsync` needs a successful import marker before it can skip stored days that Graph can no longer change.

#285 correctly made the phase withhold that stamp when any report fails, so a broken cycle is not recorded as complete. But that same `null` stamp also made every successful report's skip list empty on the next cycle, so one failing report forced all 11 usage reports to re-download their full window every retry cycle.

## Fix

Add `IReportCompletionStore` with Redis and in-memory implementations, mirroring the existing phase store shape:

- the **phase marker** remains the once-a-day throttle and is still saved only when every report succeeds;
- each daily report now reads its **own** last-success stamp for the finalized-date skip list;
- each report clears its stamp before work starts and saves it only after Graph download, SQL save and columnstore compaction return;
- a failed report therefore retries its own full window, while reports that succeeded keep skipping their finalized stored dates.

The store is created once in `Program.cs` and passed through `ProgramTasks`, so the in-memory fallback survives across import cycles just like the existing `ISingleDateStore` / `IImportLastRunStore` fallbacks.

## Rebase notes

`dev` had since refactored Graph import composition behind `ProductionGraphImportSectionFactory` and added `IClock`-driven cadence gates. This revival keeps that structure intact: the usage-report phase remains the ungated section supplied to the factory, and the per-report store stays inside `GraphImporter.GetAndSaveActivityReportsMultiThreaded` where the skip-list decisions live.

The public `GraphImporter` and `ProgramTasks` constructor signatures from current `dev` are preserved as compatibility overloads. The new overloads take `IReportCompletionStore` separately, avoiding the positional-null ambiguity found during review.

## First upgraded / first-ever run

Missing per-report stamps deliberately do **not** seed from the legacy phase marker. That marker predates the strict-paging fixes (#285 / #310), so an older build may have written it after a partial day. Trusting it could skip a partial date forever once Graph retention passes. The first upgraded cycle therefore pays one bounded full download per report; a first-ever install still backfills because every per-report stamp is absent and the skip list is empty.

## Weekly SharePoint sites report

The weekly sites report has no finalized-date skip list: it pages the whole report before checking stored data. It now has its own per-report 24-hour gate, bypassed by `ForceUsageReportsImport`. In the healthy case the phase throttle fires first, so normal behaviour is unchanged.

## Expected saving

With one permanently failing report and `C` retry cycles before the underlying issue is fixed, this avoids re-downloading:

- `10 successful daily reports × max(DaysBeforeNowToDownload - 3 refreshable days, 0) × C` finalized report-days; plus
- the weekly SharePoint sites report's full payload on retry cycles inside its own 24-hour completion window.

At the ~200,000-user design baseline and the default 6-day lookback, that is up to `10 × 3 × C = 30C` unchanged daily report-days, or about `6,000,000 × C` unchanged user-row payloads avoided before the weekly sites saving. At a 28-day lookback, the avoided daily work is `10 × 25 × C = 250C` report-days, or about `50,000,000 × C` unchanged user-row payloads.

## Validation

- No EF migration, no manual SQL, no config-schema change.
- `MSBuild.exe "O365 Advanced Analytics Engine.sln" /p:Configuration=Debug /m:2` passed.
- Targeted tests passed: `ReportCompletionStoreTests`, `UsageReportRefreshPolicyTests`, `UsageReportTableNameTests` (29/29).
- Full local `Tests.UnitTests` run under the shared lock: 1,475 passed / 1 skipped / 12 failed. Failures were the four known VNet installer tests plus eight local-environment credential/endpoint failures (Cognitive, Service Bus, SharePoint/Teams tenant auth, Redis RBAC), not usage-report regressions. GitHub Actions `test_dotnet (Release)` passed.
- Three-model code-review loop (`claude-opus-4.8`, `gpt-5.6-sol`, `grok-4.6`) found constructor compatibility/ambiguity issues; fixed and final re-review came back clean.

## Reviewer hotspots

- Decision not to seed per-report stamps from the legacy phase marker.
- Weekly report's independent per-report daily gate.
- Constructor overload compatibility around `GraphImporter` / `ProgramTasks`.

Addresses #311

