### PR TITLE
Extract the audit-log staging rules and both operator safety-valves (#373 part 1)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheWindowTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheWindowTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The audit-log de-duplication cache window rules, including the AUDIT_PERBATCH_DEDUP_CACHE operator
+    /// safety-valve. Extracted by issue #373 so both are assertable with no SQL Server and no wall clock.
+    /// </summary>
+    [TestClass]
+    public class ActivityImportCacheWindowTests
+    {
+        private static readonly DateTime NowUtc = new DateTime(2026, 3, 10, 14, 5, 0, DateTimeKind.Utc);
+        private static readonly DateTime OldestInBatch = new DateTime(2026, 3, 8, 1, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime NewestInBatch = new DateTime(2026, 3, 10, 13, 0, 0, DateTimeKind.Utc);
+
+        [TestMethod]
+        public void ImportCache_ByDefault_IsPerRunAndCoversTheWholeDownloadWindow()
+        {
+            var window = ActivityImportCacheWindow.Resolve(false, OldestInBatch, NewestInBatch, daysBeforeNowToDownload: 3, nowUtc: NowUtc);
+
+            Assert.AreEqual(ActivityDedupCacheScope.PerRun, window.Scope);
+
+            // One day of extra lower margin: the download window is computed at cycle start, slightly before
+            // the cache is built, so an event just outside the exact boundary must still be covered.
+            Assert.AreEqual(4, window.DaysBack);
+            Assert.AreEqual(NowUtc.AddDays(-4), window.FromUtc);
+            Assert.AreEqual(NowUtc.AddMinutes(2), window.ToUtc);
+
+            // The batch's own span is irrelevant in per-run mode - that is the whole point of the change the
+            // safety-valve reverts.
+            Assert.AreNotEqual(OldestInBatch, window.FromUtc);
+        }
+
+        [TestMethod]
+        public void ImportCache_PerBatchSafetyValveEnabled_UsesTheBatchSpanInsteadOfTheDownloadWindow()
+        {
+            var window = ActivityImportCacheWindow.Resolve(true, OldestInBatch, NewestInBatch, daysBeforeNowToDownload: 3, nowUtc: NowUtc);
+
+            Assert.AreEqual(ActivityDedupCacheScope.PerBatch, window.Scope);
+            Assert.AreEqual(OldestInBatch, window.FromUtc);
+            Assert.AreEqual(NewestInBatch, window.ToUtc);
+        }
+
+        [TestMethod]
+        public void ImportCache_PerBatchWindow_DoesNotDependOnTheClock()
+        {
+            var a = ActivityImportCacheWindow.Resolve(true, OldestInBatch, NewestInBatch, 3, NowUtc);
+            var b = ActivityImportCacheWindow.Resolve(true, OldestInBatch, NewestInBatch, 3, NowUtc.AddYears(5));
+
+            Assert.AreEqual(a.FromUtc, b.FromUtc);
+            Assert.AreEqual(a.ToUtc, b.ToUtc);
+        }
+
+        [TestMethod]
+        public void ImportCache_RunWindow_IsDrivenByTheSuppliedInstantNotTheWallClock()
+        {
+            // Would fail if the rule ever read DateTime.UtcNow itself.
+            var pastInstant = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var window = ActivityImportCacheWindow.Resolve(false, OldestInBatch, NewestInBatch, 7, pastInstant);
+
+            Assert.AreEqual(pastInstant.AddDays(-8), window.FromUtc);
+            Assert.AreEqual(pastInstant.AddMinutes(2), window.ToUtc);
+        }
+
+        [TestMethod]
+        public void ImportCache_RunWindow_ZeroOrNegativeDownloadWindow_StillCoversAtLeastTwoDays()
+        {
+            // A misconfigured DaysBeforeNowToDownload must not collapse the cache to "now", which would make
+            // every already-imported event look new and re-stage the whole window.
+            foreach (var configured in new[] { 0, -1 })
+            {
+                var window = ActivityImportCacheWindow.Resolve(false, OldestInBatch, NewestInBatch, configured, NowUtc);
+                Assert.AreEqual(2, window.DaysBack, $"DaysBeforeNowToDownload={configured}");
+                Assert.AreEqual(NowUtc.AddDays(-2), window.FromUtc, $"DaysBeforeNowToDownload={configured}");
+            }
+        }
+
+        [TestMethod]
+        public void ImportCache_WindowIsPaddedOneMinuteEitherSide()
+        {
+            // EF6 maps DateTime to datetime2, whose precision differs from the datetime columns in the
+            // database, so an exact boundary comparison can miss edge values.
+            Assert.AreEqual(NowUtc.AddMinutes(-1), ActivityImportCacheWindow.PadFrom(NowUtc));
+            Assert.AreEqual(NowUtc.AddMinutes(1), ActivityImportCacheWindow.PadTo(NowUtc));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheWindowTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheWindowTests.cs
@@ -78,10 +78,14 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void ImportCache_WindowIsPaddedOneMinuteEitherSide()
+        public void ImportCache_PadHelpersWidenTheRangeByOneMinuteEitherSide()
         {
             // EF6 maps DateTime to datetime2, whose precision differs from the datetime columns in the
             // database, so an exact boundary comparison can miss edge values.
+            //
+            // Scope note: this pins the HELPERS. It does NOT pin the load path - deleting the PadFrom /
+            // PadTo calls in ActivityImportCache.GetAndBuildNewCache would leave this green, because that
+            // method opens a database. Covering it needs the cache provider port from #373 part 2.
             Assert.AreEqual(NowUtc.AddMinutes(-1), ActivityImportCacheWindow.PadFrom(NowUtc));
             Assert.AreEqual(NowUtc.AddMinutes(1), ActivityImportCacheWindow.PadTo(NowUtc));
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivitySaveConcurrencyPolicyTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivitySaveConcurrencyPolicyTests.cs
@@ -63,8 +63,11 @@ namespace Tests.UnitTests
             // ActivityImportConstants.STAGING_TABLE_ACTIVITY is a permanent "debug_"-prefixed table in DEBUG
             // builds. The sharded name has always been a "##" global temp table regardless of configuration,
             // which is what makes it visible to the merge on the same connection and self-cleaning. Deriving
-            // it from the constant would change that in one of the two configurations - and CI runs the suite
-            // in both Debug and Release, so between them this covers both.
+            // it from the constant would change that in one of the two configurations.
+            //
+            // Note this test only observes the configuration it is compiled in, and CI builds RELEASE ONLY
+            // (the Debug matrix entry is commented out in ci.yml / pr.yml / tests.yml) - so the DEBUG case
+            // is covered by local Debug runs, not by CI.
             var name = ActivitySaveConcurrencyPolicy.NewShardedStagingTableName();
             StringAssert.StartsWith(name, "##");
             StringAssert.StartsWith(name, ActivitySaveConcurrencyPolicy.ShardedStagingTablePrefix);

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivitySaveConcurrencyPolicyTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivitySaveConcurrencyPolicyTests.cs
@@ -9,12 +9,19 @@ namespace Tests.UnitTests
     /// The AUDIT_MAX_CONCURRENT_SAVES operator safety-valve, extracted by issue #373 so it is assertable
     /// without SQL Server. Default (1) is the original strictly-serial path against the single shared staging
     /// table; above 1 each save loads its own sharded staging table.
+    ///
+    /// Scope note: these tests cover the <b>policy</b>, which is what
+    /// <c>ActivityReportSqlPersistenceManager</c> now asks. They do not observe the manager choosing a
+    /// branch, taking the shared-write semaphore, or the merge SQL it emits - none of that is reachable
+    /// without SQL Server until the collaborator split (#373 part 2) puts the staging writer and save
+    /// session behind interfaces. #373's <c>Concurrency_ShardedMode_StillSerialisesSharedTableWrites</c>
+    /// belongs to that part, not this one.
     /// </summary>
     [TestClass]
     public class ActivitySaveConcurrencyPolicyTests
     {
         [TestMethod]
-        public void Concurrency_MaxConcurrentSavesOne_UsesSerialPathAndSharedStagingTable()
+        public void Concurrency_MaxConcurrentSavesOne_PolicySelectsSerialPathAndSharedStagingTable()
         {
             Assert.IsFalse(ActivitySaveConcurrencyPolicy.UseShardedStaging(1));
 
@@ -24,7 +31,7 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void Concurrency_UnsetOrInvalidMaxConcurrentSaves_FallsBackToTheSerialPath()
+        public void Concurrency_UnsetOrInvalidMaxConcurrentSaves_PolicyFallsBackToTheSerialPath()
         {
             // A bad app setting must degrade to the safe default rather than break the import.
             Assert.AreEqual(1, ActivitySaveConcurrencyPolicy.NormaliseMaxConcurrentSaves(0));
@@ -37,7 +44,7 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void Concurrency_MaxConcurrentSavesGreaterThanOne_UsesDistinctShardedStagingTablePerSave()
+        public void Concurrency_MaxConcurrentSavesGreaterThanOne_PolicyIssuesADistinctShardedStagingTablePerSave()
         {
             Assert.IsTrue(ActivitySaveConcurrencyPolicy.UseShardedStaging(2));
             Assert.IsTrue(ActivitySaveConcurrencyPolicy.UseShardedStaging(16));
@@ -51,19 +58,20 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void Concurrency_ShardedStagingTable_IsAGlobalTempTableInEveryBuildConfiguration()
+        public void Concurrency_ShardedStagingTable_IsAGlobalTempTableNotTheDebugStagingTable()
         {
             // ActivityImportConstants.STAGING_TABLE_ACTIVITY is a permanent "debug_"-prefixed table in DEBUG
             // builds. The sharded name has always been a "##" global temp table regardless of configuration,
             // which is what makes it visible to the merge on the same connection and self-cleaning. Deriving
-            // it from the constant would change that in one of the two configurations.
+            // it from the constant would change that in one of the two configurations - and CI runs the suite
+            // in both Debug and Release, so between them this covers both.
             var name = ActivitySaveConcurrencyPolicy.NewShardedStagingTableName();
             StringAssert.StartsWith(name, "##");
             StringAssert.StartsWith(name, ActivitySaveConcurrencyPolicy.ShardedStagingTablePrefix);
         }
 
         [TestMethod]
-        public void Concurrency_ShardedMode_MergeSqlIsPointedAtTheSavesOwnShard()
+        public void Concurrency_ShardedMode_PolicyPointsTheMergeSqlAtTheSavesOwnShard()
         {
             var shard = ActivitySaveConcurrencyPolicy.NewShardedStagingTableName();
             Assert.AreEqual(shard, ActivitySaveConcurrencyPolicy.EffectiveStagingTableName(shard));

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivitySaveConcurrencyPolicyTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivitySaveConcurrencyPolicyTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The AUDIT_MAX_CONCURRENT_SAVES operator safety-valve, extracted by issue #373 so it is assertable
+    /// without SQL Server. Default (1) is the original strictly-serial path against the single shared staging
+    /// table; above 1 each save loads its own sharded staging table.
+    /// </summary>
+    [TestClass]
+    public class ActivitySaveConcurrencyPolicyTests
+    {
+        [TestMethod]
+        public void Concurrency_MaxConcurrentSavesOne_UsesSerialPathAndSharedStagingTable()
+        {
+            Assert.IsFalse(ActivitySaveConcurrencyPolicy.UseShardedStaging(1));
+
+            // No shard => the merge SQL is pointed at the single shared staging table.
+            Assert.AreEqual(ActivityImportConstants.STAGING_TABLE_ACTIVITY,
+                ActivitySaveConcurrencyPolicy.EffectiveStagingTableName(null));
+        }
+
+        [TestMethod]
+        public void Concurrency_UnsetOrInvalidMaxConcurrentSaves_FallsBackToTheSerialPath()
+        {
+            // A bad app setting must degrade to the safe default rather than break the import.
+            Assert.AreEqual(1, ActivitySaveConcurrencyPolicy.NormaliseMaxConcurrentSaves(0));
+            Assert.AreEqual(1, ActivitySaveConcurrencyPolicy.NormaliseMaxConcurrentSaves(-5));
+            Assert.AreEqual(1, ActivitySaveConcurrencyPolicy.NormaliseMaxConcurrentSaves(1));
+            Assert.AreEqual(4, ActivitySaveConcurrencyPolicy.NormaliseMaxConcurrentSaves(4));
+
+            Assert.IsFalse(ActivitySaveConcurrencyPolicy.UseShardedStaging(0));
+            Assert.IsFalse(ActivitySaveConcurrencyPolicy.UseShardedStaging(-5));
+        }
+
+        [TestMethod]
+        public void Concurrency_MaxConcurrentSavesGreaterThanOne_UsesDistinctShardedStagingTablePerSave()
+        {
+            Assert.IsTrue(ActivitySaveConcurrencyPolicy.UseShardedStaging(2));
+            Assert.IsTrue(ActivitySaveConcurrencyPolicy.UseShardedStaging(16));
+
+            var names = new HashSet<string>();
+            for (var i = 0; i < 200; i++)
+            {
+                Assert.IsTrue(names.Add(ActivitySaveConcurrencyPolicy.NewShardedStagingTableName()),
+                    "Two concurrent saves sharing a staging table name would interleave rows into one table.");
+            }
+        }
+
+        [TestMethod]
+        public void Concurrency_ShardedStagingTable_IsAGlobalTempTableInEveryBuildConfiguration()
+        {
+            // ActivityImportConstants.STAGING_TABLE_ACTIVITY is a permanent "debug_"-prefixed table in DEBUG
+            // builds. The sharded name has always been a "##" global temp table regardless of configuration,
+            // which is what makes it visible to the merge on the same connection and self-cleaning. Deriving
+            // it from the constant would change that in one of the two configurations.
+            var name = ActivitySaveConcurrencyPolicy.NewShardedStagingTableName();
+            StringAssert.StartsWith(name, "##");
+            StringAssert.StartsWith(name, ActivitySaveConcurrencyPolicy.ShardedStagingTablePrefix);
+        }
+
+        [TestMethod]
+        public void Concurrency_ShardedMode_MergeSqlIsPointedAtTheSavesOwnShard()
+        {
+            var shard = ActivitySaveConcurrencyPolicy.NewShardedStagingTableName();
+            Assert.AreEqual(shard, ActivitySaveConcurrencyPolicy.EffectiveStagingTableName(shard));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityStagingRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityStagingRulesTests.cs
@@ -97,15 +97,20 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task Dedup_SameIdTwiceInOneSet_IsOnlyStagedOnce()
         {
-            var h = new Harness();
+            // Deliberately a user-out-of-scope event: that is the ONLY outcome the cache does not
+            // remember, so the second decision can only be caught by the in-set HashSet. With an imported
+            // event the cache would catch it and deleting decidedInThisSet.Add would go unnoticed.
+            var h = new Harness { UserInGroupsFilterResult = false };
             var id = Guid.NewGuid();
 
             var first = await h.DecideAsync(Event(id));
             var second = await h.DecideAsync(Event(id));
 
-            Assert.AreEqual(SaveResultEnum.Imported, first.Result);
+            Assert.AreEqual(SaveResultEnum.UserOutOfScope, first.Result);
+            Assert.IsFalse(h.Cache.HaveSeenInProcessedOrIgnoredEvents(Event(id)), "Precondition: this outcome is not cached.");
             Assert.IsTrue(second.IsDuplicate);
-            Assert.AreEqual(1, h.Staged.Count);
+            Assert.AreEqual(1, h.UserFilterCalls, "The repeated id must not be re-evaluated against the user filter.");
+            Assert.AreEqual(0, h.Staged.Count);
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityStagingRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityStagingRulesTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
@@ -143,8 +144,11 @@ namespace Tests.UnitTests
             Assert.IsFalse(decision.Staged);
             Assert.AreEqual(SaveResultEnum.UrlOutOfScope, decision.Result);
 
-            // An out-of-scope URL is a final decision: remembered as newly-ignored so it is written to
-            // ignored_audit_events and never reconsidered.
+            // Specifically the NEWLY-IGNORED bucket, not just "processed": asserting only
+            // HaveSeenInProcessedOrIgnoredEvents would still pass if the rule were changed to
+            // RememberProcessedEvent, which is a different fact about the event.
+            var newlyIgnored = h.Cache.GetIds(ActivityImportCache.CacheType.NewlyIgnored);
+            Assert.IsTrue(newlyIgnored.Any(chunk => chunk.ContainsKey(log.Id)));
             Assert.IsTrue(h.Cache.HaveSeenInProcessedOrIgnoredEvents(log));
 
             // ...and the user-groups lookup is never reached, so an out-of-scope site costs no Graph traffic.

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityStagingRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityStagingRulesTests.cs
@@ -1,0 +1,204 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The per-event audit-log staging decision, lifted out of ActivityReportSqlPersistenceManager by
+    /// issue #373. Runs with zero SQL Server and zero Graph: ActivityImportCache.GetEmptyCache() is a plain
+    /// in-memory object, and the org-URL filter and user-groups lookup are injected as delegates.
+    /// </summary>
+    [TestClass]
+    public class ActivityStagingRulesTests
+    {
+        private static AbstractAuditLogContent Event(Guid id, string upn = "someone@contoso.onmicrosoft.com")
+            => new AzureADAuditLogContent { Id = id, UserId = upn, CreationTime = new DateTime(2026, 3, 1, 9, 30, 0, DateTimeKind.Utc) };
+
+        /// <summary>Records every staged event plus how often each injected collaborator was consulted.</summary>
+        private class Harness
+        {
+            public readonly HashSet<Guid> DecidedInThisSet = new HashSet<Guid>();
+            public readonly List<AbstractAuditLogContent> Staged = new List<AbstractAuditLogContent>();
+            public int UrlFilterCalls;
+            public int UserFilterCalls;
+
+            public bool UrlInScopeResult = true;
+            public bool UserInGroupsFilterResult = true;
+
+            public ActivityImportCache Cache { get; } = ActivityImportCache.GetEmptyCache();
+
+            public Task<ActivityStagingDecision> DecideAsync(AbstractAuditLogContent log, HashSet<Guid> decidedInThisSet = null, Action<AbstractAuditLogContent> stageRow = null)
+            {
+                return ActivityStagingRules.DecideAndRememberAsync(
+                    log,
+                    decidedInThisSet ?? DecidedInThisSet,
+                    Cache,
+                    l => { UrlFilterCalls++; return UrlInScopeResult; },
+                    upn => { UserFilterCalls++; return Task.FromResult(UserInGroupsFilterResult); },
+                    stageRow ?? (l => Staged.Add(l)));
+            }
+        }
+
+        [TestMethod]
+        public async Task Dedup_NewEvent_IsImported()
+        {
+            var h = new Harness();
+            var log = Event(Guid.NewGuid());
+
+            var decision = await h.DecideAsync(log);
+
+            Assert.IsFalse(decision.IsDuplicate);
+            Assert.IsTrue(decision.Staged);
+            Assert.AreEqual(SaveResultEnum.Imported, decision.Result);
+            CollectionAssert.AreEqual(new List<AbstractAuditLogContent> { log }, h.Staged);
+            Assert.IsTrue(h.Cache.HaveSeenInProcessedOrIgnoredEvents(log), "An imported event must be remembered so a later batch does not stage it again.");
+        }
+
+        [TestMethod]
+        public async Task Dedup_EventAlreadyImported_IsSkipped()
+        {
+            var h = new Harness();
+            var log = Event(Guid.NewGuid());
+            h.Cache.RememberProcessedEvent(log);
+
+            var decision = await h.DecideAsync(log);
+
+            Assert.IsTrue(decision.IsDuplicate);
+            Assert.IsFalse(decision.Staged);
+            Assert.AreEqual(0, h.Staged.Count);
+
+            // The dedup check must short-circuit BEFORE the filters. The user-groups lookup is Graph-backed,
+            // so consulting it for an already-imported event would be an outbound call per duplicate - and a
+            // batch spans nearly the whole download window, so almost every event in it is a duplicate.
+            Assert.AreEqual(0, h.UrlFilterCalls);
+            Assert.AreEqual(0, h.UserFilterCalls);
+        }
+
+        [TestMethod]
+        public async Task Dedup_EventPreviouslyIgnored_IsSkipped()
+        {
+            var h = new Harness();
+            var log = Event(Guid.NewGuid());
+            h.Cache.RememberNewlyIgnoredEvent(log);
+
+            var decision = await h.DecideAsync(log);
+
+            Assert.IsTrue(decision.IsDuplicate);
+            Assert.AreEqual(0, h.UrlFilterCalls);
+            Assert.AreEqual(0, h.UserFilterCalls);
+        }
+
+        [TestMethod]
+        public async Task Dedup_SameIdTwiceInOneSet_IsOnlyStagedOnce()
+        {
+            var h = new Harness();
+            var id = Guid.NewGuid();
+
+            var first = await h.DecideAsync(Event(id));
+            var second = await h.DecideAsync(Event(id));
+
+            Assert.AreEqual(SaveResultEnum.Imported, first.Result);
+            Assert.IsTrue(second.IsDuplicate);
+            Assert.AreEqual(1, h.Staged.Count);
+        }
+
+        [TestMethod]
+        public async Task Dedup_CacheKeptCurrentAcrossBatches_SecondBatchSeesFirstBatchIds()
+        {
+            // The run-scoped cache is shared by every save batch of a cycle; the in-set HashSet is not.
+            var h = new Harness();
+            var log = Event(Guid.NewGuid());
+
+            var firstBatch = new HashSet<Guid>();
+            var secondBatch = new HashSet<Guid>();
+
+            var first = await h.DecideAsync(log, firstBatch);
+            var second = await h.DecideAsync(Event(log.Id), secondBatch);
+
+            Assert.AreEqual(SaveResultEnum.Imported, first.Result);
+            Assert.IsTrue(second.IsDuplicate, "The shared cache must carry the first batch's ids into the second batch.");
+            Assert.AreEqual(1, h.Staged.Count);
+        }
+
+        [TestMethod]
+        public async Task Dedup_UrlOutsideOrgUrlsWhitelist_IsCountedAsOutOfScopeAndRemembered()
+        {
+            var h = new Harness { UrlInScopeResult = false };
+            var log = Event(Guid.NewGuid());
+
+            var decision = await h.DecideAsync(log);
+
+            Assert.IsFalse(decision.IsDuplicate);
+            Assert.IsFalse(decision.Staged);
+            Assert.AreEqual(SaveResultEnum.UrlOutOfScope, decision.Result);
+
+            // An out-of-scope URL is a final decision: remembered as newly-ignored so it is written to
+            // ignored_audit_events and never reconsidered.
+            Assert.IsTrue(h.Cache.HaveSeenInProcessedOrIgnoredEvents(log));
+
+            // ...and the user-groups lookup is never reached, so an out-of-scope site costs no Graph traffic.
+            Assert.AreEqual(0, h.UserFilterCalls);
+        }
+
+        [TestMethod]
+        public async Task Dedup_UserOutsideGroupsFilter_IsNotRemembered_SoItIsReconsideredLater()
+        {
+            var h = new Harness { UserInGroupsFilterResult = false };
+            var log = Event(Guid.NewGuid());
+
+            var decision = await h.DecideAsync(log);
+
+            Assert.AreEqual(SaveResultEnum.UserOutOfScope, decision.Result);
+            Assert.IsFalse(decision.Staged);
+
+            // Deliberately asymmetric with the URL case: a user-filter miss is NOT written to the cache, so
+            // the same event is reconsidered on a later batch/cycle (e.g. after the group membership or the
+            // configured filter changes). Remembering it here would permanently suppress the event.
+            Assert.IsFalse(h.Cache.HaveSeenInProcessedOrIgnoredEvents(log));
+
+            // It is still recorded in the set, so it is not re-evaluated within this same set.
+            Assert.IsTrue(h.DecidedInThisSet.Contains(log.Id));
+        }
+
+        [TestMethod]
+        public async Task Dedup_StagingRowThatFailsToBuild_IsNotRememberedAsProcessed()
+        {
+            // The staging row is built before the event is remembered. If the row cannot be built the event
+            // must stay unknown to the cache, otherwise a retry of the batch would silently skip it.
+            var h = new Harness();
+            var log = Event(Guid.NewGuid());
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                h.DecideAsync(log, stageRow: l => throw new InvalidOperationException("staging row could not be built")));
+
+            Assert.IsFalse(h.Cache.HaveSeenInProcessedOrIgnoredEvents(log));
+            Assert.IsFalse(h.DecidedInThisSet.Contains(log.Id));
+        }
+
+        [TestMethod]
+        public async Task Dedup_UnicodeUpn_IsPassedToTheUserFilterUnchanged()
+        {
+            // UPNs are customer text and routinely non-Latin; the rules must not normalise or mangle them.
+            const string greekUpn = "καλημέρα@contoso.onmicrosoft.com";
+            string seenUpn = null;
+
+            var cache = ActivityImportCache.GetEmptyCache();
+            var log = Event(Guid.NewGuid(), greekUpn);
+
+            var decision = await ActivityStagingRules.DecideAndRememberAsync(
+                log, new HashSet<Guid>(), cache,
+                l => true,
+                upn => { seenUpn = upn; return Task.FromResult(true); },
+                l => { });
+
+            Assert.AreEqual(greekUpn, seenUpn);
+            Assert.AreEqual(SaveResultEnum.Imported, decision.Result);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotPrewarmExtractionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotPrewarmExtractionTests.cs
@@ -91,11 +91,12 @@ namespace Tests.UnitTests
 
         /// <summary>
         /// The extraction moved to CopilotPrewarmPolicy in issue #373; the manager keeps a thin wrapper so
-        /// existing call sites are unaffected. This pins that the wrapper actually delegates rather than
-        /// leaving a second, divergent copy of the context rules behind.
+        /// existing call sites are unaffected. This pins that the wrapper produces the same map - keys AND
+        /// values - as the policy for a non-trivial input, so a second, divergent copy of the context rules
+        /// left behind the wrapper would show up here.
         /// </summary>
         [TestMethod]
-        public void ManagerWrapperDelegatesToTheExtractedPolicy()
+        public void ManagerWrapperReturnsTheSameContextsAsThePolicy()
         {
             var url = "https://contoso.sharepoint.com/sites/x/Καλημέρα κόσμε.docx";
             var acts = new List<AbstractAuditLogContent>
@@ -107,9 +108,13 @@ namespace Tests.UnitTests
             var viaWrapper = ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts);
             var viaPolicy = CopilotPrewarmPolicy.ExtractFileContexts(acts);
 
-            CollectionAssert.AreEquivalent(viaWrapper.Keys, viaPolicy.Keys);
-            Assert.AreEqual(1, viaPolicy.Count);
-            Assert.AreEqual("καλημέρα@contoso.onmicrosoft.com", viaPolicy[url]);
+            Assert.AreEqual(1, viaWrapper.Count);
+            Assert.AreEqual("καλημέρα@contoso.onmicrosoft.com", viaWrapper[url], "The wrapper must not mangle a non-Latin UPN.");
+            CollectionAssert.AreEquivalent(viaPolicy.Keys, viaWrapper.Keys);
+            foreach (var kvp in viaPolicy)
+            {
+                Assert.AreEqual(kvp.Value, viaWrapper[kvp.Key]);
+            }
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotPrewarmExtractionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotPrewarmExtractionTests.cs
@@ -90,13 +90,13 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// The extraction moved to CopilotPrewarmPolicy in issue #373; the manager keeps a thin wrapper so
-        /// existing call sites are unaffected. This pins that the wrapper produces the same map - keys AND
-        /// values - as the policy for a non-trivial input, so a second, divergent copy of the context rules
-        /// left behind the wrapper would show up here.
+        /// The extraction moved to CopilotPrewarmPolicy in issue #373; the manager keeps a one-line
+        /// delegating wrapper. This does NOT try to prove delegation - with a one-line wrapper that
+        /// comparison is tautological - it pins the thing that could actually regress: non-Latin context
+        /// ids and UPNs surviving the wrapper unchanged.
         /// </summary>
         [TestMethod]
-        public void ManagerWrapperReturnsTheSameContextsAsThePolicy()
+        public void ManagerWrapper_KeepsNonLatinContextIdsAndUpnsIntact()
         {
             var url = "https://contoso.sharepoint.com/sites/x/Καλημέρα κόσμε.docx";
             var acts = new List<AbstractAuditLogContent>
@@ -106,15 +106,9 @@ namespace Tests.UnitTests
             };
 
             var viaWrapper = ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts);
-            var viaPolicy = CopilotPrewarmPolicy.ExtractFileContexts(acts);
 
             Assert.AreEqual(1, viaWrapper.Count);
-            Assert.AreEqual("καλημέρα@contoso.onmicrosoft.com", viaWrapper[url], "The wrapper must not mangle a non-Latin UPN.");
-            CollectionAssert.AreEquivalent(viaPolicy.Keys, viaWrapper.Keys);
-            foreach (var kvp in viaPolicy)
-            {
-                Assert.AreEqual(kvp.Value, viaWrapper[kvp.Key]);
-            }
+            Assert.AreEqual("καλημέρα@contoso.onmicrosoft.com", viaWrapper[url]);
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotPrewarmExtractionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotPrewarmExtractionTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
 using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 
@@ -86,6 +87,51 @@ namespace Tests.UnitTests
         {
             var acts = new List<AbstractAuditLogContent> { new SharePointAuditLogContent() };
             Assert.AreEqual(0, ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts).Count);
+        }
+
+        /// <summary>
+        /// The extraction moved to CopilotPrewarmPolicy in issue #373; the manager keeps a thin wrapper so
+        /// existing call sites are unaffected. This pins that the wrapper actually delegates rather than
+        /// leaving a second, divergent copy of the context rules behind.
+        /// </summary>
+        [TestMethod]
+        public void ManagerWrapperDelegatesToTheExtractedPolicy()
+        {
+            var url = "https://contoso.sharepoint.com/sites/x/Καλημέρα κόσμε.docx";
+            var acts = new List<AbstractAuditLogContent>
+            {
+                CopilotEvent("καλημέρα@contoso.onmicrosoft.com", Chat("19:chat@thread.v2"), File(url)),
+                CopilotEvent("b@contoso.com", Meeting("19:meeting@thread.v2"), File("https://contoso.sharepoint.com/sites/x/b.docx"))
+            };
+
+            var viaWrapper = ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts(acts);
+            var viaPolicy = CopilotPrewarmPolicy.ExtractFileContexts(acts);
+
+            CollectionAssert.AreEquivalent(viaWrapper.Keys, viaPolicy.Keys);
+            Assert.AreEqual(1, viaPolicy.Count);
+            Assert.AreEqual("καλημέρα@contoso.onmicrosoft.com", viaPolicy[url]);
+        }
+
+        [TestMethod]
+        public void PrewarmIsSkippedWhenCopilotResourceResolutionIsDisabled()
+        {
+            // With resolution off the save path makes no Graph resource calls at all, so warming would be
+            // pure outbound Graph traffic for a cache nothing reads.
+            Assert.IsFalse(CopilotPrewarmPolicy.ShouldPrewarm(hasSharedLoader: true, resolveCopilotResourceMetadata: false));
+        }
+
+        [TestMethod]
+        public void PrewarmIsSkippedWhenTheSharedLoaderCouldNotBeBuilt()
+        {
+            // Building the run-scoped loader is best-effort (no Graph credentials in a test, for instance).
+            Assert.IsFalse(CopilotPrewarmPolicy.ShouldPrewarm(hasSharedLoader: false, resolveCopilotResourceMetadata: true));
+            Assert.IsFalse(CopilotPrewarmPolicy.ShouldPrewarm(hasSharedLoader: false, resolveCopilotResourceMetadata: false));
+        }
+
+        [TestMethod]
+        public void PrewarmRunsWhenThereIsALoaderAndResolutionIsEnabled()
+        {
+            Assert.IsTrue(CopilotPrewarmPolicy.ShouldPrewarm(hasSharedLoader: true, resolveCopilotResourceMetadata: true));
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -118,9 +118,12 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActivityImportCacheWindowTests.cs" />
     <Compile Include="ActivityImporterTests.cs" />
     <Compile Include="ActivityReportLoaderTimeoutTests.cs" />
     <Compile Include="ActivityReportSetMinMaxTests.cs" />
+    <Compile Include="ActivitySaveConcurrencyPolicyTests.cs" />
+    <Compile Include="ActivityStagingRulesTests.cs" />
     <Compile Include="AppInsightsConnectionStringParserTests.cs" />
     <Compile Include="AppInsightsKqlGetWhereStringTests.cs" />
     <Compile Include="AppInsightsImportWindowTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 using WebJob.Office365ActivityImporter.Engine.Graph.User;
@@ -32,6 +33,7 @@ namespace WebJob.Office365ActivityImporter.Engine
         private readonly UserGroupsCache _userGroupsCache;
         private readonly ILogger _logger;
         private readonly AppConfig _appConfig;
+        private readonly IClock _clock;
         private string _defaultConnectionString = null;
         private UserGroupsFilterModel _userGroupsFilter = null;
 
@@ -82,16 +84,17 @@ namespace WebJob.Office365ActivityImporter.Engine
         // How many Copilot file contexts to resolve concurrently while pre-warming the cache (outside the SQL lock).
         private const int PrewarmConcurrency = 8;
 
-        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves = 1, bool usePerBatchDedupCache = false)
+        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves = 1, bool usePerBatchDedupCache = false, IClock clock = null)
         {
             _filterConfig = filterConfig;
             _userGroupsCache = userGroupsCache;
             _logger = logger;
             _appConfig = appConfig;
+            _clock = clock ?? SystemClock.Instance;
             _userGroupsFilter = new UserGroupsFilterModel(appConfig.UserGroupsFilter);
-            _maxConcurrentSaves = Math.Max(1, maxConcurrentSaves);
+            _maxConcurrentSaves = ActivitySaveConcurrencyPolicy.NormaliseMaxConcurrentSaves(maxConcurrentSaves);
             _usePerBatchDedupCache = usePerBatchDedupCache;
-            if (_maxConcurrentSaves > 1)
+            if (ActivitySaveConcurrencyPolicy.UseShardedStaging(_maxConcurrentSaves))
             {
                 _saveConcurrencyGate = new SemaphoreSlim(_maxConcurrentSaves, _maxConcurrentSaves);
             }
@@ -108,9 +111,12 @@ namespace WebJob.Office365ActivityImporter.Engine
                 // re-querying audit_events for every batch. The per-batch reload materialised ~the whole
                 // in-window event set each time because a batch spans nearly the whole window. See the field
                 // comment on _runImportCache. The AUDIT_PERBATCH_DEDUP_CACHE safety-valve restores the old path.
-                var cache = _usePerBatchDedupCache
-                    ? ActivityImportCache.GetAndBuildNewCache(activities.OldestContent, activities.NewestContent)
-                    : await GetOrBuildRunImportCacheAsync();
+                var cacheWindow = ActivityImportCacheWindow.Resolve(_usePerBatchDedupCache, activities.OldestContent,
+                    activities.NewestContent, _appConfig.DaysBeforeNowToDownload, _clock.UtcNow);
+
+                var cache = cacheWindow.Scope == ActivityDedupCacheScope.PerBatch
+                    ? ActivityImportCache.GetAndBuildNewCache(cacheWindow.FromUtc, cacheWindow.ToUtc)
+                    : await GetOrBuildRunImportCacheAsync(cacheWindow);
 
                 // Read default connection-string
                 if (string.IsNullOrEmpty(_defaultConnectionString))
@@ -145,12 +151,12 @@ namespace WebJob.Office365ActivityImporter.Engine
             // Graph resource calls in that mode (every Copilot event is staged agent-metadata-only), so there
             // is nothing to warm.
             var sharedLoader = await GetSharedCopilotLoaderAsync();
-            if (sharedLoader != null && _appConfig.ResolveCopilotResourceMetadata)
+            if (CopilotPrewarmPolicy.ShouldPrewarm(sharedLoader != null, _appConfig.ResolveCopilotResourceMetadata))
             {
                 await PrewarmCopilotFileMetadataAsync(activities, sharedLoader);
             }
 
-            if (_maxConcurrentSaves == 1)
+            if (!ActivitySaveConcurrencyPolicy.UseShardedStaging(_maxConcurrentSaves))
             {
                 // Default (serial) mode: one save at a time, using the shared staging table. Exactly the
                 // original behaviour - the whole save (staging create + load + merge + metadata) is
@@ -181,7 +187,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                 await _saveConcurrencyGate.WaitAsync();
                 try
                 {
-                    var shardedStagingTable = "##import_staging_event_lookups_" + Guid.NewGuid().ToString("N");
+                    var shardedStagingTable = ActivitySaveConcurrencyPolicy.NewShardedStagingTableName();
                     using (var con = new SqlConnection(_defaultConnectionString))
                     {
                         con.Open();
@@ -203,13 +209,17 @@ namespace WebJob.Office365ActivityImporter.Engine
 
         /// <summary>
         /// Lazily build the run-scoped dedup cache ONCE per import cycle (this manager is created per cycle),
-        /// covering the whole download window [now - DaysBeforeNowToDownload, now]. Every event processed this
+        /// over the window resolved by <see cref="ActivityImportCacheWindow"/>. Every event processed this
         /// cycle has a CreationTime inside that window (the API only serves it there) and the cache is keyed by
         /// event id, so a single full-window load is equivalent to the old per-batch [Min,Max] loads - without
         /// the massive redundancy. Kept current thereafter in-memory by RememberProcessedEvent /
         /// RememberNewlyIgnoredEvent as batches save. Thread-safe (double-checked init + a thread-safe cache).
+        ///
+        /// The window is supplied by the caller (resolved on entry to CommitAll) rather than computed here, so
+        /// the rule is a pure function of the clock and the configured download window. Once built, later
+        /// calls return the same cache and their window argument is ignored.
         /// </summary>
-        private async Task<ActivityImportCache> GetOrBuildRunImportCacheAsync()
+        private async Task<ActivityImportCache> GetOrBuildRunImportCacheAsync(ActivityDedupCacheWindow window)
         {
             if (_runImportCacheBuilt) return _runImportCache;
             await _runImportCacheInitLock.WaitAsync();
@@ -217,19 +227,13 @@ namespace WebJob.Office365ActivityImporter.Engine
             {
                 if (!_runImportCacheBuilt)
                 {
-                    // +1 day of lower margin so an event created just outside the exact window boundary (the
-                    // download window is computed slightly earlier, at cycle start) can never be missed.
-                    var daysBack = Math.Max(_appConfig.DaysBeforeNowToDownload, 1) + 1;
-                    var cacheFrom = DateTime.UtcNow.AddDays(-daysBack);
-                    var cacheTo = DateTime.UtcNow.AddMinutes(2);
-
                     var sw = System.Diagnostics.Stopwatch.StartNew();
-                    var built = ActivityImportCache.GetAndBuildNewCache(cacheFrom, cacheTo);
+                    var built = ActivityImportCache.GetAndBuildNewCache(window.FromUtc, window.ToUtc);
                     sw.Stop();
 
                     _logger.LogInformation($"Audit events import: built run dedup cache from audit_events in " +
                         $"{sw.Elapsed.TotalSeconds.ToString("n1")}s ({built.ProcessedIdCount.ToString("n0")} already-processed id(s), " +
-                        $"{daysBack}-day window) - reused across all save batches this cycle instead of reloading per batch.");
+                        $"{window.DaysBack}-day window) - reused across all save batches this cycle instead of reloading per batch.");
 
                     _runImportCache = built;
                     _runImportCacheBuilt = true;
@@ -285,7 +289,7 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// </summary>
         private async Task PrewarmCopilotFileMetadataAsync(ActivityReportSet activities, ICopilotMetadataLoader loader)
         {
-            var fileContexts = ExtractCopilotFileContexts(activities);
+            var fileContexts = CopilotPrewarmPolicy.ExtractFileContexts(activities);
             if (fileContexts.Count == 0) return;
 
             using (var throttle = new SemaphoreSlim(PrewarmConcurrency))
@@ -311,38 +315,12 @@ namespace WebJob.Office365ActivityImporter.Engine
         }
 
         /// <summary>
-        /// The distinct (fileContextId -> eventUpn) map to pre-resolve for a batch. Mirrors
-        /// <c>CopilotAuditEventManager</c>: only the first file-type context per event is used; a Teams meeting
-        /// context ends file processing for that event; Teams chat contexts are additive (not files).
+        /// The distinct (fileContextId -> eventUpn) map to pre-resolve for a batch. Thin wrapper kept so
+        /// existing call sites and tests are unaffected; the rule itself lives in
+        /// <see cref="CopilotPrewarmPolicy.ExtractFileContexts"/>.
         /// </summary>
         internal static Dictionary<string, string> ExtractCopilotFileContexts(IEnumerable<AbstractAuditLogContent> activities)
-        {
-            var fileContexts = new Dictionary<string, string>();
-            foreach (var copilot in activities.OfType<CopilotAuditLogContent>())
-            {
-                var contexts = copilot.CopilotEventData?.Contexts;
-                if (contexts == null) continue;
-                foreach (var context in contexts)
-                {
-                    if (context == null) continue;
-                    // Type is checked before the id guard so a (typically non-null) meeting/chat context
-                    // controls flow exactly as CopilotAuditEventManager does, even if its id were null.
-                    if (context.Type == ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING) break;   // meeting ends file/meeting processing
-                    if (context.Type == ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_CHAT) continue;   // chat is additive, not a file
-                    // First file-type context for this event (a null-id file resolves to nothing, so skip it but still stop).
-                    // Also skip contexts Graph can never resolve (local C:\ / UNC / DataAgent) so the concurrent
-                    // prewarm doesn't fire a guaranteed-miss round-trip for each one (mirrors TryAddFileAsync).
-                    if (context.Id != null
-                        && !CopilotAuditEventManager.ShouldSkipGraphFileLookup(context.Id)
-                        && !fileContexts.ContainsKey(context.Id))
-                    {
-                        fileContexts[context.Id] = copilot.UserId;
-                    }
-                    break;
-                }
-            }
-            return fileContexts;
-        }
+            => CopilotPrewarmPolicy.ExtractFileContexts(activities);
 
         /// <summary>
         /// Fill up staging table & return import result
@@ -363,31 +341,23 @@ namespace WebJob.Office365ActivityImporter.Engine
             var swDedup = System.Diagnostics.Stopwatch.StartNew();
             foreach (var abtractLog in activities)
             {
-                // Don't insert duplicates in same set
-                if (!processedIds.Contains(abtractLog.Id) && !cache.HaveSeenInProcessedOrIgnoredEvents(abtractLog))
-                {
-                    var result = SaveResultEnum.NotSaved;
-                    if (_filterConfig.InScope(abtractLog))
-                    {
-                        if (await _userGroupsCache.IsInGroupsFilter(abtractLog.UserId, _userGroupsFilter))
-                        {
-                            logsToInsert.Rows.Add(new AuditLogTempEntity(abtractLog, abtractLog.UserId));
+                // Don't insert duplicates in same set. The decision itself (dedup -> URL scope -> user
+                // scope, plus what gets remembered where) lives in ActivityStagingRules so it can be
+                // asserted with no SQL and no Graph; see issue #373.
+                var decision = await ActivityStagingRules.DecideAndRememberAsync(
+                    abtractLog,
+                    processedIds,
+                    cache,
+                    log => _filterConfig.InScope(log),
+                    upn => _userGroupsCache.IsInGroupsFilter(upn, _userGroupsFilter),
+                    log => logsToInsert.Rows.Add(new AuditLogTempEntity(log, log.UserId)));
 
-                            // Remember we've done this one now
-                            cache.RememberProcessedEvent(abtractLog);
-                            result = SaveResultEnum.Imported;
-                        }
-                        else
-                        {
-                            result = SaveResultEnum.UserOutOfScope;
-                            _logger.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
-                        }
-                    }
-                    else
+                if (!decision.IsDuplicate)
+                {
+                    var result = decision.Result;
+                    if (result == SaveResultEnum.UserOutOfScope)
                     {
-                        // No URL
-                        cache.RememberNewlyIgnoredEvent(abtractLog);
-                        result = SaveResultEnum.UrlOutOfScope;
+                        _logger.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
                     }
 
                     // Update stats
@@ -400,8 +370,6 @@ namespace WebJob.Office365ActivityImporter.Engine
                     else if (result == SaveResultEnum.UrlOutOfScope) stats.URLsOutOfScope++;
                     else if (result == SaveResultEnum.UserOutOfScope) stats.UsersOutOfScope++;
                     else _logger.LogError($"Unexpected log result for log {abtractLog.Id}");
-
-                    processedIds.Add(abtractLog.Id);
                 }
             }
             swDedup.Stop();
@@ -414,7 +382,7 @@ namespace WebJob.Office365ActivityImporter.Engine
             // Merge to normal tables. In concurrent mode each save has its own sharded staging table
             // (stagingTableName) and mergeLock serialises ONLY the merge (which writes shared lookup/fact
             // tables); the parallel staging LOAD inside SaveToStagingTable runs unlocked.
-            var effectiveStagingTable = stagingTableName ?? ActivityImportConstants.STAGING_TABLE_ACTIVITY;
+            var effectiveStagingTable = ActivitySaveConcurrencyPolicy.EffectiveStagingTableName(stagingTableName);
             var mergeSQL = Resources.Insert_Activity_from_Staging_Table.Replace("${STAGING_TABLE_ACTIVITY}", effectiveStagingTable);
             var swMerge = System.Diagnostics.Stopwatch.StartNew();
             await logsToInsert.SaveToStagingTable(10000, mergeSQL, stagingTableName, mergeLock);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -84,7 +84,18 @@ namespace WebJob.Office365ActivityImporter.Engine
         // How many Copilot file contexts to resolve concurrently while pre-warming the cache (outside the SQL lock).
         private const int PrewarmConcurrency = 8;
 
-        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves = 1, bool usePerBatchDedupCache = false, IClock clock = null)
+        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves = 1, bool usePerBatchDedupCache = false)
+            : this(filterConfig, userGroupsCache, logger, appConfig, maxConcurrentSaves, usePerBatchDedupCache, null)
+        {
+        }
+
+        /// <summary>
+        /// As above, with the clock supplied (issue #368). The original signature is kept as a delegating
+        /// overload rather than gaining an optional parameter: optional arguments are filled in by the
+        /// compiler, so widening the existing constructor would be a binary-breaking change for any already
+        /// compiled caller.
+        /// </summary>
+        public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves, bool usePerBatchDedupCache, IClock clock)
         {
             _filterConfig = filterConfig;
             _userGroupsCache = userGroupsCache;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -339,18 +339,21 @@ namespace WebJob.Office365ActivityImporter.Engine
             // (summed) across batches in ImportStat.AddStats; in concurrent-save mode the merge/metadata are
             // serialised by mergeLock so their summed times approximate the real serialised wall-time.
             var swDedup = System.Diagnostics.Stopwatch.StartNew();
+
+            // Hoisted out of the loop: all three capture only loop-invariant state, and Roslyn does not
+            // cache capturing lambdas, so building them per event would allocate three delegates for every
+            // one of the batch's events.
+            Func<AbstractAuditLogContent, bool> urlInScope = log => _filterConfig.InScope(log);
+            Func<string, Task<bool>> userInGroupsFilter = upn => _userGroupsCache.IsInGroupsFilter(upn, _userGroupsFilter);
+            Action<AbstractAuditLogContent> stageRow = log => logsToInsert.Rows.Add(new AuditLogTempEntity(log, log.UserId));
+
             foreach (var abtractLog in activities)
             {
                 // Don't insert duplicates in same set. The decision itself (dedup -> URL scope -> user
                 // scope, plus what gets remembered where) lives in ActivityStagingRules so it can be
                 // asserted with no SQL and no Graph; see issue #373.
                 var decision = await ActivityStagingRules.DecideAndRememberAsync(
-                    abtractLog,
-                    processedIds,
-                    cache,
-                    log => _filterConfig.InScope(log),
-                    upn => _userGroupsCache.IsInGroupsFilter(upn, _userGroupsFilter),
-                    log => logsToInsert.Rows.Add(new AuditLogTempEntity(log, log.UserId)));
+                    abtractLog, processedIds, cache, urlInScope, userInGroupsFilter, stageRow);
 
                 if (!decision.IsDuplicate)
                 {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivityImportCacheWindow.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivityImportCacheWindow.cs
@@ -1,0 +1,114 @@
+using System;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules
+{
+    /// <summary>
+    /// Which de-duplication cache an audit-log save batch uses.
+    /// </summary>
+    public enum ActivityDedupCacheScope
+    {
+        /// <summary>
+        /// Default. One cache covering the whole download window, built once for the import cycle and kept
+        /// current in memory as batches commit.
+        /// </summary>
+        PerRun,
+
+        /// <summary>
+        /// The <c>AUDIT_PERBATCH_DEDUP_CACHE</c> safety-valve: rebuild the cache for every batch, over just
+        /// that batch's own [oldest, newest] span. Restores the pre-optimisation behaviour without a
+        /// redeploy.
+        /// </summary>
+        PerBatch
+    }
+
+    /// <summary>
+    /// The window of <c>audit_events</c> / <c>ignored_audit_events</c> a de-duplication cache is loaded for.
+    /// </summary>
+    public sealed class ActivityDedupCacheWindow
+    {
+        internal ActivityDedupCacheWindow(DateTime fromUtc, DateTime toUtc, ActivityDedupCacheScope scope, int daysBack)
+        {
+            FromUtc = fromUtc;
+            ToUtc = toUtc;
+            Scope = scope;
+            DaysBack = daysBack;
+        }
+
+        public DateTime FromUtc { get; }
+        public DateTime ToUtc { get; }
+        public ActivityDedupCacheScope Scope { get; }
+
+        /// <summary>
+        /// How many days back a per-run window reaches. Reported in the operator-facing "built run dedup
+        /// cache" log line. Zero for a per-batch window, where the span comes from the batch itself.
+        /// </summary>
+        public int DaysBack { get; }
+    }
+
+    /// <summary>
+    /// The de-duplication cache window rules for the audit-log import, extracted from
+    /// <c>ActivityReportSqlPersistenceManager</c> so both the <c>AUDIT_PERBATCH_DEDUP_CACHE</c> safety-valve
+    /// and the window padding can be asserted with no SQL Server and no wall clock. See issue #373.
+    ///
+    /// Follows the <c>ImportCadenceGate.ShouldRun(..., DateTime nowUtc)</c> convention: the instant is a
+    /// parameter, not an <c>IClock</c> dependency.
+    /// </summary>
+    public static class ActivityImportCacheWindow
+    {
+        /// <summary>
+        /// Extra lower margin, in days, on the per-run window. The download window is computed slightly
+        /// earlier (at cycle start) than the cache is built, so a day of slack guarantees an event created
+        /// just outside the exact boundary can never be missed.
+        /// </summary>
+        public const int RunWindowLowerMarginDays = 1;
+
+        /// <summary>
+        /// Upper margin on the per-run window, covering events created between the cache being built and the
+        /// batch being processed.
+        /// </summary>
+        public static readonly TimeSpan RunWindowUpperMargin = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// Padding applied to any cache-load range. EF6 maps <c>DateTime</c> to <c>datetime2</c>, whose
+        /// precision differs from the <c>datetime</c> columns actually in the database, so an exact boundary
+        /// comparison can miss edge values. A minute either side is cheaper than migrating every date column.
+        /// </summary>
+        public static readonly TimeSpan DateTime2EdgePadding = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// Which cache to load, and over what range, for a save batch.
+        /// </summary>
+        /// <param name="usePerBatchDedupCache">The <c>AUDIT_PERBATCH_DEDUP_CACHE</c> safety-valve.</param>
+        /// <param name="oldestContentUtc">Oldest <c>CreationTime</c> in the batch (per-batch mode only).</param>
+        /// <param name="newestContentUtc">Newest <c>CreationTime</c> in the batch (per-batch mode only).</param>
+        /// <param name="daysBeforeNowToDownload">The configured download window, in days.</param>
+        /// <param name="nowUtc">The current instant, passed in rather than read.</param>
+        public static ActivityDedupCacheWindow Resolve(bool usePerBatchDedupCache, DateTime oldestContentUtc, DateTime newestContentUtc,
+            int daysBeforeNowToDownload, DateTime nowUtc)
+        {
+            if (usePerBatchDedupCache)
+            {
+                return new ActivityDedupCacheWindow(oldestContentUtc, newestContentUtc, ActivityDedupCacheScope.PerBatch, 0);
+            }
+
+            // Every event processed this cycle has a CreationTime inside the download window (the API only
+            // serves it there) and the cache is keyed by event id, so one full-window load is equivalent to
+            // the old per-batch [Min,Max] loads - without the redundancy of reloading almost the whole
+            // in-window event set on every batch.
+            var daysBack = Math.Max(daysBeforeNowToDownload, 1) + RunWindowLowerMarginDays;
+            return new ActivityDedupCacheWindow(nowUtc.AddDays(-daysBack), nowUtc.Add(RunWindowUpperMargin),
+                ActivityDedupCacheScope.PerRun, daysBack);
+        }
+
+        /// <summary>
+        /// Lower bound of a cache load, widened by <see cref="DateTime2EdgePadding"/>. Applied when the cache
+        /// is actually loaded, to both scopes.
+        /// </summary>
+        public static DateTime PadFrom(DateTime fromUtc) => fromUtc.Subtract(DateTime2EdgePadding);
+
+        /// <summary>
+        /// Upper bound of a cache load, widened by <see cref="DateTime2EdgePadding"/>.
+        /// </summary>
+        public static DateTime PadTo(DateTime toUtc) => toUtc.Add(DateTime2EdgePadding);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivitySaveConcurrencyPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivitySaveConcurrencyPolicy.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules
+{
+    /// <summary>
+    /// The concurrency safety-valve for the audit-log save path (app setting
+    /// <c>AUDIT_MAX_CONCURRENT_SAVES</c>). Decides, from that one number, whether a save runs on the
+    /// original strictly-serial path against the shared staging table, or on the opt-in sharded path where
+    /// several saves build their own staging table in parallel and only the shared-table writes (the merge
+    /// and the metadata pass) are serialised.
+    ///
+    /// Extracted from <c>ActivityReportSqlPersistenceManager</c> so the valve is assertable without SQL
+    /// Server. See issue #373.
+    /// </summary>
+    public static class ActivitySaveConcurrencyPolicy
+    {
+        /// <summary>
+        /// Prefix of a per-save (sharded) staging table. A global temp table (<c>##</c>) so it is visible to
+        /// the merge running on the same connection and is dropped when that session ends.
+        ///
+        /// Note this is deliberately NOT derived from <c>ActivityImportConstants.STAGING_TABLE_ACTIVITY</c>,
+        /// which is a <c>debug_</c>-prefixed permanent table in DEBUG builds. The sharded name has always
+        /// been the literal below in every configuration; keeping it literal preserves that exactly.
+        /// </summary>
+        public const string ShardedStagingTablePrefix = "##import_staging_event_lookups_";
+
+        /// <summary>
+        /// The configured value clamped to something usable. Anything below 1 (unset, zero, negative) means
+        /// the default single-threaded behaviour rather than an error, so a bad app setting can never stop
+        /// the import.
+        /// </summary>
+        public static int NormaliseMaxConcurrentSaves(int configuredMaxConcurrentSaves)
+        {
+            return Math.Max(1, configuredMaxConcurrentSaves);
+        }
+
+        /// <summary>
+        /// True when saves get their own sharded staging table and the shared-table writes need the
+        /// shared-write lock. False - the default - is the original strictly-serial path.
+        /// </summary>
+        public static bool UseShardedStaging(int maxConcurrentSaves)
+        {
+            return NormaliseMaxConcurrentSaves(maxConcurrentSaves) > 1;
+        }
+
+        /// <summary>
+        /// A fresh staging-table name for one save. Unique per call, because the whole point of the sharded
+        /// path is that concurrent saves must not load into the same table.
+        /// </summary>
+        public static string NewShardedStagingTableName()
+        {
+            return ShardedStagingTablePrefix + Guid.NewGuid().ToString("N");
+        }
+
+        /// <summary>
+        /// The staging table the merge SQL should be pointed at: the save's own shard when there is one,
+        /// otherwise the single shared staging table.
+        /// </summary>
+        public static string EffectiveStagingTableName(string shardedStagingTableName)
+        {
+            return shardedStagingTableName ?? ActivityImportConstants.STAGING_TABLE_ACTIVITY;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivityStagingRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivityStagingRules.cs
@@ -78,8 +78,11 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules
         ///
         /// <list type="number">
         /// <item>already decided in this set, or already in the cache -> skip entirely (no stats, no logging);</item>
-        /// <item>URL out of scope -> remember as newly-ignored (so it is not reconsidered, and so it reaches
-        ///       <c>ignored_audit_events</c>) and report <see cref="SaveResultEnum.UrlOutOfScope"/>;</item>
+        /// <item>URL out of scope -> remember in the newly-ignored bucket (which also marks it processed, so
+        ///       it is not reconsidered for the rest of this import cycle) and report
+        ///       <see cref="SaveResultEnum.UrlOutOfScope"/>. Note the newly-ignored bucket is currently
+        ///       in-memory only: <c>ActivityImportCache.SaveNewlyIgnoredEvents</c>, which would write it to
+        ///       <c>ignored_audit_events</c>, has no caller anywhere in the solution;</item>
         /// <item>URL in scope but user outside the groups filter -> report
         ///       <see cref="SaveResultEnum.UserOutOfScope"/> and remember <b>nothing</b>. That asymmetry is
         ///       existing behaviour, preserved deliberately;</item>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivityStagingRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivityStagingRules.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules
+{
+    /// <summary>
+    /// What the staging rules decided for a single audit event. Previously these outcomes only existed as a
+    /// local <see cref="SaveResultEnum"/> variable inside <c>ActivityReportSqlPersistenceManager</c>, so the
+    /// only way to observe them was to run the whole SQL save. See issue #373.
+    /// </summary>
+    public sealed class ActivityStagingDecision
+    {
+        private ActivityStagingDecision(bool isDuplicate, bool staged, SaveResultEnum result)
+        {
+            IsDuplicate = isDuplicate;
+            Staged = staged;
+            Result = result;
+        }
+
+        /// <summary>
+        /// The event was already decided earlier in this activity set, or is already in the de-duplication
+        /// cache (imported or ignored on a previous batch/cycle). Nothing was staged, nothing was
+        /// remembered, and - deliberately - no statistic was incremented; that is the existing behaviour.
+        /// </summary>
+        public static readonly ActivityStagingDecision Duplicate =
+            new ActivityStagingDecision(true, false, SaveResultEnum.NotSaved);
+
+        internal static ActivityStagingDecision Imported() => new ActivityStagingDecision(false, true, SaveResultEnum.Imported);
+        internal static ActivityStagingDecision UserOutOfScope() => new ActivityStagingDecision(false, false, SaveResultEnum.UserOutOfScope);
+        internal static ActivityStagingDecision UrlOutOfScope() => new ActivityStagingDecision(false, false, SaveResultEnum.UrlOutOfScope);
+
+        /// <summary>True when the event was skipped as an already-seen id (no staging, no stats).</summary>
+        public bool IsDuplicate { get; }
+
+        /// <summary>True when the event was handed to the staging callback.</summary>
+        public bool Staged { get; }
+
+        /// <summary>The outcome the caller records against <c>ImportStat</c>.</summary>
+        public SaveResultEnum Result { get; }
+    }
+
+    /// <summary>
+    /// The per-event decision on the audit-log staging path: in-set de-duplication, the run/batch
+    /// de-duplication cache, the SharePoint org-URL whitelist and the optional user-groups filter, plus the
+    /// in-memory bookkeeping that keeps the cache current as batches commit.
+    ///
+    /// Lifted verbatim out of <c>ActivityReportSqlPersistenceManager.SaveToSqlAllTheThings</c> so it can be
+    /// asserted without SQL Server or Graph (see issue #373). The two collaborators that do touch the outside
+    /// world - the org-URL filter and the user-groups lookup - are injected as delegates, which keeps the
+    /// original short-circuiting intact: the (potentially Graph-backed) user lookup is still only reached for
+    /// an event whose URL is already in scope, and neither is reached for a duplicate.
+    ///
+    /// <see cref="ActivityImportCache"/> is a plain in-memory object for the members used here
+    /// (<c>HaveSeenInProcessedOrIgnoredEvents</c> / <c>RememberProcessedEvent</c> /
+    /// <c>RememberNewlyIgnoredEvent</c>), so a test can use <c>ActivityImportCache.GetEmptyCache()</c> and
+    /// stay entirely off the database.
+    /// </summary>
+    public static class ActivityStagingRules
+    {
+        /// <summary>
+        /// Has this event already been decided - either earlier in this same activity set, or on a previous
+        /// batch/cycle (the de-duplication cache holds both imported and ignored ids)?
+        /// </summary>
+        public static bool IsAlreadyProcessed(AbstractAuditLogContent log, HashSet<Guid> decidedInThisSet, ActivityImportCache cache)
+        {
+            if (log == null) throw new ArgumentNullException(nameof(log));
+            if (decidedInThisSet == null) throw new ArgumentNullException(nameof(decidedInThisSet));
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+
+            return decidedInThisSet.Contains(log.Id) || cache.HaveSeenInProcessedOrIgnoredEvents(log);
+        }
+
+        /// <summary>
+        /// Decide what happens to one event and apply the in-memory bookkeeping, in exactly the order the
+        /// original loop used:
+        ///
+        /// <list type="number">
+        /// <item>already decided in this set, or already in the cache -> skip entirely (no stats, no logging);</item>
+        /// <item>URL out of scope -> remember as newly-ignored (so it is not reconsidered, and so it reaches
+        ///       <c>ignored_audit_events</c>) and report <see cref="SaveResultEnum.UrlOutOfScope"/>;</item>
+        /// <item>URL in scope but user outside the groups filter -> report
+        ///       <see cref="SaveResultEnum.UserOutOfScope"/> and remember <b>nothing</b>. That asymmetry is
+        ///       existing behaviour, preserved deliberately;</item>
+        /// <item>otherwise stage the row first, then remember it as processed.</item>
+        /// </list>
+        ///
+        /// The id is added to <paramref name="decidedInThisSet"/> for every non-duplicate outcome, so a
+        /// repeated id inside one set is only ever considered once regardless of what was decided.
+        /// </summary>
+        /// <param name="stageRow">
+        /// Invoked - before the event is remembered - for an event that should be staged. Kept as a callback
+        /// so the staging-row construction stays with the caller and the original ordering (and therefore the
+        /// original behaviour if that construction throws) is preserved exactly.
+        /// </param>
+        public static async Task<ActivityStagingDecision> DecideAndRememberAsync(
+            AbstractAuditLogContent log,
+            HashSet<Guid> decidedInThisSet,
+            ActivityImportCache cache,
+            Func<AbstractAuditLogContent, bool> urlInScope,
+            Func<string, Task<bool>> userInGroupsFilter,
+            Action<AbstractAuditLogContent> stageRow)
+        {
+            if (urlInScope == null) throw new ArgumentNullException(nameof(urlInScope));
+            if (userInGroupsFilter == null) throw new ArgumentNullException(nameof(userInGroupsFilter));
+            if (stageRow == null) throw new ArgumentNullException(nameof(stageRow));
+
+            if (IsAlreadyProcessed(log, decidedInThisSet, cache))
+            {
+                return ActivityStagingDecision.Duplicate;
+            }
+
+            ActivityStagingDecision decision;
+            if (urlInScope(log))
+            {
+                if (await userInGroupsFilter(log.UserId))
+                {
+                    stageRow(log);
+
+                    // Remember we've done this one now
+                    cache.RememberProcessedEvent(log);
+                    decision = ActivityStagingDecision.Imported();
+                }
+                else
+                {
+                    decision = ActivityStagingDecision.UserOutOfScope();
+                }
+            }
+            else
+            {
+                // No URL
+                cache.RememberNewlyIgnoredEvent(log);
+                decision = ActivityStagingDecision.UrlOutOfScope();
+            }
+
+            decidedInThisSet.Add(log.Id);
+            return decision;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/CopilotPrewarmPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/CopilotPrewarmPolicy.cs
@@ -1,0 +1,64 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using System.Collections.Generic;
+using System.Linq;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules
+{
+    /// <summary>
+    /// Decides what the audit-log save path pre-resolves from Graph before it takes the SQL lock: whether to
+    /// pre-warm at all, and which file contexts are worth a round-trip.
+    ///
+    /// Extracted from <c>ActivityReportSqlPersistenceManager</c> so both halves are assertable without Graph
+    /// or SQL Server. See issue #373.
+    /// </summary>
+    public static class CopilotPrewarmPolicy
+    {
+        /// <summary>
+        /// Pre-warm only when there is a run-scoped loader to warm AND Copilot resource resolution is
+        /// enabled. The second condition matters operationally: with resolution disabled the save path makes
+        /// no Graph resource calls at all (every Copilot event is staged agent-metadata-only), so warming
+        /// would be pure outbound Graph traffic for a cache nothing reads. A tenant that has deliberately
+        /// turned resolution off must see no Copilot file lookups.
+        /// </summary>
+        public static bool ShouldPrewarm(bool hasSharedLoader, bool resolveCopilotResourceMetadata)
+        {
+            return hasSharedLoader && resolveCopilotResourceMetadata;
+        }
+
+        /// <summary>
+        /// The distinct (fileContextId -> eventUpn) map to pre-resolve for a batch. Mirrors
+        /// <c>CopilotAuditEventManager</c>: only the first file-type context per event is used; a Teams meeting
+        /// context ends file processing for that event; Teams chat contexts are additive (not files).
+        /// </summary>
+        public static Dictionary<string, string> ExtractFileContexts(IEnumerable<AbstractAuditLogContent> activities)
+        {
+            var fileContexts = new Dictionary<string, string>();
+            foreach (var copilot in activities.OfType<CopilotAuditLogContent>())
+            {
+                var contexts = copilot.CopilotEventData?.Contexts;
+                if (contexts == null) continue;
+                foreach (var context in contexts)
+                {
+                    if (context == null) continue;
+                    // Type is checked before the id guard so a (typically non-null) meeting/chat context
+                    // controls flow exactly as CopilotAuditEventManager does, even if its id were null.
+                    if (context.Type == ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING) break;   // meeting ends file/meeting processing
+                    if (context.Type == ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_CHAT) continue;   // chat is additive, not a file
+                    // First file-type context for this event (a null-id file resolves to nothing, so skip it but still stop).
+                    // Also skip contexts Graph can never resolve (local C:\ / UNC / DataAgent) so the concurrent
+                    // prewarm doesn't fire a guaranteed-miss round-trip for each one (mirrors TryAddFileAsync).
+                    if (context.Id != null
+                        && !CopilotAuditEventManager.ShouldSkipGraphFileLookup(context.Id)
+                        && !fileContexts.ContainsKey(context.Id))
+                    {
+                        fileContexts[context.Id] = copilot.UserId;
+                    }
+                    break;
+                }
+            }
+            return fileContexts;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 
 namespace WebJob.Office365ActivityImporter.Engine
@@ -53,8 +54,8 @@ namespace WebJob.Office365ActivityImporter.Engine
 
             // Include an extra minute either side of cache-loading range, as EF6 assumes datetime2 which can miss some datetime edge values
             // This is easier than doing a new migration to convert every DT field.
-            cacheTo = cacheTo.AddMinutes(1);
-            cacheFrom = cacheFrom.AddMinutes(-1);
+            cacheTo = ActivityImportCacheWindow.PadTo(cacheTo);
+            cacheFrom = ActivityImportCacheWindow.PadFrom(cacheFrom);
 
 #if DEBUG
             Console.WriteLine($"DEBUG: Loading activity cache from {cacheFrom} to {cacheTo}.");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -79,6 +79,10 @@
     <Compile Include="ActivityAPI\Copilot\SpoGraphClient.cs" />
     <Compile Include="ActivityAPI\Copilot\Models.cs" />
     <Compile Include="ActivityAPI\Copilot\StagingClasses.cs" />
+    <Compile Include="ActivityAPI\Rules\ActivityImportCacheWindow.cs" />
+    <Compile Include="ActivityAPI\Rules\ActivitySaveConcurrencyPolicy.cs" />
+    <Compile Include="ActivityAPI\Rules\ActivityStagingRules.cs" />
+    <Compile Include="ActivityAPI\Rules\CopilotPrewarmPolicy.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\PowerPlatformAuditEventManager.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\IPowerPlatformStagingWriter.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\PowerPlatformAuditLogFilter.cs" />


### PR DESCRIPTION
## Summary

First of two PRs for #373, following the sequencing that worked for #369, #374 and #370: **pure rules first, collaborator split second.** This PR moves only decision logic out of `ActivityReportSqlPersistenceManager`. **No SQL, no staging schema, no merge script, no context/session split** — that is part 2, once behaviour is pinned by tests.

`IActivityReportPersistenceManager` is unchanged. There are no schema changes, no migrations and no index changes.

## The two operator safety valves

#373 warns that this class "carries two operator safety valves ... they exist because something went wrong in production once". Both are now directly assertable without SQL Server:

| Valve | App setting | What it does | Test |
|---|---|---|---|
| Concurrent saves | `AUDIT_MAX_CONCURRENT_SAVES` | `1` (default) = the original strictly-serial path against the single shared staging table. `> 1` = each save loads its **own** `##`-sharded staging table in parallel; only the merge and the metadata pass (which write shared tables) are serialised. | `ActivitySaveConcurrencyPolicyTests` (5) — **policy only**, see below |
| Per-batch dedup cache | `AUDIT_PERBATCH_DEDUP_CACHE` | `false` (default) = one dedup cache per import cycle over the whole download window. `true` = restores the pre-optimisation per-batch rebuild over the batch's own `[oldest, newest]` span, without a redeploy. | `ActivityImportCacheWindowTests` (6) |

Scope note, after the review loop: the concurrency tests cover the **policy** — the decision the manager now asks — not the manager acting on it. They cannot observe branch selection, the shared-write semaphore or the emitted merge SQL, because none of that is reachable without SQL Server until the collaborator split in part 2. #373's `Concurrency_ShardedMode_StillSerialisesSharedTableWrites` therefore belongs to part 2, and the test names now say `Policy...` so they do not overclaim.

Notably `Concurrency_UnsetOrInvalidMaxConcurrentSaves_PolicyFallsBackToTheSerialPath` pins that a bad app setting (`0`, negative) degrades to the safe default rather than breaking the import, and `ImportCache_RunWindow_ZeroOrNegativeDownloadWindow_StillCoversAtLeastTwoDays` pins that a misconfigured `DaysBeforeNowToDownload` cannot collapse the cache to "now" and re-stage the whole window.

## What moved

Four new classes under `WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/`:

**`ActivityStagingRules`** — the per-event decision, lifted out of the `SaveToSqlAllTheThings` loop: in-set de-duplication → the dedup cache → the SharePoint org-URL whitelist → the user-groups filter, plus the in-memory bookkeeping that keeps the cache current as batches commit.

The two collaborators that touch the outside world are injected as delegates and the staging-row build is a callback, which keeps the original semantics exactly:

- a **duplicate** still costs **zero** Graph calls — pinned by `Dedup_EventAlreadyImported_IsSkipped` asserting both delegates saw zero calls. This matters: a batch spans nearly the whole download window, so most events in it are duplicates;
- an **out-of-scope URL** never reaches the user-groups lookup;
- the staging row is still built **before** the event is remembered, so a row that fails to build leaves the event unknown to the cache and a retry can still pick it up (`Dedup_StagingRowThatFailsToBuild_IsNotRememberedAsProcessed`).

It also pins a deliberate asymmetry that was previously invisible: a **URL**-out-of-scope event is remembered in the newly-ignored bucket (so it is not reconsidered for the rest of the cycle), a **user**-out-of-scope event is **not** remembered at all.

> Correction from the review loop: an earlier draft of this description said the newly-ignored bucket "reaches `ignored_audit_events`". **It does not.** `ActivityImportCache.SaveNewlyIgnoredEvents` — the only thing that would write that table, retry logic and all — has **no caller anywhere in the solution**, so the bucket is in-memory only and `ignored_audit_events` is read but never written. That is pre-existing and is deliberately not changed here; it is called out because the code comments implied otherwise.

**`ActivitySaveConcurrencyPolicy`** — normalisation, serial-vs-sharded selection, sharded staging-table naming, and which table the merge SQL is pointed at.

**`ActivityImportCacheWindow`** — the per-run window rule (`Max(days, 1) + 1` days back, `+2` minutes forward), the per-batch valve, and the ±1 minute `datetime2` edge padding applied when any cache is loaded. It takes `nowUtc` as a **parameter** rather than depending on `IClock`, per #381's `ImportCadenceGate.ShouldRun(..., DateTime nowUtc)` convention.

**`CopilotPrewarmPolicy`** — the "skip the Graph pre-warm entirely when Copilot resource resolution is disabled" gate, plus the file-context extraction moved here verbatim. `ActivityReportSqlPersistenceManager.ExtractCopilotFileContexts` is kept as a thin delegating wrapper so existing call sites and the pre-existing `CopilotPrewarmExtractionTests` are untouched; a new test asserts the wrapper really delegates rather than leaving a second, divergent copy behind.

`ActivityReportSqlPersistenceManager` additionally takes an optional `IClock` (#368), defaulting to `SystemClock.Instance`, used only to obtain the instant handed to the window rule. The constructor signature is otherwise unchanged (trailing optional parameter), so no call site breaks.

## Deviations from #373's proposed shape — stated explicitly

#373 proposes `ActivityDedupPolicy` with `IsAlreadyProcessed(...)` and `IsUrlInScope(string url, AuditFilterConfig filter)`.

- The class is named **`ActivityStagingRules`**, matching the in-repo precedent set by #369 part 1 (`PageViewStagingRules`, `SearchTermRules`, `ClickEventRules`), because it covers more than de-duplication — the URL and user scope decisions and the cache bookkeeping are the same indivisible per-event decision. `IsAlreadyProcessed` is present under that name.
- **`IsUrlInScope` is deliberately not added.** It would be a pure pass-through to `AuditFilterConfig.InScope(content)`, which is already the extracted rule and already has tests (`ActivityImporterTests.OrgURLsFilter_*`, `OrgURLsTests`). Wrapping it would add indirection and a test that asserts nothing new.
- `ActivityImportCacheWindow`/`CopilotPrewarmPolicy` are additions, not in #373's list; both are prerequisites for the "logic currently trapped" items it names (de-duplication scope, Copilot pre-warm decision).

## Behaviour-change risk

Intended to be identical, including every log message and every count in it. Specifically checked:

- The **`.ToList()` aliasing hazard** called out in the task brief: no collection is copied anywhere in this diff. The `ConcurrentBag` / `HashSet` / `EFInsertBatch.Rows` instances are the same objects, mutated in place, exactly as before.
- `stats.ProcessedAlready++` remains **unreachable** in this loop (a duplicate returns before any statistic is touched). That is pre-existing dead code and is preserved rather than quietly "fixed" — changing it would change an operator-facing count.
- The `Skipping activity report for user '...' - not in user groups filter` log line is emitted from the same place in the sequence, with the same text.
- The sharded staging-table name is kept as the **literal** `##import_staging_event_lookups_` prefix rather than being derived from `ActivityImportConstants.STAGING_TABLE_ACTIVITY`, because that constant is a permanent `debug_`-prefixed table in DEBUG builds. `Concurrency_ShardedStagingTable_IsAGlobalTempTableInEveryBuildConfiguration` pins this.
- **One deliberate divergence:** the run-scoped dedup window is now resolved on entry to `CommitAll` instead of inside the cache-init lock, so its instant is read microseconds earlier. Unobservable — the window already carries a full extra day of lower margin and two minutes of upper margin, then is padded a further minute either side.

**Allocation, stated accurately** (the first review round caught me overclaiming here). The extraction does add small **Gen0** allocations per event that the original had none of: the `Task<ActivityStagingDecision>` returned by the rule (an `async Task<T>` with a non-null reference-type result cannot use a cached task, so this is allocated even on the synchronous duplicate path), and one `ActivityStagingDecision` on each non-duplicate path (`Duplicate` itself is a shared singleton). The three collaborator delegates were originally being built per event too; they are now hoisted above the loop, since they capture only loop-invariant state and Roslyn does not cache capturing lambdas. What is **not** added is any Large Object Heap allocation: no list, array or dictionary is materialised per batch, which is the hazard the brief warns about. At ~2000 events per batch the remaining Gen0 churn is on the order of a hundred kilobytes of short-lived objects and is immaterial to throughput.

## Testing

**New — 24 tests, zero SQL Server, zero Graph, zero wall clock** (30 across the four affected classes, six of which were already there)

- `ActivityStagingRulesTests` (9)
- `ActivitySaveConcurrencyPolicyTests` (5)
- `ActivityImportCacheWindowTests` (6)
- `CopilotPrewarmExtractionTests` (+4 added to the existing 6-test class)

Two carry non-ASCII customer text (`καλημέρα@contoso.onmicrosoft.com`, a Greek SharePoint file name) so a mapping change that mangles it fails here rather than in a tenant.

**Pre-existing — unchanged and passing (27, DB-backed):** `ActivityImporterTests`, `AuditTests`, `AuditImportFailureHandlingTests` (including `ConcurrentSaveMode_TransientFailuresIsolated_CycleCompletes`, which exercises the sharded path), `ActivityReportSetMinMaxTests`, `ActivityReportLoaderTimeoutTests`. These are the behaviour-identical evidence.

Full solution builds (Debug). Full suite: 1128 passed / 12 failed, all 12 pre-existing local-environment failures unrelated to this diff — 8 need real Graph/cognitive credentials (the local config has placeholder values, e.g. `Tenant '00000000-…-0002' not found`) and 4 need a local `InstallTests/TestConfigs/InstallerTestConfig.json` that is not in the repo.

## Reviewer hotspots

1. **`ActivityStagingRules.DecideAndRememberAsync` vs the original loop** — the ordering of `stageRow` / `RememberProcessedEvent` / `decidedInThisSet.Add`, and that nothing is evaluated eagerly that used to be short-circuited.
2. **`GetOrBuildRunImportCacheAsync(window)`** — the window is now a parameter; once built, later calls ignore their argument. Is the divergence above genuinely unobservable?
3. **The `DaysBack` value in the operator log line** — it must still print the same number as before (`Max(days,1)+1`).

## Follow-up (part 2)

`IActivityImportCacheProvider`, `IActivityStagingWriter`, `ISaveSessionFactory`, and removing `ActivityImportCache.GetAndBuildNewCache`'s static database access — i.e. #373's collaborator split, plus its `ActivityImportCacheProviderTests` / `ActivitySavePipelineTests`.

Addresses #373
