### PR TITLE
Extract the App Insights source, watermark and persistence ports; fix the culture-formatted KQL window (#374, #398)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsApiClientTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsApiClientTests.cs
@@ -148,18 +148,19 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public async Task AppInsightsClient_BackoffIsCappedSoAnOutageCannotStallTheWebJob()
+        public void AppInsightsClient_BackoffDoublesThenCapsSoAnOutageCannotStallTheWebJob()
         {
-            var handler = new StubHandler { Fallback = () => Status(HttpStatusCode.BadGateway) };
-            var delay = new RecordingDelay();
+            // Asserted on the pure calculation, not through the retry loop: MaxRetries stops the loop at
+            // attempt 4 (16 seconds), so the cap is unreachable from there and a test driven through the
+            // loop would stay green if Math.Min were deleted.
+            Assert.AreEqual(1, AppInsightsAPIClient.BackoffSecondsFor(0));
+            Assert.AreEqual(2, AppInsightsAPIClient.BackoffSecondsFor(1));
+            Assert.AreEqual(16, AppInsightsAPIClient.BackoffSecondsFor(4));
+            Assert.AreEqual(32, AppInsightsAPIClient.BackoffSecondsFor(5));
 
-            using (var client = NewClient(handler, delay: delay))
-            {
-                await Assert.ThrowsExceptionAsync<HttpRequestException>(() => client.GetPageViewsAsync(Day, false));
-
-                Assert.IsTrue(delay.Requested.All(d => d <= TimeSpan.FromSeconds(AppInsightsAPIClient.MaxBackoffSeconds)),
-                    "No single wait may exceed the cap: " + string.Join(", ", delay.Requested));
-            }
+            // 2^6 = 64 > 60, so this is the first attempt the cap actually bites on.
+            Assert.AreEqual(AppInsightsAPIClient.MaxBackoffSeconds, AppInsightsAPIClient.BackoffSecondsFor(6));
+            Assert.AreEqual(AppInsightsAPIClient.MaxBackoffSeconds, AppInsightsAPIClient.BackoffSecondsFor(20));
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsApiClientTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsApiClientTests.cs
@@ -1,0 +1,239 @@
+using Azure.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WebJob.AppInsightsImporter.Engine;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The App Insights HTTP client's retry, back-off, transient classification and token-refresh rules,
+    /// driven against a stub HttpMessageHandler. Zero network. See issue #374.
+    /// </summary>
+    [TestClass]
+    public class AppInsightsApiClientTests
+    {
+        private const string ConnectionString =
+            "InstrumentationKey=11111111-1111-1111-1111-111111111111;ApplicationId=22222222-2222-2222-2222-222222222222";
+
+        private const string EmptyTableJson =
+            "{\"tables\":[{\"name\":\"PrimaryResult\",\"columns\":[{\"name\":\"timestamp\",\"type\":\"datetime\"}],\"rows\":[]}]}";
+
+        /// <summary>Returns a queued sequence of responses and counts the requests it saw.</summary>
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly Queue<Func<HttpResponseMessage>> _responses = new Queue<Func<HttpResponseMessage>>();
+
+            public int RequestCount { get; private set; }
+            public List<string> AuthorizationHeaders { get; } = new List<string>();
+
+            public StubHandler Then(Func<HttpResponseMessage> response)
+            {
+                _responses.Enqueue(response);
+                return this;
+            }
+
+            /// <summary>Used when the queue runs dry - lets a test say "and then always this".</summary>
+            public Func<HttpResponseMessage> Fallback { get; set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                RequestCount++;
+                AuthorizationHeaders.Add(request.Headers.Authorization?.Parameter);
+                var factory = _responses.Count > 0 ? _responses.Dequeue() : Fallback;
+                if (factory == null)
+                {
+                    throw new InvalidOperationException("Stub handler ran out of queued responses.");
+                }
+                return Task.FromResult(factory());
+            }
+        }
+
+        private static HttpResponseMessage Ok() => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(EmptyTableJson)
+        };
+
+        private static HttpResponseMessage Status(HttpStatusCode code, int? retryAfterSeconds = null)
+        {
+            var response = new HttpResponseMessage(code) { Content = new StringContent("{}") };
+            if (retryAfterSeconds.HasValue)
+            {
+                response.Headers.TryAddWithoutValidation("Retry-After", retryAfterSeconds.Value.ToString(CultureInfo.InvariantCulture));
+            }
+            return response;
+        }
+
+        /// <summary>Hands out tokens with a caller-controlled lifetime, counting how often it was asked.</summary>
+        private sealed class CountingCredential : TokenCredential
+        {
+            private readonly TimeSpan _lifetime;
+            private int _issued;
+
+            public CountingCredential(TimeSpan lifetime)
+            {
+                _lifetime = lifetime;
+            }
+
+            public int TokensIssued => _issued;
+
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                _issued++;
+                return new AccessToken($"token-{_issued}", DateTimeOffset.UtcNow.Add(_lifetime));
+            }
+
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+                => new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+        }
+
+        private static AppInsightsAPIClient NewClient(StubHandler handler, TokenCredential credential = null)
+            => new AppInsightsAPIClient(ConnectionString, credential ?? new CountingCredential(TimeSpan.FromHours(1)),
+                NullLogger.Instance, handler);
+
+        private static readonly DateTime Day = new DateTime(2026, 5, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        [TestMethod]
+        public async Task AppInsightsClient_TransientHttpError_IsRetriedWithBackoff()
+        {
+            var handler = new StubHandler()
+                .Then(() => Status(HttpStatusCode.ServiceUnavailable))
+                .Then(Ok);
+
+            using (var client = NewClient(handler))
+            {
+                var sw = Stopwatch.StartNew();
+                var result = await client.GetPageViewsAsync(Day, false);
+                sw.Stop();
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(2, handler.RequestCount, "A 503 must be retried.");
+
+                // First retry waits min(2^0, 60) = 1 second. Without a back-off the call would return
+                // essentially instantly, so this is what distinguishes "retried" from "retried politely".
+                Assert.IsTrue(sw.Elapsed >= TimeSpan.FromMilliseconds(900), $"Expected a ~1s back-off, waited {sw.Elapsed}.");
+            }
+        }
+
+        [TestMethod]
+        public async Task AppInsightsClient_RetryAfterHeader_IsPreferredOverExponentialBackoff()
+        {
+            // Two 429s that each say "retry immediately". Exponential back-off would have waited 1s then
+            // 2s, so completing well inside that proves the server's Retry-After was honoured.
+            var handler = new StubHandler()
+                .Then(() => Status((HttpStatusCode)429, retryAfterSeconds: 0))
+                .Then(() => Status((HttpStatusCode)429, retryAfterSeconds: 0))
+                .Then(Ok);
+
+            using (var client = NewClient(handler))
+            {
+                var sw = Stopwatch.StartNew();
+                await client.GetCustomEventsAsync(Day, false);
+                sw.Stop();
+
+                Assert.AreEqual(3, handler.RequestCount);
+                Assert.IsTrue(sw.Elapsed < TimeSpan.FromSeconds(2),
+                    $"Exponential back-off would have taken at least 3s; took {sw.Elapsed}.");
+            }
+        }
+
+        [TestMethod]
+        public async Task AppInsightsClient_NonTransientError_IsNotRetried()
+        {
+            // A 403 means a missing API permission. Retrying it five times just delays the error the
+            // operator needs to see.
+            var handler = new StubHandler();
+            handler.Fallback = () => Status(HttpStatusCode.Forbidden);
+
+            using (var client = NewClient(handler))
+            {
+                await Assert.ThrowsExceptionAsync<HttpRequestException>(() => client.GetPageViewsAsync(Day, false));
+                Assert.AreEqual(1, handler.RequestCount);
+            }
+        }
+
+        [TestMethod]
+        public async Task AppInsightsClient_TransientErrors_AreCappedAndTheFailureSurfaces()
+        {
+            // Retry-After: 0 keeps the test fast while still exercising the cap.
+            var handler = new StubHandler();
+            handler.Fallback = () => Status(HttpStatusCode.BadGateway, retryAfterSeconds: 0);
+
+            using (var client = NewClient(handler))
+            {
+                await Assert.ThrowsExceptionAsync<HttpRequestException>(() => client.GetPageViewsAsync(Day, false));
+
+                // The initial attempt plus MaxRetries more, then the failure is returned rather than
+                // retried forever - an App Insights outage must not hang the web-job indefinitely.
+                Assert.AreEqual(AppInsightsAPIClient.MaxRetries + 1, handler.RequestCount);
+            }
+        }
+
+        [TestMethod]
+        public async Task AppInsightsClient_ExpiredToken_IsRefreshedBeforeTheNextCall()
+        {
+            // The client refreshes when the cached token is within 5 minutes of expiry.
+            var shortLived = new CountingCredential(TimeSpan.FromMinutes(1));
+            var handler = new StubHandler { Fallback = Ok };
+
+            using (var client = NewClient(handler, shortLived))
+            {
+                await client.GetPageViewsAsync(Day, false);
+                await client.GetPageViewsAsync(Day.AddDays(1), false);
+
+                Assert.AreEqual(2, shortLived.TokensIssued, "A token expiring inside the refresh margin must be re-fetched.");
+                Assert.AreEqual("token-1", handler.AuthorizationHeaders[0]);
+                Assert.AreEqual("token-2", handler.AuthorizationHeaders[1]);
+            }
+        }
+
+        [TestMethod]
+        public async Task AppInsightsClient_ValidToken_IsReusedRatherThanRefetchedPerRequest()
+        {
+            var longLived = new CountingCredential(TimeSpan.FromHours(1));
+            var handler = new StubHandler { Fallback = Ok };
+
+            using (var client = NewClient(handler, longLived))
+            {
+                await client.GetPageViewsAsync(Day, false);
+                await client.GetCustomEventsAsync(Day, false);
+                await client.GetPageViewsAsync(Day.AddDays(1), false);
+
+                Assert.AreEqual(1, longLived.TokensIssued, "A still-valid token must not cost an Entra ID round-trip per request.");
+            }
+        }
+
+        [TestMethod]
+        public void AppInsightsClient_BuildsKqlWindow_ForRequestedDayInUtc_UnderAnyCulture()
+        {
+            // The current culture picks the CALENDAR, not just the separators: under th-TH the year renders
+            // as 2569 and under ar-SA the whole date shifts, and KQL todatetime() then matches nothing -
+            // silently, with an empty result set rather than an error. See issue #398.
+            var original = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                foreach (var cultureName in new[] { "th-TH", "ar-SA", "en-US" })
+                {
+                    Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+                    using (var client = NewClient(new StubHandler { Fallback = Ok }))
+                    {
+                        var where = client.GetWhereString(Day);
+                        StringAssert.Contains(where, "timestamp >= todatetime('2026-05-30 00:00:00')", $"culture {cultureName}");
+                        StringAssert.Contains(where, "timestamp < todatetime('2026-05-31 00:00:00')", $"culture {cultureName}");
+                    }
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsApiClientTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsApiClientTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -94,53 +95,89 @@ namespace Tests.UnitTests
                 => new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
         }
 
-        private static AppInsightsAPIClient NewClient(StubHandler handler, TokenCredential credential = null)
-            => new AppInsightsAPIClient(ConnectionString, credential ?? new CountingCredential(TimeSpan.FromHours(1)),
+        /// <summary>Records every retry wait the client asked for, and returns immediately.</summary>
+        private sealed class RecordingDelay
+        {
+            public List<TimeSpan> Requested { get; } = new List<TimeSpan>();
+
+            public Task Wait(TimeSpan delay)
+            {
+                Requested.Add(delay);
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        /// The retry wait is always replaced, so no test here measures wall-clock time. Elapsed time would
+        /// include scheduling, GC and deserialisation as well as the back-off, which makes it both flaky
+        /// under CI load and capable of passing after a no-back-off regression.
+        /// </summary>
+        private static AppInsightsAPIClient NewClient(StubHandler handler, TokenCredential credential = null, RecordingDelay delay = null)
+        {
+            var client = new AppInsightsAPIClient(ConnectionString, credential ?? new CountingCredential(TimeSpan.FromHours(1)),
                 NullLogger.Instance, handler);
+            client.RetryDelay = (delay ?? new RecordingDelay()).Wait;
+            return client;
+        }
 
         private static readonly DateTime Day = new DateTime(2026, 5, 30, 0, 0, 0, DateTimeKind.Utc);
 
         [TestMethod]
-        public async Task AppInsightsClient_TransientHttpError_IsRetriedWithBackoff()
+        public async Task AppInsightsClient_TransientHttpError_IsRetriedWithExponentialBackoff()
         {
             var handler = new StubHandler()
                 .Then(() => Status(HttpStatusCode.ServiceUnavailable))
+                .Then(() => Status(HttpStatusCode.ServiceUnavailable))
+                .Then(() => Status(HttpStatusCode.ServiceUnavailable))
                 .Then(Ok);
+            var delay = new RecordingDelay();
 
-            using (var client = NewClient(handler))
+            using (var client = NewClient(handler, delay: delay))
             {
-                var sw = Stopwatch.StartNew();
                 var result = await client.GetPageViewsAsync(Day, false);
-                sw.Stop();
 
                 Assert.IsNotNull(result);
-                Assert.AreEqual(2, handler.RequestCount, "A 503 must be retried.");
+                Assert.AreEqual(4, handler.RequestCount, "A 503 must be retried.");
 
-                // First retry waits min(2^0, 60) = 1 second. Without a back-off the call would return
-                // essentially instantly, so this is what distinguishes "retried" from "retried politely".
-                Assert.IsTrue(sw.Elapsed >= TimeSpan.FromMilliseconds(900), $"Expected a ~1s back-off, waited {sw.Elapsed}.");
+                // 2^0, 2^1, 2^2 seconds. Asserted on the delays the client actually asked for, so a
+                // regression that dropped the wait - or made it constant - fails here.
+                CollectionAssert.AreEqual(
+                    new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4) },
+                    delay.Requested.ToArray());
+            }
+        }
+
+        [TestMethod]
+        public async Task AppInsightsClient_BackoffIsCappedSoAnOutageCannotStallTheWebJob()
+        {
+            var handler = new StubHandler { Fallback = () => Status(HttpStatusCode.BadGateway) };
+            var delay = new RecordingDelay();
+
+            using (var client = NewClient(handler, delay: delay))
+            {
+                await Assert.ThrowsExceptionAsync<HttpRequestException>(() => client.GetPageViewsAsync(Day, false));
+
+                Assert.IsTrue(delay.Requested.All(d => d <= TimeSpan.FromSeconds(AppInsightsAPIClient.MaxBackoffSeconds)),
+                    "No single wait may exceed the cap: " + string.Join(", ", delay.Requested));
             }
         }
 
         [TestMethod]
         public async Task AppInsightsClient_RetryAfterHeader_IsPreferredOverExponentialBackoff()
         {
-            // Two 429s that each say "retry immediately". Exponential back-off would have waited 1s then
-            // 2s, so completing well inside that proves the server's Retry-After was honoured.
+            // The server said "wait 7 seconds"; exponential back-off would have asked for 1 then 2.
             var handler = new StubHandler()
-                .Then(() => Status((HttpStatusCode)429, retryAfterSeconds: 0))
-                .Then(() => Status((HttpStatusCode)429, retryAfterSeconds: 0))
+                .Then(() => Status((HttpStatusCode)429, retryAfterSeconds: 7))
+                .Then(() => Status((HttpStatusCode)429, retryAfterSeconds: 7))
                 .Then(Ok);
+            var delay = new RecordingDelay();
 
-            using (var client = NewClient(handler))
+            using (var client = NewClient(handler, delay: delay))
             {
-                var sw = Stopwatch.StartNew();
                 await client.GetCustomEventsAsync(Day, false);
-                sw.Stop();
 
                 Assert.AreEqual(3, handler.RequestCount);
-                Assert.IsTrue(sw.Elapsed < TimeSpan.FromSeconds(2),
-                    $"Exponential back-off would have taken at least 3s; took {sw.Elapsed}.");
+                CollectionAssert.AreEqual(new[] { TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(7) }, delay.Requested.ToArray());
             }
         }
 
@@ -162,7 +199,6 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task AppInsightsClient_TransientErrors_AreCappedAndTheFailureSurfaces()
         {
-            // Retry-After: 0 keeps the test fast while still exercising the cap.
             var handler = new StubHandler();
             handler.Fallback = () => Status(HttpStatusCode.BadGateway, retryAfterSeconds: 0);
 

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImportWindowTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImportWindowTests.cs
@@ -12,13 +12,13 @@ namespace Tests.UnitTests
     ///
     /// Scope note: these methods take the instant as a parameter and never read <c>DateTime.Now</c> or
     /// <c>TimeZoneInfo.Local</c>, so nothing here can be shifted by the host's timezone. The bug the
-    /// importer's code comment warns about - a caller supplying a LOCAL clock - is a call-site concern
-    /// and is <b>not covered by any current test</b>. <c>AppInsightsImporter</c> does read
-    /// <c>_clock.UtcNow</c> today, and <c>ClockAndContextFactoryTests</c> covers the adapter
-    /// (<c>SystemClock.UtcNow</c> returns a UTC instant) and the constructor wiring (the injected clock
-    /// is stored) - but nothing invokes <c>ImportAndSave</c>, so replacing those reads with
-    /// <c>DateTime.Now</c> would leave every test green. A caller-level test can follow once the
-    /// importer's database and HTTP dependencies are behind seams (the rest of #374).
+    /// importer's code comment warns about - a caller supplying a LOCAL clock - is a call-site concern,
+    /// and it is now covered: the rest of #374 put the importer's database and HTTP dependencies behind
+    /// ports, so <c>AppInsightsImporterOrchestrationTests.AppInsightsImporter_WindowIsDrivenByTheInjected
+    /// Clock_NotTheWallClock</c> runs <c>ImportAndSave</c> end to end against a clock fixed years in the
+    /// past and asserts the days actually requested. Swapping <c>_clock.UtcNow</c> for
+    /// <c>DateTime.Now</c>/<c>DateTime.UtcNow</c> inside <c>ImportAndSave</c> now fails a test rather
+    /// than leaving every test green.
     ///
     /// Runs with zero SQL Server, zero HTTP and zero wall-clock dependency.
     /// </summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImporterOrchestrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImporterOrchestrationTests.cs
@@ -126,7 +126,12 @@ namespace Tests.UnitTests
             // catch, so JobTimer.TrackFinishedEventAndStopTimer never ran. Extracting the day loop into its
             // own method made that `return` exit only the inner method, which would have emitted
             // FinishedSectionImport for a cycle that imported nothing - a false success to liveness
-            // monitoring, visible only in Release because DEBUG rethrows.
+            // monitoring.
+            //
+            // The production path is #if DEBUG-forked, so this test is too. Note CI currently builds and
+            // tests RELEASE ONLY (the Debug matrix entry is commented out in ci.yml / pr.yml / tests.yml),
+            // so it is the #else arm - the one guarding the actual regression - that CI runs. The DEBUG arm
+            // only runs in a local Debug build.
             var h = new Harness();
             h.Watermark.NewestHitTimestampUtc = FixedNowUtc.AddHours(-2);
             h.Source.DaysThatFailToDownload.Add(FixedNowUtc.Date);

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImporterOrchestrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImporterOrchestrationTests.cs
@@ -1,0 +1,138 @@
+using Common.Entities.Config;
+using DataUtils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using UnitTests.FakeLoaderClasses;
+using WebJob.AppInsightsImporter.Engine;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The App Insights importer's orchestration - the day loop, the window it derives, and the per-day
+    /// failure isolation - driven entirely through the ports added by issue #374. No HTTP, no SQL Server,
+    /// no wall clock.
+    /// </summary>
+    [TestClass]
+    public class AppInsightsImporterOrchestrationTests
+    {
+        private static readonly DateTime FixedNowUtc = new DateTime(2026, 5, 10, 9, 0, 0, DateTimeKind.Utc);
+
+        private class Harness
+        {
+            public readonly FakeAppInsightsSourceLoader Source = new FakeAppInsightsSourceLoader();
+            public readonly FakeImportDbMaintenance Maintenance = new FakeImportDbMaintenance();
+            public readonly FakeSiteFilterLoader SiteFilters = new FakeSiteFilterLoader();
+            public readonly InMemoryHitWatermarkStore Watermark = new InMemoryHitWatermarkStore();
+            public readonly InMemoryAppInsightsDayPersistenceManager Persistence = new InMemoryAppInsightsDayPersistenceManager();
+            public FixedClock Clock = new FixedClock(FixedNowUtc);
+
+            public Task RunAsync() => new AppInsightsImporter(
+                new Common.Entities.Config.AppConfig(),
+                AnalyticsLogger.ConsoleOnlyTracer(),
+                Clock,
+                Source,
+                Maintenance,
+                SiteFilters,
+                Watermark,
+                Persistence).ImportAndSave(saveRestResponses: false, daysBeforeOverride: null);
+        }
+
+        [TestMethod]
+        public async Task AppInsightsImporter_RunsWithFakeSourceAndFakePersistence_WithoutHttpOrSql()
+        {
+            var h = new Harness();
+            h.Watermark.NewestHitTimestampUtc = new DateTime(2026, 5, 8, 14, 0, 0, DateTimeKind.Utc);
+            h.SiteFilters.Filters.Add(new FilterUrlConfig { Url = "https://contoso.sharepoint.com" });
+            h.Source.PageViewCountByDay[new DateTime(2026, 5, 9)] = 3;
+            h.Source.CustomEventCountByDay[new DateTime(2026, 5, 9)] = 2;
+
+            await h.RunAsync();
+
+            // Startup maintenance runs exactly once for the whole run, not per day.
+            Assert.AreEqual(1, h.Maintenance.RunCount);
+            Assert.AreEqual(1, h.Watermark.ReadCount);
+
+            // 8th (the watermark day, rewound a minute), 9th, 10th (today).
+            CollectionAssert.AreEqual(
+                new[] { new DateTime(2026, 5, 8), new DateTime(2026, 5, 9), new DateTime(2026, 5, 10) },
+                h.Source.PageViewDaysRequested.ToArray());
+            CollectionAssert.AreEqual(h.Source.PageViewDaysRequested.ToArray(), h.Source.CustomEventDaysRequested.ToArray());
+
+            // Only the day with data is saved; empty days are skipped entirely.
+            Assert.AreEqual(1, h.Persistence.SavedPageViews.Count);
+            Assert.AreEqual(3, h.Persistence.SavedPageViews.Single().Rows.Count);
+            Assert.AreEqual(2, h.Persistence.SavedCustomEvents.Single().Rows.Count);
+
+            // The org-URL filter loaded at startup is the one handed to the save, not a fresh empty list.
+            Assert.AreSame(h.SiteFilters.Filters, h.Persistence.FiltersSeen);
+        }
+
+        [TestMethod]
+        public async Task AppInsightsImporter_WindowIsDrivenByTheInjectedClock_NotTheWallClock()
+        {
+            // A clock fixed years in the past: no wall-clock-derived window could produce these days, so
+            // this fails if ImportAndSave ever goes back to reading DateTime.UtcNow / DateTime.Now.
+            var h = new Harness { Clock = new FixedClock(new DateTime(2019, 2, 14, 6, 0, 0, DateTimeKind.Utc)) };
+            h.Watermark.NewestHitTimestampUtc = new DateTime(2019, 2, 12, 23, 30, 0, DateTimeKind.Utc);
+
+            await h.RunAsync();
+
+            CollectionAssert.AreEqual(
+                new[] { new DateTime(2019, 2, 12), new DateTime(2019, 2, 13), new DateTime(2019, 2, 14) },
+                h.Source.PageViewDaysRequested.ToArray());
+        }
+
+        [TestMethod]
+        public async Task AppInsightsImporter_NoHitsYet_ScansTheFallbackWindow()
+        {
+            var h = new Harness();
+            h.Watermark.NewestHitTimestampUtc = null;
+
+            await h.RunAsync();
+
+            // 31 days back, rewound a minute (so the first day is the 32nd back), through today inclusive.
+            Assert.AreEqual(FixedNowUtc.AddDays(-AppInsightsImportWindow.NoHitsFallbackDays).AddMinutes(-1).Date,
+                h.Source.PageViewDaysRequested.First());
+            Assert.AreEqual(FixedNowUtc.Date, h.Source.PageViewDaysRequested.Last());
+        }
+
+        [TestMethod]
+        public async Task AppInsightsImporter_OneDayFailing_DoesNotAbortRemainingDays()
+        {
+            // A single bad day - historically a page-update event tripping a DbUpdateException - must not
+            // stall the whole multi-day run and freeze the watermark.
+            var h = new Harness();
+            h.Watermark.NewestHitTimestampUtc = new DateTime(2026, 5, 8, 14, 0, 0, DateTimeKind.Utc);
+            foreach (var day in new[] { new DateTime(2026, 5, 8), new DateTime(2026, 5, 9), new DateTime(2026, 5, 10) })
+            {
+                h.Source.PageViewCountByDay[day] = 1;
+            }
+            h.Persistence.DaysThatFailToSave.Add(new DateTime(2026, 5, 9));
+
+            await h.RunAsync();
+
+            Assert.AreEqual(3, h.Source.PageViewDaysRequested.Count, "Every day should still be fetched.");
+            CollectionAssert.AreEqual(
+                new[] { new DateTime(2026, 5, 8), new DateTime(2026, 5, 10) },
+                h.Persistence.SavedPageViews.Select(p => p.Rows[0].Timestamp.Date).ToArray());
+        }
+
+        [TestMethod]
+        public async Task AppInsightsImporter_DayThatSavesNothing_StillCountsAsProcessed()
+        {
+            // No data at all: the loop must complete without touching persistence rather than saving
+            // empty collections (which would run the merge SQL for nothing, every cycle).
+            var h = new Harness();
+            h.Watermark.NewestHitTimestampUtc = FixedNowUtc.AddHours(-2);
+
+            await h.RunAsync();
+
+            Assert.AreEqual(1, h.Source.PageViewDaysRequested.Count);
+            Assert.AreEqual(0, h.Persistence.SavedPageViews.Count);
+            Assert.AreEqual(0, h.Persistence.SavedCustomEvents.Count);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImporterOrchestrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImporterOrchestrationTests.cs
@@ -2,7 +2,9 @@ using Common.Entities.Config;
 using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
 using UnitTests.FakeLoaderClasses;
@@ -29,7 +31,7 @@ namespace Tests.UnitTests
             public readonly InMemoryAppInsightsDayPersistenceManager Persistence = new InMemoryAppInsightsDayPersistenceManager();
             public FixedClock Clock = new FixedClock(FixedNowUtc);
 
-            public Task RunAsync() => new AppInsightsImporter(
+            public Task RunAsync(int? daysBeforeOverride = null) => new AppInsightsImporter(
                 new Common.Entities.Config.AppConfig(),
                 AnalyticsLogger.ConsoleOnlyTracer(),
                 Clock,
@@ -37,7 +39,7 @@ namespace Tests.UnitTests
                 Maintenance,
                 SiteFilters,
                 Watermark,
-                Persistence).ImportAndSave(saveRestResponses: false, daysBeforeOverride: null);
+                Persistence).ImportAndSave(saveRestResponses: false, daysBeforeOverride: daysBeforeOverride);
         }
 
         [TestMethod]
@@ -86,6 +88,24 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public async Task AppInsightsImporter_DaysBeforeOverride_IsAlsoResolvedFromTheInjectedClock()
+        {
+            // ResolveOverrideStartUtc ignores its clock argument when no override is supplied, so the test
+            // above cannot see the FIRST _clock.UtcNow read in ImportAndSave. With an override it can:
+            // swapping that read for DateTime.Now would shift the window on any non-UTC host.
+            var h = new Harness { Clock = new FixedClock(new DateTime(2019, 2, 14, 6, 0, 0, DateTimeKind.Utc)) };
+            h.Watermark.NewestHitTimestampUtc = new DateTime(2019, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            await h.RunAsync(daysBeforeOverride: 2);
+
+            // The override wins over the (much older) watermark: 2 days back from the fixed clock, rewound
+            // a minute, through "today" inclusive.
+            CollectionAssert.AreEqual(
+                new[] { new DateTime(2019, 2, 12), new DateTime(2019, 2, 13), new DateTime(2019, 2, 14) },
+                h.Source.PageViewDaysRequested.ToArray());
+        }
+
+        [TestMethod]
         public async Task AppInsightsImporter_NoHitsYet_ScansTheFallbackWindow()
         {
             var h = new Harness();
@@ -97,6 +117,64 @@ namespace Tests.UnitTests
             Assert.AreEqual(FixedNowUtc.AddDays(-AppInsightsImportWindow.NoHitsFallbackDays).AddMinutes(-1).Date,
                 h.Source.PageViewDaysRequested.First());
             Assert.AreEqual(FixedNowUtc.Date, h.Source.PageViewDaysRequested.Last());
+        }
+
+        [TestMethod]
+        public async Task AppInsightsImporter_FatalDownloadFailure_DoesNotReportTheSectionAsFinished()
+        {
+            // Regression guard. The original code returned straight out of ImportAndSave from the download
+            // catch, so JobTimer.TrackFinishedEventAndStopTimer never ran. Extracting the day loop into its
+            // own method made that `return` exit only the inner method, which would have emitted
+            // FinishedSectionImport for a cycle that imported nothing - a false success to liveness
+            // monitoring, visible only in Release because DEBUG rethrows.
+            var h = new Harness();
+            h.Watermark.NewestHitTimestampUtc = FixedNowUtc.AddHours(-2);
+            h.Source.DaysThatFailToDownload.Add(FixedNowUtc.Date);
+
+            var console = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(console);
+            try
+            {
+#if DEBUG
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => h.RunAsync());
+#else
+                await h.RunAsync();
+#endif
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            // AnalyticsLogger.TrackEvent writes "New event '<name>'" to the console, so this is how the
+            // event is observable without a real App Insights key. Asserted in BOTH configurations: DEBUG
+            // must not track it either, because it never gets that far.
+            StringAssert.DoesNotMatch(console.ToString(), new Regex("New event '" + nameof(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport) + "'"),
+                "A failed download must not report the section as finished.");
+        }
+
+        [TestMethod]
+        public async Task AppInsightsImporter_SuccessfulRun_DoesReportTheSectionAsFinished()
+        {
+            // The other half of the guard above: without this, making the failure path skip the event could
+            // be "fixed" by never emitting it at all.
+            var h = new Harness();
+            h.Watermark.NewestHitTimestampUtc = FixedNowUtc.AddHours(-2);
+
+            var console = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(console);
+            try
+            {
+                await h.RunAsync();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            StringAssert.Matches(console.ToString(), new Regex("New event '" + nameof(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport) + "'"));
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAppInsightsPorts.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAppInsightsPorts.cs
@@ -34,7 +34,11 @@ namespace Tests.UnitTests.FakeLoaderClasses
             PageViewDaysRequested.Add(forDateUtc);
             if (DaysThatFailToDownload.Contains(forDateUtc))
             {
-                throw new InvalidOperationException($"Fake download failure for {forDateUtc:yyyy-MM-dd}");
+                // A FAULTED TASK, not a synchronous throw: that is the shape a real HTTP failure arrives in,
+                // and the importer observes it at `await Task.WhenAll(...)`. A fake that threw synchronously
+                // would let a regression that only handled the synchronous case pass.
+                return Task.FromException<PageViewCollection>(
+                    new InvalidOperationException($"Fake download failure for {forDateUtc:yyyy-MM-dd}"));
             }
 
             var result = new PageViewCollection();
@@ -51,7 +55,8 @@ namespace Tests.UnitTests.FakeLoaderClasses
             CustomEventDaysRequested.Add(forDateUtc);
             if (DaysThatFailToDownload.Contains(forDateUtc))
             {
-                throw new InvalidOperationException($"Fake download failure for {forDateUtc:yyyy-MM-dd}");
+                return Task.FromException<CustomEventsResultCollection>(
+                    new InvalidOperationException($"Fake download failure for {forDateUtc:yyyy-MM-dd}"));
             }
 
             var result = new CustomEventsResultCollection();

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAppInsightsPorts.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAppInsightsPorts.cs
@@ -1,0 +1,122 @@
+using Common.Entities.Config;
+using DataUtils;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.AppInsightsImporter.Engine;
+using WebJob.AppInsightsImporter.Engine.ApiImporter;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="IAppInsightsSourceLoader"/> - the App Insights REST API replaced by a
+    /// dictionary, so the importer's day loop can be driven with no HTTP at all. See issue #374.
+    /// </summary>
+    public class FakeAppInsightsSourceLoader : IAppInsightsSourceLoader
+    {
+        /// <summary>Every day the importer asked for, in the order it asked.</summary>
+        public List<DateTime> PageViewDaysRequested { get; } = new List<DateTime>();
+        public List<DateTime> CustomEventDaysRequested { get; } = new List<DateTime>();
+
+        /// <summary>How many page-views / custom events each day returns. Missing day = empty.</summary>
+        public Dictionary<DateTime, int> PageViewCountByDay { get; } = new Dictionary<DateTime, int>();
+        public Dictionary<DateTime, int> CustomEventCountByDay { get; } = new Dictionary<DateTime, int>();
+
+        public Task<PageViewCollection> GetPageViewsAsync(DateTime forDateUtc, bool saveRestResponses)
+        {
+            PageViewDaysRequested.Add(forDateUtc);
+
+            var result = new PageViewCollection();
+            var count = PageViewCountByDay.TryGetValue(forDateUtc, out var c) ? c : 0;
+            for (var i = 0; i < count; i++)
+            {
+                result.Rows.Add(new PageViewAppInsightsQueryResult { AppInsightsTimestamp = forDateUtc.AddMinutes(i) });
+            }
+            return Task.FromResult(result);
+        }
+
+        public Task<CustomEventsResultCollection> GetCustomEventsAsync(DateTime forDateUtc, bool saveRestResponses)
+        {
+            CustomEventDaysRequested.Add(forDateUtc);
+
+            var result = new CustomEventsResultCollection();
+            var count = CustomEventCountByDay.TryGetValue(forDateUtc, out var c) ? c : 0;
+            for (var i = 0; i < count; i++)
+            {
+                result.Rows.Add(new PageExitEventAppInsightsQueryResult { AppInsightsTimestamp = forDateUtc.AddMinutes(i) });
+            }
+            return Task.FromResult(result);
+        }
+    }
+
+    /// <summary>In-memory <see cref="IHitWatermarkStore"/>.</summary>
+    public class InMemoryHitWatermarkStore : IHitWatermarkStore
+    {
+        public InMemoryHitWatermarkStore(DateTime? newestHitTimestampUtc = null)
+        {
+            NewestHitTimestampUtc = newestHitTimestampUtc;
+        }
+
+        public DateTime? NewestHitTimestampUtc { get; set; }
+        public int ReadCount { get; private set; }
+
+        public Task<DateTime?> GetNewestHitTimestampUtcAsync()
+        {
+            ReadCount++;
+            return Task.FromResult(NewestHitTimestampUtc);
+        }
+    }
+
+    /// <summary>In-memory <see cref="ISiteFilterLoader"/>.</summary>
+    public class FakeSiteFilterLoader : ISiteFilterLoader
+    {
+        public List<FilterUrlConfig> Filters { get; set; } = new List<FilterUrlConfig>();
+
+        public Task<List<FilterUrlConfig>> LoadAsync() => Task.FromResult(Filters);
+    }
+
+    /// <summary><see cref="IImportDbMaintenance"/> that only records that it was asked to run.</summary>
+    public class FakeImportDbMaintenance : IImportDbMaintenance
+    {
+        public int RunCount { get; private set; }
+
+        public Task RunStartupMaintenanceAsync()
+        {
+            RunCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IAppInsightsDayPersistenceManager"/>, recording what each day saved and able to
+    /// fail on demand so the per-day failure isolation can be asserted.
+    /// </summary>
+    public class InMemoryAppInsightsDayPersistenceManager : IAppInsightsDayPersistenceManager
+    {
+        public List<PageViewCollection> SavedPageViews { get; } = new List<PageViewCollection>();
+        public List<CustomEventsResultCollection> SavedCustomEvents { get; } = new List<CustomEventsResultCollection>();
+        public List<FilterUrlConfig> FiltersSeen { get; private set; }
+
+        /// <summary>Throw when the page-view batch's first row falls on one of these days.</summary>
+        public HashSet<DateTime> DaysThatFailToSave { get; } = new HashSet<DateTime>();
+
+        public Task SavePageViewsAsync(PageViewCollection pageViews, List<FilterUrlConfig> filterUrls)
+        {
+            FiltersSeen = filterUrls;
+            var day = pageViews.Rows.Count > 0 ? pageViews.Rows[0].Timestamp.Date : (DateTime?)null;
+            if (day.HasValue && DaysThatFailToSave.Contains(day.Value))
+            {
+                throw new InvalidOperationException($"Fake save failure for {day.Value:yyyy-MM-dd}");
+            }
+            SavedPageViews.Add(pageViews);
+            return Task.CompletedTask;
+        }
+
+        public Task SaveCustomEventsAsync(CustomEventsResultCollection events)
+        {
+            SavedCustomEvents.Add(events);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAppInsightsPorts.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeAppInsightsPorts.cs
@@ -23,9 +23,19 @@ namespace Tests.UnitTests.FakeLoaderClasses
         public Dictionary<DateTime, int> PageViewCountByDay { get; } = new Dictionary<DateTime, int>();
         public Dictionary<DateTime, int> CustomEventCountByDay { get; } = new Dictionary<DateTime, int>();
 
+        /// <summary>
+        /// Days whose download blows up. The importer treats that as fatal for the whole run - DEBUG
+        /// rethrows, Release abandons the run without reporting the section finished.
+        /// </summary>
+        public HashSet<DateTime> DaysThatFailToDownload { get; } = new HashSet<DateTime>();
+
         public Task<PageViewCollection> GetPageViewsAsync(DateTime forDateUtc, bool saveRestResponses)
         {
             PageViewDaysRequested.Add(forDateUtc);
+            if (DaysThatFailToDownload.Contains(forDateUtc))
+            {
+                throw new InvalidOperationException($"Fake download failure for {forDateUtc:yyyy-MM-dd}");
+            }
 
             var result = new PageViewCollection();
             var count = PageViewCountByDay.TryGetValue(forDateUtc, out var c) ? c : 0;
@@ -39,6 +49,10 @@ namespace Tests.UnitTests.FakeLoaderClasses
         public Task<CustomEventsResultCollection> GetCustomEventsAsync(DateTime forDateUtc, bool saveRestResponses)
         {
             CustomEventDaysRequested.Add(forDateUtc);
+            if (DaysThatFailToDownload.Contains(forDateUtc))
+            {
+                throw new InvalidOperationException($"Fake download failure for {forDateUtc:yyyy-MM-dd}");
+            }
 
             var result = new CustomEventsResultCollection();
             var count = CustomEventCountByDay.TryGetValue(forDateUtc, out var c) ? c : 0;

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -33,7 +33,9 @@
     <Compile Include="AppConfigDefaultsTests.cs" />
     <Compile Include="PreInstallAdvisorTests.cs" />
     <Compile Include="ImportCadenceTests.cs" />
+    <Compile Include="AppInsightsApiClientTests.cs" />
     <Compile Include="AppInsightsAuthTests.cs" />
+    <Compile Include="AppInsightsImporterOrchestrationTests.cs" />
     <Compile Include="CheckpointTableClientFactoryTests.cs" />
     <Compile Include="CopilotAuditLogContentSchemaTests.cs" />
     <Compile Include="CopilotEventManagerAccessedResourcesTests.cs" />
@@ -207,6 +209,7 @@
     <Compile Include="FakeEntities\FakeOfficeServicesDB.cs" />
     <Compile Include="CallRecordTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeActivityImporter.cs" />
+    <Compile Include="FakeLoaderClasses\FakeAppInsightsPorts.cs" />
     <Compile Include="FakeLoaderClasses\FakeActivityReportLoader.cs" />
     <Compile Include="FakeLoaderClasses\FakeActivityReportPersistenceManager.cs" />
     <Compile Include="FakeLoaderClasses\FakeContentMetaDataLoader.cs" />

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsAPIClient.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsAPIClient.cs
@@ -16,7 +16,7 @@ namespace WebJob.AppInsightsImporter.Engine
     /// <summary>
     /// HTTP client for App Insights calls, authenticated via Entra ID (OAuth).
     /// </summary>
-    public class AppInsightsAPIClient : IDisposable
+    public class AppInsightsAPIClient : IAppInsightsSourceLoader, IDisposable
     {
         private readonly ILogger _logger;
         private readonly string _appInsightsId;
@@ -35,8 +35,18 @@ namespace WebJob.AppInsightsImporter.Engine
         /// </summary>
         /// <param name="appInsightsConnectionString">The Application Insights connection string. The ApplicationId is parsed from it for use in the query URL.</param>
         /// <param name="credential">A TokenCredential (e.g. ClientSecretCredential) for Entra ID authentication.</param>
-        /// <param name="debugTracer">Logger instance.</param>
+        /// <param name="logger">Logger instance.</param>
         public AppInsightsAPIClient(string appInsightsConnectionString, TokenCredential credential, ILogger logger)
+            : this(appInsightsConnectionString, credential, logger, null)
+        {
+        }
+
+        /// <summary>
+        /// As above, but with the HTTP transport supplied by the caller. Used by the tests to drive the
+        /// retry, back-off and transient-classification logic against a stub handler instead of the real
+        /// App Insights endpoint (issue #374). A <c>null</c> handler means the production transport.
+        /// </summary>
+        public AppInsightsAPIClient(string appInsightsConnectionString, TokenCredential credential, ILogger logger, HttpMessageHandler messageHandler)
         {
             if (string.IsNullOrEmpty(appInsightsConnectionString))
             {
@@ -51,6 +61,10 @@ namespace WebJob.AppInsightsImporter.Engine
                 throw new ArgumentException("Could not parse ApplicationId from the provided connection string.", nameof(appInsightsConnectionString));
             }
 
+            client = messageHandler == null
+                ? new HttpClient { Timeout = TimeSpan.FromMinutes(10) }
+                : new HttpClient(messageHandler, disposeHandler: false) { Timeout = TimeSpan.FromMinutes(10) };
+
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             _logger = logger;
@@ -63,7 +77,7 @@ namespace WebJob.AppInsightsImporter.Engine
         // Per-instance HttpClient. Cannot be made static because callers set the
         // Authorization header on DefaultRequestHeaders per token refresh; sharing
         // would race between instances. Lifetime is bounded by the importer run.
-        private HttpClient client = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        private readonly HttpClient client;
 
         #endregion
 
@@ -179,6 +193,20 @@ namespace WebJob.AppInsightsImporter.Engine
         }
 
         /// <summary>
+        /// <see cref="IAppInsightsSourceLoader"/>. Kept as a thin alias over the original method name so no
+        /// existing call site or test changes.
+        /// </summary>
+        public Task<PageViewCollection> GetPageViewsAsync(DateTime forDateUtc, bool saveRestResponses)
+            => GetPageViewsFromAppInsights(forDateUtc, saveRestResponses);
+
+        /// <summary>
+        /// <see cref="IAppInsightsSourceLoader"/>. Kept as a thin alias over the original method name so no
+        /// existing call site or test changes.
+        /// </summary>
+        public Task<CustomEventsResultCollection> GetCustomEventsAsync(DateTime forDateUtc, bool saveRestResponses)
+            => GetCustomEventsFromAppInsights(forDateUtc, saveRestResponses);
+
+        /// <summary>
         /// Load page-views
         /// </summary>
         public async Task<PageViewCollection> GetPageViewsFromAppInsights(DateTime forDate, bool saveRestResponses)
@@ -218,9 +246,19 @@ namespace WebJob.AppInsightsImporter.Engine
             return new CustomEventsResultCollection(result.DefaultTable, forDate, _logger);
         }
 
+        /// <summary>
+        /// The KQL time window for one UTC day.
+        ///
+        /// Formatted with <see cref="System.Globalization.CultureInfo.InvariantCulture"/> deliberately: the
+        /// current culture selects the calendar, so on a host whose culture uses a non-Gregorian calendar
+        /// this rendered a completely different date - "2569-05-30" under th-TH (Buddhist), "1447-12-13"
+        /// under ar-SA (Umm al-Qura) - and App Insights then returned no rows for the window, silently and
+        /// without an error. KQL <c>todatetime()</c> only understands Gregorian ISO dates.
+        /// </summary>
         internal string GetWhereString(DateTime forDate)
         {
-            return $"timestamp >= todatetime('{forDate.ToString("yyyy-MM-dd HH:mm:ss")}') and timestamp < todatetime('{forDate.AddDays(1).ToString("yyyy-MM-dd HH:mm:ss")}')";
+            var culture = System.Globalization.CultureInfo.InvariantCulture;
+            return $"timestamp >= todatetime('{forDate.ToString("yyyy-MM-dd HH:mm:ss", culture)}') and timestamp < todatetime('{forDate.AddDays(1).ToString("yyyy-MM-dd HH:mm:ss", culture)}')";
         }
 
         async Task<T> HandleResponse<T>(HttpResponseMessage response, bool saveRestResponses, string operationType)

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsAPIClient.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsAPIClient.cs
@@ -29,6 +29,17 @@ namespace WebJob.AppInsightsImporter.Engine
         internal const int MaxBackoffSeconds = 60;
 
         /// <summary>
+        /// The exponential back-off for a retry attempt, in seconds: 1, 2, 4, 8 ... capped at
+        /// <see cref="MaxBackoffSeconds"/>. Used when the response carries no <c>Retry-After</c> header.
+        /// Pure, so the cap is assertable at an attempt number the retry loop itself never reaches
+        /// (<see cref="MaxRetries"/> stops at 16 seconds).
+        /// </summary>
+        internal static int BackoffSecondsFor(int attempt)
+        {
+            return Math.Min((int)Math.Pow(2, attempt), MaxBackoffSeconds);
+        }
+
+        /// <summary>
         /// How the client waits between retries. Replaceable by tests so the retry and back-off rules can be
         /// asserted on the delays actually <b>requested</b>, rather than inferred from elapsed wall-clock
         /// time - which measures scheduling, GC and deserialisation as well, and is therefore both flaky
@@ -155,7 +166,7 @@ namespace WebJob.AppInsightsImporter.Engine
                     }
 
                     var retryAfterSeconds = GetRetryAfterSeconds(response);
-                    var backoff = retryAfterSeconds ?? Math.Min((int)Math.Pow(2, attempt), MaxBackoffSeconds);
+                    var backoff = retryAfterSeconds ?? BackoffSecondsFor(attempt);
                     _logger.LogWarning($"Transient HTTP {(int)response.StatusCode} from App Insights API. Retrying in {backoff}s (attempt {attempt + 1}/{MaxRetries})...");
 
                     response.Dispose();
@@ -163,7 +174,7 @@ namespace WebJob.AppInsightsImporter.Engine
                 }
                 catch (Exception ex) when (IsTransientException(ex) && attempt < MaxRetries)
                 {
-                    var backoff = Math.Min((int)Math.Pow(2, attempt), MaxBackoffSeconds);
+                    var backoff = BackoffSecondsFor(attempt);
                     _logger.LogWarning($"Transient error calling App Insights API: {ex.Message}. Retrying in {backoff}s (attempt {attempt + 1}/{MaxRetries})...");
                     await RetryDelay(TimeSpan.FromSeconds(backoff));
                 }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsAPIClient.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsAPIClient.cs
@@ -28,6 +28,14 @@ namespace WebJob.AppInsightsImporter.Engine
         internal const int MaxRetries = 5;
         internal const int MaxBackoffSeconds = 60;
 
+        /// <summary>
+        /// How the client waits between retries. Replaceable by tests so the retry and back-off rules can be
+        /// asserted on the delays actually <b>requested</b>, rather than inferred from elapsed wall-clock
+        /// time - which measures scheduling, GC and deserialisation as well, and is therefore both flaky
+        /// under load and capable of passing after a no-back-off regression. See issue #374.
+        /// </summary>
+        internal Func<TimeSpan, Task> RetryDelay { get; set; } = Task.Delay;
+
         #region Constructors
 
         /// <summary>
@@ -151,13 +159,13 @@ namespace WebJob.AppInsightsImporter.Engine
                     _logger.LogWarning($"Transient HTTP {(int)response.StatusCode} from App Insights API. Retrying in {backoff}s (attempt {attempt + 1}/{MaxRetries})...");
 
                     response.Dispose();
-                    await Task.Delay(TimeSpan.FromSeconds(backoff));
+                    await RetryDelay(TimeSpan.FromSeconds(backoff));
                 }
                 catch (Exception ex) when (IsTransientException(ex) && attempt < MaxRetries)
                 {
                     var backoff = Math.Min((int)Math.Pow(2, attempt), MaxBackoffSeconds);
                     _logger.LogWarning($"Transient error calling App Insights API: {ex.Message}. Retrying in {backoff}s (attempt {attempt + 1}/{MaxRetries})...");
-                    await Task.Delay(TimeSpan.FromSeconds(backoff));
+                    await RetryDelay(TimeSpan.FromSeconds(backoff));
                 }
             }
         }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
@@ -118,7 +118,14 @@ namespace WebJob.AppInsightsImporter.Engine
 
             if (_source != null)
             {
-                await ImportDaysAndSave(_source, saveRestResponses, startDate, filterUrls, persistence, sw);
+                if (!await ImportDaysAndSave(_source, saveRestResponses, startDate, filterUrls, persistence, sw))
+                {
+                    // A fatal download failure aborted the run. The original code returned straight out of
+                    // ImportAndSave here, so the section was never reported as finished; keep that, or
+                    // liveness monitoring would see a successful section import for a cycle that imported
+                    // nothing. (Release only - DEBUG rethrows.)
+                    return;
+                }
             }
             else
             {
@@ -129,7 +136,10 @@ namespace WebJob.AppInsightsImporter.Engine
                     this._importConfig.ClientSecret);
                 using (var ai = new AppInsightsAPIClient(this._importConfig.AppInsightsConnectionString, credential, _logger))
                 {
-                    await ImportDaysAndSave(ai, saveRestResponses, startDate, filterUrls, persistence, sw);
+                    if (!await ImportDaysAndSave(ai, saveRestResponses, startDate, filterUrls, persistence, sw))
+                    {
+                        return;
+                    }
                 }
             }
 
@@ -140,7 +150,11 @@ namespace WebJob.AppInsightsImporter.Engine
         /// <summary>
         /// The day loop: fetch a day, save it, and never let one bad day abort the rest of the run.
         /// </summary>
-        private async Task ImportDaysAndSave(IAppInsightsSourceLoader source, bool saveRestResponses, DateTime startDate,
+        /// <returns>
+        /// False when a download failure aborted the whole run, so the caller must NOT report the section as
+        /// finished. Only reachable in Release: the DEBUG build rethrows instead.
+        /// </returns>
+        private async Task<bool> ImportDaysAndSave(IAppInsightsSourceLoader source, bool saveRestResponses, DateTime startDate,
             List<FilterUrlConfig> filterUrls, IAppInsightsDayPersistenceManager persistence, Stopwatch sw)
         {
             // UTC to match App Insights' UTC timestamps (see startDate above).
@@ -177,7 +191,7 @@ namespace WebJob.AppInsightsImporter.Engine
 #if DEBUG
                     throw;
 #else
-                    return;
+                    return false;
 #endif
                 }
 
@@ -230,6 +244,7 @@ namespace WebJob.AppInsightsImporter.Engine
             }
 
             _logger.LogInformation($"Import loop finished: {totalDays} days processed, {totalPageViews:n0} total page-views, {totalEvents:n0} total events");
+            return true;
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
@@ -4,7 +4,7 @@ using Common.Entities.Config;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Data.Entity;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,17 +22,66 @@ namespace WebJob.AppInsightsImporter.Engine
         private readonly AppConfig _importConfig;
         private readonly AnalyticsLogger _logger;
         private readonly IClock _clock;
+        private readonly IAnalyticsDbContextFactory _contextFactory;
 
-        public AppInsightsImporter(AppConfig importConfig, AnalyticsLogger logger, IClock clock = null)
+        // Optional ports (issue #374). When all of them are supplied the import runs with no database
+        // context and no HTTP client created at all, which is what makes the orchestration testable.
+        private readonly IAppInsightsSourceLoader _source;
+        private readonly IImportDbMaintenance _dbMaintenance;
+        private readonly ISiteFilterLoader _siteFilterLoader;
+        private readonly IHitWatermarkStore _hitWatermarkStore;
+        private readonly IAppInsightsDayPersistenceManager _persistence;
+
+        public AppInsightsImporter(AppConfig importConfig, AnalyticsLogger logger, IClock clock = null,
+            IAppInsightsSourceLoader source = null,
+            IImportDbMaintenance dbMaintenance = null,
+            ISiteFilterLoader siteFilterLoader = null,
+            IHitWatermarkStore hitWatermarkStore = null,
+            IAppInsightsDayPersistenceManager persistence = null,
+            IAnalyticsDbContextFactory contextFactory = null)
         {
             _importConfig = importConfig;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _clock = clock ?? SystemClock.Instance;
+            _contextFactory = contextFactory ?? DefaultAnalyticsDbContextFactory.Instance;
+            _source = source;
+            _dbMaintenance = dbMaintenance;
+            _siteFilterLoader = siteFilterLoader;
+            _hitWatermarkStore = hitWatermarkStore;
+            _persistence = persistence;
         }
+
+        /// <summary>
+        /// True when every database-backed port was supplied, so no context needs creating at all.
+        /// </summary>
+        private bool AllDatabasePortsSupplied =>
+            _dbMaintenance != null && _siteFilterLoader != null && _hitWatermarkStore != null && _persistence != null;
 
         public async Task ImportAndSave(bool saveRestResponses, int? daysBeforeOverride)
         {
+            if (AllDatabasePortsSupplied)
+            {
+                await ImportAndSaveWith(saveRestResponses, daysBeforeOverride,
+                    _dbMaintenance, _siteFilterLoader, _hitWatermarkStore, _persistence);
+                return;
+            }
 
+            // Production: one context for the whole run, exactly as before, with SQL adapters over it for
+            // whichever ports were not supplied.
+            using (var db = _contextFactory.Create())
+            {
+                await ImportAndSaveWith(saveRestResponses, daysBeforeOverride,
+                    _dbMaintenance ?? new SqlImportDbMaintenance(db),
+                    _siteFilterLoader ?? new SqlSiteFilterLoader(db),
+                    _hitWatermarkStore ?? new SqlHitWatermarkStore(db),
+                    _persistence ?? new SqlAppInsightsDayPersistenceManager(db, _logger, _importConfig));
+            }
+        }
+
+        private async Task ImportAndSaveWith(bool saveRestResponses, int? daysBeforeOverride,
+            IImportDbMaintenance dbMaintenance, ISiteFilterLoader siteFilterLoader,
+            IHitWatermarkStore hitWatermarkStore, IAppInsightsDayPersistenceManager persistence)
+        {
             // App Insights timestamps are UTC, so the scan window must be UTC too. Using local
             // DateTime.Now on a non-UTC host shifts the day boundaries and the per-day KQL filter,
             // missing or duplicating edge hits near midnight. The rule itself lives in
@@ -40,34 +89,39 @@ namespace WebJob.AppInsightsImporter.Engine
             var scanFromDateOverride = AppInsightsImportWindow.ResolveOverrideStartUtc(daysBeforeOverride, _clock.UtcNow);
 
             var sw = Stopwatch.StartNew();
-            using (var db = new AnalyticsEntitiesContext())
+
+            // Delete duplicate hits 1st. It also creates the page-request-ID index
+            await dbMaintenance.RunStartupMaintenanceAsync();
+            _logger.LogInformation($"Startup: duplicate-hit cleanup completed in {sw.Elapsed.TotalSeconds:N1}s");
+
+            sw.Restart();
+            var filterUrls = await siteFilterLoader.LoadAsync();
+            _logger.LogInformation($"Startup: loaded {filterUrls.Count} URL filters in {sw.Elapsed.TotalSeconds:N1}s");
+
+            var newestHitTimestamp = await hitWatermarkStore.GetNewestHitTimestampUtcAsync();
+
+            // Figure out when to start. Either the debug override, or last hit (if there is one), or 31 days ago,
+            // rewound a little to catch edge hits. hit_timestamp is stored in UTC; the clock keeps the
+            // fallback on the same clock. See AppInsightsImportWindow (#374).
+            var startDate = AppInsightsImportWindow.ResolveStartDateUtc(
+                scanFromDateOverride, newestHitTimestamp, _clock.UtcNow);
+
+            var jobTimer = new JobTimer(_logger, "Hits import");
+            if (newestHitTimestamp.HasValue)
             {
-                // Delete duplicate hits 1st. It also creates the page-request-ID index
-                await ImportDbHacks.CleanDuplicateHitsAndCreateIX_PageRequestID(db);
-                _logger.LogInformation($"Startup: duplicate-hit cleanup completed in {sw.Elapsed.TotalSeconds:N1}s");
+                _logger.LogInformation($"Requesting data from AppInsights from {startDate} (newest hit is from {newestHitTimestamp.Value})...");
+            }
+            else
+            {
+                _logger.LogInformation($"Requesting data from AppInsights from {startDate} (no hits yet to start from previous)...");
+            }
 
-                sw.Restart();
-                var filterUrls = await SiteFilterLoader.Load(db);
-                _logger.LogInformation($"Startup: loaded {filterUrls.Count} URL filters in {sw.Elapsed.TotalSeconds:N1}s");
-
-                var newestHit = await db.hits.OrderByDescending(h => h.hit_timestamp).Take(1).FirstOrDefaultAsync();
-
-                // Figure out when to start. Either the debug override, or last hit (if there is one), or 31 days ago,
-                // rewound a little to catch edge hits. hit_timestamp is stored in UTC; the clock keeps the
-                // fallback on the same clock. See AppInsightsImportWindow (#374).
-                var startDate = AppInsightsImportWindow.ResolveStartDateUtc(
-                    scanFromDateOverride, newestHit?.hit_timestamp, _clock.UtcNow);
-
-                var jobTimer = new JobTimer(_logger, "Hits import");
-                if (newestHit != null)
-                {
-                    _logger.LogInformation($"Requesting data from AppInsights from {startDate} (newest hit is from {newestHit.hit_timestamp})...");
-                }
-                else
-                {
-                    _logger.LogInformation($"Requesting data from AppInsights from {startDate} (no hits yet to start from previous)...");
-                }
-
+            if (_source != null)
+            {
+                await ImportDaysAndSave(_source, saveRestResponses, startDate, filterUrls, persistence, sw);
+            }
+            else
+            {
                 // Import page-views first
                 var credential = new ClientSecretCredential(
                     this._importConfig.TenantGUID.ToString(),
@@ -75,99 +129,107 @@ namespace WebJob.AppInsightsImporter.Engine
                     this._importConfig.ClientSecret);
                 using (var ai = new AppInsightsAPIClient(this._importConfig.AppInsightsConnectionString, credential, _logger))
                 {
+                    await ImportDaysAndSave(ai, saveRestResponses, startDate, filterUrls, persistence, sw);
+                }
+            }
 
-                    // UTC to match App Insights' UTC timestamps (see startDate above).
-                    var endDate = _clock.UtcNow;
-                    var daysToRead = AppInsightsImportWindow.EnumerateDays(startDate, endDate);
-                    _logger.LogInformation($"Importing hits for {daysToRead.Count} days...");
-                    var totalDays = 0;
-                    var totalPageViews = 0;
-                    var totalEvents = 0;
-                    foreach (var d in daysToRead)
-                    {
-                        totalDays++;
-                        var dayTimer = Stopwatch.StartNew();
-                        _logger.LogInformation($"Importing day {totalDays}/{daysToRead.Count}: {d.ToString("yyyy-MM-dd")}...");
+            // Track finished event 
+            jobTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
+        }
 
-                        // Fetch page-views and custom events for the same day in parallel.
-                        // Both are independent read-only API calls with no shared state.
-                        PageViewCollection pageViewsResult;
-                        CustomEventsResultCollection events;
-                        try
-                        {
-                            sw.Restart();
-                            var pageViewsTask = ai.GetPageViewsFromAppInsights(d, saveRestResponses);
-                            var eventsTask = ai.GetCustomEventsFromAppInsights(d, saveRestResponses);
-                            await Task.WhenAll(pageViewsTask, eventsTask);
+        /// <summary>
+        /// The day loop: fetch a day, save it, and never let one bad day abort the rest of the run.
+        /// </summary>
+        private async Task ImportDaysAndSave(IAppInsightsSourceLoader source, bool saveRestResponses, DateTime startDate,
+            List<FilterUrlConfig> filterUrls, IAppInsightsDayPersistenceManager persistence, Stopwatch sw)
+        {
+            // UTC to match App Insights' UTC timestamps (see startDate above).
+            var endDate = _clock.UtcNow;
+            var daysToRead = AppInsightsImportWindow.EnumerateDays(startDate, endDate);
+            _logger.LogInformation($"Importing hits for {daysToRead.Count} days...");
+            var totalDays = 0;
+            var totalPageViews = 0;
+            var totalEvents = 0;
+            foreach (var d in daysToRead)
+            {
+                totalDays++;
+                var dayTimer = Stopwatch.StartNew();
+                _logger.LogInformation($"Importing day {totalDays}/{daysToRead.Count}: {d.ToString("yyyy-MM-dd")}...");
 
-                            pageViewsResult = await pageViewsTask;
-                            events = await eventsTask;
-                            _logger.LogInformation($"API fetch completed in {sw.Elapsed.TotalSeconds:N1}s - {pageViewsResult.Rows.Count:n0} page-views, {events.Rows.Count:n0} events");
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex, $"Got fatal exception downloading from Application Insights REST: {ex.Message}");
+                // Fetch page-views and custom events for the same day in parallel.
+                // Both are independent read-only API calls with no shared state.
+                PageViewCollection pageViewsResult;
+                CustomEventsResultCollection events;
+                try
+                {
+                    sw.Restart();
+                    var pageViewsTask = source.GetPageViewsAsync(d, saveRestResponses);
+                    var eventsTask = source.GetCustomEventsAsync(d, saveRestResponses);
+                    await Task.WhenAll(pageViewsTask, eventsTask);
+
+                    pageViewsResult = await pageViewsTask;
+                    events = await eventsTask;
+                    _logger.LogInformation($"API fetch completed in {sw.Elapsed.TotalSeconds:N1}s - {pageViewsResult.Rows.Count:n0} page-views, {events.Rows.Count:n0} events");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, $"Got fatal exception downloading from Application Insights REST: {ex.Message}");
 #if DEBUG
-                            throw;
+                    throw;
 #else
-                            return;
+                    return;
 #endif
-                        }
-
-                        if (pageViewsResult.Rows.Count > 0)
-                        {
-                            var earliest = pageViewsResult.Rows.OrderBy(v => v.Timestamp).Take(1).First();
-                            var latest = pageViewsResult.Rows.OrderByDescending(v => v.Timestamp).Take(1).First();
-                            _logger.LogInformation($"Hits range: {earliest.Timestamp:yyyy-MM-dd HH:mm:ss.ff} to {latest.Timestamp:yyyy-MM-dd HH:mm:ss.ff}");
-                        }
-
-                        if (pageViewsResult.Rows.Count > 0 || events.Rows.Count > 0)
-                        {
-                            // Save to DB
-                            try
-                            {
-                                sw.Restart();
-                                await pageViewsResult.SaveToSQL(db, _logger, filterUrls);
-                                _logger.LogInformation($"Page-views SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
-
-                                sw.Restart();
-                                await events.SaveAllEventTypesToSql(_logger, _importConfig);
-                                _logger.LogInformation($"Events SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
-                            }
-                            catch (Exception ex)
-                            {
-                                // Isolate per-day save failures. A single bad day - e.g. a page-update
-                                // event that trips a DbUpdateException - must never abort the whole
-                                // multi-day run and stall the importer's watermark indefinitely (the
-                                // SqlException-only catch used to let any other exception escape, which
-                                // permanently stuck the importer re-processing the same day). Log the
-                                // full error, record it, and carry on with the next day.
-                                _logger.TrackException(ex);
-                                _logger.LogError($"Failed saving data for day {d:yyyy-MM-dd}: {CommonExceptionHandler.GetErrorText(ex)}. Skipping this day and continuing.");
-                                _logger.LogError($"Exception detail: {ex}");
-                                if (Debugger.IsAttached)
-                                {
-                                    throw;
-                                }
-                                continue;
-                            }
-
-                            totalPageViews += pageViewsResult.Rows.Count;
-                            totalEvents += events.Rows.Count;
-                            _logger.LogInformation($"Day {d:yyyy-MM-dd} completed in {dayTimer.Elapsed.TotalSeconds:N1}s - saved {pageViewsResult.Rows.Count:n0} page-views, {events.Rows.Count:n0} events");
-                        }
-                        else
-                        {
-                            _logger.LogInformation($"Day {d:yyyy-MM-dd} completed in {dayTimer.Elapsed.TotalSeconds:N1}s - no new data.");
-                        }
-                    }
-
-                    _logger.LogInformation($"Import loop finished: {totalDays} days processed, {totalPageViews:n0} total page-views, {totalEvents:n0} total events");
                 }
 
-                // Track finished event 
-                jobTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
+                if (pageViewsResult.Rows.Count > 0)
+                {
+                    var earliest = pageViewsResult.Rows.OrderBy(v => v.Timestamp).Take(1).First();
+                    var latest = pageViewsResult.Rows.OrderByDescending(v => v.Timestamp).Take(1).First();
+                    _logger.LogInformation($"Hits range: {earliest.Timestamp:yyyy-MM-dd HH:mm:ss.ff} to {latest.Timestamp:yyyy-MM-dd HH:mm:ss.ff}");
+                }
+
+                if (pageViewsResult.Rows.Count > 0 || events.Rows.Count > 0)
+                {
+                    // Save to DB
+                    try
+                    {
+                        sw.Restart();
+                        await persistence.SavePageViewsAsync(pageViewsResult, filterUrls);
+                        _logger.LogInformation($"Page-views SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
+
+                        sw.Restart();
+                        await persistence.SaveCustomEventsAsync(events);
+                        _logger.LogInformation($"Events SQL save completed in {sw.Elapsed.TotalSeconds:N1}s");
+                    }
+                    catch (Exception ex)
+                    {
+                        // Isolate per-day save failures. A single bad day - e.g. a page-update
+                        // event that trips a DbUpdateException - must never abort the whole
+                        // multi-day run and stall the importer's watermark indefinitely (the
+                        // SqlException-only catch used to let any other exception escape, which
+                        // permanently stuck the importer re-processing the same day). Log the
+                        // full error, record it, and carry on with the next day.
+                        _logger.TrackException(ex);
+                        _logger.LogError($"Failed saving data for day {d:yyyy-MM-dd}: {CommonExceptionHandler.GetErrorText(ex)}. Skipping this day and continuing.");
+                        _logger.LogError($"Exception detail: {ex}");
+                        if (Debugger.IsAttached)
+                        {
+                            throw;
+                        }
+                        continue;
+                    }
+
+                    totalPageViews += pageViewsResult.Rows.Count;
+                    totalEvents += events.Rows.Count;
+                    _logger.LogInformation($"Day {d:yyyy-MM-dd} completed in {dayTimer.Elapsed.TotalSeconds:N1}s - saved {pageViewsResult.Rows.Count:n0} page-views, {events.Rows.Count:n0} events");
+                }
+                else
+                {
+                    _logger.LogInformation($"Day {d:yyyy-MM-dd} completed in {dayTimer.Elapsed.TotalSeconds:N1}s - no new data.");
+                }
             }
+
+            _logger.LogInformation($"Import loop finished: {totalDays} days processed, {totalPageViews:n0} total page-views, {totalEvents:n0} total events");
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Interfaces.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Interfaces.cs
@@ -1,0 +1,60 @@
+using Common.Entities.Config;
+using DataUtils;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.AppInsightsImporter.Engine.ApiImporter;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+
+namespace WebJob.AppInsightsImporter.Engine
+{
+    /// <summary>
+    /// Reads a day of telemetry from Application Insights. Implemented in production by
+    /// <see cref="AppInsightsAPIClient"/>; a fake lets the importer's orchestration - the day loop, the
+    /// per-day failure isolation, the window - be tested with no HTTP at all. See issue #374.
+    /// </summary>
+    public interface IAppInsightsSourceLoader
+    {
+        Task<PageViewCollection> GetPageViewsAsync(DateTime forDateUtc, bool saveRestResponses);
+        Task<CustomEventsResultCollection> GetCustomEventsAsync(DateTime forDateUtc, bool saveRestResponses);
+    }
+
+    /// <summary>
+    /// The high-water mark the import resumes from: the newest hit already stored. Returns <c>null</c> when
+    /// nothing has been imported yet, which the window rule treats as "start 31 days ago".
+    /// </summary>
+    public interface IHitWatermarkStore
+    {
+        Task<DateTime?> GetNewestHitTimestampUtcAsync();
+    }
+
+    /// <summary>
+    /// Loads the org-URL whitelist that decides which page-views are in scope.
+    /// </summary>
+    public interface ISiteFilterLoader
+    {
+        Task<List<FilterUrlConfig>> LoadAsync();
+    }
+
+    /// <summary>
+    /// One-off schema maintenance run at importer startup. This is deployment-time work, not import logic -
+    /// it is behind a port so the importer can be exercised without it, and so it has an obvious home if it
+    /// ever moves to a migration where it belongs. Also named in issue #369.
+    /// </summary>
+    public interface IImportDbMaintenance
+    {
+        Task RunStartupMaintenanceAsync();
+    }
+
+    /// <summary>
+    /// Writes one day's telemetry. Deliberately coarse - one method per thing the importer saves - because
+    /// this is the seam the day loop needs. Issue #369 decomposes the SQL side further (page-views,
+    /// searches, clicks, page-updates, hit-updates); those become collaborators of the SQL adapter rather
+    /// than changes to this port.
+    /// </summary>
+    public interface IAppInsightsDayPersistenceManager
+    {
+        Task SavePageViewsAsync(PageViewCollection pageViews, List<FilterUrlConfig> filterUrls);
+        Task SaveCustomEventsAsync(CustomEventsResultCollection events);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SqlAppInsightsAdapters.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SqlAppInsightsAdapters.cs
@@ -1,0 +1,89 @@
+using Common.Entities;
+using Common.Entities.Config;
+using DataUtils;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using WebJob.AppInsightsImporter.Engine.ApiImporter;
+using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;
+
+namespace WebJob.AppInsightsImporter.Engine.Sql
+{
+    /// <summary>
+    /// SQL adapters for the App Insights importer's read/write ports (issue #374). Each wraps the query or
+    /// call that previously sat inline in <see cref="AppInsightsImporter"/>, unchanged.
+    ///
+    /// All of them borrow the caller's <see cref="AnalyticsEntitiesContext"/> rather than creating one, so
+    /// the whole import keeps using the single context it always has - creating a context per day would
+    /// change both the change-tracker lifetime and the connection churn.
+    /// </summary>
+    public sealed class SqlHitWatermarkStore : IHitWatermarkStore
+    {
+        private readonly AnalyticsEntitiesContext _db;
+
+        public SqlHitWatermarkStore(AnalyticsEntitiesContext db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+
+        public async Task<DateTime?> GetNewestHitTimestampUtcAsync()
+        {
+            var newestHit = await _db.hits.OrderByDescending(h => h.hit_timestamp).Take(1).FirstOrDefaultAsync();
+            return newestHit?.hit_timestamp;
+        }
+    }
+
+    /// <summary>SQL <see cref="ISiteFilterLoader"/>, delegating to the existing loader.</summary>
+    public sealed class SqlSiteFilterLoader : ISiteFilterLoader
+    {
+        private readonly AnalyticsEntitiesContext _db;
+
+        public SqlSiteFilterLoader(AnalyticsEntitiesContext db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+
+        public Task<List<FilterUrlConfig>> LoadAsync() => SiteFilterLoader.Load(_db);
+    }
+
+    /// <summary>
+    /// SQL <see cref="IImportDbMaintenance"/>: the duplicate-hit cleanup and the page-request-id index.
+    /// </summary>
+    public sealed class SqlImportDbMaintenance : IImportDbMaintenance
+    {
+        private readonly AnalyticsEntitiesContext _db;
+
+        public SqlImportDbMaintenance(AnalyticsEntitiesContext db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+
+        public Task RunStartupMaintenanceAsync() => ImportDbHacks.CleanDuplicateHitsAndCreateIX_PageRequestID(_db);
+    }
+
+    /// <summary>
+    /// SQL <see cref="IAppInsightsDayPersistenceManager"/>, calling the existing save extensions verbatim.
+    /// </summary>
+    public sealed class SqlAppInsightsDayPersistenceManager : IAppInsightsDayPersistenceManager
+    {
+        private readonly AnalyticsEntitiesContext _db;
+        private readonly AnalyticsLogger _logger;
+        private readonly AppConfig _config;
+
+        public SqlAppInsightsDayPersistenceManager(AnalyticsEntitiesContext db, AnalyticsLogger logger, AppConfig config)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _config = config;
+        }
+
+        public Task SavePageViewsAsync(PageViewCollection pageViews, List<FilterUrlConfig> filterUrls)
+            => pageViews.SaveToSQL(_db, _logger, filterUrls);
+
+        public Task SaveCustomEventsAsync(CustomEventsResultCollection events)
+            => events.SaveAllEventTypesToSql(_logger, _config);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
@@ -73,6 +73,7 @@
     <Compile Include="AppInsightsColumn.cs" />
     <Compile Include="AppInsightsImporter.cs" />
     <Compile Include="AppInsightsImportWindow.cs" />
+    <Compile Include="Interfaces.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="PageUpdates\PageCommentsExtensions.cs" />
     <Compile Include="PageUpdates\PageUpdateManager.cs" />
@@ -84,6 +85,7 @@
     </Compile>
     <Compile Include="Sql\HitUpdatesSqlExtension.cs" />
     <Compile Include="Sql\ImportDbHacks.cs" />
+    <Compile Include="Sql\SqlAppInsightsAdapters.cs" />
     <Compile Include="Sql\Models\ClickTempEntity.cs" />
     <Compile Include="Sql\Models\HitTempEntity.cs" />
     <Compile Include="Sql\Models\HitUpdate.cs" />


### PR DESCRIPTION
## Summary

Finishes #374. Part 1 (PR #390) extracted the pure window rule; this puts the importer's remaining I/O behind ports, so the **orchestration itself** — the day loop, the window it derives, the per-day failure isolation — runs in a unit test with **zero HTTP and zero SQL Server**.

It also fixes a real, silent, production bug found while writing the culture test the task called for: **#398**. That change is deliberately separate from the extraction and is called out below.

## Ports

`WebJob.AppInsightsImporter.Engine/Interfaces.cs`:

| Port | Replaces |
|---|---|
| `IAppInsightsSourceLoader` | `ai.GetPageViewsFromAppInsights` / `GetCustomEventsFromAppInsights` |
| `IHitWatermarkStore` | `db.hits.OrderByDescending(h => h.hit_timestamp).Take(1)` |
| `ISiteFilterLoader` | `SiteFilterLoader.Load(db)` |
| `IImportDbMaintenance` | `ImportDbHacks.CleanDuplicateHitsAndCreateIX_PageRequestID(db)` |
| `IAppInsightsDayPersistenceManager` | `pageViewsResult.SaveToSQL(...)` / `events.SaveAllEventTypesToSql(...)` |

`Sql/SqlAppInsightsAdapters.cs` holds the four SQL adapters. Each wraps the original query or call **verbatim** and **borrows** the caller's `AnalyticsEntitiesContext` rather than creating one, so the whole run keeps using the single context it has always used — creating a context per day would change both the change-tracker lifetime and the connection churn.

`IImportDbMaintenance` is also named in #369; it is defined once, here. #369 part 2b will use this definition rather than adding a second.

`IAppInsightsDayPersistenceManager` is deliberately coarse — one method per thing the day loop saves. #369 decomposes the SQL side further (page-views, searches, clicks, page-updates, hit-updates); those become collaborators *of the SQL adapter*, not changes to this port.

## `AppInsightsAPIClient`

- Implements `IAppInsightsSourceLoader` via thin `GetPageViewsAsync` / `GetCustomEventsAsync` aliases over the existing method names, so **no existing call site or test changes**.
- Gained a constructor overload taking an `HttpMessageHandler`. That is what makes the retry, back-off, transient classification and token-refresh logic testable. The handler is passed with `disposeHandler: false` so a caller-owned stub is not disposed by the client; the production constructor is unchanged in behaviour (`new HttpClient { Timeout = 10 min }`).

## `AppInsightsImporter`

Takes the five ports plus `IAnalyticsDbContextFactory` (#368), all optional trailing parameters — no call site breaks. When **every database-backed port** is supplied it runs without creating a context at all; otherwise it opens one exactly as before and builds SQL adapters over whichever ports were not supplied. The day loop moved into its own method so it can be driven by either the injected source or the production API client.

Every log message, its wording and its ordering is unchanged. Two shape-only differences worth a reviewer's eye:

- `newestHit != null` became `newestHitTimestamp.HasValue`, and the log interpolates `newestHitTimestamp.Value` where it used to interpolate `newestHit.hit_timestamp`. Same rendered text (`hit_timestamp` is a non-nullable `DateTime` on the entity, and `Nullable<DateTime>.ToString()` on a value-bearing instance is identical to the underlying value's).
- The API client is now disposed *after* `jobTimer.TrackFinishedEventAndStopTimer` rather than just before it, because the `using` moved out one level. It is an `HttpClient` with no outstanding requests at that point.

## Separate change: fixes #398 — the KQL window was culture-formatted

`GetWhereString` built the per-day KQL window with a culture-sensitive `ToString("yyyy-MM-dd HH:mm:ss")`. **The current culture selects the calendar**, not just the separators:

| Culture | `new DateTime(2026, 5, 30)` renders as |
|---|---|
| `en-US` / invariant | `2026-05-30 00:00:00` |
| `th-TH` (Thai Buddhist) | `2569-05-30 00:00:00` |
| `ar-SA` (Umm al-Qura) | `1447-12-13 00:00:00` |

(verified on this machine, not assumed). KQL `todatetime()` only understands Gregorian ISO dates, so on such a host the importer asks App Insights for a window centuries away, gets an **empty result set rather than an error**, logs `0 page-views, 0 events` for every day, and completes "successfully" — forever, with nothing in the logs explaining why the tenant has no hits data.

Fixed by formatting with `InvariantCulture`, with `AppInsightsClient_BuildsKqlWindow_ForRequestedDayInUtc_UnderAnyCulture` pinning it across `th-TH`, `ar-SA` and `en-US`.

Note the *window rule* (`AppInsightsImportWindow`) is **not** affected — .NET date arithmetic is tick-based and Gregorian, so culture is a no-op there. This is exactly the distinction PR #390 drew: a culture test is theatre where nothing formats, and meaningful where something does. Here something does.

## Found by the review loop: a real regression, now fixed

The first review round caught an actual behavioural defect in this PR — the first the loop has found across five PRs, so it is worth calling out.

Extracting the day loop into `ImportDaysAndSave` changed what the download catch''s Release-only `return` did. It used to return out of `ImportAndSave` entirely, so `jobTimer.TrackFinishedEventAndStopTimer` never ran; after the extraction it returned only out of the inner method, and control resumed in `ImportAndSaveWith` and **emitted `FinishedSectionImport`** — reporting a successful section import for a cycle that downloaded nothing. Invisible in DEBUG, which rethrows.

`ImportDaysAndSave` now returns `false` on that path and the caller skips the completion event. Guarded in **both** build configurations by `AppInsightsImporter_FatalDownloadFailure_DoesNotReportTheSectionAsFinished` (DEBUG asserts the throw, Release asserts the return; both assert the event is absent), paired with `AppInsightsImporter_SuccessfulRun_DoesReportTheSectionAsFinished` so the fix cannot be "achieved" by never emitting the event at all.

Two test-quality findings from the same round were also applied:

- **The retry tests no longer measure wall-clock time.** They inferred back-off from elapsed time, which also measures scheduling, GC and deserialisation — flaky under CI load, and capable of passing after a no-back-off regression. `AppInsightsAPIClient` now has an internal `RetryDelay` function (defaulting to `Task.Delay`) and the tests assert the delays actually **requested**: 1s / 2s / 4s for exponential back-off, and 7s twice when the server sends `Retry-After: 7`.
- **The injected-clock guard covered only half the call site.** Every orchestration test passed `daysBeforeOverride: null`, and `ResolveOverrideStartUtc` ignores its clock argument in that case, so the *first* `_clock.UtcNow` read in `ImportAndSave` was unguarded. Added `AppInsightsImporter_DaysBeforeOverride_IsAlsoResolvedFromTheInjectedClock`.

## Testing

**New: 16 tests, zero HTTP, zero SQL Server, zero wall clock.**

`AppInsightsApiClientTests` (8) — against a stub `HttpMessageHandler`:
- a 503 is retried, and the exponential back-off actually requested is 1s / 2s / 4s;
- the back-off doubles and then **caps** — asserted on the extracted pure `BackoffSecondsFor(attempt)`, because the retry loop stops at `MaxRetries` (16s) and can never reach the 60s cap, so a loop-driven test would stay green if `Math.Min` were deleted;
- `Retry-After: 7` is preferred over exponential back-off — asserted as two 7s waits where the exponential path would have asked for 1s then 2s;
- a 403 is **not** retried (retrying a missing API permission five times just delays the error the operator needs);
- transient failures are capped at `MaxRetries + 1` attempts and the failure then surfaces, so an App Insights outage cannot hang the web-job;
- a token inside the 5-minute refresh margin is re-fetched, and the new token reaches the `Authorization` header;
- a still-valid token is **not** re-fetched per request (an Entra ID round-trip per API call at scale);
- the KQL window is Gregorian under any culture (above).

`AppInsightsImporterOrchestrationTests` (8):
- the whole import runs on fakes: startup maintenance runs once (not per day), the watermark is read once, the requested days match the window, only days with data are saved, and the org-URL filter loaded at startup is the same instance handed to the save;
- **the window is driven by the injected clock** — the clock is fixed years in the past, so no wall-clock-derived window could produce those days. This closes the gap `AppInsightsImportWindowTests` documented ("nothing invokes `ImportAndSave`, so replacing those reads with `DateTime.Now` would leave every test green"); that docstring is updated in this PR;
- an empty database scans the 31-day fallback window;
- **one day failing to save does not abort the remaining days** — every day is still fetched and the other two are still saved;
- a run with no data touches persistence zero times rather than running the merge SQL on empty collections every cycle.

**Pre-existing tests unchanged and passing**, including `AppInsightsKqlGetWhereStringTests`, `AppInsightsImportWindowTests`, `AppInsightsAuthTests`, `AppInsightsImportTests`, `HitImportFanoutTests` and `DuplicateUrlTests`. Area run: **107 passed / 1 failed of 108** — the failure is the pre-existing `CommentsCognitiveTests`, which cannot resolve the placeholder cognitive endpoint locally and passes in CI. Full solution builds (Debug).

## Reviewer hotspots

1. **The two-branch structure in `ImportAndSave`** — is the "all database ports supplied" fast path genuinely equivalent to the adapter path, and does the context still live exactly as long as it did?
2. **Log fidelity** — particularly the `newestHitTimestamp.Value` interpolation and the moved `using` noted above.
3. **`disposeHandler: false`** — correct for a caller-owned stub, but confirm the production path (which passes `null` and uses the plain `HttpClient` constructor) still owns and disposes its own handler.
4. **The `#if DEBUG` in `AppInsightsImporter_FatalDownloadFailure_DoesNotReportTheSectionAsFinished`** — it is there because the production path it guards is itself `#if DEBUG`-forked, and CI runs the suite in both configurations. Is there a cleaner way to cover both, short of removing the fork?

Addresses #374
Addresses #398
