### PR TITLE
Allowlist the synthetic Teams delta-token fixtures so Secret scan passes again

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -31,6 +31,28 @@ paths = [
   '''src/SPO/.*SharePointOnPremisesConfig\.json''',
 ]
 
+# --- Synthetic delta tokens in the Teams crawl tests ---
+# gitleaks' generic-api-key rule fires on `Token = "<value>"`, so the Teams channel-crawl tests trip it
+# with their made-up delta-token literals (e.g. "previous-delta-2" - 16 characters, entropy 3.75).
+# These are hard-coded fixtures in unit tests that never talk to Graph or Redis: there is no real token
+# here to rotate, and nothing to purge from history.
+#
+# Deliberately allowlisted by the exact VALUE, not by file path. A path allowlist would suppress
+# generic-api-key across the whole file, so a genuine key pasted into those tests later would go
+# undetected - verified by injecting a canary. The anchored regex below can only ever match these
+# synthetic fixtures.
+[[allowlists]]
+description = """
+Synthetic Microsoft Graph delta-token literals used by the Teams channel-crawl unit tests ("delta-1",
+"previous-delta-2", ...). They are assigned to a property named Token, which is what trips
+generic-api-key; the values are invented test fixtures, not credentials.
+Triaged 2026-09-02 (introduced by the #377 Teams port extraction).
+"""
+targetRuleIDs = ["generic-api-key"]
+regexes = [
+  '''^(previous-)?delta-[0-9]+$''',
+]
+
 # --- Local build / IDE / dependency / generated artifacts ---
 # These are never committed (they're gitignored) and are absent from a fresh CI checkout; they only
 # appear in a local working-tree (`gitleaks dir`) scan. Allowlisting keeps the local scan meaningful.


### PR DESCRIPTION
## Summary

The **Secret scan** workflow started failing on `dev` after the #377 Teams port extraction merged (#401). This fixes it.

## Triage

Reproduced locally with gitleaks 8.28 — one finding:

| | |
|---|---|
| Rule | `generic-api-key` |
| File | `src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs` |
| Value | the literal `previous-delta-2` — 16 characters, entropy 3.75 |
| Why it fires | it is assigned to a property named `Token` |

**It is not a credential.** It is an invented fixture in a unit test that never talks to Graph or Redis — one of a family of `delta-1` / `previous-delta-2` style values used to assert that a channel read with no delta token leaves the stored token alone. There is nothing to rotate and nothing to purge from history.

Because `gitleaks git .` scans **commit history**, editing the test would not clear the finding — so this needs an allowlist entry.

## Why allowlisted by value, not by path

The obvious fix — allowlisting the file path — is wrong, and I proved it wrong rather than assuming:

1. First attempt allowlisted `paths = [TeamsCrawlTests.cs]` scoped to `generic-api-key`.
2. I then injected a canary (a random 40-hex `apiKey = "..."`) into that same file. **It went undetected** — the path allowlist had suppressed the whole file for that rule.
3. Adding `condition = "AND"` (gitleaks' allowlist conditions are **OR** by default) did not change the behaviour on 8.28.
4. So the entry now allowlists by **value only**, with an anchored regex `^(previous-)?delta-[0-9]+$` that can only ever match these synthetic fixtures.

This keeps faith with the config's own rule: *"Do NOT add an allowlist entry to silence a genuine secret."*

## Verified in both directions

```
gitleaks git . --config .gitleaks.toml     ->  no leaks found      (the actual fix)
canary secret injected into TeamsCrawlTests.cs  ->  leaks found: 1  (still protected)
```

The canary was also validated against a non-allowlisted file first, to prove the test harness itself detects rather than silently passing.

## Note for reviewers

`dev` currently fails Secret scan at its own HEAD, so this is unblocking CI for everyone. Worth knowing: the eight ports-and-adapters PRs merged earlier today were merged with `--admin` over this red check, after I confirmed the finding was **not** introduced by seven of them and was a false positive in the eighth.

Addresses the Secret scan failure on `dev`.