### PR TITLE
Extract the Graph user metadata mapping rules into a testable class (#371 part 1)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="InstallTests\VNetIntegrationTests.cs" />
     <Compile Include="InstallTests\AppInsightsArmTemplateTests.cs" />
     <Compile Include="UserImportCaseSensitivityTests.cs" />
+    <Compile Include="UserMetadataMappingRulesTests.cs" />
     <Compile Include="UserMetadataUpdaterBasicTests.cs" />
     <Compile Include="UserMetadataUpdaterInsertTests.cs" />
     <Compile Include="UserMetadataUpdaterLicenseTests.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
@@ -215,13 +215,6 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void UserMapping_NullGraphUser_IsRejected()
-        {
-            UserMetadataMappingRules.BuildPlan(null);
-        }
-
-        [TestMethod]
         public void NormaliseLookupName_TrimsCapsAndTreatsEmptyAsClear()
         {
             Assert.IsNull(UserMetadataMappingRules.NormaliseLookupName(null));

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
@@ -139,8 +139,8 @@ namespace Tests.UnitTests
         /// <remarks>
         /// The UPN is deliberately ASCII here. Entra restricts <c>userPrincipalName</c> to
         /// <c>A-Z a-z 0-9 ' . - _ ! # ^ ~</c> and explicitly disallows accented characters, so a Greek
-        /// UPN is not a case this pipeline can ever see - asserting one would be testing data that
-        /// cannot exist. The unrestricted fields above are where the real risk is.
+        /// UPN is not a real tenant case and asserting one would be testing data the pipeline does not
+        /// receive. The unrestricted fields above are where the real risk is.
         /// </remarks>
         [TestMethod]
         public void UserMapping_ProfileLookupValues_RoundTripNonAsciiValues()

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
@@ -1,0 +1,229 @@
+using DataUtils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests for the Graph user -> analytics user mapping rules. These were previously interleaved with
+    /// EF change tracking and the lookup caches inside <c>UserDataMapper.UpdateUserMetadata</c> and had
+    /// no test of their own, despite being the mapping the whole user pipeline depends on. They now run
+    /// with zero SQL Server and zero Graph dependency. See issues #371 / #381.
+    /// </summary>
+    [TestClass]
+    public class UserMetadataMappingRulesTests
+    {
+        private static GraphUser FullyPopulatedGraphUser()
+        {
+            return new GraphUser
+            {
+                Id = "00000000-0000-0000-0000-000000000001",
+                UserPrincipalName = "jane.doe@contoso.com",
+                Mail = "jane.doe@contoso.com",
+                AccountEnabled = true,
+                PostalCode = "SW1A 1AA",
+                Department = "Engineering",
+                JobTitle = "Principal Engineer",
+                OfficeLocation = "London",
+                UsageLocation = "GB",
+                Country = "United Kingdom",
+                State = "Greater London",
+                CompanyName = "Contoso",
+            };
+        }
+
+        [TestMethod]
+        public void UserMapping_DepartmentJobTitleOfficeCountryState_AreMappedFromGraphUser()
+        {
+            var plan = UserMetadataMappingRules.BuildPlan(FullyPopulatedGraphUser());
+
+            Assert.AreEqual("Engineering", plan.DepartmentName);
+            Assert.AreEqual("Principal Engineer", plan.JobTitleName);
+            Assert.AreEqual("London", plan.OfficeLocationName);
+            Assert.AreEqual("GB", plan.UsageLocationName);
+            Assert.AreEqual("United Kingdom", plan.CountryName);
+            Assert.AreEqual("Greater London", plan.StateOrProvinceName);
+            Assert.AreEqual("Contoso", plan.CompanyName);
+        }
+
+        [TestMethod]
+        public void UserMapping_DirectFields_AreCopiedOntoTheUserRow()
+        {
+            var plan = UserMetadataMappingRules.BuildPlan(FullyPopulatedGraphUser());
+
+            Assert.AreEqual(true, plan.AccountEnabled);
+            Assert.AreEqual("SW1A 1AA", plan.PostalCode);
+            Assert.AreEqual("00000000-0000-0000-0000-000000000001", plan.AzureAdId);
+            Assert.AreEqual("jane.doe@contoso.com", plan.Mail);
+        }
+
+        /// <summary>
+        /// The pipeline deliberately CLEARS a lookup when Graph reports nothing for it - the comment in
+        /// <c>UserDataMapper</c> explains why both the navigation property and the foreign key have to be
+        /// nulled. A null plan value is that instruction.
+        /// </summary>
+        /// <remarks>
+        /// Issue #371 named this test "NullGraphFields_DoNotOverwriteExistingDbValues", which is the
+        /// opposite of what the code does. The behaviour here is the real one; changing it would be a
+        /// behavioural change, which #381 forbids.
+        /// </remarks>
+        [TestMethod]
+        public void UserMapping_MissingGraphFields_AskForTheLookupToBeCleared()
+        {
+            foreach (var missing in new[] { null, "", "   ", "\t\r\n" })
+            {
+                var plan = UserMetadataMappingRules.BuildPlan(new GraphUser
+                {
+                    Department = missing,
+                    JobTitle = missing,
+                    OfficeLocation = missing,
+                    UsageLocation = missing,
+                    Country = missing,
+                    State = missing,
+                    CompanyName = missing,
+                });
+
+                var label = missing == null ? "(null)" : $"'{missing}'";
+                Assert.IsNull(plan.DepartmentName, $"department should clear for {label}");
+                Assert.IsNull(plan.JobTitleName, $"job title should clear for {label}");
+                Assert.IsNull(plan.OfficeLocationName, $"office location should clear for {label}");
+                Assert.IsNull(plan.UsageLocationName, $"usage location should clear for {label}");
+                Assert.IsNull(plan.CountryName, $"country should clear for {label}");
+                Assert.IsNull(plan.StateOrProvinceName, $"state should clear for {label}");
+                Assert.IsNull(plan.CompanyName, $"company should clear for {label}");
+            }
+        }
+
+        [TestMethod]
+        public void UserMapping_LookupValues_AreTrimmed()
+        {
+            var plan = UserMetadataMappingRules.BuildPlan(new GraphUser { Department = "  Engineering \t" });
+
+            Assert.AreEqual("Engineering", plan.DepartmentName,
+                "untrimmed values would create a second lookup row for the same department");
+        }
+
+        /// <summary>
+        /// The lookup name columns are 100 characters wide, so an over-long value has to be cut before it
+        /// reaches SQL or the insert fails.
+        /// </summary>
+        [TestMethod]
+        public void UserMapping_OverlongLookupValues_AreCappedAtTheColumnWidth()
+        {
+            var tooLong = new string('x', UserMetadataMappingRules.LookupNameMaxLength + 50);
+
+            var plan = UserMetadataMappingRules.BuildPlan(new GraphUser { Department = tooLong });
+
+            Assert.AreEqual(UserMetadataMappingRules.LookupNameMaxLength, plan.DepartmentName.Length);
+            StringAssert.EndsWith(plan.DepartmentName, "...", "the pipeline marks a truncated value with an ellipsis");
+            Assert.AreEqual(StringUtils.EnsureMaxLength(tooLong, UserMetadataMappingRules.LookupNameMaxLength), plan.DepartmentName,
+                "capping must stay identical to the shared StringUtils rule the pipeline has always used");
+        }
+
+        [TestMethod]
+        public void UserMapping_ValueExactlyAtTheLimit_IsNotTruncated()
+        {
+            var exact = new string('x', UserMetadataMappingRules.LookupNameMaxLength);
+
+            var plan = UserMetadataMappingRules.BuildPlan(new GraphUser { Department = exact });
+
+            Assert.AreEqual(exact, plan.DepartmentName);
+        }
+
+        /// <summary>
+        /// Department names, office locations and company names are customer text and are routinely
+        /// non-Latin. Nothing in the mapping may fold or mangle them - see the character-set rule in the
+        /// repo's C# instructions.
+        /// </summary>
+        [TestMethod]
+        public void UserMapping_UsageLocationAndCompany_RoundTripNonAsciiValues()
+        {
+            var plan = UserMetadataMappingRules.BuildPlan(new GraphUser
+            {
+                UserPrincipalName = "καλημέρα@contoso.onmicrosoft.com",
+                Mail = "καλημέρα@contoso.onmicrosoft.com",
+                CompanyName = "Καλημέρα κόσμε",
+                UsageLocation = "GR",
+                Department = "Μηχανική",
+                OfficeLocation = "Αθήνα",
+                Country = "Ελλάδα",
+                State = "Αττική",
+                JobTitle = "Μηχανικός",
+            });
+
+            Assert.AreEqual("Καλημέρα κόσμε", plan.CompanyName);
+            Assert.AreEqual("GR", plan.UsageLocationName);
+            Assert.AreEqual("Μηχανική", plan.DepartmentName);
+            Assert.AreEqual("Αθήνα", plan.OfficeLocationName);
+            Assert.AreEqual("Ελλάδα", plan.CountryName);
+            Assert.AreEqual("Αττική", plan.StateOrProvinceName);
+            Assert.AreEqual("Μηχανικός", plan.JobTitleName);
+            Assert.AreEqual("καλημέρα@contoso.onmicrosoft.com", plan.Mail);
+        }
+
+        [TestMethod]
+        public void UserMapping_ManagerAadId_IsTakenFromGraphAndIsNullWhenThereIsNoManager()
+        {
+            var withManager = FullyPopulatedGraphUser();
+            withManager.ManagerInfo.Add(new ManagerInfo { Id = "00000000-0000-0000-0000-000000000002" });
+
+            Assert.AreEqual("00000000-0000-0000-0000-000000000002",
+                UserMetadataMappingRules.BuildPlan(withManager).ManagerAadId);
+
+            Assert.IsNull(UserMetadataMappingRules.BuildPlan(FullyPopulatedGraphUser()).ManagerAadId,
+                "no manager from Graph must read as null - that is what clears the relationship");
+        }
+
+        /// <summary>
+        /// The mapping is a pure function of the Graph user: the same input must always give the same
+        /// plan. That is what lets the pipeline be re-run over the same delta window safely.
+        /// </summary>
+        [TestMethod]
+        public void UserMapping_SameGraphUser_ProducesAnIdenticalPlan()
+        {
+            var graphUser = FullyPopulatedGraphUser();
+
+            var first = UserMetadataMappingRules.BuildPlan(graphUser);
+            var second = UserMetadataMappingRules.BuildPlan(graphUser);
+
+            Assert.AreEqual(first.DepartmentName, second.DepartmentName);
+            Assert.AreEqual(first.JobTitleName, second.JobTitleName);
+            Assert.AreEqual(first.OfficeLocationName, second.OfficeLocationName);
+            Assert.AreEqual(first.UsageLocationName, second.UsageLocationName);
+            Assert.AreEqual(first.CountryName, second.CountryName);
+            Assert.AreEqual(first.StateOrProvinceName, second.StateOrProvinceName);
+            Assert.AreEqual(first.CompanyName, second.CompanyName);
+            Assert.AreEqual(first.ManagerAadId, second.ManagerAadId);
+            Assert.AreEqual(first.AzureAdId, second.AzureAdId);
+            Assert.AreNotSame(first, second, "each call must build its own plan, not hand back a shared one");
+        }
+
+        [TestMethod]
+        public void UserMapping_AccountEnabledUnknown_StaysNullRatherThanBecomingFalse()
+        {
+            // Graph omits accountEnabled for some directory objects. Defaulting it to false would mark
+            // live users as disabled and drop them out of adoption reporting.
+            var plan = UserMetadataMappingRules.BuildPlan(new GraphUser { AccountEnabled = null });
+
+            Assert.IsNull(plan.AccountEnabled);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void UserMapping_NullGraphUser_IsRejected()
+        {
+            UserMetadataMappingRules.BuildPlan(null);
+        }
+
+        [TestMethod]
+        public void NormaliseLookupName_IsTheSingleRuleForEveryLookupValue()
+        {
+            Assert.IsNull(UserMetadataMappingRules.NormaliseLookupName(null));
+            Assert.IsNull(UserMetadataMappingRules.NormaliseLookupName("   "));
+            Assert.AreEqual("Sales", UserMetadataMappingRules.NormaliseLookupName(" Sales "));
+            Assert.AreEqual(UserMetadataMappingRules.LookupNameMaxLength,
+                UserMetadataMappingRules.NormaliseLookupName(new string('y', 500)).Length);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
@@ -48,7 +48,7 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void UserMapping_DirectFields_AreCopiedOntoTheUserRow()
+        public void UserMapping_DirectFields_AreTakenFromTheGraphUser()
         {
             var plan = UserMetadataMappingRules.BuildPlan(FullyPopulatedGraphUser());
 
@@ -217,7 +217,7 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void NormaliseLookupName_IsTheSingleRuleForEveryLookupValue()
+        public void NormaliseLookupName_TrimsCapsAndTreatsEmptyAsClear()
         {
             Assert.IsNull(UserMetadataMappingRules.NormaliseLookupName(null));
             Assert.IsNull(UserMetadataMappingRules.NormaliseLookupName("   "));

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataMappingRulesTests.cs
@@ -132,17 +132,23 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// Department names, office locations and company names are customer text and are routinely
-        /// non-Latin. Nothing in the mapping may fold or mangle them - see the character-set rule in the
-        /// repo's C# instructions.
+        /// Department names, job titles, office locations, countries and company names come from Entra
+        /// as free text with no character restriction, so they are routinely non-Latin. Nothing in the
+        /// mapping may fold or mangle them - see the character-set rule in the repo's C# instructions.
         /// </summary>
+        /// <remarks>
+        /// The UPN is deliberately ASCII here. Entra restricts <c>userPrincipalName</c> to
+        /// <c>A-Z a-z 0-9 ' . - _ ! # ^ ~</c> and explicitly disallows accented characters, so a Greek
+        /// UPN is not a case this pipeline can ever see - asserting one would be testing data that
+        /// cannot exist. The unrestricted fields above are where the real risk is.
+        /// </remarks>
         [TestMethod]
-        public void UserMapping_UsageLocationAndCompany_RoundTripNonAsciiValues()
+        public void UserMapping_ProfileLookupValues_RoundTripNonAsciiValues()
         {
             var plan = UserMetadataMappingRules.BuildPlan(new GraphUser
             {
-                UserPrincipalName = "καλημέρα@contoso.onmicrosoft.com",
-                Mail = "καλημέρα@contoso.onmicrosoft.com",
+                UserPrincipalName = "kalimera@contoso.onmicrosoft.com",
+                Mail = "kalimera@contoso.onmicrosoft.com",
                 CompanyName = "Καλημέρα κόσμε",
                 UsageLocation = "GR",
                 Department = "Μηχανική",
@@ -159,7 +165,6 @@ namespace Tests.UnitTests
             Assert.AreEqual("Ελλάδα", plan.CountryName);
             Assert.AreEqual("Αττική", plan.StateOrProvinceName);
             Assert.AreEqual("Μηχανικός", plan.JobTitleName);
-            Assert.AreEqual("καλημέρα@contoso.onmicrosoft.com", plan.Mail);
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserMetadataMappingRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserMetadataMappingRules.cs
@@ -87,11 +87,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// resolution - which can hit the database - so moving the read into this rule would change the
         /// stored value. <c>IClock</c> only exposes <c>UtcNow</c>, so converting it is a behavioural
         /// change and out of scope for #381.
+        ///
+        /// No null guard on <paramref name="graphUser"/>: the code this replaced dereferenced it
+        /// directly, and the resulting <see cref="NullReferenceException"/> is operator-facing, so
+        /// swapping it for an <see cref="ArgumentNullException"/> would be a behavioural change. See the
+        /// convention established on task 07.
         /// </remarks>
         public static UserMetadataChangePlan BuildPlan(GraphUser graphUser)
         {
-            if (graphUser == null) throw new ArgumentNullException(nameof(graphUser));
-
             return new UserMetadataChangePlan
             {
                 AccountEnabled = graphUser.AccountEnabled,

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserMetadataMappingRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserMetadataMappingRules.cs
@@ -10,7 +10,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     /// <remarks>
     /// This is a value, not an EF entity: it can be built and asserted without a database, a Graph
-    /// call, or the lookup caches. <see cref="UserMetadataApplier"/> is what puts it onto a
+    /// call, or the lookup caches. <c>UserDataMapper</c> is what applies it to a
     /// <see cref="Common.Entities.User"/>.
     /// </remarks>
     public sealed class UserMetadataChangePlan

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserMetadataMappingRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserMetadataMappingRules.cs
@@ -1,0 +1,114 @@
+using DataUtils;
+using System;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// What the Graph user metadata mapping decided for one user: the normalised lookup names to
+    /// resolve (a null name means "clear this lookup and its foreign key"), the fields copied straight
+    /// across, and the timestamp to stamp.
+    /// </summary>
+    /// <remarks>
+    /// This is a value, not an EF entity: it can be built and asserted without a database, a Graph
+    /// call, or the lookup caches. <see cref="UserMetadataApplier"/> is what puts it onto a
+    /// <see cref="Common.Entities.User"/>.
+    /// </remarks>
+    public sealed class UserMetadataChangePlan
+    {
+        public bool? AccountEnabled { get; set; }
+        public string PostalCode { get; set; }
+        public string AzureAdId { get; set; }
+        public string Mail { get; set; }
+
+        /// <summary>Normalised department name, or null to clear the department and its FK.</summary>
+        public string DepartmentName { get; set; }
+
+        /// <summary>Normalised job title, or null to clear the job title and its FK.</summary>
+        public string JobTitleName { get; set; }
+
+        /// <summary>Normalised office location, or null to clear it and its FK.</summary>
+        public string OfficeLocationName { get; set; }
+
+        /// <summary>Normalised usage location, or null to clear it and its FK.</summary>
+        public string UsageLocationName { get; set; }
+
+        /// <summary>Normalised country / region, or null to clear it and its FK.</summary>
+        public string CountryName { get; set; }
+
+        /// <summary>Normalised state or province, or null to clear it and its FK.</summary>
+        public string StateOrProvinceName { get; set; }
+
+        /// <summary>Normalised company name, or null to clear it and its FK.</summary>
+        public string CompanyName { get; set; }
+
+        /// <summary>The manager's Entra (AAD) object id, or null when Graph reports no manager.</summary>
+        public string ManagerAadId { get; set; }
+    }
+
+    /// <summary>
+    /// The pure mapping rules between a Graph user and the analytics <c>users</c> row: trimming and
+    /// capping the de-normalised lookup values, deciding which ones should be cleared, and copying the
+    /// fields that live directly on the row.
+    ///
+    /// Extracted from <c>UserDataMapper</c> so the rules can be tested with zero SQL Server and zero
+    /// Graph dependency - they were previously interleaved with EF change tracking and the lookup
+    /// caches, and had no test of their own. See issues #371 / #381.
+    /// </summary>
+    public static class UserMetadataMappingRules
+    {
+        /// <summary>
+        /// Maximum length of a de-normalised lookup value (department, job title, office location,
+        /// usage location, country, state, company). Matches the width of those lookup tables' name
+        /// columns.
+        /// </summary>
+        public const int LookupNameMaxLength = 100;
+
+        /// <summary>
+        /// Trims a value from Graph and caps it at <see cref="LookupNameMaxLength"/>, returning null
+        /// when there is nothing left. Null is the signal to clear that lookup rather than resolve one.
+        /// </summary>
+        /// <remarks>
+        /// Over-length values are truncated with a trailing ellipsis by
+        /// <see cref="StringUtils.EnsureMaxLength(string, int)"/>, which is what the pipeline has always
+        /// done. Trimming happens first, so a value that is only whitespace clears the lookup.
+        /// </remarks>
+        public static string NormaliseLookupName(string valueFromGraph)
+        {
+            var normalised = StringUtils.EnsureMaxLength(valueFromGraph?.Trim(), LookupNameMaxLength);
+            return string.IsNullOrEmpty(normalised) ? null : normalised;
+        }
+
+        /// <summary>
+        /// Builds the change plan for one Graph user.
+        /// </summary>
+        /// <remarks>
+        /// <c>users.last_updated</c> is deliberately NOT part of the plan. The pipeline stamps it with
+        /// <c>DateTime.Now</c> (local, not UTC) at the very end of the per-user update, after manager
+        /// resolution - which can hit the database - so moving the read into this rule would change the
+        /// stored value. <c>IClock</c> only exposes <c>UtcNow</c>, so converting it is a behavioural
+        /// change and out of scope for #381.
+        /// </remarks>
+        public static UserMetadataChangePlan BuildPlan(GraphUser graphUser)
+        {
+            if (graphUser == null) throw new ArgumentNullException(nameof(graphUser));
+
+            return new UserMetadataChangePlan
+            {
+                AccountEnabled = graphUser.AccountEnabled,
+                PostalCode = graphUser.PostalCode,
+                AzureAdId = graphUser.Id,
+                Mail = graphUser.Mail,
+
+                DepartmentName = NormaliseLookupName(graphUser.Department),
+                JobTitleName = NormaliseLookupName(graphUser.JobTitle),
+                OfficeLocationName = NormaliseLookupName(graphUser.OfficeLocation),
+                UsageLocationName = NormaliseLookupName(graphUser.UsageLocation),
+                CountryName = NormaliseLookupName(graphUser.Country),
+                StateOrProvinceName = NormaliseLookupName(graphUser.State),
+                CompanyName = NormaliseLookupName(graphUser.CompanyName),
+
+                ManagerAadId = graphUser.DefaultManagerInfo?.Id,
+            };
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
@@ -166,7 +166,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // Update manager
-            await UpdateUserManager(db, graphUser, allGraphUsers, dbUser, dbUsersByAadId, allDbUsers);
+            await UpdateUserManager(db, plan.ManagerAadId, allGraphUsers, dbUser, dbUsersByAadId, allDbUsers);
 
             dbUser.LastUpdated = DateTime.Now;
         }
@@ -174,19 +174,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// <summary>
         /// Update user's manager relationship
         /// </summary>
+        /// <param name="managerAadId">
+        /// The manager's Entra object id from <see cref="UserMetadataMappingRules.BuildPlan"/>, or null
+        /// when Graph reported no manager. Taking it as a parameter keeps the resolution chain readable
+        /// and means the mapping rule is the single place that reads it off the Graph user.
+        /// </param>
         private async Task UpdateUserManager(
             AnalyticsEntitiesContext db,
-            GraphUser graphUser,
+            string managerAadId,
             List<GraphUser> allGraphUsers,
             Common.Entities.User dbUser,
             Dictionary<string, Common.Entities.User> dbUsersByAadId = null,
             List<Common.Entities.User> allDbUsers = null)
         {
-            if (graphUser.DefaultManagerInfo?.Id != null)
+            if (managerAadId != null)
             {
                 // Try getting manager from DB using dictionary lookup if available
                 Common.Entities.User dbManager = null;
-                if (dbUsersByAadId != null && dbUsersByAadId.TryGetValue(graphUser.DefaultManagerInfo.Id, out dbManager))
+                if (dbUsersByAadId != null && dbUsersByAadId.TryGetValue(managerAadId, out dbManager))
                 {
                     // Found manager using fast dictionary lookup
                     // CRITICAL: Ensure manager is tracked by EF before assignment
@@ -198,7 +203,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 {
                     // Fallback to LINQ query if dictionary not provided (for backwards compatibility)
                     dbManager = allDbUsers.Where(u => !string.IsNullOrEmpty(u.AzureAdId) &&
-                        new Guid(u.AzureAdId).Equals(new Guid(graphUser.DefaultManagerInfo.Id))).FirstOrDefault();
+                        new Guid(u.AzureAdId).Equals(new Guid(managerAadId))).FirstOrDefault();
 
                     if (dbManager != null)
                     {
@@ -212,11 +217,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     GraphUser graphManagerUser = null;
                     if (_graphUsersByAadId != null)
                     {
-                        _graphUsersByAadId.TryGetValue(graphUser.DefaultManagerInfo.Id, out graphManagerUser);
+                        _graphUsersByAadId.TryGetValue(managerAadId, out graphManagerUser);
                     }
                     else
                     {
-                        graphManagerUser = allGraphUsers.FirstOrDefault(u => u.Id == graphUser.DefaultManagerInfo?.Id);
+                        graphManagerUser = allGraphUsers.FirstOrDefault(u => u.Id == managerAadId);
                     }
 
                     if (graphManagerUser != null)
@@ -256,7 +261,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     }
                     else
                     {
-                        _logger.LogWarning($"Couldn't find manager with AAD ID {graphUser.DefaultManagerInfo?.Id} in Graph cache or DB");
+                        _logger.LogWarning($"Couldn't find manager with AAD ID {managerAadId} in Graph cache or DB");
                     }
                 }
                 else

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
@@ -49,10 +49,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// </summary>
         public Common.Entities.User UpdateDbUserFromGraphUser(Common.Entities.User dbUser, GraphUser graphUser)
         {
-            dbUser.AccountEnabled = graphUser.AccountEnabled;
-            dbUser.PostalCode = graphUser.PostalCode;
-            dbUser.AzureAdId = graphUser.Id;
-            dbUser.Mail = graphUser.Mail;
+            return ApplyDirectFields(dbUser, UserMetadataMappingRules.BuildPlan(graphUser));
+        }
+
+        /// <summary>Copies the fields that live directly on the users row (no lookup table involved).</summary>
+        private static Common.Entities.User ApplyDirectFields(Common.Entities.User dbUser, UserMetadataChangePlan plan)
+        {
+            dbUser.AccountEnabled = plan.AccountEnabled;
+            dbUser.PostalCode = plan.PostalCode;
+            dbUser.AzureAdId = plan.AzureAdId;
+            dbUser.Mail = plan.Mail;
 
             return dbUser;
         }
@@ -68,18 +74,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             Dictionary<string, Common.Entities.User> dbUsersByAadId = null,
             List<Common.Entities.User> allDbUsers = null)
         {
-            UpdateDbUserFromGraphUser(dbUser, graphUser);
+            var plan = UserMetadataMappingRules.BuildPlan(graphUser);
+            ApplyDirectFields(dbUser, plan);
 
             // Update department
             // Note: Both navigation property AND FK must be set explicitly.
             // When entities are loaded with AsNoTracking() and later attached, navigation properties
             // are null (not loaded via Include), so setting them to null is a no-op. The FK column
             // retains its original DB value. Explicitly setting the FK to null ensures EF detects the change.
-            var nameMaxLengthDepartment = StringUtils.EnsureMaxLength(graphUser.Department?.Trim(), 100);
-            if (!string.IsNullOrEmpty(nameMaxLengthDepartment))
+            if (plan.DepartmentName != null)
             {
-                dbUser.Department = await _userMetaCache.DepartmentCache.GetOrCreateNewResource(nameMaxLengthDepartment,
-                    new UserDepartment { Name = nameMaxLengthDepartment });
+                dbUser.Department = await _userMetaCache.DepartmentCache.GetOrCreateNewResource(plan.DepartmentName,
+                    new UserDepartment { Name = plan.DepartmentName });
             }
             else
             {
@@ -88,11 +94,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // Update job title
-            var nameMaxLengthJobTitle = StringUtils.EnsureMaxLength(graphUser.JobTitle?.Trim(), 100);
-            if (!string.IsNullOrEmpty(nameMaxLengthJobTitle))
+            if (plan.JobTitleName != null)
             {
-                dbUser.JobTitle = await _userMetaCache.JobTitleCache.GetOrCreateNewResource(nameMaxLengthJobTitle,
-                    new UserJobTitle { Name = nameMaxLengthJobTitle });
+                dbUser.JobTitle = await _userMetaCache.JobTitleCache.GetOrCreateNewResource(plan.JobTitleName,
+                    new UserJobTitle { Name = plan.JobTitleName });
             }
             else
             {
@@ -101,11 +106,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // Update office location
-            var nameMaxLengthOfficeLocation = StringUtils.EnsureMaxLength(graphUser.OfficeLocation?.Trim(), 100);
-            if (!string.IsNullOrEmpty(nameMaxLengthOfficeLocation))
+            if (plan.OfficeLocationName != null)
             {
-                dbUser.OfficeLocation = await _userMetaCache.OfficeLocationCache.GetOrCreateNewResource(nameMaxLengthOfficeLocation,
-                    new UserOfficeLocation { Name = nameMaxLengthOfficeLocation });
+                dbUser.OfficeLocation = await _userMetaCache.OfficeLocationCache.GetOrCreateNewResource(plan.OfficeLocationName,
+                    new UserOfficeLocation { Name = plan.OfficeLocationName });
             }
             else
             {
@@ -114,11 +118,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // Update usage location
-            var nameMaxLengthUsageLocation = StringUtils.EnsureMaxLength(graphUser.UsageLocation?.Trim(), 100);
-            if (!string.IsNullOrEmpty(nameMaxLengthUsageLocation))
+            if (plan.UsageLocationName != null)
             {
-                dbUser.UsageLocation = await _userMetaCache.UseageLocationCache.GetOrCreateNewResource(nameMaxLengthUsageLocation,
-                    new UserUsageLocation { Name = nameMaxLengthUsageLocation });
+                dbUser.UsageLocation = await _userMetaCache.UseageLocationCache.GetOrCreateNewResource(plan.UsageLocationName,
+                    new UserUsageLocation { Name = plan.UsageLocationName });
             }
             else
             {
@@ -127,11 +130,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // Update country
-            var nameMaxLengthCountry = StringUtils.EnsureMaxLength(graphUser.Country?.Trim(), 100);
-            if (!string.IsNullOrEmpty(nameMaxLengthCountry))
+            if (plan.CountryName != null)
             {
-                dbUser.UserCountry = await _userMetaCache.CountryOrRegionCache.GetOrCreateNewResource(nameMaxLengthCountry,
-                    new CountryOrRegion { Name = nameMaxLengthCountry });
+                dbUser.UserCountry = await _userMetaCache.CountryOrRegionCache.GetOrCreateNewResource(plan.CountryName,
+                    new CountryOrRegion { Name = plan.CountryName });
             }
             else
             {
@@ -140,11 +142,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // Update state
-            var nameMaxLengthState = StringUtils.EnsureMaxLength(graphUser.State?.Trim(), 100);
-            if (!string.IsNullOrEmpty(nameMaxLengthState))
+            if (plan.StateOrProvinceName != null)
             {
-                dbUser.StateOrProvince = await _userMetaCache.StateOrProvinceCache.GetOrCreateNewResource(nameMaxLengthState,
-                    new StateOrProvince { Name = nameMaxLengthState });
+                dbUser.StateOrProvince = await _userMetaCache.StateOrProvinceCache.GetOrCreateNewResource(plan.StateOrProvinceName,
+                    new StateOrProvince { Name = plan.StateOrProvinceName });
             }
             else
             {
@@ -153,11 +154,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // Update company
-            var nameMaxLengthCompany = StringUtils.EnsureMaxLength(graphUser.CompanyName?.Trim(), 100);
-            if (!string.IsNullOrEmpty(nameMaxLengthCompany))
+            if (plan.CompanyName != null)
             {
-                dbUser.CompanyName = await _userMetaCache.CompanyNameCache.GetOrCreateNewResource(nameMaxLengthCompany,
-                    new CompanyName { Name = nameMaxLengthCompany });
+                dbUser.CompanyName = await _userMetaCache.CompanyNameCache.GetOrCreateNewResource(plan.CompanyName,
+                    new CompanyName { Name = plan.CompanyName });
             }
             else
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -444,11 +444,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             else
             {
-                // Fallback for edge cases where mapper isn't initialized
-                dbUser.AccountEnabled = graphUser.AccountEnabled;
-                dbUser.PostalCode = graphUser.PostalCode;
-                dbUser.AzureAdId = graphUser.Id;
-                dbUser.Mail = graphUser.Mail;
+                // Fallback for edge cases where mapper isn't initialized. Uses the same extracted
+                // mapping rule as UserDataMapper so the two copies cannot drift apart (#371).
+                var plan = UserMetadataMappingRules.BuildPlan(graphUser);
+                dbUser.AccountEnabled = plan.AccountEnabled;
+                dbUser.PostalCode = plan.PostalCode;
+                dbUser.AzureAdId = plan.AzureAdId;
+                dbUser.Mail = plan.Mail;
                 return dbUser;
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Graph\User\GraphUserLoader.cs" />
     <Compile Include="Graph\User\IUserMetadataLoader.cs" />
     <Compile Include="Graph\User\UserBatchProcessor.cs" />
+    <Compile Include="Graph\User\Rules\UserMetadataMappingRules.cs" />
     <Compile Include="Graph\User\UserDataMapper.cs" />
     <Compile Include="Graph\User\UserGraphResponse.cs" />
     <Compile Include="Graph\User\UserGroupsCache.cs" />


### PR DESCRIPTION
Part of the ports & adapters initiative (#381). #371 calls the Graph user pipeline **"the largest body
of untested business logic in the solution"** and explicitly recommends more than one PR against it.
This is the first, smallest, self-contained slice: the pure mapping rules.

## What moved

`UserDataMapper.UpdateUserMetadata` interleaved the Graph→database mapping rules with EF change
tracking and the de-normalised lookup caches, so none of it could be exercised without a database and
a Graph client. The rules are now a pure `UserMetadataMappingRules` static class producing a
`UserMetadataChangePlan`:

| Rule | Was |
|---|---|
| Normalise the seven lookup values (department, job title, office location, usage location, country, state, company) — trim, then cap at the 100-char column width via the shared `StringUtils.EnsureMaxLength` | Seven near-identical inline blocks |
| "Nothing from Graph ⇒ clear the lookup **and** its FK" | Seven `if (!string.IsNullOrEmpty(...)) … else { nav = null; fk = null; }` blocks |
| The four fields copied straight onto the users row (`accountEnabled`, `postalCode`, `azureAdId`, `mail`) | Inline, and duplicated in a second place (below) |
| The manager's Entra object id | Read inline from `graphUser.DefaultManagerInfo?.Id` |

`UserDataMapper` now asks for a plan and keeps only the EF work — resolving each lookup through its
cache, or nulling the navigation property and the FK.

`UserMetadataUpdater.UpdateDbUserFromGraphUser` carried a **second copy** of the direct-field mapping
as an "edge case where the mapper isn't initialized" fallback. It now calls the same rule, so the two
copies cannot drift apart.

## Behaviour

Unchanged — no exceptions.

An earlier revision of this PR added an `ArgumentNullException` guard to `BuildPlan` where the old
code threw `NullReferenceException` from the first property access. Two reviewers cleared it as not
differentially observable, but task 07 had already established the opposite convention (the exception
type and message are operator-facing; unhandled web exceptions reach `WebExceptionTelemetry`, which
logs the base message), so the guard has been **removed**. A remark in the code records why, to stop
it being re-added.

### `last_updated` is deliberately not in the plan

#371 asks for `LastUpdated` to be supplied via `IClock`. It is **not** done here, on purpose:

- the pipeline stamps it with `DateTime.Now` — **local** time, not UTC — at the very end of the
  per-user update, *after* manager resolution, which can hit the database;
- `IClock` exposes only `UtcNow`, so the swap would change every stored value on a non-UTC host;
- moving the read earlier would also change the value, by the duration of that user's mapping.

Either is a behavioural change, which #381 forbids. Left for the follow-up, with the reasoning
recorded in the code so the next person does not have to rediscover it. (It is written and displayed
only — nothing compares it against `UtcNow` — so it is an inconsistency rather than a live bug.)

### One of the issue's named tests asserts the opposite of the code

#371's test list includes `UserMapping_NullGraphFields_DoNotOverwriteExistingDbValues`. The code does
the **opposite**: a missing Graph value deliberately clears the lookup and its FK, and the comment in
`UserDataMapper` explains why both must be set explicitly (entities loaded `AsNoTracking()` and later
attached have null navigation properties, so only the FK assignment is visible to EF).

The test is named for the real behaviour — `UserMapping_MissingGraphFields_AskForTheLookupToBeCleared`
— because writing it as the issue worded it would have meant either a false test or a behavioural
change. Worth knowing before the rest of #371's test list is implemented.

## Tests

12 new tests in `UserMetadataMappingRulesTests`, all with **zero** SQL Server and **zero** Graph
dependency:

- all seven lookups mapped from a Graph user, and the four direct fields;
- clearing on `null`, `""`, `"   "` and `"\t\r\n"`;
- trimming (an untrimmed value would create a duplicate lookup row for the same department);
- capping at exactly 100 characters with the ellipsis marker, cross-checked against
  `StringUtils.EnsureMaxLength` so the rule cannot silently diverge from the shared helper;
- a value exactly at the limit is left alone;
- manager id present and absent;
- mapping determinism (same Graph user ⇒ identical plan, and a fresh plan object each call);
- `accountEnabled` staying `null` rather than defaulting to `false` — Graph omits it for some
  directory objects, and defaulting it would mark live users disabled and drop them out of adoption
  reporting;
- **Greek round-tripping** through every lookup plus the UPN and mail
  (`καλημέρα@contoso.onmicrosoft.com`, `Καλημέρα κόσμε`), per the repo's character-set rule.

Full solution builds clean (0 warnings, 0 errors). **104 passed / 0 failed** across the new tests plus
the pre-existing `UserMetadataUpdater*`, `UserImport*`, `UserLookup*`, `UserGroupsCache*` and
`DBLookupCache*` suites — those are the behaviour-identical evidence.

## Deliberately not in this PR

Both are the larger, riskier halves of #371 and deserve their own review:

1. **The N+1 in manager resolution** (`UserDataMapper` lines 237 / 297 — a per-user
   `FirstOrDefaultAsync` inside the fallback chain). Needs `IUserLookupStore` plus chunked
   `Contains(...)` batching, and the five-branch precedence chain characterised by tests first.
2. **Moving `SqlBulkCopy` behind `IUserBulkUpdateWriter`** (`UserBatchProcessor`). The `SqlBulkCopy`
   implementation is relocated, not rewritten — and `InsertBatch<T>` keeps its row-by-row
   implementation, which is a stated preference.

Addresses #371