### PR TITLE
Extract the usage-report refresh policy and the storage inspector port (#375 part 1)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUsageReportStorageInspector.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUsageReportStorageInspector.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="IUsageReportStorageInspector"/> - the two raw <c>sys.indexes</c> queries the
+    /// daily usage-report loaders used to issue inline, replaced by a flag and a counter. See issue #375.
+    /// </summary>
+    public class FakeUsageReportStorageInspector : IUsageReportStorageInspector
+    {
+        public FakeUsageReportStorageInspector(bool hasLeadingDateIndex = true)
+        {
+            HasLeadingDateIndex = hasLeadingDateIndex;
+        }
+
+        /// <summary>What <see cref="HasLeadingDateIndexAsync"/> answers.</summary>
+        public bool HasLeadingDateIndex { get; set; }
+
+        /// <summary>Table names the index question was asked about, in order.</summary>
+        public List<string> IndexQuestionsAsked { get; } = new List<string>();
+
+        /// <summary>Table names compaction was requested for, in order.</summary>
+        public List<string> CompactionsRequested { get; } = new List<string>();
+
+        public Task<bool> HasLeadingDateIndexAsync(string qualifiedTableName)
+        {
+            IndexQuestionsAsked.Add(qualifiedTableName);
+            return Task.FromResult(HasLeadingDateIndex);
+        }
+
+        public Task CompactColumnstoreAsync(string qualifiedTableName)
+        {
+            CompactionsRequested.Add(qualifiedTableName);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/TablelessDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/TablelessDailyActivityLoader.cs
@@ -24,9 +24,11 @@ namespace Tests.UnitTests.FakeLoaderClasses
     /// <see cref="TablelessUsageActivityLog"/>, existing only so the storage-inspector wiring can be
     /// exercised without SQL Server or Graph.
     ///
-    /// Neither method under test reaches the database: <c>CompactColumnstoreAsync</c> returns before it
-    /// touches the inspector, and <c>HasLeadingDateIndexAsync</c> resolves the inspector (the injected fake)
-    /// before evaluating the table name, so both can be called with a null context.
+    /// Callers pass a null <c>AnalyticsEntitiesContext</c>. That is safe because they also set
+    /// <c>StorageInspector</c>, which short-circuits the loader's
+    /// <c>StorageInspector ?? new SqlUsageReportStorageInspector(db)</c> - so the SQL adapter is never
+    /// constructed and the null is never dereferenced. Leave <c>StorageInspector</c> unset and the adapter's
+    /// own null guard throws instead.
     /// </summary>
     public class TablelessDailyActivityLoader
         : AbstractUserDailyActivityLoader<TablelessUsageActivityLog, OutlookUserActivityUserDetail>

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/TablelessDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/TablelessDailyActivityLoader.cs
@@ -1,0 +1,49 @@
+using Common.Entities;
+using Common.Entities.ActivityReports;
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using System.Data.Entity;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// A report entity that deliberately declares NO <c>[Table]</c> attribute, so the two loader methods
+    /// that resolve a table name can be driven down their missing-attribute paths. See issue #375.
+    /// </summary>
+    public class TablelessUsageActivityLog : AbstractUsageActivityLog
+    {
+        public override int AssociatedLookupId { get; set; }
+    }
+
+    /// <summary>
+    /// Minimal concrete <see cref="AbstractDailyActivityLoader{,,,}"/> over
+    /// <see cref="TablelessUsageActivityLog"/>, existing only so the storage-inspector wiring can be
+    /// exercised without SQL Server or Graph.
+    ///
+    /// Neither method under test reaches the database: <c>CompactColumnstoreAsync</c> returns before it
+    /// touches the inspector, and <c>HasLeadingDateIndexAsync</c> resolves the inspector (the injected fake)
+    /// before evaluating the table name, so both can be called with a null context.
+    /// </summary>
+    public class TablelessDailyActivityLoader
+        : AbstractUserDailyActivityLoader<TablelessUsageActivityLog, OutlookUserActivityUserDetail>
+    {
+        public TablelessDailyActivityLoader(ILogger logger)
+            : base(null, null, new UserGroupsFilterModel(null), logger)
+        {
+        }
+
+        public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/thisReportDoesNotExist";
+
+        public override DbSet<TablelessUsageActivityLog> GetTable(AnalyticsEntitiesContext context) => null;
+
+        protected override void PopulateReportSpecificMetadata(TablelessUsageActivityLog todaysLog, OutlookUserActivityUserDetail page)
+        {
+        }
+
+        protected override long CountActivity(OutlookUserActivityUserDetail activityPage) => 0;
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="DBLookupCacheDuplicateKeyErrorTests.cs" />
     <Compile Include="DBLookupCacheTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeUserMetadataLoader.cs" />
+    <Compile Include="FakeLoaderClasses\FakeUsageReportStorageInspector.cs" />
     <Compile Include="FakeLoaderClasses\FakeOrgUrlStore.cs" />
     <Compile Include="OrgUrlStoreTests.cs" />
     <Compile Include="FakeLoaderClasses\FixedClock.cs" />
@@ -235,6 +236,7 @@
     <Compile Include="StreamTests.cs" />
     <Compile Include="UserGroupsCacheTests.cs" />
     <Compile Include="UserGroupsFilterModelTests.cs" />
+    <Compile Include="UsageReportRefreshPolicyTests.cs" />
     <Compile Include="UserImportTests.cs" />
     <Compile Include="UserLookupTests.cs" />
   </ItemGroup>

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="DBLookupCacheTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeUserMetadataLoader.cs" />
     <Compile Include="FakeLoaderClasses\FakeUsageReportStorageInspector.cs" />
+    <Compile Include="FakeLoaderClasses\TablelessDailyActivityLoader.cs" />
     <Compile Include="FakeLoaderClasses\FakeOrgUrlStore.cs" />
     <Compile Include="OrgUrlStoreTests.cs" />
     <Compile Include="FakeLoaderClasses\FixedClock.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/UsageReportRefreshPolicyTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UsageReportRefreshPolicyTests.cs
@@ -171,9 +171,11 @@ namespace Tests.UnitTests
             // Asserted through the LOADER, not the helper: swapping which of Resolve/TryResolve each loader
             // method uses would reverse this behaviour, and a helper-only test would not notice.
             //
-            // No database is reached. CompactColumnstoreAsync returns before touching the inspector, and
-            // HasLeadingDateIndexAsync resolves the inspector (the injected fake) before evaluating the
-            // table name, so a null context is safe for both.
+            // A null context is safe because the INJECTED INSPECTOR short-circuits InspectorFor's
+            // `StorageInspector ?? new SqlUsageReportStorageInspector(db)`, so the adapter is never
+            // constructed and the null is never dereferenced. (It is not, as an earlier version of this
+            // comment claimed, about C# evaluating the receiver before the argument - that ordering is
+            // guaranteed, but it is not what makes this safe.)
             var inspector = new FakeUsageReportStorageInspector();
             var loader = new TablelessDailyActivityLoader(NullLogger.Instance) { StorageInspector = inspector };
 

--- a/src/AnalyticsEngine/Tests.UnitTests/UsageReportRefreshPolicyTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UsageReportRefreshPolicyTests.cs
@@ -1,7 +1,11 @@
+using Common.Entities.Config;
 using Common.Entities.Entities.Teams;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Rules;
 
@@ -92,17 +96,6 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void UsageReports_CompletionMarkerIsNormalisedToUtcBeforeComparing()
-        {
-            // The marker arrives from a store that may hand back a local or unspecified kind; comparing it
-            // raw against a UTC "today" would shift the cutoff by the host's offset.
-            var localMarker = new DateTime(2026, 6, 10, 23, 30, 0, DateTimeKind.Local);
-            var window = Window(28, localMarker);
-
-            Assert.AreEqual(localMarker.ToUniversalTime().Date, window.SafeCutoffUtc);
-        }
-
-        [TestMethod]
         public void UsageReports_LookBackIsClampedToWhatGraphCanAnswer()
         {
             // Graph retains ~28 days of daily detail, and reports lag 2-3 days, so a configured value
@@ -111,8 +104,25 @@ namespace Tests.UnitTests
             Assert.AreEqual(UsageReportRefreshPolicy.MinDaysBack, UsageReportRefreshPolicy.ClampDaysBack(-7));
             Assert.AreEqual(UsageReportRefreshPolicy.MaxDaysBack, UsageReportRefreshPolicy.ClampDaysBack(365));
             Assert.AreEqual(14, UsageReportRefreshPolicy.ClampDaysBack(14));
+        }
 
-            Assert.AreEqual(UsageReportRefreshPolicy.MaxDaysBack, Window(365, NowUtc).DaysBackMax);
+        [TestMethod]
+        public void UsageReports_ClampIsAppliedBeforeTheWindowIsComputed()
+        {
+            // Reporting the clamped DaysBackMax while computing WindowStartUtc from the raw value would be
+            // invisible to a test that only checked DaysBackMax - and would make the indexed path issue 362
+            // existence queries instead of 25, and the unindexed path scan a year of a 200k-user table.
+            var wide = Window(365, NowUtc);
+            Assert.AreEqual(UsageReportRefreshPolicy.MaxDaysBack, wide.DaysBackMax);
+            Assert.AreEqual(NowUtc.Date.AddDays(-UsageReportRefreshPolicy.MaxDaysBack), wide.WindowStartUtc);
+            Assert.AreEqual(UsageReportRefreshPolicy.MaxDaysBack - RefreshableRecentDays,
+                UsageReportRefreshPolicy.EnumerateSkipCandidates(wide).Count());
+
+            var narrow = Window(0, NowUtc);
+            Assert.AreEqual(UsageReportRefreshPolicy.MinDaysBack, narrow.DaysBackMax);
+            Assert.AreEqual(NowUtc.Date.AddDays(-UsageReportRefreshPolicy.MinDaysBack), narrow.WindowStartUtc);
+            Assert.AreEqual(0, UsageReportRefreshPolicy.EnumerateSkipCandidates(narrow).Count(),
+                "At the minimum look-back the whole window is still mutable, so there is nothing to skip.");
         }
 
         [TestMethod]
@@ -128,9 +138,10 @@ namespace Tests.UnitTests
     }
 
     /// <summary>
-    /// The table-name resolution behind the storage-inspector port. The two callers react differently to a
-    /// missing TableAttribute - the index question throws, the maintenance silently skips - and that
-    /// asymmetry is existing behaviour worth pinning.
+    /// The table-name resolution behind the storage-inspector port, and the loader wiring that uses it.
+    /// The two callers react differently to a missing TableAttribute - the index question throws, the
+    /// maintenance silently skips - and that asymmetry is existing behaviour worth pinning at the level
+    /// that could actually regress.
     /// </summary>
     [TestClass]
     public class UsageReportTableNameTests
@@ -148,12 +159,48 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void UsageReports_EntityWithoutATable_ThrowsForTheIndexQuestionButNotForMaintenance()
+        public void UsageReports_TableNameHelper_TryResolveReturnsNullWhereResolveThrows()
         {
-            Assert.IsNull(UsageReportTableName.TryResolve(typeof(NoTableAttribute)),
-                "Maintenance skips silently, so it needs the non-throwing form.");
-            Assert.ThrowsException<InvalidOperationException>(() => UsageReportTableName.Resolve(typeof(NoTableAttribute)),
-                "The index question cannot be answered without a table, so it must fail loudly.");
+            Assert.IsNull(UsageReportTableName.TryResolve(typeof(NoTableAttribute)));
+            Assert.ThrowsException<InvalidOperationException>(() => UsageReportTableName.Resolve(typeof(NoTableAttribute)));
+        }
+
+        [TestMethod]
+        public async Task UsageReports_LoaderWithoutATable_ThrowsForTheIndexQuestionButSkipsMaintenance()
+        {
+            // Asserted through the LOADER, not the helper: swapping which of Resolve/TryResolve each loader
+            // method uses would reverse this behaviour, and a helper-only test would not notice.
+            //
+            // No database is reached. CompactColumnstoreAsync returns before touching the inspector, and
+            // HasLeadingDateIndexAsync resolves the inspector (the injected fake) before evaluating the
+            // table name, so a null context is safe for both.
+            var inspector = new FakeUsageReportStorageInspector();
+            var loader = new TablelessDailyActivityLoader(NullLogger.Instance) { StorageInspector = inspector };
+
+            await loader.CompactColumnstoreAsync(null);
+            Assert.AreEqual(0, inspector.CompactionsRequested.Count,
+                "Maintenance for an entity with no table must be skipped silently, not attempted.");
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => loader.HasLeadingDateIndexAsync(null));
+            Assert.AreEqual(0, inspector.IndexQuestionsAsked.Count);
+        }
+
+        [TestMethod]
+        public async Task UsageReports_LoaderWithATable_AsksTheInspectorForThatTable()
+        {
+            // The other half: a normal loader must reach the inspector with its own schema-qualified name.
+            var inspector = new FakeUsageReportStorageInspector(hasLeadingDateIndex: false);
+            var loader = new OutlookUserActivityLoader(null, null, new UserGroupsFilterModel(null), NullLogger.Instance)
+            {
+                StorageInspector = inspector
+            };
+
+            Assert.IsFalse(await loader.HasLeadingDateIndexAsync(null), "The loader must return what the inspector answers.");
+            await loader.CompactColumnstoreAsync(null);
+
+            var expected = UsageReportTableName.Resolve(typeof(OutlookUsageActivityLog));
+            CollectionAssert.AreEqual(new[] { expected }, inspector.IndexQuestionsAsked.ToArray());
+            CollectionAssert.AreEqual(new[] { expected }, inspector.CompactionsRequested.ToArray());
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/UsageReportRefreshPolicyTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UsageReportRefreshPolicyTests.cs
@@ -1,0 +1,159 @@
+using Common.Entities.Entities.Teams;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Rules;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The finalized-date skip rule for the Graph daily usage reports, extracted by issue #375. Zero SQL
+    /// Server, zero Graph, zero wall clock.
+    ///
+    /// This decision governs whether a day's report is re-downloaded or trusted as final, and it is
+    /// expensive to get wrong in both directions: too eager re-downloads and rewrites every report on every
+    /// cycle, too lax freezes stale numbers permanently.
+    /// </summary>
+    [TestClass]
+    public class UsageReportRefreshPolicyTests
+    {
+        private static readonly DateTime NowUtc = new DateTime(2026, 6, 20, 11, 15, 0, DateTimeKind.Utc);
+        private const int RefreshableRecentDays = 3;
+
+        private static UsageReportSkipWindow Window(int daysBackMax, DateTime? lastSuccessfulImport, int recentDays = RefreshableRecentDays)
+            => UsageReportRefreshPolicy.ResolveSkipWindow(daysBackMax, lastSuccessfulImport, recentDays, NowUtc);
+
+        [TestMethod]
+        public void UsageReports_UsageReportPhaseNeverCompleted_SkipsNothing()
+        {
+            // Stored rows could be from an interrupted save, so nothing is proven complete enough to skip.
+            var window = Window(28, null);
+
+            Assert.IsFalse(window.CanSkipAnyDate);
+            Assert.AreEqual(0, UsageReportRefreshPolicy.EnumerateSkipCandidates(window).Count());
+        }
+
+        [TestMethod]
+        public void UsageReports_DateOlderThanRefreshWindow_IsASkipCandidate()
+        {
+            // A completed phase well in the past: the Graph mutability window (3 days) is then the binding
+            // cutoff, so everything from the window start up to now-3d is skippable.
+            var window = Window(28, NowUtc.AddDays(-1));
+
+            Assert.IsTrue(window.CanSkipAnyDate);
+            Assert.AreEqual(NowUtc.Date.AddDays(-28), window.WindowStartUtc);
+            Assert.AreEqual(NowUtc.Date.AddDays(-3), window.SafeCutoffUtc);
+
+            var candidates = UsageReportRefreshPolicy.EnumerateSkipCandidates(window).ToList();
+            CollectionAssert.Contains(candidates, NowUtc.Date.AddDays(-10));
+        }
+
+        [TestMethod]
+        public void UsageReports_DateInsideRefreshWindow_IsNeverASkipCandidate()
+        {
+            // Graph gap-fills the most recent few days, so those must always be re-downloaded even though
+            // they are stored and even though a phase has completed since.
+            var window = Window(28, NowUtc);
+            var candidates = UsageReportRefreshPolicy.EnumerateSkipCandidates(window).ToList();
+
+            foreach (var recent in new[] { NowUtc.Date, NowUtc.Date.AddDays(-1), NowUtc.Date.AddDays(-2) })
+            {
+                CollectionAssert.DoesNotContain(candidates, recent, $"{recent:yyyy-MM-dd} can still change in Graph.");
+            }
+            CollectionAssert.Contains(candidates, NowUtc.Date.AddDays(-3).AddDays(-1));
+        }
+
+        [TestMethod]
+        public void UsageReports_BoundaryDateExactlyOnWindowEdge_IsReloaded()
+        {
+            // The cutoff is EXCLUSIVE. now-3d is the first mutable day, so it must not be skipped; the day
+            // before it is the last skippable one. An off-by-one here either re-downloads a finalized day
+            // forever or freezes a still-changing one.
+            var window = Window(28, NowUtc);
+            var candidates = UsageReportRefreshPolicy.EnumerateSkipCandidates(window).ToList();
+
+            CollectionAssert.DoesNotContain(candidates, window.SafeCutoffUtc);
+            CollectionAssert.Contains(candidates, window.SafeCutoffUtc.AddDays(-1));
+            Assert.AreEqual(window.SafeCutoffUtc.AddDays(-1), candidates.Last());
+        }
+
+        [TestMethod]
+        public void UsageReports_CompletedPhaseOlderThanTheMutabilityWindow_BecomesTheBindingCutoff()
+        {
+            // The earlier of the two cutoffs wins. With the last completed phase 10 days ago, dates between
+            // then and the 3-day mutability edge are NOT skippable - they may be from an interrupted save.
+            var window = Window(28, NowUtc.AddDays(-10));
+
+            Assert.AreEqual(NowUtc.Date.AddDays(-10), window.SafeCutoffUtc);
+            var candidates = UsageReportRefreshPolicy.EnumerateSkipCandidates(window).ToList();
+            CollectionAssert.DoesNotContain(candidates, NowUtc.Date.AddDays(-5));
+            CollectionAssert.Contains(candidates, NowUtc.Date.AddDays(-11));
+        }
+
+        [TestMethod]
+        public void UsageReports_CompletionMarkerIsNormalisedToUtcBeforeComparing()
+        {
+            // The marker arrives from a store that may hand back a local or unspecified kind; comparing it
+            // raw against a UTC "today" would shift the cutoff by the host's offset.
+            var localMarker = new DateTime(2026, 6, 10, 23, 30, 0, DateTimeKind.Local);
+            var window = Window(28, localMarker);
+
+            Assert.AreEqual(localMarker.ToUniversalTime().Date, window.SafeCutoffUtc);
+        }
+
+        [TestMethod]
+        public void UsageReports_LookBackIsClampedToWhatGraphCanAnswer()
+        {
+            // Graph retains ~28 days of daily detail, and reports lag 2-3 days, so a configured value
+            // outside those bounds is corrected rather than rejected - a bad setting must not stop the import.
+            Assert.AreEqual(UsageReportRefreshPolicy.MinDaysBack, UsageReportRefreshPolicy.ClampDaysBack(0));
+            Assert.AreEqual(UsageReportRefreshPolicy.MinDaysBack, UsageReportRefreshPolicy.ClampDaysBack(-7));
+            Assert.AreEqual(UsageReportRefreshPolicy.MaxDaysBack, UsageReportRefreshPolicy.ClampDaysBack(365));
+            Assert.AreEqual(14, UsageReportRefreshPolicy.ClampDaysBack(14));
+
+            Assert.AreEqual(UsageReportRefreshPolicy.MaxDaysBack, Window(365, NowUtc).DaysBackMax);
+        }
+
+        [TestMethod]
+        public void UsageReports_WindowIsDrivenByTheSuppliedInstantNotTheWallClock()
+        {
+            // Would fail if the rule went back to reading DateTime.UtcNow itself.
+            var pastInstant = new DateTime(2004, 8, 3, 0, 0, 0, DateTimeKind.Utc);
+            var window = UsageReportRefreshPolicy.ResolveSkipWindow(28, pastInstant, RefreshableRecentDays, pastInstant);
+
+            Assert.AreEqual(pastInstant.Date.AddDays(-28), window.WindowStartUtc);
+            Assert.AreEqual(pastInstant.Date.AddDays(-3), window.SafeCutoffUtc);
+        }
+    }
+
+    /// <summary>
+    /// The table-name resolution behind the storage-inspector port. The two callers react differently to a
+    /// missing TableAttribute - the index question throws, the maintenance silently skips - and that
+    /// asymmetry is existing behaviour worth pinning.
+    /// </summary>
+    [TestClass]
+    public class UsageReportTableNameTests
+    {
+        private class NoTableAttribute { }
+
+        [TestMethod]
+        public void UsageReports_TableNameIsSchemaQualified()
+        {
+            // Every report entity in this assembly declares [Table(...)]; pick one to prove the attribute is
+            // what is read, and that the default schema is applied when the attribute states none.
+            var resolved = UsageReportTableName.TryResolve(typeof(SharePointUserActivityLog));
+
+            Assert.AreEqual("dbo.sharepoint_user_activity_log", resolved);
+        }
+
+        [TestMethod]
+        public void UsageReports_EntityWithoutATable_ThrowsForTheIndexQuestionButNotForMaintenance()
+        {
+            Assert.IsNull(UsageReportTableName.TryResolve(typeof(NoTableAttribute)),
+                "Maintenance skips silently, so it needs the non-throwing form.");
+            Assert.ThrowsException<InvalidOperationException>(() => UsageReportTableName.Resolve(typeof(NoTableAttribute)),
+                "The index question cannot be answered without a table, so it must fail loudly.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -61,10 +61,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         /// </summary>
         public int LastSaveDbWriteCount { get; private set; }
 
-        // Kept as the single source for the clamp bounds; UsageReportRefreshPolicy owns the rule itself.
-        private const int MIN_DAYS_BACK = UsageReportRefreshPolicy.MinDaysBack;
-        private const int MAX_DAYS_BACK = UsageReportRefreshPolicy.MaxDaysBack;
-
         private static int ClampDaysBack(int daysBackMax) => UsageReportRefreshPolicy.ClampDaysBack(daysBackMax);
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Rules;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 {
@@ -60,40 +61,45 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         /// </summary>
         public int LastSaveDbWriteCount { get; private set; }
 
-        private const int MIN_DAYS_BACK = 3;    // Activity reports don't tend to refresh until a couple of days late; always collect something useful.
-        private const int MAX_DAYS_BACK = 28;   // Graph only retains ~28 days of daily detail.
+        // Kept as the single source for the clamp bounds; UsageReportRefreshPolicy owns the rule itself.
+        private const int MIN_DAYS_BACK = UsageReportRefreshPolicy.MinDaysBack;
+        private const int MAX_DAYS_BACK = UsageReportRefreshPolicy.MaxDaysBack;
 
-        private static int ClampDaysBack(int daysBackMax)
-        {
-            if (daysBackMax < MIN_DAYS_BACK) return MIN_DAYS_BACK;
-            if (daysBackMax > MAX_DAYS_BACK) return MAX_DAYS_BACK;
-            return daysBackMax;
-        }
+        private static int ClampDaysBack(int daysBackMax) => UsageReportRefreshPolicy.ClampDaysBack(daysBackMax);
+
+        /// <summary>
+        /// Storage-shape questions and columnstore maintenance. Injectable so the index-aware branch and the
+        /// maintenance trigger can be exercised without SQL Server (#375); defaults to the SQL adapter over
+        /// whichever context the caller passes in.
+        /// </summary>
+        public IUsageReportStorageInspector StorageInspector { get; set; }
+
+        private IUsageReportStorageInspector InspectorFor(AnalyticsEntitiesContext db)
+            => StorageInspector ?? new SqlUsageReportStorageInspector(db);
 
         /// <summary>
         /// The set of dates within the [now-daysBackMax, now) import window that are already stored in SQL, old
         /// enough that Graph will no longer change them, and covered by a previously completed import phase. These
         /// can be skipped entirely on the next import - no re-download, no re-write. Dates within the recent window
         /// or newer than the completion marker are never returned because they can still change or be partial.
+        ///
+        /// The window rule itself is <see cref="UsageReportRefreshPolicy"/>, which takes the instant as a
+        /// parameter and so can be asserted without a database (#375).
         /// </summary>
         public async Task<HashSet<DateTime>> GetFinalizedStoredDatesToSkipAsync(
             AnalyticsEntitiesContext db,
             int daysBackMax,
             DateTime? lastSuccessfulImport)
         {
-            daysBackMax = ClampDaysBack(daysBackMax);
-            if (!lastSuccessfulImport.HasValue)
+            var window = UsageReportRefreshPolicy.ResolveSkipWindow(
+                daysBackMax, lastSuccessfulImport, RefreshableRecentDays, DateTime.UtcNow);
+
+            if (!window.CanSkipAnyDate)
             {
                 // Existing rows could be from an interrupted import. Until a full usage-report
                 // phase completes, no stored date is proven complete enough to skip safely.
                 return new HashSet<DateTime>();
             }
-
-            var today = DateTime.UtcNow.Date;
-            var windowStart = today.AddDays(-daysBackMax);
-            var mutableCutoff = today.AddDays(-RefreshableRecentDays);   // dates >= this can still change; never skip them
-            var completedCutoff = lastSuccessfulImport.Value.ToUniversalTime().Date;
-            var safeCutoff = completedCutoff < mutableCutoff ? completedCutoff : mutableCutoff;
 
             var table = GetTable(db);
             if (await HasLeadingDateIndexAsync(db))
@@ -102,7 +108,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 // still scans every user's row for every date (millions of rows at 200k users);
                 // bounded existence seeks touch one index entry per candidate date instead.
                 var storedFinalizedDates = new HashSet<DateTime>();
-                for (var date = windowStart; date < safeCutoff; date = date.AddDays(1))
+                foreach (var date in UsageReportRefreshPolicy.EnumerateSkipCandidates(window))
                 {
                     if (await table.AnyAsync(activity => activity.Date == date))
                     {
@@ -115,6 +121,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 
             // Some account/group report tables have no date-leading index. Repeated existence
             // probes would each scan the table, so use one range scan until an index is available.
+            var windowStart = window.WindowStartUtc;
+            var safeCutoff = window.SafeCutoffUtc;
             var scannedDates = await table
                 .Where(activity => activity.Date >= windowStart && activity.Date < safeCutoff)
                 .Select(activity => activity.Date)
@@ -124,91 +132,23 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             return new HashSet<DateTime>(scannedDates.Select(date => date.Date));
         }
 
-        internal async Task<bool> HasLeadingDateIndexAsync(AnalyticsEntitiesContext db)
-        {
-            var table = typeof(TReportDbType).GetCustomAttribute<TableAttribute>();
-            if (table == null)
-            {
-                throw new InvalidOperationException(
-                    $"{typeof(TReportDbType).Name} must declare TableAttribute to inspect its date index.");
-            }
-
-            var qualifiedTableName = $"{table.Schema ?? "dbo"}.{table.Name}";
-            const string sql = @"
-SELECT CAST(CASE WHEN EXISTS (
-    SELECT 1
-    FROM sys.indexes AS i
-    INNER JOIN sys.index_columns AS ic
-      ON ic.object_id = i.object_id AND ic.index_id = i.index_id
-    INNER JOIN sys.columns AS c
-      ON c.object_id = ic.object_id AND c.column_id = ic.column_id
-    WHERE i.object_id = OBJECT_ID(@tableName)
-      AND i.is_disabled = 0
-      AND i.is_hypothetical = 0
-      AND i.has_filter = 0
-      AND ic.key_ordinal = 1
-      AND c.name = N'date'
-) THEN 1 ELSE 0 END AS bit);";
-
-            return await db.Database
-                .SqlQuery<bool>(sql, new SqlParameter("@tableName", qualifiedTableName))
-                .SingleAsync();
-        }
+        internal Task<bool> HasLeadingDateIndexAsync(AnalyticsEntitiesContext db)
+            => InspectorFor(db).HasLeadingDateIndexAsync(UsageReportTableName.Resolve(typeof(TReportDbType)));
 
         /// <summary>
-        /// Compacts this report table's columnstore delta rowgroups, if it has a columnstore index.
-        ///
-        /// <para>
-        /// <see cref="SaveLoadedReportsToSql"/> writes per-(date, user) upserts row by row, and only a bulk
-        /// load of 102,400+ rows compresses straight into a compressed rowgroup - everything else lands in
-        /// the rowstore delta store, which is scanned uncompressed. Left alone, the delta store grows every
-        /// import cycle and the columnstore's advantage decays back towards the full-scan behaviour the
-        /// <c>ColumnstoreUsageReportMetrics</c> migration exists to remove.
-        /// </para>
-        /// <para>
-        /// Plain <c>REORGANIZE</c> rather than <c>WITH (COMPRESS_ALL_ROW_GROUPS = ON)</c>: it merges and
-        /// compresses CLOSED delta rowgroups and removes deleted rows, which is the cheap, safe operation to
-        /// run on every cycle. Forcing the currently-open rowgroup to compress as well would rewrite the
-        /// trailing day's rows on every single import for very little gain.
-        /// </para>
-        /// <para>
-        /// A no-op (single metadata read) when the table has no columnstore index - which is the case on any
-        /// server where the migration's columnstore attempt fell back to a B-tree, or was skipped entirely.
-        /// </para>
+        /// Compacts this report table's columnstore delta rowgroups, if it has a columnstore index. Skipped
+        /// entirely for an entity that declares no table. See <see cref="SqlUsageReportStorageInspector"/>
+        /// for why plain REORGANIZE, and why it runs outside a transaction.
         /// </summary>
-        internal async Task CompactColumnstoreAsync(AnalyticsEntitiesContext db)
+        internal Task CompactColumnstoreAsync(AnalyticsEntitiesContext db)
         {
-            var table = typeof(TReportDbType).GetCustomAttribute<TableAttribute>();
-            if (table == null)
+            var qualifiedTableName = UsageReportTableName.TryResolve(typeof(TReportDbType));
+            if (qualifiedTableName == null)
             {
-                return;
+                return Task.CompletedTask;
             }
 
-            var qualifiedTableName = $"{table.Schema ?? "dbo"}.{table.Name}";
-
-            // i.type = 6 is NONCLUSTERED COLUMNSTORE.
-            const string sql = @"
-DECLARE @ix sysname = (
-    SELECT TOP (1) i.name
-    FROM sys.indexes AS i
-    WHERE i.object_id = OBJECT_ID(@tableName) AND i.type = 6 AND i.is_disabled = 0);
-
-IF @ix IS NOT NULL
-BEGIN
-    DECLARE @sql nvarchar(max) =
-        N'ALTER INDEX ' + QUOTENAME(@ix) + N' ON ' + @tableName + N' REORGANIZE;';
-    EXEC sp_executesql @sql;
-END";
-
-            await db.Database.ExecuteSqlCommandAsync(
-                // DoNotEnsureTransaction: index maintenance has no business inside a transaction. EF6's
-                // default (EnsureTransaction) would wrap a potentially long REORGANIZE in one, holding it
-                // open and growing the log for no benefit. (Verified that REORGANIZE does still succeed
-                // under EF's default behaviour on current SQL Server, so this is hardening rather than a
-                // bug fix - but there is no reason to run maintenance transactionally.)
-                TransactionalBehavior.DoNotEnsureTransaction,
-                sql,
-                new SqlParameter("@tableName", qualifiedTableName));
+            return InspectorFor(db).CompactColumnstoreAsync(qualifiedTableName);
         }
 
         public async Task PopulateLoadedReportPagesFromGraph(int daysBackMax, ISet<DateTime> datesToSkip = null)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStorageInspector.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStorageInspector.cs
@@ -1,0 +1,144 @@
+using Common.Entities;
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
+using System.Data.SqlClient;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
+{
+    /// <summary>
+    /// Storage-shape questions and physical maintenance for a usage-report table - the things the daily
+    /// loaders used to ask SQL Server directly, in raw SQL, from inside the import logic.
+    ///
+    /// Behind a port because neither is import logic: one is an index-shape question that selects a query
+    /// strategy, the other is columnstore maintenance that belongs to deployment. See issue #375.
+    /// </summary>
+    public interface IUsageReportStorageInspector
+    {
+        /// <summary>
+        /// Does this table have a non-disabled, non-filtered index whose FIRST key column is <c>date</c>?
+        /// That decides which query shape the finalized-date scan uses: bounded existence seeks per
+        /// candidate date when it does, one range scan when it does not.
+        /// </summary>
+        Task<bool> HasLeadingDateIndexAsync(string qualifiedTableName);
+
+        /// <summary>
+        /// Compact the table's columnstore delta rowgroups, if it has a columnstore index. A no-op (single
+        /// metadata read) when it does not.
+        /// </summary>
+        Task CompactColumnstoreAsync(string qualifiedTableName);
+    }
+
+    /// <summary>
+    /// Resolves the SQL table name an EF report entity maps to. Pure, so the loaders' two different
+    /// reactions to a missing <see cref="TableAttribute"/> - throw for the index question, silently skip
+    /// the maintenance - stay explicit and testable.
+    /// </summary>
+    public static class UsageReportTableName
+    {
+        /// <summary>The <c>schema.table</c> name, or null when the entity declares no table.</summary>
+        public static string TryResolve(Type reportEntityType)
+        {
+            if (reportEntityType == null) throw new ArgumentNullException(nameof(reportEntityType));
+
+            var table = reportEntityType.GetCustomAttribute<TableAttribute>();
+            if (table == null) return null;
+
+            return $"{table.Schema ?? "dbo"}.{table.Name}";
+        }
+
+        /// <summary>As <see cref="TryResolve"/>, but throws when the entity declares no table.</summary>
+        public static string Resolve(Type reportEntityType)
+        {
+            var name = TryResolve(reportEntityType);
+            if (name == null)
+            {
+                throw new InvalidOperationException(
+                    $"{reportEntityType.Name} must declare TableAttribute to inspect its date index.");
+            }
+            return name;
+        }
+    }
+
+    /// <summary>
+    /// EF6/SQL Server <see cref="IUsageReportStorageInspector"/>. Both statements were moved verbatim out of
+    /// <c>AbstractDailyActivityLoader</c> by issue #375 - the SQL itself is unchanged.
+    /// </summary>
+    public sealed class SqlUsageReportStorageInspector : IUsageReportStorageInspector
+    {
+        private readonly AnalyticsEntitiesContext _db;
+
+        public SqlUsageReportStorageInspector(AnalyticsEntitiesContext db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+
+        public async Task<bool> HasLeadingDateIndexAsync(string qualifiedTableName)
+        {
+            const string sql = @"
+SELECT CAST(CASE WHEN EXISTS (
+    SELECT 1
+    FROM sys.indexes AS i
+    INNER JOIN sys.index_columns AS ic
+      ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+    INNER JOIN sys.columns AS c
+      ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+    WHERE i.object_id = OBJECT_ID(@tableName)
+      AND i.is_disabled = 0
+      AND i.is_hypothetical = 0
+      AND i.has_filter = 0
+      AND ic.key_ordinal = 1
+      AND c.name = N'date'
+) THEN 1 ELSE 0 END AS bit);";
+
+            return await _db.Database
+                .SqlQuery<bool>(sql, new SqlParameter("@tableName", qualifiedTableName))
+                .SingleAsync();
+        }
+
+        /// <summary>
+        /// <para>
+        /// The loaders write per-(date, user) upserts row by row, and only a bulk load of 102,400+ rows
+        /// compresses straight into a compressed rowgroup - everything else lands in the rowstore delta
+        /// store, which is scanned uncompressed. Left alone, the delta store grows every import cycle and
+        /// the columnstore's advantage decays back towards the full-scan behaviour the
+        /// <c>ColumnstoreUsageReportMetrics</c> migration exists to remove.
+        /// </para>
+        /// <para>
+        /// Plain <c>REORGANIZE</c> rather than <c>WITH (COMPRESS_ALL_ROW_GROUPS = ON)</c>: it merges and
+        /// compresses CLOSED delta rowgroups and removes deleted rows, which is the cheap, safe operation to
+        /// run on every cycle. Forcing the currently-open rowgroup to compress as well would rewrite the
+        /// trailing day's rows on every single import for very little gain.
+        /// </para>
+        /// </summary>
+        public async Task CompactColumnstoreAsync(string qualifiedTableName)
+        {
+            // i.type = 6 is NONCLUSTERED COLUMNSTORE.
+            const string sql = @"
+DECLARE @ix sysname = (
+    SELECT TOP (1) i.name
+    FROM sys.indexes AS i
+    WHERE i.object_id = OBJECT_ID(@tableName) AND i.type = 6 AND i.is_disabled = 0);
+
+IF @ix IS NOT NULL
+BEGIN
+    DECLARE @sql nvarchar(max) =
+        N'ALTER INDEX ' + QUOTENAME(@ix) + N' ON ' + @tableName + N' REORGANIZE;';
+    EXEC sp_executesql @sql;
+END";
+
+            await _db.Database.ExecuteSqlCommandAsync(
+                // DoNotEnsureTransaction: index maintenance has no business inside a transaction. EF6's
+                // default (EnsureTransaction) would wrap a potentially long REORGANIZE in one, holding it
+                // open and growing the log for no benefit. (Verified that REORGANIZE does still succeed
+                // under EF's default behaviour on current SQL Server, so this is hardening rather than a
+                // bug fix - but there is no reason to run maintenance transactionally.)
+                TransactionalBehavior.DoNotEnsureTransaction,
+                sql,
+                new SqlParameter("@tableName", qualifiedTableName));
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Rules/UsageReportRefreshPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Rules/UsageReportRefreshPolicy.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Rules
+{
+    /// <summary>
+    /// The window of report dates a daily usage-report import may skip, and the bounds it looks in.
+    /// </summary>
+    public sealed class UsageReportSkipWindow
+    {
+        internal UsageReportSkipWindow(bool canSkipAnyDate, DateTime windowStartUtc, DateTime safeCutoffUtc, int daysBackMax)
+        {
+            CanSkipAnyDate = canSkipAnyDate;
+            WindowStartUtc = windowStartUtc;
+            SafeCutoffUtc = safeCutoffUtc;
+            DaysBackMax = daysBackMax;
+        }
+
+        /// <summary>
+        /// False when nothing may be skipped at all - no usage-report phase has ever completed, so any
+        /// stored row could be from an interrupted import and must be re-downloaded.
+        /// </summary>
+        public bool CanSkipAnyDate { get; }
+
+        /// <summary>Oldest date the import looks at (inclusive).</summary>
+        public DateTime WindowStartUtc { get; }
+
+        /// <summary>
+        /// Exclusive upper bound on skippable dates: the earlier of "Graph may still change this" and
+        /// "a completed import has not covered this yet". Equal to <see cref="WindowStartUtc"/> when
+        /// nothing in the window is skippable.
+        /// </summary>
+        public DateTime SafeCutoffUtc { get; }
+
+        /// <summary>The clamped look-back, in days.</summary>
+        public int DaysBackMax { get; }
+    }
+
+    /// <summary>
+    /// The finalized-date skip rule for the Graph daily usage reports, lifted out of
+    /// <c>AbstractDailyActivityLoader</c> so it can be asserted with no SQL Server, no Graph and no wall
+    /// clock. See issue #375.
+    ///
+    /// This decision governs whether a day's report is re-downloaded or trusted as already final. Getting
+    /// it wrong is expensive in both directions: too eager and every report is re-downloaded and rewritten
+    /// on every cycle; too lax and stale numbers are frozen in permanently. It previously existed only as
+    /// inline statements around an EF query, with the instant read from <c>DateTime.UtcNow</c> in the
+    /// middle of it.
+    ///
+    /// Follows the <c>ImportCadenceGate.ShouldRun(..., DateTime nowUtc)</c> convention: the instant, and
+    /// the completed-phase marker, are parameters rather than dependencies.
+    /// </summary>
+    public static class UsageReportRefreshPolicy
+    {
+        /// <summary>Activity reports don't tend to refresh until a couple of days late; always collect something useful.</summary>
+        public const int MinDaysBack = 3;
+
+        /// <summary>Graph only retains ~28 days of daily detail.</summary>
+        public const int MaxDaysBack = 28;
+
+        /// <summary>
+        /// Clamp the configured look-back to what Graph can actually answer. A value below
+        /// <see cref="MinDaysBack"/> or above <see cref="MaxDaysBack"/> is corrected rather than rejected,
+        /// so a bad app setting cannot stop the import.
+        /// </summary>
+        public static int ClampDaysBack(int daysBackMax)
+        {
+            if (daysBackMax < MinDaysBack) return MinDaysBack;
+            if (daysBackMax > MaxDaysBack) return MaxDaysBack;
+            return daysBackMax;
+        }
+
+        /// <summary>
+        /// Which part of the import window is safe to skip.
+        ///
+        /// Two independent conditions have to hold for a stored date to be skippable, and the earlier of
+        /// the two cutoffs wins:
+        /// <list type="bullet">
+        /// <item><b>Graph must be done changing it.</b> Usage reports have a ~2-3 day latency and are
+        /// stable once finalized, so anything newer than
+        /// <paramref name="refreshableRecentDays"/> can still move and is never skipped.</item>
+        /// <item><b>A full import phase must have covered it.</b> Rows newer than the last completed
+        /// phase may be from an interrupted save, so they are retried. With no completed phase at all
+        /// (<paramref name="lastSuccessfulImport"/> is null) nothing is proven complete and
+        /// <see cref="UsageReportSkipWindow.CanSkipAnyDate"/> is false.</item>
+        /// </list>
+        /// </summary>
+        public static UsageReportSkipWindow ResolveSkipWindow(int daysBackMax, DateTime? lastSuccessfulImport,
+            int refreshableRecentDays, DateTime nowUtc)
+        {
+            daysBackMax = ClampDaysBack(daysBackMax);
+            var today = nowUtc.Date;
+            var windowStart = today.AddDays(-daysBackMax);
+
+            if (!lastSuccessfulImport.HasValue)
+            {
+                // Existing rows could be from an interrupted import. Until a full usage-report
+                // phase completes, no stored date is proven complete enough to skip safely.
+                return new UsageReportSkipWindow(false, windowStart, windowStart, daysBackMax);
+            }
+
+            var mutableCutoff = today.AddDays(-refreshableRecentDays);   // dates >= this can still change; never skip them
+            var completedCutoff = lastSuccessfulImport.Value.ToUniversalTime().Date;
+            var safeCutoff = completedCutoff < mutableCutoff ? completedCutoff : mutableCutoff;
+
+            return new UsageReportSkipWindow(true, windowStart, safeCutoff, daysBackMax);
+        }
+
+        /// <summary>
+        /// The dates in the window that are candidates for skipping, oldest first. Empty when the cutoff is
+        /// at or before the window start, which is what makes "skip nothing" fall out naturally rather than
+        /// needing a special case at the call site.
+        /// </summary>
+        public static IEnumerable<DateTime> EnumerateSkipCandidates(UsageReportSkipWindow window)
+        {
+            if (window == null) throw new ArgumentNullException(nameof(window));
+            if (!window.CanSkipAnyDate) yield break;
+
+            for (var date = window.WindowStartUtc; date < window.SafeCutoffUtc; date = date.AddDays(1))
+            {
+                yield return date;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -157,6 +157,8 @@
     <Compile Include="Graph\Teams\TeamsImporter.cs" />
     <Compile Include="Graph\Teams\TeamTokenManager.cs" />
     <Compile Include="Graph\UsageReports\AbstractDailyActivityLoader.cs" />
+    <Compile Include="Graph\UsageReports\IUsageReportStorageInspector.cs" />
+    <Compile Include="Graph\UsageReports\Rules\UsageReportRefreshPolicy.cs" />
     <Compile Include="Graph\Calls\CallQueueProcessor.cs" />
     <Compile Include="Graph\Calls\CallRecordSubscriptionInfo.cs" />
     <Compile Include="Graph\Calls\CallWebhook.cs" />


### PR DESCRIPTION
## Summary

First of two PRs for #375. This takes the two things the daily Graph usage-report loaders do that are **not import logic** — the finalized-date skip decision, and the raw `sys.indexes` SQL — and puts them behind a pure rule and a port.

**Deferred to part 2:** the site-id → URL cache (`SPSiteIdToUrlCache` / `ISiteUrlStore` / `ISiteGraphSource`) and the full `IUsageReportStore` write port. Those are a bigger, riskier change through the class hierarchy and belong in their own review.

## The refresh policy is the valuable bit

`UsageReportRefreshPolicy` (in `Graph/UsageReports/Rules/`) owns the finalized-date decision:

| Member | Rule |
|---|---|
| `ClampDaysBack` | Graph retains ~28 days of daily detail and lags 2–3 days, so a look-back outside those bounds is **corrected, not rejected** — a bad app setting must not stop the import. |
| `ResolveSkipWindow` | Two independent cutoffs, **earlier wins**: Graph must be done changing the date (`RefreshableRecentDays`), *and* a completed import phase must have covered it. No completed phase at all ⇒ nothing is skippable, because stored rows could be from an interrupted save. |
| `EnumerateSkipCandidates` | The candidate dates, so "skip nothing" falls out of an empty range rather than needing a special case at the call site. |

It takes the instant as a **parameter** rather than depending on `IClock`, per #381's `ImportCadenceGate.ShouldRun(..., DateTime nowUtc)` convention.

This decision was previously four inline statements wrapped around an EF query with `DateTime.UtcNow` read in the middle of it — observable only by running the whole import against a database, despite deciding whether every report is re-downloaded on every cycle or frozen stale forever.

## The storage inspector

`IUsageReportStorageInspector` + `SqlUsageReportStorageInspector` move the two raw SQL statements out of the loader:

- the **leading-date-index probe**, which selects the query strategy (bounded existence seeks per candidate date when the index exists; one range scan when it doesn't — because repeated probes would each scan the table);
- the **columnstore `REORGANIZE`**, which is deployment-time maintenance, not import logic.

Both are moved **verbatim** — same SQL text, same parameters, same `TransactionalBehavior.DoNotEnsureTransaction` and the comment explaining why.

`UsageReportTableName` resolves the `TableAttribute` and keeps the two callers' *different* reactions to a missing one explicit, which is existing behaviour that was easy to lose in the move: the index question **throws** (it cannot be answered without a table), the maintenance **silently skips**. `UsageReports_EntityWithoutATable_ThrowsForTheIndexQuestionButNotForMaintenance` pins the asymmetry.

`AbstractDailyActivityLoader` gains a settable `StorageInspector` defaulting to the SQL adapter over whichever context the caller passes in — so **no concrete loader constructor changes** and `GraphImporter` is untouched. That matters here because the generic base has ~11 concrete subclasses.

## What I did NOT change

- The index-aware branch and the compaction SQL, per the issue's explicit instruction.
- `SharePointSitesWeeklyUsageReportLoader`'s scale-awareness: the `OrdinalIgnoreCase` `_existingSiteIdByUrl` dictionary built from an `AsNoTracking()` projection, and the single grouped query that replaced a per-site top-1. Untouched, and `SharePointSitesUsageLoader_MatchesExistingSiteUrlCaseInsensitively` still passes — that is the case-insensitive site-matching guarantee #375 asks to keep, and it is the same class of bug as #380/#385.

## Testing

**New: 12 tests, zero SQL Server, zero Graph, zero wall clock.**

`UsageReportRefreshPolicyTests` (8):
- no completed phase ⇒ skip nothing;
- a date older than the refresh window is a candidate; a date **inside** it never is (Graph gap-fills the recent days);
- **the boundary is exclusive** — `now-3d` is the first mutable day and must not be skipped, the day before it is the last skippable one. An off-by-one here either re-downloads a finalized day forever or freezes a still-changing one;
- a completed phase *older* than the mutability window becomes the binding cutoff;
- the look-back is clamped at both ends, **and the clamp is applied before the window is computed** — clamping only the reported `DaysBackMax` while computing `windowStart` from a raw `365` would otherwise be invisible, and would make the indexed path issue 362 existence queries instead of 25;
- the window is driven by the supplied instant, not the wall clock — fails if the rule goes back to reading `DateTime.UtcNow`.

`UsageReportTableNameTests` (4): schema-qualified resolution, the helper's `TryResolve`-vs-`Resolve` contract, and — added on review — the throw-vs-skip asymmetry asserted **through the loader** rather than the helper, plus a positive case proving a normal loader reaches the inspector with its own schema-qualified name. Swapping which helper each loader method uses would reverse the behaviour, and a helper-only test could not see it. Both use a new `TablelessDailyActivityLoader` and still touch no database.

Also added `FakeUsageReportStorageInspector` to `Tests.UnitTests/FakeLoaderClasses/` for part 2 and for any loader-level test that wants to drive the index-aware branch.

**Pre-existing evidence, unchanged and passing:** `OutlookUserActivityLoaderTests` — which drives `GetFinalizedStoredDatesToSkipAsync` *and* `HasLeadingDateIndexAsync` against LocalDB, including the indexed and unindexed branches — and `GraphUsageReportImportTests`. Area run: **67 passed / 1 failed of 68**; the failure is the pre-existing `SharePointSitesUsageLoaderTest`, which needs real Graph credentials (`Tenant '00000000-…-0002' not found`) and is one of the 12 known local-environment failures. Full solution builds (Debug).

## Reviewer hotspots

1. **Is `ResolveSkipWindow` faithful to the original?** Compare against `git show origin/dev:…/AbstractDailyActivityLoader.cs`. Specifically: the clamp happens *before* the window is computed, `lastSuccessfulImport` null short-circuits before anything else, `safeCutoff` is `min(completedCutoff, mutableCutoff)`, and the loop bound is still `date < safeCutoff` (exclusive).
2. **The unindexed branch** now reads `window.WindowStartUtc` / `window.SafeCutoffUtc` into locals before the EF `Where`. Confirm that still produces the same SQL — EF6 captures locals as parameters, but I want a second pair of eyes on whether reading them off the object inside the expression would have changed anything.
3. **`StorageInspector` as a settable property** rather than a constructor parameter. It avoids touching ~11 concrete loader constructors, but it is mutable public state on a loader. Is that the right trade, or should it be constructor-injected despite the churn?
4. **Test honesty** — for each of the 10, what realistic regression makes it fail? Flag anything that would pass under a genuine regression; I would rather delete a weak test than pad it.

Addresses #375
