### PR TITLE
Profiling: stop usp_UpsertCopilot dropping the last day of every week

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/PROFILING.md
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/PROFILING.md
@@ -181,6 +181,45 @@ counts chats/files/meetings via `dbo.copilot_event_files` / `dbo.copilot_event_m
   **does not re-raise**. So a failed week is logged but the run still returns success. The
   Profiling tab / `TraceLogs` are the only place failures show up.
 - **Idempotent installer, idempotent compile** (via the row-existence guards). Re-running is safe.
+- **Date predicates: watch the column type.** All the `usp_Upsert*` procs take `@StartDate DATE,
+  @EndDate DATE` and are called with `@Monday, @Sunday` — an **inclusive** Sunday. Most of them
+  read a daily `*_user_activity_log` table whose `"date"` column, although declared `datetime`,
+  only ever holds midnight values, so `"date" <= @EndDate` is exact. **`usp_UpsertCopilot` is the
+  exception**: it aggregates raw `dbo.audit_events`, whose `time_stamp` carries a real time of day.
+  There, `time_stamp <= @EndDate` compares against the Sunday widened to `00:00:00.000` and keeps
+  only the first instant of the day — it must use a half-open
+  `time_stamp < DATEADD(DAY, 1, @EndDate)` window. This was a live bug (issue #300): every weekly
+  Copilot metric under-counted by a full day (~1/7). If you add another proc that filters a
+  timestamped table, use the half-open form.
+
+---
+
+## 6a. Recompiling history after an aggregation fix
+
+There is no update path — a week is compiled once and never revisited — so a change to *how* a week
+is aggregated does **not** correct weeks already written. Until history is recompiled, a fix shows up
+as a step change in the middle of every trend chart.
+
+To recompile, delete the affected weeks and let the next run refill them, or force a full recompile:
+
+```sql
+-- Recompile every retained week from scratch (@All = 1 starts from the retention date).
+EXEC profiling.usp_CompileWeekly @WeeksToKeep = 53, @All = 1;
+```
+
+`@All = 1` only moves the *start* date back; the row-existence guard still skips weeks that already
+have rows, so the existing rows must be removed first for the recompile to take effect:
+
+```sql
+DELETE FROM profiling.ActivitiesWeekly       WHERE MetricDate >= @FromMonday;
+DELETE FROM profiling.ActivitiesWeeklyColumns WHERE "date"    >= @FromMonday;
+DELETE FROM profiling.UsageWeekly            WHERE "date"     >= @FromMonday;
+```
+
+Recompilation is only as good as the retained raw data: `usp_CompileWeekly` reads
+`dbo.audit_events` and the `*_user_activity_log` tables, so weeks whose raw rows have already been
+aged out cannot be corrected. Recompile in a maintenance window — it re-aggregates every retained
+week in one pass.
 
 ---
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql
@@ -1905,7 +1905,15 @@ BEGIN
           event_id
         FROM dbo.copilot_chats AS c
           JOIN dbo.audit_events AS au ON c.event_id = au.id
-        WHERE @StartDate <= au.time_stamp AND au.time_stamp <= @EndDate
+        -- Half-open window, NOT "<= @EndDate". au.time_stamp is a datetime carrying a real time of
+        -- day, while @EndDate is a DATE - so SQL Server widens @EndDate to midnight and "<= @EndDate"
+        -- keeps only events at exactly 00:00:00.000 on the last day, silently dropping the whole of
+        -- it. The only caller (usp_CompileActivityWeek) passes @Monday, @Sunday with Sunday
+        -- INCLUSIVE, so every weekly Copilot metric was under-counting by a full day. Measured on
+        -- synthetic data: 158,008 chats vs 184,364 for one week (-14.3%, i.e. exactly 1/7).
+        -- The other usp_Upsert* procs are unaffected: they read the daily *_user_activity_log tables,
+        -- whose "date" values are always midnight, so the same comparison is exact for them.
+        WHERE au.time_stamp >= @StartDate AND au.time_stamp < DATEADD(DAY, 1, @EndDate)
       ) t
       PIVOT (
         COUNT(event_id)
@@ -1977,7 +1985,9 @@ BEGIN
         JOIN dbo.audit_events AS au ON c.event_id = au.id
         LEFT JOIN dbo.copilot_event_files AS f ON c.event_id = f.copilot_chat_id
         LEFT JOIN dbo.copilot_event_meetings AS m ON c.event_id = m.copilot_chat_id
-      WHERE @StartDate <= au.time_stamp AND au.time_stamp <= @EndDate
+      -- Same half-open window as hosts_pivoted above; the two must agree or the per-host counts and
+      -- the chat/file/meeting counts would cover different windows for the same week.
+      WHERE au.time_stamp >= @StartDate AND au.time_stamp < DATEADD(DAY, 1, @EndDate)
     ),
     event_counts AS (
       SELECT

--- a/src/AnalyticsEngine/Tests.UnitTests/ProfilingStoredProcedureTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ProfilingStoredProcedureTests.cs
@@ -509,23 +509,15 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        [Ignore]
         public async Task UspCompileActivityWeek_CopilotSundayActivity_IsIncluded()
         {
-            // KNOWN FAILING - kept deliberately as the reproduction for #300.
+            // The reproduction for #300, now fixed. A Copilot interaction at 23:59 on the Sunday belongs to
+            // that Mon-Sun week.
             //
-            // This asserts correct behaviour: a Copilot interaction at 23:59 on the Sunday belongs to that
-            // Mon-Sun week. It currently fails, because profiling.usp_UpsertCopilot filters with
-            // `au.time_stamp <= @EndDate` and @EndDate is the Sunday at midnight - so only the first instant
-            // of the final day is kept and the rest of Sunday is dropped.
-            //
-            // The one-line fix (a half-open `< DATEADD(DAY, 1, @EndDate)` window) was reverted out of this
-            // release: it silently changes every weekly Copilot metric the proc produces, in a direction that
-            // depends on what callers pass as @EndDate, and it arrived with a test-data generator rather than
-            // as a considered profiling change. #300 tracks the proper fix - caller audit, the same treatment
-            // for the other workloads, before/after numbers, and a decision on recompiling history.
-            //
-            // Un-ignore this as part of #300; it is the assertion that change needs to satisfy.
+            // It used to fail because profiling.usp_UpsertCopilot filtered with `au.time_stamp <= @EndDate`.
+            // audit_events.time_stamp is a datetime carrying a real time of day, while @EndDate is a DATE, so
+            // SQL Server widened @EndDate to midnight and the predicate kept only the first instant of the
+            // final day - dropping the rest of Sunday from every weekly Copilot metric.
             using (var db = new AnalyticsEntitiesContext())
             {
                 var monday = TEST_MONDAY.AddDays(98);
@@ -541,6 +533,64 @@ namespace Tests.UnitTests
                     1,
                     await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot Chats"),
                     "Copilot activity from the full Sunday must be included in the Mon-Sun week");
+            }
+        }
+
+        [TestMethod]
+        public async Task UspCompileActivityWeek_CopilotActivityAfterTheWeek_IsExcluded()
+        {
+            // The other half of the #300 fix, and the risk the issue called out: if @EndDate had been an
+            // EXCLUSIVE end (the following Monday), the half-open window would double-count a day instead of
+            // fixing an under-count. The only caller (usp_CompileActivityWeek) passes @Monday, @Sunday with
+            // Sunday inclusive, so the window must stop at the instant the next Monday begins - not a day
+            // later. Asserted from both sides so neither boundary can drift again.
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var monday = TEST_MONDAY.AddDays(105);
+                var nextMondayMidnight = monday.AddDays(7);            // 00:00:00 - the first instant of the NEXT week
+                var nextMondayLater = monday.AddDays(7).AddHours(9);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupTestData(db, monday);
+                await InsertCopilotChat(db, TEST_USER_ID, nextMondayMidnight, "Teams");
+                await InsertCopilotChat(db, TEST_USER_ID, nextMondayLater, "Teams");
+
+                await ExecuteStoredProcedure(db, "profiling.usp_CompileActivityWeek", monday);
+
+                Assert.AreEqual(
+                    0,
+                    await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot Chats"),
+                    "Activity on the following Monday belongs to the NEXT week, not this one.");
+            }
+        }
+
+        [TestMethod]
+        public async Task UspCompileActivityWeek_CopilotWholeWeekBoundaries_AreCounted()
+        {
+            // Every boundary instant of the Mon-Sun window in one assertion, so a future edit to either end
+            // of the predicate is caught immediately.
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var monday = TEST_MONDAY.AddDays(112);
+
+                await EnsureTestUserExists(db, TEST_USER_ID);
+                await CleanupTestData(db, monday);
+
+                // First instant of the week, an ordinary mid-week time, and the last minute of Sunday.
+                await InsertCopilotChat(db, TEST_USER_ID, monday, "Teams");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(3).AddHours(14), "Teams");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(6).AddHours(23).AddMinutes(59), "Teams");
+
+                // Just outside, both ends.
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddSeconds(-1), "Teams");
+                await InsertCopilotChat(db, TEST_USER_ID, monday.AddDays(7), "Teams");
+
+                await ExecuteStoredProcedure(db, "profiling.usp_CompileActivityWeek", monday);
+
+                Assert.AreEqual(
+                    3,
+                    await GetActivityMetricSum(db, monday, TEST_USER_ID, "Copilot Chats"),
+                    "Exactly the three in-week interactions should be counted.");
             }
         }
 


### PR DESCRIPTION
Resolves the review #300 asked for, and lands the fix.

## The bug is real, and it is Copilot-only

`profiling.usp_UpsertCopilot` filtered with:

```sql
WHERE @StartDate <= au.time_stamp AND au.time_stamp <= @EndDate
```

`dbo.audit_events.time_stamp` is a **`datetime`** carrying a real time of day. `@EndDate` is a **`DATE`**. SQL Server widens `@EndDate` to `Sunday 00:00:00.000`, so `<= @EndDate` keeps only events at exactly that instant and **silently discards the rest of Sunday** — from every weekly Copilot metric the proc produces.

## The four questions the issue raised

### 1. What does every caller pass as `@StartDate` / `@EndDate`?

**There is exactly one caller**, and `@EndDate` is **inclusive**:

```sql
-- usp_CompileActivityWeek
DECLARE @Sunday DATE = DATEADD(DAY, 6, @Monday);
...
EXECUTE profiling.usp_UpsertCopilot @Monday, @Sunday;
```

`Weekly.ps1` reaches this only through `usp_CompileWeekly @WeeksToKeep` and passes no dates of its own.

This settles the issue's main worry — *"if any caller already passes an exclusive end, the new form double-counts a day"*. No caller does, so the half-open window is a straight correction with no double-count. There is now a test asserting exactly that.

### 2. Does the same bug exist in the other profiling upsert procs?

**No — and the reason matters, because the surface reading says otherwise.**

Every `usp_Upsert*` proc uses the same `"date" <= @EndDate` shape, and I confirmed against a real database that **all** these columns are declared `datetime`, not `date`:

| Table | Column | Type |
|---|---|---|
| `audit_events` | `time_stamp` | `datetime` |
| `teams_user_activity_log` | `date` | `datetime` |
| `onedrive_user_activity_log` | `date` | `datetime` |
| `sharepoint_user_activity_log` | `date` | `datetime` |
| `outlook_user_activity_log` | `date` | `datetime` |

So the type alone doesn't explain it. What does is the **values**: the usage-report tables hold one row per user per *report day*, always at midnight, so `<= @EndDate` is exact for them. `audit_events` holds real event times — measured on a local synthetic set, **100% of 10,000,000 rows have a non-midnight time**.

`usp_UpsertCopilot` is the only proc aggregating raw audit events, and therefore the only one affected. Changing the others would be churn, not a fix — and would risk exactly the "silent shift" the issue warns about.

### 3. Before/after numbers

Measured on a local synthetic dataset (12M Copilot chats joined to `audit_events`), taking one Mon–Sun week and running both predicates over the same rows:

| Metric | Current (`<= @Sunday`) | Fixed (`< @Sunday + 1`) | Change |
|---|---|---|---|
| Copilot chats | 158,008 | 184,364 | **+16.7%** (old form lost 14.3% ≈ exactly 1/7) |
| Distinct active users | 32,361 | 32,950 | **+1.8%** |

Volume metrics lose a whole day. The distinct-user count loses less, because most Sunday-active users were also active earlier in the week — **but a user who only used Copilot on a Sunday vanished from that week entirely**, which is the more damaging error for an adoption metric.

*(Synthetic benchmark data — no customer figures.)*

### 4. Does previously-compiled history need recompiling?

**Yes.** There is no update path — a week is compiled once and never revisited — so existing weekly rows stay wrong and the fix would otherwise show up as a step change in the middle of every trend chart.

`PROFILING.md` now documents the procedure, including two things that are easy to get wrong:

- `@All = 1` only moves the **start** date back. The row-existence guard still skips weeks that already have rows, so the existing rows must be **deleted first** or the recompile is a no-op.
- Recompilation is bounded by raw-data retention: weeks whose `audit_events` / `*_user_activity_log` rows have aged out cannot be corrected.

Not automated — deleting and rebuilding a customer's weekly aggregates is an operator decision for a maintenance window, not something an upgrade should do silently.

## The fix

Both predicates in `usp_UpsertCopilot` (the `hosts_pivoted` PIVOT source and the `events` CTE) become half-open:

```sql
WHERE au.time_stamp >= @StartDate AND au.time_stamp < DATEADD(DAY, 1, @EndDate)
```

Both had to change together — otherwise the per-host counts and the chat/file/meeting counts would cover different windows for the same week. The reasoning is left in the SQL as a comment, since the next person to read `<= @EndDate` will assume it is fine.

## Tests

`UspCompileActivityWeek_CopilotSundayActivity_IsIncluded` was already in the suite as an `[Ignore]`d reproduction pointing at this issue ("*Un-ignore this as part of #300; it is the assertion that change needs to satisfy*"). It is now **enabled and passing**. Two boundary guards added alongside it:

- `..._CopilotActivityAfterTheWeek_IsExcluded` — activity at the following Monday `00:00` and later belongs to the **next** week. This is the over-count guard.
- `..._CopilotWholeWeekBoundaries_AreCounted` — seeds five interactions (first instant of the week, mid-week, last minute of Sunday, one second before the week, and the next Monday) and asserts exactly three are counted.

**Verified in both directions.** With the old predicate restored:

```
Failed UspCompileActivityWeek_CopilotSundayActivity_IsIncluded
  Assert.AreEqual failed. Expected:<1>. Actual:<0>.
Failed UspCompileActivityWeek_CopilotWholeWeekBoundaries_AreCounted
  Assert.AreEqual failed. Expected:<3>. Actual:<2>.
Passed UspCompileActivityWeek_CopilotActivityAfterTheWeek_IsExcluded
```

The over-count guard passing in *both* configurations is the point — it proves the fix corrects an under-count without introducing an over-count. With the fix: **19/19 profiling tests pass** against a real LocalDB running the actual stored procedure.

## Migration / risk

- **No EF migration.** The profiling schema is an idempotent `DROP`/`CREATE` SQL extension that the installer re-applies on every database upgrade, so the corrected proc ships with the normal upgrade.
- **No config change.**
- **Behavioural change is intended and now measured**: weeks compiled *after* the upgrade include the full Sunday. Weeks compiled before it do not, until recompiled — hence the documented procedure.
- Also documents the general rule in `PROFILING.md` §6 so the next proc that filters a timestamped table uses the half-open form.

## Reviewer hotspots

- The claim that **no other proc is affected**. It rests on the usage-report tables only ever holding midnight values. If any loader could write a non-midnight `date`, that proc would need the same fix.
- Whether **history recompilation should be automated** rather than documented. I've deliberately left it manual.

Addresses #300
