### PR TITLE
Extract ICopilotUsagePersistenceManager and make the "only write when changed" rule assertable (#370 part 2)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotUsagePersistencePortTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotUsagePersistencePortTests.cs
@@ -1,0 +1,339 @@
+using Common.Entities.Entities.UsageReports;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The Copilot usage-report import driven entirely through <see cref="ICopilotUsagePersistenceManager"/>
+    /// (issue #370): zero Graph, zero SQL Server.
+    ///
+    /// The point of the port is the <b>Unchanged</b> count. Both Copilot upserts carry an "only write when a
+    /// value actually moved" rule - Graph gap-fills the last few days, so re-importing an overlapping window
+    /// is normal - and before this the rule was invisible: a regression that rewrote every row on every cycle
+    /// (up to 180 days x every app, or every licensed user) returned exactly the same numbers.
+    /// </summary>
+    [TestClass]
+    public class CopilotUsagePersistencePortTests
+    {
+        private static readonly DateTime ReportDate = new DateTime(2031, 3, 19);
+
+        private sealed class StubReportSource : ICopilotReportSource
+        {
+            private readonly List<JObject> _report;
+            public StubReportSource(List<JObject> report) { _report = report; }
+            public Task<List<JObject>> LoadReportAsync(CopilotReportRequest request) => Task.FromResult(_report);
+        }
+
+        private static List<JObject> TrendReport(int activeUsers, string refreshDate = null)
+        {
+            var date = ReportDate.ToString("yyyy-MM-dd");
+            return new List<JObject>
+            {
+                new JObject
+                {
+                    ["reportRefreshDate"] = refreshDate ?? date,
+                    ["reportPeriod"] = 28,
+                    ["adoptionByDate"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["reportDate"] = date,
+                            ["anyAppEnabledUsers"] = 250,
+                            ["anyAppActiveUsers"] = activeUsers,
+                        }
+                    },
+                }
+            };
+        }
+
+        private static List<JObject> UserDetailReport(string upn, int periodDays, int prompts, int activeDays)
+        {
+            var date = ReportDate.ToString("yyyy-MM-dd");
+            return new List<JObject>
+            {
+                new JObject
+                {
+                    ["reportRefreshDate"] = date,
+                    ["userPrincipalName"] = upn,
+                    ["displayName"] = "Καλημέρα Κόσμε",
+                    ["lastActivityDate"] = date,
+                    ["copilotActivityUserDetailsByPeriod"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["reportPeriod"] = periodDays,
+                            ["promptsSubmitted"] = prompts,
+                            ["activeUsageDays"] = activeDays,
+                        }
+                    },
+                }
+            };
+        }
+
+        private static CopilotUserCountReportLoader CountLoader(List<JObject> report, ICopilotUsagePersistenceManager persistence)
+            => new CopilotUserCountReportLoader(new StubReportSource(report), NullLogger.Instance, persistence);
+
+        private static CopilotUsageUserDetailLoader DetailLoader(List<JObject> report, ICopilotUsagePersistenceManager persistence)
+            => new CopilotUsageUserDetailLoader(new StubReportSource(report), NullLogger.Instance, null, null, persistence);
+
+        private static CopilotReportRequest TrendRequest() =>
+            new CopilotReportRequest(CopilotReportNames.UserCountTrend, "D28", CopilotReportVersions.V2);
+
+        private static CopilotReportRequest DetailRequest(string period = "D28") =>
+            new CopilotReportRequest(CopilotReportNames.UsageUserDetail, period, CopilotReportVersions.V2);
+
+        // ---- The "only update when values change" rule -------------------------------------------------
+
+        [TestMethod]
+        public async Task CopilotUserCount_ValuesUnchanged_ReportsUnchanged_AndDoesNotRewriteRows()
+        {
+            var store = new InMemoryCopilotUsagePersistenceManager();
+
+            Assert.AreEqual(1, await CountLoader(TrendReport(180), store).LoadAndSaveAsync(TrendRequest()),
+                "The first import inserts the row.");
+
+            var written = await CountLoader(TrendReport(180), store).LoadAndSaveAsync(TrendRequest());
+
+            Assert.AreEqual(0, written, "Re-importing identical values must write nothing.");
+            var upsert = await store.UpsertUserCountsAsync(
+                new List<CopilotUserCountLog>(store.UserCounts.Values), CopilotUserCountReportTypes.Trend);
+            Assert.AreEqual(1, upsert.Unchanged);
+            Assert.AreEqual(0, upsert.Updated);
+        }
+
+        [TestMethod]
+        public async Task CopilotUserCount_ValueChanged_ReportsUpdated()
+        {
+            var store = new InMemoryCopilotUsagePersistenceManager();
+            await CountLoader(TrendReport(180), store).LoadAndSaveAsync(TrendRequest());
+
+            var written = await CountLoader(TrendReport(191), store).LoadAndSaveAsync(TrendRequest());
+
+            Assert.AreEqual(1, written);
+            Assert.AreEqual(191, store.UserCounts.Values.Single().ActiveUsers);
+        }
+
+        [TestMethod]
+        public async Task CopilotUserCount_OnlyTheRefreshDateMoved_IsStillUnchanged()
+        {
+            // Deliberate: the refresh date advances every day, so counting it as a change would rewrite every
+            // row in the window daily purely to restamp provenance. Report-level freshness lives on the
+            // import log instead.
+            var store = new InMemoryCopilotUsagePersistenceManager();
+            await CountLoader(TrendReport(180, "2031-03-20"), store).LoadAndSaveAsync(TrendRequest());
+
+            var written = await CountLoader(TrendReport(180, "2031-03-21"), store).LoadAndSaveAsync(TrendRequest());
+
+            Assert.AreEqual(0, written);
+        }
+
+        // ---- Per-user detail --------------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task CopilotUsage_SameReportImportedTwice_IsIdempotent()
+        {
+            var store = new InMemoryCopilotUsagePersistenceManager();
+            store.SeedUser("ada@contoso.onmicrosoft.com");
+
+            Assert.AreEqual(1, await DetailLoader(UserDetailReport("ada@contoso.onmicrosoft.com", 28, 142, 19), store)
+                .LoadAndSaveAsync(DetailRequest()));
+
+            Assert.AreEqual(0, await DetailLoader(UserDetailReport("ada@contoso.onmicrosoft.com", 28, 142, 19), store)
+                .LoadAndSaveAsync(DetailRequest()), "Nothing moved, so nothing should be rewritten.");
+
+            Assert.AreEqual(1, store.UserDetail.Count);
+        }
+
+        [TestMethod]
+        public async Task CopilotUsage_DifferentPeriodsAreDifferentFacts_NotAConflict()
+        {
+            // D7 and D28 describe the SAME user and date with different prompt counts, so both must be
+            // stored. Collapsing them would make one period silently overwrite the other.
+            var store = new InMemoryCopilotUsagePersistenceManager();
+            store.SeedUser("ada@contoso.onmicrosoft.com");
+
+            await DetailLoader(UserDetailReport("ada@contoso.onmicrosoft.com", 7, 31, 4), store).LoadAndSaveAsync(DetailRequest("D7"));
+            await DetailLoader(UserDetailReport("ada@contoso.onmicrosoft.com", 28, 142, 19), store).LoadAndSaveAsync(DetailRequest("D28"));
+
+            Assert.AreEqual(2, store.UserDetail.Count);
+            CollectionAssert.AreEquivalent(new[] { 7, 28 }, store.UserDetail.Values.Select(r => r.ReportPeriodDays).ToArray());
+        }
+
+        [TestMethod]
+        public async Task CopilotUsage_UserNotInDatabase_OnAKnownDomain_IsCreated()
+        {
+            var store = new InMemoryCopilotUsagePersistenceManager();
+            store.SeedUser("someone.else@contoso.onmicrosoft.com");   // establishes the known domain
+
+            var written = await DetailLoader(UserDetailReport("καλημέρα@contoso.onmicrosoft.com", 28, 10, 2), store)
+                .LoadAndSaveAsync(DetailRequest());
+
+            Assert.AreEqual(1, written);
+            Assert.IsTrue(store.Users.ContainsKey("καλημέρα@contoso.onmicrosoft.com"),
+                "A non-Latin UPN on a recognised domain must be created, not dropped.");
+        }
+
+        [TestMethod]
+        public async Task CopilotUsage_UserOnAnUnknownDomain_IsSkippedWithoutThrowing()
+        {
+            // An unrecognised domain is how a pseudonymised report would look, so the identity is skipped
+            // rather than invented - but the import must still complete.
+            var store = new InMemoryCopilotUsagePersistenceManager();
+            store.SeedUser("ada@contoso.onmicrosoft.com");
+
+            var written = await DetailLoader(UserDetailReport("mallory@someone-else.example", 28, 10, 2), store)
+                .LoadAndSaveAsync(DetailRequest());
+
+            Assert.AreEqual(0, written);
+            Assert.AreEqual(1, store.Users.Count, "No user should have been created on the unknown domain.");
+            Assert.AreEqual(0, store.UserDetail.Count);
+        }
+
+        // ---- Diagnostics ------------------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task CopilotUsage_PersistenceFailure_IsRecordedOnTheFailurePath()
+        {
+            // In production that path writes on a FRESH context, because the one that just failed a
+            // SaveChanges can be left holding entities in a broken state - losing the very diagnostic the
+            // Health page needs.
+            var store = new InMemoryCopilotUsagePersistenceManager
+            {
+                FailUserDetailUpsertWith = new InvalidOperationException("SQL went away")
+            };
+            store.SeedUser("ada@contoso.onmicrosoft.com");
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                DetailLoader(UserDetailReport("ada@contoso.onmicrosoft.com", 28, 1, 1), store).LoadAndSaveAsync(DetailRequest()));
+
+            Assert.AreEqual(1, store.ImportLogsRecordedAfterFailure.Count);
+            StringAssert.Contains(store.ImportLogsRecordedAfterFailure.Single().Error, "SQL went away");
+        }
+
+        [TestMethod]
+        public async Task CopilotUsage_ConcealedTenant_AbortsWithoutWritingAnyUsageRow()
+        {
+            // The highest-stakes decision in this import: importing a concealed report would create one
+            // placeholder user per licensed account. Only the diagnostic may be written.
+            var date = ReportDate.ToString("yyyy-MM-dd");
+            var concealed = new List<JObject>
+            {
+                new JObject
+                {
+                    ["reportRefreshDate"] = date,
+                    ["userPrincipalName"] = "6DA1F2E0A1E8D5B1C4F7A9B2C3D4E5F6",
+                    ["displayName"] = "1B2C3D4E5F60718293A4B5C6D7E8F901",
+                    ["lastActivityDate"] = date,
+                    ["copilotActivityUserDetailsByPeriod"] = new JArray
+                    {
+                        new JObject { ["reportPeriod"] = 28, ["promptsSubmitted"] = 5, ["activeUsageDays"] = 1 }
+                    },
+                }
+            };
+
+            var store = new InMemoryCopilotUsagePersistenceManager();
+            store.SeedUser("ada@contoso.onmicrosoft.com");
+
+            var written = await DetailLoader(concealed, store).LoadAndSaveAsync(DetailRequest());
+
+            Assert.AreEqual(0, written);
+            Assert.AreEqual(0, store.UserDetail.Count);
+            Assert.AreEqual(1, store.Users.Count, "No placeholder user may be created for a concealed identity.");
+            Assert.IsTrue(store.ImportLogs.Single().IsUpnObfuscated,
+                "The reason must reach the Health page rather than looking like an empty tenant.");
+        }
+
+        // ---- The period-key rule ----------------------------------------------------------------------
+
+        [TestMethod]
+        public void CopilotUsage_PeriodKeyNormalisation_FillsFromTheRequestAndDropsWhatItCannotKey()
+        {
+            var rows = new List<CopilotUsageUserDetailRow>
+            {
+                new CopilotUsageUserDetailRow { UserPrincipalName = "a@contoso.com", ReportPeriodDays = 7 },
+                new CopilotUsageUserDetailRow { UserPrincipalName = "b@contoso.com", ReportPeriodDays = null },
+            };
+
+            var dropped = CopilotUsageReportPolicy.ApplyPeriodKeys(rows, 28);
+
+            Assert.AreEqual(0, dropped);
+            Assert.AreEqual(7, rows[0].ReportPeriodDays, "A row that states its own period keeps it.");
+            Assert.AreEqual(28, rows[1].ReportPeriodDays, "A row without one takes the requested period.");
+        }
+
+        [TestMethod]
+        public void CopilotUsage_PeriodKeyNormalisation_RowWithNoPeriodAndNoRequestPeriod_IsDroppedInPlace()
+        {
+            // Period ALL supplies no number, so such a row has no identity at all and would otherwise be
+            // stored under the meaningless period 0.
+            var keepable = new CopilotUsageUserDetailRow { UserPrincipalName = "a@contoso.com", ReportPeriodDays = 7 };
+            var rows = new List<CopilotUsageUserDetailRow>
+            {
+                new CopilotUsageUserDetailRow { UserPrincipalName = "b@contoso.com", ReportPeriodDays = null },
+                keepable,
+                new CopilotUsageUserDetailRow { UserPrincipalName = "c@contoso.com", ReportPeriodDays = null },
+            };
+
+            var dropped = CopilotUsageReportPolicy.ApplyPeriodKeys(rows, null);
+
+            Assert.AreEqual(2, dropped);
+            Assert.AreEqual(1, rows.Count);
+            Assert.AreSame(keepable, rows[0], "Filtering must compact the caller's own list, not replace it.");
+        }
+
+        // ---- The new-user domain rule -----------------------------------------------------------------
+
+        [TestMethod]
+        public void CopilotUsage_PlanNewUsers_OnlyCreatesIdentitiesOnDomainsTheDatabaseAlreadyKnows()
+        {
+            var existing = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["ada@contoso.onmicrosoft.com"] = 1 };
+            var knownDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "contoso.onmicrosoft.com" };
+
+            var plan = CopilotUsageReportPolicy.PlanNewUsers(
+                new[] { "ada@contoso.onmicrosoft.com", "grace@contoso.onmicrosoft.com", "mallory@elsewhere.example", "6DA1F2E0A1E8D5B1" },
+                existing, knownDomains);
+
+            CollectionAssert.AreEqual(new[] { "grace@contoso.onmicrosoft.com" }, plan.ToCreate.ToArray());
+            Assert.AreEqual(2, plan.SkippedUnknownDomain, "The foreign domain and the bare hash are both rejected.");
+        }
+
+        [TestMethod]
+        public void CopilotUsage_PlanNewUsers_EmptyDatabase_CreatesEverythingSoAFreshInstallCanProgress()
+        {
+            var plan = CopilotUsageReportPolicy.PlanNewUsers(
+                new[] { "ada@contoso.onmicrosoft.com", "grace@contoso.onmicrosoft.com" },
+                new Dictionary<string, int>(), new HashSet<string>());
+
+            Assert.AreEqual(2, plan.ToCreate.Count);
+            Assert.AreEqual(0, plan.SkippedUnknownDomain);
+        }
+
+        [TestMethod]
+        public void CopilotUsage_PlanNewUsers_IsCaseInsensitiveSoOneUserIsNotCreatedTwice()
+        {
+            var plan = CopilotUsageReportPolicy.PlanNewUsers(
+                new[] { "Ada@Contoso.OnMicrosoft.com", "ada@contoso.onmicrosoft.com" },
+                new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase), new HashSet<string>());
+
+            Assert.AreEqual(1, plan.ToCreate.Count);
+        }
+
+        [TestMethod]
+        public void CopilotUsage_DomainOf_HandlesTheShapesAConcealedReportProduces()
+        {
+            Assert.AreEqual("contoso.onmicrosoft.com", CopilotUsageReportPolicy.DomainOf("ada@contoso.onmicrosoft.com"));
+            Assert.IsNull(CopilotUsageReportPolicy.DomainOf("6DA1F2E0A1E8D5B1C4F7A9B2C3D4E5F6"), "A bare hash has no domain.");
+            Assert.IsNull(CopilotUsageReportPolicy.DomainOf("@contoso.com"));
+            Assert.IsNull(CopilotUsageReportPolicy.DomainOf("ada@"));
+            Assert.IsNull(CopilotUsageReportPolicy.DomainOf(null));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotUsagePersistencePortTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotUsagePersistencePortTests.cs
@@ -103,10 +103,13 @@ namespace Tests.UnitTests
             var written = await CountLoader(TrendReport(180), store).LoadAndSaveAsync(TrendRequest());
 
             Assert.AreEqual(0, written, "Re-importing identical values must write nothing.");
-            var upsert = await store.UpsertUserCountsAsync(
-                new List<CopilotUserCountLog>(store.UserCounts.Values), CopilotUserCountReportTypes.Trend);
-            Assert.AreEqual(1, upsert.Unchanged);
-            Assert.AreEqual(0, upsert.Updated);
+
+            // The SECOND import is the interesting event, and this is its own result - not the store's rows
+            // fed back into itself, which would compare each row against its own reference and pass
+            // regardless of what the rule does.
+            Assert.AreEqual(1, store.LastUserCountUpsert.Unchanged);
+            Assert.AreEqual(0, store.LastUserCountUpsert.Updated);
+            Assert.AreEqual(0, store.LastUserCountUpsert.Inserted);
         }
 
         [TestMethod]
@@ -118,6 +121,8 @@ namespace Tests.UnitTests
             var written = await CountLoader(TrendReport(191), store).LoadAndSaveAsync(TrendRequest());
 
             Assert.AreEqual(1, written);
+            Assert.AreEqual(1, store.LastUserCountUpsert.Updated);
+            Assert.AreEqual(0, store.LastUserCountUpsert.Unchanged);
             Assert.AreEqual(191, store.UserCounts.Values.Single().ActiveUsers);
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryCopilotUsagePersistenceManager.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryCopilotUsagePersistenceManager.cs
@@ -34,6 +34,9 @@ namespace Tests.UnitTests.FakeLoaderClasses
         /// <summary>Import-log rows recorded through the after-a-failure path (a fresh context in production).</summary>
         public List<CopilotUsageReportImportLog> ImportLogsRecordedAfterFailure { get; } = new List<CopilotUsageReportImportLog>();
 
+        /// <summary>The result of the most recent upsert, so a test can assert Inserted/Updated/Unchanged.</summary>
+        public CopilotUsageUpsertResult LastUserCountUpsert { get; private set; }
+
         /// <summary>Set to make the next per-user upsert throw, to exercise the failure diagnostic path.</summary>
         public Exception FailUserDetailUpsertWith { get; set; }
 
@@ -106,19 +109,14 @@ namespace Tests.UnitTests.FakeLoaderClasses
         {
             if (FailUserCountUpsertWith != null) throw FailUserCountUpsertWith;
 
-            var result = new CopilotUsageUpsertResult();
-            foreach (var row in rows)
+            var result = new CopilotUsageUpsertResult();            foreach (var row in rows)
             {
                 var key = $"{row.ReportType}|{(row.ReportPeriodDays.HasValue ? row.ReportPeriodDays.Value.ToString() : string.Empty)}|{row.ReportDate:yyyy-MM-dd}|{row.AppName}";
                 if (UserCounts.TryGetValue(key, out var stored))
                 {
-                    // Mirrors the SQL adapter: the refresh date deliberately does NOT count as a change.
-                    var changed = stored.EnabledUsers != row.EnabledUsers
-                        || stored.ActiveUsers != row.ActiveUsers
-                        || stored.PromptsSubmitted != row.PromptsSubmitted
-                        || stored.AveragePromptsSubmitted != row.AveragePromptsSubmitted;
-
-                    if (!changed)
+                    // The production rule, not a copy of it - so a change here (e.g. letting the refresh
+                    // date count as a change again) fails these tests rather than only the DB-backed ones.
+                    if (!CopilotUsageReportPolicy.UserCountValueChanged(stored, row))
                     {
                         result.Unchanged++;
                         continue;
@@ -138,6 +136,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
                 }
             }
 
+            LastUserCountUpsert = result;
             return Task.FromResult(result);
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryCopilotUsagePersistenceManager.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryCopilotUsagePersistenceManager.cs
@@ -1,0 +1,157 @@
+using Common.Entities.Entities.UsageReports;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="ICopilotUsagePersistenceManager"/> - the Copilot usage tables replaced by
+    /// dictionaries, so the whole import runs with zero Graph and zero SQL Server. See issue #370.
+    ///
+    /// It reproduces the two behaviours the real adapter is judged on: the "only write when a value actually
+    /// moved" rule (so <see cref="CopilotUsageUpsertResult.Unchanged"/> is meaningful), and the rule that a
+    /// user is only created when its e-mail domain is one already known.
+    /// </summary>
+    public class InMemoryCopilotUsagePersistenceManager : ICopilotUsagePersistenceManager
+    {
+        private int _nextUserId = 1;
+
+        /// <summary>Users the database already knows. Seed this to control which domains are recognised.</summary>
+        public Dictionary<string, int> Users { get; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Per-user activity rows, keyed exactly as the unique index is: date | period | user id.</summary>
+        public Dictionary<string, CopilotUsageUserActivityLog> UserDetail { get; } = new Dictionary<string, CopilotUsageUserActivityLog>();
+
+        /// <summary>Aggregate rows, keyed as the unique index is: type | period | date | app.</summary>
+        public Dictionary<string, CopilotUserCountLog> UserCounts { get; } = new Dictionary<string, CopilotUserCountLog>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Every import-log row recorded, in order.</summary>
+        public List<CopilotUsageReportImportLog> ImportLogs { get; } = new List<CopilotUsageReportImportLog>();
+
+        /// <summary>Import-log rows recorded through the after-a-failure path (a fresh context in production).</summary>
+        public List<CopilotUsageReportImportLog> ImportLogsRecordedAfterFailure { get; } = new List<CopilotUsageReportImportLog>();
+
+        /// <summary>Set to make the next per-user upsert throw, to exercise the failure diagnostic path.</summary>
+        public Exception FailUserDetailUpsertWith { get; set; }
+
+        /// <summary>Set to make the next aggregate upsert throw.</summary>
+        public Exception FailUserCountUpsertWith { get; set; }
+
+        /// <summary>The UPNs the loader asked to resolve, most recent call last.</summary>
+        public List<string> LastResolveRequest { get; } = new List<string>();
+
+        public void SeedUser(string upn) => Users[upn] = _nextUserId++;
+
+        public Task<CopilotUserIdResolution> ResolveUserIdsAsync(IEnumerable<string> userPrincipalNames)
+        {
+            var requested = (userPrincipalNames ?? Enumerable.Empty<string>()).ToList();
+            LastResolveRequest.Clear();
+            LastResolveRequest.AddRange(requested);
+
+            var knownDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var existing in Users.Keys)
+            {
+                var domain = CopilotUsageReportPolicy.DomainOf(existing);
+                if (domain != null) knownDomains.Add(domain);
+            }
+
+            var plan = CopilotUsageReportPolicy.PlanNewUsers(requested, Users, knownDomains);
+            foreach (var upn in plan.ToCreate)
+            {
+                Users[upn.ToLowerInvariant()] = _nextUserId++;
+            }
+
+            return Task.FromResult(new CopilotUserIdResolution(
+                new Dictionary<string, int>(Users, StringComparer.OrdinalIgnoreCase), plan.ToCreate.Count, plan.SkippedUnknownDomain));
+        }
+
+        public Task<CopilotUsageUpsertResult> UpsertUserDetailAsync(IReadOnlyList<CopilotUsageUserDetailRow> rows,
+            IReadOnlyDictionary<string, int> userIdsByUpn, bool hasVersion2Data)
+        {
+            if (FailUserDetailUpsertWith != null) throw FailUserDetailUpsertWith;
+
+            var result = new CopilotUsageUpsertResult();
+            foreach (var row in rows)
+            {
+                if (!userIdsByUpn.TryGetValue(row.UserPrincipalName, out var userId)) continue;
+
+                var date = row.ReportRefreshDate.Date;
+                var period = row.ReportPeriodDays.Value;
+                var key = $"{date:yyyy-MM-dd}|{period}|{userId}";
+
+                var isNew = !UserDetail.TryGetValue(key, out var log);
+                if (isNew)
+                {
+                    log = new CopilotUsageUserActivityLog { Date = date, UserID = userId, ReportPeriodDays = period };
+                }
+
+                var changed = CopilotUsageUserDetailLoader.Populate(log, row, hasVersion2Data);
+
+                if (isNew)
+                {
+                    UserDetail[key] = log;
+                    result.Inserted++;
+                }
+                else if (changed) result.Updated++;
+                else result.Unchanged++;
+            }
+
+            return Task.FromResult(result);
+        }
+
+        public Task<CopilotUsageUpsertResult> UpsertUserCountsAsync(IReadOnlyList<CopilotUserCountLog> rows, string reportType)
+        {
+            if (FailUserCountUpsertWith != null) throw FailUserCountUpsertWith;
+
+            var result = new CopilotUsageUpsertResult();
+            foreach (var row in rows)
+            {
+                var key = $"{row.ReportType}|{(row.ReportPeriodDays.HasValue ? row.ReportPeriodDays.Value.ToString() : string.Empty)}|{row.ReportDate:yyyy-MM-dd}|{row.AppName}";
+                if (UserCounts.TryGetValue(key, out var stored))
+                {
+                    // Mirrors the SQL adapter: the refresh date deliberately does NOT count as a change.
+                    var changed = stored.EnabledUsers != row.EnabledUsers
+                        || stored.ActiveUsers != row.ActiveUsers
+                        || stored.PromptsSubmitted != row.PromptsSubmitted
+                        || stored.AveragePromptsSubmitted != row.AveragePromptsSubmitted;
+
+                    if (!changed)
+                    {
+                        result.Unchanged++;
+                        continue;
+                    }
+
+                    stored.ReportRefreshDate = row.ReportRefreshDate;
+                    stored.EnabledUsers = row.EnabledUsers;
+                    stored.ActiveUsers = row.ActiveUsers;
+                    stored.PromptsSubmitted = row.PromptsSubmitted;
+                    stored.AveragePromptsSubmitted = row.AveragePromptsSubmitted;
+                    result.Updated++;
+                }
+                else
+                {
+                    UserCounts[key] = row;
+                    result.Inserted++;
+                }
+            }
+
+            return Task.FromResult(result);
+        }
+
+        public Task RecordReportLoadAsync(CopilotUsageReportImportLog importLog)
+        {
+            ImportLogs.Add(importLog);
+            return Task.CompletedTask;
+        }
+
+        public Task RecordReportLoadAfterFailureAsync(CopilotUsageReportImportLog importLog)
+        {
+            ImportLogs.Add(importLog);
+            ImportLogsRecordedAfterFailure.Add(importLog);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -151,6 +151,7 @@
     <Compile Include="CopilotTests.cs" />
     <Compile Include="CopilotInteractionHistoryTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeCopilotEventAdaptor.cs" />
+    <Compile Include="FakeLoaderClasses\InMemoryCopilotUsagePersistenceManager.cs" />
     <Compile Include="FakeLoaderClasses\FakeAggregateWeeklyUsageReportLoader.cs" />
     <Compile Include="FakeLoaderClasses\FakeSpoGraphClient.cs" />
     <Compile Include="FakeLoaderClasses\MockUserGroupsCache.cs" />
@@ -182,6 +183,7 @@
     <Compile Include="StagingColumnSqlTypeOverrideTests.cs" />
     <Compile Include="UrlFullUrlMigrationPipelineTests.cs" />
     <Compile Include="IndexUsageReportSnapshotsMigrationTests.cs" />
+    <Compile Include="CopilotUsagePersistencePortTests.cs" />
     <Compile Include="CopilotUsageReportImportTests.cs" />
     <Compile Include="DenormaliseCopilotChatUserAndTimeMigrationTests.cs" />
     <Compile Include="IndexReportDateQueriesMigrationTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageReportPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageReportPolicy.cs
@@ -1,4 +1,3 @@
-using Common.Entities;
 using Common.Entities.Entities.UsageReports;
 using System;
 using System.Collections.Generic;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageReportPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageReportPolicy.cs
@@ -1,3 +1,5 @@
+using Common.Entities;
+using Common.Entities.Entities.UsageReports;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -175,6 +177,26 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             var at = upn.LastIndexOf('@');
             if (at <= 0 || at == upn.Length - 1) return null;
             return upn.Substring(at + 1);
+        }
+
+        /// <summary>
+        /// Has anything worth writing actually moved on an aggregate user-count row?
+        ///
+        /// Graph gap-fills the most recent ~3 days, so re-importing an overlapping window is normal and
+        /// usually changes nothing. The refresh date deliberately does <b>not</b> count as a change on its
+        /// own: it advances every day, so including it would rewrite every day in the window daily (up to
+        /// 180 days x every app) purely to restamp provenance. Report-level freshness lives in
+        /// <c>copilot_usage_report_import_log</c> instead.
+        ///
+        /// Lives here rather than privately in the SQL adapter so the in-memory test double asserts the
+        /// production rule instead of a second copy of it that could silently drift.
+        /// </summary>
+        public static bool UserCountValueChanged(CopilotUserCountLog stored, CopilotUserCountLog incoming)
+        {
+            return stored.EnabledUsers != incoming.EnabledUsers
+                || stored.ActiveUsers != incoming.ActiveUsers
+                || stored.PromptsSubmitted != incoming.PromptsSubmitted
+                || stored.AveragePromptsSubmitted != incoming.AveragePromptsSubmitted;
         }
     }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageReportPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageReportPolicy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -105,5 +106,82 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
                 Importable = rows,
             };
         }
+
+        /// <summary>
+        /// Stamp each row with the report period that forms part of its identity, and drop the rows that
+        /// still have none. D7 and D28 describe the SAME user and date with different prompt counts,
+        /// active-day counts and last-activity values, so they are different facts, not a conflict - a row
+        /// that states no period, from a request that cannot supply one (period ALL), has no key at all and
+        /// would otherwise be stored under the meaningless period 0.
+        ///
+        /// Filtered <b>in place</b>, deliberately. At ~200k licensed users a second full-size list is a
+        /// pointless copy of the whole report, and the caller's closing "parsed N row(s)" log reads the
+        /// original list. <c>RemoveAll</c> rather than a reverse loop of <c>RemoveAt</c>: each
+        /// <c>RemoveAt</c> shifts every surviving element after it, so dropping a scattered subset of a
+        /// 200k-row report costs O(N^2) element moves (~5 billion when half the rows are unkeyable);
+        /// <c>RemoveAll</c> is a single O(N) compaction.
+        /// </summary>
+        /// <returns>How many rows were dropped for having no usable period.</returns>
+        public static int ApplyPeriodKeys(List<CopilotUsageUserDetailRow> rows, int? requestedPeriodDays)
+        {
+            if (rows == null) return 0;
+
+            return rows.RemoveAll(row =>
+            {
+                row.ReportPeriodDays = row.ReportPeriodDays ?? requestedPeriodDays;
+                return !row.ReportPeriodDays.HasValue;
+            });
+        }
+
+        /// <summary>
+        /// Which of a report's identities may be created as new users.
+        ///
+        /// A new user is only ever created when its e-mail domain is one the database already holds users
+        /// for. Syntax alone cannot prove an identity belongs to the tenant, so this - not a UPN shape check
+        /// - is the real boundary that stops a pseudonymised report populating the users table with junk. An
+        /// identity on an unrecognised domain is skipped and counted, not invented.
+        ///
+        /// An empty <paramref name="knownDomains"/> means there is nothing to validate against yet (a
+        /// brand-new install where the user-metadata import has not run), so creating is the only way to
+        /// make progress. Microsoft's concealed identities are bare hashes with no domain at all and are
+        /// rejected long before this point.
+        /// </summary>
+        public static CopilotNewUserPlan PlanNewUsers(IEnumerable<string> reportUpns,
+            IReadOnlyDictionary<string, int> existingIdsByUpn, ISet<string> knownDomains)
+        {
+            var plan = new CopilotNewUserPlan();
+            if (reportUpns == null) return plan;
+
+            foreach (var upn in reportUpns.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                if (existingIdsByUpn != null && existingIdsByUpn.ContainsKey(upn)) continue;
+
+                if (knownDomains != null && knownDomains.Count > 0 && !knownDomains.Contains(DomainOf(upn) ?? string.Empty))
+                {
+                    plan.SkippedUnknownDomain++;
+                    continue;
+                }
+
+                plan.ToCreate.Add(upn);
+            }
+
+            return plan;
+        }
+
+        /// <summary>The domain part of a UPN, or null when there isn't a usable one.</summary>
+        public static string DomainOf(string upn)
+        {
+            if (string.IsNullOrWhiteSpace(upn)) return null;
+            var at = upn.LastIndexOf('@');
+            if (at <= 0 || at == upn.Length - 1) return null;
+            return upn.Substring(at + 1);
+        }
+    }
+
+    /// <summary>Which report identities may be created, and how many were rejected.</summary>
+    public class CopilotNewUserPlan
+    {
+        public List<string> ToCreate { get; } = new List<string>();
+        public int SkippedUnknownDomain { get; set; }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageUserDetailLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUsageUserDetailLoader.cs
@@ -35,6 +35,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
         private readonly ILogger _logger;
         private readonly UserGroupsCache _userGroupsCache;
         private readonly UserGroupsFilterModel _userGroupsFilter;
+        private readonly ICopilotUsagePersistenceManager _persistence;
 
         /// <summary>
         /// Rows per SaveChanges. Matches the value the other usage-report loaders settled on: small enough
@@ -45,11 +46,25 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
 
         public CopilotUsageUserDetailLoader(ICopilotReportSource reportSource, ILogger logger,
             UserGroupsCache userGroupsCache = null, UserGroupsFilterModel userGroupsFilter = null)
+            : this(reportSource, logger, userGroupsCache, userGroupsFilter, null)
+        {
+        }
+
+        /// <summary>
+        /// As above, with the write side supplied (issue #370). The original signature is kept as a
+        /// delegating overload rather than gaining an optional parameter, so no already-compiled caller
+        /// breaks. When <paramref name="persistence"/> is null the db-taking <c>LoadAndSaveAsync</c>
+        /// overloads build a <see cref="SqlCopilotUsagePersistenceManager"/> over the context they are given.
+        /// </summary>
+        public CopilotUsageUserDetailLoader(ICopilotReportSource reportSource, ILogger logger,
+            UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilter,
+            ICopilotUsagePersistenceManager persistence)
         {
             _reportSource = reportSource ?? throw new ArgumentNullException(nameof(reportSource));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _userGroupsCache = userGroupsCache;
             _userGroupsFilter = userGroupsFilter;
+            _persistence = persistence;
         }
 
         public Task<int> LoadAndSaveAsync(AnalyticsEntitiesContext db, string period, string version = CopilotReportVersions.V2)
@@ -58,12 +73,37 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
         }
 
         /// <summary>
-        /// Downloads, parses and upserts the per-user report. Returns rows written to SQL; 0 when the tenant
-        /// conceals user information, when Graph returned nothing, or when nothing changed.
+        /// Downloads, parses and upserts the per-user report against the supplied context. Returns rows
+        /// written to SQL; 0 when the tenant conceals user information, when Graph returned nothing, or when
+        /// nothing changed.
         /// </summary>
-        public async Task<int> LoadAndSaveAsync(AnalyticsEntitiesContext db, CopilotReportRequest request)
+        public Task<int> LoadAndSaveAsync(AnalyticsEntitiesContext db, CopilotReportRequest request)
         {
-            if (db == null) throw new ArgumentNullException(nameof(db));
+            if (_persistence == null && db == null) throw new ArgumentNullException(nameof(db));
+            return LoadAndSaveCoreAsync(PersistenceFor(db), request);
+        }
+
+        /// <summary>
+        /// As above, using the <see cref="ICopilotUsagePersistenceManager"/> this loader was constructed
+        /// with. This is the overload that lets the whole import run with no database at all.
+        /// </summary>
+        public Task<int> LoadAndSaveAsync(CopilotReportRequest request)
+        {
+            if (_persistence == null)
+            {
+                throw new InvalidOperationException(
+                    $"This overload needs an {nameof(ICopilotUsagePersistenceManager)}; construct the loader with one, or call the overload that takes a database context.");
+            }
+            return LoadAndSaveCoreAsync(_persistence, request);
+        }
+
+        private ICopilotUsagePersistenceManager PersistenceFor(AnalyticsEntitiesContext db)
+        {
+            return _persistence ?? new SqlCopilotUsagePersistenceManager(db, _logger) { SaveBatchSize = SaveBatchSize };
+        }
+
+        private async Task<int> LoadAndSaveCoreAsync(ICopilotUsagePersistenceManager persistence, CopilotReportRequest request)
+        {
             if (request == null) throw new ArgumentNullException(nameof(request));
             if (request.ReportName != CopilotReportNames.UsageUserDetail)
             {
@@ -100,7 +140,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
                 // report endpoint doesn't exist in this cloud, so there is nothing to retry; record why.
                 importLog.RowsRead = 0;
                 importLog.Error = Truncate($"Report not available: {GraphHttpException.DescribeForStorage(ex)}", 1000);
-                await SaveImportLog(db, importLog);
+                await persistence.RecordReportLoadAsync(importLog);
 
                 _logger.LogWarning($"Copilot per-user report {request} is not available on this tenant: {ex.Message} " +
                     "These reports exist only in the global cloud (not US Government or 21Vianet). No rows were imported.");
@@ -109,7 +149,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             catch (Exception ex)
             {
                 importLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
-                await SaveImportLog(db, importLog);
+                await persistence.RecordReportLoadAsync(importLog);
                 throw;
             }
 
@@ -120,7 +160,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             {
                 _logger.LogWarning($"Copilot per-user report {request} returned no rows. " +
                     "The report downloaded successfully and was genuinely empty, which is expected on a tenant with no Microsoft 365 Copilot licences.");
-                await SaveImportLog(db, importLog);
+                await persistence.RecordReportLoadAsync(importLog);
                 return 0;
             }
 
@@ -132,7 +172,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             if (concealment.Outcome == ConcealedIdentityOutcome.AbortImport)
             {
                 importLog.IsUpnObfuscated = true;
-                await SaveImportLog(db, importLog);
+                await persistence.RecordReportLoadAsync(importLog);
 
                 _logger.LogError($"Copilot per-user usage report {request} came back with concealed user identities for all {parsed.Count} row(s): " +
                     "the tenant has 'concealed user information' enabled for Microsoft 365 usage reports, so Graph replaced each user principal name with a hash. " +
@@ -168,19 +208,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             try
             {
                 importable = await FilterToUsersInScope(importable);
-                written = await SaveAsync(db, importable, request, hasVersion2Data);
+                written = await SaveAsync(persistence, importable, request, hasVersion2Data);
             }
             catch (Exception ex)
             {
                 // Persistence failures must reach the Health page too, and must be written on a FRESH context:
                 // the one that just failed a SaveChanges can be left with entities in a broken state.
                 importLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
-                await SaveImportLogOnNewContext(importLog);
+                await persistence.RecordReportLoadAfterFailureAsync(importLog);
                 throw;
             }
 
             importLog.RowsSaved = written;
-            await SaveImportLog(db, importLog);
+            await persistence.RecordReportLoadAsync(importLog);
 
             _logger.LogInformation($"Copilot per-user report {request}: parsed {parsed.Count} row(s), wrote {written} to SQL.");
             return written;
@@ -226,28 +266,25 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             return inScope;
         }
 
-        private async Task<int> SaveAsync(AnalyticsEntitiesContext db, List<CopilotUsageUserDetailRow> rows,
+        /// <summary>
+        /// Resolves users, keys the rows by report period, and hands the survivors to the persistence port.
+        ///
+        /// Order matters and is preserved: users are resolved BEFORE the period keying, over the full row
+        /// set, so an identity that appears only on rows later dropped as unkeyable is still created exactly
+        /// as it always was.
+        /// </summary>
+        private async Task<int> SaveAsync(ICopilotUsagePersistenceManager persistence, List<CopilotUsageUserDetailRow> rows,
             CopilotReportRequest request, bool hasVersion2Data)
         {
             if (rows.Count == 0) return 0;
 
-            var userIdsByUpn = await ResolveUserIds(db, rows);
+            var resolution = await persistence.ResolveUserIdsAsync(rows.Select(r => r.UserPrincipalName));
 
             // The period is part of the key: D7 and D28 describe the SAME user and date with different prompt
             // counts, active-day counts and last-activity values, so they are different facts, not a conflict.
-            // A row that states no period and a request that can't supply one (ALL) has no key, so it is
-            // dropped rather than stored under the meaningless period 0. Filtered in place: at ~200k licensed
-            // users a second full-size list is a pointless copy of the whole report.
-            //
-            // RemoveAll rather than a reverse loop calling RemoveAt: each RemoveAt shifts every surviving
-            // element after it, so dropping a scattered subset of a 200k-row report costs O(N^2) element
-            // moves (~5 billion when half the rows are unkeyable). RemoveAll is a single O(N) compaction.
-            var requestedPeriodDays = request.PeriodDays;
-            var unkeyable = rows.RemoveAll(row =>
-            {
-                row.ReportPeriodDays = row.ReportPeriodDays ?? requestedPeriodDays;
-                return !row.ReportPeriodDays.HasValue;
-            });
+            // The rule (including the in-place filtering that keeps the caller's "parsed N row(s)" count
+            // honest) lives in CopilotUsageReportPolicy so it can be asserted without a database.
+            var unkeyable = CopilotUsageReportPolicy.ApplyPeriodKeys(rows, request.PeriodDays);
 
             if (unkeyable > 0)
             {
@@ -257,209 +294,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
 
             if (rows.Count == 0) return 0;
 
-            var reportDates = rows.Select(r => r.ReportRefreshDate.Date).Distinct().ToList();
-            var periods = rows.Select(r => r.ReportPeriodDays.Value).Distinct().ToList();
-
-            var written = 0;
-            var autoDetectWasEnabled = db.Configuration.AutoDetectChangesEnabled;
-            db.Configuration.AutoDetectChangesEnabled = false;
-            try
-            {
-                // Work in batches of users rather than one pass over all of them. Batching bounds not just the
-                // SQL command trees but EF's change tracker: the previous shape loaded and kept every existing
-                // row for the report date tracked for the whole loop, which at ~200,000 licensed users is the
-                // memory profile that caused an OutOfMemoryException in the other usage-report loaders.
-                for (var offset = 0; offset < rows.Count; offset += SaveBatchSize)
-                {
-                    var batch = rows.GetRange(offset, Math.Min(SaveBatchSize, rows.Count - offset));
-                    written += await SaveBatchAsync(db, batch, userIdsByUpn, reportDates, periods, hasVersion2Data);
-                    DetachActivityLogs(db);
-                }
-            }
-            finally
-            {
-                db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
-                DetachActivityLogs(db);
-            }
-
-            return written;
-        }
-
-        private async Task<int> SaveBatchAsync(AnalyticsEntitiesContext db, List<CopilotUsageUserDetailRow> batch,
-            Dictionary<string, int> userIdsByUpn, List<DateTime> reportDates, List<int> periods, bool hasVersion2Data)
-        {
-            var batchUserIds = new List<int>(batch.Count);
-            foreach (var row in batch)
-            {
-                if (userIdsByUpn.TryGetValue(row.UserPrincipalName, out var id)) batchUserIds.Add(id);
-            }
-            if (batchUserIds.Count == 0) return 0;
-
-            var existingByKey = new Dictionary<string, CopilotUsageUserActivityLog>();
-            foreach (var existing in await db.CopilotUsageUserActivityLogs
-                .Where(r => reportDates.Contains(r.Date) && periods.Contains(r.ReportPeriodDays) && batchUserIds.Contains(r.UserID))
-                .ToListAsync())
-            {
-                existingByKey[KeyOf(existing.Date, existing.ReportPeriodDays, existing.UserID)] = existing;
-            }
-
-            var written = 0;
-            foreach (var row in batch)
-            {
-                if (!userIdsByUpn.TryGetValue(row.UserPrincipalName, out var userId)) continue;
-
-                var date = row.ReportRefreshDate.Date;
-                var periodDays = row.ReportPeriodDays.Value;
-                var key = KeyOf(date, periodDays, userId);
-
-                var isNew = !existingByKey.TryGetValue(key, out var log);
-                if (isNew)
-                {
-                    log = new CopilotUsageUserActivityLog { Date = date, UserID = userId, ReportPeriodDays = periodDays };
-                    existingByKey[key] = log;
-                }
-
-                var changed = Populate(log, row, hasVersion2Data);
-
-                if (isNew)
-                {
-                    db.CopilotUsageUserActivityLogs.Add(log);
-                }
-                else if (changed)
-                {
-                    db.Entry(log).State = EntityState.Modified;
-                }
-                else
-                {
-                    // Graph gap-fills the last few days, so re-imports are mostly identical rows. Skipping
-                    // unchanged UPDATEs is the difference between writing a handful of rows and rewriting
-                    // every licensed user every cycle.
-                    continue;
-                }
-
-                written++;
-            }
-
-            if (written > 0) await db.SaveChangesAsync();
-            return written;
-        }
-
-        private static void DetachActivityLogs(AnalyticsEntitiesContext db)
-        {
-            foreach (var entry in db.ChangeTracker.Entries<CopilotUsageUserActivityLog>().ToList())
-            {
-                entry.State = EntityState.Detached;
-            }
-        }
-
-        /// <summary>
-        /// Maps every report UPN to a user id, reading the existing users once and inserting only the ones we
-        /// have never seen. Comparisons are case-insensitive in memory rather than via SQL <c>LOWER()</c>,
-        /// which would make the predicate non-SARGable and force a table scan.
-        ///
-        /// A new user is only ever created when its email domain is one we already hold users for. Syntax
-        /// alone cannot prove an identity belongs to the tenant, so this - not the UPN shape check - is the
-        /// real boundary that stops a pseudonymised report from populating the users table with junk. An
-        /// identity on an unrecognised domain is skipped and counted, not invented.
-        /// </summary>
-        private async Task<Dictionary<string, int>> ResolveUserIds(AnalyticsEntitiesContext db, List<CopilotUsageUserDetailRow> rows)
-        {
-            var existingUsers = await db.users.AsNoTracking()
-                .Select(u => new { u.ID, u.UserPrincipalName })
-                .ToListAsync();
-
-            var idsByUpn = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            var knownDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var user in existingUsers)
-            {
-                if (string.IsNullOrWhiteSpace(user.UserPrincipalName)) continue;
-                idsByUpn[user.UserPrincipalName] = user.ID;
-
-                var domain = DomainOf(user.UserPrincipalName);
-                if (domain != null) knownDomains.Add(domain);
-            }
-
-            var missing = new List<string>();
-            var unknownDomain = 0;
-            foreach (var upn in rows.Select(r => r.UserPrincipalName).Distinct(StringComparer.OrdinalIgnoreCase))
-            {
-                if (idsByUpn.ContainsKey(upn)) continue;
-
-                // An empty users table means there is nothing to validate against yet (a brand-new install
-                // where the user-metadata import hasn't run). Creating is then the only way to make progress,
-                // and Microsoft's concealed identities are bare hashes with no domain at all, so they are
-                // already rejected before reaching here.
-                if (knownDomains.Count > 0 && !knownDomains.Contains(DomainOf(upn) ?? string.Empty))
-                {
-                    unknownDomain++;
-                    continue;
-                }
-
-                missing.Add(upn);
-            }
-
-            if (unknownDomain > 0)
-            {
-                _logger.LogWarning($"Copilot per-user report: skipped {unknownDomain} identity(ies) on an email domain this database has no users for. " +
-                    "They were not created, because an unrecognised domain is how a pseudonymised report would look. " +
-                    "If these are genuine users, run the Graph user metadata import so they are known first.");
-            }
-
-            if (missing.Count == 0) return idsByUpn;
-
-            _logger.LogInformation($"Copilot per-user report: creating {missing.Count} user record(s) not yet known to the database.");
-
-            var autoDetectWasEnabled = db.Configuration.AutoDetectChangesEnabled;
-            db.Configuration.AutoDetectChangesEnabled = false;
-            try
-            {
-                var newUsers = new List<Common.Entities.User>(Math.Min(missing.Count, SaveBatchSize));
-                for (var i = 0; i < missing.Count; i++)
-                {
-                    // Existing loaders store UPNs lower-cased; matching that avoids creating a second user
-                    // record that differs only by case.
-                    var user = new Common.Entities.User { UserPrincipalName = missing[i].ToLowerInvariant() };
-                    db.users.Add(user);
-                    newUsers.Add(user);
-
-                    if (newUsers.Count >= SaveBatchSize)
-                    {
-                        await FlushNewUsers(db, newUsers, idsByUpn);
-                    }
-                }
-
-                await FlushNewUsers(db, newUsers, idsByUpn);
-            }
-            finally
-            {
-                db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
-            }
-
-            return idsByUpn;
-        }
-
-        /// <summary>
-        /// Commits a batch of new users, records their ids, then DETACHES them.
-        /// Detaching matters at scale: auto-detect is off, so every SaveChanges needs an explicit
-        /// DetectChanges, and DetectChanges walks every tracked entity. Leaving 200,000 added users tracked
-        /// would make the per-batch scan O(total x batches) and hold them all in memory for the rest of the
-        /// import. The ids are all we need afterwards.
-        /// </summary>
-        private static async Task FlushNewUsers(AnalyticsEntitiesContext db, List<Common.Entities.User> newUsers,
-            Dictionary<string, int> idsByUpn)
-        {
-            if (newUsers.Count == 0) return;
-
-            db.ChangeTracker.DetectChanges();
-            await db.SaveChangesAsync();
-
-            foreach (var user in newUsers)
-            {
-                idsByUpn[user.UserPrincipalName] = user.ID;
-                db.Entry(user).State = EntityState.Detached;
-            }
-
-            newUsers.Clear();
+            var upsert = await persistence.UpsertUserDetailAsync(rows, resolution.IdsByUpn, hasVersion2Data);
+            return upsert.Written;
         }
 
         /// <summary>
@@ -470,7 +306,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
         /// "Graph didn't send prompt data", and blanking a previously captured prompt count is the more
         /// damaging of the two possible mistakes.
         /// </summary>
-        private static bool Populate(CopilotUsageUserActivityLog log, CopilotUsageUserDetailRow row, bool hasVersion2Data)
+        internal static bool Populate(CopilotUsageUserActivityLog log, CopilotUsageUserDetailRow row, bool hasVersion2Data)
         {
             var changed = false;
 
@@ -508,38 +344,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             if (EqualityComparer<T>.Default.Equals(current, incoming)) return false;
             assign(incoming);
             return true;
-        }
-
-        /// <summary>Matches the unique index on (date, user_id, report_period_days).</summary>
-        private static string KeyOf(DateTime date, int periodDays, int userId)
-        {
-            return $"{date:yyyy-MM-dd}|{periodDays}|{userId}";
-        }
-
-        private static string DomainOf(string upn)
-        {
-            if (string.IsNullOrWhiteSpace(upn)) return null;
-            var at = upn.LastIndexOf('@');
-            if (at <= 0 || at == upn.Length - 1) return null;
-            return upn.Substring(at + 1);
-        }
-
-        private static async Task SaveImportLog(AnalyticsEntitiesContext db, CopilotUsageReportImportLog importLog)
-        {
-            db.CopilotUsageReportImportLogs.Add(importLog);
-            await db.SaveChangesAsync();
-        }
-
-        /// <summary>
-        /// Records the import diagnostic on a brand-new context. Used on the failure path, where the context
-        /// that raised the error may itself be the reason a save can't succeed.
-        /// </summary>
-        private static async Task SaveImportLogOnNewContext(CopilotUsageReportImportLog importLog)
-        {
-            using (var freshDb = new AnalyticsEntitiesContext())
-            {
-                await SaveImportLog(freshDb, importLog);
-            }
         }
 
         private static string Truncate(string value, int maxLength)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUserCountReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/CopilotUserCountReportLoader.cs
@@ -24,6 +24,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
     {
         private readonly ICopilotReportSource _reportSource;
         private readonly ILogger _logger;
+        private readonly ICopilotUsagePersistenceManager _persistence;
 
         /// <summary>
         /// Rows persisted per SaveChanges. These reports are small (a period's worth of days x a dozen apps),
@@ -33,9 +34,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
         public int SaveBatchSize { get; set; } = 500;
 
         public CopilotUserCountReportLoader(ICopilotReportSource reportSource, ILogger logger)
+            : this(reportSource, logger, null)
+        {
+        }
+
+        /// <summary>
+        /// As above, with the write side supplied (issue #370). The original signature is kept as a
+        /// delegating overload so no already-compiled caller breaks.
+        /// </summary>
+        public CopilotUserCountReportLoader(ICopilotReportSource reportSource, ILogger logger, ICopilotUsagePersistenceManager persistence)
         {
             _reportSource = reportSource ?? throw new ArgumentNullException(nameof(reportSource));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _persistence = persistence;
         }
 
         public Task<int> LoadAndSaveSummaryAsync(AnalyticsEntitiesContext db, string period, string version = CopilotReportVersions.V2)
@@ -49,12 +60,31 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
         }
 
         /// <summary>
-        /// Downloads, parses and upserts one aggregate report. Returns the number of rows written to SQL
-        /// (0 when everything Graph returned already matched what we hold).
+        /// Downloads, parses and upserts one aggregate report against the supplied context. Returns the
+        /// number of rows written to SQL (0 when everything Graph returned already matched what we hold).
         /// </summary>
-        public async Task<int> LoadAndSaveAsync(AnalyticsEntitiesContext db, CopilotReportRequest request)
+        public Task<int> LoadAndSaveAsync(AnalyticsEntitiesContext db, CopilotReportRequest request)
         {
-            if (db == null) throw new ArgumentNullException(nameof(db));
+            if (_persistence == null && db == null) throw new ArgumentNullException(nameof(db));
+            return LoadAndSaveCoreAsync(_persistence ?? new SqlCopilotUsagePersistenceManager(db, _logger) { UserCountSaveBatchSize = SaveBatchSize }, request);
+        }
+
+        /// <summary>
+        /// As above, using the <see cref="ICopilotUsagePersistenceManager"/> this loader was constructed
+        /// with, so the import can run with no database at all.
+        /// </summary>
+        public Task<int> LoadAndSaveAsync(CopilotReportRequest request)
+        {
+            if (_persistence == null)
+            {
+                throw new InvalidOperationException(
+                    $"This overload needs an {nameof(ICopilotUsagePersistenceManager)}; construct the loader with one, or call the overload that takes a database context.");
+            }
+            return LoadAndSaveCoreAsync(_persistence, request);
+        }
+
+        private async Task<int> LoadAndSaveCoreAsync(ICopilotUsagePersistenceManager persistence, CopilotReportRequest request)
+        {
             if (request == null) throw new ArgumentNullException(nameof(request));
 
             var isTrend = request.ReportName == CopilotReportNames.UserCountTrend;
@@ -105,7 +135,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
                 // Health page shows why the table is empty instead of implying the tenant has no licences.
                 importLog.RowsRead = 0;
                 importLog.Error = Truncate($"Report not available: {GraphHttpException.DescribeForStorage(ex)}", 1000);
-                await SaveImportLog(db, importLog);
+                await persistence.RecordReportLoadAsync(importLog);
 
                 _logger.LogWarning($"Copilot aggregate report {request} is not available on this tenant: {ex.Message} " +
                     "These reports exist only in the global cloud (not US Government or 21Vianet). No rows were imported.");
@@ -114,7 +144,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             catch (Exception ex)
             {
                 importLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
-                await SaveImportLog(db, importLog);
+                await persistence.RecordReportLoadAsync(importLog);
                 throw;
             }
 
@@ -125,13 +155,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
             {
                 _logger.LogWarning($"Copilot aggregate report {request} returned no rows. " +
                     "The report downloaded successfully and was genuinely empty, which is expected on a tenant with no Microsoft 365 Copilot licences.");
-                await SaveImportLog(db, importLog);
+                await persistence.RecordReportLoadAsync(importLog);
                 return 0;
             }
 
-            var written = await UpsertOrRecordFailure(db, parsed, isTrend ? CopilotUserCountReportTypes.Trend : CopilotUserCountReportTypes.Summary, importLog);
+            var written = await UpsertOrRecordFailure(persistence, parsed, isTrend ? CopilotUserCountReportTypes.Trend : CopilotUserCountReportTypes.Summary, importLog);
             importLog.RowsSaved = written;
-            await SaveImportLog(db, importLog);
+            await persistence.RecordReportLoadAsync(importLog);
 
             _logger.LogInformation($"Copilot aggregate report {request}: parsed {parsed.Count} row(s), wrote {written} to SQL.");
             return written;
@@ -152,112 +182,22 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
                           .Sum(a => a.Count);
         }
 
-        private async Task<int> UpsertOrRecordFailure(AnalyticsEntitiesContext db, List<CopilotUserCountLog> parsed,
+        private async Task<int> UpsertOrRecordFailure(ICopilotUsagePersistenceManager persistence, List<CopilotUserCountLog> parsed,
             string reportType, CopilotUsageReportImportLog importLog)
         {
             try
             {
-                return await UpsertAsync(db, parsed, reportType);
+                var upsert = await persistence.UpsertUserCountsAsync(parsed, reportType);
+                return upsert.Written;
             }
             catch (Exception ex)
             {
                 // Persistence failures must reach the Health page too, and must be written on a FRESH context:
                 // the one that just failed a SaveChanges can be left with entities in a broken state.
                 importLog.Error = Truncate(GraphHttpException.DescribeForStorage(ex), 1000);
-                using (var freshDb = new AnalyticsEntitiesContext())
-                {
-                    await SaveImportLog(freshDb, importLog);
-                }
+                await persistence.RecordReportLoadAfterFailureAsync(importLog);
                 throw;
             }
-        }
-
-        private async Task<int> UpsertAsync(AnalyticsEntitiesContext db, List<CopilotUserCountLog> parsed, string reportType)
-        {
-            var minDate = parsed.Min(r => r.ReportDate);
-            var maxDate = parsed.Max(r => r.ReportDate);
-
-            // One query for everything we might collide with. Bounded by the report's own date range, so this
-            // stays small even after years of retained history.
-            var existing = await db.CopilotUserCountLogs
-                .Where(r => r.ReportType == reportType && r.ReportDate >= minDate && r.ReportDate <= maxDate)
-                .ToListAsync();
-
-            var existingByKey = new Dictionary<string, CopilotUserCountLog>(StringComparer.OrdinalIgnoreCase);
-            foreach (var row in existing)
-            {
-                existingByKey[KeyOf(row)] = row;
-            }
-
-            var written = 0;
-            var pending = 0;
-            var autoDetectWasEnabled = db.Configuration.AutoDetectChangesEnabled;
-            db.Configuration.AutoDetectChangesEnabled = false;
-            try
-            {
-                foreach (var row in parsed)
-                {
-                    var key = KeyOf(row);
-                    if (existingByKey.TryGetValue(key, out var stored))
-                    {
-                        // Graph gap-fills the most recent ~3 days, so re-importing an overlapping window is
-                        // normal and usually changes nothing. Only write when a value actually moved. The
-                        // refresh date deliberately does NOT count as a change on its own: it advances every
-                        // day, so including it would rewrite every day in the window daily (up to 180 days x
-                        // every app) purely to restamp provenance. Report-level freshness lives in
-                        // copilot_usage_report_import_log instead.
-                        if (!HasChanged(stored, row)) continue;
-
-                        stored.ReportRefreshDate = row.ReportRefreshDate;
-                        stored.EnabledUsers = row.EnabledUsers;
-                        stored.ActiveUsers = row.ActiveUsers;
-                        stored.PromptsSubmitted = row.PromptsSubmitted;
-                        stored.AveragePromptsSubmitted = row.AveragePromptsSubmitted;
-                        db.Entry(stored).State = EntityState.Modified;
-                    }
-                    else
-                    {
-                        db.CopilotUserCountLogs.Add(row);
-                        existingByKey[key] = row;
-                    }
-
-                    written++;
-                    pending++;
-                    if (pending >= SaveBatchSize)
-                    {
-                        await db.SaveChangesAsync();
-                        pending = 0;
-                    }
-                }
-
-                if (pending > 0) await db.SaveChangesAsync();
-            }
-            finally
-            {
-                db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
-            }
-
-            return written;
-        }
-
-        private static bool HasChanged(CopilotUserCountLog stored, CopilotUserCountLog incoming)
-        {
-            return stored.EnabledUsers != incoming.EnabledUsers
-                || stored.ActiveUsers != incoming.ActiveUsers
-                || stored.PromptsSubmitted != incoming.PromptsSubmitted
-                || stored.AveragePromptsSubmitted != incoming.AveragePromptsSubmitted;
-        }
-
-        /// <summary>Matches the unique index on (report_type, report_period_days, report_date, app_name).</summary>
-        private static string KeyOf(CopilotUserCountLog row)
-        {
-            return $"{row.ReportType}|{(row.ReportPeriodDays.HasValue ? row.ReportPeriodDays.Value.ToString() : string.Empty)}|{row.ReportDate:yyyy-MM-dd}|{row.AppName}";
-        }
-
-        private static async Task SaveImportLog(AnalyticsEntitiesContext db, CopilotUsageReportImportLog importLog)
-        {
-            db.CopilotUsageReportImportLogs.Add(importLog);
-            await db.SaveChangesAsync();
         }
 
         private static string Truncate(string value, int maxLength)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/ICopilotUsagePersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/ICopilotUsagePersistenceManager.cs
@@ -1,0 +1,84 @@
+using Common.Entities.Entities.UsageReports;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
+{
+    /// <summary>
+    /// What an upsert actually did. The <b>Unchanged</b> count is the point of this type: both Copilot
+    /// usage upserts carry an "only write when a value actually moved" rule, because Graph gap-fills the
+    /// most recent few days and re-importing an overlapping window is normal. Before issue #370 that rule
+    /// was invisible to tests - a regression that rewrote every row on every cycle (up to 180 days x every
+    /// app, or every licensed user) would have produced identical return values and gone unnoticed.
+    /// </summary>
+    public class CopilotUsageUpsertResult
+    {
+        public int Inserted { get; set; }
+        public int Updated { get; set; }
+        public int Unchanged { get; set; }
+
+        /// <summary>Rows actually written to SQL. This is what the loaders return and log.</summary>
+        public int Written => Inserted + Updated;
+    }
+
+    /// <summary>
+    /// The outcome of mapping a report's user principal names onto user ids.
+    /// </summary>
+    public class CopilotUserIdResolution
+    {
+        public CopilotUserIdResolution(IReadOnlyDictionary<string, int> idsByUpn, int created, int skippedUnknownDomain)
+        {
+            IdsByUpn = idsByUpn;
+            Created = created;
+            SkippedUnknownDomain = skippedUnknownDomain;
+        }
+
+        /// <summary>Case-insensitive UPN to user id. Only contains identities that exist after this call.</summary>
+        public IReadOnlyDictionary<string, int> IdsByUpn { get; }
+
+        /// <summary>How many user records had to be created.</summary>
+        public int Created { get; }
+
+        /// <summary>
+        /// How many report identities were skipped because their e-mail domain is not one this database
+        /// already holds users for. That is the real boundary that stops a pseudonymised report populating
+        /// the users table with junk.
+        /// </summary>
+        public int SkippedUnknownDomain { get; }
+    }
+
+    /// <summary>
+    /// Write port for the Copilot usage reports (issue #370). The read side was already abstracted by
+    /// <see cref="ICopilotReportSource"/>; this completes the seam, so the whole import - concealment
+    /// decision, period keying, user resolution and both upserts - runs in a unit test with zero Graph and
+    /// zero SQL Server.
+    /// </summary>
+    public interface ICopilotUsagePersistenceManager
+    {
+        /// <summary>
+        /// Map report UPNs to user ids, creating the ones that are missing and whose domain is recognised.
+        /// </summary>
+        Task<CopilotUserIdResolution> ResolveUserIdsAsync(IEnumerable<string> userPrincipalNames);
+
+        /// <summary>
+        /// Upsert per-user rows. <paramref name="rows"/> must already carry a report period (see
+        /// <c>CopilotUsageReportPolicy.ApplyPeriodKeys</c>); rows whose UPN is not in
+        /// <paramref name="userIdsByUpn"/> are skipped.
+        /// </summary>
+        Task<CopilotUsageUpsertResult> UpsertUserDetailAsync(IReadOnlyList<CopilotUsageUserDetailRow> rows,
+            IReadOnlyDictionary<string, int> userIdsByUpn, bool hasVersion2Data);
+
+        /// <summary>Upsert tenant-aggregate user-count rows for one report type.</summary>
+        Task<CopilotUsageUpsertResult> UpsertUserCountsAsync(IReadOnlyList<CopilotUserCountLog> rows, string reportType);
+
+        /// <summary>Record the per-report diagnostic the Health page reads.</summary>
+        Task RecordReportLoadAsync(CopilotUsageReportImportLog importLog);
+
+        /// <summary>
+        /// Record the diagnostic after a persistence failure. Implementations that use EF must do this on a
+        /// FRESH context: the one that just failed a SaveChanges can be left holding entities in a broken
+        /// state, so reusing it would lose the very diagnostic the operator needs.
+        /// </summary>
+        Task RecordReportLoadAfterFailureAsync(CopilotUsageReportImportLog importLog);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/SqlCopilotUsagePersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/SqlCopilotUsagePersistenceManager.cs
@@ -337,9 +337,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
         /// </summary>
         public int UserCountSaveBatchSize { get; set; } = 500;
 
-        private static bool HasChanged(CopilotUserCountLog stored, CopilotUserCountLog incoming)
-            => CopilotUsageReportPolicy.UserCountValueChanged(stored, incoming);
-
         /// <summary>Matches the unique index on (report_type, report_period_days, report_date, app_name).</summary>
         private static string KeyOf(CopilotUserCountLog row)
         {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/SqlCopilotUsagePersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/SqlCopilotUsagePersistenceManager.cs
@@ -1,0 +1,380 @@
+using Common.Entities;
+using Common.Entities.Entities.UsageReports;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
+{
+    /// <summary>
+    /// EF6 implementation of <see cref="ICopilotUsagePersistenceManager"/>. Every query and every batching
+    /// decision here was moved verbatim out of <c>CopilotUsageUserDetailLoader</c> and
+    /// <c>CopilotUserCountReportLoader</c> by issue #370 - including the
+    /// <c>AutoDetectChangesEnabled = false</c> blocks, the change-tracker detaching, and the bounded
+    /// min/max-date collision query.
+    /// </summary>
+    public class SqlCopilotUsagePersistenceManager : ICopilotUsagePersistenceManager
+    {
+        private readonly AnalyticsEntitiesContext _db;
+        private readonly ILogger _logger;
+        private readonly IAnalyticsDbContextFactory _contextFactory;
+
+        /// <summary>
+        /// Rows per SaveChanges. Small enough that EF6 never builds hundreds of thousands of command trees
+        /// at once (which OutOfMemoryExceptions on a small App Service) and that any IN clause stays well
+        /// under SQL Server's parameter limit.
+        /// </summary>
+        public int SaveBatchSize { get; set; } = 1000;
+
+        public SqlCopilotUsagePersistenceManager(AnalyticsEntitiesContext db, ILogger logger,
+            IAnalyticsDbContextFactory contextFactory = null)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _contextFactory = contextFactory ?? DefaultAnalyticsDbContextFactory.Instance;
+        }
+
+        #region User id resolution
+
+        /// <inheritdoc />
+        public async Task<CopilotUserIdResolution> ResolveUserIdsAsync(IEnumerable<string> userPrincipalNames)
+        {
+            // Comparisons are case-insensitive in memory rather than via SQL LOWER(), which would make the
+            // predicate non-SARGable and force a table scan.
+            var existingUsers = await _db.users.AsNoTracking()
+                .Select(u => new { u.ID, u.UserPrincipalName })
+                .ToListAsync();
+
+            var idsByUpn = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var knownDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var user in existingUsers)
+            {
+                if (string.IsNullOrWhiteSpace(user.UserPrincipalName)) continue;
+                idsByUpn[user.UserPrincipalName] = user.ID;
+
+                var domain = CopilotUsageReportPolicy.DomainOf(user.UserPrincipalName);
+                if (domain != null) knownDomains.Add(domain);
+            }
+
+            var plan = CopilotUsageReportPolicy.PlanNewUsers(userPrincipalNames, idsByUpn, knownDomains);
+
+            if (plan.SkippedUnknownDomain > 0)
+            {
+                _logger.LogWarning($"Copilot per-user report: skipped {plan.SkippedUnknownDomain} identity(ies) on an email domain this database has no users for. " +
+                    "They were not created, because an unrecognised domain is how a pseudonymised report would look. " +
+                    "If these are genuine users, run the Graph user metadata import so they are known first.");
+            }
+
+            if (plan.ToCreate.Count == 0)
+            {
+                return new CopilotUserIdResolution(idsByUpn, 0, plan.SkippedUnknownDomain);
+            }
+
+            _logger.LogInformation($"Copilot per-user report: creating {plan.ToCreate.Count} user record(s) not yet known to the database.");
+
+            var autoDetectWasEnabled = _db.Configuration.AutoDetectChangesEnabled;
+            _db.Configuration.AutoDetectChangesEnabled = false;
+            try
+            {
+                var newUsers = new List<Common.Entities.User>(Math.Min(plan.ToCreate.Count, SaveBatchSize));
+                for (var i = 0; i < plan.ToCreate.Count; i++)
+                {
+                    // Existing loaders store UPNs lower-cased; matching that avoids creating a second user
+                    // record that differs only by case.
+                    var user = new Common.Entities.User { UserPrincipalName = plan.ToCreate[i].ToLowerInvariant() };
+                    _db.users.Add(user);
+                    newUsers.Add(user);
+
+                    if (newUsers.Count >= SaveBatchSize)
+                    {
+                        await FlushNewUsers(_db, newUsers, idsByUpn);
+                    }
+                }
+
+                await FlushNewUsers(_db, newUsers, idsByUpn);
+            }
+            finally
+            {
+                _db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
+            }
+
+            return new CopilotUserIdResolution(idsByUpn, plan.ToCreate.Count, plan.SkippedUnknownDomain);
+        }
+
+        /// <summary>
+        /// Commits a batch of new users, records their ids, then DETACHES them.
+        /// Detaching matters at scale: auto-detect is off, so every SaveChanges needs an explicit
+        /// DetectChanges, and DetectChanges walks every tracked entity. Leaving 200,000 added users tracked
+        /// would make the per-batch scan O(total x batches) and hold them all in memory for the rest of the
+        /// import. The ids are all we need afterwards.
+        /// </summary>
+        private static async Task FlushNewUsers(AnalyticsEntitiesContext db, List<Common.Entities.User> newUsers, Dictionary<string, int> idsByUpn)
+        {
+            if (newUsers.Count == 0) return;
+
+            db.ChangeTracker.DetectChanges();
+            await db.SaveChangesAsync();
+
+            foreach (var user in newUsers)
+            {
+                idsByUpn[user.UserPrincipalName] = user.ID;
+                db.Entry(user).State = EntityState.Detached;
+            }
+
+            newUsers.Clear();
+        }
+
+        #endregion
+
+        #region Per-user detail upsert
+
+        /// <inheritdoc />
+        public async Task<CopilotUsageUpsertResult> UpsertUserDetailAsync(IReadOnlyList<CopilotUsageUserDetailRow> rows,
+            IReadOnlyDictionary<string, int> userIdsByUpn, bool hasVersion2Data)
+        {
+            var result = new CopilotUsageUpsertResult();
+            if (rows == null || rows.Count == 0) return result;
+
+            var reportDates = rows.Select(r => r.ReportRefreshDate.Date).Distinct().ToList();
+            var periods = rows.Select(r => r.ReportPeriodDays.Value).Distinct().ToList();
+
+            var autoDetectWasEnabled = _db.Configuration.AutoDetectChangesEnabled;
+            _db.Configuration.AutoDetectChangesEnabled = false;
+            try
+            {
+                // Work in batches of users rather than one pass over all of them. Batching bounds not just the
+                // SQL command trees but EF's change tracker: the previous shape loaded and kept every existing
+                // row for the report date tracked for the whole loop, which at ~200,000 licensed users is the
+                // memory profile that caused an OutOfMemoryException in the other usage-report loaders.
+                for (var offset = 0; offset < rows.Count; offset += SaveBatchSize)
+                {
+                    var count = Math.Min(SaveBatchSize, rows.Count - offset);
+                    var batch = new List<CopilotUsageUserDetailRow>(count);
+                    for (var i = 0; i < count; i++) batch.Add(rows[offset + i]);
+
+                    await SaveBatchAsync(batch, userIdsByUpn, reportDates, periods, hasVersion2Data, result);
+                    DetachActivityLogs(_db);
+                }
+            }
+            finally
+            {
+                _db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
+                DetachActivityLogs(_db);
+            }
+
+            return result;
+        }
+
+        private async Task SaveBatchAsync(List<CopilotUsageUserDetailRow> batch, IReadOnlyDictionary<string, int> userIdsByUpn,
+            List<DateTime> reportDates, List<int> periods, bool hasVersion2Data, CopilotUsageUpsertResult result)
+        {
+            var batchUserIds = new List<int>(batch.Count);
+            foreach (var row in batch)
+            {
+                if (userIdsByUpn.TryGetValue(row.UserPrincipalName, out var id)) batchUserIds.Add(id);
+            }
+            if (batchUserIds.Count == 0) return;
+
+            var existingByKey = new Dictionary<string, CopilotUsageUserActivityLog>();
+            foreach (var existing in await _db.CopilotUsageUserActivityLogs
+                .Where(r => reportDates.Contains(r.Date) && periods.Contains(r.ReportPeriodDays) && batchUserIds.Contains(r.UserID))
+                .ToListAsync())
+            {
+                existingByKey[KeyOf(existing.Date, existing.ReportPeriodDays, existing.UserID)] = existing;
+            }
+
+            var written = 0;
+            foreach (var row in batch)
+            {
+                if (!userIdsByUpn.TryGetValue(row.UserPrincipalName, out var userId)) continue;
+
+                var date = row.ReportRefreshDate.Date;
+                var periodDays = row.ReportPeriodDays.Value;
+                var key = KeyOf(date, periodDays, userId);
+
+                var isNew = !existingByKey.TryGetValue(key, out var log);
+                if (isNew)
+                {
+                    log = new CopilotUsageUserActivityLog { Date = date, UserID = userId, ReportPeriodDays = periodDays };
+                    existingByKey[key] = log;
+                }
+
+                var changed = Populate(log, row, hasVersion2Data);
+
+                if (isNew)
+                {
+                    _db.CopilotUsageUserActivityLogs.Add(log);
+                    result.Inserted++;
+                }
+                else if (changed)
+                {
+                    _db.Entry(log).State = EntityState.Modified;
+                    result.Updated++;
+                }
+                else
+                {
+                    // Graph gap-fills the last few days, so re-imports are mostly identical rows. Skipping
+                    // unchanged UPDATEs is the difference between writing a handful of rows and rewriting
+                    // every licensed user every cycle.
+                    result.Unchanged++;
+                    continue;
+                }
+
+                written++;
+            }
+
+            if (written > 0) await _db.SaveChangesAsync();
+        }
+
+        private static void DetachActivityLogs(AnalyticsEntitiesContext db)
+        {
+            foreach (var entry in db.ChangeTracker.Entries<CopilotUsageUserActivityLog>().ToList())
+            {
+                entry.State = EntityState.Detached;
+            }
+        }
+
+        /// <summary>
+        /// Copies report values onto the log row, returning true if any stored value actually changed.
+        ///
+        /// When the response carried no version 2 values at all, those columns are left untouched instead of
+        /// being written as NULL: that response can't distinguish "the user submitted no prompts" from
+        /// "Graph didn't send prompt data", and blanking a previously captured prompt count is the more
+        /// damaging of the two possible mistakes.
+        /// </summary>
+        internal static bool Populate(CopilotUsageUserActivityLog log, CopilotUsageUserDetailRow row, bool hasVersion2Data)
+            => CopilotUsageUserDetailLoader.Populate(log, row, hasVersion2Data);
+        /// <summary>Matches the unique index on (date, user_id, report_period_days).</summary>
+        private static string KeyOf(DateTime date, int periodDays, int userId)
+        {
+            return $"{date:yyyy-MM-dd}|{periodDays}|{userId}";
+        }
+
+        #endregion
+
+        #region Aggregate user-count upsert
+
+        /// <inheritdoc />
+        public async Task<CopilotUsageUpsertResult> UpsertUserCountsAsync(IReadOnlyList<CopilotUserCountLog> parsed, string reportType)
+        {
+            var result = new CopilotUsageUpsertResult();
+            if (parsed == null || parsed.Count == 0) return result;
+
+            var minDate = parsed.Min(r => r.ReportDate);
+            var maxDate = parsed.Max(r => r.ReportDate);
+
+            // One query for everything we might collide with. Bounded by the report's own date range, so this
+            // stays small even after years of retained history.
+            var existing = await _db.CopilotUserCountLogs
+                .Where(r => r.ReportType == reportType && r.ReportDate >= minDate && r.ReportDate <= maxDate)
+                .ToListAsync();
+
+            var existingByKey = new Dictionary<string, CopilotUserCountLog>(StringComparer.OrdinalIgnoreCase);
+            foreach (var row in existing)
+            {
+                existingByKey[KeyOf(row)] = row;
+            }
+
+            var pending = 0;
+            var autoDetectWasEnabled = _db.Configuration.AutoDetectChangesEnabled;
+            _db.Configuration.AutoDetectChangesEnabled = false;
+            try
+            {
+                foreach (var row in parsed)
+                {
+                    var key = KeyOf(row);
+                    if (existingByKey.TryGetValue(key, out var stored))
+                    {
+                        // Graph gap-fills the most recent ~3 days, so re-importing an overlapping window is
+                        // normal and usually changes nothing. Only write when a value actually moved. The
+                        // refresh date deliberately does NOT count as a change on its own: it advances every
+                        // day, so including it would rewrite every day in the window daily (up to 180 days x
+                        // every app) purely to restamp provenance. Report-level freshness lives in
+                        // copilot_usage_report_import_log instead.
+                        if (!HasChanged(stored, row))
+                        {
+                            result.Unchanged++;
+                            continue;
+                        }
+
+                        stored.ReportRefreshDate = row.ReportRefreshDate;
+                        stored.EnabledUsers = row.EnabledUsers;
+                        stored.ActiveUsers = row.ActiveUsers;
+                        stored.PromptsSubmitted = row.PromptsSubmitted;
+                        stored.AveragePromptsSubmitted = row.AveragePromptsSubmitted;
+                        _db.Entry(stored).State = EntityState.Modified;
+                        result.Updated++;
+                    }
+                    else
+                    {
+                        _db.CopilotUserCountLogs.Add(row);
+                        existingByKey[key] = row;
+                        result.Inserted++;
+                    }
+
+                    pending++;
+                    if (pending >= UserCountSaveBatchSize)
+                    {
+                        await _db.SaveChangesAsync();
+                        pending = 0;
+                    }
+                }
+
+                if (pending > 0) await _db.SaveChangesAsync();
+            }
+            finally
+            {
+                _db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Rows persisted per SaveChanges for the aggregate reports. These are small (a period's worth of
+        /// days x a dozen apps), but a D180 trend backfill across many apps still runs to a few thousand
+        /// rows, so commit in batches rather than building one enormous command tree.
+        /// </summary>
+        public int UserCountSaveBatchSize { get; set; } = 500;
+
+        private static bool HasChanged(CopilotUserCountLog stored, CopilotUserCountLog incoming)
+        {
+            return stored.EnabledUsers != incoming.EnabledUsers
+                || stored.ActiveUsers != incoming.ActiveUsers
+                || stored.PromptsSubmitted != incoming.PromptsSubmitted
+                || stored.AveragePromptsSubmitted != incoming.AveragePromptsSubmitted;
+        }
+
+        /// <summary>Matches the unique index on (report_type, report_period_days, report_date, app_name).</summary>
+        private static string KeyOf(CopilotUserCountLog row)
+        {
+            return $"{row.ReportType}|{(row.ReportPeriodDays.HasValue ? row.ReportPeriodDays.Value.ToString() : string.Empty)}|{row.ReportDate:yyyy-MM-dd}|{row.AppName}";
+        }
+
+        #endregion
+
+        #region Import log
+
+        /// <inheritdoc />
+        public async Task RecordReportLoadAsync(CopilotUsageReportImportLog importLog)
+        {
+            _db.CopilotUsageReportImportLogs.Add(importLog);
+            await _db.SaveChangesAsync();
+        }
+
+        /// <inheritdoc />
+        public async Task RecordReportLoadAfterFailureAsync(CopilotUsageReportImportLog importLog)
+        {
+            using (var freshDb = _contextFactory.Create())
+            {
+                freshDb.CopilotUsageReportImportLogs.Add(importLog);
+                await freshDb.SaveChangesAsync();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/SqlCopilotUsagePersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Copilot/SqlCopilotUsagePersistenceManager.cs
@@ -288,13 +288,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
                     var key = KeyOf(row);
                     if (existingByKey.TryGetValue(key, out var stored))
                     {
-                        // Graph gap-fills the most recent ~3 days, so re-importing an overlapping window is
-                        // normal and usually changes nothing. Only write when a value actually moved. The
-                        // refresh date deliberately does NOT count as a change on its own: it advances every
-                        // day, so including it would rewrite every day in the window daily (up to 180 days x
-                        // every app) purely to restamp provenance. Report-level freshness lives in
-                        // copilot_usage_report_import_log instead.
-                        if (!HasChanged(stored, row))
+                        // Only write when a value actually moved; the rule (including why the refresh date
+                        // is deliberately excluded) lives in CopilotUsageReportPolicy so the in-memory test
+                        // double asserts the same rule rather than a copy of it.
+                        if (!CopilotUsageReportPolicy.UserCountValueChanged(stored, row))
                         {
                             result.Unchanged++;
                             continue;
@@ -341,12 +338,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot
         public int UserCountSaveBatchSize { get; set; } = 500;
 
         private static bool HasChanged(CopilotUserCountLog stored, CopilotUserCountLog incoming)
-        {
-            return stored.EnabledUsers != incoming.EnabledUsers
-                || stored.ActiveUsers != incoming.ActiveUsers
-                || stored.PromptsSubmitted != incoming.PromptsSubmitted
-                || stored.AveragePromptsSubmitted != incoming.AveragePromptsSubmitted;
-        }
+            => CopilotUsageReportPolicy.UserCountValueChanged(stored, incoming);
 
         /// <summary>Matches the unique index on (report_type, report_period_days, report_date, app_name).</summary>
         private static string KeyOf(CopilotUserCountLog row)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -181,6 +181,8 @@
     <Compile Include="Graph\UsageReports\Copilot\CopilotReportSource.cs" />
     <Compile Include="Graph\UsageReports\Copilot\CopilotUsageUserDetailLoader.cs" />
     <Compile Include="Graph\UsageReports\Copilot\CopilotUsageReportPolicy.cs" />
+    <Compile Include="Graph\UsageReports\Copilot\ICopilotUsagePersistenceManager.cs" />
+    <Compile Include="Graph\UsageReports\Copilot\SqlCopilotUsagePersistenceManager.cs" />
     <Compile Include="Graph\UsageReports\Copilot\CopilotUsageUserDetailParser.cs" />
     <Compile Include="Graph\UsageReports\Copilot\CopilotUserCountReportLoader.cs" />
     <Compile Include="Graph\UsageReports\Copilot\CopilotUserCountReportParser.cs" />


### PR DESCRIPTION
## Summary

Finishes #370. Part 1 (PR #394) extracted `CopilotUsageReportPolicy.EvaluateConcealment`; this completes the seam so **the whole Copilot usage import runs in a unit test with zero Graph and zero SQL Server**.

## The point of the issue: `Unchanged` is now assertable

Both Copilot upserts carry an *"only write when a value actually moved"* rule — Graph gap-fills the most recent few days, so re-importing an overlapping window is normal and usually changes nothing. Before this, that rule was **invisible to tests**: a regression that rewrote every row on every cycle — up to 180 days × every app for the aggregates, or every licensed user for the per-user report — returned exactly the same numbers as the correct code.

`CopilotUsageUpsertResult` now carries **`Inserted` / `Updated` / `Unchanged`**, and `CopilotUserCount_ValuesUnchanged_ReportsUnchanged_AndDoesNotRewriteRows` asserts it directly.

`CopilotUserCount_OnlyTheRefreshDateMoved_IsStillUnchanged` pins the deliberate exclusion: the refresh date advances every day, so counting it as a change would rewrite the whole window daily purely to restamp provenance. Report-level freshness lives on `copilot_usage_report_import_log` instead.

## The port

```csharp
public interface ICopilotUsagePersistenceManager
{
    Task<CopilotUserIdResolution> ResolveUserIdsAsync(IEnumerable<string> userPrincipalNames);
    Task<CopilotUsageUpsertResult> UpsertUserDetailAsync(IReadOnlyList<CopilotUsageUserDetailRow> rows,
        IReadOnlyDictionary<string, int> userIdsByUpn, bool hasVersion2Data);
    Task<CopilotUsageUpsertResult> UpsertUserCountsAsync(IReadOnlyList<CopilotUserCountLog> rows, string reportType);
    Task RecordReportLoadAsync(CopilotUsageReportImportLog importLog);
    Task RecordReportLoadAfterFailureAsync(CopilotUsageReportImportLog importLog);
}
```

**Deviations from #370's proposed shape, stated explicitly** (the issue asks for this):

- `UpsertUserCountsAsync` is keyed by **`reportType`**, not `reportRefreshDate` — the report type (summary vs trend) is what partitions the table and bounds the collision query; the refresh date is not part of the key at all.
- `RecordReportLoadAsync` takes the whole **`CopilotUsageReportImportLog`** rather than `(reportName, refreshDate, rowsImported)`. The loaders must also record `Error`, `IsUpnObfuscated`, `ReportVersion`, `ReportPeriod` and `RowsRead` — the three-scalar signature would silently drop the concealed-identity diagnostic, which is the single most important thing on the Health page for this import.
- `RecordReportLoadAfterFailureAsync` is a **second** method rather than a flag, because it carries a requirement rather than a value: the diagnostic after a persistence failure must be written on a **fresh** context, since the one that just failed `SaveChanges` can be left holding entities in a broken state.
- `ResolveUserIdsAsync` returns a `CopilotUserIdResolution` (ids + created count + skipped-unknown-domain count) rather than a bare dictionary, so the counts the operator log reports are observable.

## SQL adapter

`SqlCopilotUsagePersistenceManager` holds the EF code **moved verbatim** from both loaders: both `AutoDetectChangesEnabled = false` blocks and their `finally` restores, the `CopilotUsageUserActivityLog` change-tracker detaching (which is what keeps a 200k-user import off the OOM path), the new-user batching and detaching in `FlushNewUsers`, and the bounded `minDate`/`maxDate` collision query.

**The two mid-flow `using (var freshDb = new AnalyticsEntitiesContext())` calls are gone** — replaced by `IAnalyticsDbContextFactory` (#368) inside `RecordReportLoadAfterFailureAsync`, keeping the reason they existed.

## Two more pure rules

Added to `CopilotUsageReportPolicy`:

- **`ApplyPeriodKeys`** — the period-key normalisation. Still filters **in place** with `RemoveAll`, deliberately: the caller's closing `"parsed N row(s)"` log reads the original list, and at ~200k licensed users a second full-size list is a pointless copy. `RemoveAll` rather than reverse `RemoveAt` because the latter is O(N²) element moves (~5 billion when half a 200k report is unkeyable). `CopilotUsage_PeriodKeyNormalisation_RowWithNoPeriodAndNoRequestPeriod_IsDroppedInPlace` asserts `AreSame` on a surviving row, so replacing the list rather than compacting it fails.
- **`PlanNewUsers` / `DomainOf`** — the rule that a user is only ever created when its e-mail domain is one the database already holds users for. That, not a UPN shape check, is the real boundary that stops a pseudonymised report populating `users` with junk; an empty database creates everything so a fresh install can make progress.

## Call-site compatibility

Both loaders keep their **original constructor and `LoadAndSaveAsync(db, …)` signatures as delegating overloads** — no call site breaks, and nothing gains a trailing optional parameter (which would be binary-breaking). Each gains a `LoadAndSaveAsync(request)` overload that uses the injected port, which is what lets the import run with no database at all.

Ordering is preserved where it matters: **users are still resolved *before* the period keying, over the full row set**, so an identity appearing only on rows later dropped as unkeyable is still created exactly as it always was.

## Testing

**New: 15 tests in `CopilotUsagePersistencePortTests`**, plus `InMemoryCopilotUsagePersistenceManager` in `Tests.UnitTests/FakeLoaderClasses/`. Zero Graph, zero SQL Server. Beyond the change-detection tests above:

- the same report imported twice is idempotent;
- D7 and D28 for the same user and date are stored as two rows (collapsing them would let one period silently overwrite the other);
- a user on a **known** domain is created — including a Greek UPN, which must not be dropped;
- a user on an **unknown** domain is skipped, no user is invented, and the import still completes;
- a persistence failure is recorded through the after-failure path with the error text intact;
- a fully concealed tenant writes **no** usage row and **no** placeholder user, and sets `IsUpnObfuscated` so the Health page shows the reason instead of looking like an empty tenant;
- the period-key and new-user-domain rules, including case-insensitivity and the shapes a concealed report produces (bare hash, `@domain`, `user@`).

**Pre-existing tests unchanged and passing**: `CopilotUsageReportImportTests` (DB-backed) and `CopilotUsageReportPolicyTests`. Area run: **45 passed / 45**. Full solution builds (Debug).

## Reviewer hotspots

1. **`SqlCopilotUsagePersistenceManager` versus the two originals** — is the EF code genuinely verbatim? Particularly the `AutoDetectChangesEnabled` save/restore, the detaching, and that `UpsertUserDetailAsync`'s batching slices the same way (I replaced `List.GetRange` with an index copy because the port takes `IReadOnlyList`; it is still O(N) with no `Skip`).
2. **`Written` vs the old `written` counter.** The old code incremented one counter for both inserts and updates and returned it; `Written => Inserted + Updated` must be the same number, including the `continue` on unchanged rows.
3. **Log fidelity.** `ResolveUserIds`' two operator log lines moved into the SQL adapter (the in-memory fake does not log). The "dropped N row(s) with no report period" warning stayed in the loader so it still reads the same list. Is anything else emitted from a different place, or in a different order?
4. **The test fake.** `InMemoryCopilotUsagePersistenceManager` re-implements the change-detection rule rather than sharing it with the SQL adapter, so the two could drift. Is that acceptable, or should the comparison move into the policy class and be shared?

## Bonus this unblocks

#389 (no regression guard for the Copilot staging writer clearing its row lists) and the loader-handoff aliasing contract documented in `CopilotUsageReportPolicyTests` are now both reachable without a database. Neither is done here — this PR stays scoped to #370.

Addresses #370
