### PR TITLE
Installer: self-heal a stale SQL firewall rule instead of failing with the site stopped

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
@@ -1,5 +1,6 @@
 ﻿using App.ControlPanel.Engine.Entities;
 using App.ControlPanel.Engine.Models;
+using CloudInstallEngine.Azure;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -36,12 +37,158 @@ namespace App.ControlPanel.Engine
             }
             if (_sqlTestDoneAlready) return true;
 
-            var sqlConnectionInfo = new SqlConnectionStringBuilder(connectionString);
-            _logger.LogInformation($"Testing connection to SQL Server '{sqlConnectionInfo.DataSource}'");
+            var (ok, error) = await TrySqlConnection(connectionString);
+            if (!ok)
+            {
+                ReportSqlConnectionFailure(connectionString, error);
+                return false;
+            }
+
+            _sqlTestDoneAlready = true;
+            return true;
+        }
+
+        /// <summary>
+        /// How long to wait between retries after repairing the firewall rule. Azure's own message says a rule
+        /// change can take up to five minutes to take effect; in practice it is seconds, so this ramps up
+        /// rather than waiting the worst case every time. Total budget ~3 minutes.
+        /// </summary>
+        static readonly TimeSpan[] _firewallRepairRetryBackoff =
+        {
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(20),
+            TimeSpan.FromSeconds(45),
+            TimeSpan.FromSeconds(60),
+        };
+
+        /// <summary>
+        /// Verify SQL connectivity, repairing the installer's own firewall rule and retrying if Azure rejects
+        /// us for coming from an address the firewall does not allow.
+        /// </summary>
+        /// <param name="repairFirewallForIp">
+        /// Creates/updates the installer's firewall rule for the given IP, returning whether it succeeded.
+        /// Null disables self-healing (e.g. a private-only deployment, where Azure rejects firewall edits with
+        /// <c>DenyPublicEndpointEnabled</c> and the right answer is the VNet guidance instead).
+        /// </param>
+        /// <remarks>
+        /// The client IP comes from Azure's own <c>40615</c> rejection message, which is authoritative: it is
+        /// the address this SQL server actually saw, so it beats asking a third-party echo service and is
+        /// correct behind NAT, proxies and split-tunnel VPNs. Retries are bounded so a permanently broken
+        /// environment cannot loop. See issue #326.
+        /// </remarks>
+        public async Task<bool> VerifySqlWithFirewallSelfHeal(string connectionString, Func<string, Task<bool>> repairFirewallForIp)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentException($"'{nameof(connectionString)}' cannot be null or empty.", nameof(connectionString));
+            }
+            if (_sqlTestDoneAlready) return true;
+
+            string repairedForIp = null;
+
+            for (var attempt = 0; ; attempt++)
+            {
+                var (ok, error) = await TrySqlConnection(connectionString);
+                if (ok)
+                {
+                    if (repairedForIp != null)
+                    {
+                        _logger.LogInformation(
+                            $"SQL connectivity restored after updating the firewall rule for {repairedForIp}. Continuing with the install.");
+                    }
+                    _sqlTestDoneAlready = true;
+                    return true;
+                }
+
+                // Only a firewall rejection is self-healable, and only while retries remain.
+                var canRetry = attempt < _firewallRepairRetryBackoff.Length;
+                if (repairFirewallForIp == null
+                    || !canRetry
+                    || error == null
+                    || error.Number != SqlFirewallRules.ClientIpNotAllowedErrorNumber
+                    || !SqlFirewallRules.TryGetBlockedClientIp(error.Message, out var blockedIp))
+                {
+                    ReportSqlConnectionFailure(connectionString, error);
+
+                    if (repairedForIp != null)
+                    {
+                        var stillFirewallBlocked = error != null
+                            && error.Number == SqlFirewallRules.ClientIpNotAllowedErrorNumber;
+
+                        if (stillFirewallBlocked)
+                        {
+                            // Azure is STILL reporting a firewall rejection, so do not claim the firewall is
+                            // ruled out - the rule was accepted by ARM but has not taken effect yet. Azure
+                            // documents propagation as taking up to five minutes; we waited less than that.
+                            _logger.LogError(
+                                $"The SQL firewall rule was updated to allow {repairedForIp} and Azure accepted the change, but SQL Server " +
+                                "is still rejecting this host. Firewall changes can take up to five minutes to take effect - wait a few " +
+                                "minutes and re-run the installer. If it persists, confirm the rule exists on the server in the Azure portal.");
+                        }
+                        else
+                        {
+                            // A different failure now, so the firewall genuinely is dealt with. Say so, or the
+                            // admin will keep chasing the IP.
+                            _logger.LogError(
+                                $"NOTE: the SQL firewall rule was updated and verified to allow {repairedForIp} during this run, and SQL Server " +
+                                "is no longer reporting a firewall rejection - so the firewall is not the remaining cause. Look at the " +
+                                "login/password, any database-level firewall, Private Link configuration, or outbound filtering on this network.");
+                        }
+                    }
+                    return false;
+                }
+
+                if (blockedIp == repairedForIp)
+                {
+                    // The rule already names this exact address; waiting longer for propagation is the only
+                    // thing left, and the backoff below does that.
+                    _logger.LogInformation(
+                        $"SQL Server still reports {blockedIp} as blocked after the rule was updated - waiting for the firewall change to take effect...");
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        $"Azure SQL rejected this host: it reports our address as {blockedIp}, which the firewall does not allow. " +
+                        "Updating the installer's firewall rule to that address and retrying - this normally means the public IP " +
+                        "changed since the last install (DHCP renewal, a different network, or VPN on/off).");
+
+                    bool repaired;
+                    try
+                    {
+                        repaired = await repairFirewallForIp(blockedIp);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError($"Could not update the SQL Server firewall rule for {blockedIp}: {ex.Message}");
+                        ReportSqlConnectionFailure(connectionString, error);
+                        return false;
+                    }
+
+                    if (!repaired)
+                    {
+                        ReportSqlConnectionFailure(connectionString, error);
+                        return false;
+                    }
+
+                    repairedForIp = blockedIp;
+                }
+
+                var wait = _firewallRepairRetryBackoff[attempt];
+                _logger.LogInformation($"Waiting {wait.TotalSeconds:0}s for the SQL Server firewall change to propagate, then retrying...");
+                await Task.Delay(wait);
+            }
+        }
+
+        /// <summary>Opens a connection and runs a trivial query. Returns the SqlException rather than logging it.</summary>
+        async Task<(bool ok, SqlException error)> TrySqlConnection(string connectionString)
+        {
             using (var conn = new SqlConnection(connectionString))
             {
                 try
                 {
+                    var sqlConnectionInfo = new SqlConnectionStringBuilder(connectionString);
+                    _logger.LogInformation($"Testing connection to SQL Server '{sqlConnectionInfo.DataSource}'");
+
                     conn.Open(); // throws if invalid
                     var cmd = conn.CreateCommand();
                     cmd.CommandText = "Select @@version";
@@ -49,20 +196,24 @@ namespace App.ControlPanel.Engine
                 }
                 catch (SqlException ex)
                 {
-                    _logger.LogError($"Error testing SQL connection to '{sqlConnectionInfo.DataSource}': '{ex.Message}'. " +
-                        $"Verify network connectivity to server.");
-
-                    if (PrivateNetworkGuidance.IsPrivateNetworkOnly(Config))
-                    {
-                        _logger.LogError(PrivateNetworkGuidance.BuildVmOnVNetGuidance("the SQL connectivity test and database schema initialisation", Config.NetworkConfig?.VNetName));
-                    }
-
-                    return false;
+                    return (false, ex);
                 }
             }
             _logger.LogInformation($"Connection test to SQL Server successful.");
-            _sqlTestDoneAlready = true;
-            return true;
+            return (true, null);
+        }
+
+        void ReportSqlConnectionFailure(string connectionString, SqlException error)
+        {
+            var dataSource = new SqlConnectionStringBuilder(connectionString).DataSource;
+
+            _logger.LogError($"Error testing SQL connection to '{dataSource}': '{error?.Message}'. " +
+                $"Verify network connectivity to server.");
+
+            if (PrivateNetworkGuidance.IsPrivateNetworkOnly(Config))
+            {
+                _logger.LogError(PrivateNetworkGuidance.BuildVmOnVNetGuidance("the SQL connectivity test and database schema initialisation", Config.NetworkConfig?.VNetName));
+            }
         }
 
         #region ExecuteAndReportFailure

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -7,7 +7,9 @@ using Azure.ResourceManager.AppService.Models;
 using Azure.ResourceManager.Automation;
 using Azure.ResourceManager.KeyVault;
 using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Sql;
 using Azure.ResourceManager.Storage;
+using CloudInstallEngine.Azure;
 using CloudInstallEngine.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -41,7 +43,8 @@ namespace App.ControlPanel.Engine
         public async Task RunPostCreatePaaSTasks(WebSiteResource webApp, DatabasePaaSInfo dbInfo, StorageAccountResource storage, AutomationAccountResource automationAccount,
             AppInsightsInfo appInsights,
             RedisInstallResult redis, CognitiveServicesInfo cognitiveServicesInfo,
-            KeyVaultResource keyVault, string serviceBusConnectionString, SubscriptionResource subscription)
+            KeyVaultResource keyVault, string serviceBusConnectionString, SubscriptionResource subscription,
+            SqlServerResource sqlServer = null)
         {
             // Configure app-service connection-strings, etc
             await ConfigureWebApp(webApp, dbInfo, storage, redis, cognitiveServicesInfo, appInsights, serviceBusConnectionString, keyVault);
@@ -50,24 +53,87 @@ namespace App.ControlPanel.Engine
             // rejects deployments while the site resource is stopped.
             var solutionSources = await GetSolutionFromSource(subscription, automationAccount, downloadReleaseOnly: true);
 
-            // Stop the runtime while applying database changes so the existing website/WebJobs
-            // cannot use a partially upgraded schema.
-            if (this.Config.TasksConfig.InstallLatestSolutionContent)
+            // Prove SQL is reachable BEFORE taking the site offline, self-healing a stale firewall rule if
+            // that is what is blocking us. Previously the site was stopped first and the connectivity test ran
+            // inside the database step, so a firewall rejection left the customer's web app stopped with no
+            // attempt to restart it (issue #326). VerifySQL caches success, so the test inside the database
+            // step below becomes a no-op.
+            var repairFirewall = BuildFirewallRepairCallback(sqlServer);
+            var sqlReachable = await VerifySqlWithFirewallSelfHeal(dbInfo.ConnectionString, repairFirewall);
+
+            // Terminate here rather than carrying a "SQL is broken" flag through the rest of the method. The
+            // database step would fail anyway, but only after more work had been done, and the App Service
+            // would have been stopped for it - which is the outage this whole change exists to prevent.
+            if (!sqlReachable && (Config.TasksConfig.UpgradeSchema || Config.TasksConfig.RegisterConfig))
             {
-                _logger.LogInformation("Stopping app-service during database upgrade...");
-                await webApp.StopAsync();
+                throw new UnexpectedInstallException(
+                    "SQL Server is not reachable from this host, so the database upgrade cannot run. The App Service has " +
+                    "deliberately NOT been stopped, so the existing deployment keeps running on its current schema. " +
+                    "Fix the connectivity problem reported above and re-run the installer.");
             }
 
             // Find downloaded installer app
             var installerExeFile = GetInstallerExe(solutionSources.GetSolutionComponentLocation(SoftwareComponent.ControlPanel));
 
-            var sqlInstallerTasks = new SqlInstallerTasks(Config, installerExeFile, dbInfo, _logger, _installedByUsername, _configPassword, async (connectionString) => await VerifySQL(connectionString));
-            await sqlInstallerTasks.UpdateSqlDatabaseSchemaAndDataFromDownloadedInstaller(installerExeFile, _installLogEvents);
+            // Stop the runtime while applying database changes so the existing website/WebJobs
+            // cannot use a partially upgraded schema.
+            var stopAttempted = false;
+            Exception upgradeFailure = null;
+            try
+            {
+                if (this.Config.TasksConfig.InstallLatestSolutionContent)
+                {
+                    _logger.LogInformation("Stopping app-service during database upgrade...");
+
+                    // Set BEFORE awaiting: Azure can complete the stop server-side while the client sees a
+                    // timeout or transport error, so "the call threw" does not mean "the site is still up".
+                    // Assuming it stopped is the safe assumption - a redundant start is harmless.
+                    stopAttempted = true;
+                    await webApp.StopAsync();
+                }
+
+                var sqlInstallerTasks = new SqlInstallerTasks(Config, installerExeFile, dbInfo, _logger, _installedByUsername, _configPassword,
+                    async (connectionString) => await VerifySqlWithFirewallSelfHeal(connectionString, repairFirewall));
+                await sqlInstallerTasks.UpdateSqlDatabaseSchemaAndDataFromDownloadedInstaller(installerExeFile, _installLogEvents);
+            }
+            catch (Exception ex)
+            {
+                upgradeFailure = ex;
+            }
+
+            // Whatever happened above, bring the site back. A database step that turns out to be impossible
+            // must never leave the customer's web app stopped.
+            if (stopAttempted)
+            {
+                try
+                {
+                    await webApp.StartAsync();
+                    _logger.LogInformation("App Service started for SCM HTTPS deployment");
+                }
+                catch (Exception startEx)
+                {
+                    if (upgradeFailure == null)
+                    {
+                        // Nothing to mask, and the site is down - this must be fatal, not a swallowed warning,
+                        // or the install would carry on deploying content to a stopped site and report success.
+                        throw new UnexpectedInstallException(
+                            "The database step completed but the App Service could not be restarted afterwards: " +
+                            $"{startEx.Message}. Start the App Service in the Azure portal, then re-run the installer.");
+                    }
+
+                    _logger.LogError($"IMPORTANT: could not restart the App Service after the database step: {startEx.Message}. " +
+                        "Start it by hand in the Azure portal.");
+                }
+            }
+
+            if (upgradeFailure != null)
+            {
+                // Rethrow preserving the original stack, now that the site is back up.
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(upgradeFailure).Throw();
+            }
 
             if (this.Config.TasksConfig.InstallLatestSolutionContent)
             {
-                await webApp.StartAsync();
-                _logger.LogInformation("App Service started for SCM HTTPS deployment");
                 await InstallSolutionContent(solutionSources, subscription, automationAccount);
             }
 
@@ -86,6 +152,76 @@ namespace App.ControlPanel.Engine
                     _logger.LogInformation("Skipping SharePoint web components (AITracker / SPFx) install because 'Update solution with latest release' is not selected.");
                 }
             }
+        }
+
+        /// <summary>
+        /// Builds the delegate that repairs the installer's own SQL firewall rule for a given client IP, or
+        /// null when self-healing must not be attempted.
+        /// </summary>
+        /// <remarks>
+        /// Returns null on a private-only deployment: Azure rejects firewall edits there with
+        /// <c>DenyPublicEndpointEnabled</c>, and a public firewall rule is the wrong answer anyway - the
+        /// existing VNet guidance is what the operator needs. Also null when no ARM server resource was
+        /// supplied, so nothing changes for callers that have not been updated.
+        /// </remarks>
+        private Func<string, Task<bool>> BuildFirewallRepairCallback(SqlServerResource sqlServer)
+        {
+            if (sqlServer == null) return null;
+
+            if (PrivateNetworkGuidance.IsPrivateNetworkOnly(Config))
+            {
+                _logger.LogInformation(
+                    "Public network access is disabled for this deployment, so the SQL Server firewall rule will not be " +
+                    "auto-repaired - Azure rejects firewall edits on a private-only server, and connectivity is expected " +
+                    "to come via the private endpoint.");
+                return null;
+            }
+
+            return async (clientIp) =>
+            {
+                try
+                {
+                    var rules = sqlServer.GetSqlFirewallRules();
+
+                    var existing = rules
+                        .Where(r => r.Data.Name == AzurePaaSInstallJob.INSTALLER_FIREWALL_RULE_NAME)
+                        .Select(r => new SqlFirewallRuleRange(r.Data.Name, r.Data.StartIPAddress, r.Data.EndIPAddress))
+                        .SingleOrDefault();
+
+                    if (!SqlFirewallRules.CanSafelyReplaceWithSingleAddress(existing))
+                    {
+                        // An admin widened our rule into a range. Narrowing it to one address would revoke
+                        // access for every other address it covers - worse than the problem being fixed.
+                        _logger.LogError(
+                            $"SQL Server firewall rule '{AzurePaaSInstallJob.INSTALLER_FIREWALL_RULE_NAME}' has been widened to the " +
+                            $"range {existing.StartIp} - {existing.EndIp}. The installer will NOT narrow it to {clientIp}, because " +
+                            "that would revoke access for every other address in that range. Extend the range to include " +
+                            $"{clientIp} (or add a separate rule for it) and re-run the installer.");
+                        return false;
+                    }
+
+                    await rules.CreateOrUpdateAsync(
+                        WaitUntil.Completed,
+                        AzurePaaSInstallJob.INSTALLER_FIREWALL_RULE_NAME,
+                        new SqlFirewallRuleData
+                        {
+                            Name = AzurePaaSInstallJob.INSTALLER_FIREWALL_RULE_NAME,
+                            StartIPAddress = clientIp,
+                            EndIPAddress = clientIp,
+                        });
+
+                    _logger.LogInformation(
+                        $"SQL Server firewall rule '{AzurePaaSInstallJob.INSTALLER_FIREWALL_RULE_NAME}' updated to allow {clientIp}.");
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        $"Could not update the SQL Server firewall rule to allow {clientIp}: {ex.Message}. " +
+                        $"Add a rule named '{AzurePaaSInstallJob.INSTALLER_FIREWALL_RULE_NAME}' for {clientIp} by hand and re-run the installer.");
+                    return false;
+                }
+            };
         }
 
         FileInfo GetInstallerExe(LocalStorageBlobInfo localStorageBlobInfo)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -64,7 +64,7 @@ namespace App.ControlPanel.Engine
             // Terminate here rather than carrying a "SQL is broken" flag through the rest of the method. The
             // database step would fail anyway, but only after more work had been done, and the App Service
             // would have been stopped for it - which is the outage this whole change exists to prevent.
-            if (!sqlReachable && (Config.TasksConfig.UpgradeSchema || Config.TasksConfig.RegisterConfig))
+            if (!sqlReachable && Config.TasksConfig.UpgradeSchema)
             {
                 throw new UnexpectedInstallException(
                     "SQL Server is not reachable from this host, so the database upgrade cannot run. The App Service has " +

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -22,6 +22,12 @@ namespace App.ControlPanel.Engine.InstallerTasks
     /// </summary>
     public class AzurePaaSInstallJob : BaseAnalyticsSolutionInstallJob
     {
+        /// <summary>
+        /// Name of the Azure SQL firewall rule the installer owns. Public so the database step can repair it
+        /// when Azure reports this host as blocked (issue #326) - it must be the same rule, not a second one.
+        /// </summary>
+        public const string INSTALLER_FIREWALL_RULE_NAME = "O365 Adv Analytics Setup Rule";
+
         private readonly GetOrCreateResourceGroupTask _rgCreateTask;
         private readonly AutomationAccountTask _automationAccountTask;
 
@@ -122,7 +128,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
             var sqlServerConfig = TaskConfig.GetConfigForName(config.SQLServerName)
                 .AddSetting(SqlServerTask.CONFIG_KEY_USERNAME, config.SQLServerAdminUsername)
                 .AddSetting(SqlServerTask.CONFIG_KEY_PASSWORD, config.SQLServerAdminPassword);
-            const string FIREWALL_RULE_NAME = "O365 Adv Analytics Setup Rule";
+            const string FIREWALL_RULE_NAME = INSTALLER_FIREWALL_RULE_NAME;
 
             _sqlServerTask = new SqlServerTask(sqlServerConfig, logger, Location, tagDic, allowPublicAccess);
 
@@ -134,7 +140,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
             // 'DenyPublicEndpointEnabled' and connectivity is expected to come via private endpoint.
             if (allowPublicAccess)
             {
-                _sqlServerFirewallConfigTask = new SqlServerFirewallConfigTask(TaskConfig.GetConfigForName(FIREWALL_RULE_NAME), logger, Location);
+                _sqlServerFirewallConfigTask = new SqlServerFirewallConfigTask(TaskConfig.GetConfigForName(FIREWALL_RULE_NAME), logger, Location, config.KeyVaultName);
                 this.AddTask(_sqlServerTask, _sqlServerFirewallConfigTask, _sqlDatabaseTask);
             }
             else

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
@@ -91,7 +91,8 @@ namespace App.ControlPanel.Engine
                     azureBackeEndCreationJob.Redis,
                     azureBackeEndCreationJob.CognitiveServicesInfo,
                     azureBackeEndCreationJob.KeyVault,
-                    azureBackeEndCreationJob.SBQueueWithConnectionString?.ConnectionString, azureBackeEndCreationJob.Subscription
+                    azureBackeEndCreationJob.SBQueueWithConnectionString?.ConnectionString, azureBackeEndCreationJob.Subscription,
+                    azureBackeEndCreationJob.CreatedSqlServer
                 );
 
                 ct.ThrowIfCancellationRequested();

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerFirewallConfigTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerFirewallConfigTask.cs
@@ -9,13 +9,30 @@ using System.Threading.Tasks;
 namespace CloudInstallEngine.Azure.InstallTasks
 {
     /// <summary>
-    /// Configure SQL Server firewall to allow local IP
+    /// Configure the Azure SQL Server firewall so the installer host can reach the database.
     /// </summary>
+    /// <remarks>
+    /// This used to decide by RULE NAME alone: if a rule called "O365 Adv Analytics Setup Rule" existed it
+    /// logged "already present ... Skipping" without ever reading the IP range it held. So once the rule went
+    /// stale - a DHCP lease renewal, a different office, VPN on/off, a mobile hotspot - every later install
+    /// reported success here and then died two minutes later at the database step with
+    /// "Client with IP address '...' is not allowed to access the server", by which point the App Service had
+    /// already been stopped. See issue #326.
+    /// </remarks>
     public class SqlServerFirewallConfigTask : InstallTaskInAzResourceGroup<SqlServerResource>
     {
         const string ALL_AZ_SERVICES_RULE_NAME = "AllowAllWindowsAzureIps";
-        public SqlServerFirewallConfigTask(TaskConfig config, ILogger logger, AzureLocation azureLocation) : base(config, logger, azureLocation, new Dictionary<string, string>())
+
+        private readonly string _keyVaultName;
+
+        /// <param name="keyVaultName">
+        /// Optional. Enables the first-party Key Vault caller-IP source (see <see cref="PublicIpResolver"/>);
+        /// harmlessly ignored when the vault does not exist yet.
+        /// </param>
+        public SqlServerFirewallConfigTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, string keyVaultName = null)
+            : base(config, logger, azureLocation, new Dictionary<string, string>())
         {
+            _keyVaultName = keyVaultName;
         }
 
         public override string TaskName => "configure SQL Server firewall for local IP";
@@ -26,41 +43,9 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
             var ruleName = _config.GetNameConfigValue();
             var server = (SqlServerResource)contextArg;
-
-            var clientIpRule = GetRuleByName(server, ruleName);
-
             var serverRules = server.GetSqlFirewallRules();
-            if (clientIpRule == null)
-            {
-                const string URL = "http://icanhazip.com";
-                _logger.LogInformation($"No SQL Server firewall exception detected for installer (no exception with name '{ruleName}'). Checking public IP address from '{URL}'...");
-                var externalip = new System.Net.WebClient().DownloadString(URL);
-                if (externalip.EndsWith("\n"))
-                {
-                    externalip = externalip.TrimEnd("\n".ToCharArray());
-                }
 
-                // Validate IP address string
-                var ipRegEx = new System.Text.RegularExpressions.Regex(@"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b");
-                if (ipRegEx.IsMatch(externalip))
-                {
-                    _logger.LogInformation($"Detected public IP address as '{externalip}'...opening firewall of SQL Server to allow edits from local machine...");
-
-                    // Add users IP
-                    await AddRule(serverRules, ruleName, externalip);
-
-                }
-                else
-                {
-                    _logger.LogInformation($"Invalid external IP address detected? '{externalip}' doesn't seem to be a valid IPv4 address.", true);
-                    _logger.LogInformation($"Add manually a rule to Azure SQL Server with name '{ruleName}' or DB tests will fail.", true);
-                }
-
-            }
-            else
-            {
-                _logger.LogInformation($"SQL Server firewall exception for installer already present ('{ruleName}'). Skipping SQL Server firewall configuration for client IP.");
-            }
+            await EnsureClientIpAllowed(server, serverRules, ruleName);
 
             var azServicesRule = GetRuleByName(server, ALL_AZ_SERVICES_RULE_NAME);
             if (azServicesRule == null)
@@ -75,6 +60,81 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
 
             return server;
+        }
+
+        /// <summary>
+        /// Make sure this host's public IP is covered by SOME rule on the server, creating or updating the
+        /// installer's own rule when it is not.
+        /// </summary>
+        private async Task EnsureClientIpAllowed(SqlServerResource server, SqlFirewallRuleCollection serverRules, string ruleName)
+        {
+            // Always resolve the public IP, whether or not our named rule exists. The old code only looked it
+            // up inside the "rule missing" branch, so when a stale rule existed the installer never even asked
+            // what its own address was - and so could not report the mismatch it was about to die from.
+            var clientIp = await PublicIpResolver.TryGetPublicIPv4Async(_keyVaultName, _logger);
+
+            var existingRules = ReadRules(server);
+            var ourRule = existingRules.FirstOrDefault(r => r.Name == ruleName);
+
+            if (clientIp == null)
+            {
+                // Already reported by the resolver. Don't touch the rule: overwriting a working rule with a
+                // guess would be worse than leaving it, and the database step can still repair it from the
+                // address Azure itself reports.
+                _logger.LogWarning(
+                    $"Could not determine this host's public IP address, so the SQL Server firewall rule '{ruleName}' " +
+                    (ourRule == null
+                        ? "could not be created. Add it by hand, or let the database step repair it automatically."
+                        : $"was left as-is ({ourRule.StartIp} - {ourRule.EndIp}). If that range no longer covers this host, " +
+                          "the database step will detect it and repair the rule automatically."));
+                return;
+            }
+
+            // "Is my IP allowed?", not "does my named rule exist?". An admin-added corporate range is a
+            // perfectly good reason to leave things alone.
+            var covering = SqlFirewallRules.RulesCovering(clientIp, existingRules);
+            if (covering.Count > 0)
+            {
+                _logger.LogInformation(
+                    $"SQL Server firewall already allows this host's IP {clientIp} via {string.Join(", ", covering.Select(r => r.ToString()))}. " +
+                    "Skipping SQL Server firewall configuration for client IP.");
+                return;
+            }
+
+            if (ourRule == null)
+            {
+                _logger.LogInformation(
+                    $"No SQL Server firewall rule allows this host's IP {clientIp}. Creating '{ruleName}' for it...");
+            }
+            else if (!SqlFirewallRules.CanSafelyReplaceWithSingleAddress(ourRule))
+            {
+                // An admin has widened the installer's rule into a range. Narrowing it back to one address
+                // would silently revoke access for every other address it covers.
+                _logger.LogError(
+                    $"SQL Server firewall rule '{ruleName}' has been widened to the range {ourRule.StartIp} - {ourRule.EndIp}, " +
+                    $"which does not include this host's IP {clientIp}. The installer will NOT narrow it to a single address, " +
+                    "because that would revoke access for every other address in that range. Extend the range to include " +
+                    $"{clientIp} (or add a separate rule for it) and re-run the installer.");
+                return;
+            }
+            else
+            {
+                // The message the old code could never produce, and the one an admin actually needs.
+                _logger.LogWarning(
+                    $"SQL Server firewall rule '{ruleName}' allows {ourRule.StartIp} - {ourRule.EndIp} but this host's public IP " +
+                    $"is {clientIp}, which no rule on this server covers. Updating the rule so the database step can connect.");
+            }
+
+            await AddRule(serverRules, ruleName, clientIp);
+            _logger.LogInformation($"SQL Server firewall rule '{ruleName}' now allows {clientIp}.");
+        }
+
+        /// <summary>Snapshot of the server's firewall rules in the shape the pure coverage logic works on.</summary>
+        private static List<SqlFirewallRuleRange> ReadRules(SqlServerResource server)
+        {
+            return server.GetSqlFirewallRules()
+                .Select(r => new SqlFirewallRuleRange(r.Data.Name, r.Data.StartIPAddress, r.Data.EndIPAddress))
+                .ToList();
         }
 
         SqlFirewallRuleResource GetRuleByName(SqlServerResource server, string name)

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/PublicIpResolver.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/PublicIpResolver.cs
@@ -1,0 +1,189 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CloudInstallEngine.Azure
+{
+    /// <summary>
+    /// Works out the installer host's public IPv4 address, for writing an Azure SQL firewall rule.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every source here answers a slightly different question, and the differences matter. The most reliable
+    /// answer of all is not in this class: it is the address Azure SQL itself reports in its
+    /// <c>40615</c> rejection message, which is ground truth for "what does THIS server see me as". That is
+    /// used by the self-heal path; this class exists for the up-front, pre-failure check.
+    /// </para>
+    /// <para>
+    /// Sources, in preference order:
+    /// </para>
+    /// <list type="number">
+    /// <item><description>
+    /// <b>Key Vault's <c>x-ms-keyvault-network-info</c> response header</b> - first-party, and returned on the
+    /// <c>401</c> of an UNAUTHENTICATED request, so it needs no token, no data-plane permission and no vault
+    /// firewall access. Only usable once the vault exists (it is created after the SQL firewall task on a
+    /// first install), hence the fallback below.
+    /// </description></item>
+    /// <item><description>
+    /// <b>An HTTPS echo service</b> - last resort. It reports the egress IP of the connection to the echo
+    /// service, which is not necessarily the egress IP Azure SQL sees: split-tunnel VPNs, proxies and
+    /// multi-address NAT pools can all make them differ, and a NAT pool can hand out a different address per
+    /// connection. It can therefore be confidently, silently wrong.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// The previous implementation used <c>new WebClient().DownloadString("http://icanhazip.com")</c>: plain
+    /// HTTP, no timeout, no exception handling, and validated with an unanchored regex so any IP-shaped text
+    /// in a captive-portal or error page passed and got written into a customer's SQL firewall.
+    /// </para>
+    /// </remarks>
+    public static class PublicIpResolver
+    {
+        /// <summary>Header Key Vault returns describing the caller, e.g. <c>conn_type=Ipv4;addr=203.0.113.10;...</c>.</summary>
+        internal const string KeyVaultNetworkInfoHeader = "x-ms-keyvault-network-info";
+
+        /// <summary>HTTPS, not HTTP: this value decides what goes into a customer's SQL firewall.</summary>
+        internal const string EchoServiceUrl = "https://icanhazip.com";
+
+        /// <summary>
+        /// Bounded so a hung or black-holed endpoint cannot stall the install. The old code had no timeout at
+        /// all, so an unreachable echo service hung the installer indefinitely.
+        /// </summary>
+        internal static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Parses the caller IP out of Key Vault's <c>x-ms-keyvault-network-info</c> header value.
+        /// Returns null when the header is absent, malformed, or reports a non-IPv4 address.
+        /// </summary>
+        internal static string ParseKeyVaultNetworkInfo(string headerValue)
+        {
+            if (string.IsNullOrWhiteSpace(headerValue)) return null;
+
+            foreach (var part in headerValue.Split(';'))
+            {
+                var kv = part.Split(new[] { '=' }, 2);
+                if (kv.Length != 2) continue;
+
+                if (!kv[0].Trim().Equals("addr", StringComparison.OrdinalIgnoreCase)) continue;
+
+                var candidate = kv[1].Trim();
+                return SqlFirewallRules.IsValidIPv4(candidate) ? candidate : null;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Parses an echo-service body into an IPv4 address, or null.
+        /// </summary>
+        /// <remarks>
+        /// Validates the WHOLE trimmed body rather than searching it. The old unanchored
+        /// <c>\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b</c> with <c>IsMatch</c> matched a SUBSTRING, so an HTML
+        /// error page or captive-portal response containing anything IP-shaped passed validation.
+        /// </remarks>
+        internal static string ParseEchoServiceBody(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body)) return null;
+
+            var trimmed = body.Trim().Trim('\r', '\n').Trim();
+
+            // A body carrying anything other than the address alone is not an answer we should trust.
+            return SqlFirewallRules.IsValidIPv4(trimmed) ? trimmed : null;
+        }
+
+        /// <summary>
+        /// Best-effort public IPv4 of this host, or null if it could not be determined. Never throws.
+        /// </summary>
+        /// <param name="keyVaultName">
+        /// Configured Key Vault name, enabling the first-party source. Null/empty (or a vault that does not
+        /// exist yet) simply falls through to the echo service.
+        /// </param>
+        public static async Task<string> TryGetPublicIPv4Async(string keyVaultName, ILogger logger)
+        {
+            var fromVault = await TryGetFromKeyVaultAsync(keyVaultName, logger);
+            if (fromVault != null)
+            {
+                logger?.LogInformation($"Detected this host's public IP address as '{fromVault}' (reported by Azure Key Vault).");
+                return fromVault;
+            }
+
+            var fromEcho = await TryGetFromEchoServiceAsync(logger);
+            if (fromEcho != null)
+            {
+                logger?.LogInformation(
+                    $"Detected this host's public IP address as '{fromEcho}' (reported by {EchoServiceUrl}). " +
+                    "Note this is the address seen by that service, which behind a proxy or split-tunnel VPN may differ " +
+                    "from the address Azure SQL sees.");
+                return fromEcho;
+            }
+
+            logger?.LogWarning(
+                "Could not determine this host's public IP address, so the Azure SQL firewall rule cannot be checked or " +
+                "repaired up-front. If the database step then fails with 'Client with IP address ... is not allowed to " +
+                "access the server', the installer will read the address from that error and repair the rule automatically.");
+            return null;
+        }
+
+        private static async Task<string> TryGetFromKeyVaultAsync(string keyVaultName, ILogger logger)
+        {
+            if (string.IsNullOrWhiteSpace(keyVaultName)) return null;
+
+            // Deliberately unauthenticated: the header comes back on the 401, so this needs no credential and
+            // works even when the vault's own firewall would reject us.
+            var url = $"https://{keyVaultName.Trim()}.vault.azure.net/secrets/installer-public-ip-probe?api-version=7.4";
+
+            try
+            {
+                using (var http = new HttpClient { Timeout = RequestTimeout })
+                using (var response = await http.GetAsync(url))
+                {
+                    if (response.Headers.TryGetValues(KeyVaultNetworkInfoHeader, out var values))
+                    {
+                        foreach (var value in values)
+                        {
+                            var parsed = ParseKeyVaultNetworkInfo(value);
+                            if (parsed != null) return parsed;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Expected on a first install (the vault does not exist yet) - not worth alarming about.
+                logger?.LogDebug($"Could not read the caller IP from Key Vault '{keyVaultName}': {ex.Message}");
+            }
+
+            return null;
+        }
+
+        private static async Task<string> TryGetFromEchoServiceAsync(ILogger logger)
+        {
+            try
+            {
+                using (var http = new HttpClient { Timeout = RequestTimeout })
+                using (var response = await http.GetAsync(EchoServiceUrl))
+                {
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        logger?.LogWarning($"Public IP lookup at {EchoServiceUrl} returned HTTP {(int)response.StatusCode}.");
+                        return null;
+                    }
+
+                    return ParseEchoServiceBody(await response.Content.ReadAsStringAsync());
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                logger?.LogWarning($"Public IP lookup at {EchoServiceUrl} timed out after {RequestTimeout.TotalSeconds:0}s.");
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning($"Public IP lookup at {EchoServiceUrl} failed: {ex.Message}");
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/SqlFirewallRules.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/SqlFirewallRules.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+
+namespace CloudInstallEngine.Azure
+{
+    /// <summary>
+    /// Pure helpers for reasoning about Azure SQL firewall rules and the client IP Azure actually sees.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately free of any network or ARM dependency so every decision here is unit-testable. The task
+    /// that calls them (<c>SqlServerFirewallConfigTask</c>) keeps the I/O.
+    /// </remarks>
+    public static class SqlFirewallRules
+    {
+        /// <summary>
+        /// The "allow all Azure services" rule. Azure represents it as the sentinel range 0.0.0.0-0.0.0.0,
+        /// which covers Azure-internal callers, NOT client IPs - so it must never be counted as covering the
+        /// installer host, or a stale rule would look fine forever.
+        /// </summary>
+        public const string AzureServicesSentinelIp = "0.0.0.0";
+
+        /// <summary>
+        /// Azure SQL error number for "Client with IP address '...' is not allowed to access the server".
+        /// </summary>
+        public const int ClientIpNotAllowedErrorNumber = 40615;
+
+        /// <summary>
+        /// Whether <paramref name="clientIp"/> falls inside any of <paramref name="rules"/>.
+        /// </summary>
+        /// <remarks>
+        /// Compares addresses as unsigned 32-bit values, not strings: '9.9.9.9' &lt;= '10.0.0.1' is false as a
+        /// string comparison and true numerically, so a string compare would silently mis-answer whole ranges.
+        /// The Azure-services sentinel range is ignored - see <see cref="AzureServicesSentinelIp"/>.
+        /// </remarks>
+        public static bool IsIpCoveredByAnyRule(string clientIp, IEnumerable<SqlFirewallRuleRange> rules)
+        {
+            if (!TryParseIPv4(clientIp, out var client)) return false;
+            if (rules == null) return false;
+
+            return rules.Any(r => RuleCovers(r, client));
+        }
+
+        /// <summary>The rules that cover <paramref name="clientIp"/>, for reporting which one is doing so.</summary>
+        public static IReadOnlyList<SqlFirewallRuleRange> RulesCovering(string clientIp, IEnumerable<SqlFirewallRuleRange> rules)
+        {
+            if (!TryParseIPv4(clientIp, out var client) || rules == null)
+            {
+                return new List<SqlFirewallRuleRange>();
+            }
+
+            return rules.Where(r => RuleCovers(r, client)).ToList();
+        }
+
+        private static bool RuleCovers(SqlFirewallRuleRange rule, uint client)
+        {
+            if (rule == null) return false;
+
+            // The Azure-services sentinel is not a client-IP range.
+            if (rule.StartIp == AzureServicesSentinelIp && rule.EndIp == AzureServicesSentinelIp) return false;
+
+            if (!TryParseIPv4(rule.StartIp, out var start)) return false;
+            if (!TryParseIPv4(rule.EndIp, out var end)) return false;
+
+            // Tolerate a rule stored back-to-front rather than silently treating it as covering nothing.
+            if (start > end)
+            {
+                var swap = start;
+                start = end;
+                end = swap;
+            }
+
+            return client >= start && client <= end;
+        }
+
+        /// <summary>
+        /// Strict IPv4 parse to an unsigned 32-bit value, big-endian so numeric ordering matches dotted-quad
+        /// ordering.
+        /// </summary>
+        /// <remarks>
+        /// Hand-rolled rather than delegating to <see cref="IPAddress.TryParse"/>, which on .NET Framework
+        /// still accepts legacy forms: "10" is 0.0.0.10, "1.2.3" is 1.2.0.3, "1.2.3.010" is 1.2.3.8 (octal)
+        /// and "1.2.3.0x10" is 1.2.3.16 (hex). Those values would then be echoed back verbatim into an ARM
+        /// firewall rule, where they mean something different from what was validated here. Only canonical
+        /// dotted-quad decimal is accepted.
+        /// </remarks>
+        public static bool TryParseIPv4(string value, out uint address)
+        {
+            address = 0;
+            if (string.IsNullOrWhiteSpace(value)) return false;
+
+            var parts = value.Trim().Split('.');
+            if (parts.Length != 4) return false;
+
+            uint result = 0;
+            foreach (var part in parts)
+            {
+                // 1-3 ASCII digits, and no leading zero (which would be octal in the legacy forms).
+                if (part.Length < 1 || part.Length > 3) return false;
+                if (part.Length > 1 && part[0] == '0') return false;
+
+                var octet = 0;
+                foreach (var c in part)
+                {
+                    if (c < '0' || c > '9') return false;
+                    octet = (octet * 10) + (c - '0');
+                }
+
+                if (octet > 255) return false;
+                result = (result << 8) | (uint)octet;
+            }
+
+            address = result;
+            return true;
+        }
+
+        /// <summary>Whether the value is a well-formed IPv4 address (and therefore usable in a firewall rule).</summary>
+        public static bool IsValidIPv4(string value) => TryParseIPv4(value, out _);
+
+        /// <summary>
+        /// Whether the installer may safely overwrite <paramref name="existingRule"/> with a single-address
+        /// range.
+        /// </summary>
+        /// <remarks>
+        /// The installer owns this rule by name, but an admin may well have widened it to a corporate range.
+        /// Replacing that with one address would silently revoke access for every other address it covered, so
+        /// a multi-address rule is left alone and reported instead. A rule that is absent, a single address, or
+        /// has unparseable bounds is ours to rewrite.
+        /// </remarks>
+        public static bool CanSafelyReplaceWithSingleAddress(SqlFirewallRuleRange existingRule)
+        {
+            if (existingRule == null) return true;
+
+            if (!TryParseIPv4(existingRule.StartIp, out var start)) return true;
+            if (!TryParseIPv4(existingRule.EndIp, out var end)) return true;
+
+            return start == end;
+        }
+
+        // Azure's message: "Cannot open server '<server>' requested by the login. Client with IP address
+        // '203.0.113.10' is not allowed to access the server." Anchored on the quoted address that follows the
+        // phrase, so an address appearing elsewhere in a wrapped message cannot be picked up by mistake.
+        private static readonly Regex _blockedIpPattern = new Regex(
+            @"[Cc]lient with IP address\s+'(?<ip>[0-9a-fA-F\.:]+)'",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Pulls the client IP out of an Azure SQL "not allowed to access the server" message.
+        /// </summary>
+        /// <remarks>
+        /// This is the authoritative answer to "what address does THIS server see me as" - better than any
+        /// echo service, which reports the egress IP of the connection to the echo service. Those differ under
+        /// split-tunnel VPNs, proxies and multi-address NAT pools, so an echo service can be confidently wrong
+        /// and we would then write a wrong rule.
+        /// </remarks>
+        public static bool TryGetBlockedClientIp(string sqlErrorMessage, out string clientIp)
+        {
+            clientIp = null;
+            if (string.IsNullOrWhiteSpace(sqlErrorMessage)) return false;
+
+            var match = _blockedIpPattern.Match(sqlErrorMessage);
+            if (!match.Success) return false;
+
+            var candidate = match.Groups["ip"].Value;
+
+            // Azure SQL firewall rules are IPv4-only; an IPv6 client cannot be repaired by writing a rule.
+            if (!IsValidIPv4(candidate)) return false;
+
+            clientIp = candidate;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// One Azure SQL firewall rule reduced to the three things that matter here, so the coverage logic can be
+    /// tested without an ARM <c>SqlFirewallRuleResource</c>.
+    /// </summary>
+    public class SqlFirewallRuleRange
+    {
+        public SqlFirewallRuleRange(string name, string startIp, string endIp)
+        {
+            Name = name;
+            StartIp = startIp;
+            EndIp = endIp;
+        }
+
+        public string Name { get; }
+        public string StartIp { get; }
+        public string EndIp { get; }
+
+        public override string ToString() => $"'{Name}' ({StartIp} - {EndIp})";
+    }
+}

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/CloudInstallEngine.csproj
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/CloudInstallEngine.csproj
@@ -5,6 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Lets the unit tests exercise the internal parsing helpers (public IP detection, firewall rule
+         coverage) without widening the public API of this library. -->
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Tests.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.ResourceManager.AppService" Version="1.5.0" />
     <PackageReference Include="Azure.ResourceManager.Authorization" Version="1.1.7" />

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/SqlFirewallSelfHealTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/SqlFirewallSelfHealTests.cs
@@ -1,0 +1,354 @@
+using CloudInstallEngine.Azure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// The SQL firewall self-heal logic (issue #326).
+    /// </summary>
+    /// <remarks>
+    /// The installer decided by RULE NAME alone: if "O365 Adv Analytics Setup Rule" existed it logged
+    /// "already present ... Skipping" without ever reading the IP range it held. So a stale rule - after a
+    /// DHCP renewal, a different network, or VPN on/off - meant the install reported success here and died
+    /// two minutes later at the database step, by which point the App Service had already been stopped.
+    /// </remarks>
+    [TestClass]
+    public class SqlFirewallRulesTests
+    {
+        private static SqlFirewallRuleRange Rule(string name, string start, string end) => new SqlFirewallRuleRange(name, start, end);
+
+        private static List<SqlFirewallRuleRange> Rules(params SqlFirewallRuleRange[] rules) => rules.ToList();
+
+        #region IP coverage
+
+        [TestMethod]
+        public void AnIpInsideARangeIsCovered()
+        {
+            var rules = Rules(Rule("Corp", "203.0.113.0", "203.0.113.255"));
+
+            Assert.IsTrue(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", rules));
+        }
+
+        [TestMethod]
+        public void RangeBoundariesAreInclusive()
+        {
+            var rules = Rules(Rule("Corp", "203.0.113.10", "203.0.113.20"));
+
+            Assert.IsTrue(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", rules), "Start of range must be covered.");
+            Assert.IsTrue(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.20", rules), "End of range must be covered.");
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.9", rules));
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.21", rules));
+        }
+
+        [TestMethod]
+        public void AStaleSingleAddressRuleDoesNotCoverADifferentAddress()
+        {
+            // The exact #326 scenario: the rule exists under the right name but points at the old IP.
+            var rules = Rules(Rule("O365 Adv Analytics Setup Rule", "198.51.100.5", "198.51.100.5"));
+
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", rules),
+                "A rule with the right NAME but the wrong IP must not count as covering us.");
+        }
+
+        [TestMethod]
+        public void AddressesAreComparedNumericallyNotAsStrings()
+        {
+            // '9.9.9.9' <= '10.0.0.1' is FALSE as a string comparison and TRUE numerically, so a string
+            // compare would mis-answer whole ranges. Same for the octet boundary at 99/100.
+            var rules = Rules(Rule("Wide", "9.0.0.0", "10.255.255.255"));
+
+            Assert.IsTrue(SqlFirewallRules.IsIpCoveredByAnyRule("9.9.9.9", rules));
+            Assert.IsTrue(SqlFirewallRules.IsIpCoveredByAnyRule("10.0.0.1", rules));
+
+            var octetRules = Rules(Rule("Octet", "203.0.113.99", "203.0.113.200"));
+            Assert.IsTrue(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.100", octetRules),
+                "'203.0.113.100' sorts before '203.0.113.99' as a string but is numerically inside the range.");
+        }
+
+        [TestMethod]
+        public void TheAzureServicesSentinelRuleNeverCoversAClientIp()
+        {
+            // 0.0.0.0-0.0.0.0 means "allow Azure-internal callers", not "allow everyone". Counting it would
+            // make every stale rule look fine for ever.
+            var rules = Rules(Rule("AllowAllWindowsAzureIps", "0.0.0.0", "0.0.0.0"));
+
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", rules));
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("0.0.0.0", rules));
+        }
+
+        [TestMethod]
+        public void AnAdminAddedRangeCountsAsCoverage()
+        {
+            // The question is "is my IP allowed?", not "does my named rule exist?" - a corporate range is a
+            // perfectly good reason to leave the installer's own rule alone.
+            var rules = Rules(
+                Rule("AllowAllWindowsAzureIps", "0.0.0.0", "0.0.0.0"),
+                Rule("O365 Adv Analytics Setup Rule", "198.51.100.5", "198.51.100.5"),
+                Rule("Corporate egress", "203.0.113.0", "203.0.113.255"));
+
+            Assert.IsTrue(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", rules));
+
+            var covering = SqlFirewallRules.RulesCovering("203.0.113.10", rules);
+            Assert.AreEqual(1, covering.Count);
+            Assert.AreEqual("Corporate egress", covering.Single().Name);
+        }
+
+        [TestMethod]
+        public void ARuleStoredBackToFrontIsStillEvaluated()
+        {
+            var rules = Rules(Rule("Reversed", "203.0.113.255", "203.0.113.0"));
+
+            Assert.IsTrue(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", rules),
+                "A reversed range should be tolerated rather than silently covering nothing.");
+        }
+
+        [TestMethod]
+        public void MalformedOrMissingInputsAreNotCoverage()
+        {
+            var rules = Rules(Rule("Corp", "203.0.113.0", "203.0.113.255"));
+
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule(null, rules));
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("", rules));
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("not-an-ip", rules));
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", null));
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", Rules()));
+
+            // A rule with unparseable bounds must not throw, and must not count as covering anything.
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", Rules(Rule("Bad", "junk", "junk"))));
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("203.0.113.10", Rules(Rule("Null", null, null))));
+        }
+
+        [TestMethod]
+        public void IPv6IsNotTreatedAsAnIPv4ClientAddress()
+        {
+            // Azure SQL firewall rules are IPv4-only, so an IPv6 address can never be "covered".
+            var rules = Rules(Rule("Corp", "0.0.0.1", "255.255.255.255"));
+
+            Assert.IsFalse(SqlFirewallRules.IsIpCoveredByAnyRule("2001:db8::1", rules));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("2001:db8::1"));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("::1"));
+        }
+
+        [TestMethod]
+        public void ShorthandFormsAreRejectedAsIPv4()
+        {
+            // IPAddress.TryParse alone accepts these as IPv4 (e.g. "10" => 0.0.0.10), which would write a
+            // nonsense firewall rule.
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("10"));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("1.2.3"));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("1.2.3.4.5"));
+            Assert.IsTrue(SqlFirewallRules.IsValidIPv4("1.2.3.4"));
+            Assert.IsTrue(SqlFirewallRules.IsValidIPv4("  203.0.113.10  "), "Surrounding whitespace should be tolerated.");
+        }
+
+        [TestMethod]
+        public void LegacyOctalAndHexFormsAreRejected()
+        {
+            // .NET Framework's IPAddress.TryParse reads "1.2.3.010" as 1.2.3.8 (octal) and "1.2.3.0x10" as
+            // 1.2.3.16 (hex). Accepting those would validate one address and then echo the original text into
+            // an ARM firewall rule, where it may mean something else entirely.
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("1.2.3.010"));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("1.2.3.0x10"));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("010.2.3.4"));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("1.2.3.256"), "Octets above 255 are not addresses.");
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("1.2.3.-4"));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("1.2.3."));
+            Assert.IsFalse(SqlFirewallRules.IsValidIPv4("1.2.3.4 5"));
+
+            // A single zero octet is canonical and must still be accepted.
+            Assert.IsTrue(SqlFirewallRules.IsValidIPv4("10.0.0.1"));
+            Assert.IsTrue(SqlFirewallRules.IsValidIPv4("0.0.0.0"));
+            Assert.IsTrue(SqlFirewallRules.IsValidIPv4("255.255.255.255"));
+        }
+
+        [TestMethod]
+        public void OrderingIsPreservedAcrossOctetBoundaries()
+        {
+            Assert.IsTrue(SqlFirewallRules.TryParseIPv4("0.0.0.0", out var min));
+            Assert.IsTrue(SqlFirewallRules.TryParseIPv4("255.255.255.255", out var max));
+            Assert.IsTrue(SqlFirewallRules.TryParseIPv4("0.0.1.0", out var justOverAnOctet));
+            Assert.IsTrue(SqlFirewallRules.TryParseIPv4("0.0.0.255", out var topOfFirstOctet));
+
+            Assert.AreEqual(0u, min);
+            Assert.AreEqual(uint.MaxValue, max);
+            Assert.IsTrue(topOfFirstOctet < justOverAnOctet, "Parsing must be big-endian for ordering to work.");
+        }
+
+        #endregion
+
+        #region Not narrowing a rule an admin widened
+
+        [TestMethod]
+        public void ASingleAddressRuleCanBeReplaced()
+        {
+            Assert.IsTrue(SqlFirewallRules.CanSafelyReplaceWithSingleAddress(
+                Rule("O365 Adv Analytics Setup Rule", "198.51.100.5", "198.51.100.5")));
+        }
+
+        [TestMethod]
+        public void AMissingRuleCanBeCreated()
+        {
+            Assert.IsTrue(SqlFirewallRules.CanSafelyReplaceWithSingleAddress(null));
+        }
+
+        [TestMethod]
+        public void AnAdminWidenedRangeIsNotOverwritten()
+        {
+            // The installer owns this rule by name, but an admin may well have widened it to a corporate
+            // range. Narrowing it back to one address would silently revoke access for every other address it
+            // covers - worse than the problem being fixed.
+            Assert.IsFalse(SqlFirewallRules.CanSafelyReplaceWithSingleAddress(
+                Rule("O365 Adv Analytics Setup Rule", "203.0.113.0", "203.0.113.255")));
+        }
+
+        [TestMethod]
+        public void ARuleWithUnparseableBoundsIsOursToRewrite()
+        {
+            // Nothing useful is being protected, so repairing it is strictly an improvement.
+            Assert.IsTrue(SqlFirewallRules.CanSafelyReplaceWithSingleAddress(Rule("Broken", "junk", "junk")));
+            Assert.IsTrue(SqlFirewallRules.CanSafelyReplaceWithSingleAddress(Rule("Broken", null, null)));
+        }
+
+        #endregion
+
+        #region Reading the blocked IP out of Azure's own error
+
+        [TestMethod]
+        public void TheBlockedClientIpIsReadFromAzuresRejectionMessage()
+        {
+            // This is the authoritative answer to "what address does THIS server see me as" - better than any
+            // echo service, which reports the egress IP of the connection to the echo service.
+            const string message =
+                "Cannot open server 'contosoanalytics' requested by the login. Client with IP address " +
+                "'203.0.113.10' is not allowed to access the server. To enable access, use the Windows Azure " +
+                "Management Portal or run sp_set_firewall_rule on the master database...";
+
+            Assert.IsTrue(SqlFirewallRules.TryGetBlockedClientIp(message, out var ip));
+            Assert.AreEqual("203.0.113.10", ip);
+        }
+
+        [TestMethod]
+        public void TheBlockedClientIpIsFoundInAWrappedMessage()
+        {
+            const string message =
+                "Error testing SQL connection to 'contosoanalytics.database.windows.net': 'Cannot open server " +
+                "'contosoanalytics' requested by the login. Client with IP address '198.51.100.7' is not allowed " +
+                "to access the server.'. Verify network connectivity to server.";
+
+            Assert.IsTrue(SqlFirewallRules.TryGetBlockedClientIp(message, out var ip));
+            Assert.AreEqual("198.51.100.7", ip);
+        }
+
+        [TestMethod]
+        public void AnIPv6ClientCannotBeRepairedByAFirewallRule()
+        {
+            // Azure SQL firewall rules are IPv4-only. Reporting a repair we cannot perform would be worse than
+            // falling through to the normal error.
+            const string message = "Client with IP address '2001:db8::1' is not allowed to access the server.";
+
+            Assert.IsFalse(SqlFirewallRules.TryGetBlockedClientIp(message, out var ip));
+            Assert.IsNull(ip);
+        }
+
+        [TestMethod]
+        public void AnUnrelatedMessageYieldsNoIp()
+        {
+            Assert.IsFalse(SqlFirewallRules.TryGetBlockedClientIp(null, out _));
+            Assert.IsFalse(SqlFirewallRules.TryGetBlockedClientIp("", out _));
+            Assert.IsFalse(SqlFirewallRules.TryGetBlockedClientIp("Login failed for user 'sqladmin'.", out _));
+
+            // An IP-shaped string elsewhere in the message must not be mistaken for the blocked client. The old
+            // detection regex was unanchored and used IsMatch, so any IP-shaped substring passed.
+            Assert.IsFalse(
+                SqlFirewallRules.TryGetBlockedClientIp("A network-related error occurred contacting 10.1.2.3.", out _));
+        }
+
+        [TestMethod]
+        public void TheErrorNumberMatchesAzuresDocumentedFirewallRejection()
+        {
+            Assert.AreEqual(40615, SqlFirewallRules.ClientIpNotAllowedErrorNumber);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Public-IP detection hardening (issue #326). The old code read
+    /// <c>http://icanhazip.com</c> over plain HTTP with <c>WebClient</c> - no timeout, no exception handling -
+    /// and validated the response with an UNANCHORED regex plus <c>IsMatch</c>, so any IP-shaped text in a
+    /// captive-portal or error page passed and got written into a customer's SQL firewall.
+    /// </summary>
+    [TestClass]
+    public class PublicIpResolverTests
+    {
+        [TestMethod]
+        public void TheEchoServiceIsCalledOverHttps()
+        {
+            StringAssert.StartsWith(PublicIpResolver.EchoServiceUrl, "https://",
+                "This value decides what goes into a customer's SQL firewall; it must not travel over plain HTTP.");
+        }
+
+        [TestMethod]
+        public void RequestsAreBounded()
+        {
+            Assert.IsTrue(PublicIpResolver.RequestTimeout > System.TimeSpan.Zero);
+            Assert.IsTrue(PublicIpResolver.RequestTimeout <= System.TimeSpan.FromSeconds(30),
+                "A hung endpoint must not be able to stall the install.");
+        }
+
+        [TestMethod]
+        public void AnEchoBodyIsAcceptedOnlyWhenItIsAnAddressAndNothingElse()
+        {
+            Assert.AreEqual("203.0.113.10", PublicIpResolver.ParseEchoServiceBody("203.0.113.10"));
+            Assert.AreEqual("203.0.113.10", PublicIpResolver.ParseEchoServiceBody("203.0.113.10\n"));
+            Assert.AreEqual("203.0.113.10", PublicIpResolver.ParseEchoServiceBody("  203.0.113.10\r\n"));
+        }
+
+        [TestMethod]
+        public void AnErrorOrCaptivePortalPageIsRejectedEvenIfItContainsAnIp()
+        {
+            // The exact failure mode the old unanchored IsMatch allowed.
+            Assert.IsNull(PublicIpResolver.ParseEchoServiceBody(
+                "<html><body>Sign in to continue. Gateway 192.168.0.1</body></html>"));
+            Assert.IsNull(PublicIpResolver.ParseEchoServiceBody("Your IP is 203.0.113.10"));
+            Assert.IsNull(PublicIpResolver.ParseEchoServiceBody("error"));
+            Assert.IsNull(PublicIpResolver.ParseEchoServiceBody(""));
+            Assert.IsNull(PublicIpResolver.ParseEchoServiceBody(null));
+        }
+
+        [TestMethod]
+        public void AnIPv6EchoResponseIsRejected()
+        {
+            // Azure SQL firewall rules are IPv4-only, so an IPv6-only host must fall through to an explicit
+            // failure rather than having a nonsense rule written for it.
+            Assert.IsNull(PublicIpResolver.ParseEchoServiceBody("2001:db8::1"));
+        }
+
+        [TestMethod]
+        public void TheCallerIpIsReadFromKeyVaultsNetworkInfoHeader()
+        {
+            // First-party and returned on the 401 of an UNAUTHENTICATED request, so it needs no token and no
+            // vault firewall access - and unlike an echo service it is a Microsoft endpoint.
+            Assert.AreEqual("203.0.113.10",
+                PublicIpResolver.ParseKeyVaultNetworkInfo("conn_type=Ipv4;addr=203.0.113.10;act_addr_fam=InterNetwork;"));
+
+            Assert.AreEqual("203.0.113.10",
+                PublicIpResolver.ParseKeyVaultNetworkInfo("addr=203.0.113.10"));
+
+            Assert.AreEqual("203.0.113.10",
+                PublicIpResolver.ParseKeyVaultNetworkInfo("conn_type=Ipv4; ADDR = 203.0.113.10 ;x=y"));
+        }
+
+        [TestMethod]
+        public void AMalformedOrIPv6KeyVaultHeaderYieldsNothing()
+        {
+            Assert.IsNull(PublicIpResolver.ParseKeyVaultNetworkInfo(null));
+            Assert.IsNull(PublicIpResolver.ParseKeyVaultNetworkInfo(""));
+            Assert.IsNull(PublicIpResolver.ParseKeyVaultNetworkInfo("conn_type=Ipv4;act_addr_fam=InterNetwork;"));
+            Assert.IsNull(PublicIpResolver.ParseKeyVaultNetworkInfo("conn_type=Ipv6;addr=2001:db8::1;"));
+            Assert.IsNull(PublicIpResolver.ParseKeyVaultNetworkInfo("addr=not-an-ip"));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -263,6 +263,7 @@
     <Compile Include="InstallTests\ServiceBusNamespaceInstallTaskTests.cs" />
     <Compile Include="InstallTests\RbacPermissionProbeTests.cs" />
     <Compile Include="InstallTests\TeamsUserActivityReportUrlTests.cs" />
+    <Compile Include="InstallTests\SqlFirewallSelfHealTests.cs" />
     <Compile Include="InstallTests\SpoInstallTests.cs" />
     <Compile Include="InstallTests\SpoAuthAndAppCatalogTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Makes the installer repair its own stale SQL firewall rule instead of failing the install and leaving the customer's App Service stopped.

## Problem

`SqlServerFirewallConfigTask` decided whether the installer host could reach Azure SQL by looking for a firewall rule with a matching **name** — it never read the `StartIPAddress` / `EndIPAddress` the rule held. So once the rule went stale, the install reported success and then died later with `Client with IP address '...' is not allowed to access the server` — after `webApp.StopAsync()`, which was never undone. A re-run that changed nothing could take a working deployment offline.

Frequency is high: DHCP renewal, a different office/home network, VPN on/off, or a mobile hotspot.

## Changes

### 1. Ask the right question up front

`Common/CloudInstallEngine/Azure/SqlFirewallRules.cs` is new pure logic, with no network or ARM dependency.

- The public IP is now resolved every run, not only when the named rule is missing.
- The check is **"is my IP covered by any rule?"**, not "does my named rule exist?" — an admin-added corporate range is valid coverage.
- Addresses compare numerically as `uint`, not strings.
- The `0.0.0.0`-`0.0.0.0` Azure-services sentinel is excluded because it covers Azure-internal callers, not installer client IPs.
- The "already present / skipping" path now names the IP and the rule doing the covering.

### 2. Self-heal from Azure SQL's own answer, then retry

`BaseInstallProcess.VerifySqlWithFirewallSelfHeal` handles SQL error `40615`. The client IP is taken from Azure SQL's rejection message, which is authoritative for what that server actually saw and is safer than trusting an echo service behind NAT, a proxy, or split-tunnel VPN. The installer's own firewall rule is updated and connectivity is retried with bounded backoff.

If SQL still fails, the log distinguishes:

- still `40615`: Azure accepted the rule but it may not have propagated yet;
- a different SQL error: the firewall is no longer the reported cause, so investigate credentials, database-level firewall, Private Link, or outbound filtering.

`VerifySQL` remains available for callers that do not need self-healing.

### 3. The App Service is no longer collateral damage

`ConfigureAzureComponentsTasks.RunPostCreatePaaSTasks` now proves SQL connectivity before stopping the App Service when a schema upgrade needs the database. If schema upgrade SQL is unreachable, the install terminates with the site still running on its current schema.

The database step is also wrapped so any attempted stop is followed by a start before the original exception is rethrown with `ExceptionDispatchInfo`. If the database step succeeded but the restart failed, that restart failure is fatal instead of letting the installer report success with a stopped site.

### 4. Guard rails

- Private-only deployments do not attempt public firewall repair; the existing VNet/private endpoint guidance remains the right answer.
- Only `AzurePaaSInstallJob.INSTALLER_FIREWALL_RULE_NAME` (`O365 Adv Analytics Setup Rule`) is written by the repair path; no second rule is added.
- An admin-widened installer rule is never narrowed to a single IP. The installer logs that the range does not include the current IP and tells the admin to extend it or add a separate rule.
- Configuration registration failures remain non-fatal when schema upgrade is not selected, matching `SqlInstallerTasks`' existing behavior.
- Retries are bounded.

### 5. Public-IP detection hardening

`Common/CloudInstallEngine/Azure/PublicIpResolver.cs` replaces the old plain-HTTP `WebClient` echo lookup with:

1. Key Vault's first-party `x-ms-keyvault-network-info` header from an unauthenticated request, when a vault name is available; then
2. `https://icanhazip.com` with timeout, exception handling, and whole-body validation.

IPv4 parsing rejects shorthand, octal/hex legacy forms, IPv6, and captive-portal/error pages containing an IP-shaped substring.

## Tests / validation

- `MSBuild.exe "O365 Advanced Analytics Engine.sln" /p:Configuration=Debug /m:2` passed.
- `vstest.console.exe Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~Tests.UnitTests.InstallTests.SqlFirewallRulesTests|FullyQualifiedName~Tests.UnitTests.InstallTests.PublicIpResolverTests"` passed: 28/28.
- Multi-model code review: first round found one behavior regression in the SQL preflight fatality condition; fixed. Second round was clean on claude-opus-4.8, gpt-5.6-sol, and grok-4.6.

## Risk / scope

- No EF migration and no database schema change.
- No persisted installer config property change; no `CONFIG_VERSION` bump needed.
- `CloudInstallEngine.csproj` only adds `InternalsVisibleTo("Tests.UnitTests")` so tests can exercise internal parsing helpers. It adds/upgrades no NuGet package, so no binding redirect or .NET Framework consumer package changes are required.
- Up-front public-IP lookup is best effort and bounded. If it fails, the installer leaves existing rules untouched and the database step can still repair from Azure SQL's own `40615` message.
- The install can now write a firewall rule where before it only failed. The write is constrained to the installer's own rule, skipped on private-only, and refused when that rule has been widened.

## Reviewer hotspots

1. Stop / database upgrade / start sequencing in `ConfigureAzureComponentsTasks`.
2. The SQL preflight fatality condition: fatal for schema upgrade, non-fatal for config registration-only paths.
3. Public IP source ordering and fallback behavior in `PublicIpResolver` and the `40615` self-heal path.
4. Admin-managed firewall ranges: coverage can come from any rule, but repair writes only the installer-owned single-address rule.

Addresses #326
