### PR TITLE
Harden the user-data-lookup integration fixture against leaks and fixture drift

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/StagingColumnSqlTypeOverrideTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StagingColumnSqlTypeOverrideTests.cs
@@ -166,10 +166,15 @@ namespace Tests.UnitTests
         /// The App Insights "searches" staging table (created from the Create Searches Import Temp
         /// Table.sql resource by SearchesSaveExtension) stores the authenticated user's UPN and the
         /// search term. Both must be nvarchar - not varchar - or a non-Latin value (e.g. Greek) is
-        /// corrupted to '?'. For user_name that breaks the merge's inner join to the nvarchar
-        /// users.user_name and silently drops that user's searches. See issue #122 and the
-        /// "Character set support (Unicode / Greek)" convention.
+        /// corrupted to '?'. That matters most for search_term, which is free-form text a user types
+        /// in any script. See issue #122 and the "Character set support (Unicode / Greek)" convention.
         /// </summary>
+        /// <remarks>
+        /// Note the target column dbo.users.user_name is varchar(250), not nvarchar - so this staging
+        /// column being nvarchar does not, on its own, make a non-Latin UPN survive the merge. In
+        /// practice that is moot: Entra restricts userPrincipalName to A-Z a-z 0-9 ' . - _ ! # ^ ~
+        /// with accented characters disallowed, so the values arriving here are ASCII.
+        /// </remarks>
         [TestMethod]
         public void SearchesStagingUserNameAndTermAreNvarchar()
         {

--- a/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupServiceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupServiceTests.cs
@@ -298,23 +298,29 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// UPNs are customer text and can be non-Latin. Nothing in the lookup's own logic may fold or
-        /// mangle them - see the character-set rule in the repo's C# instructions. (The database column
-        /// currently does mangle them; that is a separate schema bug, issue #402.)
+        /// The service must be encoding-neutral: whatever UPN string it is handed comes back unchanged,
+        /// both on the profile and inside the SQL shown to the admin. Nothing here may normalise, fold
+        /// or ASCII-filter it.
         /// </summary>
+        /// <remarks>
+        /// A non-ASCII sample is used because it is the value most likely to be silently mangled by an
+        /// accidental <c>Normalize()</c> or encoding round trip - not because Entra can issue one.
+        /// Entra restricts <c>userPrincipalName</c> to <c>A-Z a-z 0-9 ' . - _ ! # ^ ~</c> and disallows
+        /// accented characters, so a Greek UPN is not a real tenant case.
+        /// </remarks>
         [TestMethod]
-        public async Task Summary_UpnWithNonAsciiCharacters_IsMatchedAndEmittedVerbatim()
+        public async Task Summary_UpnIsPassedThroughWithoutReEncoding()
         {
-            const string greekUpn = "καλημέρα.κόσμε@contoso.com";
+            const string nonAsciiUpn = "καλημέρα.κόσμε@contoso.com";
             var store = new InMemoryUserDataLookupQuery();
-            store.AddUser(11, greekUpn);
+            store.AddUser(11, nonAsciiUpn);
             var service = new UserDataLookupService(store);
 
-            var result = await service.GetSummaryAsync(greekUpn, AllWorkloadsOn);
+            var result = await service.GetSummaryAsync(nonAsciiUpn, AllWorkloadsOn);
 
             Assert.AreEqual(UserDataLookupStatus.Ok, result.Status);
-            Assert.AreEqual(greekUpn, result.Value.Profile.UserPrincipalName);
-            StringAssert.Contains(result.Value.Categories.First().SqlQuery, "user_name = '" + greekUpn + "'");
+            Assert.AreEqual(nonAsciiUpn, result.Value.Profile.UserPrincipalName);
+            StringAssert.Contains(result.Value.Categories.First().SqlQuery, "user_name = '" + nonAsciiUpn + "'");
         }
 
         #endregion

--- a/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupServiceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupServiceTests.cs
@@ -304,7 +304,7 @@ namespace Tests.UnitTests
         /// </summary>
         /// <remarks>
         /// A non-ASCII sample is used because it is the value most likely to be silently mangled by an
-        /// accidental <c>Normalize()</c> or encoding round trip - not because Entra can issue one.
+        /// accidental <c>Normalize()</c> or encoding round trip - not because it is realistic data.
         /// Entra restricts <c>userPrincipalName</c> to <c>A-Z a-z 0-9 ' . - _ ! # ^ ~</c> and disallows
         /// accented characters, so a Greek UPN is not a real tenant case.
         /// </remarks>

--- a/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
@@ -45,7 +45,8 @@ namespace Tests.UnitTests
         {
             // The seeded URL below is Unicode because urls.full_url is nvarchar and genuinely carries
             // non-Latin SharePoint paths. The UPN is ASCII because Entra restricts userPrincipalName to
-            // A-Z a-z 0-9 ' . - _ ! # ^ ~ - a non-Latin UPN is not a case this pipeline can receive.
+            // A-Z a-z 0-9 ' . - _ ! # ^ ~ with accented characters disallowed, so a non-Latin UPN is not
+            // a real tenant case.
             var upn = $"userdatalookup.{Guid.NewGuid():N}@contoso.com";
 
             using (var db = new AnalyticsEntitiesContext())
@@ -230,7 +231,7 @@ namespace Tests.UnitTests
         /// data.
         /// </summary>
         /// <remarks>
-        /// The UPN here is ASCII because that is all Entra can issue: <c>userPrincipalName</c> is
+        /// The UPN here is ASCII because that is what Entra issues: <c>userPrincipalName</c> is
         /// restricted to <c>A-Z a-z 0-9 ' . - _ ! # ^ ~</c> with accented characters disallowed, so a
         /// non-Latin UPN is not a real tenant case. That the service does not itself re-encode whatever
         /// string it is given is covered without a database in

--- a/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
@@ -46,7 +46,7 @@ namespace Tests.UnitTests
             // Deliberately ASCII: dbo.users.user_name is still varchar(250), so a non-Latin UPN is
             // stored mangled (issue #402). The seeded URL below is Unicode, because urls.full_url IS
             // nvarchar and must round-trip.
-            var upn = $"userdatalookup.{DateTime.UtcNow.Ticks}@contoso.com";
+            var upn = $"userdatalookup.{Guid.NewGuid():N}@contoso.com";
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -107,7 +107,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task DisplaySql_ReproducesTheCountItIsShownNextTo()
         {
-            var upn = $"displaysql.{DateTime.UtcNow.Ticks}@contoso.com";
+            var upn = $"displaysql.{Guid.NewGuid():N}@contoso.com";
 
             using (var db = new AnalyticsEntitiesContext())
             {
@@ -138,7 +138,7 @@ namespace Tests.UnitTests
         {
             using (var db = new AnalyticsEntitiesContext())
             {
-                var upn = $"batchkeys.{DateTime.UtcNow.Ticks}@contoso.com";
+                var upn = $"batchkeys.{Guid.NewGuid():N}@contoso.com";
                 try
                 {
                     var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
@@ -171,7 +171,7 @@ namespace Tests.UnitTests
         {
             using (var db = new AnalyticsEntitiesContext())
             {
-                var upn = $"roundtrips.{DateTime.UtcNow.Ticks}@contoso.com";
+                var upn = $"roundtrips.{Guid.NewGuid():N}@contoso.com";
                 CommandCountingInterceptor counter = null;
                 try
                 {
@@ -218,7 +218,7 @@ namespace Tests.UnitTests
         public async Task UnknownUpn_ResolvesToNoProfileAndNoUserId()
         {
             var query = new SqlUserDataLookupQuery();
-            var upn = $"definitely-not-a-user.{DateTime.UtcNow.Ticks}@contoso.com";
+            var upn = $"definitely-not-a-user.{Guid.NewGuid():N}@contoso.com";
 
             Assert.IsNull(await query.GetProfileAsync(upn));
             Assert.IsNull(await query.GetUserIdAsync(upn));
@@ -240,7 +240,7 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task Profile_AndUserIdLookup_ResolveTheSameUser()
         {
-            var upn = $"profilelookup.{DateTime.UtcNow.Ticks}@contoso.com";
+            var upn = $"profilelookup.{Guid.NewGuid():N}@contoso.com";
             using (var db = new AnalyticsEntitiesContext())
             {
                 try
@@ -270,13 +270,17 @@ namespace Tests.UnitTests
         private sealed class SeededUser
         {
             /// <summary>
-            /// A value unique to this test run, embedded in every row's natural key. Cleanup is driven
-            /// off these rather than off generated ids, so it still works if a save committed but the
-            /// identity value never made it back (EF commits before <c>AcceptAllChanges</c>).
+            /// A GUID unique to this test run. Every natural key below is derived from it, and cleanup
+            /// matches on those keys rather than on generated ids, so it still works if a save committed
+            /// but the identity value never made it back (EF commits before <c>AcceptAllChanges</c>).
             /// </summary>
-            public string Tag { get; set; }
+            public string Token { get; set; }
 
             public string Upn { get; set; }
+            public string OperationName { get; set; }
+            public string LookupName { get; set; }
+            public string SessionId { get; set; }
+            public string FullUrl { get; set; }
             public int UserId { get; set; }
             public User User { get; set; }
             public EventOperation Operation { get; set; }
@@ -300,12 +304,16 @@ namespace Tests.UnitTests
         /// </summary>
         private static async Task SeedUserWithDataAsync(AnalyticsEntitiesContext db, string upn, SeededUser seeded)
         {
-            var ticks = DateTime.UtcNow.Ticks;
-
-            // Recorded BEFORE the first write: cleanup keys off these, so a save that commits without
-            // handing back its identity value still gets undone.
-            seeded.Tag = "userdatalookup-" + ticks;
+            // Every natural key this run creates is derived from one GUID, recorded BEFORE the first
+            // write. A GUID rather than DateTime.Ticks: on .NET Framework the tick counter only advances
+            // about every 15.6 ms, so two fixtures starting close together could share a key - and then
+            // one's cleanup would delete the other's rows.
+            seeded.Token = Guid.NewGuid().ToString("N");
             seeded.Upn = upn;
+            seeded.OperationName = "UserDataLookupIntegrationTest " + seeded.Token;
+            seeded.LookupName = "UserDataLookupTest " + seeded.Token;
+            seeded.SessionId = "userdatalookup-" + seeded.Token;
+            seeded.FullUrl = $"https://contoso.sharepoint.com/sites/test/Καλημέρα-{seeded.Token}.pdf";
 
             var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
             db.users.Add(user);
@@ -313,7 +321,7 @@ namespace Tests.UnitTests
             seeded.User = user;
             seeded.UserId = user.ID;
 
-            var operation = new EventOperation { Name = "UserDataLookupIntegrationTest " + seeded.Tag };
+            var operation = new EventOperation { Name = seeded.OperationName };
             db.event_operations.Add(operation);
             await db.SaveChangesAsync();
             seeded.Operation = operation;
@@ -345,8 +353,8 @@ namespace Tests.UnitTests
             AddAuditChildren(db, seeded, UserDataLookupRules.CatAuditGeneral, 4, e => db.general_audit_events.Add(new GeneralEventMetada { AuditEvent = e }));
 
             // Stream events need a client application and a video: both FK columns are non-nullable.
-            var clientApp = new O365ClientApplication { Name = "UserDataLookupTest " + seeded.Tag, ClientApplicationId = Guid.NewGuid() };
-            var video = new StreamVideo { Name = "UserDataLookupTest " + seeded.Tag, StreamID = Guid.NewGuid() };
+            var clientApp = new O365ClientApplication { Name = seeded.LookupName, ClientApplicationId = Guid.NewGuid() };
+            var video = new StreamVideo { Name = seeded.LookupName, StreamID = Guid.NewGuid() };
             db.O365ClientApplications.Add(clientApp);
             db.Streams.Add(video);
             await db.SaveChangesAsync();
@@ -371,8 +379,8 @@ namespace Tests.UnitTests
 
             // --- web hits: linked to the user indirectly, hits -> sessions -> users ---
             const int hitCount = 12;
-            var url = new Url { FullUrl = $"https://contoso.sharepoint.com/sites/test/Καλημέρα-{seeded.Tag}.pdf" };
-            var session = new UserSession { user = user, ai_session_id = seeded.Tag };
+            var url = new Url { FullUrl = seeded.FullUrl };
+            var session = new UserSession { user = user, ai_session_id = seeded.SessionId };
             db.sessions.Add(session);
             for (var i = 0; i < hitCount; i++)
             {
@@ -410,7 +418,7 @@ namespace Tests.UnitTests
                     FromAddress = fromAddress,
                     SentDate = DateTime.UtcNow.AddMinutes(-i),
                     Subject = $"Καλημέρα {i}",
-                    GraphMessageId = $"{seeded.Tag}-{i}",
+                    GraphMessageId = $"{seeded.Token}-{i}",
                 });
             }
             seeded.ExpectedCounts[UserDataLookupRules.CatSentEmails] = sentEmailCount;
@@ -451,7 +459,7 @@ namespace Tests.UnitTests
         /// </summary>
         private static async Task CleanUpAsync(SeededUser seeded)
         {
-            if (seeded?.Tag == null)
+            if (seeded?.Token == null)
             {
                 // Seeding never started, so there is nothing to undo.
                 return;
@@ -493,14 +501,18 @@ namespace Tests.UnitTests
                     userId);
 
                 // The lookup rows the deleted children pointed at, now nothing references them. Matched on
-                // this run's tag rather than on captured ids, for the same reason as the user above.
+                // this run's exact natural keys - not on captured ids, and not on a substring match that
+                // could reach another fixture's rows.
                 await db.Database.ExecuteSqlCommandAsync(
-                    @"DELETE FROM dbo.urls WHERE full_url LIKE N'%' + @p0 + N'%';
-                      DELETE FROM dbo.event_operations WHERE operation_name LIKE N'%' + @p0 + N'%';
-                      DELETE FROM dbo.o365_client_applications WHERE name LIKE N'%' + @p0 + N'%';
-                      DELETE FROM dbo.stream_videos WHERE name LIKE N'%' + @p0 + N'%';
-                      DELETE FROM dbo.email_addresses WHERE address = @p1;",
-                    seeded.Tag, seeded.Upn ?? string.Empty);
+                    @"DELETE FROM dbo.urls WHERE full_url = @p0;
+                      DELETE FROM dbo.event_operations WHERE operation_name = @p1;
+                      DELETE FROM dbo.o365_client_applications WHERE name = @p2;
+                      DELETE FROM dbo.stream_videos WHERE name = @p2;
+                      DELETE FROM dbo.email_addresses WHERE address = @p3;",
+                    seeded.FullUrl ?? string.Empty,
+                    seeded.OperationName ?? string.Empty,
+                    seeded.LookupName ?? string.Empty,
+                    seeded.Upn ?? string.Empty);
 
                 var leftOver = (await db.Database.SqlQuery<int>(
                     "SELECT COUNT(*) FROM dbo.users WHERE user_name = @p0", seeded.Upn ?? string.Empty).ToListAsync()).Single();

--- a/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
@@ -139,12 +139,12 @@ namespace Tests.UnitTests
             using (var db = new AnalyticsEntitiesContext())
             {
                 var upn = $"batchkeys.{DateTime.UtcNow.Ticks}@contoso.com";
-                var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
-                db.users.Add(user);
-                await db.SaveChangesAsync();
-
                 try
                 {
+                    var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
+                    db.users.Add(user);
+                    await db.SaveChangesAsync();
+
                     var batched = await new SqlUserDataLookupQuery().GetCountsByCategoryAsync(user.ID);
 
                     CollectionAssert.AreEquivalent(
@@ -155,8 +155,7 @@ namespace Tests.UnitTests
                 }
                 finally
                 {
-                    db.users.Remove(user);
-                    await db.SaveChangesAsync();
+                    await DeleteUserByUpnAsync(db, upn);
                 }
             }
         }
@@ -173,10 +172,10 @@ namespace Tests.UnitTests
             using (var db = new AnalyticsEntitiesContext())
             {
                 var upn = $"roundtrips.{DateTime.UtcNow.Ticks}@contoso.com";
-                var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
                 CommandCountingInterceptor counter = null;
                 try
                 {
+                    var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
                     db.users.Add(user);
                     await db.SaveChangesAsync();
 
@@ -206,12 +205,11 @@ namespace Tests.UnitTests
                 finally
                 {
                     // The interceptor is process-wide, and the user row is in a database shared with the
-                    // rest of the suite: both must go even if the warm-up or an assertion threw.
+                    // rest of the suite: both must go even if the warm-up or an assertion threw. The user
+                    // is removed by UPN, not by a captured id, so a save that committed without handing
+                    // the id back is still undone.
                     if (counter != null) DbInterception.Remove(counter);
-                    if (user.ID != 0)
-                    {
-                        await db.Database.ExecuteSqlCommandAsync("DELETE FROM dbo.users WHERE id = @p0", user.ID);
-                    }
+                    await DeleteUserByUpnAsync(db, upn);
                 }
             }
         }
@@ -245,12 +243,12 @@ namespace Tests.UnitTests
             var upn = $"profilelookup.{DateTime.UtcNow.Ticks}@contoso.com";
             using (var db = new AnalyticsEntitiesContext())
             {
-                var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
-                db.users.Add(user);
-                await db.SaveChangesAsync();
-
                 try
                 {
+                    var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
+                    db.users.Add(user);
+                    await db.SaveChangesAsync();
+
                     var query = new SqlUserDataLookupQuery();
 
                     var profile = await query.GetProfileAsync(upn);
@@ -262,8 +260,7 @@ namespace Tests.UnitTests
                 }
                 finally
                 {
-                    db.users.Remove(user);
-                    await db.SaveChangesAsync();
+                    await DeleteUserByUpnAsync(db, upn);
                 }
             }
         }
@@ -272,13 +269,20 @@ namespace Tests.UnitTests
 
         private sealed class SeededUser
         {
+            /// <summary>
+            /// A value unique to this test run, embedded in every row's natural key. Cleanup is driven
+            /// off these rather than off generated ids, so it still works if a save committed but the
+            /// identity value never made it back (EF commits before <c>AcceptAllChanges</c>).
+            /// </summary>
+            public string Tag { get; set; }
+
+            public string Upn { get; set; }
             public int UserId { get; set; }
             public User User { get; set; }
             public EventOperation Operation { get; set; }
             public O365ClientApplication ClientApp { get; set; }
             public StreamVideo Video { get; set; }
             public EmailAddress FromAddress { get; set; }
-            public int UrlId { get; set; }
             public List<CommonAuditEvent> AuditEvents { get; } = new List<CommonAuditEvent>();
 
             /// <summary>The row count deliberately given to each category, all different from each other.</summary>
@@ -298,13 +302,18 @@ namespace Tests.UnitTests
         {
             var ticks = DateTime.UtcNow.Ticks;
 
+            // Recorded BEFORE the first write: cleanup keys off these, so a save that commits without
+            // handing back its identity value still gets undone.
+            seeded.Tag = "userdatalookup-" + ticks;
+            seeded.Upn = upn;
+
             var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
             db.users.Add(user);
             await db.SaveChangesAsync();
             seeded.User = user;
             seeded.UserId = user.ID;
 
-            var operation = new EventOperation { Name = "UserDataLookupIntegrationTest " + ticks };
+            var operation = new EventOperation { Name = "UserDataLookupIntegrationTest " + seeded.Tag };
             db.event_operations.Add(operation);
             await db.SaveChangesAsync();
             seeded.Operation = operation;
@@ -336,8 +345,8 @@ namespace Tests.UnitTests
             AddAuditChildren(db, seeded, UserDataLookupRules.CatAuditGeneral, 4, e => db.general_audit_events.Add(new GeneralEventMetada { AuditEvent = e }));
 
             // Stream events need a client application and a video: both FK columns are non-nullable.
-            var clientApp = new O365ClientApplication { Name = "UserDataLookupTest " + ticks, ClientApplicationId = Guid.NewGuid() };
-            var video = new StreamVideo { Name = "UserDataLookupTest " + ticks, StreamID = Guid.NewGuid() };
+            var clientApp = new O365ClientApplication { Name = "UserDataLookupTest " + seeded.Tag, ClientApplicationId = Guid.NewGuid() };
+            var video = new StreamVideo { Name = "UserDataLookupTest " + seeded.Tag, StreamID = Guid.NewGuid() };
             db.O365ClientApplications.Add(clientApp);
             db.Streams.Add(video);
             await db.SaveChangesAsync();
@@ -362,8 +371,8 @@ namespace Tests.UnitTests
 
             // --- web hits: linked to the user indirectly, hits -> sessions -> users ---
             const int hitCount = 12;
-            var url = new Url { FullUrl = $"https://contoso.sharepoint.com/sites/test/Καλημέρα-{ticks}.pdf" };
-            var session = new UserSession { user = user, ai_session_id = "userdatalookup-" + ticks };
+            var url = new Url { FullUrl = $"https://contoso.sharepoint.com/sites/test/Καλημέρα-{seeded.Tag}.pdf" };
+            var session = new UserSession { user = user, ai_session_id = seeded.Tag };
             db.sessions.Add(session);
             for (var i = 0; i < hitCount; i++)
             {
@@ -377,7 +386,6 @@ namespace Tests.UnitTests
             }
             seeded.ExpectedCounts[UserDataLookupRules.CatWebHits] = hitCount;
             await db.SaveChangesAsync();
-            seeded.UrlId = url.ID;
 
             // --- the daily usage-report logs: direct FK, one distinct count each ---
             AddUsageDays(db, seeded, UserDataLookupRules.CatUsageOutlook, 15, (u, d) => db.OutlookUsageActivityLogs.Add(new OutlookUsageActivityLog { User = u, Date = d }));
@@ -402,7 +410,7 @@ namespace Tests.UnitTests
                     FromAddress = fromAddress,
                     SentDate = DateTime.UtcNow.AddMinutes(-i),
                     Subject = $"Καλημέρα {i}",
-                    GraphMessageId = $"userdatalookup-{ticks}-{i}",
+                    GraphMessageId = $"{seeded.Tag}-{i}",
                 });
             }
             seeded.ExpectedCounts[UserDataLookupRules.CatSentEmails] = sentEmailCount;
@@ -443,15 +451,19 @@ namespace Tests.UnitTests
         /// </summary>
         private static async Task CleanUpAsync(SeededUser seeded)
         {
-            if (seeded == null || seeded.UserId == 0)
+            if (seeded?.Tag == null)
             {
-                // Nothing was committed (or the user insert itself failed), so there is nothing to undo.
+                // Seeding never started, so there is nothing to undo.
                 return;
             }
 
             using (var db = new AnalyticsEntitiesContext())
             {
-                var userId = seeded.UserId;
+                // Resolve the user from its UPN rather than trusting the captured identity value: EF
+                // commits before it hands the id back, so a failure in between would leave UserId at 0
+                // with the row already in the database.
+                var userId = (await db.Database.SqlQuery<int>(
+                    "SELECT ISNULL((SELECT TOP 1 id FROM dbo.users WHERE user_name = @p0), 0)", seeded.Upn).ToListAsync()).Single();
 
                 // Children of audit_events and of the user, before their parents.
                 await db.Database.ExecuteSqlCommandAsync(
@@ -480,24 +492,30 @@ namespace Tests.UnitTests
                       DELETE FROM dbo.users WHERE id = @p0;",
                     userId);
 
-                // The lookup rows the deleted children pointed at, now nothing references them. Each id is
-                // 0 when seeding never got that far, and no row has id 0, so the DELETE is simply a no-op.
+                // The lookup rows the deleted children pointed at, now nothing references them. Matched on
+                // this run's tag rather than on captured ids, for the same reason as the user above.
                 await db.Database.ExecuteSqlCommandAsync(
-                    @"DELETE FROM dbo.urls WHERE id = @p0;
-                      DELETE FROM dbo.event_operations WHERE id = @p1;
-                      DELETE FROM dbo.o365_client_applications WHERE id = @p2;
-                      DELETE FROM dbo.stream_videos WHERE id = @p3;
-                      DELETE FROM dbo.email_addresses WHERE id = @p4;",
-                    seeded.UrlId,
-                    seeded.Operation?.ID ?? 0,
-                    seeded.ClientApp?.ID ?? 0,
-                    seeded.Video?.ID ?? 0,
-                    seeded.FromAddress?.ID ?? 0);
+                    @"DELETE FROM dbo.urls WHERE full_url LIKE N'%' + @p0 + N'%';
+                      DELETE FROM dbo.event_operations WHERE operation_name LIKE N'%' + @p0 + N'%';
+                      DELETE FROM dbo.o365_client_applications WHERE name LIKE N'%' + @p0 + N'%';
+                      DELETE FROM dbo.stream_videos WHERE name LIKE N'%' + @p0 + N'%';
+                      DELETE FROM dbo.email_addresses WHERE address = @p1;",
+                    seeded.Tag, seeded.Upn ?? string.Empty);
 
                 var leftOver = (await db.Database.SqlQuery<int>(
-                    "SELECT COUNT(*) FROM dbo.users WHERE id = @p0", userId).ToListAsync()).Single();
+                    "SELECT COUNT(*) FROM dbo.users WHERE user_name = @p0", seeded.Upn ?? string.Empty).ToListAsync()).Single();
                 Assert.AreEqual(0, leftOver, "the test user should have been removed - later tests share this database");
             }
+        }
+
+        /// <summary>
+        /// Removes a user by its UPN, which is unique per test run. Deliberately not by a captured
+        /// identity value: EF commits before it returns the generated id, so a failure in between would
+        /// leave the row behind in a database the whole suite shares.
+        /// </summary>
+        private static Task DeleteUserByUpnAsync(AnalyticsEntitiesContext db, string upn)
+        {
+            return db.Database.ExecuteSqlCommandAsync("DELETE FROM dbo.users WHERE user_name = @p0", upn ?? string.Empty);
         }
 
         #endregion

--- a/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
@@ -43,9 +43,9 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task BatchedCounts_MatchThePerCategoryCounts_ForEveryCategory()
         {
-            // Deliberately ASCII: dbo.users.user_name is still varchar(250), so a non-Latin UPN is
-            // stored mangled (issue #402). The seeded URL below is Unicode, because urls.full_url IS
-            // nvarchar and must round-trip.
+            // The seeded URL below is Unicode because urls.full_url is nvarchar and genuinely carries
+            // non-Latin SharePoint paths. The UPN is ASCII because Entra restricts userPrincipalName to
+            // A-Z a-z 0-9 ' . - _ ! # ^ ~ - a non-Latin UPN is not a case this pipeline can receive.
             var upn = $"userdatalookup.{Guid.NewGuid():N}@contoso.com";
 
             using (var db = new AnalyticsEntitiesContext())
@@ -230,12 +230,11 @@ namespace Tests.UnitTests
         /// data.
         /// </summary>
         /// <remarks>
-        /// This deliberately uses an ASCII UPN. A non-Latin UPN cannot be asserted here yet:
-        /// <c>dbo.users.user_name</c> is still <c>varchar(250)</c> on the default CP1 collation, so a
-        /// Greek UPN is written to the database as <c>?a??µ??a...</c> and never matches on read. That is
-        /// a pre-existing schema bug, filed as issue #402 - fixing it needs a migration, which #381
-        /// rules out. The service-level Unicode guarantee is covered without a database in
-        /// <c>UserDataLookupServiceTests.Summary_UpnWithNonAsciiCharacters_IsMatchedAndEmittedVerbatim</c>.
+        /// The UPN here is ASCII because that is all Entra can issue: <c>userPrincipalName</c> is
+        /// restricted to <c>A-Z a-z 0-9 ' . - _ ! # ^ ~</c> with accented characters disallowed, so a
+        /// non-Latin UPN is not a real tenant case. That the service does not itself re-encode whatever
+        /// string it is given is covered without a database in
+        /// <c>UserDataLookupServiceTests.Summary_UpnIsPassedThroughWithoutReEncoding</c>.
         /// </remarks>
         [TestMethod]
         public async Task Profile_AndUserIdLookup_ResolveTheSameUser()

--- a/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserDataLookupSqlIntegrationTests.cs
@@ -50,9 +50,13 @@ namespace Tests.UnitTests
 
             using (var db = new AnalyticsEntitiesContext())
             {
-                var seeded = await SeedUserWithDataAsync(db, upn);
+                // The seed state is created BEFORE the first write and cleanup is armed immediately, so a
+                // failure part-way through seeding still removes whatever it managed to commit - this
+                // database is shared with the rest of the suite.
+                var seeded = new SeededUser();
                 try
                 {
+                    await SeedUserWithDataAsync(db, upn, seeded);
                     var query = new SqlUserDataLookupQuery();
 
                     var batched = await query.GetCountsByCategoryAsync(seeded.UserId);
@@ -73,9 +77,18 @@ namespace Tests.UnitTests
                             $"'{expected.Key}' reported the wrong number - its subquery or dictionary entry is counting something else");
                     }
 
-                    var seededCounts = seeded.ExpectedCounts.Values.ToList();
-                    CollectionAssert.AllItemsAreUnique(seededCounts, "the seeded counts must all differ, or a crossed mapping could still pass");
-                    Assert.AreEqual(21, seededCounts.Count,
+                    CollectionAssert.AllItemsAreUnique(seeded.ExpectedCounts.Values.ToList(),
+                        "the seeded counts must all differ, or a crossed mapping could still pass");
+
+                    // Assert against what the DATABASE actually returned, not the fixture's own
+                    // bookkeeping: exactly the seeded categories carry data and the rest really are zero.
+                    // This is what makes the class comment's "21 of 30" claim checkable.
+                    var nonZero = batched.Where(c => c.Value != 0).Select(c => c.Key).OrderBy(k => k).ToList();
+                    CollectionAssert.AreEqual(
+                        seeded.ExpectedCounts.Keys.OrderBy(k => k).ToList(),
+                        nonZero,
+                        "the categories reporting data are not the ones that were seeded");
+                    Assert.AreEqual(21, nonZero.Count,
                         "the class comment says 21 of the 30 categories carry data; keep it honest if that changes");
                 }
                 finally
@@ -98,9 +111,10 @@ namespace Tests.UnitTests
 
             using (var db = new AnalyticsEntitiesContext())
             {
-                var seeded = await SeedUserWithDataAsync(db, upn);
+                var seeded = new SeededUser();
                 try
                 {
+                    await SeedUserWithDataAsync(db, upn, seeded);
                     var batched = await new SqlUserDataLookupQuery().GetCountsByCategoryAsync(seeded.UserId);
 
                     foreach (var meta in UserDataLookupRules.Categories)
@@ -160,18 +174,20 @@ namespace Tests.UnitTests
             {
                 var upn = $"roundtrips.{DateTime.UtcNow.Ticks}@contoso.com";
                 var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
-                db.users.Add(user);
-                await db.SaveChangesAsync();
-
-                var query = new SqlUserDataLookupQuery();
-
-                // Warm up first: the very first context in a run can issue its own schema commands.
-                await query.GetUserIdAsync(upn);
-
-                var counter = new CommandCountingInterceptor();
-                DbInterception.Add(counter);
+                CommandCountingInterceptor counter = null;
                 try
                 {
+                    db.users.Add(user);
+                    await db.SaveChangesAsync();
+
+                    var query = new SqlUserDataLookupQuery();
+
+                    // Warm up first: the very first context in a run can issue its own schema commands.
+                    await query.GetUserIdAsync(upn);
+
+                    counter = new CommandCountingInterceptor();
+                    DbInterception.Add(counter);
+
                     counter.Reset();
                     await query.GetCountsByCategoryAsync(user.ID);
                     var batchedCommands = counter.Count;
@@ -189,9 +205,13 @@ namespace Tests.UnitTests
                 }
                 finally
                 {
-                    DbInterception.Remove(counter);
-                    db.users.Remove(user);
-                    await db.SaveChangesAsync();
+                    // The interceptor is process-wide, and the user row is in a database shared with the
+                    // rest of the suite: both must go even if the warm-up or an assertion threw.
+                    if (counter != null) DbInterception.Remove(counter);
+                    if (user.ID != 0)
+                    {
+                        await db.Database.ExecuteSqlCommandAsync("DELETE FROM dbo.users WHERE id = @p0", user.ID);
+                    }
                 }
             }
         }
@@ -274,10 +294,9 @@ namespace Tests.UnitTests
         ///
         /// See the class comment for which nine categories are deliberately left at zero.
         /// </summary>
-        private static async Task<SeededUser> SeedUserWithDataAsync(AnalyticsEntitiesContext db, string upn)
+        private static async Task SeedUserWithDataAsync(AnalyticsEntitiesContext db, string upn, SeededUser seeded)
         {
             var ticks = DateTime.UtcNow.Ticks;
-            var seeded = new SeededUser();
 
             var user = new User { UserPrincipalName = upn, AzureAdId = Guid.NewGuid().ToString() };
             db.users.Add(user);
@@ -389,7 +408,6 @@ namespace Tests.UnitTests
             seeded.ExpectedCounts[UserDataLookupRules.CatSentEmails] = sentEmailCount;
 
             await db.SaveChangesAsync();
-            return seeded;
         }
 
         /// <summary>Adds <paramref name="count"/> rows hanging off distinct audit events (they are keyed or uniquely indexed by event_id).</summary>
@@ -416,12 +434,21 @@ namespace Tests.UnitTests
         /// Removes everything the test added. These tests share the unit-test database with the rest of
         /// the suite, so leaving audit events or hits behind would skew anything that counts them.
         ///
+        /// Tolerates partial state: it is armed before the first write, so it may be called when seeding
+        /// failed half way and only some of the ids were assigned.
+        ///
         /// Runs entirely as raw SQL on a <b>fresh</b> context: the seeding context still tracks all the
         /// rows, and deleting a parent out from under a tracked child makes EF try to null a
         /// non-nullable foreign key on the next <c>SaveChanges</c>.
         /// </summary>
         private static async Task CleanUpAsync(SeededUser seeded)
         {
+            if (seeded == null || seeded.UserId == 0)
+            {
+                // Nothing was committed (or the user insert itself failed), so there is nothing to undo.
+                return;
+            }
+
             using (var db = new AnalyticsEntitiesContext())
             {
                 var userId = seeded.UserId;
@@ -453,14 +480,19 @@ namespace Tests.UnitTests
                       DELETE FROM dbo.users WHERE id = @p0;",
                     userId);
 
-                // The lookup rows the deleted children pointed at, now nothing references them.
+                // The lookup rows the deleted children pointed at, now nothing references them. Each id is
+                // 0 when seeding never got that far, and no row has id 0, so the DELETE is simply a no-op.
                 await db.Database.ExecuteSqlCommandAsync(
                     @"DELETE FROM dbo.urls WHERE id = @p0;
                       DELETE FROM dbo.event_operations WHERE id = @p1;
                       DELETE FROM dbo.o365_client_applications WHERE id = @p2;
                       DELETE FROM dbo.stream_videos WHERE id = @p3;
                       DELETE FROM dbo.email_addresses WHERE id = @p4;",
-                    seeded.UrlId, seeded.Operation.ID, seeded.ClientApp.ID, seeded.Video.ID, seeded.FromAddress.ID);
+                    seeded.UrlId,
+                    seeded.Operation?.ID ?? 0,
+                    seeded.ClientApp?.ID ?? 0,
+                    seeded.Video?.ID ?? 0,
+                    seeded.FromAddress?.ID ?? 0);
 
                 var leftOver = (await db.Database.SqlQuery<int>(
                     "SELECT COUNT(*) FROM dbo.users WHERE id = @p0", userId).ToListAsync()).Single();


### PR DESCRIPTION
Test-only follow-up to #405 (issue #379). Review round 2 finished after #405 merged, so these two
findings ship separately. **No production code changes** — `git diff` touches one test file.

## Why

Round 2 (claude-opus-4.8, gpt-5.6-sol, grok-4.6) returned two findings against the integration
fixture added in #405. Both are about the fixture rather than the extraction, but both matter because
`UserDataLookupSqlIntegrationTests` writes to the **unit-test database shared with the whole suite**.

## 1. Committed rows could leak when setup failed

`SeedUserWithDataAsync` was called *outside* the `try`/`finally` that arms cleanup, and it commits
incrementally as it walks ~20 tables. Any failure part-way through — a transient deadlock, or a
constraint we have not met yet — left everything committed so far in the database. Leaked
`audit_events` / `hits` rows would skew any other test that counts them, and the failure would look
like it came from the *other* test.

Fix: the seed-state object is created before the first write and passed in, so cleanup is armed
before anything is committed. `CleanUpAsync` now tolerates partial state — it returns early when no
user row was created, and the lookup-row deletes use `?.ID ?? 0` (no row has id 0, so a step that was
never reached is simply a no-op).

`BatchedCounts_AreOneCommand_WherePerCategoryCountsAreOneEach` had the same shape — it committed its
user and ran the warm-up query before entering the `try` — and additionally registered a
**process-wide** `DbInterception` interceptor that would have been left installed for the rest of the
run if the warm-up threw. Both are now inside the guarded region, and the interceptor is removed only
if it was registered.

## 2. "Exactly 21 categories carry data" was checked against the fixture, not the database

`Assert.AreEqual(21, seededCounts.Count)` counted entries in the fixture's own `ExpectedCounts`
dictionary. That proves a property of the test, not of the query: a category could carry data while
the class comment and #405's description both said it was empty, and every assertion would still
pass. The all-category loop only asserts `batched == per-category`, so it never pinned the unseeded
categories at zero either.

It now asserts **set equality** between the seeded keys and the categories the database actually
returned a non-zero count for. That is what makes the "21 of 30 seeded, the other nine are zero"
claim checkable, and it keeps the class comment honest if the fixture grows.

Verified in both directions: recording a category in `ExpectedCounts` without seeding it makes the
test fail with `Assert.AreEqual failed. Expected:<99>. Actual:<0>. 'page-likes' reported the wrong
number`.

## Round 2 outcome

- **grok-4.6** — clean, no findings.
- **claude-opus-4.8** — *"No significant issues found"*; independently re-verified the three round-1
  fixes against the pre-extraction baseline, confirmed each regression test genuinely fails against
  the pre-fix code, and checked every claim in #405's body. It noted the seeding-outside-`try` gap as
  below its reporting bar; this PR closes it anyway.
- **gpt-5.6-sol** — the two findings above, plus the "no new SQL string" wording, which was corrected
  in #405's description while the round was running (it is accurate as scoped to the production path;
  the test cleanup does add raw `DELETE` SQL, and the description now says so).

## Validation

Full solution builds clean (0 warnings, 0 errors). **219 passed / 0 failed** across the new lookup and
health tests plus the pre-existing `HealthRollupTests`, `ReportsAPIControllerTests`,
`CopilotAdoption*`, `UserDataLookupTests`, `UpdateCheck*` and `AppConfigDefaultsTests`.



## Round 3 — cleanup now keys off natural keys, not generated ids

A further review round found the fixture still recovered state captured **after** the commit it has to
undo. EF6 commits inside `SaveChangesToStoreAsync` *before* calling `AcceptAllChanges`, and this
solution configures `SqlAzureExecutionStrategy`, so a transient failure in that window commits the row
but never hands back its identity value — leaving cleanup with `UserId == 0` and the row still in the
shared database.

Every seeded row now embeds a per-run tag recorded **before the first write**, and cleanup matches on
that tag and on the UPN instead of on any generated id: the user by `user_name`; `urls`,
`event_operations`, `o365_client_applications` and `stream_videos` by the tag in their
`full_url` / `operation_name` / `name`; `email_addresses` by `address`. The three smaller tests now
create their user inside the guarded region and remove it through a shared `DeleteUserByUpnAsync`.

**Verified empirically rather than by inspection.** Earlier iterations of this fixture had in fact
leaked into the CC5 unit-test database:

| Table | Leaked rows |
|---|---|
| `users` | 6 |
| `urls` | 3 |
| `event_operations` | 14 |
| `o365_client_applications` | 10 |
| `stream_videos` | 10 |
| `email_addresses` | 8 |

After clearing those and re-running the suite, every one of those counts — plus orphaned
`audit_events` — is **0**.

That round also caught a wrong column name the natural-key deletes exposed
(`event_operations.operation_name`, not `name`), which only a real run would have found.

Addresses #379
