### PR TITLE
Extract the page-update rules from PageUpdateManager and inject IClock (#369 part 2a)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsPageUpdateRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsPageUpdateRulesTests.cs
@@ -116,12 +116,6 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void PageUpdateRefresh_ZeroWindow_MeansRefreshEveryUrlSeenBeforeNow()
-        {
-            Assert.AreEqual(NowUtc, PageUpdateRefreshPolicy.StaleBeforeUtc(0, NowUtc));
-        }
-
-        [TestMethod]
         public void PageUpdateRefresh_IsDrivenByTheSuppliedInstantNotTheWallClock()
         {
             var fixedInstant = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsPageUpdateRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsPageUpdateRulesTests.cs
@@ -1,0 +1,240 @@
+using Common.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+using WebJob.AppInsightsImporter.Engine.PageUpdates.Rules;
+using static WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents.PageUpdateEventAppInsightsQueryResult;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The page-update rules extracted from PageUpdateManager by issue #369 part 2: URL grouping, the
+    /// metadata refresh-suppression window, the comment/like de-duplication and the sentiment-enrichment
+    /// gate. All run with zero SQL Server, zero cognitive services and zero wall clock.
+    /// </summary>
+    [TestClass]
+    public class AppInsightsPageUpdateRulesTests
+    {
+        private static readonly DateTime NowUtc = new DateTime(2026, 5, 4, 11, 0, 0, DateTimeKind.Utc);
+
+        private static PageUpdateEventAppInsightsQueryResult UpdateFor(string url, string name = null)
+        {
+            var e = new PageUpdateEventAppInsightsQueryResult { Name = name };
+            e.CustomProperties.Url = url;
+            return e;
+        }
+
+        #region Grouping
+
+        [TestMethod]
+        public void PageUpdateGrouping_UrlsDifferingOnlyByCase_ShareOneBucket()
+        {
+            // SharePoint emits the same page with different casing constantly, and the SQL collation is
+            // case-insensitive. Grouping them apart would create a second urls row for the same page.
+            var grouped = PageUpdateGroupingRules.GroupByUrl(new List<PageUpdateEventAppInsightsQueryResult>
+            {
+                UpdateFor("https://contoso.sharepoint.com/sites/Marketing/SitePages/Home.aspx", "a"),
+                UpdateFor("https://contoso.sharepoint.com/sites/marketing/sitepages/home.aspx", "b")
+            });
+
+            Assert.AreEqual(1, grouped.Count);
+            Assert.AreEqual(2, grouped.Values.Single().Count);
+        }
+
+        [TestMethod]
+        public void PageUpdateGrouping_QueryStringAndFragmentAreIgnored()
+        {
+            var grouped = PageUpdateGroupingRules.GroupByUrl(new List<PageUpdateEventAppInsightsQueryResult>
+            {
+                UpdateFor("https://contoso.sharepoint.com/sites/x/SitePages/Home.aspx"),
+                UpdateFor("https://contoso.sharepoint.com/sites/x/SitePages/Home.aspx?web=1&xsdata=abc"),
+                UpdateFor("https://contoso.sharepoint.com/sites/x/SitePages/Home.aspx#section")
+            });
+
+            Assert.AreEqual(1, grouped.Count);
+            Assert.AreEqual(3, grouped.Values.Single().Count);
+            Assert.AreEqual("https://contoso.sharepoint.com/sites/x/SitePages/Home.aspx", grouped.Keys.Single());
+        }
+
+        [TestMethod]
+        public void PageUpdateGrouping_EventWithNoUsableUrl_IsDropped()
+        {
+            var withoutCustomProps = new PageUpdateEventAppInsightsQueryResult();
+            withoutCustomProps.CustomProperties = null;
+
+            var grouped = PageUpdateGroupingRules.GroupByUrl(new List<PageUpdateEventAppInsightsQueryResult>
+            {
+                UpdateFor(null),
+                UpdateFor(string.Empty),
+                withoutCustomProps,
+                UpdateFor("https://contoso.sharepoint.com/sites/x/SitePages/Home.aspx")
+            });
+
+            Assert.AreEqual(1, grouped.Count, "Only the one event with a usable URL should survive.");
+        }
+
+        [TestMethod]
+        public void PageUpdateGrouping_PreservesEventOrderWithinABucket()
+        {
+            // The compile step takes Name/Username from the FIRST update in the bucket, so order is load
+            // bearing rather than incidental.
+            const string url = "https://contoso.sharepoint.com/sites/x/SitePages/Home.aspx";
+            var grouped = PageUpdateGroupingRules.GroupByUrl(new List<PageUpdateEventAppInsightsQueryResult>
+            {
+                UpdateFor(url, "first"), UpdateFor(url, "second"), UpdateFor(url, "third")
+            });
+
+            CollectionAssert.AreEqual(new[] { "first", "second", "third" }, grouped[url].Select(e => e.Name).ToArray());
+        }
+
+        [TestMethod]
+        public void PageUpdateGrouping_NonLatinUrl_IsGroupedNotDropped()
+        {
+            // Customer file names are routinely non-Latin; a URL that fails to parse would silently lose
+            // every metadata update for that page.
+            const string greekUrl = "https://contoso.sharepoint.com/sites/x/Shared Documents/Καλημέρα κόσμε.aspx";
+            var grouped = PageUpdateGroupingRules.GroupByUrl(new List<PageUpdateEventAppInsightsQueryResult> { UpdateFor(greekUrl) });
+
+            Assert.AreEqual(1, grouped.Count);
+            StringAssert.Contains(Uri.UnescapeDataString(grouped.Keys.Single()), "Καλημέρα κόσμε");
+        }
+
+        #endregion
+
+        #region Refresh suppression
+
+        [TestMethod]
+        public void PageUpdateRefresh_StaleCutoffIsTheConfiguredWindowBeforeNow()
+        {
+            // A sign flip here would make every URL look stale and rewrite the whole page-metadata set on
+            // every import cycle.
+            Assert.AreEqual(NowUtc.AddMinutes(-1440), PageUpdateRefreshPolicy.StaleBeforeUtc(1440, NowUtc));
+            Assert.AreEqual(NowUtc.AddMinutes(-15), PageUpdateRefreshPolicy.StaleBeforeUtc(15, NowUtc));
+            Assert.IsTrue(PageUpdateRefreshPolicy.StaleBeforeUtc(1440, NowUtc) < NowUtc);
+        }
+
+        [TestMethod]
+        public void PageUpdateRefresh_ZeroWindow_MeansRefreshEveryUrlSeenBeforeNow()
+        {
+            Assert.AreEqual(NowUtc, PageUpdateRefreshPolicy.StaleBeforeUtc(0, NowUtc));
+        }
+
+        [TestMethod]
+        public void PageUpdateRefresh_IsDrivenByTheSuppliedInstantNotTheWallClock()
+        {
+            var fixedInstant = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            Assert.AreEqual(fixedInstant.AddMinutes(-1440), PageUpdateRefreshPolicy.StaleBeforeUtc(1440, fixedInstant));
+        }
+
+        #endregion
+
+        #region Metadata property filter
+
+        [TestMethod]
+        public void UrlMetadataProps_SharePointSystemFieldsAreDropped()
+        {
+            Assert.IsFalse(UrlMetadataPropertyRules.IsImportableSimpleProp("vti_x005fparserversion"));
+            Assert.IsTrue(UrlMetadataPropertyRules.IsImportableSimpleProp("vti_parserversion"),
+                "Only the escaped-underscore system prefix is filtered, not everything starting with 'vti_'.");
+        }
+
+        [TestMethod]
+        public void UrlMetadataProps_FieldNameLengthBoundaryIsExclusiveAtOneHundred()
+        {
+            Assert.IsTrue(UrlMetadataPropertyRules.IsImportableSimpleProp(new string('a', 99)));
+            Assert.IsFalse(UrlMetadataPropertyRules.IsImportableSimpleProp(new string('a', 100)));
+        }
+
+        [TestMethod]
+        public void UrlMetadataProps_OrdinaryAndNonLatinFieldNamesAreKept()
+        {
+            Assert.IsTrue(UrlMetadataPropertyRules.IsImportableSimpleProp("Title"));
+            Assert.IsTrue(UrlMetadataPropertyRules.IsImportableSimpleProp("Κατηγορία"));
+        }
+
+        #endregion
+
+        #region Comments and likes
+
+        private static PageCommentEvent Comment(int? spId, string email) => new PageCommentEvent { SharePointId = spId, Email = email, Comment = "hi" };
+
+        [TestMethod]
+        public void PageUserEvents_EventWithoutEmailOrSharePointId_IsInvalid()
+        {
+            var decisions = PageUserEventRules.Classify(new List<PageCommentEvent>
+            {
+                Comment(1, null),
+                Comment(2, string.Empty),
+                Comment(null, "a@contoso.com")
+            }, new List<PageComment>());
+
+            Assert.IsTrue(decisions.All(d => d.Outcome == PageUserEventOutcome.Invalid));
+            Assert.IsTrue(decisions.All(d => d.NormalisedEmail == null));
+        }
+
+        [TestMethod]
+        public void PageUserEvents_EmailIsLowerCasedForTheUserLookup()
+        {
+            // The user cache is keyed on the address, so a mixed-case address must not create a second user.
+            var decisions = PageUserEventRules.Classify(new List<PageCommentEvent> { Comment(1, "KAΛHMEPA@Contoso.OnMicrosoft.com") },
+                new List<PageComment>());
+
+            Assert.AreEqual(PageUserEventOutcome.New, decisions.Single().Outcome);
+            Assert.AreEqual("kaλhmepa@contoso.onmicrosoft.com", decisions.Single().NormalisedEmail);
+        }
+
+        [TestMethod]
+        public void PageUserEvents_AlreadyStoredSharePointId_IsNotRecreated()
+        {
+            var stored = new List<PageComment> { new PageComment { SpID = 7 } };
+            var decisions = PageUserEventRules.Classify(new List<PageCommentEvent> { Comment(7, "a@contoso.com") }, stored);
+
+            Assert.AreEqual(PageUserEventOutcome.AlreadyStored, decisions.Single().Outcome);
+        }
+
+        [TestMethod]
+        public void PageUserEvents_DecisionsComeBackInInputOrder()
+        {
+            // The caller walks this list logging invalid events and creating new ones, so re-ordering would
+            // change the operator-facing log sequence and what has already been created when a create throws.
+            var stored = new List<PageComment> { new PageComment { SpID = 2 } };
+            var decisions = PageUserEventRules.Classify(new List<PageCommentEvent>
+            {
+                Comment(1, "a@contoso.com"),   // new
+                Comment(2, "b@contoso.com"),   // already stored
+                Comment(3, null)               // invalid
+            }, stored);
+
+            CollectionAssert.AreEqual(
+                new[] { PageUserEventOutcome.New, PageUserEventOutcome.AlreadyStored, PageUserEventOutcome.Invalid },
+                decisions.Select(d => d.Outcome).ToArray());
+        }
+
+        [TestMethod]
+        public void PageUserEvents_LikesAreClassifiedTheSameWayAsComments()
+        {
+            var stored = new List<PageLike> { new PageLike { SpID = 5 } };
+            var decisions = PageUserEventRules.Classify(new List<UserBasedCustomAIEvent>
+            {
+                new UserBasedCustomAIEvent { SharePointId = 5, Email = "a@contoso.com" },
+                new UserBasedCustomAIEvent { SharePointId = 6, Email = "a@contoso.com" }
+            }, stored);
+
+            Assert.AreEqual(PageUserEventOutcome.AlreadyStored, decisions[0].Outcome);
+            Assert.AreEqual(PageUserEventOutcome.New, decisions[1].Outcome);
+        }
+
+        [TestMethod]
+        public void Sentiment_IsOnlyRequestedWhenConfiguredAndThereAreNewComments()
+        {
+            // A cycle with no new comments must produce no cognitive-services traffic (and no bill).
+            Assert.IsFalse(PageUserEventRules.ShouldRequestSentiment(hasCognitiveClient: true, newCommentCount: 0));
+            Assert.IsFalse(PageUserEventRules.ShouldRequestSentiment(hasCognitiveClient: false, newCommentCount: 5));
+            Assert.IsTrue(PageUserEventRules.ShouldRequestSentiment(hasCognitiveClient: true, newCommentCount: 5));
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="AppInsightsKqlGetWhereStringTests.cs" />
     <Compile Include="AppInsightsImportWindowTests.cs" />
     <Compile Include="AppInsightsClickRulesTests.cs" />
+    <Compile Include="AppInsightsPageUpdateRulesTests.cs" />
     <Compile Include="AppInsightsPageViewRulesTests.cs" />
     <Compile Include="AppInsightsSearchRulesTests.cs" />
     <Compile Include="CopilotDroppedAuditFieldsTests.cs" />

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
 using WebJob.AppInsightsImporter.Engine.PageUpdates;
+using WebJob.AppInsightsImporter.Engine.PageUpdates.Rules;
 using WebJob.AppInsightsImporter.Engine.Sql;
 using static WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents.PageUpdateEventAppInsightsQueryResult;
 
@@ -29,15 +30,17 @@ namespace WebJob.AppInsightsImporter.Engine
         private readonly int _chunkSize;
         private readonly CognitiveServicesClient _cognitiveClient = null;
         private readonly AppConfig _config;
+        private readonly IClock _clock;
 
-        public PageUpdateManager(ILogger logger, AppConfig config) : this(logger, 1000, config)
+        public PageUpdateManager(ILogger logger, AppConfig config, IClock clock = null) : this(logger, 1000, config, clock)
         {
         }
-        public PageUpdateManager(ILogger logger, int chunkSize, AppConfig config)
+        public PageUpdateManager(ILogger logger, int chunkSize, AppConfig config, IClock clock = null)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _chunkSize = chunkSize;
             _config = config;
+            _clock = clock ?? SystemClock.Instance;
             if (chunkSize < 0)
             {
                 throw new ArgumentOutOfRangeException("Chunk size must be > 0", nameof(chunkSize));
@@ -70,7 +73,7 @@ namespace WebJob.AppInsightsImporter.Engine
             if (uniqueUpdatedUrls.Count > 0)
             {
                 const int URL_LOOKUP_BATCH = 1000;
-                var now = DateTime.UtcNow;
+                var now = _clock.UtcNow;
                 using (var db = new AnalyticsEntitiesContext())
                 {
                     db.Configuration.AutoDetectChangesEnabled = false;
@@ -116,25 +119,13 @@ namespace WebJob.AppInsightsImporter.Engine
                 // Old code: for each matched URL, ran chunk.Where(...).ToList() which re-invokes
                 // GetUrlBaseAddressIfValidUrl on every event for every URL -> O(events * urls).
                 // At 200k users and large chunk sizes this is the dominant cost.
-                var chunkByUrl = new Dictionary<string, List<PageUpdateEventAppInsightsQueryResult>>(StringComparer.OrdinalIgnoreCase);
-                foreach (var e in chunk)
-                {
-                    var key = StringUtils.GetUrlBaseAddressIfValidUrl(e.CustomProperties?.Url);
-                    if (string.IsNullOrEmpty(key))
-                        continue;
-                    if (!chunkByUrl.TryGetValue(key, out var list))
-                    {
-                        list = new List<PageUpdateEventAppInsightsQueryResult>();
-                        chunkByUrl[key] = list;
-                    }
-                    list.Add(e);
-                }
+                var chunkByUrl = PageUpdateGroupingRules.GroupByUrl(chunk);
                 var urlsForPageUpdateChunk = chunkByUrl.Keys.ToList();
 
                 // Get all URLs that have not been updated recently
-                var minusMetadataRefreshMinutes = _config.MetadataRefreshMinutes * -1;
+                var staleBeforeUtc = PageUpdateRefreshPolicy.StaleBeforeUtc(_config.MetadataRefreshMinutes, _clock.UtcNow);
                 var matchingUrlsNotUpdatedRecently = await context.urls
-                    .Where(u => urlsForPageUpdateChunk.Contains(u.FullUrl) && (u.MetadataLastRefreshed == null || u.MetadataLastRefreshed < DbFunctions.AddMinutes(DateTime.UtcNow, minusMetadataRefreshMinutes)))
+                    .Where(u => urlsForPageUpdateChunk.Contains(u.FullUrl) && (u.MetadataLastRefreshed == null || u.MetadataLastRefreshed < staleBeforeUtc))
                     .ToListAsync();
 
                 foreach (var urlToUpdate in matchingUrlsNotUpdatedRecently)
@@ -208,11 +199,11 @@ namespace WebJob.AppInsightsImporter.Engine
                     await db.SaveChangesAsync();
                 }
                 newComments.Add(commentEvent, new PageCommentTemp
-                    (commentEvent.Comment, commentEvent.Created ?? DateTime.UtcNow, user.ID, commentEvent.SharePointId.Value, url.ID, commentEvent.ParentSharePointId));
+                    (commentEvent.Comment, commentEvent.Created ?? _clock.UtcNow, user.ID, commentEvent.SharePointId.Value, url.ID, commentEvent.ParentSharePointId));
             });
 
             // Get sentiment scores for new comments, if we have cognitive services configured
-            if (_cognitiveClient != null && newComments.Count > 0)
+            if (PageUserEventRules.ShouldRequestSentiment(_cognitiveClient != null, newComments.Count))
             {
                 var cognitiveResults = await newComments.Keys
                     .ToTextAnalysisSampleList()
@@ -248,7 +239,7 @@ namespace WebJob.AppInsightsImporter.Engine
                 {
                     Url = url,
                     User = await userCache.GetOrCreateNewResource(email, new User { UserPrincipalName = email }),
-                    Created = like.Created ?? DateTime.UtcNow,
+                    Created = like.Created ?? _clock.UtcNow,
                     SpID = like.SharePointId.Value
                 };
 
@@ -264,24 +255,22 @@ namespace WebJob.AppInsightsImporter.Engine
         {
             var updatesMade = false;
 
-            // Insert new not seen before
-            foreach (var eventVal in eventValues)
+            // Insert new not seen before. The validation + de-duplication rule lives in PageUserEventRules
+            // so it can be asserted without a database; the decisions come back in input order, so the log
+            // sequence and the "what has already happened when a create throws" behaviour are unchanged.
+            foreach (var decision in PageUserEventRules.Classify(eventValues, dbValues))
             {
-                if (!string.IsNullOrEmpty(eventVal.Email) && eventVal.SharePointId.HasValue)
+                if (decision.Outcome == PageUserEventOutcome.Invalid)
                 {
-                    var email = eventVal.Email.ToLowerInvariant();
-
-                    // Hack: should be an index here preventing multiple records with the same SPID for URL, but apparently it's possible to have mulitple likes/comments from the same user on the same URL
-                    var existingDbRecord = dbValues.Where(c => c.SpID == eventVal.SharePointId).FirstOrDefault();
-                    if (existingDbRecord == null)
-                    {
-                        updatesMade = true;
-                        await callBackOnNew.Invoke(eventVal, email);
-                    }
+                    _logger.LogError($"WARNING: Invalid comment/like metadata in event: {decision.Event}");
+                    continue;
                 }
-                else
+
+                // Hack: should be an index here preventing multiple records with the same SPID for URL, but apparently it's possible to have mulitple likes/comments from the same user on the same URL
+                if (decision.Outcome == PageUserEventOutcome.New)
                 {
-                    _logger.LogError($"WARNING: Invalid comment/like metadata in event: {eventVal}");
+                    updatesMade = true;
+                    await callBackOnNew.Invoke(decision.Event, decision.NormalisedEmail);
                 }
             }
 
@@ -325,7 +314,7 @@ namespace WebJob.AppInsightsImporter.Engine
                         db.FileMetadataPropertyValues.Add(urlPropVal);
                     }
                     urlPropVal.FieldValue = taxonomyProp.Label;
-                    urlPropVal.Updated = DateTime.UtcNow;
+                    urlPropVal.Updated = _clock.UtcNow;
                     updatesMade = true;
                 }
             }
@@ -342,7 +331,7 @@ namespace WebJob.AppInsightsImporter.Engine
             // Standard props
             foreach (var prop in correspondingPageUpdate.CustomProperties.SimplePropsDic)
             {
-                if (prop.Key.Length < 100 && !prop.Key.StartsWith("vti_x005f"))     // Ignore system & over-sized fields (usually the same)
+                if (UrlMetadataPropertyRules.IsImportableSimpleProp(prop.Key))
                 {
                     // Get/create field def
                     var urlPropNameDef = await urlMetadataFieldNameCache.GetResource(prop.Key, () =>
@@ -386,7 +375,7 @@ namespace WebJob.AppInsightsImporter.Engine
                     if (urlPropVal.TagGuid == null)
                     {
                         urlPropVal.FieldValue = prop.Value;
-                        urlPropVal.Updated = DateTime.UtcNow;
+                        urlPropVal.Updated = _clock.UtcNow;
                         updatesMade = true;
                     }
                 }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/PageUpdateGroupingRules.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/PageUpdateGroupingRules.cs
@@ -1,0 +1,52 @@
+using DataUtils;
+using System;
+using System.Collections.Generic;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+
+namespace WebJob.AppInsightsImporter.Engine.PageUpdates.Rules
+{
+    /// <summary>
+    /// Groups a chunk of page-update events by the URL they belong to, which is the key the rest of the
+    /// page-update save works from.
+    ///
+    /// Extracted from <c>PageUpdateManager.SaveChunk</c> (issue #369). The grouping is deliberately built
+    /// ONCE per chunk: the code this replaced re-ran <c>chunk.Where(...)</c> - re-invoking
+    /// <see cref="StringUtils.GetUrlBaseAddressIfValidUrl"/> on every event - once per matched URL, which is
+    /// O(events x urls) and the dominant cost of a large chunk on a busy tenant.
+    /// </summary>
+    public static class PageUpdateGroupingRules
+    {
+        /// <summary>
+        /// Bucket events by their URL's base address (scheme + host + path, query and fragment discarded).
+        ///
+        /// Matching is case-insensitive because SharePoint URLs differ only in casing all the time and the
+        /// SQL collation is case-insensitive too; treating them as distinct would create duplicate URL rows.
+        /// Events whose URL is null, empty, or resolves to an empty base address are dropped without being
+        /// counted - they have nothing to attach metadata to.
+        /// </summary>
+        public static Dictionary<string, List<PageUpdateEventAppInsightsQueryResult>> GroupByUrl(
+            IEnumerable<PageUpdateEventAppInsightsQueryResult> chunk)
+        {
+            var chunkByUrl = new Dictionary<string, List<PageUpdateEventAppInsightsQueryResult>>(StringComparer.OrdinalIgnoreCase);
+            if (chunk == null)
+            {
+                return chunkByUrl;
+            }
+
+            foreach (var e in chunk)
+            {
+                var key = StringUtils.GetUrlBaseAddressIfValidUrl(e.CustomProperties?.Url);
+                if (string.IsNullOrEmpty(key))
+                    continue;
+                if (!chunkByUrl.TryGetValue(key, out var list))
+                {
+                    list = new List<PageUpdateEventAppInsightsQueryResult>();
+                    chunkByUrl[key] = list;
+                }
+                list.Add(e);
+            }
+
+            return chunkByUrl;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/PageUpdateRefreshPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/PageUpdateRefreshPolicy.cs
@@ -10,6 +10,18 @@ namespace WebJob.AppInsightsImporter.Engine.PageUpdates.Rules
     /// EF query and so could only be observed by running the import against a database. See issue #369.
     /// Takes the instant as a parameter, following the <c>ImportCadenceGate.ShouldRun(..., DateTime nowUtc)</c>
     /// convention.
+    ///
+    /// <para><b>One deliberate behavioural change.</b> The original predicate was
+    /// <c>u.MetadataLastRefreshed &lt; DbFunctions.AddMinutes(DateTime.UtcNow, -N)</c>. EF6 does <b>not</b>
+    /// evaluate a bare <c>DateTime.UtcNow</c> inside a LINQ-to-Entities query on the client - it maps it to
+    /// the canonical function <c>CurrentUtcDateTime()</c>, which the SQL Server provider renders as
+    /// <c>SysUtcDateTime()</c>. So "now" used to be the <b>database server's</b> clock; it is now the
+    /// web-job <b>host's</b> clock. The difference is bounded by app-to-database clock skew (sub-second on
+    /// NTP-synced Azure) against a 24-hour staleness window, and it is arguably more self-consistent:
+    /// <c>MetadataLastRefreshed</c> is stamped from the host clock in <c>SaveAll</c>, so the comparison now
+    /// uses one clock rather than two. Note there is no form of this predicate that both keeps the database
+    /// clock and is injectable - passing <c>_clock.UtcNow</c> to <c>DbFunctions.AddMinutes</c> would
+    /// parameterise the host clock just the same.</para>
     /// </summary>
     public static class PageUpdateRefreshPolicy
     {

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/PageUpdateRefreshPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/PageUpdateRefreshPolicy.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace WebJob.AppInsightsImporter.Engine.PageUpdates.Rules
+{
+    /// <summary>
+    /// The metadata refresh-suppression rule: a URL whose metadata was refreshed recently is skipped, so a
+    /// page that emits page-update events all day is not re-written on every import cycle.
+    ///
+    /// Extracted from <c>PageUpdateManager.SaveChunk</c>, which read <c>DateTime.UtcNow</c> inline inside the
+    /// EF query and so could only be observed by running the import against a database. See issue #369.
+    /// Takes the instant as a parameter, following the <c>ImportCadenceGate.ShouldRun(..., DateTime nowUtc)</c>
+    /// convention.
+    /// </summary>
+    public static class PageUpdateRefreshPolicy
+    {
+        /// <summary>
+        /// URLs whose <c>MetadataLastRefreshed</c> is <c>null</c> or strictly older than this instant are
+        /// re-read; everything else is left alone until the window elapses.
+        ///
+        /// <paramref name="metadataRefreshMinutes"/> comes from <c>AppConfig.MetadataRefreshMinutes</c>, which
+        /// already falls back to its 24-hour default for a missing, unparseable or negative app setting
+        /// (see <c>AppConfigDefaultsTests.MetadataRefreshMinutes_*</c>), so this does not re-validate it.
+        /// </summary>
+        public static DateTime StaleBeforeUtc(int metadataRefreshMinutes, DateTime nowUtc)
+        {
+            return nowUtc.AddMinutes(-metadataRefreshMinutes);
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/PageUserEventRules.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/PageUserEventRules.cs
@@ -1,0 +1,115 @@
+using Common.Entities;
+using System.Collections.Generic;
+using static WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents.PageUpdateEventAppInsightsQueryResult;
+
+namespace WebJob.AppInsightsImporter.Engine.PageUpdates.Rules
+{
+    /// <summary>What the comment/like rules decided for one incoming event.</summary>
+    public enum PageUserEventOutcome
+    {
+        /// <summary>No email or no SharePoint id - nothing usable to key the record on.</summary>
+        Invalid,
+
+        /// <summary>A record with this SharePoint id is already stored against the URL.</summary>
+        AlreadyStored,
+
+        /// <summary>Not seen before; create it.</summary>
+        New
+    }
+
+    /// <summary>One incoming comment or like, classified.</summary>
+    public sealed class PageUserEventDecision<TEvent> where TEvent : UserBasedCustomAIEvent
+    {
+        internal PageUserEventDecision(TEvent pageUserEvent, PageUserEventOutcome outcome, string normalisedEmail)
+        {
+            Event = pageUserEvent;
+            Outcome = outcome;
+            NormalisedEmail = normalisedEmail;
+        }
+
+        public TEvent Event { get; }
+        public PageUserEventOutcome Outcome { get; }
+
+        /// <summary>
+        /// The e-mail lower-cased, as it is used to look a user up. <c>null</c> for an
+        /// <see cref="PageUserEventOutcome.Invalid"/> event, since there was nothing to normalise.
+        /// </summary>
+        public string NormalisedEmail { get; }
+    }
+
+    /// <summary>
+    /// De-duplication and validation for the page comments and likes carried on a page-update event.
+    ///
+    /// Extracted from <c>PageUpdateManager.ProcessCustomAppInsightsEvents</c> (issue #369) so the rule can be
+    /// asserted without a database or cognitive services.
+    /// </summary>
+    public static class PageUserEventRules
+    {
+        /// <summary>
+        /// Classify every incoming event, <b>in input order</b>, against what is already stored for the URL.
+        /// Order matters: the caller logs invalid events and creates new ones as it walks this list, so
+        /// re-ordering would change the operator-facing log sequence and what has already happened when a
+        /// creation throws.
+        ///
+        /// Two pieces of existing behaviour are preserved deliberately:
+        /// <list type="bullet">
+        /// <item>matching is by SharePoint id only. There is no unique index on (url, spID) - a user really
+        ///       can leave two comments on the same page - so the id is the only thing that can identify a
+        ///       record already stored;</item>
+        /// <item>duplicate ids <b>within one batch</b> are each reported as <see cref="PageUserEventOutcome.New"/>,
+        ///       because the stored set is not updated as the caller creates records. In practice the
+        ///       page-update compile step has already de-duplicated likes and comments by SharePoint id
+        ///       before this is reached.</item>
+        /// </list>
+        /// </summary>
+        public static List<PageUserEventDecision<TEvent>> Classify<TEvent, TStored>(List<TEvent> eventValues, List<TStored> storedRecords)
+            where TEvent : UserBasedCustomAIEvent
+            where TStored : SPUrlUserRecord
+        {
+            var decisions = new List<PageUserEventDecision<TEvent>>();
+            if (eventValues == null)
+            {
+                return decisions;
+            }
+
+            foreach (var eventVal in eventValues)
+            {
+                if (string.IsNullOrEmpty(eventVal.Email) || !eventVal.SharePointId.HasValue)
+                {
+                    decisions.Add(new PageUserEventDecision<TEvent>(eventVal, PageUserEventOutcome.Invalid, null));
+                    continue;
+                }
+
+                var email = eventVal.Email.ToLowerInvariant();
+
+                var alreadyStored = false;
+                if (storedRecords != null)
+                {
+                    foreach (var stored in storedRecords)
+                    {
+                        if (stored.SpID == eventVal.SharePointId)
+                        {
+                            alreadyStored = true;
+                            break;
+                        }
+                    }
+                }
+
+                decisions.Add(new PageUserEventDecision<TEvent>(eventVal,
+                    alreadyStored ? PageUserEventOutcome.AlreadyStored : PageUserEventOutcome.New, email));
+            }
+
+            return decisions;
+        }
+
+        /// <summary>
+        /// Whether to call the cognitive-services text analytics API for this batch of new comments. Skipped
+        /// when the service is not configured, and when there is nothing new to score - a tenant with no new
+        /// comments in a cycle must generate no cognitive-services traffic (and no bill).
+        /// </summary>
+        public static bool ShouldRequestSentiment(bool hasCognitiveClient, int newCommentCount)
+        {
+            return hasCognitiveClient && newCommentCount > 0;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/UrlMetadataPropertyRules.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/UrlMetadataPropertyRules.cs
@@ -1,0 +1,34 @@
+namespace WebJob.AppInsightsImporter.Engine.PageUpdates.Rules
+{
+    /// <summary>
+    /// Which of a page's SharePoint metadata properties are worth storing.
+    ///
+    /// Extracted from <c>PageUpdateManager.UpdateUrlMetadataWith</c> (issue #369) so the filter can be
+    /// asserted without a database.
+    /// </summary>
+    public static class UrlMetadataPropertyRules
+    {
+        /// <summary>Field names at or above this length are treated as system noise and dropped.</summary>
+        public const int MaxFieldNameLength = 100;
+
+        /// <summary>
+        /// SharePoint's internal fields arrive with this escaped prefix (an encoded underscore); they are
+        /// duplicates of the readable fields and of no analytic value.
+        /// </summary>
+        public const string SystemFieldNamePrefix = "vti_x005f";
+
+        /// <summary>
+        /// True for a simple (non-taxonomy) page property that should be stored.
+        ///
+        /// Preserved verbatim, including two things worth knowing about:
+        /// a <c>null</c> name throws (as it always has - a JSON object cannot have a null key, so this is
+        /// unreachable from the importer), and <c>StartsWith(string)</c> is the culture-sensitive overload.
+        /// Neither is changed here, because this issue forbids behavioural change.
+        /// </summary>
+        public static bool IsImportableSimpleProp(string fieldName)
+        {
+            // Ignore system & over-sized fields (usually the same)
+            return fieldName.Length < MaxFieldNameLength && !fieldName.StartsWith(SystemFieldNamePrefix);
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
@@ -76,6 +76,10 @@
     <Compile Include="Constants.cs" />
     <Compile Include="PageUpdates\PageCommentsExtensions.cs" />
     <Compile Include="PageUpdates\PageUpdateManager.cs" />
+    <Compile Include="PageUpdates\Rules\PageUpdateGroupingRules.cs" />
+    <Compile Include="PageUpdates\Rules\PageUpdateRefreshPolicy.cs" />
+    <Compile Include="PageUpdates\Rules\PageUserEventRules.cs" />
+    <Compile Include="PageUpdates\Rules\UrlMetadataPropertyRules.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
## Summary

First of two PRs finishing #369 (the App Insights importer half of #381). This one lifts `PageUpdateManager`'s pure decisions into testable classes and injects `IClock`. **The persistence ports (`I*PersistenceManager`, `IImportDbMaintenance`), `HitPatch`/`HitUpdatesSqlExtension` and `PageViewSaveResult` follow in part 2b** — this PR touches no SQL, no staging schema and no merge script.

Part 1 (PR #386) extracted `PageViewStagingRules`, `SearchTermRules` and `ClickEventRules` from the *save extensions*. This PR does the same job for the *page-update manager*, which the issue calls out as the largest remaining piece.

## What moved

Four new classes under `WebJob.AppInsightsImporter.Engine/PageUpdates/Rules/`:

| Class | Rule | Why it matters |
|---|---|---|
| `PageUpdateGroupingRules.GroupByUrl` | Bucket a chunk of page-update events by their URL's base address | Keeps the `StringComparer.OrdinalIgnoreCase` comparer that stops a casing-only difference producing a second `urls` row — the same class of bug as #380/#385. Also keeps the "build the buckets once" property that replaced an O(events × urls) scan. |
| `PageUpdateRefreshPolicy.StaleBeforeUtc` | The metadata refresh-suppression window | A sign flip here makes every URL look stale and rewrites the whole page-metadata set every cycle. |
| `PageUserEventRules` | Validation + de-duplication of the comments and likes on a page-update event, plus the sentiment-enrichment gate | Decides what gets created and what triggers a billable cognitive-services call. |
| `UrlMetadataPropertyRules.IsImportableSimpleProp` | The "ignore system and over-sized fields" filter | Moved verbatim. |

`PageUpdateManager` now takes an optional `IClock` (#368), defaulting to `SystemClock.Instance`, and uses it for **all six** `DateTime.UtcNow` sites it owned: the refresh cutoff, the `MetadataLastRefreshed` stamp in `SaveAll`, the two `FileMetadataPropertyValue.Updated` stamps, and the `Created` fallbacks for a comment and for a like. Both constructors gained the parameter as a trailing optional, so no call site breaks.

## Ordering is preserved deliberately

`ProcessCustomAppInsightsEvents` used to interleave "log this invalid event" and "create this new record" as it walked the input. `PageUserEventRules.Classify` therefore returns decisions **in input order** and the caller still walks them one at a time, so:

- the operator-facing `WARNING: Invalid comment/like metadata in event: …` lines appear in the same sequence relative to the record creations;
- if a creation throws (it can — the callback inserts users and languages), exactly the same set of earlier events has been logged and created as before.

Pre-classifying up front is safe because `dbValues` is a materialised list from the database that the callbacks never mutate — they add to `db.UrlLikes` / the `newComments` dictionary, not to it.

Two pieces of existing behaviour are documented rather than "fixed", because #369 forbids behavioural change:
- matching is by SharePoint id only (there is deliberately no unique index on `(url, sp_id)` — a user really can comment twice on a page);
- duplicate ids **within one batch** are each reported as new, because the stored set is not updated as records are created. In practice the page-update compile step has already de-duplicated likes and comments by SharePoint id before this is reached.

`UrlMetadataPropertyRules.IsImportableSimpleProp` is likewise verbatim, including two pre-existing quirks I deliberately did **not** change and have documented in its XML comment: a `null` field name throws (unreachable from the importer — a JSON object cannot have a null key), and `StartsWith(string)` is the culture-sensitive overload.

## The one deliberate divergence

The staleness cutoff is now computed in C# and passed as a parameter:

```csharp
// before
u.MetadataLastRefreshed < DbFunctions.AddMinutes(DateTime.UtcNow, minusMetadataRefreshMinutes)
// after
var staleBeforeUtc = PageUpdateRefreshPolicy.StaleBeforeUtc(_config.MetadataRefreshMinutes, _clock.UtcNow);
u.MetadataLastRefreshed < staleBeforeUtc
```

**Corrected after review — my first explanation of this was wrong.** EF6 does *not* evaluate a bare `DateTime.UtcNow` inside a LINQ-to-Entities query on the client: it maps it to the canonical function `CurrentUtcDateTime()`, which the SQL Server provider renders as `SysUtcDateTime()`. So the old predicate compared against the **database server's** clock; the new one compares against the **web-job host's** clock.

The real change is therefore the **clock source**, not `datetime`-vs-`datetime2` parameter typing. The impact is bounded by app-to-database clock skew — sub-second on NTP-synced Azure — against a 24-hour staleness window, and it is arguably *more* self-consistent: `MetadataLastRefreshed` is stamped from the host clock in `SaveAll`, so the comparison now uses one clock rather than two. Note there is no form of this predicate that keeps the database clock **and** is injectable — passing `_clock.UtcNow` into `DbFunctions.AddMinutes` parameterises the host clock just the same. The `PageUpdateRefreshPolicy` XML doc records this.

## Testing

**New: 16 tests in `AppInsightsPageUpdateRulesTests`** — zero SQL Server, zero cognitive services, zero wall clock. What each pins:

- casing-only URL differences share a bucket; query string and `#fragment` are ignored; events with no usable URL are dropped; bucket order is preserved (the compile step takes `Name`/`Username` from the *first* update); a Greek SharePoint URL is grouped rather than dropped;
- the stale cutoff is *before* now, scales with the configured window, and is driven by the supplied instant rather than the wall clock (a third, near-tautological zero-window test was dropped on review advice rather than padded);
- the field-name length boundary is exclusive at 100 (99 in, 100 out), `vti_x005f…` is dropped but `vti_…` is not, and a Greek field name is kept;
- an event with no e-mail or no SharePoint id is invalid with a `null` normalised e-mail; the e-mail is lower-cased for the user lookup; an already-stored SharePoint id is not recreated; decisions come back in input order; likes classify identically to comments;
- sentiment is requested only when the client is configured **and** there is at least one new comment.

**Pre-existing, unchanged, still passing (DB-backed):** `PageUpdateManagerTests`, `PageUpdateManagerMultithreadTests`, `PageUpdateManagerMultithreadSamePropNameValTests`, `PageUpdateManagerSamePropNameValTests`, `CommentsSaveTests`, `PageUpdateManagerCommentsAndLikesTests`, `DupTaxonomoyPropertiesWithDifferentGuidsPageUpdateManagerTests`, `PageUpdateEventAppInsightsQueryResultMergeTest`, `PageUpdateEventAppInsightsQueryResultCommentsAndLikesMergeTest`, and both `PageUpdateManagerPerfTests`.

Area run: **111 passed / 1 failed of 112** — the failure is the pre-existing `CommentsCognitiveTests`, which cannot resolve the placeholder `example-cognitive.cognitiveservices.azure.com` endpoint in the local dev config and passes in CI. Full solution builds (Debug).

## Reviewer hotspots

1. **The `datetime` parameter-typing divergence above** — is the ≤3.33 ms rounding acceptable, or should the `DbFunctions.AddMinutes` form be restored?
2. **`PageUserEventRules.Classify` versus the original loop** — in particular that pre-classifying cannot observe a stale `dbValues`, and that ordering/partial-failure semantics really are identical.
3. **The tests** — for each, what realistic regression makes it fail? I have tried not to add anything that only asserts `Math.Max`-grade arithmetic; call out anything that reads as theatre and I will delete it rather than pad it.

## Still to come in part 2b

`IPageViewsPersistenceManager` / `ISearchesPersistenceManager` / `IClicksPersistenceManager` / `IPageUpdatePersistenceManager` / `IHitUpdatePersistenceManager` / `IImportDbMaintenance` with `Sql*` adapters and in-memory fakes, `PageViewSaveResult` carrying the counts `PageViewStagingPlan` already computes, and removing `new SPOInsightsEntitiesContext()` + `Console.WriteLine` from `HitPatch.cs`. `IImportDbMaintenance` is shared with #374, so it will be defined once — whichever of the two lands first.

Addresses #369
