### PR TITLE
Extract read/write ports and crawl rules from the Teams import

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeTeamsPorts.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeTeamsPorts.cs
@@ -43,12 +43,18 @@ namespace UnitTests.FakeLoaderClasses
         /// <c>AdditionalData</c>. Pass <c>null</c> for <paramref name="provisioningOptionsJson"/> to
         /// model a group that didn't return the property at all.
         /// </summary>
+        /// <remarks>
+        /// The property name is written as a literal on purpose, NOT as
+        /// <c>TeamsCrawlRules.ResourceProvisioningOptionsProperty</c>: this is the Graph wire contract,
+        /// and a typo in the production constant must fail these tests rather than move the reader and
+        /// the writer together.
+        /// </remarks>
         public static Group GroupWithProvisioningOptions(string id, string displayName, string provisioningOptionsJson)
         {
             var group = new Group { Id = id, DisplayName = displayName };
             if (provisioningOptionsJson != null)
             {
-                group.AdditionalData[TeamsCrawlRules.ResourceProvisioningOptionsProperty] = provisioningOptionsJson;
+                group.AdditionalData["resourceProvisioningOptions"] = provisioningOptionsJson;
             }
             return group;
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeTeamsPorts.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeTeamsPorts.cs
@@ -1,0 +1,106 @@
+using Common.Entities.Redis.Teams;
+using Microsoft.Graph.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.Teams;
+
+namespace UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="ITeamsGroupSourceLoader"/>, so the Teams crawl's group-selection rules can
+    /// be exercised with no Graph call. See issue #377.
+    /// </summary>
+    public class FakeTeamsGroupSourceLoader : ITeamsGroupSourceLoader
+    {
+        private readonly List<Group> _groups;
+
+        public FakeTeamsGroupSourceLoader(params Group[] groups)
+        {
+            _groups = new List<Group>(groups ?? Array.Empty<Group>());
+        }
+
+        /// <summary>How many times the v1 "read everything and filter locally" path was used.</summary>
+        public int ProvisioningOptionsReadCount { get; private set; }
+
+        /// <summary>How many times the beta "server-side filter" path was used.</summary>
+        public int FilteredToTeamsReadCount { get; private set; }
+
+        public Task<List<Group>> LoadGroupsWithProvisioningOptions()
+        {
+            ProvisioningOptionsReadCount++;
+            return Task.FromResult(new List<Group>(_groups));
+        }
+
+        public Task<List<Group>> LoadGroupsFilteredToTeams()
+        {
+            FilteredToTeamsReadCount++;
+            return Task.FromResult(new List<Group>(_groups));
+        }
+
+        /// <summary>
+        /// Build a group as the v1 Graph endpoint returns it, with its provisioned workloads in
+        /// <c>AdditionalData</c>. Pass <c>null</c> for <paramref name="provisioningOptionsJson"/> to
+        /// model a group that didn't return the property at all.
+        /// </summary>
+        public static Group GroupWithProvisioningOptions(string id, string displayName, string provisioningOptionsJson)
+        {
+            var group = new Group { Id = id, DisplayName = displayName };
+            if (provisioningOptionsJson != null)
+            {
+                group.AdditionalData[TeamsCrawlRules.ResourceProvisioningOptionsProperty] = provisioningOptionsJson;
+            }
+            return group;
+        }
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IChannelMessagesSourceLoader"/>. Returns a scripted delta token (or throws)
+    /// per channel id, so <see cref="TeamsChannelCrawler"/> can be tested with no Graph and no Redis.
+    /// See issue #377.
+    /// </summary>
+    public class FakeChannelMessagesSourceLoader : IChannelMessagesSourceLoader
+    {
+        private readonly Dictionary<string, TeamsRedisManager.TeamChannelDeltaTokenInfo> _tokensByChannelId
+            = new Dictionary<string, TeamsRedisManager.TeamChannelDeltaTokenInfo>(StringComparer.Ordinal);
+
+        private readonly HashSet<string> _failingChannelIds = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>Channel ids this loader was asked to read, in order.</summary>
+        public List<string> ChannelsRead { get; } = new List<string>();
+
+        /// <summary>Script a channel read that returns a new delta token.</summary>
+        public FakeChannelMessagesSourceLoader ReturningToken(string channelId, string token)
+        {
+            _tokensByChannelId[channelId] = new TeamsRedisManager.TeamChannelDeltaTokenInfo { Token = token, LastUpdated = DateTime.Now };
+            return this;
+        }
+
+        /// <summary>Script a channel read that succeeds but hands back no delta token.</summary>
+        public FakeChannelMessagesSourceLoader ReturningNoToken(string channelId)
+        {
+            _tokensByChannelId[channelId] = null;
+            return this;
+        }
+
+        /// <summary>Script a channel read that fails the way an expired user token does.</summary>
+        public FakeChannelMessagesSourceLoader Failing(string channelId)
+        {
+            _failingChannelIds.Add(channelId);
+            return this;
+        }
+
+        public Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> LoadMessagesAndReactions(ChannelWithReactions channel, string teamId)
+        {
+            ChannelsRead.Add(channel.Id);
+
+            if (_failingChannelIds.Contains(channel.Id))
+            {
+                throw new ChannelMessagesReadException(new InvalidOperationException("simulated expired user token"));
+            }
+
+            _tokensByChannelId.TryGetValue(channel.Id, out var token);
+            return Task.FromResult(token);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
@@ -22,23 +22,23 @@ namespace Tests.UnitTests
 
         /// <summary>
         /// A group only counts as having a Team if its <c>resourceProvisioningOptions</c> array says so.
-        /// A group that didn't return the property at all is neither crawled nor reported as
-        /// "has no Team associated" - reporting it would spam the importer log with every security
-        /// group and distribution list in the tenant.
+        /// The three-way answer matters: a group that didn't report the property at all is neither
+        /// crawled nor reported as "has no Team associated" — reporting it would spam the importer log
+        /// with every security group and distribution list in the tenant, on every cycle.
         /// </summary>
         [TestMethod]
-        public void PartitionGroupsWithTeams_SplitsOnResourceProvisioningOptions()
+        public void ClassifyGroup_DistinguishesNoTeamFromWorkloadsNotReported()
         {
             var withTeam = FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-team", "Contoso Marketing", "[\"Team\",\"Exchange\"]");
             var withoutTeam = FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-noteam", "Contoso Distribution List", "[\"Exchange\"]");
             var noPropertyAtAll = FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-unknown", "Contoso Security Group", null);
 
-            var partition = TeamsCrawlRules.PartitionGroupsWithTeams(new[] { withTeam, withoutTeam, noPropertyAtAll });
+            Assert.AreEqual(GroupTeamStatus.HasTeam, TeamsCrawlRules.ClassifyGroup(withTeam));
+            Assert.AreEqual(GroupTeamStatus.NoTeam, TeamsCrawlRules.ClassifyGroup(withoutTeam));
+            Assert.AreEqual(GroupTeamStatus.WorkloadsNotReported, TeamsCrawlRules.ClassifyGroup(noPropertyAtAll),
+                "A group with no resourceProvisioningOptions property must be distinguishable from one that reported no Team.");
 
-            CollectionAssert.AreEqual(new[] { "g-team" }, partition.WithTeam.Select(g => g.Id).ToArray(),
-                "Only the group whose provisioning options include Team should be crawled.");
-            CollectionAssert.AreEqual(new[] { "g-noteam" }, partition.WithoutTeam.Select(g => g.Id).ToArray(),
-                "A group with no resourceProvisioningOptions property must not be reported as 'has no Team associated'.");
+            Assert.IsFalse(TeamsCrawlRules.GroupHasTeam(noPropertyAtAll), "Either way it is not crawled.");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
@@ -174,8 +174,10 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// The channel object must end up holding what the rule selected - a wrapper that computed the
-        /// scope but forgot to assign it would silently import nothing.
+        /// The channel object must end up holding what the rule selected - and must be holding it
+        /// because the delta filter ran. The fixture deliberately mixes before-token and after-token
+        /// content, so a wrapper that passed <c>null</c> for the delta timestamp, or assigned everything
+        /// Graph returned, fails here rather than looking correct.
         /// </summary>
         [TestMethod]
         public void CalculateAndSetNewMessagesAndReactions_ReplacesChannelMessagesAndReactions()
@@ -184,13 +186,16 @@ namespace Tests.UnitTests
             channel.Messages.Add(Msg("stale-from-a-previous-cycle", BeforeToken));
             channel.Reactions.Add(new ChatMessageReaction { ReactionType = "stale" });
 
-            var root = Msg("root", AfterToken, AfterToken);
+            // An old thread parent, re-served by the delta only because it was replied to and reacted to.
+            var reServedParent = Msg("old-parent", BeforeToken, BeforeToken, AfterToken);
+            reServedParent.Replies.Add(Msg("new-reply", AfterToken));
 
-            channel.CalculateAndSetNewMessagesAndReactions(new List<ChatMessage> { root }, DeltaTokenWrittenAt, AnalyticsLogger.ConsoleOnlyTracer());
+            channel.CalculateAndSetNewMessagesAndReactions(new List<ChatMessage> { reServedParent }, DeltaTokenWrittenAt, AnalyticsLogger.ConsoleOnlyTracer());
 
-            CollectionAssert.AreEqual(new[] { "root" }, channel.Messages.Select(m => m.Id).ToArray());
-            Assert.AreEqual(1, channel.Reactions.Count);
-            Assert.AreEqual("like", channel.Reactions[0].ReactionType);
+            CollectionAssert.AreEqual(new[] { "new-reply" }, channel.Messages.Select(m => m.Id).ToArray(),
+                "The channel must end up with the delta-filtered set, not everything Graph returned.");
+            Assert.AreEqual(1, channel.Reactions.Count, "Only the reaction added since the delta token is new.");
+            Assert.AreEqual(new DateTimeOffset(AfterToken), channel.Reactions[0].CreatedDateTime);
         }
 
         #endregion

--- a/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
@@ -1,0 +1,270 @@
+using Common.Entities.Redis.Teams;
+using DataUtils;
+using Microsoft.Graph.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph.Teams;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// First unit coverage for the Teams import (issue #377). Everything here runs with no Graph, no
+    /// Redis and no SQL: the crawl's decisions are now behind pure rules and ports.
+    /// </summary>
+    [TestClass]
+    public class TeamsCrawlTests
+    {
+        #region Which groups get crawled
+
+        /// <summary>
+        /// A group only counts as having a Team if its <c>resourceProvisioningOptions</c> array says so.
+        /// A group that didn't return the property at all is neither crawled nor reported as
+        /// "has no Team associated" - reporting it would spam the importer log with every security
+        /// group and distribution list in the tenant.
+        /// </summary>
+        [TestMethod]
+        public void PartitionGroupsWithTeams_SplitsOnResourceProvisioningOptions()
+        {
+            var withTeam = FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-team", "Contoso Marketing", "[\"Team\",\"Exchange\"]");
+            var withoutTeam = FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-noteam", "Contoso Distribution List", "[\"Exchange\"]");
+            var noPropertyAtAll = FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-unknown", "Contoso Security Group", null);
+
+            var partition = TeamsCrawlRules.PartitionGroupsWithTeams(new[] { withTeam, withoutTeam, noPropertyAtAll });
+
+            CollectionAssert.AreEqual(new[] { "g-team" }, partition.WithTeam.Select(g => g.Id).ToArray(),
+                "Only the group whose provisioning options include Team should be crawled.");
+            CollectionAssert.AreEqual(new[] { "g-noteam" }, partition.WithoutTeam.Select(g => g.Id).ToArray(),
+                "A group with no resourceProvisioningOptions property must not be reported as 'has no Team associated'.");
+        }
+
+        /// <summary>
+        /// Graph has returned this value with varying casing; the importer has always compared
+        /// case-insensitively, and a group whose workload reads "TEAM" must still be crawled.
+        /// </summary>
+        [TestMethod]
+        public void ProvisioningOptionsIncludeTeam_IgnoresCase()
+        {
+            Assert.IsTrue(TeamsCrawlRules.ProvisioningOptionsIncludeTeam("[\"TEAM\"]"));
+            Assert.IsTrue(TeamsCrawlRules.ProvisioningOptionsIncludeTeam("[\"Team\"]"));
+            Assert.IsFalse(TeamsCrawlRules.ProvisioningOptionsIncludeTeam("[\"Teams\"]"),
+                "'Teams' is not the workload name - matching it would crawl groups that have no Team.");
+            Assert.IsFalse(TeamsCrawlRules.ProvisioningOptionsIncludeTeam("[]"));
+        }
+
+        /// <summary>
+        /// The blacklist beats the whitelist, and both partitions keep the order the groups arrived in -
+        /// that ordering is what keeps the importer's "Excluding group ..." log identical.
+        /// </summary>
+        [TestMethod]
+        public void PartitionByCrawlConfig_AppliesWhitelistAndBlacklistPreservingOrder()
+        {
+            var config = new TeamsCrawlConfig();
+            config.WhitelistTeamsIds.Add("g1");
+            config.WhitelistTeamsIds.Add("g3");
+            config.BlacklistTeamsIds.Add("g3");
+
+            var groups = new[]
+            {
+                FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g1", "One", "[\"Team\"]"),
+                FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g2", "Two", "[\"Team\"]"),
+                FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g3", "Three", "[\"Team\"]"),
+            };
+
+            var partition = TeamsCrawlRules.PartitionByCrawlConfig(groups, config);
+
+            CollectionAssert.AreEqual(new[] { "g1" }, partition.ToCrawl.Select(g => g.Id).ToArray(),
+                "Only whitelisted groups that aren't also blacklisted should be crawled.");
+            CollectionAssert.AreEqual(new[] { "g2", "g3" }, partition.Excluded.Select(g => g.Id).ToArray(),
+                "Excluded groups must stay in source order so the log lines are emitted in the same order as before.");
+        }
+
+        /// <summary>
+        /// End to end through the real <see cref="TeamsFinder"/> with a fake Graph source: only groups
+        /// that both have a Team and pass the crawl config come back, and the importer still uses the v1
+        /// "read everything then filter" path rather than the unfinished beta server-side filter.
+        /// </summary>
+        [TestMethod]
+        public async Task FindGroupsWithTeamToCrawl_ReturnsOnlyCrawlableGroupsWithATeam()
+        {
+            var source = new FakeTeamsGroupSourceLoader(
+                FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-crawl", "Contoso Marketing", "[\"Team\"]"),
+                FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-blocked", "Contoso HR", "[\"Team\"]"),
+                FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-noteam", "Contoso Distribution List", "[\"Exchange\"]"),
+                FakeTeamsGroupSourceLoader.GroupWithProvisioningOptions("g-unknown", "Contoso Security Group", null));
+
+            var crawlConfig = new TeamsCrawlConfig();
+            crawlConfig.BlacklistTeamsIds.Add("g-blocked");
+
+            var finder = new TeamsFinder(AnalyticsLogger.ConsoleOnlyTracer(), new Common.Entities.Config.AppConfig(), source);
+            var toCrawl = await finder.FindGroupsWithTeamToCrawl(crawlConfig);
+
+            CollectionAssert.AreEqual(new[] { "g-crawl" }, toCrawl.Select(g => g.Id).ToArray());
+            Assert.AreEqual(1, source.ProvisioningOptionsReadCount, "The finder should read groups from Graph exactly once per crawl.");
+            Assert.AreEqual(0, source.FilteredToTeamsReadCount, "The beta server-side filter is not in use; switching to it changes which groups are crawled.");
+        }
+
+        #endregion
+
+        #region What counts as new in a channel
+
+        // Local (unspecified-kind) instants on purpose: the stored delta timestamp is written as
+        // DateTime.Now and compared against Graph's DateTimeOffset, so this mirrors production and
+        // stays correct whatever timezone the test machine is in.
+        private static readonly DateTime DeltaTokenWrittenAt = new DateTime(2026, 1, 10, 12, 0, 0);
+        private static readonly DateTime BeforeToken = DeltaTokenWrittenAt.AddHours(-1);
+        private static readonly DateTime AfterToken = DeltaTokenWrittenAt.AddHours(1);
+
+        private static ChatMessage Msg(string id, DateTime created, params DateTime[] reactionTimes)
+        {
+            return new ChatMessage
+            {
+                Id = id,
+                CreatedDateTime = new DateTimeOffset(created),
+                Replies = new List<ChatMessage>(),
+                Reactions = reactionTimes.Select(t => new ChatMessageReaction
+                {
+                    ReactionType = "like",
+                    CreatedDateTime = new DateTimeOffset(t)
+                }).ToList()
+            };
+        }
+
+        /// <summary>
+        /// With no delta token (the first read of a channel) everything Graph returned is new, replies
+        /// included.
+        /// </summary>
+        [TestMethod]
+        public void SelectNewMessagesAndReactions_FirstRead_TakesEverything()
+        {
+            var root = Msg("root", BeforeToken, BeforeToken);
+            root.Replies.Add(Msg("reply", AfterToken, AfterToken));
+
+            var scope = ChannelMessageScopeRules.SelectNewMessagesAndReactions(new[] { root }, null);
+
+            CollectionAssert.AreEqual(new[] { "root", "reply" }, scope.NewMessages.Select(m => m.Id).ToArray());
+            Assert.AreEqual(2, scope.NewReactions.Count, "Reactions on both the root message and its replies count on a full read.");
+            Assert.AreEqual(1, scope.RepliesSeen);
+        }
+
+        /// <summary>
+        /// This is the rule the delta read depends on. Graph re-serves a thread's parent whenever a
+        /// reply or a reaction changes, so without the created-date filter the importer would re-count
+        /// old messages on every cycle and inflate every channel's message stats.
+        /// </summary>
+        [TestMethod]
+        public void SelectNewMessagesAndReactions_DeltaRead_TakesOnlyContentCreatedAfterTheToken()
+        {
+            // An old parent message, re-served by the delta only because someone reacted to it and
+            // replied to it since the last read.
+            var reServedParent = Msg("old-parent", BeforeToken, BeforeToken, AfterToken);
+            reServedParent.Replies.Add(Msg("new-reply", AfterToken));
+            reServedParent.Replies.Add(Msg("old-reply", BeforeToken));
+
+            var scope = ChannelMessageScopeRules.SelectNewMessagesAndReactions(new[] { reServedParent }, DeltaTokenWrittenAt);
+
+            CollectionAssert.AreEqual(new[] { "new-reply" }, scope.NewMessages.Select(m => m.Id).ToArray(),
+                "Only content created after the delta token is new; the re-served parent and the old reply are not.");
+            Assert.AreEqual(1, scope.NewReactions.Count, "Only the reaction added after the delta token is new.");
+            Assert.AreEqual(new DateTimeOffset(AfterToken), scope.NewReactions[0].CreatedDateTime);
+            Assert.AreEqual(2, scope.RepliesSeen);
+        }
+
+        /// <summary>
+        /// The channel object must end up holding what the rule selected - a wrapper that computed the
+        /// scope but forgot to assign it would silently import nothing.
+        /// </summary>
+        [TestMethod]
+        public void CalculateAndSetNewMessagesAndReactions_ReplacesChannelMessagesAndReactions()
+        {
+            var channel = new ChannelWithReactions { Id = "channel-1", DisplayName = "General" };
+            channel.Messages.Add(Msg("stale-from-a-previous-cycle", BeforeToken));
+            channel.Reactions.Add(new ChatMessageReaction { ReactionType = "stale" });
+
+            var root = Msg("root", AfterToken, AfterToken);
+
+            channel.CalculateAndSetNewMessagesAndReactions(new List<ChatMessage> { root }, DeltaTokenWrittenAt, AnalyticsLogger.ConsoleOnlyTracer());
+
+            CollectionAssert.AreEqual(new[] { "root" }, channel.Messages.Select(m => m.Id).ToArray());
+            Assert.AreEqual(1, channel.Reactions.Count);
+            Assert.AreEqual("like", channel.Reactions[0].ReactionType);
+        }
+
+        #endregion
+
+        #region Crawling a team's channels
+
+        private static ChannelWithReactions Channel(string id) => new ChannelWithReactions { Id = id, DisplayName = id };
+
+        /// <summary>
+        /// A channel read that hands back no delta token must leave the stored token alone. Overwriting
+        /// it with null would silently turn every later read into a full channel crawl (or, worse,
+        /// discard the incremental position), and every channel must still be visited.
+        /// </summary>
+        [TestMethod]
+        public async Task TeamsChannelCrawler_SavesADeltaTokenOnlyWhenTheReadReturnedOne()
+        {
+            var source = new FakeChannelMessagesSourceLoader()
+                .ReturningToken("channel-1", "delta-1")
+                .ReturningNoToken("channel-2");
+
+            var store = new InMemoryTeamChannelDeltaTokenStore();
+            await store.SetDeltaToken("team-1", "channel-2", new TeamsRedisManager.TeamChannelDeltaTokenInfo { Token = "previous-delta-2" });
+
+            var crawler = new TeamsChannelCrawler(source, store);
+            await crawler.PopulateNewMessagesAndReactions(new List<ChannelWithReactions> { Channel("channel-1"), Channel("channel-2") }, "team-1");
+
+            CollectionAssert.AreEqual(new[] { "channel-1", "channel-2" }, source.ChannelsRead.ToArray(),
+                "Every channel in the team must be crawled, in order.");
+            Assert.AreEqual("delta-1", (await store.GetDeltaToken("team-1", "channel-1"))?.Token);
+            Assert.AreEqual("previous-delta-2", (await store.GetDeltaToken("team-1", "channel-2"))?.Token,
+                "A read that returned no delta token must not overwrite the token already stored.");
+        }
+
+        /// <summary>
+        /// An expired user-delegated token aborts the whole team's crawl (the caller deletes the team's
+        /// auth token and retries next cycle), but the channels already crawled keep their new delta
+        /// tokens so the next run doesn't re-read them from scratch.
+        /// </summary>
+        [TestMethod]
+        public async Task TeamsChannelCrawler_AbortsTheTeamOnAReadFailureButKeepsEarlierTokens()
+        {
+            var source = new FakeChannelMessagesSourceLoader()
+                .ReturningToken("channel-1", "delta-1")
+                .Failing("channel-2")
+                .ReturningToken("channel-3", "delta-3");
+
+            var store = new InMemoryTeamChannelDeltaTokenStore();
+            var crawler = new TeamsChannelCrawler(source, store);
+
+            await Assert.ThrowsExceptionAsync<ChannelMessagesReadException>(() =>
+                crawler.PopulateNewMessagesAndReactions(
+                    new List<ChannelWithReactions> { Channel("channel-1"), Channel("channel-2"), Channel("channel-3") }, "team-1"));
+
+            CollectionAssert.AreEqual(new[] { "channel-1", "channel-2" }, source.ChannelsRead.ToArray(),
+                "The crawl stops at the failing channel rather than carrying on with a token we know is bad.");
+            Assert.AreEqual("delta-1", (await store.GetDeltaToken("team-1", "channel-1"))?.Token);
+            Assert.IsNull(await store.GetDeltaToken("team-1", "channel-3"));
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The paging caps are the crawl's only defence against a runaway Graph <c>nextLink</c>. The
+        /// stop condition is evaluated after the item has been counted, so the cap is the size of the
+        /// set we keep - an off-by-one here either drops a message or lets the loop run one page longer
+        /// than intended.
+        /// </summary>
+        [TestMethod]
+        public void ShouldContinuePaging_StopsExactlyAtTheCap()
+        {
+            Assert.IsTrue(TeamsCrawlPagingPolicy.ShouldContinuePaging(1, 3));
+            Assert.IsTrue(TeamsCrawlPagingPolicy.ShouldContinuePaging(2, 3));
+            Assert.IsFalse(TeamsCrawlPagingPolicy.ShouldContinuePaging(3, 3));
+            Assert.IsFalse(TeamsCrawlPagingPolicy.ShouldContinuePaging(4, 3));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="DBLookupCacheTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeUserMetadataLoader.cs" />
     <Compile Include="FakeLoaderClasses\FakeOrgUrlStore.cs" />
+    <Compile Include="FakeLoaderClasses\FakeTeamsPorts.cs" />
     <Compile Include="OrgUrlStoreTests.cs" />
     <Compile Include="FakeLoaderClasses\FixedClock.cs" />
     <Compile Include="GraphFileMetadataLoaderTests.cs" />
@@ -215,6 +216,7 @@
     <Compile Include="SingleDateStoreTests.cs" />
     <Compile Include="AutoThrottleHttpClientTests.cs" />
     <Compile Include="GraphImportTests.cs" />
+    <Compile Include="TeamsCrawlTests.cs" />
     <Compile Include="InstallTests\FakeInstallClasses.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
     <Compile Include="InstallTests\KeyVaultFirewallConfigTaskTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelMessagesLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelMessagesLoader.cs
@@ -17,20 +17,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
     /// </summary>
     public class ChannelMessagesLoader
     {
-        // Safety cap for delta/replies paging at 200k-user scale: a single channel should
-        // never legitimately return more than this many messages in one delta window, but a
-        // misbehaving nextLink could otherwise loop forever or fill memory.
-        private const int MAX_MESSAGES_PER_CHANNEL = 100_000;
-        private const int MAX_REPLIES_PER_MESSAGE = 10_000;
-
         private readonly GraphServiceClient _client;
-        private readonly CacheConnectionManager _cacheConnectionManager;
+        private readonly ITeamChannelDeltaTokenStore _deltaTokenStore;
         private readonly ILogger _logger;
 
+        /// <summary>
+        /// Production constructor: delta tokens are cached in Redis.
+        /// </summary>
         public ChannelMessagesLoader(GraphServiceClient client, CacheConnectionManager cacheConnectionManager, ILogger logger)
+            : this(client, new RedisTeamChannelDeltaTokenStore(cacheConnectionManager, logger), logger) { }
+
+        /// <summary>
+        /// Constructor taking the delta-token store as a port, so the token handling can be exercised
+        /// without Redis. See issue #377.
+        /// </summary>
+        public ChannelMessagesLoader(GraphServiceClient client, ITeamChannelDeltaTokenStore deltaTokenStore, ILogger logger)
         {
             this._client = client;
-            this._cacheConnectionManager = cacheConnectionManager;
+            this._deltaTokenStore = deltaTokenStore ?? throw new ArgumentNullException(nameof(deltaTokenStore));
             this._logger = logger;
         }
 
@@ -41,7 +45,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         {
             if (string.IsNullOrEmpty(teamId)) throw new ArgumentException($"'{nameof(teamId)}' cannot be null or empty", nameof(teamId));
 
-            var channelDeltaInfo = await _cacheConnectionManager.GetTeamChannelDeltaTokenInfo(teamId, channel.Id);
+            var channelDeltaInfo = await _deltaTokenStore.GetDeltaToken(teamId, channel.Id);
 
             // v5+ removed QueryOption / $deltatoken support on the typed Delta request builder. To
             // keep using the SDK serialiser for ChatMessage we construct the full URL ourselves
@@ -65,7 +69,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             {
                 if (ex.Error?.Code == "BadRequest" && channelDeltaInfo != null)
                 {
-                    await _cacheConnectionManager.RemoveTeamChannelDeltaToken(teamId, channel.Id, _logger);
+                    await _deltaTokenStore.RemoveDeltaToken(teamId, channel.Id);
                     _logger.LogError(ex, $"Got bad request using delta token for messages. Removing from cache & will try full read next time.");
                 }
                 else throw;
@@ -79,14 +83,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                     {
                         rootMsgs.Add(msg);
                         loaded++;
-                        return loaded < MAX_MESSAGES_PER_CHANNEL;
+                        return TeamsCrawlPagingPolicy.ShouldContinuePaging(loaded, TeamsCrawlPagingPolicy.MaxMessagesPerChannel);
                     });
 
                 await iterator.IterateAsync();
 
                 if (iterator.State == PagingState.Paused)
                 {
-                    _logger.LogWarning($"Channel '{channel.DisplayName}' on Team '{teamId}': hit MAX_MESSAGES_PER_CHANNEL ({MAX_MESSAGES_PER_CHANNEL:N0}). Returning partial set of {rootMsgs.Count:N0} root messages.");
+                    _logger.LogWarning($"Channel '{channel.DisplayName}' on Team '{teamId}': hit MAX_MESSAGES_PER_CHANNEL ({TeamsCrawlPagingPolicy.MaxMessagesPerChannel:N0}). Returning partial set of {rootMsgs.Count:N0} root messages.");
                 }
 
                 if (!string.IsNullOrEmpty(iterator.Deltalink))
@@ -137,14 +141,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 {
                     allReplies.Add(reply);
                     loaded++;
-                    return loaded < MAX_REPLIES_PER_MESSAGE;
+                    return TeamsCrawlPagingPolicy.ShouldContinuePaging(loaded, TeamsCrawlPagingPolicy.MaxRepliesPerMessage);
                 });
 
             await iterator.IterateAsync();
 
             if (iterator.State == PagingState.Paused)
             {
-                _logger.LogWarning($"Channel {channelId} msg {messageId}: hit MAX_REPLIES_PER_MESSAGE ({MAX_REPLIES_PER_MESSAGE:N0}). Returning partial reply list of {allReplies.Count:N0}.");
+                _logger.LogWarning($"Channel {channelId} msg {messageId}: hit MAX_REPLIES_PER_MESSAGE ({TeamsCrawlPagingPolicy.MaxRepliesPerMessage:N0}). Returning partial reply list of {allReplies.Count:N0}.");
             }
 
             return allReplies;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelWithReactions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelWithReactions.cs
@@ -30,78 +30,25 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         public List<TeamsTab> Tabs { get; internal set; }
 
         /// <summary>
-        /// Sort through messages found and decide what's new since last delta. Set on this object
+        /// Sort through messages found and decide what's new since last delta. Set on this object.
+        /// The selection rule itself lives in <see cref="ChannelMessageScopeRules"/> so it can be
+        /// tested without Graph.
         /// </summary>
         public void CalculateAndSetNewMessagesAndReactions(List<ChatMessage> rootMsgs, DateTime? newSince, ILogger logger)
         {
-            var repliesLoadedCount = 0;
-            var newMsgs = new List<ChatMessage>();
-            var newReactions = new List<ChatMessageReaction>();
-
-
             // Process read messages & figure out which one is relevant.
             // I.e "liked" messages will be included in the delta, even if the message content hasn't changed. 
             // Read new reactions & messages only. Ignore the rest. 
-            foreach (var rootMsg in rootMsgs)
-            {
-                // Parse replies
-                repliesLoadedCount += ParseMessageAndReplies(rootMsg, newMsgs, newReactions, newSince);
-            }
+            var scope = ChannelMessageScopeRules.SelectNewMessagesAndReactions(rootMsgs, newSince);
 
             // Output the results
-            if (newMsgs.Count > 0 || newReactions.Count > 0)
+            if (scope.NewMessages.Count > 0 || scope.NewReactions.Count > 0)
             {
-                logger.LogInformation($"Processed {newMsgs.Count.ToString("N0")} new message(s) and {newReactions.Count.ToString("N0")} new reactions(s) in total.");
+                logger.LogInformation($"Processed {scope.NewMessages.Count.ToString("N0")} new message(s) and {scope.NewReactions.Count.ToString("N0")} new reactions(s) in total.");
             }
 
-            this.Messages = newMsgs;
-            this.Reactions = newReactions;
-        }
-
-        static int ParseMessageAndReplies(ChatMessage rootMsg, List<ChatMessage> newMsgs, List<ChatMessageReaction> newReactions, DateTime? newSince)
-        {
-            var repliesLoadedCount = 0;
-            if (MessageInScope(newSince, rootMsg))
-            {
-                newMsgs.Add(rootMsg);
-            }
-            foreach (var r in rootMsg.Reactions)
-            {
-                if (ReactionInScope(newSince, r))
-                {
-                    newReactions.Add(r);
-                }
-            }
-
-            repliesLoadedCount += rootMsg.Replies.Count;
-            foreach (var reply in rootMsg.Replies)
-            {
-                if (MessageInScope(newSince, reply))
-                {
-                    newMsgs.Add(reply);
-                }
-                foreach (var r in reply.Reactions)
-                {
-                    if (ReactionInScope(newSince, r))
-                    {
-                        newReactions.Add(r);
-                    }
-                }
-            }
-
-            return repliesLoadedCount;
-        }
-
-        private static bool ReactionInScope(DateTime? newSince, ChatMessageReaction r)
-        {
-            return (newSince == null || (newSince.HasValue && r.CreatedDateTime > newSince.Value));
-        }
-
-        // If we've done a delta read, only include messages with a more recent created date than the last refresh.
-        // This is because for thread replies, in the delta results will be the original thread parent, even though it's not changed & we should have it already.
-        private static bool MessageInScope(DateTime? newSince, ChatMessage msg)
-        {
-            return (newSince == null || (newSince.HasValue && msg.CreatedDateTime > newSince.Value));
+            this.Messages = scope.NewMessages;
+            this.Reactions = scope.NewReactions;
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
@@ -51,9 +51,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         public static async Task PopulateNewMessagesAndReactions(this List<ChannelWithReactions> channels, Team team, RefreshOAuthToken refreshToken,
             CacheConnectionManager cacheConnectionManager, ILogger logger)
         {
-            // Nothing to crawl: return before building any adapter, so a team with no channels still
-            // touches neither Redis nor the logger, exactly as the original per-channel loop did.
-            if (channels.Count == 0)
+            // Nothing to crawl: return before building any adapter, so a team with no channels - or one
+            // we hold no user token for - still touches neither Redis, the logger nor team.Id, exactly
+            // as the original per-channel loop did (it read messages only when a token was present, and
+            // saved a delta token only when one came back).
+            if (channels.Count == 0 || refreshToken == null)
             {
                 return;
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
@@ -45,54 +45,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         }
         /// <summary>
         /// Sets the "Messages" prop on each channel by reading each channel messages.
+        /// The crawl itself lives in <see cref="TeamsChannelCrawler"/> so it can be tested without
+        /// Graph or Redis; this overload wires up the production adapters.
         /// </summary>
         public static async Task PopulateNewMessagesAndReactions(this List<ChannelWithReactions> channels, Team team, RefreshOAuthToken refreshToken,
             CacheConnectionManager cacheConnectionManager, ILogger logger)
         {
+            var deltaTokenStore = new RedisTeamChannelDeltaTokenStore(cacheConnectionManager, logger);
+            var messagesSource = new GraphChannelMessagesSourceLoader(refreshToken, deltaTokenStore, logger);
 
-            foreach (var channel in channels)
-            {
-                // Load stats. Will throw ChannelMessagesReadException if token is invalid
-                var channelDelta = await channel.GetChannelMessagesAndReactions(team, refreshToken, cacheConnectionManager, logger);
-
-                // Save delta token for next read
-                if (channelDelta != null)
-                {
-                    await cacheConnectionManager.SetTeamChannelDeltaTokenInfo(team.Id, channel.Id, channelDelta, logger);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Save this channel stats. Channel object should be fully-loaded with tabs
-        /// </summary>
-        static async Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> GetChannelMessagesAndReactions(this ChannelWithReactions channel, Team parentTeam, RefreshOAuthToken refreshToken,
-            CacheConnectionManager cacheConnectionManager, ILogger logger)
-        {
-            TeamsRedisManager.TeamChannelDeltaTokenInfo channelDeltaInfo = null;
-
-            // Try and get user-delegated channel stats
-            if (refreshToken != null)
-            {
-                // Managed to get user-delegated token from refresh-token. Impersonate user.
-                // v5+ removed DelegateAuthenticationProvider — drop in our own
-                // IAuthenticationProvider that pins the supplied bearer token onto every request.
-                var _preCachedTokenClient = new GraphServiceClient(new BearerTokenAuthenticationProvider(refreshToken.AccessToken));
-
-                var channelMessagesLoader = new ChannelMessagesLoader(_preCachedTokenClient, cacheConnectionManager, logger);
-                try
-                {
-                    // Load msgs using user token
-                    channelDeltaInfo = await channelMessagesLoader.LoadTeamMessagesAndReplies(channel, parentTeam.Id);
-                }
-                catch (ODataError ex)
-                {
-                    // Assume there's an issue with the token. Parent will handle token clean-up
-                    throw new ChannelMessagesReadException(ex);
-                }
-            }
-
-            return channelDeltaInfo;
+            await new TeamsChannelCrawler(messagesSource, deltaTokenStore).PopulateNewMessagesAndReactions(channels, team.Id);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
@@ -51,6 +51,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         public static async Task PopulateNewMessagesAndReactions(this List<ChannelWithReactions> channels, Team team, RefreshOAuthToken refreshToken,
             CacheConnectionManager cacheConnectionManager, ILogger logger)
         {
+            // Nothing to crawl: return before building any adapter, so a team with no channels still
+            // touches neither Redis nor the logger, exactly as the original per-channel loop did.
+            if (channels.Count == 0)
+            {
+                return;
+            }
+
             var deltaTokenStore = new RedisTeamChannelDeltaTokenStore(cacheConnectionManager, logger);
             var messagesSource = new GraphChannelMessagesSourceLoader(refreshToken, deltaTokenStore, logger);
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/GraphChannelMessagesSourceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/GraphChannelMessagesSourceLoader.cs
@@ -1,0 +1,61 @@
+using Common.Entities.Models;
+using Common.Entities.Redis.Teams;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using Microsoft.Graph.Models.ODataErrors;
+using System;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// Graph implementation of <see cref="IChannelMessagesSourceLoader"/>, reading channel messages as
+    /// the user whose refresh token we hold (channel message content is not available to an
+    /// application-only identity). Extracted from <c>TeamChannelExtensions</c>. See issue #377.
+    /// </summary>
+    public class GraphChannelMessagesSourceLoader : IChannelMessagesSourceLoader
+    {
+        private readonly RefreshOAuthToken _refreshToken;
+        private readonly ITeamChannelDeltaTokenStore _deltaTokenStore;
+        private readonly ILogger _logger;
+
+        /// <param name="refreshToken">
+        /// User-delegated token to impersonate. May be <c>null</c>, in which case nothing is read and no
+        /// delta token is returned - the same "no token, no deep analytics" behaviour as before.
+        /// </param>
+        public GraphChannelMessagesSourceLoader(RefreshOAuthToken refreshToken, ITeamChannelDeltaTokenStore deltaTokenStore, ILogger logger)
+        {
+            _refreshToken = refreshToken;
+            _deltaTokenStore = deltaTokenStore ?? throw new ArgumentNullException(nameof(deltaTokenStore));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> LoadMessagesAndReactions(ChannelWithReactions channel, string teamId)
+        {
+            TeamsRedisManager.TeamChannelDeltaTokenInfo channelDeltaInfo = null;
+
+            // Try and get user-delegated channel stats
+            if (_refreshToken != null)
+            {
+                // Managed to get user-delegated token from refresh-token. Impersonate user.
+                // v5+ removed DelegateAuthenticationProvider - drop in our own
+                // IAuthenticationProvider that pins the supplied bearer token onto every request.
+                var _preCachedTokenClient = new GraphServiceClient(new BearerTokenAuthenticationProvider(_refreshToken.AccessToken));
+
+                var channelMessagesLoader = new ChannelMessagesLoader(_preCachedTokenClient, _deltaTokenStore, _logger);
+                try
+                {
+                    // Load msgs using user token
+                    channelDeltaInfo = await channelMessagesLoader.LoadTeamMessagesAndReplies(channel, teamId);
+                }
+                catch (ODataError ex)
+                {
+                    // Assume there's an issue with the token. Parent will handle token clean-up
+                    throw new ChannelMessagesReadException(ex);
+                }
+            }
+
+            return channelDeltaInfo;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/GraphTeamsGroupSourceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/GraphTeamsGroupSourceLoader.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// Graph implementation of <see cref="ITeamsGroupSourceLoader"/>. Holds the paging that used to
+    /// live inside <see cref="TeamsFinder"/> so the finder itself is left with only the selection
+    /// rules. See issue #377.
+    /// </summary>
+    public class GraphTeamsGroupSourceLoader : ITeamsGroupSourceLoader
+    {
+        private readonly GraphServiceClient _graphServiceClient;
+        private readonly ILogger _logger;
+
+        public GraphTeamsGroupSourceLoader(GraphServiceClient graphServiceClient, ILogger logger)
+        {
+            _graphServiceClient = graphServiceClient ?? throw new ArgumentNullException(nameof(graphServiceClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task<List<Group>> LoadGroupsWithProvisioningOptions()
+        {
+            return GetGroupsAsync(rc =>
+            {
+                rc.QueryParameters.Select = new[] { "displayName", "id", TeamsCrawlRules.ResourceProvisioningOptionsProperty };
+            });
+        }
+
+        public Task<List<Group>> LoadGroupsFilteredToTeams()
+        {
+            // Beta API uses a much cleaner search for groups with a Team
+            return GetGroupsAsync(rc =>
+            {
+                rc.QueryParameters.Filter = "resourceProvisioningOptions/Any(x:x eq 'Team')";
+            });
+        }
+
+        private async Task<List<Group>> GetGroupsAsync(Action<Microsoft.Kiota.Abstractions.RequestConfiguration<Microsoft.Graph.Groups.GroupsRequestBuilder.GroupsRequestBuilderGetQueryParameters>> configure)
+        {
+            // v5+ replaces .Request().NextPageRequest walking with PageIterator over the
+            // typed CollectionResponse.
+            var allGroups = new List<Group>();
+
+            var firstPage = await _graphServiceClient.Groups.GetAsync(configure);
+            if (firstPage == null) return allGroups;
+
+            int loaded = 0;
+            var iterator = PageIterator<Group, GroupCollectionResponse>
+                .CreatePageIterator(_graphServiceClient, firstPage, group =>
+                {
+                    allGroups.Add(group);
+                    loaded++;
+                    return TeamsCrawlPagingPolicy.ShouldContinuePaging(loaded, TeamsCrawlPagingPolicy.MaxGroups);
+                });
+
+            await iterator.IterateAsync();
+
+            if (iterator.State == PagingState.Paused)
+            {
+                _logger.LogWarning($"TeamsFinder: hit MAX_GROUPS ({TeamsCrawlPagingPolicy.MaxGroups:N0}) walking groups. Returning partial list of {allGroups.Count:N0}.");
+            }
+
+            return allGroups;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/IChannelMessagesSourceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/IChannelMessagesSourceLoader.cs
@@ -1,0 +1,26 @@
+using Common.Entities.Redis.Teams;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// Read port for a single Teams channel's new messages, replies and reactions. Extracted from
+    /// <c>TeamChannelExtensions.GetChannelMessagesAndReactions</c> so the channel-crawl loop can be
+    /// tested without Graph. See issue #377.
+    /// </summary>
+    public interface IChannelMessagesSourceLoader
+    {
+        /// <summary>
+        /// Read the channel and set its new messages/reactions on <paramref name="channel"/>.
+        /// </summary>
+        /// <returns>
+        /// The delta token to store for the next incremental read, or <c>null</c> when the source did
+        /// not hand one back - in which case the caller must leave any previously stored token alone.
+        /// </returns>
+        /// <exception cref="ChannelMessagesReadException">
+        /// The user-delegated token was rejected. The caller treats this as "the cached token is bad",
+        /// deletes it and retries next cycle.
+        /// </exception>
+        Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> LoadMessagesAndReactions(ChannelWithReactions channel, string teamId);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ITeamsGroupSourceLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ITeamsGroupSourceLoader.cs
@@ -1,0 +1,28 @@
+using Microsoft.Graph.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// Read port for the M365 groups the Teams crawl starts from, so <see cref="TeamsFinder"/>'s
+    /// selection rules can be exercised without Graph. See issue #377.
+    ///
+    /// The two methods mirror the two Graph strategies the finder supports; the caller picks one and
+    /// applies <see cref="TeamsCrawlRules"/> to whatever comes back.
+    /// </summary>
+    public interface ITeamsGroupSourceLoader
+    {
+        /// <summary>
+        /// Every group in the tenant, with the <c>resourceProvisioningOptions</c> property loaded so the
+        /// caller can work out which ones have a Team (the v1 endpoint has no server-side filter for it).
+        /// </summary>
+        Task<List<Group>> LoadGroupsWithProvisioningOptions();
+
+        /// <summary>
+        /// Only groups that have a Team, filtered server-side. Requires the beta endpoint, which the
+        /// importer does not use yet.
+        /// </summary>
+        Task<List<Group>> LoadGroupsFilteredToTeams();
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/O365Team.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/O365Team.cs
@@ -327,7 +327,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             // Safety cap on paging: at 200k-user scale a single group rarely exceeds ~50k members
             // but a runaway nextLink shouldn't ever fill memory unbounded. 200k members per group
             // is comfortably above any realistic limit.
-            const int MAX_MEMBERS = 200_000;
             var all = new List<DirectoryObject>();
 
             var firstPage = await client.Groups[groupId].Members.GetAsync();
@@ -339,14 +338,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 {
                     all.Add(item);
                     loaded++;
-                    return loaded < MAX_MEMBERS;
+                    return TeamsCrawlPagingPolicy.ShouldContinuePaging(loaded, TeamsCrawlPagingPolicy.MaxTeamMembers);
                 });
 
             await iterator.IterateAsync();
 
             if (iterator.State == PagingState.Paused)
             {
-                logger.LogWarning($"Group {groupId}: hit MAX_MEMBERS ({MAX_MEMBERS:N0}). Returning partial list of {all.Count:N0} members.");
+                logger.LogWarning($"Group {groupId}: hit MAX_MEMBERS ({TeamsCrawlPagingPolicy.MaxTeamMembers:N0}). Returning partial list of {all.Count:N0} members.");
             }
 
             return all;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/ChannelMessageScopeRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/ChannelMessageScopeRules.cs
@@ -12,6 +12,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
     /// Why this is not simply "everything the delta returned": a delta response also re-serves the
     /// unchanged parent of a thread whose reply changed, and re-serves a message whose only change was
     /// a reaction. Without this filter the importer would re-count old messages every cycle.
+    ///
+    /// Argument null-checks are deliberately absent, matching the code this was extracted from: a null
+    /// message list, or a message with null <c>Replies</c>/<c>Reactions</c>, threw a
+    /// <see cref="NullReferenceException"/> before and still does.
     /// </summary>
     public static class ChannelMessageScopeRules
     {
@@ -25,8 +29,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// </param>
         public static ChannelMessageScope SelectNewMessagesAndReactions(IEnumerable<ChatMessage> rootMsgs, DateTime? newSince)
         {
-            if (rootMsgs is null) throw new ArgumentNullException(nameof(rootMsgs));
-
             var scope = new ChannelMessageScope();
 
             foreach (var rootMsg in rootMsgs)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/ChannelMessageScopeRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/ChannelMessageScopeRules.cs
@@ -1,0 +1,102 @@
+using Microsoft.Graph.Models;
+using System;
+using System.Collections.Generic;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// Pure decision logic for "of everything Graph returned for a channel, what is actually new since
+    /// the last delta read?". Extracted from <c>ChannelWithReactions.CalculateAndSetNewMessagesAndReactions</c>
+    /// so the rule can be unit tested without Graph or Redis. See issue #377.
+    ///
+    /// Why this is not simply "everything the delta returned": a delta response also re-serves the
+    /// unchanged parent of a thread whose reply changed, and re-serves a message whose only change was
+    /// a reaction. Without this filter the importer would re-count old messages every cycle.
+    /// </summary>
+    public static class ChannelMessageScopeRules
+    {
+        /// <summary>
+        /// Select the messages and reactions that count as new.
+        /// </summary>
+        /// <param name="rootMsgs">Root messages from the channel delta read, with their replies already loaded.</param>
+        /// <param name="newSince">
+        /// When the delta token was last updated, or <c>null</c> for a full (first) read - in which case
+        /// everything is new.
+        /// </param>
+        public static ChannelMessageScope SelectNewMessagesAndReactions(IEnumerable<ChatMessage> rootMsgs, DateTime? newSince)
+        {
+            if (rootMsgs is null) throw new ArgumentNullException(nameof(rootMsgs));
+
+            var scope = new ChannelMessageScope();
+
+            foreach (var rootMsg in rootMsgs)
+            {
+                if (MessageInScope(newSince, rootMsg))
+                {
+                    scope.NewMessages.Add(rootMsg);
+                }
+                foreach (var r in rootMsg.Reactions)
+                {
+                    if (ReactionInScope(newSince, r))
+                    {
+                        scope.NewReactions.Add(r);
+                    }
+                }
+
+                scope.RepliesSeen += rootMsg.Replies.Count;
+                foreach (var reply in rootMsg.Replies)
+                {
+                    if (MessageInScope(newSince, reply))
+                    {
+                        scope.NewMessages.Add(reply);
+                    }
+                    foreach (var r in reply.Reactions)
+                    {
+                        if (ReactionInScope(newSince, r))
+                        {
+                            scope.NewReactions.Add(r);
+                        }
+                    }
+                }
+            }
+
+            return scope;
+        }
+
+        /// <summary>
+        /// If we've done a delta read, only include messages created after the last refresh. This is
+        /// because a thread's parent message appears in the delta results whenever a reply changes,
+        /// even though the parent itself hasn't changed and we already have it.
+        /// </summary>
+        public static bool MessageInScope(DateTime? newSince, ChatMessage msg)
+        {
+            return (newSince == null || (newSince.HasValue && msg.CreatedDateTime > newSince.Value));
+        }
+
+        /// <summary>
+        /// Same rule for a reaction: on a delta read only reactions added since the last refresh count.
+        /// </summary>
+        public static bool ReactionInScope(DateTime? newSince, ChatMessageReaction reaction)
+        {
+            return (newSince == null || (newSince.HasValue && reaction.CreatedDateTime > newSince.Value));
+        }
+    }
+
+    /// <summary>
+    /// What <see cref="ChannelMessageScopeRules.SelectNewMessagesAndReactions"/> decided was new.
+    /// </summary>
+    public class ChannelMessageScope
+    {
+        /// <summary>New root messages and new replies, in the order Graph returned them.</summary>
+        public List<ChatMessage> NewMessages { get; } = new List<ChatMessage>();
+
+        /// <summary>New reactions, from both root messages and replies.</summary>
+        public List<ChatMessageReaction> NewReactions { get; } = new List<ChatMessageReaction>();
+
+        /// <summary>
+        /// Total replies walked, in or out of scope. Counted because the original code counted it;
+        /// nothing consumes it yet.
+        /// </summary>
+        public int RepliesSeen { get; set; }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/TeamsCrawlPagingPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/TeamsCrawlPagingPolicy.cs
@@ -1,0 +1,37 @@
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// How deep the Teams crawl is allowed to page, and when it must stop. Previously four separate
+    /// private consts spread across <see cref="TeamsFinder"/>, <c>O365Team</c> and
+    /// <see cref="ChannelMessagesLoader"/>; collected here so the crawl's depth limits are stated in
+    /// one place and the stop condition can be unit tested. See issue #377.
+    ///
+    /// The values are unchanged from the ones the importer shipped with - this is a move, not a
+    /// re-tuning. They exist so a misbehaving <c>nextLink</c> cannot loop forever or fill memory at
+    /// 200k-user scale; each call site logs a warning and returns a partial set when it trips one.
+    /// </summary>
+    public static class TeamsCrawlPagingPolicy
+    {
+        /// <summary>Maximum groups walked when searching the tenant for groups with a Team.</summary>
+        public const int MaxGroups = 500_000;
+
+        /// <summary>Maximum members read for a single group/Team.</summary>
+        public const int MaxTeamMembers = 200_000;
+
+        /// <summary>Maximum root messages read from one channel in a single delta window.</summary>
+        public const int MaxMessagesPerChannel = 100_000;
+
+        /// <summary>Maximum replies read for a single root message.</summary>
+        public const int MaxRepliesPerMessage = 10_000;
+
+        /// <summary>
+        /// Whether the page iterator should keep going. Called after the item has been counted, so
+        /// <paramref name="loadedSoFar"/> includes the item just added: at the cap we stop, which is
+        /// what keeps the retained set exactly <paramref name="max"/> items.
+        /// </summary>
+        public static bool ShouldContinuePaging(int loadedSoFar, int max)
+        {
+            return loadedSoFar < max;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/TeamsCrawlRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/TeamsCrawlRules.cs
@@ -11,6 +11,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
     ///
     /// Deliberately a <c>static</c> class rather than an interface: it is a rule, not a dependency
     /// (the convention in issue #381, matching <c>ImportCadenceGate</c> and <c>AuditLogContentDispatcher</c>).
+    ///
+    /// These methods deliberately do NOT null-check the arguments they iterate or dereference. The
+    /// code they were extracted from didn't either, and the resulting <see cref="NullReferenceException"/>
+    /// is part of the behaviour being preserved - converting it to an <see cref="ArgumentNullException"/>
+    /// would change the exception type and message an operator sees for no benefit.
     /// </summary>
     public static class TeamsCrawlRules
     {
@@ -22,22 +27,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
         /// <summary>
         /// Whether a group returned by the v1 Graph endpoint has a Team attached, decided from its
-        /// <c>resourceProvisioningOptions</c> array.
+        /// <c>resourceProvisioningOptions</c> array. A group that didn't report its workloads at all
+        /// counts as not having one - use <see cref="ClassifyGroup"/> when that distinction matters.
         /// </summary>
-        /// <remarks>
-        /// A group with no <c>resourceProvisioningOptions</c> at all is treated as having no Team, and
-        /// is NOT reported as such - see <see cref="PartitionGroupsWithTeams"/>.
-        /// </remarks>
         public static bool GroupHasTeam(Group group)
         {
-            if (group is null) throw new ArgumentNullException(nameof(group));
-
-            if (!group.AdditionalData.ContainsKey(ResourceProvisioningOptionsProperty))
-            {
-                return false;
-            }
-
-            return ProvisioningOptionsIncludeTeam(group.AdditionalData[ResourceProvisioningOptionsProperty].ToString());
+            return ClassifyGroup(group) == GroupTeamStatus.HasTeam;
         }
 
         /// <summary>
@@ -62,36 +57,28 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         }
 
         /// <summary>
-        /// Split groups returned by the v1 endpoint into those with a Team and those without.
+        /// Classify a group returned by the v1 endpoint: does it have a Team, does it definitely not,
+        /// or did it not tell us?
         /// </summary>
         /// <remarks>
-        /// Groups that carry no <c>resourceProvisioningOptions</c> property land in neither list: the
-        /// original code neither crawled nor logged them, and that is preserved so operator-facing
-        /// log output is unchanged.
+        /// The three-way answer matters. A group that carries no <c>resourceProvisioningOptions</c>
+        /// property at all is neither crawled nor reported as "has no Team associated" - reporting it
+        /// would log every security group and distribution list in the tenant on every cycle.
+        ///
+        /// Classification is per group, rather than a partition of the whole list, so the caller emits
+        /// its log line for each group as it goes: a malformed <c>resourceProvisioningOptions</c> on a
+        /// later group must not swallow the lines already emitted for earlier ones.
         /// </remarks>
-        public static GroupTeamPartition PartitionGroupsWithTeams(IEnumerable<Group> groups)
+        public static GroupTeamStatus ClassifyGroup(Group group)
         {
-            if (groups is null) throw new ArgumentNullException(nameof(groups));
-
-            var partition = new GroupTeamPartition();
-            foreach (var group in groups)
+            if (!group.AdditionalData.ContainsKey(ResourceProvisioningOptionsProperty))
             {
-                if (!group.AdditionalData.ContainsKey(ResourceProvisioningOptionsProperty))
-                {
-                    continue;
-                }
-
-                if (GroupHasTeam(group))
-                {
-                    partition.WithTeam.Add(group);
-                }
-                else
-                {
-                    partition.WithoutTeam.Add(group);
-                }
+                return GroupTeamStatus.WorkloadsNotReported;
             }
 
-            return partition;
+            return ProvisioningOptionsIncludeTeam(group.AdditionalData[ResourceProvisioningOptionsProperty].ToString())
+                ? GroupTeamStatus.HasTeam
+                : GroupTeamStatus.NoTeam;
         }
 
         /// <summary>
@@ -101,9 +88,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// </summary>
         public static GroupCrawlPartition PartitionByCrawlConfig(IEnumerable<Group> groupsWithTeams, TeamsCrawlConfig crawlConfig)
         {
-            if (groupsWithTeams is null) throw new ArgumentNullException(nameof(groupsWithTeams));
-            if (crawlConfig is null) throw new ArgumentNullException(nameof(crawlConfig));
-
             var partition = new GroupCrawlPartition();
             foreach (var group in groupsWithTeams)
             {
@@ -127,9 +111,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// </summary>
         public static bool ShouldCrawlGroup(ICollection<string> whitelistGroupIds, ICollection<string> blacklistGroupIds, string groupId)
         {
-            if (whitelistGroupIds is null) throw new ArgumentNullException(nameof(whitelistGroupIds));
-            if (blacklistGroupIds is null) throw new ArgumentNullException(nameof(blacklistGroupIds));
-
             if (whitelistGroupIds.Count == 0)
             {
                 return !blacklistGroupIds.Contains(groupId);
@@ -140,17 +121,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
     }
 
     /// <summary>
-    /// Result of <see cref="TeamsCrawlRules.PartitionGroupsWithTeams"/>.
+    /// What <see cref="TeamsCrawlRules.ClassifyGroup"/> made of a group's provisioned workloads.
     /// </summary>
-    public class GroupTeamPartition
+    public enum GroupTeamStatus
     {
-        public List<Group> WithTeam { get; } = new List<Group>();
+        /// <summary>The group has a Team, so it is crawled.</summary>
+        HasTeam,
+
+        /// <summary>The group reported its workloads and none of them is a Team.</summary>
+        NoTeam,
 
         /// <summary>
-        /// Groups that advertised their provisioned workloads but have no Team. These are the ones the
-        /// importer logs as "has no Team associated".
+        /// The group returned no <c>resourceProvisioningOptions</c> at all. Not crawled, and not
+        /// reported - see <see cref="TeamsCrawlRules.ClassifyGroup"/>.
         /// </summary>
-        public List<Group> WithoutTeam { get; } = new List<Group>();
+        WorkloadsNotReported
     }
 
     /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/TeamsCrawlRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Rules/TeamsCrawlRules.cs
@@ -1,0 +1,164 @@
+using Microsoft.Graph.Models;
+using System;
+using System.Collections.Generic;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// Pure decision logic for "which groups does the Teams crawl visit?", extracted from
+    /// <see cref="TeamsFinder"/> and <see cref="TeamsCrawlConfig"/> so it can be unit tested without
+    /// Graph or SQL. See issue #377.
+    ///
+    /// Deliberately a <c>static</c> class rather than an interface: it is a rule, not a dependency
+    /// (the convention in issue #381, matching <c>ImportCadenceGate</c> and <c>AuditLogContentDispatcher</c>).
+    /// </summary>
+    public static class TeamsCrawlRules
+    {
+        /// <summary>
+        /// Graph property (returned in <c>AdditionalData</c>) that says which workloads have been
+        /// provisioned onto an M365 group. A group with a Team has "Team" in this array.
+        /// </summary>
+        public const string ResourceProvisioningOptionsProperty = "resourceProvisioningOptions";
+
+        /// <summary>
+        /// Whether a group returned by the v1 Graph endpoint has a Team attached, decided from its
+        /// <c>resourceProvisioningOptions</c> array.
+        /// </summary>
+        /// <remarks>
+        /// A group with no <c>resourceProvisioningOptions</c> at all is treated as having no Team, and
+        /// is NOT reported as such - see <see cref="PartitionGroupsWithTeams"/>.
+        /// </remarks>
+        public static bool GroupHasTeam(Group group)
+        {
+            if (group is null) throw new ArgumentNullException(nameof(group));
+
+            if (!group.AdditionalData.ContainsKey(ResourceProvisioningOptionsProperty))
+            {
+                return false;
+            }
+
+            return ProvisioningOptionsIncludeTeam(group.AdditionalData[ResourceProvisioningOptionsProperty].ToString());
+        }
+
+        /// <summary>
+        /// Whether a raw <c>resourceProvisioningOptions</c> JSON array (e.g. <c>["Team"]</c>) includes Team.
+        /// </summary>
+        /// <exception cref="Newtonsoft.Json.JsonReaderException">
+        /// The value is not a JSON array. This propagates, exactly as it did before the extraction -
+        /// a Graph response we can't parse is a real problem, not something to swallow per group.
+        /// </exception>
+        public static bool ProvisioningOptionsIncludeTeam(string resourceProvisioningOptionsJson)
+        {
+            var options = Newtonsoft.Json.Linq.JArray.Parse(resourceProvisioningOptionsJson);
+            foreach (var option in options)
+            {
+                if (option.ToString().ToLower() == "team")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Split groups returned by the v1 endpoint into those with a Team and those without.
+        /// </summary>
+        /// <remarks>
+        /// Groups that carry no <c>resourceProvisioningOptions</c> property land in neither list: the
+        /// original code neither crawled nor logged them, and that is preserved so operator-facing
+        /// log output is unchanged.
+        /// </remarks>
+        public static GroupTeamPartition PartitionGroupsWithTeams(IEnumerable<Group> groups)
+        {
+            if (groups is null) throw new ArgumentNullException(nameof(groups));
+
+            var partition = new GroupTeamPartition();
+            foreach (var group in groups)
+            {
+                if (!group.AdditionalData.ContainsKey(ResourceProvisioningOptionsProperty))
+                {
+                    continue;
+                }
+
+                if (GroupHasTeam(group))
+                {
+                    partition.WithTeam.Add(group);
+                }
+                else
+                {
+                    partition.WithoutTeam.Add(group);
+                }
+            }
+
+            return partition;
+        }
+
+        /// <summary>
+        /// Split groups-with-a-Team into those the configured white/blacklist allows us to crawl and
+        /// those it excludes. Order within each list is the order the groups were supplied in, which is
+        /// what keeps the importer's log output identical.
+        /// </summary>
+        public static GroupCrawlPartition PartitionByCrawlConfig(IEnumerable<Group> groupsWithTeams, TeamsCrawlConfig crawlConfig)
+        {
+            if (groupsWithTeams is null) throw new ArgumentNullException(nameof(groupsWithTeams));
+            if (crawlConfig is null) throw new ArgumentNullException(nameof(crawlConfig));
+
+            var partition = new GroupCrawlPartition();
+            foreach (var group in groupsWithTeams)
+            {
+                if (crawlConfig.CrawlGroup(group.Id))
+                {
+                    partition.ToCrawl.Add(group);
+                }
+                else
+                {
+                    partition.Excluded.Add(group);
+                }
+            }
+
+            return partition;
+        }
+
+        /// <summary>
+        /// Whether a single group id passes the crawl white/blacklist.
+        /// An empty whitelist means "everything except the blacklist"; a non-empty whitelist means
+        /// "only these, and still never the blacklist".
+        /// </summary>
+        public static bool ShouldCrawlGroup(ICollection<string> whitelistGroupIds, ICollection<string> blacklistGroupIds, string groupId)
+        {
+            if (whitelistGroupIds is null) throw new ArgumentNullException(nameof(whitelistGroupIds));
+            if (blacklistGroupIds is null) throw new ArgumentNullException(nameof(blacklistGroupIds));
+
+            if (whitelistGroupIds.Count == 0)
+            {
+                return !blacklistGroupIds.Contains(groupId);
+            }
+
+            return !blacklistGroupIds.Contains(groupId) && whitelistGroupIds.Contains(groupId);
+        }
+    }
+
+    /// <summary>
+    /// Result of <see cref="TeamsCrawlRules.PartitionGroupsWithTeams"/>.
+    /// </summary>
+    public class GroupTeamPartition
+    {
+        public List<Group> WithTeam { get; } = new List<Group>();
+
+        /// <summary>
+        /// Groups that advertised their provisioned workloads but have no Team. These are the ones the
+        /// importer logs as "has no Team associated".
+        /// </summary>
+        public List<Group> WithoutTeam { get; } = new List<Group>();
+    }
+
+    /// <summary>
+    /// Result of <see cref="TeamsCrawlRules.PartitionByCrawlConfig"/>.
+    /// </summary>
+    public class GroupCrawlPartition
+    {
+        public List<Group> ToCrawl { get; } = new List<Group>();
+        public List<Group> Excluded { get; } = new List<Group>();
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamChannelDeltaTokenStores.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamChannelDeltaTokenStores.cs
@@ -1,0 +1,88 @@
+using Common.Entities.Redis;
+using Common.Entities.Redis.Teams;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// Store for the per-channel Graph delta token that makes each Teams channel read incremental.
+    /// Extracted so the crawl logic no longer depends on <see cref="CacheConnectionManager"/> directly
+    /// and can be tested without Redis. See issue #377.
+    ///
+    /// Losing a token is not fatal - the next read falls back to a full channel read - but silently
+    /// *keeping a stale one* means missed messages, which is why the crawl only ever writes a token
+    /// Graph actually handed back.
+    /// </summary>
+    public interface ITeamChannelDeltaTokenStore
+    {
+        /// <summary>The stored token for a channel, or <c>null</c> when there isn't one (full read).</summary>
+        Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> GetDeltaToken(string teamId, string channelId);
+
+        Task SetDeltaToken(string teamId, string channelId, TeamsRedisManager.TeamChannelDeltaTokenInfo deltaTokenInfo);
+
+        /// <summary>Forget a channel's token, so the next read is a full one.</summary>
+        Task RemoveDeltaToken(string teamId, string channelId);
+    }
+
+    /// <summary>
+    /// Redis-backed <see cref="ITeamChannelDeltaTokenStore"/> - the production implementation. A thin
+    /// wrapper over the existing <see cref="TeamsRedisManager"/> extension methods, so the cache keys
+    /// and the operator-facing log lines they emit are unchanged.
+    /// </summary>
+    public class RedisTeamChannelDeltaTokenStore : ITeamChannelDeltaTokenStore
+    {
+        private readonly CacheConnectionManager _cacheConnectionManager;
+        private readonly ILogger _logger;
+
+        public RedisTeamChannelDeltaTokenStore(CacheConnectionManager cacheConnectionManager, ILogger logger)
+        {
+            _cacheConnectionManager = cacheConnectionManager ?? throw new ArgumentNullException(nameof(cacheConnectionManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> GetDeltaToken(string teamId, string channelId)
+            => _cacheConnectionManager.GetTeamChannelDeltaTokenInfo(teamId, channelId);
+
+        public Task SetDeltaToken(string teamId, string channelId, TeamsRedisManager.TeamChannelDeltaTokenInfo deltaTokenInfo)
+            => _cacheConnectionManager.SetTeamChannelDeltaTokenInfo(teamId, channelId, deltaTokenInfo, _logger);
+
+        public Task RemoveDeltaToken(string teamId, string channelId)
+            => _cacheConnectionManager.RemoveTeamChannelDeltaToken(teamId, channelId, _logger);
+    }
+
+    /// <summary>
+    /// In-memory <see cref="ITeamChannelDeltaTokenStore"/> for tests.
+    ///
+    /// NOT a production fallback: when Redis isn't configured the importer deliberately reads no
+    /// channel messages at all (there is no refresh token to impersonate a user with), so substituting
+    /// this in production would not make deep Teams analytics work - it would only hide that.
+    /// </summary>
+    public class InMemoryTeamChannelDeltaTokenStore : ITeamChannelDeltaTokenStore
+    {
+        private readonly ConcurrentDictionary<string, TeamsRedisManager.TeamChannelDeltaTokenInfo> _tokens
+            = new ConcurrentDictionary<string, TeamsRedisManager.TeamChannelDeltaTokenInfo>(StringComparer.Ordinal);
+
+        private static string Key(string teamId, string channelId) => $"{teamId}-{channelId}";
+
+        public Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> GetDeltaToken(string teamId, string channelId)
+        {
+            _tokens.TryGetValue(Key(teamId, channelId), out var info);
+            return Task.FromResult(info);
+        }
+
+        public Task SetDeltaToken(string teamId, string channelId, TeamsRedisManager.TeamChannelDeltaTokenInfo deltaTokenInfo)
+        {
+            _tokens[Key(teamId, channelId)] = deltaTokenInfo;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveDeltaToken(string teamId, string channelId)
+        {
+            _tokens.TryRemove(Key(teamId, channelId), out _);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsChannelCrawler.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsChannelCrawler.cs
@@ -33,8 +33,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// </remarks>
         public async Task PopulateNewMessagesAndReactions(List<ChannelWithReactions> channels, string teamId)
         {
-            if (channels is null) throw new ArgumentNullException(nameof(channels));
-
             foreach (var channel in channels)
             {
                 // Load stats. Will throw ChannelMessagesReadException if token is invalid

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsChannelCrawler.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsChannelCrawler.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// Walks a Team's channels, reading each one's new messages/reactions and storing the delta token
+    /// that makes the next read incremental. Extracted from
+    /// <c>TeamChannelExtensions.PopulateNewMessagesAndReactions</c> so the crawl can be tested with no
+    /// Graph and no Redis. See issue #377.
+    /// </summary>
+    public class TeamsChannelCrawler
+    {
+        private readonly IChannelMessagesSourceLoader _messagesSource;
+        private readonly ITeamChannelDeltaTokenStore _deltaTokenStore;
+
+        public TeamsChannelCrawler(IChannelMessagesSourceLoader messagesSource, ITeamChannelDeltaTokenStore deltaTokenStore)
+        {
+            _messagesSource = messagesSource ?? throw new ArgumentNullException(nameof(messagesSource));
+            _deltaTokenStore = deltaTokenStore ?? throw new ArgumentNullException(nameof(deltaTokenStore));
+        }
+
+        /// <summary>
+        /// Sets the "Messages" prop on each channel by reading each channel's messages, then saves the
+        /// delta token for the next read.
+        /// </summary>
+        /// <remarks>
+        /// A channel that returns no delta token leaves the stored token untouched, so a read that
+        /// couldn't produce one doesn't destroy the incremental position. Channels are crawled in
+        /// order and a read failure aborts the whole team's crawl, exactly as before - the caller
+        /// deletes the team's auth token and retries next cycle.
+        /// </remarks>
+        public async Task PopulateNewMessagesAndReactions(List<ChannelWithReactions> channels, string teamId)
+        {
+            if (channels is null) throw new ArgumentNullException(nameof(channels));
+
+            foreach (var channel in channels)
+            {
+                // Load stats. Will throw ChannelMessagesReadException if token is invalid
+                var channelDelta = await _messagesSource.LoadMessagesAndReactions(channel, teamId);
+
+                // Save delta token for next read
+                if (channelDelta != null)
+                {
+                    await _deltaTokenStore.SetDeltaToken(teamId, channel.Id, channelDelta);
+                }
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsCrawlConfig.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsCrawlConfig.cs
@@ -25,16 +25,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         public List<string> BlacklistTeamsIds { get; set; } = new List<string>();
         public static TeamsCrawlConfig AllGroupsConfig => new TeamsCrawlConfig();
 
+        /// <summary>
+        /// Whether this group should be crawled. The rule itself lives in
+        /// <see cref="TeamsCrawlRules.ShouldCrawlGroup"/> so it can be tested without a database.
+        /// </summary>
         public bool CrawlGroup(string groupId)
         {
-            if (WhitelistTeamsIds.Count == 0)
-            {
-                return !BlacklistTeamsIds.Contains(groupId);
-            }
-            else
-            {
-                return !BlacklistTeamsIds.Contains(groupId) && WhitelistTeamsIds.Contains(groupId);
-            }
+            return TeamsCrawlRules.ShouldCrawlGroup(WhitelistTeamsIds, BlacklistTeamsIds, groupId);
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsFinder.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsFinder.cs
@@ -10,16 +10,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 {
     public class TeamsFinder : AbstractApiLoader
     {
-        // Safety cap on paging at 200k-user scale: a single tenant should not exceed this
-        // many groups in any realistic scenario. Trips a warning rather than letting a
-        // misbehaving nextLink fill memory indefinitely.
-        private const int MAX_GROUPS = 500_000;
+        private readonly ITeamsGroupSourceLoader _groupSource;
 
-        private readonly GraphServiceClient _graphServiceClient;
+        /// <summary>
+        /// Production constructor: reads groups straight from Graph.
+        /// </summary>
+        public TeamsFinder(AnalyticsLogger logger, AppConfig settings, GraphServiceClient graphServiceClient)
+            : this(logger, settings, new GraphTeamsGroupSourceLoader(graphServiceClient, logger)) { }
 
-        public TeamsFinder(AnalyticsLogger logger, AppConfig settings, GraphServiceClient graphServiceClient) : base(logger, settings)
+        /// <summary>
+        /// Constructor taking the group source as a port, so the crawl-selection rules can be exercised
+        /// without Graph. See issue #377.
+        /// </summary>
+        public TeamsFinder(AnalyticsLogger logger, AppConfig settings, ITeamsGroupSourceLoader groupSource) : base(logger, settings)
         {
-            this._graphServiceClient = graphServiceClient;
+            _groupSource = groupSource ?? throw new ArgumentNullException(nameof(groupSource));
         }
 
         public async Task<List<Group>> FindGroupsWithTeamToCrawl(TeamsCrawlConfig filterConfig)
@@ -37,90 +42,33 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             if (legacyAPIMode)
             {
-                var v1Groups = await GetGroupsAsync(rc =>
-                {
-                    rc.QueryParameters.Select = new[] { "displayName", "id", "resourceProvisioningOptions" };
-                });
+                var v1Groups = await _groupSource.LoadGroupsWithProvisioningOptions();
 
-                foreach (var group in v1Groups)
+                // Filter v1 groups by those that have a Team
+                var teamPartition = TeamsCrawlRules.PartitionGroupsWithTeams(v1Groups);
+                allGroupsWithTeams = teamPartition.WithTeam;
+
+                foreach (var group in teamPartition.WithoutTeam)
                 {
-                    // Filter v1 groups by those that have a Team
-                    bool groupHasTeam = false;
-                    if (group.AdditionalData.ContainsKey("resourceProvisioningOptions"))
-                    {
-                        var resourceProvisioningOptions = group.AdditionalData["resourceProvisioningOptions"].ToString();
-                        var options = Newtonsoft.Json.Linq.JArray.Parse(resourceProvisioningOptions);
-                        foreach (var option in options)
-                        {
-                            if (option.ToString().ToLower() == "team")
-                            {
-                                allGroupsWithTeams.Add(group);
-                                groupHasTeam = true;
-                                break;
-                            }
-                        }
-                        if (!groupHasTeam)
-                        {
-                            _logger.LogInformation($"Group name '{group.DisplayName}' has no Team associated.");
-                        }
-                    }
+                    _logger.LogInformation($"Group name '{group.DisplayName}' has no Team associated.");
                 }
             }
             else
             {
                 // Beta API uses a much cleaner search for groups with a Team
-                allGroupsWithTeams = await GetGroupsAsync(rc =>
-                {
-                    rc.QueryParameters.Filter = "resourceProvisioningOptions/Any(x:x eq 'Team')";
-                });
+                allGroupsWithTeams = await _groupSource.LoadGroupsFilteredToTeams();
             }
 
             // Do the needful
             _logger.LogInformation($"Searching for groups with a team attached...");
 
-            var filteredTeams = new List<Group>();
-            foreach (var g in allGroupsWithTeams)
+            var crawlPartition = TeamsCrawlRules.PartitionByCrawlConfig(allGroupsWithTeams, filterConfig);
+            foreach (var g in crawlPartition.Excluded)
             {
-                if (filterConfig.CrawlGroup(g.Id))
-                {
-                    filteredTeams.Add(g);
-                }
-                else
-                {
-                    _logger.LogInformation($"Excluding group '{g.DisplayName}' from crawl due to crawl configuration");
-                }
+                _logger.LogInformation($"Excluding group '{g.DisplayName}' from crawl due to crawl configuration");
             }
 
-            return filteredTeams;
+            return crawlPartition.ToCrawl;
         }
-
-        private async Task<List<Group>> GetGroupsAsync(Action<Microsoft.Kiota.Abstractions.RequestConfiguration<Microsoft.Graph.Groups.GroupsRequestBuilder.GroupsRequestBuilderGetQueryParameters>> configure)
-        {
-            // v5+ replaces .Request().NextPageRequest walking with PageIterator over the
-            // typed CollectionResponse.
-            var allGroups = new List<Group>();
-
-            var firstPage = await _graphServiceClient.Groups.GetAsync(configure);
-            if (firstPage == null) return allGroups;
-
-            int loaded = 0;
-            var iterator = PageIterator<Group, GroupCollectionResponse>
-                .CreatePageIterator(_graphServiceClient, firstPage, group =>
-                {
-                    allGroups.Add(group);
-                    loaded++;
-                    return loaded < MAX_GROUPS;
-                });
-
-            await iterator.IterateAsync();
-
-            if (iterator.State == PagingState.Paused)
-            {
-                _logger.LogWarning($"TeamsFinder: hit MAX_GROUPS ({MAX_GROUPS:N0}) walking groups. Returning partial list of {allGroups.Count:N0}.");
-            }
-
-            return allGroups;
-        }
-
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsFinder.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsFinder.cs
@@ -44,13 +44,22 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             {
                 var v1Groups = await _groupSource.LoadGroupsWithProvisioningOptions();
 
-                // Filter v1 groups by those that have a Team
-                var teamPartition = TeamsCrawlRules.PartitionGroupsWithTeams(v1Groups);
-                allGroupsWithTeams = teamPartition.WithTeam;
-
-                foreach (var group in teamPartition.WithoutTeam)
+                foreach (var group in v1Groups)
                 {
-                    _logger.LogInformation($"Group name '{group.DisplayName}' has no Team associated.");
+                    // Filter v1 groups by those that have a Team. Classified and logged one group at a
+                    // time, deliberately: partitioning the whole list first would swallow the log lines
+                    // for earlier groups if a later group's resourceProvisioningOptions failed to parse.
+                    var status = TeamsCrawlRules.ClassifyGroup(group);
+                    if (status == GroupTeamStatus.HasTeam)
+                    {
+                        allGroupsWithTeams.Add(group);
+                    }
+                    else if (status == GroupTeamStatus.NoTeam)
+                    {
+                        _logger.LogInformation($"Group name '{group.DisplayName}' has no Team associated.");
+                    }
+
+                    // GroupTeamStatus.WorkloadsNotReported: neither crawled nor logged, as before.
                 }
             }
             else

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -150,6 +150,15 @@
     <Compile Include="Graph\SPSiteIdToUrlCache.cs" />
     <Compile Include="Graph\Teams\ChannelWithReactions.cs" />
     <Compile Include="Graph\Teams\CognitiveHelper.cs" />
+    <Compile Include="Graph\Teams\GraphChannelMessagesSourceLoader.cs" />
+    <Compile Include="Graph\Teams\GraphTeamsGroupSourceLoader.cs" />
+    <Compile Include="Graph\Teams\IChannelMessagesSourceLoader.cs" />
+    <Compile Include="Graph\Teams\ITeamsGroupSourceLoader.cs" />
+    <Compile Include="Graph\Teams\Rules\ChannelMessageScopeRules.cs" />
+    <Compile Include="Graph\Teams\Rules\TeamsCrawlPagingPolicy.cs" />
+    <Compile Include="Graph\Teams\Rules\TeamsCrawlRules.cs" />
+    <Compile Include="Graph\Teams\TeamChannelDeltaTokenStores.cs" />
+    <Compile Include="Graph\Teams\TeamsChannelCrawler.cs" />
     <Compile Include="Graph\Teams\Extensions\ChatMessageListExtensions.cs" />
     <Compile Include="Graph\Teams\Extensions\TeamsCognitiveExtensions.cs" />
     <Compile Include="Graph\Teams\TeamsCrawlConfig.cs" />


### PR DESCRIPTION
## What and why

The Teams import is one of only two roles in #381's coverage table with **nothing at all** — no read seam, no write seam and no tests. Every decision it makes (which groups to crawl, what counts as new in a channel, how deep to page) was welded to a `GraphServiceClient` and a Redis `CacheConnectionManager`, so none of it could be asserted without a live tenant.

This PR extracts those decisions into pure rules and puts the I/O behind ports, then adds the first unit coverage these paths have ever had. Part of the ports-and-adapters work in #381.

**Behaviour is unchanged** — including operator-facing log text, log order, and the numbers inside log lines. There is no pre-existing test suite for these paths, so rather than lean on one that doesn't exist, the extraction was kept mechanical: each rule keeps its original branch structure verbatim, including the parts that look like latent bugs (listed under *Deliberately unchanged*).

## Pure rules

Static classes, not interfaces, per #381's conventions section (matching `ImportCadenceGate` / `AuditLogContentDispatcher`).

| Class | Extracted from | Decides |
|---|---|---|
| `TeamsCrawlRules` | `TeamsFinder`, `TeamsCrawlConfig` | Which groups the crawl visits: a three-way `ClassifyGroup` over `resourceProvisioningOptions` (has a Team / reported no Team / didn't report its workloads), plus the whitelist/blacklist rule `TeamsCrawlConfig.CrawlGroup` now delegates to |
| `ChannelMessageScopeRules` | `ChannelWithReactions.CalculateAndSetNewMessagesAndReactions` | What counts as new since the last delta token |
| `TeamsCrawlPagingPolicy` | `TeamsFinder`, `O365Team`, `ChannelMessagesLoader` | How deep the crawl may page and when it stops |

`ChannelMessageScopeRules` is the valuable one: Graph re-serves a thread's parent message whenever a *reply or reaction* on it changes, so without the created-date filter the importer would re-count old messages every cycle and inflate every channel's message stats. That rule now has a test.

`TeamsCrawlRules.ClassifyGroup` is per group rather than a partition over the whole list, specifically so `TeamsFinder` can emit its log line for each group as it goes — byte-identical lines, for the same groups, **in the same order** as before, and with no way for a later group to swallow the lines already emitted for earlier ones. The crawl-config filter, which cannot throw, is still a partition.

`TeamsCrawlPagingPolicy` collects the four paging caps that were private `const`s in three separate files (`MAX_GROUPS`, `MAX_MEMBERS`, `MAX_MESSAGES_PER_CHANNEL`, `MAX_REPLIES_PER_MESSAGE`) into one place with a single stop condition. **Values are unchanged** — this is a move, not a re-tuning.

## Ports

| Port | Direction | Production adapter | Test double |
|---|---|---|---|
| `ITeamsGroupSourceLoader` | read | `GraphTeamsGroupSourceLoader` | `FakeTeamsGroupSourceLoader` |
| `IChannelMessagesSourceLoader` | read | `GraphChannelMessagesSourceLoader` | `FakeChannelMessagesSourceLoader` |
| `ITeamChannelDeltaTokenStore` | write | `RedisTeamChannelDeltaTokenStore` | `InMemoryTeamChannelDeltaTokenStore` |

`TeamsChannelCrawler` holds the per-channel loop and takes both a source and a store, which is what makes the delta-token behaviour assertable.

Call-site compatibility, per #381 and the reviewer finding on #396 — no trailing optional parameters:

- `TeamsFinder(AnalyticsLogger, AppConfig, GraphServiceClient)` is kept as a **delegating overload**; the new constructor takes `ITeamsGroupSourceLoader` as a **required** parameter.
- `ChannelMessagesLoader(GraphServiceClient, CacheConnectionManager, ILogger)` likewise delegates to a new constructor taking `ITeamChannelDeltaTokenStore`.
- `TeamChannelExtensions.PopulateNewMessagesAndReactions` keeps its exact signature and wires up the production adapters.

The delta-token store mirrors `Graph/Email/DeltaTokenStores.cs`. The Redis implementation is a thin wrapper over the existing `TeamsRedisManager` extension methods, so cache keys **and the log lines those methods emit** are byte-identical.

`InMemoryTeamChannelDeltaTokenStore` is documented as test-only and is deliberately **not** wired in as a "no Redis" fallback: without Redis there is no team refresh token, so the importer reads no channel messages at all. Substituting an in-memory store there would hide that, not fix it.

## Tests

`Tests.UnitTests/TeamsCrawlTests.cs` — 10 tests, zero Graph / Redis / SQL / Service Bus, MSTest with hand-rolled fakes in `FakeLoaderClasses/FakeTeamsPorts.cs`.

Coverage:
- group selection: `ClassifyGroup` distinguishing "reported no Team" from "no `resourceProvisioningOptions` property at all" (the latter is neither crawled **nor** logged — logging it would spam the importer log with every security group in the tenant), case-insensitivity, whitelist/blacklist precedence, and order preservation;
- `TeamsFinder.FindGroupsWithTeamToCrawl` end to end against a fake source, including an assertion that the unfinished beta server-side-filter path is **not** used;
- delta scope: full read takes everything; delta read takes only content created after the token, and excludes the re-served thread parent;
- `ChannelWithReactions` actually assigns what the rule selected;
- crawler: a read that returns no delta token leaves the stored token alone, and a read failure aborts that team while keeping the tokens already written.

**Mutation-checked**, because "the token isn't overwritten" is exactly the kind of assertion that can pass for the wrong reason: deleting the `if (channelDelta != null)` guard in `TeamsChannelCrawler` fails `TeamsChannelCrawler_SavesADeltaTokenOnlyWhenTheReadReturnedOne` with `Expected:<previous-delta-2>. Actual:<(null)>`, and no other test in the suite notices.

Pre-existing tests over the same area (`TeamsCrawlConfigTests`, `MessageCognitiveStatsTests`) still pass unchanged. Being precise about what that does and does not prove: `TeamsCrawlConfigTests` exercises `TeamsCrawlConfig.CrawlGroup`, which is one of the retained delegations, so it is real evidence for that one. For the two retained **constructors**, the honest position is weaker. `TeamsFinder(…, GraphServiceClient)` is reached directly by the `#if DEBUG` `MessageImportTests` and indirectly by `AllTeamsLoadTest` (which is **not** `#if DEBUG`-guarded, so Release CI does run it) via `TeamsImporter` — but both call `auth.InitClientCredential()` first, so neither reaches the constructor without real Graph credentials, and neither is zero-I/O coverage. `ChannelMessagesLoader(…, CacheConnectionManager, …)` now has **no call site at all**: it is kept purely for source compatibility, so it is compiled but never executed.

## Review round 1 (applied)

Reviewed by `claude-opus-4.8`, `gpt-5.6-sol` and `grok-4.6` in parallel. **No production defect was found** in the original push; all four findings were parity gaps or claim/test-quality problems, and all are fixed in the follow-up commit:

1. **Log parity under a malformed `resourceProvisioningOptions` value** (flagged independently by two reviewers). Partitioning the whole list before logging meant a later group whose value failed `JArray.Parse` would lose the "has no Team associated." lines already emitted by the original. Fixed by classifying and logging per group via `ClassifyGroup`; `PartitionGroupsWithTeams` is gone.
2. **Exception parity.** The extracted rules had gained `ArgumentNullException` guards where the original dereferenced the argument and threw `NullReferenceException` — an operator-facing difference, since the type and message reach App Insights. Guards removed; the convention is now stated on the rule classes (pure rules don't null-check what they iterate; adapter constructors still do).
3. **`PopulateNewMessagesAndReactions` built its adapters eagerly**, so a call with an empty channel list could throw where it was previously a no-op that touched neither Redis, the logger nor `team.Id`. It now returns first.
4. **The group fake wrote `AdditionalData` using the production constant**, so a typo in `ResourceProvisioningOptionsProperty` would have moved reader and writer together and left both tests green. It now writes the Graph wire literal.

Also noted and accepted: `ShouldContinuePaging_StopsExactlyAtTheCap` pins the helper's off-by-one only — it does not pin the four cap values or their wiring into the three page iterators, and re-tuning a constant would leave it green. That is deliberate; asserting the constants would only be a change-detector test.

## Review round 2 (applied)

`claude-opus-4.8` returned clean. `gpt-5.6-sol` found two more items, both fixed in `d3d9a14`:

1. **`PopulateNewMessagesAndReactions` now also returns before building any adapter when there is no refresh token**, not just when the channel list is empty. The original read nothing and saved nothing in that case (the per-channel helper short-circuited on a null token), so it touched neither Redis, the logger nor `team.Id`. Round 1 closed the empty-list half; this closes the other half.
2. **`CalculateAndSetNewMessagesAndReactions_ReplacesChannelMessagesAndReactions` was weak.** Its fixture held only after-token content, so the delta-filtered result and an unfiltered result were the same list — the test would have passed if the wrapper had stopped filtering entirely, which is precisely the production failure this extraction exists to prevent. The fixture now mixes before- and after-token messages, replies and reactions. **Mutation-verified:** making the wrapper pass `null` instead of `newSince` now fails it; before this change it passed.

The third round-2 item was a PR-description inaccuracy about which retained constructors are covered by tests, corrected under *Tests* above.

## Deliberately unchanged

- `ChannelMessageScopeRules` iterates `msg.Reactions` and `msg.Replies` with no null guard, exactly as the original did. Adding one would be a silent behavioural change.
- `TeamsCrawlRules.ProvisioningOptionsIncludeTeam` keeps the original culture-sensitive `.ToLower()` comparison rather than switching to ordinal.
- **No per-team or per-channel cap was added.** #381 warns about unbounded per-entity Graph pulls and there is no such cap here; adding one is a behavioural change and belongs in its own PR. Filed as follow-up rather than smuggled in here.
- `TeamTokenManager` still holds a process-wide `static` token cache keyed by `O365Team` instance. Out of scope for this PR; noted for #376.

## Reviewer hotspots

1. **Log order in `TeamsFinder.FindGroupsWithTeamToCrawl`.** The finder still emits its "has no Team associated" lines from a single per-group pass, exactly as the original did — an earlier revision of this PR partitioned first, which review round 1 caught and reverted (see above). Only the crawl-config filter is a partition, and it cannot throw. This is still the thing most likely to have gone wrong, so worth checking against the diff.
2. **One intentional strictness change, and one source-compatibility break.** The Graph adapters null-check their constructor arguments, so `new TeamsFinder(logger, settings, (GraphServiceClient)null)` now throws `ArgumentNullException` while evaluating the chained argument, rather than NRE-ing on first use. Separately, a **bare** `new TeamsFinder(logger, settings, null)` no longer compiles at all: `GraphServiceClient` and `ITeamsGroupSourceLoader` are unrelated, so the null literal is ambiguous — the same break as the `ChannelMessagesLoader` pair below. No call site in the solution does either: `TeamsImporter` rejects a null client before it reaches `TeamsFinder`.
3. **`ChannelMessagesLoader` now has two 3-arg constructors**, one taking `CacheConnectionManager` and one taking `ITeamChannelDeltaTokenStore`. Passing a literal `null` for that argument would now be ambiguous; no call site does.

## Scope

Teams only. Issue #378 (Calls) is the other half of task 07 and ships as a separate PR — the two roles share no files beyond the two `.csproj`s, where conflicts will be additive `<Compile Include>` lines.

Addresses #377
