### PR TITLE
Extract pure staging rules from the App Insights save extensions

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsClickRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsClickRulesTests.cs
@@ -1,0 +1,121 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+using WebJob.AppInsightsImporter.Engine.Sql.Rules;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Coverage for the click staging rules extracted from PageClicksSaveExtension (issue #369).
+    /// Runs with zero SQL Server, Graph, Redis or Service Bus dependency.
+    /// </summary>
+    [TestClass]
+    public class AppInsightsClickRulesTests
+    {
+        private static ClickEventAppInsightsQueryResult Click(Guid? pageRequestId, string linkText, DateTime? when = null)
+        {
+            return new ClickEventAppInsightsQueryResult
+            {
+                CustomProperties = new ClickCustomProps
+                {
+                    PageRequestId = pageRequestId,
+                    LinkText = linkText,
+                    HRef = "https://contoso.sharepoint.com/sites/example/καλημέρα.aspx",
+                    EventTimestamp = when ?? new DateTime(2026, 1, 5, 9, 30, 0, DateTimeKind.Utc)
+                }
+            };
+        }
+
+        [TestMethod]
+        public void Clicks_ValidEvent_IsStaged()
+        {
+            var plan = ClickEventRules.Plan(new[] { Click(Guid.NewGuid(), "Quarterly report") });
+
+            Assert.AreEqual(1, plan.RowsToStage.Count);
+            Assert.AreEqual(0, plan.InvalidClicks);
+        }
+
+        [TestMethod]
+        public void Clicks_EventWithoutRequiredProperties_IsNotStaged()
+        {
+            var events = new[]
+            {
+                Click(Guid.Empty, "Empty id"),
+                Click(Guid.NewGuid(), null),
+                Click(Guid.NewGuid(), string.Empty),
+                Click(Guid.NewGuid(), "No timestamp", DateTime.MinValue),
+            };
+
+            var plan = ClickEventRules.Plan(events);
+
+            Assert.AreEqual(0, plan.RowsToStage.Count, "None of these carry enough data to stage.");
+            Assert.AreEqual(events.Length, plan.InvalidClicks, "Every rejection must be counted, not just logged.");
+        }
+
+        [TestMethod]
+        public void Clicks_NullPageRequestId_IsRejectedInsteadOfThrowing()
+        {
+            // Regression guard. ClickEventAppInsightsQueryResult.IsValid tests
+            //     CustomProperties?.PageRequestId != Guid.Empty
+            // where PageRequestId is a Guid?. When it is null the lifted comparison is
+            // (null != Guid.Empty) == true, so the event passed IsValid and reached the
+            // ClickTempEntity constructor, which requires HasValue and throws ArgumentNullException.
+            // That exception was caught by SaveSectionSafe, discarding EVERY click in the cycle
+            // rather than just this one row.
+            var offending = Click(null, "Has link text but no page-request id");
+
+            Assert.IsTrue(offending.IsValid, "Precondition: the original IsValid still lets this through.");
+            Assert.IsFalse(ClickEventRules.CanStage(offending), "The rule must reject it before it can throw.");
+
+            var plan = ClickEventRules.Plan(new BaseCustomEventAppInsightsQueryResult[]
+            {
+                offending,
+                Click(Guid.NewGuid(), "Good click")
+            });
+
+            Assert.AreEqual(1, plan.RowsToStage.Count, "The good click must still be staged.");
+            Assert.AreEqual(1, plan.InvalidClicks);
+        }
+
+        [TestMethod]
+        public void Clicks_NullCustomProperties_IsRejected()
+        {
+            var click = new ClickEventAppInsightsQueryResult { CustomProperties = null };
+
+            Assert.IsFalse(ClickEventRules.CanStage(click));
+        }
+
+        [TestMethod]
+        public void Clicks_NonClickEvents_AreIgnoredNotCountedAsInvalid()
+        {
+            var events = new BaseCustomEventAppInsightsQueryResult[]
+            {
+                new SearchEventAppInsightsQueryResult { CustomProperties = new SearchCustomProps { SearchText = "report", SessionId = "s1" } },
+                Click(Guid.NewGuid(), "Real click")
+            };
+
+            var plan = ClickEventRules.Plan(events);
+
+            Assert.AreEqual(1, plan.RowsToStage.Count);
+            Assert.AreEqual(0, plan.InvalidClicks, "A search event is another section's business, not an invalid click.");
+        }
+
+        [TestMethod]
+        public void Clicks_EmptyOrNullCollection_StagesNothing()
+        {
+            Assert.AreEqual(0, ClickEventRules.Plan(Enumerable.Empty<BaseCustomEventAppInsightsQueryResult>()).RowsToStage.Count);
+            Assert.AreEqual(0, ClickEventRules.Plan(null).RowsToStage.Count);
+        }
+
+        [TestMethod]
+        public void Clicks_UnicodeLinkTarget_SurvivesProjection()
+        {
+            var plan = ClickEventRules.Plan(new[] { Click(Guid.NewGuid(), "Καλημέρα") });
+
+            Assert.AreEqual(1, plan.RowsToStage.Count);
+            StringAssert.Contains(plan.RowsToStage[0].Url, "καλημέρα", "A Greek URL must not be mangled on the way to staging.");
+            Assert.AreEqual("Καλημέρα", plan.RowsToStage[0].LinkText);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsPageViewRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsPageViewRulesTests.cs
@@ -1,0 +1,196 @@
+using DataUtils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using WebJob.AppInsightsImporter.Engine.ApiImporter;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+using WebJob.AppInsightsImporter.Engine.Sql.Rules;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Coverage for the page-view staging rules extracted from PageViewsSaveExtension (issue #369) -
+    /// de-duplication by page-request id and the org URL in-scope filter, plus the counts that were
+    /// previously local variables only ever written to a log line.
+    /// Runs with zero SQL Server, Graph, Redis or Service Bus dependency.
+    /// </summary>
+    [TestClass]
+    public class AppInsightsPageViewRulesTests
+    {
+        private const string InScopeSite = "https://contoso.sharepoint.com/sites/example";
+
+        private static PageViewAppInsightsQueryResult PageView(Guid? pageRequestId, string url, string siteUrl = InScopeSite)
+        {
+            return new PageViewAppInsightsQueryResult
+            {
+                Url = url,
+                CustomProperties = new PageViewCustomProps
+                {
+                    PageRequestId = pageRequestId,
+                    SiteUrl = siteUrl,
+                    SessionId = "session-1",
+                    EventTimestamp = new DateTime(2026, 1, 5, 9, 30, 0, DateTimeKind.Utc)
+                }
+            };
+        }
+
+        private static PageViewCollection CollectionOf(params PageViewAppInsightsQueryResult[] rows)
+        {
+            var collection = new PageViewCollection();
+            collection.Rows.AddRange(rows);
+            return collection;
+        }
+
+        private static List<FilterUrlConfig> FilterFor(params string[] urls)
+        {
+            var list = new List<FilterUrlConfig>();
+            foreach (var u in urls)
+            {
+                list.Add(new FilterUrlConfig { Url = u });
+            }
+            return list;
+        }
+
+        [TestMethod]
+        public void PageViews_UrlMatchingFilterList_IsStaged()
+        {
+            var plan = PageViewStagingRules.Plan(
+                CollectionOf(PageView(Guid.NewGuid(), InScopeSite + "/pages/home.aspx")),
+                FilterFor("https://contoso.sharepoint.com"));
+
+            Assert.AreEqual(1, plan.RowsToStage.Count);
+            Assert.AreEqual(0, plan.OutOfScopeUrls);
+            Assert.AreEqual(0, plan.DuplicatePageRequestIds);
+            Assert.AreEqual(1, plan.RawPageViews);
+        }
+
+        [TestMethod]
+        public void PageViews_UrlOutsideFilterList_IsExcludedAndCounted()
+        {
+            var plan = PageViewStagingRules.Plan(
+                CollectionOf(
+                    PageView(Guid.NewGuid(), "https://fabrikam.sharepoint.com/sites/other/home.aspx", "https://fabrikam.sharepoint.com/sites/other"),
+                    PageView(Guid.NewGuid(), InScopeSite + "/pages/home.aspx")),
+                FilterFor("https://contoso.sharepoint.com"));
+
+            Assert.AreEqual(1, plan.RowsToStage.Count, "Only the in-scope page-view is staged.");
+            Assert.AreEqual(1, plan.OutOfScopeUrls, "The rejection must be counted, not just logged.");
+        }
+
+        [TestMethod]
+        public void PageViews_DuplicatePageRequestIds_AreSkippedAndCounted()
+        {
+            var sharedId = Guid.NewGuid();
+            var plan = PageViewStagingRules.Plan(
+                CollectionOf(
+                    PageView(sharedId, InScopeSite + "/pages/home.aspx"),
+                    PageView(sharedId, InScopeSite + "/pages/home.aspx"),
+                    PageView(sharedId, InScopeSite + "/pages/home.aspx")),
+                FilterFor("https://contoso.sharepoint.com"));
+
+            Assert.AreEqual(1, plan.RowsToStage.Count, "Only the first occurrence is staged.");
+            Assert.AreEqual(2, plan.DuplicatePageRequestIds);
+        }
+
+        [TestMethod]
+        public void PageViews_EmptyPageRequestId_IsNotStaged()
+        {
+            // Guid.Empty is treated as 'not new' and lands in the duplicate count. That is the existing
+            // behaviour and the number operators see today, so the extraction preserves it deliberately.
+            var plan = PageViewStagingRules.Plan(
+                CollectionOf(PageView(Guid.Empty, InScopeSite + "/pages/home.aspx")),
+                FilterFor("https://contoso.sharepoint.com"));
+
+            Assert.AreEqual(0, plan.RowsToStage.Count);
+            Assert.AreEqual(1, plan.DuplicatePageRequestIds);
+        }
+
+        [TestMethod]
+        public void PageViews_NullPageRequestId_IsIgnoredEntirely()
+        {
+            // The original Where clause dropped these before any counting, so they appear in neither
+            // the staged rows nor either reject count.
+            var plan = PageViewStagingRules.Plan(
+                CollectionOf(PageView(null, InScopeSite + "/pages/home.aspx")),
+                FilterFor("https://contoso.sharepoint.com"));
+
+            Assert.AreEqual(0, plan.RowsToStage.Count);
+            Assert.AreEqual(0, plan.DuplicatePageRequestIds);
+            Assert.AreEqual(0, plan.OutOfScopeUrls);
+            Assert.AreEqual(1, plan.RawPageViews, "It still counts as a raw page-view that was considered.");
+        }
+
+        [TestMethod]
+        public void PageViews_EmptyCollection_PerformsNoWrite()
+        {
+            var plan = PageViewStagingRules.Plan(CollectionOf(), FilterFor("https://contoso.sharepoint.com"));
+
+            Assert.AreEqual(0, plan.RowsToStage.Count);
+            Assert.AreEqual(0, plan.RawPageViews);
+        }
+
+        [TestMethod]
+        public void PageViews_NoFilterConfigured_StagesEverything()
+        {
+            // An empty rule list means "no filtering" (FilterUrlConfigExtensions.UrlInScope returns true).
+            var plan = PageViewStagingRules.Plan(
+                CollectionOf(PageView(Guid.NewGuid(), "https://fabrikam.sharepoint.com/sites/other/home.aspx")),
+                new List<FilterUrlConfig>());
+
+            Assert.AreEqual(1, plan.RowsToStage.Count);
+            Assert.AreEqual(0, plan.OutOfScopeUrls);
+        }
+
+        [TestMethod]
+        public void PageViews_GreekUrl_SurvivesProjectionToStaging()
+        {
+            var greekUrl = InScopeSite + "/Shared Documents/καλημέρα κόσμε.aspx";
+
+            var plan = PageViewStagingRules.Plan(
+                CollectionOf(PageView(Guid.NewGuid(), greekUrl)),
+                FilterFor("https://contoso.sharepoint.com"));
+
+            Assert.AreEqual(1, plan.RowsToStage.Count);
+
+            // HitTempEntity normalises through StringUtils.GetUrlBaseAddressIfValidUrl, which
+            // percent-encodes. That is lossless, so the test asserts the round trip rather than the
+            // raw characters - the failure this guards against is degradation to '?', not escaping.
+            // (Note ClickTempEntity takes a different path and keeps the characters unescaped.)
+            var staged = plan.RowsToStage[0].Url;
+            StringAssert.Contains(Uri.UnescapeDataString(staged), "καλημέρα κόσμε",
+                "A Greek URL must survive the round trip intact, not degrade to '?'.");
+            Assert.IsFalse(staged.Contains("?"), "No character may be replaced by '?'.");
+        }
+
+        [TestMethod]
+        public void PageViews_DuplicateCheckHappensBeforeTheUrlFilter()
+        {
+            // Pins the ORDER of the two rules, which no other test does. The same id appears first on
+            // an out-of-scope URL and then on an in-scope one.
+            //   dedup first  (current): row 1 consumes the id then fails the filter -> 0 staged,
+            //                           1 out-of-scope, 1 duplicate.
+            //   filter first (broken):  row 1 is dropped without consuming the id, so row 2 looks new
+            //                           -> 1 staged, 1 out-of-scope, 0 duplicates.
+            var sharedId = Guid.NewGuid();
+            var plan = PageViewStagingRules.Plan(
+                CollectionOf(
+                    PageView(sharedId, "https://fabrikam.sharepoint.com/sites/other/home.aspx", "https://fabrikam.sharepoint.com/sites/other"),
+                    PageView(sharedId, InScopeSite + "/pages/home.aspx")),
+                FilterFor("https://contoso.sharepoint.com"));
+
+            Assert.AreEqual(0, plan.RowsToStage.Count, "An id consumed by an out-of-scope row must not be re-staged.");
+            Assert.AreEqual(1, plan.OutOfScopeUrls);
+            Assert.AreEqual(1, plan.DuplicatePageRequestIds);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void PageViews_NullFilterList_Throws()
+        {
+            // Deliberate hardening rather than exact preservation: the original only threw once a row
+            // reached UrlInScope, so an empty batch used to survive a null list. Unobservable in
+            // production - the only caller dereferences filterUrls.Count immediately after loading it.
+            PageViewStagingRules.Plan(CollectionOf(), null);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsSearchRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsSearchRulesTests.cs
@@ -1,0 +1,171 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+using WebJob.AppInsightsImporter.Engine.Sql.Rules;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Coverage for the search-term staging rules extracted from SearchesSaveExtension (issue #369).
+    /// Runs with zero SQL Server, Graph, Redis or Service Bus dependency.
+    /// </summary>
+    [TestClass]
+    public class AppInsightsSearchRulesTests
+    {
+        private static SearchEventAppInsightsQueryResult SearchFor(string text)
+        {
+            return new SearchEventAppInsightsQueryResult
+            {
+                CustomProperties = new SearchCustomProps { SearchText = text, SessionId = "session-1" }
+            };
+        }
+
+        [TestMethod]
+        public void Searches_SearchTextOver250Chars_IsTruncatedToExactly250()
+        {
+            var result = SearchTermRules.Truncate(new string('a', 400));
+
+            Assert.AreEqual(SearchTermRules.MaxSearchTermLength, result.Length,
+                "The staged value must fit the nvarchar(250) parameter exactly.");
+            Assert.IsTrue(result.EndsWith("..."), "Truncation keeps the trailing ellipsis the original code wrote.");
+            Assert.AreEqual(new string('a', 247) + "...", result);
+        }
+
+        [TestMethod]
+        public void Searches_SearchTextExactly250Chars_IsNotTruncated()
+        {
+            var exact = new string('b', 250);
+
+            Assert.AreEqual(exact, SearchTermRules.Truncate(exact), "A term that already fits must be left alone.");
+        }
+
+        [TestMethod]
+        public void Searches_ShortSearchText_IsUnchanged()
+        {
+            Assert.AreEqual("quarterly report", SearchTermRules.Truncate("quarterly report"));
+        }
+
+        [TestMethod]
+        public void Searches_SearchTextWithGreekCharacters_TruncatesByCharacterNotByte()
+        {
+            // Greek is two bytes per character in UTF-8 but one UTF-16 char, which is what both
+            // string.Length and the nvarchar(250) parameter count. Truncating by byte would cut this
+            // to roughly half the characters it should keep.
+            var greek = string.Concat(System.Linq.Enumerable.Repeat("καλημέρα", 50)); // 400 chars
+
+            var result = SearchTermRules.Truncate(greek);
+
+            Assert.AreEqual(250, result.Length, "Must be limited to 250 characters, not 250 bytes.");
+            Assert.AreEqual(greek.Substring(0, 247) + "...", result);
+            Assert.IsTrue(result.StartsWith("καλημέρα"), "Greek characters must survive intact, not become '?'.");
+        }
+
+        [TestMethod]
+        public void Searches_TruncationNeverSplitsASurrogatePair()
+        {
+            // An emoji is a surrogate pair. Cutting at a fixed offset can land between the two halves
+            // and leave an unpaired surrogate - a string SQL Server stores but which is not valid UTF-16.
+            // Pad so that the 247-char cut falls exactly in the middle of a pair.
+            var emoji = "\U0001F600";
+            var text = new string('x', 246) + emoji + new string('y', 100);
+
+            var result = SearchTermRules.Truncate(text);
+
+            Assert.IsTrue(result.Length <= SearchTermRules.MaxSearchTermLength);
+            AssertNoLoneSurrogates(result);
+            Assert.AreEqual(new string('x', 246) + "...", result,
+                "The straddling pair must be dropped whole, not halved.");
+        }
+
+        [TestMethod]
+        public void Searches_TruncationKeepsWholeSurrogatePairsThatFit()
+        {
+            // Guards against an over-eager fix that strips every surrogate rather than only the pair
+            // straddling the cut: a complete pair well inside the kept portion must survive untouched.
+            var emoji = "\U0001F600";
+            var text = emoji + new string('x', 400);
+
+            var result = SearchTermRules.Truncate(text);
+
+            Assert.IsTrue(result.StartsWith(emoji), "A complete pair inside the kept portion must be preserved.");
+            Assert.AreEqual(SearchTermRules.MaxSearchTermLength, result.Length);
+            AssertNoLoneSurrogates(result);
+        }
+
+        [TestMethod]
+        public void Searches_AllEmojiInput_TruncatesToWholePairsOnly()
+        {
+            // The pathological case for the boundary: every even index is a high surrogate. Guards
+            // against both halving a pair and stripping supplementary characters wholesale.
+            var emoji = "\U0001F600";
+            var text = string.Concat(System.Linq.Enumerable.Repeat(emoji, 200)); // 400 UTF-16 units
+
+            var result = SearchTermRules.Truncate(text);
+
+            // Exact expectation, not just invariants: index 246 is a high surrogate, so the cut moves
+            // back to 246, keeping 123 whole pairs. Asserting the precise value stops a degenerate
+            // implementation (e.g. returning just "<emoji>...") from satisfying the looser checks.
+            Assert.AreEqual(string.Concat(System.Linq.Enumerable.Repeat(emoji, 123)) + "...", result);
+            Assert.AreEqual(249, result.Length);
+            Assert.IsTrue(result.Length <= SearchTermRules.MaxSearchTermLength);
+            AssertNoLoneSurrogates(result);
+        }
+
+        /// <summary>
+        /// Walks the string in pairs. Note a per-char "is not a surrogate" assertion would be wrong: a
+        /// valid emoji is made of two surrogate chars, so that check really asserts "contains no emoji"
+        /// and passes only while the test data happens to truncate every pair away.
+        /// </summary>
+        private static void AssertNoLoneSurrogates(string value)
+        {
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (char.IsHighSurrogate(value[i]))
+                {
+                    Assert.IsTrue(i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]),
+                        $"High surrogate at index {i} has no low partner.");
+                    i++; // consume the matched pair
+                }
+                else
+                {
+                    Assert.IsFalse(char.IsLowSurrogate(value[i]), $"Lone low surrogate at index {i}.");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void Searches_NullOrEmptySearchText_IsSkipped()
+        {
+            // Regression guard: the old save path went straight to searchTerm.Length, so a null
+            // SearchText threw a NullReferenceException that aborted the entire Searches section.
+            //
+            // The empty-string case cannot arrive from the API - the parser only adds events for which
+            // IsValid holds, and that already requires a non-empty SearchText - but Rows is a public
+            // settable list, so the guard still matters for collections built any other way.
+            Assert.IsFalse(SearchTermRules.ShouldStage(SearchFor(null)));
+            Assert.IsFalse(SearchTermRules.ShouldStage(SearchFor(string.Empty)));
+            Assert.IsFalse(SearchTermRules.ShouldStage(null));
+        }
+
+        [TestMethod]
+        public void Searches_WhitespaceOnlySearchText_IsStillStaged()
+        {
+            // Pins the boundary deliberately: this is IsNullOrEmpty, not IsNullOrWhiteSpace, so a
+            // whitespace-only term stages exactly as it did before. Tightening it would be a real
+            // behavioural change to what lands in search_terms, not a crash fix.
+            Assert.IsTrue(SearchTermRules.ShouldStage(SearchFor("   ")));
+        }
+
+        [TestMethod]
+        public void Searches_ValidSearchText_IsStaged()
+        {
+            Assert.IsTrue(SearchTermRules.ShouldStage(SearchFor("καλημέρα κόσμε")));
+        }
+
+        [TestMethod]
+        public void Searches_NullSearchText_DoesNotThrowOnTruncate()
+        {
+            Assert.IsNull(SearchTermRules.Truncate(null));
+            Assert.AreEqual(string.Empty, SearchTermRules.Truncate(string.Empty));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -123,6 +123,9 @@
     <Compile Include="ActivityReportSetMinMaxTests.cs" />
     <Compile Include="AppInsightsConnectionStringParserTests.cs" />
     <Compile Include="AppInsightsKqlGetWhereStringTests.cs" />
+    <Compile Include="AppInsightsClickRulesTests.cs" />
+    <Compile Include="AppInsightsPageViewRulesTests.cs" />
+    <Compile Include="AppInsightsSearchRulesTests.cs" />
     <Compile Include="CopilotDroppedAuditFieldsTests.cs" />
     <Compile Include="CopilotExtendedDataTests.cs" />
     <Compile Include="DBLookupCacheDuplicateKeyErrorTests.cs" />

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageClicksSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageClicksSaveExtension.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
 using WebJob.AppInsightsImporter.Engine.Properties;
 using WebJob.AppInsightsImporter.Engine.Sql.Models;
+using WebJob.AppInsightsImporter.Engine.Sql.Rules;
 
 namespace WebJob.AppInsightsImporter.Engine.Sql
 {
@@ -16,21 +17,13 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
         {
             var logsToInsert = new EFInsertBatch<ClickTempEntity>(database, logger);
 
-            // Only process click events
-            foreach (var p in events.Rows)
+            // Pure decision logic - which clicks can be staged. See issue #369.
+            var plan = ClickEventRules.Plan(events.Rows);
+            logsToInsert.Rows.AddRange(plan.RowsToStage);
+
+            if (plan.InvalidClicks > 0)
             {
-                if (p is ClickEventAppInsightsQueryResult)
-                {
-                    var click = (ClickEventAppInsightsQueryResult)p;
-                    if (click.IsValid)
-                    {
-                        logsToInsert.Rows.Add(new ClickTempEntity(click));
-                    }
-                    else
-                    {
-                        logger.LogWarning("Found invalid click data");
-                    }
-                }
+                logger.LogWarning($"Found {plan.InvalidClicks:n0} click event(s) with invalid data; skipping those rows.");
             }
 
             const int MAX_HITS_PER_THREAD = 1000;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageViewsSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/PageViewsSaveExtension.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using WebJob.AppInsightsImporter.Engine.ApiImporter;
 using WebJob.AppInsightsImporter.Engine.Properties;
 using WebJob.AppInsightsImporter.Engine.Sql.Models;
+using WebJob.AppInsightsImporter.Engine.Sql.Rules;
 
 namespace WebJob.AppInsightsImporter.Engine.Sql
 {
@@ -24,45 +25,22 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
             // Hack to change/ensure correct DB schema. Needs moving to a migration
             await ImportDbHacks.EnsureSessionTableHasRightCollation(database.Database);
 
-            // HashSet for O(1) duplicate lookups instead of O(n) List.Contains
-            var pageRequestIdProcessed = new HashSet<Guid>();
-            var duplicateCount = 0;
-            var outOfScopeCount = 0;
+            // Which rows to stage, and why the rest were dropped. Pure decision logic - see issue #369.
+            var plan = PageViewStagingRules.Plan(pageViews, filterUrls);
 
             var logsToInsert = new EFInsertBatch<HitTempEntity>(database, logger);
-            foreach (var pv in pageViews.Rows.Where(p => p.CustomProperties?.PageRequestId != null))
-            {
-                var hitIsNew = pv.CustomProperties.PageRequestId != Guid.Empty && pageRequestIdProcessed.Add(pv.CustomProperties.PageRequestId.Value);
+            logsToInsert.Rows.AddRange(plan.RowsToStage);
 
-                if (hitIsNew)
-                {
-                    // Filter URLs based on org_urls table 
-                    if (!filterUrls.UrlInScope(pv.CustomProperties.SiteUrl, pv.Url))
-                    {
-                        outOfScopeCount++;
-                    }
-                    else
-                    {
-                        // URL is in scope. Add to staging table. 
-                        logsToInsert.Rows.Add(new HitTempEntity(pv));
-                    }
-                }
-                else
-                {
-                    duplicateCount++;
-                }
+            if (plan.OutOfScopeUrls > 0)
+            {
+                logger.LogInformation($"Filtered {plan.OutOfScopeUrls} out-of-scope URLs.");
+            }
+            if (plan.DuplicatePageRequestIds > 0)
+            {
+                logger.LogInformation($"Skipped {plan.DuplicatePageRequestIds} duplicate page-request IDs.");
             }
 
-            if (outOfScopeCount > 0)
-            {
-                logger.LogInformation($"Filtered {outOfScopeCount} out-of-scope URLs.");
-            }
-            if (duplicateCount > 0)
-            {
-                logger.LogInformation($"Skipped {duplicateCount} duplicate page-request IDs.");
-            }
-
-            logger.LogInformation($"Staging {logsToInsert.Rows.Count:n0} hits for SQL import (filtered from {pageViews.Rows.Count:n0} raw page-views in {sw.Elapsed.TotalSeconds:N1}s)...");
+            logger.LogInformation($"Staging {plan.RowsToStage.Count:n0} hits for SQL import (filtered from {plan.RawPageViews:n0} raw page-views in {sw.Elapsed.TotalSeconds:N1}s)...");
 
             sw.Restart();
             const int MAX_HITS_PER_THREAD = 1000;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Rules/ClickEventRules.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Rules/ClickEventRules.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+using WebJob.AppInsightsImporter.Engine.Sql.Models;
+
+namespace WebJob.AppInsightsImporter.Engine.Sql.Rules
+{
+    /// <summary>
+    /// What the click rules decided to stage, and what they rejected. The reject count was previously
+    /// only ever written to the log, so it could not be asserted. See issue #369.
+    /// </summary>
+    internal class ClickStagingPlan
+    {
+        public List<ClickTempEntity> RowsToStage { get; } = new List<ClickTempEntity>();
+
+        /// <summary>Click events that did not carry enough data to be staged.</summary>
+        public int InvalidClicks { get; set; }
+    }
+
+    /// <summary>
+    /// Pure rules deciding which click events can be staged - no SQL, no ADO.NET, no logging.
+    /// </summary>
+    internal static class ClickEventRules
+    {
+        /// <summary>
+        /// Whether a click event can be turned into a staging row.
+        ///
+        /// This deliberately does NOT simply defer to <see cref="ClickEventAppInsightsQueryResult.IsValid"/>,
+        /// which has a null-lifting hole: <c>CustomProperties?.PageRequestId</c> is a <c>Guid?</c>, so when
+        /// the id is null the comparison <c>null != Guid.Empty</c> evaluates to TRUE and the event passes.
+        /// The <see cref="ClickTempEntity"/> constructor then requires <c>PageRequestId.HasValue</c> and
+        /// throws <c>ArgumentNullException</c>, which <c>SaveSectionSafe</c> catches - discarding every
+        /// click in that cycle rather than just the malformed one. Requiring HasValue here keeps a single
+        /// bad event from costing the whole batch.
+        /// </summary>
+        public static bool CanStage(ClickEventAppInsightsQueryResult click)
+        {
+            var props = click?.CustomProperties;
+            if (props == null)
+            {
+                return false;
+            }
+
+            return props.PageRequestId.HasValue
+                && props.PageRequestId.Value != Guid.Empty
+                && !string.IsNullOrEmpty(props.LinkText)
+                && click.Timestamp > DateTime.MinValue;
+        }
+
+        /// <summary>
+        /// Select the click events out of a mixed custom-event collection and project the stageable ones.
+        /// </summary>
+        public static ClickStagingPlan Plan(IEnumerable<BaseCustomEventAppInsightsQueryResult> events)
+        {
+            var plan = new ClickStagingPlan();
+            if (events == null)
+            {
+                return plan;
+            }
+
+            foreach (var e in events)
+            {
+                var click = e as ClickEventAppInsightsQueryResult;
+                if (click == null)
+                {
+                    continue; // a different event type - not this section's business
+                }
+
+                if (CanStage(click))
+                {
+                    plan.RowsToStage.Add(new ClickTempEntity(click));
+                }
+                else
+                {
+                    plan.InvalidClicks++;
+                }
+            }
+
+            return plan;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Rules/PageViewStagingRules.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Rules/PageViewStagingRules.cs
@@ -1,0 +1,99 @@
+using DataUtils;
+using System;
+using System.Collections.Generic;
+using WebJob.AppInsightsImporter.Engine.ApiImporter;
+using WebJob.AppInsightsImporter.Engine.Sql.Models;
+
+namespace WebJob.AppInsightsImporter.Engine.Sql.Rules
+{
+    /// <summary>
+    /// What the page-view rules decided to stage, and why the rest was dropped. These counts were
+    /// previously local variables that only ever reached a log line, so no test could assert them.
+    /// See issue #369.
+    /// </summary>
+    internal class PageViewStagingPlan
+    {
+        public List<HitTempEntity> RowsToStage { get; } = new List<HitTempEntity>();
+
+        /// <summary>
+        /// Page-views rejected because their page-request id had already been seen in this batch.
+        ///
+        /// Note this also counts a page-view whose id is <c>Guid.Empty</c>, which is not really a
+        /// duplicate. That is the existing behaviour and the number that is logged today, so it is
+        /// preserved deliberately rather than quietly changed.
+        /// </summary>
+        public int DuplicatePageRequestIds { get; set; }
+
+        /// <summary>Page-views rejected because their URL is outside the configured org URL filters.</summary>
+        public int OutOfScopeUrls { get; set; }
+
+        /// <summary>Total page-views considered, before any filtering.</summary>
+        public int RawPageViews { get; set; }
+    }
+
+    /// <summary>
+    /// Pure rules for the page-view staging path - de-duplication by page-request id and the org URL
+    /// in-scope filter, with no SQL, no ADO.NET and no logging. Modelled on
+    /// ActivityAPI/Loaders/AuditLogContentDispatcher.
+    /// </summary>
+    internal static class PageViewStagingRules
+    {
+        /// <summary>
+        /// Reproduces the original save-path loop: rows with no page-request id are dropped without
+        /// being counted, <c>Guid.Empty</c> counts as a duplicate, and de-duplication is decided
+        /// BEFORE the URL filter (so an id first seen on an out-of-scope URL still consumes that id).
+        ///
+        /// One deliberate divergence: a null <paramref name="filterUrls"/> fails fast here, whereas the
+        /// original only threw once a row actually reached the filter - so an empty batch used to
+        /// succeed with a null list. That is hardening, not preservation. It is unobservable in
+        /// production because the only caller loads the list via SiteFilterLoader.Load and dereferences
+        /// filterUrls.Count immediately (AppInsightsImporter.cs), long before this is reached.
+        /// </summary>
+        public static PageViewStagingPlan Plan(PageViewCollection pageViews, List<FilterUrlConfig> filterUrls)
+        {
+            if (filterUrls == null)
+            {
+                throw new ArgumentNullException(nameof(filterUrls));
+            }
+
+            var plan = new PageViewStagingPlan();
+            if (pageViews?.Rows == null)
+            {
+                return plan;
+            }
+
+            plan.RawPageViews = pageViews.Rows.Count;
+
+            // O(1) duplicate lookups. At a 200k-user tenant a single cycle can carry a very large
+            // page-view batch, so this must not become a List.Contains scan.
+            var seenPageRequestIds = new HashSet<Guid>();
+
+            foreach (var pv in pageViews.Rows)
+            {
+                if (pv?.CustomProperties?.PageRequestId == null)
+                {
+                    continue; // no id at all - not counted, matching the original Where clause
+                }
+
+                var isNew = pv.CustomProperties.PageRequestId != Guid.Empty
+                    && seenPageRequestIds.Add(pv.CustomProperties.PageRequestId.Value);
+
+                if (!isNew)
+                {
+                    plan.DuplicatePageRequestIds++;
+                    continue;
+                }
+
+                if (!filterUrls.UrlInScope(pv.CustomProperties.SiteUrl, pv.Url))
+                {
+                    plan.OutOfScopeUrls++;
+                    continue;
+                }
+
+                plan.RowsToStage.Add(new HitTempEntity(pv));
+            }
+
+            return plan;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Rules/SearchTermRules.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/Rules/SearchTermRules.cs
@@ -1,0 +1,71 @@
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+
+namespace WebJob.AppInsightsImporter.Engine.Sql.Rules
+{
+    /// <summary>
+    /// Pure rules for the search-term staging path - no SQL, no ADO.NET, no logging.
+    /// Modelled on ActivityAPI/Loaders/AuditLogContentDispatcher, which keeps routing/filter decisions
+    /// separate from I/O. See issue #369.
+    /// </summary>
+    public static class SearchTermRules
+    {
+        /// <summary>
+        /// Width of the [search_term] staging parameter, which mirrors the target column.
+        /// </summary>
+        public const int MaxSearchTermLength = 250;
+
+        private const string Ellipsis = "...";
+
+        /// <summary>
+        /// Whether a search event carries enough to stage a row.
+        ///
+        /// On the API path this is defence in depth rather than a behaviour change: the parser only ever
+        /// adds an event to the collection when <c>IsValid</c> holds (<c>AppInsightsQueryResultCollection</c>
+        /// calls <c>Rows.Add</c> solely on a non-null <c>Build(...)</c> result, and
+        /// <c>CustomEventsResultCollection.Build</c> returns null unless <c>e.IsValid</c>), and
+        /// <see cref="SearchEventAppInsightsQueryResult.IsValid"/> already requires a non-empty SearchText.
+        ///
+        /// It matters because <c>Rows</c> is a public settable list, so a collection can be populated by
+        /// other means. The save path only selected events by type and never re-checked validity, then
+        /// went straight to <c>searchTerm.Length</c> - so a null SearchText threw a NullReferenceException
+        /// that took the entire Searches section down with it.
+        ///
+        /// Empty (as opposed to null) is rejected for the same reason <c>IsValid</c> rejects it; note that
+        /// a whitespace-only term still stages, exactly as before, since this is IsNullOrEmpty and not
+        /// IsNullOrWhiteSpace.
+        /// </summary>
+        public static bool ShouldStage(SearchEventAppInsightsQueryResult searchEvent)
+        {
+            return !string.IsNullOrEmpty(searchEvent?.CustomProperties?.SearchText);
+        }
+
+        /// <summary>
+        /// Truncate a search term to <see cref="MaxSearchTermLength"/> characters, preserving the
+        /// original behaviour of replacing the tail with an ellipsis.
+        ///
+        /// Counting is by UTF-16 char, which is what both <c>string.Length</c> and the
+        /// <c>nvarchar(250)</c> parameter measure - so a Greek term is limited to 250 characters, not
+        /// 250 bytes. The one refinement over the original <c>Substring(0, 247)</c> is that the cut is
+        /// not allowed to land between a surrogate pair (e.g. an emoji), which would otherwise store a
+        /// lone surrogate: a string SQL Server accepts but which is not valid UTF-16.
+        /// </summary>
+        public static string Truncate(string searchText)
+        {
+            if (string.IsNullOrEmpty(searchText) || searchText.Length <= MaxSearchTermLength)
+            {
+                return searchText;
+            }
+
+            var cut = MaxSearchTermLength - Ellipsis.Length;
+
+            // Never split a surrogate pair: if the last kept char is a high surrogate, its low partner
+            // would be cut away, leaving an unpaired surrogate.
+            if (char.IsHighSurrogate(searchText[cut - 1]))
+            {
+                cut--;
+            }
+
+            return searchText.Substring(0, cut) + Ellipsis;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SearchesSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SearchesSaveExtension.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
 using WebJob.AppInsightsImporter.Engine.Properties;
+using WebJob.AppInsightsImporter.Engine.Sql.Rules;
 
 namespace WebJob.AppInsightsImporter.Engine.Sql
 {
@@ -22,12 +23,29 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
             }
 
             var searches = new List<SearchEventAppInsightsQueryResult>();
+            var skipped = 0;
             foreach (var r in eventList.Rows)
             {
                 if (r is SearchEventAppInsightsQueryResult)
                 {
-                    searches.Add((SearchEventAppInsightsQueryResult)r);
+                    var search = (SearchEventAppInsightsQueryResult)r;
+
+                    // Pure rule - see issue #369. The old code went straight to searchTerm.Length, so a
+                    // null SearchText threw a NullReferenceException that took the whole section down.
+                    if (SearchTermRules.ShouldStage(search))
+                    {
+                        searches.Add(search);
+                    }
+                    else
+                    {
+                        skipped++;
+                    }
                 }
+            }
+
+            if (skipped > 0)
+            {
+                logger.LogWarning($"Skipped {skipped:n0} search event(s) with no search text.");
             }
 
             if (searches.Count == 0)
@@ -59,17 +77,13 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
 
                     var pSessionId = cmd.Parameters.Add("@p0", SqlDbType.NVarChar, 100);
                     var pUserName = cmd.Parameters.Add("@p1", SqlDbType.NVarChar, 250);
-                    var pSearchTerm = cmd.Parameters.Add("@p2", SqlDbType.NVarChar, 250);
+                    var pSearchTerm = cmd.Parameters.Add("@p2", SqlDbType.NVarChar, SearchTermRules.MaxSearchTermLength);
                     var pDateTime = cmd.Parameters.Add("@p3", SqlDbType.DateTime);
                     cmd.Prepare();
 
                     foreach (var customEvent in searches)
                     {
-                        string searchTerm = customEvent.CustomProperties.SearchText;
-                        if (searchTerm.Length > 250)
-                        {
-                            searchTerm = searchTerm.Substring(0, 247) + "...";
-                        }
+                        var searchTerm = SearchTermRules.Truncate(customEvent.CustomProperties.SearchText);
 
                         pSessionId.Value = (object)customEvent.CustomProperties.SessionId ?? DBNull.Value;
                         pUserName.Value = (object)customEvent.Username ?? DBNull.Value;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
@@ -88,6 +88,9 @@
     <Compile Include="Sql\Models\HitUpdate.cs" />
     <Compile Include="Sql\PageClicksSaveExtension.cs" />
     <Compile Include="Sql\PageViewsSaveExtension.cs" />
+    <Compile Include="Sql\Rules\ClickEventRules.cs" />
+    <Compile Include="Sql\Rules\PageViewStagingRules.cs" />
+    <Compile Include="Sql\Rules\SearchTermRules.cs" />
     <Compile Include="Sql\PageUpdatesSaveExtension.cs" />
     <Compile Include="Sql\SearchesSaveExtension.cs" />
   </ItemGroup>


### PR DESCRIPTION
Addresses #369. Part of the ports & adapters initiative (#381).

Scoped to the **page-views, searches and clicks** sections, which #369 itself recommends landing first ("Recommend landing PageViews + Searches + Clicks first, then PageUpdateManager and HitPatch as a follow-up PR against the same issue"). The `I*PersistenceManager` interfaces, `PageUpdateManager` and `HitPatch` follow in a second PR.

## Why

The App Insights importer was the least abstracted import role in the solution and had **no unit tests at all**, because its filtering and truncation rules were interleaved with ADO.NET inside static save extensions. This lifts those rules into pure classes, modelled on `ActivityAPI/Loaders/AuditLogContentDispatcher`.

Per #381's conventions, pure decision logic is a **static/stateless `*Rules` class**, not an interface — interfaces are for the I/O ports, which are the deferred half. Both nominated reference implementations (`ImportCadenceGate`, `AuditLogContentDispatcher`) are `public static class`.

## Changes

| File | Change |
|---|---|
| `Sql/Rules/PageViewStagingRules.cs` | **New.** Dedup by page-request id + org URL filter, returning a `PageViewStagingPlan` with the staged rows and the duplicate / out-of-scope / raw counts |
| `Sql/Rules/SearchTermRules.cs` | **New.** 250-char truncation + null/empty guard |
| `Sql/Rules/ClickEventRules.cs` | **New.** Which clicks can be staged, plus the reject count |
| `Sql/PageViewsSaveExtension.cs`, `PageClicksSaveExtension.cs`, `SearchesSaveExtension.cs` | Delegate the decisions; keep their signatures, call sites and all the SQL |

The counts were previously local variables that only ever reached a log line, so nothing could assert them.

## Two latent defects this fixes

**1. One malformed click discarded every click in the cycle.**
`ClickEventAppInsightsQueryResult.IsValid` tests `CustomProperties?.PageRequestId != Guid.Empty`, where `PageRequestId` is a `Guid?`. When the id is **null**, the lifted comparison `null != Guid.Empty` is **true**, so the event passes `IsValid` — and `ClickTempEntity`'s constructor then throws `ArgumentNullException` because it requires `HasValue`. `SaveSectionSafe` catches that, so the whole Clicks section returned 0 and every click in that import cycle was lost. `ClickEventRules.CanStage` requires `HasValue`, so one bad event now costs one row.

**2. A null search term took down the whole Searches section.**
The save path selected search events by type and never re-checked validity, then went straight to `searchTerm.Length` — a null `SearchText` threw a `NullReferenceException` caught by the same `SaveSectionSafe`. Those events are now skipped and counted.

## One deliberate refinement

Truncation no longer cuts between a UTF-16 surrogate pair. The original `Substring(0, 247)` could split an emoji and store a lone surrogate — accepted by SQL Server but not valid UTF-16. Counting stays by **character**, so a Greek term is still limited to 250 characters rather than 250 bytes, and a complete pair that fits is preserved untouched.

## Scope of the empty-string guard

`SearchTermRules.ShouldStage` rejects empty as well as null. On the API path that is **defence in depth, not a behavioural change**: `AppInsightsQueryResultCollection` calls `Rows.Add` only on a non-null `Build(...)` result, `CustomEventsResultCollection.Build` returns null unless `e.IsValid`, and `SearchEventAppInsightsQueryResult.IsValid` already requires a non-empty `SearchText`. It still matters because `Rows` is a public settable list. A whitespace-only term continues to stage exactly as before (`IsNullOrEmpty`, not `IsNullOrWhiteSpace`) — pinned by a test, since tightening it would change what lands in `search_terms`.

## Behaviour preserved deliberately

- A page-view whose id is `Guid.Empty` is still counted as a **duplicate** rather than its own category — that is the number operators see today. Documented in `PageViewStagingPlan` rather than quietly changed.
- Dedup is still decided **before** the URL filter, so an id first seen on an out-of-scope URL still consumes that id.
- The per-invalid-click warning is now aggregated into one line instead of one per row; staged rows are unchanged.

One divergence, called out honestly rather than claimed as preservation: `Plan` fails fast on a null `filterUrls`, whereas the original only threw once a row reached `UrlInScope` (so an empty batch used to survive a null list). Unobservable in production — the only caller loads the list via `SiteFilterLoader.Load` and dereferences `filterUrls.Count` on the next line.

## Tests

**28 new tests** across `AppInsightsPageViewRulesTests`, `AppInsightsSearchRulesTests` and `AppInsightsClickRulesTests` — the first unit tests this project has had — all running with **zero SQL Server, Graph, Redis or Service Bus** dependency.

Beyond the cases named in #369: regression guards for both defects above, surrogate-pair safety in both directions (a straddling pair is dropped whole, a fitting pair survives), an all-emoji boundary case, the whitespace boundary, and rule **ordering**.

The page-view Greek assertion checks the round trip rather than raw characters: `HitTempEntity` normalises through `StringUtils.GetUrlBaseAddressIfValidUrl`, which percent-encodes (losslessly), whereas `ClickTempEntity` keeps the characters unescaped. The failure guarded against is degradation to `?`, not escaping.

### Verification

Full solution builds in Debug; 28/28 pass. Each fix was tested **in reverse**:

| Probe | Result |
|---|---|
| Restore `Substring(0, 247)` | surrogate test fails: `High surrogate at index 246 has no low partner` |
| Swap dedup and filter blocks | ordering test fails (`Expected:<0>. Actual:<1>`) — and is the **only** one of ten page-view tests that does |

`Truncate` was additionally property-checked over 4,000 randomised ASCII/Greek/emoji inputs (lengths 240-320) via reflection against the compiled method: no output exceeded 250 chars, and no lone surrogate was ever produced.

## Review

Reviewed over two rounds by four models (Claude Opus 4.8, GPT-5.6 Sol, Gemini 3.1 Pro, Grok 4.6) until a round came back clean. Round 1 found three real issues — **all in this PR's own new code, none in the pre-existing logic**:

- The surrogate test asserted "contains no surrogate at all" rather than "no *lone* surrogate", so it would have **false-failed on any valid surviving emoji**. Replaced with a pair-walking helper plus retained-pair and all-emoji coverage.
- `ShouldStage`'s empty-string rejection needed investigating rather than assuming; the reviewer that raised it later retracted the "reaches final data" claim after I traced the parser's admission gate.
- **No test pinned the dedup-before-filter ordering** — the rules were right, but nothing would have stopped a future refactor reordering them, which would let an out-of-scope URL free up its page-request id and re-stage a duplicate hit.

No schema change, no migration.