### PR TITLE
Extract staging-writer ports from the Copilot and Power Platform audit managers

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAuditEventManagerStagingTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAuditEventManagerStagingTests.cs
@@ -1,0 +1,258 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using Common.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Coverage for the Copilot adaptation rules that issue #367 freed from the SQL dependency - the
+    /// context-priority order, agent-metadata-only mode and the null-record guard.
+    ///
+    /// These run with zero SQL Server, Graph, Redis or Service Bus: the manager now takes an
+    /// <c>ICopilotStagingWriter</c>, so an in-memory writer captures what would have been staged.
+    /// The pre-existing CopilotTests suite still covers the SQL merge end to end.
+    /// </summary>
+    [TestClass]
+    public class CopilotAuditEventManagerStagingTests
+    {
+        // Must contain the literal "19:meeting_" - StringUtils.GetMeetingIdFragmentFromMeetingThreadUrl
+        // parses from there, and throws (so the row is not staged) for anything else.
+        private const string MeetingContextId = "https://contoso.teams.com/threads/19:meeting_NDkyZTJhMWEtM2Y@thread.v2";
+        private const string ChatContextId = "https://contoso.teams.com/threads/19:chat@thread.v2";
+        private const string FileContextId = "https://contoso.sharepoint.com/sites/example/Shared Documents/καλημέρα.docx";
+
+        private static CommonAuditEvent NewEvent()
+        {
+            return new CommonAuditEvent
+            {
+                TimeStamp = new DateTime(2026, 4, 1, 9, 0, 0, DateTimeKind.Utc),
+                Operation = new EventOperation { Name = "Copilot Interaction" },
+                User = new User { AzureAdId = "00000000-0000-0000-0000-000000000000", UserPrincipalName = "chris@contoso.onmicrosoft.com" },
+                Id = Guid.NewGuid()
+            };
+        }
+
+        private static CopilotAuditLogContent ContentWith(params Context[] contexts)
+        {
+            return new CopilotAuditLogContent
+            {
+                CopilotEventData = new CopilotEventData
+                {
+                    AppHost = "Teams",
+                    Contexts = new List<Context>(contexts)
+                }
+            };
+        }
+
+        private static Context Meeting() => new Context { Id = MeetingContextId, Type = ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING };
+        private static Context Chat() => new Context { Id = ChatContextId, Type = ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_CHAT };
+        private static Context File() => new Context { Id = FileContextId, Type = "SharePointFile" };
+
+        private static CopilotAuditEventManager NewManager(InMemoryCopilotStagingWriter writer, bool resolveResourceMetadata = true)
+        {
+            return new CopilotAuditEventManager(writer, new FakeCopilotMetadataLoader(), NullLogger.Instance, resolveResourceMetadata);
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_MeetingContext_TakesPriorityOverChat_StagesMeetingOnly()
+        {
+            // Documented, load-bearing behaviour: a meeting context ends iteration, so a trailing chat
+            // context is never staged. The `break` is intentional - see the note in the manager.
+            var writer = new InMemoryCopilotStagingWriter();
+
+            await NewManager(writer).SaveSingleCopilotEventToSqlStaging(ContentWith(Meeting(), Chat()), NewEvent());
+
+            Assert.AreEqual(1, writer.TeamsRows.Count, "The meeting context must be staged.");
+            Assert.AreEqual(0, writer.ChatOnlyRows.Count, "The trailing chat context must not also be staged.");
+            Assert.AreEqual(0, writer.SharePointRows.Count);
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_FileContext_BreaksBeforeChat()
+        {
+            var writer = new InMemoryCopilotStagingWriter();
+
+            await NewManager(writer).SaveSingleCopilotEventToSqlStaging(ContentWith(File(), Chat()), NewEvent());
+
+            Assert.AreEqual(1, writer.SharePointRows.Count, "The file context must be staged.");
+            Assert.AreEqual(0, writer.ChatOnlyRows.Count, "The trailing chat context must not also be staged.");
+            Assert.AreEqual(0, writer.TeamsRows.Count);
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_MultipleMeetingContexts_StagesOnlyOne()
+        {
+            // Pins the `eventMeetings == 0` guard specifically - the regression that used to put the same
+            // event_id in staging twice and blow up the copilot_chats primary key during the merge.
+            // The `break` itself is pinned by MeetingContext_TakesPriorityOverChat, not by this test.
+            var writer = new InMemoryCopilotStagingWriter();
+
+            await NewManager(writer).SaveSingleCopilotEventToSqlStaging(ContentWith(Meeting(), Meeting(), Meeting()), NewEvent());
+
+            Assert.AreEqual(1, writer.TeamsRows.Count);
+            Assert.AreEqual(1, writer.TotalStaged);
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_MultipleChatContexts_StagesOnlyOne()
+        {
+            var writer = new InMemoryCopilotStagingWriter();
+
+            await NewManager(writer).SaveSingleCopilotEventToSqlStaging(ContentWith(Chat(), Chat(), Chat()), NewEvent());
+
+            Assert.AreEqual(1, writer.ChatOnlyRows.Count);
+            Assert.AreEqual(1, writer.TotalStaged);
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_ResolveResourceMetadataFalse_StagesEveryEventAsChatOnly_AndMakesNoGraphCall()
+        {
+            // Agent-metadata-only mode: every interaction becomes a chat-only row and no Graph
+            // file/meeting resolution happens at all - that is the whole point, since those calls are
+            // serial and network-bound on the save path.
+            var writer = new InMemoryCopilotStagingWriter();
+            var loader = new RecordingCopilotMetadataLoader();
+            var manager = new CopilotAuditEventManager(writer, loader, NullLogger.Instance, resolveResourceMetadata: false);
+
+            await manager.SaveSingleCopilotEventToSqlStaging(ContentWith(Meeting()), NewEvent());
+            await manager.SaveSingleCopilotEventToSqlStaging(ContentWith(File()), NewEvent());
+            await manager.SaveSingleCopilotEventToSqlStaging(ContentWith(Chat()), NewEvent());
+
+            Assert.AreEqual(3, writer.ChatOnlyRows.Count, "Every interaction is staged chat-only, whatever its context.");
+            Assert.AreEqual(0, writer.TeamsRows.Count);
+            Assert.AreEqual(0, writer.SharePointRows.Count);
+            Assert.AreEqual(0, (loader.MeetingCalls + loader.FileCalls + loader.UserIdCalls), "No Graph resolution may happen in agent-metadata-only mode.");
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_ResolveResourceMetadataTrue_DoesCallGraph()
+        {
+            // Counterpart to the test above, so it cannot pass merely because the loader is never used.
+            var writer = new InMemoryCopilotStagingWriter();
+            var loader = new RecordingCopilotMetadataLoader();
+            var manager = new CopilotAuditEventManager(writer, loader, NullLogger.Instance, resolveResourceMetadata: true);
+
+            await manager.SaveSingleCopilotEventToSqlStaging(ContentWith(Meeting()), NewEvent());
+
+            Assert.IsTrue((loader.MeetingCalls + loader.FileCalls + loader.UserIdCalls) > 0, "With resolution enabled the meeting context must be resolved via Graph.");
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_NullAuditRecordOrBaseEvent_StagesNothing()
+        {
+            var writer = new InMemoryCopilotStagingWriter();
+            var manager = NewManager(writer);
+
+            await manager.SaveSingleCopilotEventToSqlStaging(null, NewEvent());
+            await manager.SaveSingleCopilotEventToSqlStaging(ContentWith(Chat()), null);
+            await manager.SaveSingleCopilotEventToSqlStaging(null, null);
+
+            Assert.AreEqual(0, writer.TotalStaged, "A null record must be dropped, not staged and not thrown.");
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_NoContexts_StagesChatOnly()
+        {
+            var writer = new InMemoryCopilotStagingWriter();
+
+            await NewManager(writer).SaveSingleCopilotEventToSqlStaging(ContentWith(), NewEvent());
+
+            Assert.AreEqual(1, writer.ChatOnlyRows.Count, "An interaction with no context still carries agent metadata worth keeping.");
+        }
+
+        [TestMethod]
+        public void CopilotEventManager_BothDependenciesNull_ReportsTheAdaptorFirst_AsBefore()
+        {
+            // A constructor initialiser runs before the constructor body, so routing through the SQL
+            // writer would otherwise report "logger" where the original reported "copilotEventAdaptor".
+            // Nothing depends on that ParamName today, but silently changing it is not an extraction.
+            try
+            {
+                new CopilotAuditEventManager("Server=.;Database=x;Integrated Security=true", null, null);
+                Assert.Fail("Expected an ArgumentNullException.");
+            }
+            catch (ArgumentNullException ex)
+            {
+                Assert.AreEqual("copilotEventAdaptor", ex.ParamName,
+                    "Validation order must stay connection string -> adaptor -> logger.");
+            }
+        }
+
+        [TestMethod]
+        public void CopilotEventManager_BlankConnectionString_StillThrowsArgumentException()
+        {
+            foreach (var bad in new[] { null, string.Empty })
+            {
+                try
+                {
+                    new CopilotAuditEventManager(bad, new FakeCopilotMetadataLoader(), NullLogger.Instance);
+                    Assert.Fail("The original constructor rejected a blank connection string; that must not change.");
+                }
+                catch (ArgumentException ex)
+                {
+                    Assert.AreEqual(typeof(ArgumentException), ex.GetType(),
+                        "Must stay a plain ArgumentException - ArgumentNullException derives from it, so a bare catch would not notice the type changing.");
+                    Assert.AreEqual("connectionString", ex.ParamName);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_CommitAllChanges_ClearsStagedRows()
+        {
+            // Pins the SEAM CONTRACT - that the manager delegates the commit and does not re-stage the
+            // same batch.
+            //
+            // It deliberately cannot pin SqlCopilotStagingWriter's own Rows.Clear() calls, and neither
+            // does anything else today: the DB-backed CopilotEventManagerCommitResetsStateForNextBatch
+            // stages only a chat-only row and asserts final copilot_chats counts, which stay correct
+            // even if the lists were never cleared, because the common merge de-duplicates chats.
+            //
+            // The consequence of losing those Clear() calls differs per table, and is worse than mere
+            // repeated work for two of the three:
+            //   * chat-only - the root copilot_chats row is de-duplicated by the merge, so the usual
+            //     cost is an unboundedly growing batch on the hot path. It is NOT purely cost, though:
+            //     common_upsert_copilot_agents.sql deliberately does not de-duplicate messages that
+            //     have no Id (ISNULL(pm.message_id, NEWID()) plus "WHERE pm.message_id IS NULL"), so a
+            //     retained chat-only row carrying such a message inserts a fresh copilot_event_messages
+            //     row on every commit. Cost-only holds only when the event has no messages, or every
+            //     message has a stable Id;
+            //   * SharePoint and Teams - insert_sp_copilot_events_from_staging_table.sql and
+            //     insert_teams_copilot_events_from_staging_table.sql insert into copilot_event_files /
+            //     copilot_event_meetings with NO NOT EXISTS guard, and both inherit [Key] on
+            //     copilot_chat_id from BaseCopilotSpecificEvent - so a retained row THAT SUCCESSFULLY
+            //     INSERTED its metadata can make the NEXT commit fail on a duplicate primary key.
+            //     (Both managers deliberately stage rows even when Graph resolution returns null; those
+            //     rows fail the workload scripts' inner joins against the lookup tables, so they never
+            //     inserted a metadata row and have no key to collide with.)
+            //
+            // A guard needs a real database: under the current hard-wired InsertBatch design, staging is
+            // only List.Add, but committing a non-empty batch opens a connection. It must cover all
+            // three tables, not just the existing chat-only reset case.
+            var writer = new InMemoryCopilotStagingWriter();
+            var manager = NewManager(writer);
+
+            await manager.SaveSingleCopilotEventToSqlStaging(ContentWith(Chat()), NewEvent());
+            Assert.AreEqual(1, writer.TotalStaged);
+
+            await manager.CommitAllChanges();
+
+            Assert.AreEqual(1, writer.CommitCount);
+            Assert.AreEqual(0, writer.TotalStaged, "A committed batch must not be re-staged by the next commit.");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void CopilotEventManager_NullStagingWriter_Throws()
+        {
+            new CopilotAuditEventManager((ICopilotStagingWriter)null, new FakeCopilotMetadataLoader(), NullLogger.Instance);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryStagingWriters.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryStagingWriters.cs
@@ -1,0 +1,82 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform;
+
+namespace UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="ICopilotStagingWriter"/>. Exposes the staged rows so the manager's
+    /// adaptation rules - context priority, agent-metadata-only mode, the null guard - can be asserted
+    /// with no SQL Server. See issue #367.
+    /// </summary>
+    internal class InMemoryCopilotStagingWriter : ICopilotStagingWriter
+    {
+        public List<SPCopilotLogTempEntity> SharePointRows { get; } = new List<SPCopilotLogTempEntity>();
+        public List<TeamsCopilotLogTempEntity> TeamsRows { get; } = new List<TeamsCopilotLogTempEntity>();
+        public List<ChatOnlyCopilotLogTempEntity> ChatOnlyRows { get; } = new List<ChatOnlyCopilotLogTempEntity>();
+
+        /// <summary>How many times the batch was committed.</summary>
+        public int CommitCount { get; private set; }
+
+        /// <summary>Total rows staged across all three tables.</summary>
+        public int TotalStaged => SharePointRows.Count + TeamsRows.Count + ChatOnlyRows.Count;
+
+        public void StageSharePoint(SPCopilotLogTempEntity row) => SharePointRows.Add(row);
+
+        public void StageTeams(TeamsCopilotLogTempEntity row) => TeamsRows.Add(row);
+
+        public void StageChatOnly(ChatOnlyCopilotLogTempEntity row) => ChatOnlyRows.Add(row);
+
+        public Task<CopilotStagingCommitTimings> CommitAllChanges()
+        {
+            CommitCount++;
+            // The SQL adapter clears its staged rows on commit; mirror that so a test can assert the
+            // second batch independently of the first.
+            SharePointRows.Clear();
+            TeamsRows.Clear();
+            ChatOnlyRows.Clear();
+            return Task.FromResult(new CopilotStagingCommitTimings());
+        }
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IPowerPlatformStagingWriter"/>. See issue #367.
+    /// </summary>
+    internal class InMemoryPowerPlatformStagingWriter : IPowerPlatformStagingWriter
+    {
+        public List<PowerAppLogTempEntity> PowerAppRows { get; } = new List<PowerAppLogTempEntity>();
+        public List<PowerAppShareLogTempEntity> PowerAppShareRows { get; } = new List<PowerAppShareLogTempEntity>();
+        public List<PowerAutomateFlowLogTempEntity> FlowRows { get; } = new List<PowerAutomateFlowLogTempEntity>();
+        public List<PowerAutomateFlowShareLogTempEntity> FlowShareRows { get; } = new List<PowerAutomateFlowShareLogTempEntity>();
+        public List<PowerBILogTempEntity> PowerBiRows { get; } = new List<PowerBILogTempEntity>();
+        public List<CopilotStudioLogTempEntity> CopilotStudioRows { get; } = new List<CopilotStudioLogTempEntity>();
+
+        public int CommitCount { get; private set; }
+
+        public void StagePowerApp(PowerAppLogTempEntity row) => PowerAppRows.Add(row);
+
+        public void StagePowerAppShare(PowerAppShareLogTempEntity row) => PowerAppShareRows.Add(row);
+
+        public void StageFlow(PowerAutomateFlowLogTempEntity row) => FlowRows.Add(row);
+
+        public void StageFlowShare(PowerAutomateFlowShareLogTempEntity row) => FlowShareRows.Add(row);
+
+        public void StagePowerBi(PowerBILogTempEntity row) => PowerBiRows.Add(row);
+
+        public void StageCopilotStudio(CopilotStudioLogTempEntity row) => CopilotStudioRows.Add(row);
+
+        public Task CommitAllChanges()
+        {
+            CommitCount++;
+            PowerAppRows.Clear();
+            PowerAppShareRows.Clear();
+            FlowRows.Clear();
+            FlowShareRows.Clear();
+            PowerBiRows.Clear();
+            CopilotStudioRows.Clear();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/PowerPlatformAuditEventManagerStagingTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/PowerPlatformAuditEventManagerStagingTests.cs
@@ -1,0 +1,127 @@
+using Common.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Coverage for the Power Platform staging rules that issue #367 freed from the SQL dependency -
+    /// share-record expansion and the app display-name fallback. Both decide what rows get written, so
+    /// before the <c>IPowerPlatformStagingWriter</c> seam existed they could only be checked against a
+    /// live database.
+    ///
+    /// Runs with zero SQL Server, Graph, Redis or Service Bus.
+    /// </summary>
+    [TestClass]
+    public class PowerPlatformAuditEventManagerStagingTests
+    {
+        private static CommonAuditEvent NewEvent()
+        {
+            return new CommonAuditEvent
+            {
+                TimeStamp = new DateTime(2026, 4, 1, 9, 0, 0, DateTimeKind.Utc),
+                Operation = new EventOperation { Name = "ShareApp" },
+                User = new User { AzureAdId = "00000000-0000-0000-0000-000000000000", UserPrincipalName = "chris@contoso.onmicrosoft.com" },
+                Id = Guid.NewGuid()
+            };
+        }
+
+        private static PowerPlatformAuditEventManager NewManager(InMemoryPowerPlatformStagingWriter writer)
+        {
+            return new PowerPlatformAuditEventManager(writer, NullLogger.Instance);
+        }
+
+        [TestMethod]
+        public async Task PowerPlatform_ShareEvent_StagesOneRowPerPermission_AndSkipsEmptyPrincipalName()
+        {
+            var writer = new InMemoryPowerPlatformStagingWriter();
+            var record = new PowerAppsAuditLogContent
+            {
+                AppName = "contoso-expenses-app",
+                AppDisplayName = "Contoso Expenses",
+                Permissions = new List<PowerPlatformPermissionEntry>
+                {
+                    new PowerPlatformPermissionEntry { PrincipalName = "alex@contoso.onmicrosoft.com", RoleName = "CanEdit" },
+                    new PowerPlatformPermissionEntry { PrincipalName = null,                            RoleName = "CanView" },
+                    new PowerPlatformPermissionEntry { PrincipalName = string.Empty,                    RoleName = "CanView" },
+                    new PowerPlatformPermissionEntry { PrincipalName = "καλημέρα@contoso.onmicrosoft.com", RoleName = "CanView" },
+                }
+            };
+
+            await NewManager(writer).SaveSinglePowerAppEventToSqlStaging(record, NewEvent());
+
+            Assert.AreEqual(1, writer.PowerAppRows.Count, "The app event itself is staged once.");
+            Assert.AreEqual(2, writer.PowerAppShareRows.Count, "One share row per usable recipient; blanks are skipped.");
+            CollectionAssert.AreEquivalent(
+                new[] { "alex@contoso.onmicrosoft.com", "καλημέρα@contoso.onmicrosoft.com" },
+                new List<string> { writer.PowerAppShareRows[0].SharedWithUpn, writer.PowerAppShareRows[1].SharedWithUpn },
+                "Non-Latin recipients must survive intact.");
+        }
+
+        [TestMethod]
+        public async Task PowerPlatform_NoPermissions_StagesNoShareRows()
+        {
+            var writer = new InMemoryPowerPlatformStagingWriter();
+
+            await NewManager(writer).SaveSinglePowerAppEventToSqlStaging(
+                new PowerAppsAuditLogContent { AppName = "contoso-expenses-app", Permissions = null }, NewEvent());
+
+            Assert.AreEqual(1, writer.PowerAppRows.Count);
+            Assert.AreEqual(0, writer.PowerAppShareRows.Count);
+        }
+
+        [TestMethod]
+        public async Task PowerPlatform_AppDisplayNameMissing_FallsBackToAppName()
+        {
+            var writer = new InMemoryPowerPlatformStagingWriter();
+
+            await NewManager(writer).SaveSinglePowerAppEventToSqlStaging(
+                new PowerAppsAuditLogContent { AppName = "contoso-expenses-app", AppDisplayName = null }, NewEvent());
+            await NewManager(writer).SaveSinglePowerAppEventToSqlStaging(
+                new PowerAppsAuditLogContent { AppName = "contoso-hr-app", AppDisplayName = string.Empty }, NewEvent());
+
+            Assert.AreEqual("contoso-expenses-app", writer.PowerAppRows[0].AppName,
+                "With no display name the report would otherwise show a blank app.");
+            Assert.AreEqual("contoso-hr-app", writer.PowerAppRows[1].AppName,
+                "Empty must fall back too, not just null.");
+        }
+
+        [TestMethod]
+        public async Task PowerPlatform_AppDisplayNamePresent_IsPreferred()
+        {
+            var writer = new InMemoryPowerPlatformStagingWriter();
+
+            await NewManager(writer).SaveSinglePowerAppEventToSqlStaging(
+                new PowerAppsAuditLogContent { AppName = "contoso-expenses-app", AppDisplayName = "Contoso Expenses" }, NewEvent());
+
+            Assert.AreEqual("Contoso Expenses", writer.PowerAppRows[0].AppName);
+            Assert.AreEqual("contoso-expenses-app", writer.PowerAppRows[0].AppId, "The raw name is still kept as the id.");
+        }
+
+        [TestMethod]
+        public async Task PowerPlatform_NullRecordOrEvent_StagesNothing()
+        {
+            var writer = new InMemoryPowerPlatformStagingWriter();
+            var manager = NewManager(writer);
+
+            await manager.SaveSinglePowerAppEventToSqlStaging(null, NewEvent());
+            await manager.SaveSinglePowerAppEventToSqlStaging(new PowerAppsAuditLogContent { AppName = "x" }, null);
+
+            Assert.AreEqual(0, writer.PowerAppRows.Count);
+            Assert.AreEqual(0, writer.PowerAppShareRows.Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void PowerPlatform_NullStagingWriter_Throws()
+        {
+            new PowerPlatformAuditEventManager((IPowerPlatformStagingWriter)null, NullLogger.Instance);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -135,6 +135,9 @@
     <Compile Include="HitImportFanoutTests.cs" />
     <Compile Include="InsertBatchOverWidthTests.cs" />
     <Compile Include="AppInsightsImportTests.cs" />
+    <Compile Include="CopilotAuditEventManagerStagingTests.cs" />
+    <Compile Include="FakeLoaderClasses\InMemoryStagingWriters.cs" />
+    <Compile Include="PowerPlatformAuditEventManagerStagingTests.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="CopilotTests.cs" />
     <Compile Include="CopilotInteractionHistoryTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using DataUtils;
 using DataUtils.Sql.Inserts;
 using Microsoft.Extensions.Logging;
@@ -23,37 +23,51 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
     /// </summary>
     public class CopilotAuditEventManager : IDisposable
     {
-        // Chunk size for the staging-table inserts. ParallelListProcessor spreads the batch across one
-        // connection per chunk (capped at its own max), so a smaller chunk => more parallel inserts. The
-        // default (10000) meant a single thread for every realistic Copilot batch (<= a couple thousand rows),
-        // serializing every row's insert round-trip. On Azure SQL those round-trips are network-latency-bound,
-        // so parallelizing them is a large win; on LocalDB (no latency) it's a no-op. Kept modest so we don't
-        // open an excessive number of connections for the shared global temp table.
-        private const int STAGING_INSERTS_PER_THREAD = 200;
-
         private readonly ICopilotMetadataLoader _copilotEventAdaptor;
         private readonly ILogger _logger;
         private readonly bool _resolveResourceMetadata;
-        private readonly InsertBatch<SPCopilotLogTempEntity> _copilotInsertsSP;
-        private readonly InsertBatch<TeamsCopilotLogTempEntity> _copilotInsertsTeams;
-        private readonly InsertBatch<ChatOnlyCopilotLogTempEntity> _copilotInsertsChatsNoContext;
-        private readonly ProjectResourceReader _rr;
+        private readonly ICopilotStagingWriter _stagingWriter;
 
         // Batch-level totals (across all processed events since last commit)
         private int _totalMeetingsCount;
         private int _totalFilesCount;
         private int _totalChatOnlyCount;
 
+        /// <summary>
+        /// Production entry point: builds the SQL staging writer from a connection string. Kept as a thin
+        /// overload so SaveSession.Init() and every other existing call site is unchanged. See issue #367.
+        /// </summary>
         public CopilotAuditEventManager(string connectionString, ICopilotMetadataLoader copilotEventAdaptor, ILogger logger, bool resolveResourceMetadata = true)
+            : this(BuildSqlStagingWriter(connectionString, copilotEventAdaptor, logger), copilotEventAdaptor, logger, resolveResourceMetadata)
+        {
+        }
+
+        /// <summary>
+        /// Validates in the original order - connection string, then adaptor, then logger - before building
+        /// the writer. A constructor initialiser runs before the constructor body, so without this the
+        /// writer's own logger check would fire first and change the ParamName reported when more than one
+        /// argument is null.
+        /// </summary>
+        private static ICopilotStagingWriter BuildSqlStagingWriter(string connectionString, ICopilotMetadataLoader copilotEventAdaptor, ILogger logger)
         {
             if (string.IsNullOrEmpty(connectionString)) throw new ArgumentException($"'{nameof(connectionString)}' cannot be null or empty.", nameof(connectionString));
+            if (copilotEventAdaptor == null) throw new ArgumentNullException(nameof(copilotEventAdaptor));
+            if (logger == null) throw new ArgumentNullException(nameof(logger));
+
+            return new SqlCopilotStagingWriter(connectionString, logger);
+        }
+
+        /// <summary>
+        /// Testable entry point: the adaptation rules run against any <see cref="ICopilotStagingWriter"/>,
+        /// so the context-priority order, agent-metadata-only mode and the null-record guard can all be
+        /// asserted with no database.
+        /// </summary>
+        internal CopilotAuditEventManager(ICopilotStagingWriter stagingWriter, ICopilotMetadataLoader copilotEventAdaptor, ILogger logger, bool resolveResourceMetadata = true)
+        {
+            _stagingWriter = stagingWriter ?? throw new ArgumentNullException(nameof(stagingWriter));
             _copilotEventAdaptor = copilotEventAdaptor ?? throw new ArgumentNullException(nameof(copilotEventAdaptor));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _resolveResourceMetadata = resolveResourceMetadata;
-            _rr = new ProjectResourceReader(System.Reflection.Assembly.GetExecutingAssembly());
-            _copilotInsertsSP = new InsertBatch<SPCopilotLogTempEntity>(connectionString, logger);
-            _copilotInsertsTeams = new InsertBatch<TeamsCopilotLogTempEntity>(connectionString, logger);
-            _copilotInsertsChatsNoContext = new InsertBatch<ChatOnlyCopilotLogTempEntity>(connectionString, logger);
         }
 
         /// <summary>
@@ -164,7 +178,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     MeetingName = meetingInfo?.Subject,
                 };
                 PopulateCommonStagingFields(row, auditRecord, baseOfficeEvent);
-                _copilotInsertsTeams.Rows.Add(row);
+                _stagingWriter.StageTeams(row);
                 return true; // staged regardless of meetingInfo retrieval success
             }
             catch (Exception ex)
@@ -212,7 +226,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     UrlBase = spFileInfo?.SiteUrl,
                 };
                 PopulateCommonStagingFields(row, auditRecord, baseOfficeEvent);
-                _copilotInsertsSP.Rows.Add(row);
+                _stagingWriter.StageSharePoint(row);
                 return true; // staged regardless
             }
             catch (Exception ex)
@@ -265,7 +279,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         {
             var row = new ChatOnlyCopilotLogTempEntity();
             PopulateCommonStagingFields(row, auditRecord, baseOfficeEvent);
-            _copilotInsertsChatsNoContext.Rows.Add(row);
+            _stagingWriter.StageChatOnly(row);
         }
 
         /// <summary>
@@ -448,40 +462,24 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
         /// </summary>
         public async Task CommitAllChanges()
         {
-            var docsMergeSql = GetSql(ActivityImportConstants.STAGING_TABLE_COPILOT_SP, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot.SQL.insert_sp_copilot_events_from_staging_table.sql");
-            var teamsMergeSql = GetSql(ActivityImportConstants.STAGING_TABLE_COPILOT_TEAMS, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot.SQL.insert_teams_copilot_events_from_staging_table.sql");
-            var chatOnlyMergeSql = GetSql(ActivityImportConstants.STAGING_TABLE_COPILOT_CHATONLY, null);
-
             _logger.LogDebug($"Committing batch: {_totalFilesCount} file(s), {_totalMeetingsCount} meeting(s), {_totalChatOnlyCount} chat-only event(s) to SQL.");
 
-            // Per-staging-table timing. Each of the three Copilot staging tables runs the shared
-            // accessed-resource / agents merge (common_upsert_copilot_agents.sql), which on Copilot-heavy
-            // tenants is the dominant save cost - so time each separately to see which workload's merge is
-            // expensive (the chat-only path carries accessed resources too, so it is often the largest).
-            var swSp = System.Diagnostics.Stopwatch.StartNew();
-            await _copilotInsertsSP.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, docsMergeSql);
-            swSp.Stop();
-            var swTeams = System.Diagnostics.Stopwatch.StartNew();
-            await _copilotInsertsTeams.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, teamsMergeSql);
-            swTeams.Stop();
-            var swChat = System.Diagnostics.Stopwatch.StartNew();
-            await _copilotInsertsChatsNoContext.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, chatOnlyMergeSql);
-            swChat.Stop();
+            // The staging tables, merge scripts and per-table timing now live in the writer (see #367).
+            // The timings come back so this trace keeps interleaving them with the per-workload event
+            // counts, which only the manager knows.
+            var timings = await _stagingWriter.CommitAllChanges();
 
-            var copilotTimingMsg = $"Copilot commit timing: SP-docs {(swSp.Elapsed.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalFilesCount.ToString("n0")} file event(s)), " +
-                $"Teams {(swTeams.Elapsed.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalMeetingsCount.ToString("n0")} meeting event(s)), " +
-                $"chat-only {(swChat.Elapsed.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalChatOnlyCount.ToString("n0")} chat-only event(s)).";
+            var copilotTimingMsg = $"Copilot commit timing: SP-docs {(timings.SharePoint.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalFilesCount.ToString("n0")} file event(s)), " +
+                $"Teams {(timings.Teams.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalMeetingsCount.ToString("n0")} meeting event(s)), " +
+                $"chat-only {(timings.ChatOnly.TotalMilliseconds / 1000.0).ToString("n1")}s ({_totalChatOnlyCount.ToString("n0")} chat-only event(s)).";
             // Surface a slow Copilot merge (the usual bottleneck) at Information so it stands out in the traces;
             // keep routine fast batches at Debug to avoid per-batch noise.
-            if (swSp.Elapsed.TotalMilliseconds + swTeams.Elapsed.TotalMilliseconds + swChat.Elapsed.TotalMilliseconds >= 5000)
+            if (timings.Total.TotalMilliseconds >= 5000)
                 _logger.LogInformation(copilotTimingMsg);
             else
                 _logger.LogDebug(copilotTimingMsg);
 
-            // Clear lists & counters for next batch
-            _copilotInsertsSP.Rows.Clear();
-            _copilotInsertsTeams.Rows.Clear();
-            _copilotInsertsChatsNoContext.Rows.Clear();
+            // Clear counters for next batch. The staged rows are cleared by the writer.
             _totalFilesCount = 0;
             _totalMeetingsCount = 0;
             _totalChatOnlyCount = 0;
@@ -558,17 +556,6 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                     "Could not repair denormalised Copilot columns this cycle. The import itself succeeded; "
                     + "any affected interactions stay hidden from Copilot reports until a later cycle repairs them.");
             }
-        }
-
-        private string GetSql(string tempTableName, string workloadSpecificScriptName)
-        {
-            var commonMergeSql = _rr.ReadResourceString("WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot.SQL.common_upsert_copilot_agents.sql")
-                .Replace(ActivityImportConstants.STAGING_TABLE_VARNAME, tempTableName);
-
-            var workloadSpecificSql = workloadSpecificScriptName != null
-                ? _rr.ReadResourceString(workloadSpecificScriptName).Replace(ActivityImportConstants.STAGING_TABLE_VARNAME, tempTableName)
-                : string.Empty;
-            return commonMergeSql + Environment.NewLine + workloadSpecificSql;
         }
 
         public void Dispose()

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/ICopilotStagingWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/ICopilotStagingWriter.cs
@@ -1,0 +1,136 @@
+using DataUtils;
+using DataUtils.Sql.Inserts;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
+
+namespace ActivityImporter.Engine.ActivityAPI.Copilot
+{
+    /// <summary>
+    /// How long each of the three Copilot staging tables took to commit. Returned rather than logged
+    /// inside the adapter so <c>CopilotAuditEventManager</c> can keep emitting the existing
+    /// "Copilot commit timing" trace verbatim - it interleaves these durations with the manager's own
+    /// per-workload event counts, and that trace is a documented tool for diagnosing a slow import.
+    /// </summary>
+    internal class CopilotStagingCommitTimings
+    {
+        public TimeSpan SharePoint { get; set; }
+        public TimeSpan Teams { get; set; }
+        public TimeSpan ChatOnly { get; set; }
+
+        public TimeSpan Total => SharePoint + Teams + ChatOnly;
+    }
+
+    /// <summary>
+    /// Write port for the Copilot staging tables, so the manager's adaptation rules - the context
+    /// priority order, agent-metadata-only mode, the null-record guard - can be exercised without a
+    /// database. See issue #367.
+    ///
+    /// The SQL itself is unchanged: the adapter wraps the existing <c>InsertBatch&lt;T&gt;</c> instances
+    /// and merge scripts. <c>InsertBatch</c> keeps its row-by-row implementation, per project convention.
+    /// </summary>
+    internal interface ICopilotStagingWriter
+    {
+        void StageSharePoint(SPCopilotLogTempEntity row);
+        void StageTeams(TeamsCopilotLogTempEntity row);
+        void StageChatOnly(ChatOnlyCopilotLogTempEntity row);
+
+        /// <summary>
+        /// Commits every staged row to its staging table + merge script, then clears the staged rows.
+        /// </summary>
+        Task<CopilotStagingCommitTimings> CommitAllChanges();
+    }
+
+    /// <summary>
+    /// SQL Server adapter for <see cref="ICopilotStagingWriter"/>, holding the three
+    /// <c>InsertBatch&lt;T&gt;</c> batches that <c>CopilotAuditEventManager</c> used to build itself.
+    /// </summary>
+    internal class SqlCopilotStagingWriter : ICopilotStagingWriter
+    {
+        /// <summary>
+        /// Chunk size for the staging-table inserts. ParallelListProcessor spreads the batch across one
+        /// connection per chunk, so a smaller chunk => more parallel inserts. The default (10000) meant a
+        /// single thread for every realistic Copilot batch, serializing every row's insert round-trip.
+        /// On Azure SQL those round-trips are network-latency-bound, so parallelising them is a large win;
+        /// on LocalDB (no latency) it is a no-op. Kept modest so we do not open an excessive number of
+        /// connections for the shared global temp table.
+        /// </summary>
+        private const int STAGING_INSERTS_PER_THREAD = 200;
+
+        private readonly InsertBatch<SPCopilotLogTempEntity> _copilotInsertsSP;
+        private readonly InsertBatch<TeamsCopilotLogTempEntity> _copilotInsertsTeams;
+        private readonly InsertBatch<ChatOnlyCopilotLogTempEntity> _copilotInsertsChatsNoContext;
+        private readonly ProjectResourceReader _rr;
+
+        public SqlCopilotStagingWriter(string connectionString, ILogger logger)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentException($"'{nameof(connectionString)}' cannot be null or empty.", nameof(connectionString));
+            }
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            _rr = new ProjectResourceReader(System.Reflection.Assembly.GetExecutingAssembly());
+            _copilotInsertsSP = new InsertBatch<SPCopilotLogTempEntity>(connectionString, logger);
+            _copilotInsertsTeams = new InsertBatch<TeamsCopilotLogTempEntity>(connectionString, logger);
+            _copilotInsertsChatsNoContext = new InsertBatch<ChatOnlyCopilotLogTempEntity>(connectionString, logger);
+        }
+
+        public void StageSharePoint(SPCopilotLogTempEntity row) => _copilotInsertsSP.Rows.Add(row);
+
+        public void StageTeams(TeamsCopilotLogTempEntity row) => _copilotInsertsTeams.Rows.Add(row);
+
+        public void StageChatOnly(ChatOnlyCopilotLogTempEntity row) => _copilotInsertsChatsNoContext.Rows.Add(row);
+
+        public async Task<CopilotStagingCommitTimings> CommitAllChanges()
+        {
+            var docsMergeSql = GetSql(ActivityImportConstants.STAGING_TABLE_COPILOT_SP, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot.SQL.insert_sp_copilot_events_from_staging_table.sql");
+            var teamsMergeSql = GetSql(ActivityImportConstants.STAGING_TABLE_COPILOT_TEAMS, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot.SQL.insert_teams_copilot_events_from_staging_table.sql");
+            var chatOnlyMergeSql = GetSql(ActivityImportConstants.STAGING_TABLE_COPILOT_CHATONLY, null);
+
+            // Per-staging-table timing. Each of the three Copilot staging tables runs the shared
+            // accessed-resource / agents merge (common_upsert_copilot_agents.sql), which on Copilot-heavy
+            // tenants is the dominant save cost - so time each separately to see which workload's merge is
+            // expensive (the chat-only path carries accessed resources too, so it is often the largest).
+            var timings = new CopilotStagingCommitTimings();
+
+            var swSp = Stopwatch.StartNew();
+            await _copilotInsertsSP.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, docsMergeSql);
+            swSp.Stop();
+            timings.SharePoint = swSp.Elapsed;
+
+            var swTeams = Stopwatch.StartNew();
+            await _copilotInsertsTeams.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, teamsMergeSql);
+            swTeams.Stop();
+            timings.Teams = swTeams.Elapsed;
+
+            var swChat = Stopwatch.StartNew();
+            await _copilotInsertsChatsNoContext.SaveToStagingTable(STAGING_INSERTS_PER_THREAD, chatOnlyMergeSql);
+            swChat.Stop();
+            timings.ChatOnly = swChat.Elapsed;
+
+            _copilotInsertsSP.Rows.Clear();
+            _copilotInsertsTeams.Rows.Clear();
+            _copilotInsertsChatsNoContext.Rows.Clear();
+
+            return timings;
+        }
+
+        private string GetSql(string tempTableName, string workloadSpecificScriptName)
+        {
+            var commonMergeSql = _rr.ReadResourceString("WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot.SQL.common_upsert_copilot_agents.sql")
+                .Replace(ActivityImportConstants.STAGING_TABLE_VARNAME, tempTableName);
+
+            var workloadSpecificSql = workloadSpecificScriptName != null
+                ? _rr.ReadResourceString(workloadSpecificScriptName).Replace(ActivityImportConstants.STAGING_TABLE_VARNAME, tempTableName)
+                : string.Empty;
+            return commonMergeSql + Environment.NewLine + workloadSpecificSql;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/IPowerPlatformStagingWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/IPowerPlatformStagingWriter.cs
@@ -1,0 +1,99 @@
+using DataUtils;
+using DataUtils.Sql.Inserts;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
+{
+    /// <summary>
+    /// Write port for the six Power Platform staging tables, so the manager's adaptation rules -
+    /// client-type normalisation, connector joining, share-record expansion, display-name fallback -
+    /// can be exercised without a database. See issue #367.
+    ///
+    /// Internal because the staging entities it carries are internal; <c>InternalsVisibleTo("Tests.UnitTests")</c>
+    /// makes it reachable from the test project. The SQL is unchanged: the adapter wraps the existing
+    /// <c>InsertBatch&lt;T&gt;</c> instances and merge scripts, and <c>InsertBatch</c> keeps its row-by-row
+    /// implementation per project convention.
+    /// </summary>
+    internal interface IPowerPlatformStagingWriter
+    {
+        void StagePowerApp(PowerAppLogTempEntity row);
+        void StagePowerAppShare(PowerAppShareLogTempEntity row);
+        void StageFlow(PowerAutomateFlowLogTempEntity row);
+        void StageFlowShare(PowerAutomateFlowShareLogTempEntity row);
+        void StagePowerBi(PowerBILogTempEntity row);
+        void StageCopilotStudio(CopilotStudioLogTempEntity row);
+
+        /// <summary>
+        /// Commits every staged row to its staging table + merge script, then clears the staged rows.
+        /// </summary>
+        Task CommitAllChanges();
+    }
+
+    /// <summary>
+    /// SQL Server adapter for <see cref="IPowerPlatformStagingWriter"/>, holding the six
+    /// <c>InsertBatch&lt;T&gt;</c> batches that <c>PowerPlatformAuditEventManager</c> used to build itself.
+    /// </summary>
+    internal class SqlPowerPlatformStagingWriter : IPowerPlatformStagingWriter
+    {
+        private readonly ProjectResourceReader _rr;
+
+        private readonly InsertBatch<PowerAppLogTempEntity> _appInserts;
+        private readonly InsertBatch<PowerAppShareLogTempEntity> _appShareInserts;
+        private readonly InsertBatch<PowerAutomateFlowLogTempEntity> _flowInserts;
+        private readonly InsertBatch<PowerAutomateFlowShareLogTempEntity> _flowShareInserts;
+        private readonly InsertBatch<PowerBILogTempEntity> _powerBiInserts;
+        private readonly InsertBatch<CopilotStudioLogTempEntity> _copilotStudioInserts;
+
+        public SqlPowerPlatformStagingWriter(string connectionString, ILogger logger)
+        {
+            // Deliberately no connection-string guard: the original manager did not validate it either.
+            // InsertBatch<T> just stores the string, and a commit with no staged rows returns before any
+            // connection is opened - so rejecting it here would be a new failure mode, not an extraction.
+            // (The Copilot manager DID validate, so its adapter keeps that check.)
+            _rr = new ProjectResourceReader(System.Reflection.Assembly.GetExecutingAssembly());
+            _appInserts = new InsertBatch<PowerAppLogTempEntity>(connectionString, logger);
+            _appShareInserts = new InsertBatch<PowerAppShareLogTempEntity>(connectionString, logger);
+            _flowInserts = new InsertBatch<PowerAutomateFlowLogTempEntity>(connectionString, logger);
+            _flowShareInserts = new InsertBatch<PowerAutomateFlowShareLogTempEntity>(connectionString, logger);
+            _powerBiInserts = new InsertBatch<PowerBILogTempEntity>(connectionString, logger);
+            _copilotStudioInserts = new InsertBatch<CopilotStudioLogTempEntity>(connectionString, logger);
+        }
+
+        public void StagePowerApp(PowerAppLogTempEntity row) => _appInserts.Rows.Add(row);
+
+        public void StagePowerAppShare(PowerAppShareLogTempEntity row) => _appShareInserts.Rows.Add(row);
+
+        public void StageFlow(PowerAutomateFlowLogTempEntity row) => _flowInserts.Rows.Add(row);
+
+        public void StageFlowShare(PowerAutomateFlowShareLogTempEntity row) => _flowShareInserts.Rows.Add(row);
+
+        public void StagePowerBi(PowerBILogTempEntity row) => _powerBiInserts.Rows.Add(row);
+
+        public void StageCopilotStudio(CopilotStudioLogTempEntity row) => _copilotStudioInserts.Rows.Add(row);
+
+        public async Task CommitAllChanges()
+        {
+            await _appInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_APP, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_app_events_from_staging_table.sql"));
+            await _appShareInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_APP_SHARE, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_app_share_events_from_staging_table.sql"));
+            await _flowInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_AUTOMATE, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_automate_events_from_staging_table.sql"));
+            await _flowShareInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_AUTOMATE_SHARE, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_automate_share_events_from_staging_table.sql"));
+            await _powerBiInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_BI, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_bi_events_from_staging_table.sql"));
+            await _copilotStudioInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_COPILOT_STUDIO, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_copilot_studio_events_from_staging_table.sql"));
+
+            _appInserts.Rows.Clear();
+            _appShareInserts.Rows.Clear();
+            _flowInserts.Rows.Clear();
+            _flowShareInserts.Rows.Clear();
+            _powerBiInserts.Rows.Clear();
+            _copilotStudioInserts.Rows.Clear();
+        }
+
+        private string GetSql(string tempTableName, string embeddedScriptName)
+        {
+            return _rr.ReadResourceString(embeddedScriptName)
+                .Replace(ActivityImportConstants.STAGING_TABLE_VARNAME, tempTableName);
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/PowerPlatformAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/PowerPlatform/PowerPlatformAuditEventManager.cs
@@ -1,4 +1,4 @@
-﻿using Common.Entities;
+using Common.Entities;
 using DataUtils;
 using DataUtils.Sql.Inserts;
 using Microsoft.Extensions.Logging;
@@ -18,14 +18,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
     public class PowerPlatformAuditEventManager : IDisposable
     {
         private readonly ILogger _logger;
-        private readonly ProjectResourceReader _rr;
-
-        private readonly InsertBatch<PowerAppLogTempEntity> _appInserts;
-        private readonly InsertBatch<PowerAppShareLogTempEntity> _appShareInserts;
-        private readonly InsertBatch<PowerAutomateFlowLogTempEntity> _flowInserts;
-        private readonly InsertBatch<PowerAutomateFlowShareLogTempEntity> _flowShareInserts;
-        private readonly InsertBatch<PowerBILogTempEntity> _powerBiInserts;
-        private readonly InsertBatch<CopilotStudioLogTempEntity> _copilotStudioInserts;
+        private readonly IPowerPlatformStagingWriter _stagingWriter;
 
         private int _totalAppCount;
         private int _totalAppShareCount;
@@ -34,16 +27,23 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
         private int _totalPowerBiCount;
         private int _totalCopilotStudioCount;
 
+        /// <summary>
+        /// Production entry point: builds the SQL staging writer from a connection string. Kept as a thin
+        /// overload so SaveSession.Init() and every other existing call site is unchanged. See issue #367.
+        /// </summary>
         public PowerPlatformAuditEventManager(string connectionString, ILogger logger)
+            : this(new SqlPowerPlatformStagingWriter(connectionString, logger), logger)
         {
-            _rr = new ProjectResourceReader(System.Reflection.Assembly.GetExecutingAssembly());
+        }
+
+        /// <summary>
+        /// Testable entry point: the adaptation rules run against any <see cref="IPowerPlatformStagingWriter"/>,
+        /// so client-type normalisation, connector joining and share expansion can be asserted with no database.
+        /// </summary>
+        internal PowerPlatformAuditEventManager(IPowerPlatformStagingWriter stagingWriter, ILogger logger)
+        {
+            _stagingWriter = stagingWriter ?? throw new ArgumentNullException(nameof(stagingWriter));
             _logger = logger;
-            _appInserts = new InsertBatch<PowerAppLogTempEntity>(connectionString, logger);
-            _appShareInserts = new InsertBatch<PowerAppShareLogTempEntity>(connectionString, logger);
-            _flowInserts = new InsertBatch<PowerAutomateFlowLogTempEntity>(connectionString, logger);
-            _flowShareInserts = new InsertBatch<PowerAutomateFlowShareLogTempEntity>(connectionString, logger);
-            _powerBiInserts = new InsertBatch<PowerBILogTempEntity>(connectionString, logger);
-            _copilotStudioInserts = new InsertBatch<CopilotStudioLogTempEntity>(connectionString, logger);
         }
 
         public int StagedAppCount => _totalAppCount;
@@ -61,7 +61,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 return Task.CompletedTask;
             }
 
-            _appInserts.Rows.Add(new PowerAppLogTempEntity
+            _stagingWriter.StagePowerApp(new PowerAppLogTempEntity
             {
                 EventId = baseOfficeEvent.Id,
                 AppId = auditRecord.AppName,
@@ -81,7 +81,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 foreach (var p in auditRecord.Permissions)
                 {
                     if (string.IsNullOrEmpty(p?.PrincipalName)) continue;
-                    _appShareInserts.Rows.Add(new PowerAppShareLogTempEntity
+                    _stagingWriter.StagePowerAppShare(new PowerAppShareLogTempEntity
                     {
                         EventId = baseOfficeEvent.Id,
                         AppId = auditRecord.AppName,
@@ -111,7 +111,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 return Task.CompletedTask;
             }
 
-            _flowInserts.Rows.Add(new PowerAutomateFlowLogTempEntity
+            _stagingWriter.StageFlow(new PowerAutomateFlowLogTempEntity
             {
                 EventId = baseOfficeEvent.Id,
                 FlowId = auditRecord.FlowId,
@@ -129,7 +129,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 foreach (var p in auditRecord.Permissions)
                 {
                     if (string.IsNullOrEmpty(p?.PrincipalName)) continue;
-                    _flowShareInserts.Rows.Add(new PowerAutomateFlowShareLogTempEntity
+                    _stagingWriter.StageFlowShare(new PowerAutomateFlowShareLogTempEntity
                     {
                         EventId = baseOfficeEvent.Id,
                         FlowId = auditRecord.FlowId,
@@ -161,7 +161,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 return Task.CompletedTask;
             }
 
-            _powerBiInserts.Rows.Add(new PowerBILogTempEntity
+            _stagingWriter.StagePowerBi(new PowerBILogTempEntity
             {
                 EventId = baseOfficeEvent.Id,
                 WorkspaceId = auditRecord.WorkspaceId,
@@ -192,7 +192,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 return Task.CompletedTask;
             }
 
-            _copilotStudioInserts.Rows.Add(new CopilotStudioLogTempEntity
+            _stagingWriter.StageCopilotStudio(new CopilotStudioLogTempEntity
             {
                 EventId = baseOfficeEvent.Id,
                 BotId = auditRecord.BotId,
@@ -237,31 +237,15 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform
                 $"{_totalFlowCount} flow events, {_totalFlowShareCount} flow shares, {_totalPowerBiCount} Power BI events, " +
                 $"{_totalCopilotStudioCount} Copilot Studio events.");
 
-            await _appInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_APP, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_app_events_from_staging_table.sql"));
-            await _appShareInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_APP_SHARE, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_app_share_events_from_staging_table.sql"));
-            await _flowInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_AUTOMATE, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_automate_events_from_staging_table.sql"));
-            await _flowShareInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_AUTOMATE_SHARE, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_automate_share_events_from_staging_table.sql"));
-            await _powerBiInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_POWER_BI, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_power_bi_events_from_staging_table.sql"));
-            await _copilotStudioInserts.SaveToStagingTable(GetSql(ActivityImportConstants.STAGING_TABLE_COPILOT_STUDIO, "WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform.SQL.insert_copilot_studio_events_from_staging_table.sql"));
+            // The staging tables and merge scripts now live in the writer (see #367).
+            await _stagingWriter.CommitAllChanges();
 
-            _appInserts.Rows.Clear();
-            _appShareInserts.Rows.Clear();
-            _flowInserts.Rows.Clear();
-            _flowShareInserts.Rows.Clear();
-            _powerBiInserts.Rows.Clear();
-            _copilotStudioInserts.Rows.Clear();
             _totalAppCount = 0;
             _totalAppShareCount = 0;
             _totalFlowCount = 0;
             _totalFlowShareCount = 0;
             _totalPowerBiCount = 0;
             _totalCopilotStudioCount = 0;
-        }
-
-        private string GetSql(string tempTableName, string embeddedScriptName)
-        {
-            return _rr.ReadResourceString(embeddedScriptName)
-                .Replace(ActivityImportConstants.STAGING_TABLE_VARNAME, tempTableName);
         }
 
         public void Dispose()

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ActivityAPI\BlobCheckpoint\ProcessedBlobStoreFactory.cs" />
     <Compile Include="ActivityAPI\AuditTraceConfig.cs" />
     <Compile Include="ActivityAPI\Copilot\CopilotAuditEventManager.cs" />
+    <Compile Include="ActivityAPI\Copilot\ICopilotStagingWriter.cs" />
     <Compile Include="ActivityAPI\Copilot\CostEstimate\CopilotCreditEstimation.cs" />
     <Compile Include="ActivityAPI\Copilot\CostEstimate\Models.cs" />
     <Compile Include="ActivityAPI\Copilot\GraphCaches.cs" />
@@ -79,6 +80,7 @@
     <Compile Include="ActivityAPI\Copilot\Models.cs" />
     <Compile Include="ActivityAPI\Copilot\StagingClasses.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\PowerPlatformAuditEventManager.cs" />
+    <Compile Include="ActivityAPI\PowerPlatform\IPowerPlatformStagingWriter.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\PowerPlatformAuditLogFilter.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\StagingClasses.cs" />
     <Compile Include="ActivityAPI\Interfaces.cs" />


### PR DESCRIPTION
Addresses #367. Part of the ports & adapters initiative (#381). Independent of #384, #386 and #387 — no file overlap.

## Why

`CopilotAuditEventManager` and `PowerPlatformAuditEventManager` both own genuine **business rules**, but each built its own SQL writers in its constructor from a raw connection string. The rules and the SQL were welded together, so none of the rules could be exercised without a live database — every existing Copilot test is DB-backed for that reason alone.

## New ports

| File | Contents |
|---|---|
| `ActivityAPI/Copilot/ICopilotStagingWriter.cs` | `StageSharePoint` / `StageTeams` / `StageChatOnly` / `CommitAllChanges`, plus `SqlCopilotStagingWriter` holding the three `InsertBatch<T>` batches, the merge-script reader and the per-table timing |
| `ActivityAPI/PowerPlatform/IPowerPlatformStagingWriter.cs` | the six `Stage*` methods and `CommitAllChanges`, plus `SqlPowerPlatformStagingWriter` holding the six batches |

Both are `internal`, because the staging entities they carry are internal; `InternalsVisibleTo("Tests.UnitTests")` is already declared on the assembly.

**No SQL text, staging schema or merge script changed**, and `InsertBatch` keeps its row-by-row implementation per project convention.

Both managers keep their existing `(string connectionString, ...)` constructor as a **thin overload** that builds the SQL adapter, so `SaveSession.Init()` and every other call site is untouched.

## One deviation from the sketch in #367

`ICopilotStagingWriter.CommitAllChanges` returns `CopilotStagingCommitTimings` rather than a bare `Task`.

The existing `Copilot commit timing` trace interleaves the three per-staging-table durations with the manager's **per-workload event counts** — and that trace is a documented tool for diagnosing a slow Copilot import. Returning the timings keeps the message byte-identical; a bare `Task` would have forced splitting it in two or dropping the counts.

## Tests

All with **zero SQL Server, Graph, Redis or Service Bus**.

`CopilotAuditEventManagerStagingTests` — 10 tests over the context-priority rules, which the code explicitly flags as intentional and load-bearing:
- a meeting context ends iteration, so a trailing chat is **not** staged; a file context does the same
- repeated meeting/chat contexts stage only one row — the regression that used to put the same `event_id` in staging twice and blow up the `copilot_chats` primary key during the merge
- agent-metadata-only mode stages everything chat-only **and makes no Graph call at all**
- the null-record guard, and that a committed batch is cleared

It includes the **positive counterpart** (with resolution enabled, Graph *is* called) so the "no Graph call" assertion cannot pass vacuously.

`PowerPlatformAuditEventManagerStagingTests` — 6 tests over share-record expansion (one row per recipient, blanks skipped, non-Latin recipients intact) and the app display-name fallback in both directions.

`FakeLoaderClasses/InMemoryStagingWriters.cs` — in-memory writers exposing the staged rows and mirroring the adapter's clear-on-commit. The existing `RecordingCopilotMetadataLoader` fake was reused for the no-Graph-call assertion rather than adding a near-duplicate.

### Verification

Full solution builds in Debug; **42 tests pass** — 10 new Copilot staging, 6 new Power Platform staging, and the **26 pre-existing Power Platform tests**, which exercise the unchanged rules through the rewired manager and are the main evidence that behaviour is identical.

One fixture bug worth noting for reviewers: `StringUtils.GetMeetingIdFragmentFromMeetingThreadUrl` requires the literal `19:meeting_` prefix and throws otherwise (swallowed by `TryAddMeetingAsync`, which then stages nothing). My first meeting fixture used `19:meeting@...` and the test correctly failed — the fixture was wrong, not the code.

No schema change, no migration, no behavioural change.

---

## Review round 1 — two behavioural deltas found and fixed

Both reviewers (Grok 4.6, GPT-5.6 Sol) independently identified the same two places where the "mechanical extraction" was not in fact behaviour-preserving. Both are now fixed, at `c165560`:

**1. Copilot constructor validation order.** A constructor initialiser runs *before* the constructor body, so routing through `new SqlCopilotStagingWriter(connectionString, logger)` made the writer's own `logger` null-check fire first. With **both** `copilotEventAdaptor` and `logger` null, the original threw `ArgumentNullException(ParamName = "copilotEventAdaptor")`; the extracted version reported `"logger"`.

Fixed by a `BuildSqlStagingWriter` helper that validates in the original order — connection string → adaptor → logger — before constructing the writer. Pinned by `CopilotEventManager_BothDependenciesNull_ReportsTheAdaptorFirst_AsBefore`.

**2. Power Platform gained an eager connection-string guard.** I had added `ArgumentException` on a blank connection string to `SqlPowerPlatformStagingWriter`, mirroring the Copilot adapter. But the original Power Platform manager **never validated it**: `InsertBatch<T>` merely stores the string, and a commit with no staged rows returns before any connection is opened. That guard was therefore a new failure mode, not an extraction.

Guard removed, with a comment recording why the two adapters legitimately differ — the Copilot manager *did* validate, so its adapter keeps the check.

### Also tightened

Two tests now state precisely what they pin, rather than implying more:
- `MultipleMeetingContexts_StagesOnlyOne` pins the `eventMeetings == 0` guard; the `break` is pinned by `MeetingContext_TakesPriorityOverChat`.
- `CommitAllChanges_ClearsStagedRows` pins the **seam contract** (the manager delegates and does not re-stage), not `SqlCopilotStagingWriter`'s own `Rows.Clear()` calls — that is inherent to a zero-SQL test and is covered by the DB-backed `CopilotTests` suite.

Now **44 tests** pass; full solution builds in Debug.