### PR TITLE
Replace tenant-derived figures with synthetic ones, and measure migration 2's build cost

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
@@ -22,8 +22,9 @@ namespace Common.Entities.CopilotAdoption
     ///   carries denormalised <c>user_id</c> / <c>time_stamp</c> columns, written on the same row by the
     ///   same statement that inserts the chat (<c>common_upsert_copilot_agents.sql</c>) and indexed by
     ///   <c>IX_copilot_chats_time_stamp_user_id</c>.
-    ///   <br/>Measured on a bench matching a real customer's shape (10.85M audit_events at ~1.7 KB/row,
-    ///   6.0M copilot_chats, 55% Copilot): <c>LicensedUsers</c> at a 28-day window went 13.0s -&gt; 5.6s
+    ///   <br/>Measured on a synthetic bench sized for a large tenant (~10M audit_events at ~1.7 KB/row,
+    ///   ~6M copilot_chats, Copilot a large share of them): <c>LicensedUsers</c> at a 28-day window went
+    ///   13.0s -&gt; 5.6s
     ///   (2.3x). A covering index on <c>copilot_chats(event_id)</c> - which needs no duplication - only
     ///   reached 10.4s, because an index key must be a column of the table it indexes, so no index on
     ///   <c>copilot_chats</c> can be date-ordered unless the date is ON <c>copilot_chats</c>. See migration

--- a/src/AnalyticsEngine/Common/Entities/Entities/AuditLog/CopilotEvents.cs
+++ b/src/AnalyticsEngine/Common/Entities/Entities/AuditLog/CopilotEvents.cs
@@ -77,8 +77,9 @@ namespace Common.Entities.Entities.AuditLog
         /// <c>copilot_chats -&gt; audit_events</c>. Carrying the two values here removes that join.
         /// </para>
         /// <para>
-        /// Measured on a bench matching a real customer's shape (10.85M audit_events at ~1.7 KB/row, 6.0M
-        /// copilot_chats, 55% Copilot): <c>LicensedUsers</c> at a 28-day window went 13.0s -&gt; 5.6s.
+        /// Measured on a synthetic bench sized for a large tenant (~10M audit_events at ~1.7 KB/row, ~6M
+        /// copilot_chats, Copilot a large share of them): <c>LicensedUsers</c> at a 28-day window went
+        /// 13.0s -&gt; 5.6s.
         /// The duplication is structural rather than a tuning shortcut - an index key must be a column of
         /// the table it indexes, so no index on <c>copilot_chats</c> can be date-ordered unless the date is
         /// on <c>copilot_chats</c>. Full option comparison, including why an indexed view was rejected, is

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608310747353_DenormaliseCopilotChatUserAndTime.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608310747353_DenormaliseCopilotChatUserAndTime.cs
@@ -18,19 +18,19 @@ namespace Common.Entities.Migrations
     /// <para>
     /// <b>An earlier explanation of this migration was WRONG and is withdrawn.</b> It claimed the optimiser
     /// seeked <c>IX_user_id</c> once per licensed user and dragged in every audit event those users ever
-    /// generated. A read-only diagnostic against a real customer tenant denied it: <c>IX_user_id</c> showed
-    /// 3 seeks against 230 on <c>IX_audit_events_time_stamp</c>, Copilot is 55% of <c>audit_events</c> (not a
-    /// small minority), and licensed users' audit activity is ~87% Copilot - so there is little non-Copilot
-    /// data to drag in. The structural argument above is the one that survived contact with real data; do not
-    /// reinstate the plan-shape story.
+    /// generated. Index-usage diagnostics denied it: <c>IX_user_id</c> is barely seeked compared with
+    /// <c>IX_audit_events_time_stamp</c>, Copilot interactions are a large share of <c>audit_events</c>
+    /// rather than a small minority, and licensed users' audit activity is overwhelmingly Copilot - so there
+    /// is little non-Copilot data to drag in. The structural argument above is the one that survived contact
+    /// with real data; do not reinstate the plan-shape story.
     /// </para>
     ///
     /// <para>
-    /// <b>Measured before / after.</b> The numbers below come from a bench built to match a REAL customer
-    /// tenant's measured shape - 10.85M <c>audit_events</c> at ~1.7 KB/row (a 19.9 GB clustered index,
-    /// because <c>event_data</c> holds the raw JSON), 6.0M <c>copilot_chats</c>, Copilot = 55% of
-    /// <c>audit_events</c>, 4.4 years of retention with 85% of Copilot activity inside the last year, and
-    /// licensed users whose audit activity is ~87% Copilot. Query text extracted from the compiled
+    /// <b>Measured before / after.</b> The numbers below come from a synthetic bench sized for a large
+    /// tenant - roughly 10M <c>audit_events</c> at ~1.7 KB/row (the bulk of it <c>event_data</c> holding raw
+    /// JSON, giving a multi-GB clustered index), roughly 6M <c>copilot_chats</c>, Copilot forming a large
+    /// share of <c>audit_events</c>, and several years of retention with most Copilot activity inside the
+    /// last year. Query text extracted from the compiled
     /// assembly, medians of 3 warm runs, cold run discarded, <c>DBCC FREEPROCCACHE</c> before each run,
     /// <c>OPTION (RECOMPILE)</c>. <c>LicensedUsers</c>, 28-day window:
     /// </para>
@@ -63,12 +63,13 @@ namespace Common.Entities.Migrations
     /// </para>
     ///
     /// <para>
-    /// <b>Honest limits of this evidence.</b> The bench reproduces the customer's data SHAPE but not their
-    /// environment: production is Azure SQL Database (tier-capped IOPS/CPU) with the importer running
-    /// concurrently, and their <c>copilot_chats</c> is ~7x wider than the synthetic one. The observed
-    /// production p50 for this step is ~90 s, whereas the same shape runs the un-migrated query in ~13 s on
-    /// the bench hardware - so the absolute production improvement is an EXTRAPOLATION from the 2.3x ratio,
-    /// not a measurement. The ratio is the defensible claim; "90 s becomes 39 s" is not.
+    /// <b>Honest limits of this evidence.</b> The bench reproduces a large tenant's data SHAPE but not a
+    /// production environment: production is typically Azure SQL Database (tier-capped IOPS/CPU) with the
+    /// importer running concurrently, and a real <c>copilot_chats</c> row can be several times wider than
+    /// the synthetic one. The reported production p50 for this step (see issue #360) is far above what the
+    /// same shape costs on bench hardware, so the absolute production improvement is an EXTRAPOLATION from
+    /// the 2.3x ratio, not a measurement. The ratio is the defensible claim; a specific
+    /// "N seconds becomes M seconds" is not.
     /// </para>
     ///
     /// <para>

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608310747353_DenormaliseCopilotChatUserAndTime.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608310747353_DenormaliseCopilotChatUserAndTime.manual.sql
@@ -18,8 +18,8 @@
      no matter how narrow the reporting window was. See issue #360.
 
    MEASURED IMPACT
-     Measured on a bench built to match a REAL customer tenant's shape (10.85M audit_events at ~1.7 KB
-     per row, 6.0M copilot_chats, Copilot = 55% of audit_events, 4.4 years retention). Medians of 3
+     Measured on a synthetic bench sized for a large tenant (~10M audit_events at ~1.7 KB per row,
+     ~6M copilot_chats, Copilot a large share of them, several years of retention). Medians of 3
      warm runs with the plan cache cleared. LicensedUsers query, 28-day window:
 
        baseline (joins audit_events)                  13.0 s

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202608310800001_ColumnstoreUsageReportMetrics.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202608310800001_ColumnstoreUsageReportMetrics.cs
@@ -41,6 +41,43 @@ namespace Common.Entities.Migrations
     /// </para>
     ///
     /// <para>
+    /// <b>Two selectivities - the benefit GROWS with the window.</b> The same <c>TeamsUsage</c> aggregate,
+    /// re-run at both a narrow and a wide window on the same 13.2M-row table (medians of 3 warm runs, cold
+    /// run discarded, <c>DBCC FREEPROCCACHE</c> per run, <c>OPTION (RECOMPILE)</c>):
+    /// </para>
+    /// <code>
+    ///   window    | IX_date only (before) | + COLUMNSTORE | speed-up
+    ///   ----------+-----------------------+---------------+---------
+    ///    28 days  |   281 ms              |   128 ms      | 2.2x
+    ///   365 days  | 2,652 ms              |   389 ms      | 6.8x
+    /// </code>
+    /// <para>
+    /// There is no regression at either end, and the wide window - the expensive case, and the one an admin
+    /// reaching for a year of history actually hits - benefits most, because a scan grows with the range
+    /// while the columnstore aggregate stays close to flat. (These absolute numbers are lower than the table
+    /// above because that run carried <c>SET STATISTICS IO, TIME ON</c> and a colder buffer pool; the RATIOS
+    /// agree - 1.9x there against 2.2x here at 28 days - which is the claim being made.)
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Build time and storage - measured</b>, on the same 13.2M-row / 1,395 MB table, so an admin can size
+    /// the maintenance window. Both builds are OFFLINE on every edition (this migration does not attempt
+    /// <c>ONLINE</c>), so the table is locked for the duration:
+    /// </para>
+    /// <code>
+    ///   index built                | build time | resulting size | per 1M rows
+    ///   ---------------------------+------------+----------------+-------------------
+    ///   nonclustered COLUMNSTORE   | 40.6 s     |    86 MB       | ~3.1 s,  ~6.5 MB
+    ///   covering B-tree (fallback) | 24.3 s     |   883 MB       | ~1.8 s, ~67 MB
+    /// </code>
+    /// <para>
+    /// The columnstore takes ~1.7x longer to build but is <b>10x smaller</b> (86 MB against 883 MB). Repeat
+    /// build measured 44.7 s, so ~40-45 s is the stable figure. Scale roughly linearly and multiply by the
+    /// four tables. Note the fallback's 883 MB per table is precisely why Express is excluded below: four of
+    /// those would consume a third of an Express database's 10 GB ceiling.
+    /// </para>
+    ///
+    /// <para>
     /// <b>Availability, and why this is attempt-and-catch rather than a version check.</b> Nonclustered
     /// columnstore is available in ALL editions only from SQL Server 2016 <b>SP1</b>; 2016 RTM Standard and
     /// Express reject it, as do Azure SQL Database Basic / S0-S2 and elastic pools under 100 eDTU. Detecting


### PR DESCRIPTION
Documentation and comments only — **no executable SQL or C# behaviour changes**. Both migrations' `Up_Sql` / `Down_Sql` bodies are untouched, so nothing about how they apply changes.

Addresses two findings from the pre-publication review of the 1809 release, which is still in draft.

## 1. Sanitise measurements sourced from a production database

The migration doc comments, the entity/SQL class comments and the manual upgrade script described the benchmark as *"a bench built to match a REAL customer tenant's measured shape"* — and then gave that shape precisely: exact `audit_events` and `copilot_chats` row counts, the clustered index size in GB, the retention period in years, the Copilot share of `audit_events`, and index seek counts from a read-only diagnostic against the tenant.

The repository policy names **row counts** explicitly, alongside DB names, GUIDs and payloads, and says to *reproduce the shape, not the data*. These were on public `main` and inside an attached release asset.

They are replaced with rounded synthetic magnitudes that carry the same engineering argument — `~10M audit_events at ~1.7 KB/row`, `Copilot a large share of them` — without disclosing any tenant's numbers. The structural argument (an index key must be a column of the table being indexed) is unaffected, because it never depended on the exact figures.

**Kept deliberately:**
- The benchmark **results** (`13.0s -> 5.6s`, the four-option comparison, the `+95%` indexed-view write penalty) — these are from the synthetic bench, not from a customer.
- Production timings, now as a pointer to #360 rather than restated. That issue is public and already carries them.

No history rewrite: the figures are anonymous aggregates with no tenant name, GUID or URL, so this is a forward fix.

## 2. Record migration 2's build cost and a second selectivity

`ColumnstoreUsageReportMetrics` shipped with a single 28-day query benchmark and **no build-time measurement** — yet its index builds are **offline on every edition** (it does not attempt `ONLINE`), so build time is precisely the number that sizes an admin's maintenance window. The repo's schema-change gate asks for build time, storage, and more than one selectivity.

Measured on the same synthetic 13.2M-row / 1,396 MB `teams_user_activity_log`:

| Index built | Build time | Size | Per 1M rows |
|---|---|---|---|
| Nonclustered columnstore | 40.6 s | **86 MB** | ~3.1 s, ~6.5 MB |
| Covering B-tree (fallback) | 24.3 s | **883 MB** | ~1.8 s, ~67 MB |

The columnstore takes ~1.7× longer to build but is **10× smaller**. That also quantifies, rather than merely asserts, why Express is excluded from the fallback: four 883 MB indexes would consume a third of an Express database's 10 GB ceiling. A repeat build measured 44.7 s, so ~40–45 s is the stable figure.

Second selectivity, same aggregate, same harness:

| Window | `IX_date` only | + columnstore | Speed-up |
|---|---|---|---|
| 28 days | 281 ms | 128 ms | 2.2× |
| 365 days | 2,652 ms | **389 ms** | **6.8×** |

**No regression at either end, and the benefit grows with the window** — the wide range is both the expensive case and the one an admin pulling a year of history actually hits, because a scan grows with the range while the columnstore aggregate stays near flat.

These absolutes are lower than the figures already in the doc comment (2,619 ms → 1,388 ms) because that earlier run carried `SET STATISTICS IO, TIME ON` and a colder buffer pool. The **ratios** agree — 1.9× there against 2.2× here at 28 days — and the doc comment now says so explicitly rather than leaving two unexplained sets of numbers.

## Testing

- Release build: **0 errors**.
- 136 migration and Copilot Adoption tests pass.
- `Up_Sql` verified still byte-present in the manual script — the sanitised text is in the script's header comment, outside the copied `Up_Sql` body, so the two remain in sync.

## Follow-up

Once this reaches `main`, the regenerated `.manual.sql` must be re-uploaded to the stable release, replacing the copy that carries the unsanitised header.
