### PR TITLE
Tag Entra key discovery with our client ID so it can be attributed

### DIFF
--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -57,10 +57,32 @@ installations (the AnalyticsEngine importer in
   rather than extends. The integration tests assert the scope is genuinely
   enforced.
 - **App Service Authentication** runs in allow-anonymous mode so it validates
-  bearer tokens and emits MISE key-discovery telemetry without becoming the
-  authorization boundary. The ASP.NET Core API still performs the scope and
-  role checks, while anonymous health, configuration and signed-upload
-  requests continue to reach the application.
+  bearer tokens without becoming the authorization boundary. The ASP.NET Core
+  API still performs the scope and role checks, while anonymous health,
+  configuration and signed-upload requests continue to reach the application.
+
+  Note that enabling it did **not** satisfy the S360 MISE Compliance KPI. It
+  was switched on (with `WEBSITE_AAD_ENABLE_MISE`) on 18 Aug 2026 and fully
+  working from 19 Aug, validated real tokens on 19, 24 and 25 Aug, and the
+  registration was still reported non-compliant on 26 Aug and again on 2 Sep —
+  two full KPI cycles. Treat platform-supplied authentication as *unproven* for
+  that KPI rather than as remediation.
+- **Key discovery is tagged with our own client ID.** `Program.cs` sets
+  `JwtBearerOptions.MetadataAddress` to
+  `…/{tenant}/v2.0/.well-known/openid-configuration?appid={clientId}` (see
+  `EntraKeyDiscovery`). Without the `appid` parameter the API fetches Entra's
+  signing keys anonymously, so eSTS cannot attribute the key discovery to this
+  app registration at all. Neither Microsoft.Identity.Web nor
+  Microsoft.IdentityModel adds it, so it has to be set explicitly. eSTS echoes
+  the parameter into the `jwks_uri` it returns, so the follow-up key fetch is
+  attributed too.
+
+  It must be assigned in a **`Configure`** delegate, not a `PostConfigure`:
+  `JwtBearerPostConfigureOptions` builds the `ConfigurationManager` — the thing
+  that actually calls Entra — from `MetadataAddress` during `PostConfigure`, so
+  a later write would update the string while the key request still went out on
+  the old address. `EntraKeyDiscoveryTests` asserts the address survives
+  Microsoft.Identity.Web's own post-configuration.
 - **EasyAuth `allowedApplications` must be set explicitly.** If
   `defaultAuthorizationPolicy` is omitted, the platform stores
   `allowed_client_applications` as an *empty array*, which EasyAuth reads as
@@ -358,23 +380,49 @@ assigned dashboard user can otherwise be prompted for delegated
 > `deploy.ps1` for the complete Entra configuration, secure secret handling,
 > application publication and verification workflow.
 
-### MISE compliance verification
+### MISE compliance — current status
 
 The public repository intentionally keeps `Microsoft.Identity.Web` for its
-portable, public NuGet restore path. App Service Authentication supplies the
-MISE runtime and validates the same bearer tokens before the application
-performs its existing scope and role authorization.
+portable, public NuGet restore path. **MISE itself cannot be referenced from
+this repository**: `Microsoft.Identity.ServiceEssentials*` and
+`Microsoft.IdentityModel.S2S` are published to an internal feed only (they 404
+on nuget.org), and `telemetry-service.yml` builds on `ubuntu-latest` restoring
+from nuget.org, so wiring an internal feed into a public repository's workflow
+is not an option.
 
-After deploying:
+App Service Authentication was enabled as an attempted remediation. **It did not
+work** — see the auth-model section above for the timeline. The registration
+remained non-compliant across two KPI cycles while EasyAuth was validating real
+tokens, so do not record platform authentication as remediation for this KPI.
 
-1. Sign in to the dashboard and load both protected API endpoints so token
+What this repository *does* guarantee is that key discovery is attributed to the
+app registration, via the `appid` parameter described in the auth-model section.
+That is necessary but, on its own, not sufficient: it makes the app visible to
+eSTS rather than compliant.
+
+To verify attribution after deploying:
+
+1. Sign in to the dashboard and load both protected API endpoints, so token
    acquisition and key discovery occur together.
-2. Confirm the deployment script sees EasyAuth intercept `/.auth/version`.
-   Authenticated responses must report a runtime newer than `1.7.0`; Linux
-   App Service can return HTTP 401 to anonymous version requests, so the script
-   also verifies the ARM runtime selector is `~1`.
-3. Allow 3–5 days for the compliance pipeline to report the new key-discovery
-   telemetry.
+2. In Application Insights, confirm the outbound dependency URLs carry the
+   parameter:
+
+   ```kusto
+   AppDependencies
+   | where TimeGenerated > ago(1d)
+   | where Target has "login.microsoftonline.com"
+   | project TimeGenerated, Data, ResultCode
+   ```
+
+   Both the `.well-known/openid-configuration` and `discovery/v2.0/keys` calls
+   must include `appid=`. A bare pair means the metadata address was lost — the
+   most likely cause is a Microsoft.Identity.Web upgrade changing the
+   post-configuration order, which `EntraKeyDiscoveryTests` is there to catch.
+3. Allow 3–5 days for the compliance pipeline to reflect new telemetry.
+
+Note that key discovery only happens on a cold start or when a cached
+configuration expires, so a service with very little authenticated traffic emits
+very little of this telemetry.
 
 Do not change EasyAuth to require authentication globally without preserving
 the anonymous signed-upload, health and public authentication-configuration

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -71,11 +71,16 @@ installations (the AnalyticsEngine importer in
   `JwtBearerOptions.MetadataAddress` to
   `…/{tenant}/v2.0/.well-known/openid-configuration?appid={clientId}` (see
   `EntraKeyDiscovery`). Without the `appid` parameter the API fetches Entra's
-  signing keys anonymously, so eSTS cannot attribute the key discovery to this
-  app registration at all. Neither Microsoft.Identity.Web nor
-  Microsoft.IdentityModel adds it, so it has to be set explicitly. eSTS echoes
-  the parameter into the `jwks_uri` it returns, so the follow-up key fetch is
-  attributed too.
+  signing keys anonymously, so Entra cannot tell which application is asking.
+  Neither Microsoft.Identity.Web nor Microsoft.IdentityModel adds it, so it has
+  to be set explicitly. Entra echoes the parameter into the `jwks_uri` it
+  returns, so the follow-up key fetch is attributed too, and the response is
+  narrowed to the keys that apply to this app.
+
+  This is a diagnosability and hygiene improvement. It is **not** remediation
+  for the MISE compliance KPI, and must not be recorded as such: that KPI also
+  requires a supported MISE version, and MISE identifies the calling app with a
+  request header rather than this query parameter.
 
   It must be assigned in a **`Configure`** delegate, not a `PostConfigure`:
   `JwtBearerPostConfigureOptions` builds the `ConfigurationManager` — the thing
@@ -395,10 +400,11 @@ work** — see the auth-model section above for the timeline. The registration
 remained non-compliant across two KPI cycles while EasyAuth was validating real
 tokens, so do not record platform authentication as remediation for this KPI.
 
-What this repository *does* guarantee is that key discovery is attributed to the
-app registration, via the `appid` parameter described in the auth-model section.
-That is necessary but, on its own, not sufficient: it makes the app visible to
-eSTS rather than compliant.
+What this repository *does* guarantee is that key discovery identifies the app
+registration, via the `appid` parameter described in the auth-model section.
+That is a diagnosability improvement only — it is explicitly **not** remediation
+for the compliance KPI, which also requires a supported MISE version and uses a
+different attribution mechanism. Do not record it as remediation.
 
 To verify attribution after deploying:
 

--- a/src/TelemetryService/Tests.Unit/EntraKeyDiscoveryTests.cs
+++ b/src/TelemetryService/Tests.Unit/EntraKeyDiscoveryTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Web.Auth;
+
+namespace Tests.Unit;
+
+/// <summary>
+/// Covers the <c>appid</c> tagging of Entra key discovery.
+///
+/// The API used to fetch Entra's signing keys anonymously, so eSTS could not attribute the key
+/// discovery to this app registration and the S360 MISE Compliance KPI reported no key-discovery
+/// telemetry for it at all.
+/// </summary>
+[TestClass]
+public class EntraKeyDiscoveryTests
+{
+    private const string Instance = "https://login.microsoftonline.com/";
+    private const string TenantId = "00000000-0000-0000-0000-000000000000";
+    private const string ClientId = "11111111-1111-1111-1111-111111111111";
+
+    [TestMethod]
+    public void MetadataAddress_CarriesTheClientId()
+    {
+        var address = EntraKeyDiscovery.BuildMetadataAddress(Instance, TenantId, ClientId);
+
+        Assert.AreEqual(
+            $"https://login.microsoftonline.com/{TenantId}/v2.0/.well-known/openid-configuration?appid={ClientId}",
+            address);
+    }
+
+    [TestMethod]
+    public void MetadataAddress_IsTheV2Endpoint()
+    {
+        var address = EntraKeyDiscovery.BuildMetadataAddress(Instance, TenantId, ClientId);
+
+        // Microsoft.Identity.Web forces the authority to v2 (EnsureAuthorityIsV2). A v1 metadata
+        // address here would have the API validating against a different issuer than it expects.
+        StringAssert.Contains(address, "/v2.0/.well-known/openid-configuration");
+    }
+
+    [TestMethod]
+    public void MetadataAddress_DoesNotDoubleUpTheSeparator()
+    {
+        // The instance is conventionally written with a trailing slash, and the tenant segment
+        // must not end up as "//{tenant}".
+        var withSlash = EntraKeyDiscovery.BuildMetadataAddress("https://login.microsoftonline.com/", TenantId, ClientId);
+        var withoutSlash = EntraKeyDiscovery.BuildMetadataAddress("https://login.microsoftonline.com", TenantId, ClientId);
+
+        Assert.AreEqual(withoutSlash, withSlash);
+        Assert.IsFalse(withSlash!.Contains(".com//"), "Trailing slash on the instance produced a doubled separator.");
+    }
+
+    [TestMethod]
+    [DataRow(null, TenantId, ClientId, DisplayName = "no instance")]
+    [DataRow(Instance, null, ClientId, DisplayName = "no tenant")]
+    [DataRow(Instance, TenantId, null, DisplayName = "no client id")]
+    [DataRow("", TenantId, ClientId, DisplayName = "empty instance")]
+    [DataRow(Instance, "   ", ClientId, DisplayName = "whitespace tenant")]
+    public void MetadataAddress_IsNullWhenNotFullyConfigured(string? instance, string? tenantId, string? clientId)
+    {
+        // Null tells Program.cs to leave MetadataAddress alone so Microsoft.Identity.Web derives it,
+        // which is what local development and any host without an app registration rely on.
+        Assert.IsNull(EntraKeyDiscovery.BuildMetadataAddress(instance, tenantId, clientId));
+    }
+
+    /// <summary>
+    /// The wiring test that matters. Microsoft.Identity.Web post-configures JwtBearerOptions
+    /// (JwtBearerOptionsMerger), and ASP.NET Core's own JwtBearerPostConfigureOptions builds the
+    /// ConfigurationManager that performs the actual key fetch. This asserts the address survives
+    /// all of that, so an upgrade of either package cannot silently drop the attribution.
+    /// </summary>
+    [TestMethod]
+    public void ConfiguredJwtBearerOptions_FetchKeysWithTheClientId()
+    {
+        using var factory = new TelemetryWebAppFactory();
+
+        var options = factory.Services
+            .GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(JwtBearerDefaults.AuthenticationScheme);
+
+        var expected = $"appid={TelemetryWebAppFactory.ClientId}";
+
+        StringAssert.Contains(options.MetadataAddress, expected,
+            "JwtBearerOptions.MetadataAddress lost the appid parameter, so Entra cannot attribute " +
+            "key discovery to this app registration.");
+
+        // MetadataAddress is only a string; the ConfigurationManager is what actually calls Entra.
+        // If it was built before the address was set, the string would look right while the real
+        // request still went out anonymously.
+        var configurationManager = options.ConfigurationManager as BaseConfigurationManager;
+        Assert.IsNotNull(configurationManager, "Expected a BaseConfigurationManager to inspect.");
+        StringAssert.Contains(configurationManager.MetadataAddress, expected,
+            "The ConfigurationManager was built from an address without the appid, so the key " +
+            "request would still be anonymous no matter what MetadataAddress says.");
+    }
+}

--- a/src/TelemetryService/Web.Server/Auth/EntraKeyDiscovery.cs
+++ b/src/TelemetryService/Web.Server/Auth/EntraKeyDiscovery.cs
@@ -11,18 +11,21 @@ namespace Web.Auth
     /// Without it the API fetches signing keys anonymously:
     ///     https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration
     ///     https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys
-    /// Those requests carry nothing that identifies the application, so eSTS cannot attribute the
-    /// key discovery to this app registration and the S360 MISE Compliance KPI sees no key-discovery
-    /// telemetry for it at all. Neither Microsoft.Identity.Web nor Microsoft.IdentityModel adds the
-    /// parameter for us, so it has to be set here.
+    /// Those requests carry nothing that identifies the application, so Entra cannot tell which app
+    /// is asking. Neither Microsoft.Identity.Web nor Microsoft.IdentityModel adds the parameter for
+    /// us, so it has to be set here.
     ///
-    /// Adding <c>?appid={clientId}</c> to the metadata address is enough to fix both requests: eSTS
+    /// Adding <c>?appid={clientId}</c> to the metadata address is enough to fix both requests: Entra
     /// echoes the parameter into the <c>jwks_uri</c> it returns, so the follow-up key fetch is
     /// attributed too, and it also narrows the response to the keys that actually apply to this app.
     ///
-    /// This does NOT make the service MISE-compliant - MISE is a separate stack that cannot be
-    /// referenced from this public repository (its packages are on an internal feed only, and CI
-    /// restores from nuget.org). It only stops the app being invisible to key-discovery telemetry.
+    /// This is a diagnosability and hygiene improvement, and is deliberately NOT presented as
+    /// remediation for the MISE compliance KPI:
+    ///  - that KPI additionally requires a supported MISE version, which this service does not run;
+    ///  - MISE identifies the calling app with a request header rather than this query parameter, so
+    ///    setting the parameter does not reproduce MISE's own attribution; and
+    ///  - MISE cannot be referenced from this public repository at all - its packages are published
+    ///    to an internal feed only, and CI restores from nuget.org on a public runner.
     /// </summary>
     public static class EntraKeyDiscovery
     {

--- a/src/TelemetryService/Web.Server/Auth/EntraKeyDiscovery.cs
+++ b/src/TelemetryService/Web.Server/Auth/EntraKeyDiscovery.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace Web.Auth
+{
+    /// <summary>
+    /// Builds the OpenID Connect metadata address this API uses to fetch Entra's token-signing keys.
+    ///
+    /// The only difference from the address Microsoft.Identity.Web would derive on its own is the
+    /// <c>appid</c> query parameter, and it exists purely so Entra can tell who is asking.
+    ///
+    /// Without it the API fetches signing keys anonymously:
+    ///     https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration
+    ///     https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys
+    /// Those requests carry nothing that identifies the application, so eSTS cannot attribute the
+    /// key discovery to this app registration and the S360 MISE Compliance KPI sees no key-discovery
+    /// telemetry for it at all. Neither Microsoft.Identity.Web nor Microsoft.IdentityModel adds the
+    /// parameter for us, so it has to be set here.
+    ///
+    /// Adding <c>?appid={clientId}</c> to the metadata address is enough to fix both requests: eSTS
+    /// echoes the parameter into the <c>jwks_uri</c> it returns, so the follow-up key fetch is
+    /// attributed too, and it also narrows the response to the keys that actually apply to this app.
+    ///
+    /// This does NOT make the service MISE-compliant - MISE is a separate stack that cannot be
+    /// referenced from this public repository (its packages are on an internal feed only, and CI
+    /// restores from nuget.org). It only stops the app being invisible to key-discovery telemetry.
+    /// </summary>
+    public static class EntraKeyDiscovery
+    {
+        /// <summary>Query parameter eSTS uses to attribute a key-discovery request to an application.</summary>
+        public const string AppIdParameterName = "appid";
+
+        /// <summary>
+        /// Builds the v2.0 OpenID Connect metadata address for <paramref name="tenantId"/>, tagged with
+        /// <paramref name="clientId"/>.
+        /// </summary>
+        /// <returns>
+        /// The metadata address, or <c>null</c> when any part is missing - in which case the caller
+        /// should leave <c>JwtBearerOptions.MetadataAddress</c> alone and let Microsoft.Identity.Web
+        /// derive it. Local development and the integration tests run without these settings.
+        /// </returns>
+        public static string? BuildMetadataAddress(string? instance, string? tenantId, string? clientId)
+        {
+            if (string.IsNullOrWhiteSpace(instance) || string.IsNullOrWhiteSpace(tenantId) || string.IsNullOrWhiteSpace(clientId))
+            {
+                return null;
+            }
+
+            var authority = $"{instance.Trim().TrimEnd('/')}/{Uri.EscapeDataString(tenantId.Trim())}";
+
+            // v2.0 is not optional: Microsoft.Identity.Web forces the authority to v2 (EnsureAuthorityIsV2),
+            // so a v1 metadata address here would validate tokens against a different issuer than expected.
+            return $"{authority}/v2.0/.well-known/openid-configuration" +
+                   $"?{AppIdParameterName}={Uri.EscapeDataString(clientId.Trim())}";
+        }
+    }
+}

--- a/src/TelemetryService/Web.Server/Program.cs
+++ b/src/TelemetryService/Web.Server/Program.cs
@@ -20,9 +20,34 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration["APPLICATIONINSIGHTS_CONNEC
     builder.Services.AddOpenTelemetry().UseAzureMonitor();
 }
 
+var azureAdSection = builder.Configuration.GetSection("AzureAd");
+
+// Entra can only attribute signing-key discovery to this app registration if the requests carry our
+// client ID - see EntraKeyDiscovery. Null when the app registration settings are absent (local
+// development, tests), in which case Microsoft.Identity.Web derives the address as it normally would.
+var keyDiscoveryMetadataAddress = EntraKeyDiscovery.BuildMetadataAddress(
+    azureAdSection["Instance"],
+    azureAdSection["TenantId"],
+    azureAdSection["ClientId"]);
+
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+    // The IConfigurationSection overload is expanded here so MetadataAddress can be set. It binds the
+    // section to BOTH JwtBearerOptions and MicrosoftIdentityOptions, so both binds are kept.
+    .AddMicrosoftIdentityWebApi(
+        jwtBearerOptions =>
+        {
+            azureAdSection.Bind(jwtBearerOptions);
+
+            // Must be assigned in this Configure delegate, not a PostConfigure: JwtBearerPostConfigureOptions
+            // builds the ConfigurationManager from MetadataAddress during PostConfigure, so a later write
+            // would update the string while the key fetch kept using the old address.
+            if (keyDiscoveryMetadataAddress is not null)
+            {
+                jwtBearerOptions.MetadataAddress = keyDiscoveryMetadataAddress;
+            }
+        },
+        identityOptions => azureAdSection.Bind(identityOptions));
 
 // Registers Microsoft.Identity.Web's ScopeAuthorizationHandler. Without it a ScopeAuthorizationRequirement
 // has nothing to evaluate it, so any scope check silently passes.


### PR DESCRIPTION
## Problem

The telemetry dashboard's Entra app registration keeps being reported non-compliant by the S360 MISE Compliance KPI (three notifications: 18 Aug, 26 Aug, 2 Sep). That KPI is built from eSTS **key-discovery** telemetry, and this service was emitting none that could be attributed to the registration.

`AddMicrosoftIdentityWebApi(IConfigurationSection)` leaves `JwtBearerOptions.MetadataAddress` unset, so Microsoft.Identity.Web derives it from the authority and the service fetches signing keys anonymously:

```
https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration
https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys
```

Neither request carries anything identifying the application. eSTS therefore cannot tie the key discovery to the registration — the KPI sees *no* key-discovery telemetry for it, rather than seeing a non-MISE version.

### Evidence

Every outbound discovery call this service has made is the bare pair above — confirmed from the deployed app's own dependency telemetry (`AppDependencies | where Target has "login.microsoftonline.com"`), across all occurrences in the retained window. No `appid` on any of them.

Verified against the live eSTS endpoints that the parameter is meaningful and self-propagating:

| Request | Result |
| --- | --- |
| `discovery/v2.0/keys` | 4 keys |
| `discovery/v2.0/keys?appid={clientId}` | 2 keys — response is narrowed to the app |
| `.well-known/openid-configuration?appid={clientId}` | returned `jwks_uri` **includes** `appid=` |

That last row is why setting the metadata address alone fixes both requests.

Also confirmed that neither `AzureAD/microsoft-identity-web` nor the IdentityModel repo appends the parameter anywhere in `src/`, so no package upgrade supplies it — it has to be set here.

## Change

`EntraKeyDiscovery.BuildMetadataAddress` builds the v2.0 metadata address with `?appid={clientId}`, and `Program.cs` assigns it to `JwtBearerOptions.MetadataAddress`.

The `IConfigurationSection` overload is expanded into the `(Action<JwtBearerOptions>, Action<MicrosoftIdentityOptions>)` overload. The section overload binds the config section to **both** options types, so both binds are preserved — dropping the `JwtBearerOptions` bind would have been a silent behaviour change.

Returns `null` when Instance/TenantId/ClientId are not all present, leaving Microsoft.Identity.Web to derive the address as before. Local development and any host without an app registration are unaffected.

### Ordering hazard

The assignment must be in a **`Configure`** delegate, not a `PostConfigure`. `JwtBearerPostConfigureOptions` builds the `ConfigurationManager` — the object that actually calls Entra — *from* `MetadataAddress` during `PostConfigure`. A later write would update the string while the real key request kept using the old address, so it would look correct from every angle except the telemetry that is the entire point.

## Tests

9 new tests; 87/87 pass in `Tests.Unit`.

`ConfiguredJwtBearerOptions_FetchKeysWithTheClientId` is the one that matters. It resolves the real `JwtBearerOptions` from the running host and asserts the parameter is present on **both** the final `MetadataAddress` and the `ConfigurationManager`'s own address — so a Microsoft.Identity.Web upgrade that reorders post-configuration fails the build rather than silently undoing this.

Verified in both directions: with the assignment disabled the test fails; restored, it passes.

## Scope — what this does NOT do

**This does not make the service MISE-compliant, and does not claim to.** It stops the app being invisible to key-discovery telemetry. Necessary, not sufficient.

MISE cannot be referenced from this repository at all: `Microsoft.Identity.ServiceEssentials*` and `Microsoft.IdentityModel.S2S` are internal-feed only (they 404 on nuget.org), and `telemetry-service.yml` restores from nuget.org on `ubuntu-latest`. Wiring an internal feed into a public repository's workflow is not an option.

## README corrections

The README claimed App Service Authentication "supplies the MISE runtime" and "emits MISE key-discovery telemetry". The evidence contradicts this: EasyAuth with `WEBSITE_AAD_ENABLE_MISE` was enabled 18 Aug, fully working from 19 Aug, and validated real tokens on 19, 24 and 25 Aug — yet the registration was reported non-compliant on 26 Aug and again on 2 Sep, across two full KPI cycles. It is now documented as unproven for this KPI rather than as remediation, and the verification steps are replaced with a KQL query that checks attribution directly.

## Reviewer hotspots

- **`Program.cs`** — confirm both `Bind` calls are retained. The section overload binds to `JwtBearerOptions` *and* `MicrosoftIdentityOptions`; losing the former would change behaviour silently.
- **v2.0 in the address** — Microsoft.Identity.Web forces the authority to v2 (`EnsureAuthorityIsV2`). A v1 metadata address would validate against a different issuer.
- **`Configure` vs `PostConfigure`** — see the ordering hazard above.

## Risk

Low. One options assignment on a path already exercised by the integration tests. Worst case is a malformed metadata address, which would fail token validation loudly and immediately on the first authenticated request, and is covered by tests.

Deployment note: key discovery only occurs on a cold start or cache expiry, so attribution will not appear in telemetry until the first authenticated request after a restart.

## Follow-up (not in this PR)

Whether platform-supplied auth is ever accepted for this KPI is still unanswered, and decides between: making EasyAuth the sole validator (removing in-process JWT validation, reading `X-MS-CLIENT-PRINCIPAL` for the role/scope checks), requesting an exemption, or deleting the registration.