### PR TITLE
Extract ISiteUrlStore from the site-id to URL cache (#375 part 2)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemorySiteUrlStore.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemorySiteUrlStore.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="ISiteUrlStore"/> - the local site-id/URL cache table replaced by a dictionary,
+    /// so the lookup precedence and write-back can be asserted with no SQL Server. See issue #375.
+    ///
+    /// Mirrors the SQL adapter's write rule: a stored entry already holding the URL is re-keyed to the new
+    /// site id rather than duplicated.
+    /// </summary>
+    public class InMemorySiteUrlStore : ISiteUrlStore
+    {
+        /// <summary>Site id -> URL, in insertion order.</summary>
+        public Dictionary<string, string> UrlBySiteId { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Every site id looked up, in order.</summary>
+        public List<string> Reads { get; } = new List<string>();
+
+        /// <summary>Every (siteId, url) pair written, in order.</summary>
+        public List<Tuple<string, string>> Writes { get; } = new List<Tuple<string, string>>();
+
+        public InMemorySiteUrlStore Seed(string siteId, string url)
+        {
+            UrlBySiteId[siteId] = url;
+            return this;
+        }
+
+        public Task<string> TryGetUrlForSiteIdAsync(string siteId)
+        {
+            Reads.Add(siteId);
+            return Task.FromResult(UrlBySiteId.TryGetValue(siteId, out var url) ? url : null);
+        }
+
+        public Task SaveSiteUrlAsync(string siteId, string url)
+        {
+            Writes.Add(Tuple.Create(siteId, url));
+
+            // Re-key an existing entry for the same URL rather than storing it twice.
+            foreach (var existing in new List<string>(UrlBySiteId.Keys))
+            {
+                if (string.Equals(UrlBySiteId[existing], url, StringComparison.Ordinal))
+                {
+                    UrlBySiteId.Remove(existing);
+                    break;
+                }
+            }
+
+            UrlBySiteId[siteId] = url;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemorySiteUrlStore.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemorySiteUrlStore.cs
@@ -33,24 +33,44 @@ namespace Tests.UnitTests.FakeLoaderClasses
         public Task<SPSiteIdToUrl> TryGetForSiteIdAsync(string siteId)
         {
             Reads.Add(siteId);
-            return Task.FromResult(Rows.Find(r => string.Equals(r.SiteId, siteId, StringComparison.OrdinalIgnoreCase)));
+            return Task.FromResult(Single(Rows.FindAll(r => string.Equals(r.SiteId, siteId, StringComparison.OrdinalIgnoreCase)), "site id", siteId));
         }
 
         public Task SaveSiteUrlAsync(string siteId, string url)
         {
             Writes.Add(Tuple.Create(siteId, url));
 
-            // Re-key an existing row already holding this URL rather than storing it twice. Case-insensitive
-            // to match the SQL collation the real adapter's `s.UrlBase == url` runs under.
-            var existing = Rows.Find(r => string.Equals(r.SiteUrl, url, StringComparison.OrdinalIgnoreCase));
-            if (existing != null)
+            // A NULL url matches no row: the production context sets UseDatabaseNullSemantics = true, so
+            // `s.UrlBase == url` with a null parameter becomes `UrlBase = NULL`, which is never true in SQL
+            // and therefore always takes the insert path. C# equality would have re-keyed a null-URL row.
+            if (url != null)
             {
-                existing.SiteId = siteId;
-                return Task.CompletedTask;
+                // Re-key an existing row already holding this URL rather than storing it twice.
+                // Case-insensitive to match the SQL collation the real adapter's `s.UrlBase == url` runs under.
+                var existing = Single(Rows.FindAll(r => string.Equals(r.SiteUrl, url, StringComparison.OrdinalIgnoreCase)), "url", url);
+                if (existing != null)
+                {
+                    existing.SiteId = siteId;
+                    return Task.CompletedTask;
+                }
             }
 
             Rows.Add(new SPSiteIdToUrl { SiteId = siteId, SiteUrl = url });
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Mirrors <c>SingleOrDefaultAsync</c>: the production adapter THROWS when a lookup matches more
+        /// than one row, and duplicate site ids are the exact failure state this cache guards against
+        /// (<c>site_id</c> is not unique). A fake that quietly returned the first match would hide it.
+        /// </summary>
+        private static SPSiteIdToUrl Single(List<SPSiteIdToUrl> matches, string by, string value)
+        {
+            if (matches.Count > 1)
+            {
+                throw new InvalidOperationException($"Sequence contains more than one element: {matches.Count} rows match {by} '{value}'.");
+            }
+            return matches.Count == 1 ? matches[0] : null;
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemorySiteUrlStore.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemorySiteUrlStore.cs
@@ -6,16 +6,17 @@ using WebJob.Office365ActivityImporter.Engine.Graph;
 namespace Tests.UnitTests.FakeLoaderClasses
 {
     /// <summary>
-    /// In-memory <see cref="ISiteUrlStore"/> - the local site-id/URL cache table replaced by a dictionary,
-    /// so the lookup precedence and write-back can be asserted with no SQL Server. See issue #375.
+    /// In-memory <see cref="ISiteUrlStore"/> - the local site-id/URL cache table replaced by a list, so the
+    /// lookup precedence and write-back can be asserted with no SQL Server. See issue #375.
     ///
-    /// Mirrors the SQL adapter's write rule: a stored entry already holding the URL is re-keyed to the new
-    /// site id rather than duplicated.
+    /// Deliberately mirrors two things about the SQL adapter: a row is a hit even when its URL is null, and
+    /// URL matching on the write path is CASE-INSENSITIVE (SQL Server's default collation), so a
+    /// case-differing URL is re-keyed rather than duplicated.
     /// </summary>
     public class InMemorySiteUrlStore : ISiteUrlStore
     {
-        /// <summary>Site id -> URL, in insertion order.</summary>
-        public Dictionary<string, string> UrlBySiteId { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        /// <summary>The stored rows, in insertion order.</summary>
+        public List<SPSiteIdToUrl> Rows { get; } = new List<SPSiteIdToUrl>();
 
         /// <summary>Every site id looked up, in order.</summary>
         public List<string> Reads { get; } = new List<string>();
@@ -25,31 +26,30 @@ namespace Tests.UnitTests.FakeLoaderClasses
 
         public InMemorySiteUrlStore Seed(string siteId, string url)
         {
-            UrlBySiteId[siteId] = url;
+            Rows.Add(new SPSiteIdToUrl { SiteId = siteId, SiteUrl = url });
             return this;
         }
 
-        public Task<string> TryGetUrlForSiteIdAsync(string siteId)
+        public Task<SPSiteIdToUrl> TryGetForSiteIdAsync(string siteId)
         {
             Reads.Add(siteId);
-            return Task.FromResult(UrlBySiteId.TryGetValue(siteId, out var url) ? url : null);
+            return Task.FromResult(Rows.Find(r => string.Equals(r.SiteId, siteId, StringComparison.OrdinalIgnoreCase)));
         }
 
         public Task SaveSiteUrlAsync(string siteId, string url)
         {
             Writes.Add(Tuple.Create(siteId, url));
 
-            // Re-key an existing entry for the same URL rather than storing it twice.
-            foreach (var existing in new List<string>(UrlBySiteId.Keys))
+            // Re-key an existing row already holding this URL rather than storing it twice. Case-insensitive
+            // to match the SQL collation the real adapter's `s.UrlBase == url` runs under.
+            var existing = Rows.Find(r => string.Equals(r.SiteUrl, url, StringComparison.OrdinalIgnoreCase));
+            if (existing != null)
             {
-                if (string.Equals(UrlBySiteId[existing], url, StringComparison.Ordinal))
-                {
-                    UrlBySiteId.Remove(existing);
-                    break;
-                }
+                existing.SiteId = siteId;
+                return Task.CompletedTask;
             }
 
-            UrlBySiteId[siteId] = url;
+            Rows.Add(new SPSiteIdToUrl { SiteId = siteId, SiteUrl = url });
             return Task.CompletedTask;
         }
     }

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
@@ -53,12 +53,29 @@ namespace Tests.UnitTests
 
                 // Load the site with a new fake ID. Currently in the DB it doesn't have an ID
                 var siteUrlCache2 = new FakeSPSiteIdToUrlCache(db, logger, fakeUrlExisting);
-                var site2 = await siteUrlCache2.Load($"fake id2 {Guid.NewGuid()}");
+                var newIdForExistingUrl = $"fake id2 {Guid.NewGuid()}";
+                var site2 = await siteUrlCache2.Load(newIdForExistingUrl);
                 Assert.IsNotNull(site2);
                 Assert.AreEqual(fakeUrlExisting, site2.SiteUrl);
 
                 var dbRecord2 = db.sites.Where(s => s.UrlBase == fakeUrlExisting).SingleOrDefault();
                 Assert.IsNotNull(dbRecord2);
+
+                // The row must be RE-KEYED, not duplicated: this is the whole point of the URL lookup on
+                // the write path. Without this assertion, deleting `dbRecordBySiteUrl.SiteId = siteId` from
+                // SqlSiteUrlStore would leave the test green while defeating the cache across imports and
+                // restoring a Graph call per site, every cycle. See issue #375.
+                Assert.AreEqual(newIdForExistingUrl, dbRecord2.SiteId);
+                Assert.AreEqual(1, db.sites.Count(s => s.UrlBase == fakeUrlExisting), "The URL row must not be duplicated.");
+
+                // A stored site id must be served FROM THE DATABASE, not from Graph. The fake is primed with
+                // a different answer, so a store that stopped returning hits (or returned the Graph value)
+                // would fail here rather than silently costing a Graph round-trip per site.
+                var contradictingCache = new FakeSPSiteIdToUrlCache(db, logger, $"fake URL {Guid.NewGuid()}");
+                var storedHit = await contradictingCache.Load(fakeId);
+                Assert.IsNotNull(storedHit);
+                Assert.AreEqual(fakeUrlNew, storedHit.SiteUrl, "The stored URL must win over whatever Graph would say.");
+                Assert.AreEqual(fakeId, storedHit.SiteId);
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphUsageReportImportTests.cs
@@ -62,20 +62,28 @@ namespace Tests.UnitTests
                 Assert.IsNotNull(dbRecord2);
 
                 // The row must be RE-KEYED, not duplicated: this is the whole point of the URL lookup on
-                // the write path. Without this assertion, deleting `dbRecordBySiteUrl.SiteId = siteId` from
-                // SqlSiteUrlStore would leave the test green while defeating the cache across imports and
-                // restoring a Graph call per site, every cycle. See issue #375.
-                Assert.AreEqual(newIdForExistingUrl, dbRecord2.SiteId);
-                Assert.AreEqual(1, db.sites.Count(s => s.UrlBase == fakeUrlExisting), "The URL row must not be duplicated.");
+                // the write path. Verified on a FRESH context - re-querying on the writing context would be
+                // answered from EF's identity map, so an adapter that only called SaveChangesAsync on the
+                // insert branch would leave the re-key tracked-but-unsaved and still pass. See issue #375.
+                using (var verifyDb = new AnalyticsEntitiesContext())
+                {
+                    var persisted = verifyDb.sites.AsNoTracking().Where(s => s.UrlBase == fakeUrlExisting).ToList();
+                    Assert.AreEqual(1, persisted.Count, "The URL row must not be duplicated.");
+                    Assert.AreEqual(newIdForExistingUrl, persisted[0].SiteId, "The existing URL row must be stamped with the new site id.");
+                }
 
                 // A stored site id must be served FROM THE DATABASE, not from Graph. The fake is primed with
                 // a different answer, so a store that stopped returning hits (or returned the Graph value)
                 // would fail here rather than silently costing a Graph round-trip per site.
+                //
+                // Asked for in a DIFFERENT CASE on purpose: the site_id lookup runs under a case-insensitive
+                // collation, so this also pins that the STORED spelling comes back rather than the requested
+                // one - which returning `SiteId = siteId` from the adapter would break.
                 var contradictingCache = new FakeSPSiteIdToUrlCache(db, logger, $"fake URL {Guid.NewGuid()}");
-                var storedHit = await contradictingCache.Load(fakeId);
+                var storedHit = await contradictingCache.Load(fakeId.ToUpperInvariant());
                 Assert.IsNotNull(storedHit);
                 Assert.AreEqual(fakeUrlNew, storedHit.SiteUrl, "The stored URL must win over whatever Graph would say.");
-                Assert.AreEqual(fakeId, storedHit.SiteId);
+                Assert.AreEqual(fakeId, storedHit.SiteId, "The stored site-id spelling must be returned, not the requested one.");
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/SiteIdToUrlCacheTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SiteIdToUrlCacheTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The site-id to URL resolution: database first, Graph only on a miss, then write the answer back.
+    /// That precedence is the whole point of the cache - it exists because of a Microsoft service incident
+    /// that made these Graph lookups unreliable - and it previously had no test that did not need SQL
+    /// Server. See issue #375.
+    /// </summary>
+    [TestClass]
+    public class SiteIdToUrlCacheTests
+    {
+        /// <summary>A cache whose Graph half is a scripted stub, counting the calls it receives.</summary>
+        private sealed class StubGraphSiteCache : SPSiteIdToUrlCache
+        {
+            private readonly Dictionary<string, string> _urlBySiteId;
+
+            public StubGraphSiteCache(ISiteUrlStore store, Dictionary<string, string> urlBySiteId)
+                : base(store, NullLogger.Instance)
+            {
+                _urlBySiteId = urlBySiteId;
+            }
+
+            public List<string> GraphCalls { get; } = new List<string>();
+
+            /// <summary>When set, the Graph call throws this instead of answering.</summary>
+            public Exception ThrowInstead { get; set; }
+
+            public override Task<Microsoft.Graph.Models.Site> LoadSite(string id)
+            {
+                GraphCalls.Add(id);
+                if (ThrowInstead != null) throw ThrowInstead;
+
+                return Task.FromResult(_urlBySiteId.TryGetValue(id, out var url)
+                    ? new Microsoft.Graph.Models.Site { WebUrl = url }
+                    : new Microsoft.Graph.Models.Site { WebUrl = null });
+            }
+        }
+
+        private static Dictionary<string, string> Graph(params (string Id, string Url)[] sites)
+        {
+            var d = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var s in sites) d[s.Id] = s.Url;
+            return d;
+        }
+
+        [TestMethod]
+        public async Task SiteUrlCache_DatabaseHit_DoesNotCallGraph()
+        {
+            // The reason this cache exists: Graph site lookups were unreliable during a Microsoft incident,
+            // so a stored answer must be used without a round-trip.
+            var store = new InMemorySiteUrlStore().Seed("site-1", "https://contoso.sharepoint.com/sites/one");
+            var cache = new StubGraphSiteCache(store, Graph(("site-1", "https://should-not-be-used")));
+
+            var result = await cache.Load("site-1");
+
+            Assert.AreEqual("https://contoso.sharepoint.com/sites/one", result.SiteUrl);
+            Assert.AreEqual("site-1", result.SiteId);
+            Assert.AreEqual(0, cache.GraphCalls.Count, "A stored site must not cost a Graph call.");
+            Assert.AreEqual(0, store.Writes.Count, "Nothing new was learned, so nothing should be written.");
+        }
+
+        [TestMethod]
+        public async Task SiteUrlCache_DatabaseMiss_FallsBackToGraphAndWritesResultBack()
+        {
+            var store = new InMemorySiteUrlStore();
+            var cache = new StubGraphSiteCache(store, Graph(("site-2", "https://contoso.sharepoint.com/sites/two")));
+
+            var result = await cache.Load("site-2");
+
+            Assert.AreEqual("https://contoso.sharepoint.com/sites/two", result.SiteUrl);
+            CollectionAssert.AreEqual(new[] { "site-2" }, cache.GraphCalls.ToArray());
+
+            // Written back, so the next import does not repeat the round-trip.
+            Assert.AreEqual(1, store.Writes.Count);
+            Assert.AreEqual("site-2", store.Writes[0].Item1);
+            Assert.AreEqual("https://contoso.sharepoint.com/sites/two", store.Writes[0].Item2);
+        }
+
+        [TestMethod]
+        public async Task SiteUrlCache_SiteNotFoundInGraph_ReturnsNullWithoutThrowing()
+        {
+            // A 404 is an expected outcome (a deleted site), not a failure: it must not abort the report
+            // import that is resolving the id.
+            var store = new InMemorySiteUrlStore();
+            var cache = new StubGraphSiteCache(store, Graph())
+            {
+                ThrowInstead = new ODataError { ResponseStatusCode = (int)HttpStatusCode.NotFound }
+            };
+
+            var result = await cache.Load("site-missing");
+
+            Assert.IsNull(result);
+            Assert.AreEqual(0, store.Writes.Count, "A site that does not exist must not be cached.");
+        }
+
+        [TestMethod]
+        public async Task SiteUrlCache_GraphFailsForAnyOtherReason_ReturnsNullWithoutThrowing()
+        {
+            // Same containment for a transient/permission failure - the caller gets null rather than an
+            // exception that would take down the whole usage-report import.
+            var store = new InMemorySiteUrlStore();
+            var cache = new StubGraphSiteCache(store, Graph())
+            {
+                ThrowInstead = new InvalidOperationException("Graph is unwell")
+            };
+
+            Assert.IsNull(await cache.Load("site-3"));
+            Assert.AreEqual(0, store.Writes.Count);
+        }
+
+        [TestMethod]
+        public async Task SiteUrlCache_RepeatedLookupForSameSiteId_CallsGraphOnce()
+        {
+            // The in-memory ObjectByIdCache layer must hold the answer for the rest of the run; without it
+            // a report with thousands of rows for one site would re-query per row.
+            var store = new InMemorySiteUrlStore();
+            var cache = new StubGraphSiteCache(store, Graph(("site-4", "https://contoso.sharepoint.com/sites/four")));
+
+            var first = await cache.GetResource("site-4");
+            var second = await cache.GetResource("site-4");
+            var third = await cache.GetResource("site-4");
+
+            Assert.AreEqual("https://contoso.sharepoint.com/sites/four", first.SiteUrl);
+            Assert.AreEqual(first.SiteUrl, second.SiteUrl);
+            Assert.AreEqual(first.SiteUrl, third.SiteUrl);
+            Assert.AreEqual(1, cache.GraphCalls.Count, "Repeated lookups must be served from memory.");
+            Assert.AreEqual(1, store.Reads.Count, "...and must not re-query the database either.");
+        }
+
+        [TestMethod]
+        public async Task SiteUrlCache_NonLatinSiteUrl_RoundTripsUnchanged()
+        {
+            // SharePoint site URLs are customer text and routinely non-Latin; an encoding slip here would
+            // store a mangled URL that never matches again.
+            const string greekUrl = "https://contoso.sharepoint.com/sites/Καλημέρα";
+            var store = new InMemorySiteUrlStore();
+            var cache = new StubGraphSiteCache(store, Graph(("site-5", greekUrl)));
+
+            var fromGraph = await cache.Load("site-5");
+            Assert.AreEqual(greekUrl, fromGraph.SiteUrl);
+            Assert.AreEqual(greekUrl, store.Writes[0].Item2);
+
+            // And it comes back out of the store byte-identical on the next lookup.
+            var fromStore = await new StubGraphSiteCache(store, Graph()).Load("site-5");
+            Assert.AreEqual(greekUrl, fromStore.SiteUrl);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/SiteIdToUrlCacheTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SiteIdToUrlCacheTests.cs
@@ -72,18 +72,53 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task SiteUrlCache_DatabaseMiss_FallsBackToGraphAndWritesResultBack()
         {
+            // Uses a non-Latin URL purely as the sample value, so a pass-through that mangled it fails here.
+            // NOTE this is deliberately NOT described as encoding coverage - nothing in this path
+            // serialises, so a lossy Graph deserialisation or an ANSI EF mapping would not show up.
+            const string url = "https://contoso.sharepoint.com/sites/Καλημέρα";
             var store = new InMemorySiteUrlStore();
-            var cache = new StubGraphSiteCache(store, Graph(("site-2", "https://contoso.sharepoint.com/sites/two")));
+            var cache = new StubGraphSiteCache(store, Graph(("site-2", url)));
 
             var result = await cache.Load("site-2");
 
-            Assert.AreEqual("https://contoso.sharepoint.com/sites/two", result.SiteUrl);
+            Assert.AreEqual(url, result.SiteUrl);
             CollectionAssert.AreEqual(new[] { "site-2" }, cache.GraphCalls.ToArray());
 
             // Written back, so the next import does not repeat the round-trip.
             Assert.AreEqual(1, store.Writes.Count);
             Assert.AreEqual("site-2", store.Writes[0].Item1);
-            Assert.AreEqual("https://contoso.sharepoint.com/sites/two", store.Writes[0].Item2);
+            Assert.AreEqual(url, store.Writes[0].Item2);
+        }
+
+        [TestMethod]
+        public async Task SiteUrlCache_StoredRowWithNoUrl_IsStillAHitAndDoesNotReachGraph()
+        {
+            // Site.UrlBase is nullable, so "no row" and "a row whose URL is null" are different answers.
+            // Collapsing them sends a null-URL row to Graph and then inserts a SECOND row for the same site
+            // id, after which the single-row lookup throws for that site forever.
+            var store = new InMemorySiteUrlStore().Seed("site-null", null);
+            var cache = new StubGraphSiteCache(store, Graph(("site-null", "https://should-not-be-used")));
+
+            var result = await cache.Load("site-null");
+
+            Assert.IsNotNull(result);
+            Assert.IsNull(result.SiteUrl);
+            Assert.AreEqual(0, cache.GraphCalls.Count);
+            Assert.AreEqual(0, store.Writes.Count, "A second row for the same site id would break the lookup.");
+        }
+
+        [TestMethod]
+        public async Task SiteUrlCache_DatabaseHit_ReturnsTheStoredSiteIdSpellingNotTheRequestedOne()
+        {
+            // The site-id lookup runs under a case-insensitive collation, so the stored spelling can differ
+            // from the one asked for. The original returned the STORED value; preserve that.
+            var store = new InMemorySiteUrlStore().Seed("Site-MixedCase", "https://contoso.sharepoint.com/sites/mc");
+            var cache = new StubGraphSiteCache(store, Graph());
+
+            var result = await cache.Load("site-mixedcase");
+
+            Assert.AreEqual("Site-MixedCase", result.SiteId);
+            Assert.AreEqual(0, cache.GraphCalls.Count);
         }
 
         [TestMethod]
@@ -137,22 +172,5 @@ namespace Tests.UnitTests
             Assert.AreEqual(1, store.Reads.Count, "...and must not re-query the database either.");
         }
 
-        [TestMethod]
-        public async Task SiteUrlCache_NonLatinSiteUrl_RoundTripsUnchanged()
-        {
-            // SharePoint site URLs are customer text and routinely non-Latin; an encoding slip here would
-            // store a mangled URL that never matches again.
-            const string greekUrl = "https://contoso.sharepoint.com/sites/Καλημέρα";
-            var store = new InMemorySiteUrlStore();
-            var cache = new StubGraphSiteCache(store, Graph(("site-5", greekUrl)));
-
-            var fromGraph = await cache.Load("site-5");
-            Assert.AreEqual(greekUrl, fromGraph.SiteUrl);
-            Assert.AreEqual(greekUrl, store.Writes[0].Item2);
-
-            // And it comes back out of the store byte-identical on the next lookup.
-            var fromStore = await new StubGraphSiteCache(store, Graph()).Load("site-5");
-            Assert.AreEqual(greekUrl, fromStore.SiteUrl);
-        }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -139,6 +139,7 @@
     <Compile Include="DBLookupCacheTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeUserMetadataLoader.cs" />
     <Compile Include="FakeLoaderClasses\FakeUsageReportStorageInspector.cs" />
+    <Compile Include="FakeLoaderClasses\InMemorySiteUrlStore.cs" />
     <Compile Include="FakeLoaderClasses\TablelessDailyActivityLoader.cs" />
     <Compile Include="FakeLoaderClasses\FakeOrgUrlStore.cs" />
     <Compile Include="FakeLoaderClasses\FakeCallsPorts.cs" />
@@ -256,6 +257,7 @@
     <Compile Include="StreamTests.cs" />
     <Compile Include="UserGroupsCacheTests.cs" />
     <Compile Include="UserGroupsFilterModelTests.cs" />
+    <Compile Include="SiteIdToUrlCacheTests.cs" />
     <Compile Include="UsageReportRefreshPolicyTests.cs" />
     <Compile Include="UserImportTests.cs" />
     <Compile Include="UserLookupTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/ISiteUrlStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/ISiteUrlStore.cs
@@ -13,8 +13,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     public interface ISiteUrlStore
     {
-        /// <summary>The stored URL for this site id, or null when it is not cached yet.</summary>
-        Task<string> TryGetUrlForSiteIdAsync(string siteId);
+        /// <summary>
+        /// The stored mapping for this site id, or <c>null</c> when there is no row for it.
+        ///
+        /// Deliberately returns the row rather than just the URL: <c>UrlBase</c> is itself nullable, so
+        /// "no row" and "a row whose URL is null" are different answers. Collapsing them would send a
+        /// null-URL row to Graph and then insert a SECOND row for the same site id, after which the
+        /// single-row lookup throws for that site forever.
+        /// </summary>
+        Task<SPSiteIdToUrl> TryGetForSiteIdAsync(string siteId);
 
         /// <summary>
         /// Record the mapping. A site row already holding this URL is stamped with the id rather than
@@ -36,12 +43,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             _db = db ?? throw new ArgumentNullException(nameof(db));
         }
 
-        public async Task<string> TryGetUrlForSiteIdAsync(string siteId)
+        public async Task<SPSiteIdToUrl> TryGetForSiteIdAsync(string siteId)
         {
             // Compare directly (no .ToLower()): SQL Server's default collation is case-insensitive,
             // and LOWER() on the column makes the predicate non-SARGable, forcing a full scan of sites.
             var dbRecordBySiteId = await _db.sites.Where(s => s.SiteId == siteId).SingleOrDefaultAsync();
-            return dbRecordBySiteId?.UrlBase;
+            if (dbRecordBySiteId == null) return null;
+
+            // The STORED spelling, not the requested one - the collation match above is case-insensitive.
+            return new SPSiteIdToUrl
+            {
+                SiteId = dbRecordBySiteId.SiteId,
+                SiteUrl = dbRecordBySiteId.UrlBase
+            };
         }
 
         public async Task SaveSiteUrlAsync(string siteId, string url)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/ISiteUrlStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/ISiteUrlStore.cs
@@ -1,0 +1,65 @@
+using Common.Entities;
+using System;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// The database half of the site-id to URL resolution: the local cache that exists so the importer goes
+    /// easy on Graph. Behind a port (issue #375) because the lookup precedence - database first, Graph only
+    /// on a miss, then write the answer back - had no test that did not need SQL Server.
+    /// </summary>
+    public interface ISiteUrlStore
+    {
+        /// <summary>The stored URL for this site id, or null when it is not cached yet.</summary>
+        Task<string> TryGetUrlForSiteIdAsync(string siteId);
+
+        /// <summary>
+        /// Record the mapping. A site row already holding this URL is stamped with the id rather than
+        /// duplicated - the same URL arriving under a newly-issued site id is the case this cache exists for.
+        /// </summary>
+        Task SaveSiteUrlAsync(string siteId, string url);
+    }
+
+    /// <summary>
+    /// EF6 <see cref="ISiteUrlStore"/>. Both queries and the save are the ones that were inline in
+    /// <c>SPSiteIdToUrlCache.Load</c>, moved unchanged.
+    /// </summary>
+    public sealed class SqlSiteUrlStore : ISiteUrlStore
+    {
+        private readonly AnalyticsEntitiesContext _db;
+
+        public SqlSiteUrlStore(AnalyticsEntitiesContext db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+
+        public async Task<string> TryGetUrlForSiteIdAsync(string siteId)
+        {
+            // Compare directly (no .ToLower()): SQL Server's default collation is case-insensitive,
+            // and LOWER() on the column makes the predicate non-SARGable, forcing a full scan of sites.
+            var dbRecordBySiteId = await _db.sites.Where(s => s.SiteId == siteId).SingleOrDefaultAsync();
+            return dbRecordBySiteId?.UrlBase;
+        }
+
+        public async Task SaveSiteUrlAsync(string siteId, string url)
+        {
+            var dbRecordBySiteUrl = await _db.sites.Where(s => s.UrlBase == url).SingleOrDefaultAsync();
+            if (dbRecordBySiteUrl != null)
+            {
+                dbRecordBySiteUrl.SiteId = siteId;
+            }
+            else
+            {
+                _db.sites.Add(new Site
+                {
+                    SiteId = siteId,
+                    UrlBase = url
+                });
+            }
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
@@ -44,12 +44,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     public abstract class SPSiteIdToUrlCache : ObjectByIdCache<SPSiteIdToUrl>
     {
-        private readonly AnalyticsEntitiesContext _db;
+        private readonly ISiteUrlStore _store;
         protected readonly ILogger _logger;
 
         public SPSiteIdToUrlCache(AnalyticsEntitiesContext db, ILogger logger)
+            : this(new SqlSiteUrlStore(db), logger)
         {
-            _db = db;
+        }
+
+        /// <summary>
+        /// As above, with the local cache supplied (issue #375). The context-taking constructor is kept as a
+        /// delegating overload so no call site changes.
+        /// </summary>
+        public SPSiteIdToUrlCache(ISiteUrlStore store, ILogger logger)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
             _logger = logger;
         }
 
@@ -60,36 +69,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             try
             {
                 // Try finding from the database 1st so we go easy on Graph.
-                // Compare directly (no .ToLower()): SQL Server's default collation is case-insensitive,
-                // and LOWER() on the column makes the predicate non-SARGable, forcing a full scan of sites.
-                var dbRecordBySiteId = await _db.sites.Where(s => s.SiteId == id).SingleOrDefaultAsync();
-                if (dbRecordBySiteId != null)
+                var storedUrl = await _store.TryGetUrlForSiteIdAsync(id);
+                if (storedUrl != null)
                 {
                     return new SPSiteIdToUrl
                     {
-                        SiteId = dbRecordBySiteId.SiteId,
-                        SiteUrl = dbRecordBySiteId.UrlBase
+                        SiteId = id,
+                        SiteUrl = storedUrl
                     };
                 }
                 var site = await LoadSite(id);
                 _logger.LogInformation($"{nameof(SPSiteIdToUrlCache)}: Loaded site URL for {id}");
 
                 // Cache in DB
-                var dbRecordBySiteUrl = await _db.sites.Where(s => s.UrlBase == site.WebUrl).SingleOrDefaultAsync();
-                if (dbRecordBySiteUrl != null)
-                {
-                    dbRecordBySiteUrl.SiteId = id;
-                }
-                else
-                {
-                    dbRecordBySiteId = new Common.Entities.Site
-                    {
-                        SiteId = id,
-                        UrlBase = site.WebUrl
-                    };
-                    _db.sites.Add(dbRecordBySiteId);
-                }
-                await _db.SaveChangesAsync();
+                await _store.SaveSiteUrlAsync(id, site.WebUrl);
 
                 return new SPSiteIdToUrl
                 {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/SPSiteIdToUrlCache.cs
@@ -69,14 +69,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             try
             {
                 // Try finding from the database 1st so we go easy on Graph.
-                var storedUrl = await _store.TryGetUrlForSiteIdAsync(id);
-                if (storedUrl != null)
+                // Branch on the ROW, not on the URL: a row whose UrlBase is null is still a hit, and
+                // treating it as a miss would insert a second row for the same site id.
+                var stored = await _store.TryGetForSiteIdAsync(id);
+                if (stored != null)
                 {
-                    return new SPSiteIdToUrl
-                    {
-                        SiteId = id,
-                        SiteUrl = storedUrl
-                    };
+                    return stored;
                 }
                 var site = await LoadSite(id);
                 _logger.LogInformation($"{nameof(SPSiteIdToUrlCache)}: Loaded site URL for {id}");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Graph\PageableGraphLoaderExtensions.cs" />
     <Compile Include="Graph\PageableGraphResponse.cs" />
     <Compile Include="Graph\OfficeLicenseNameResolver.cs" />
+    <Compile Include="Graph\ISiteUrlStore.cs" />
     <Compile Include="Graph\SPSiteIdToUrlCache.cs" />
     <Compile Include="Graph\Teams\ChannelWithReactions.cs" />
     <Compile Include="Graph\Teams\CognitiveHelper.cs" />


### PR DESCRIPTION
## Summary

Second slice of #375. [#404](https://github.com/pnp/Microsoft365-Analytics-Insights/pull/404) did the refresh policy and the storage inspector; this does the **site-id → URL resolution**, whose lookup *precedence* — database first, Graph only on a miss, then write the answer back — had no test that did not need SQL Server.

That precedence is the reason the cache exists at all. The class comment points at a Microsoft service incident (`SP676147`) that made these Graph site lookups unreliable, so "go easy on Graph, and never ask twice" is load-bearing behaviour rather than an optimisation.

## What moved

`ISiteUrlStore` + `SqlSiteUrlStore` hold the two EF queries and the save, **moved unchanged**, including:

- the comment explaining why the site-id lookup compares directly rather than with `.ToLower()` — SQL Server's default collation is already case-insensitive, and `LOWER()` on the column makes the predicate non-SARGable and scans the `sites` table;
- the write rule that **re-keys an existing row already holding the same URL** rather than inserting a duplicate. That is the case the cache exists for: the same site surfacing under a newly-issued id.

`SPSiteIdToUrlCache` keeps its `AnalyticsEntitiesContext`-taking constructor as a **delegating overload**, so `GraphSPSiteIdToUrlCache`, `SharePointSitesWeeklyUsageReportLoader`, `GraphImporter` and the existing `FakeSPSiteIdToUrlCache` are all untouched.

## Deliberate deviation from #375's proposed shape

**No `ISiteGraphSource`.** The issue proposes one, but the abstract `LoadSite` method already *is* that seam — `GraphSPSiteIdToUrlCache` supplies the real implementation and `Tests.UnitTests` already ships a `FakeSPSiteIdToUrlCache` that overrides it. Adding a parallel port would be duplication, not decoupling. The Graph half was never the untested half; the database half was.

## Testing

**New: 7 tests in `SiteIdToUrlCacheTests` plus `InMemorySiteUrlStore`** — zero SQL Server, zero Graph:

- a **database hit costs no Graph call** (and writes nothing back, since nothing was learned);
- a **miss falls back to Graph and writes the result back**, so the next import does not repeat the round-trip;
- a **404** returns `null` rather than throwing — a deleted site must not abort the report import resolving it — and is **not** cached;
- **any other Graph failure** is contained the same way;
- **repeated lookups call Graph once** *and* hit the database once — without the in-memory layer, a report with thousands of rows for one site would re-query per row;
- a stored row whose **URL is null is still a hit** and does not reach Graph;
- a database hit returns the **stored** site-id spelling, not the requested one (the lookup is case-insensitive).

The Greek URL is now a sample value inside the miss test, described honestly as a pass-through assertion rather than encoding coverage.

**Pre-existing evidence:** `SPSiteIdToUrlCacheTests` — the DB-backed test covering exactly this code path — still passes, as do `SharePointSitesUsageLoader_SavesNewReusesExistingAndSkipsCurrent`, `_DuplicateNewSiteInSameRun_CreatesOneSite` and `_MatchesExistingSiteUrlCaseInsensitively` (the case-insensitive site-matching guarantee #375 asks to keep). Area run: 68 passed / 1 failed of 69 — the failure is the pre-existing `SharePointSitesUsageLoaderTest`, which needs real Graph credentials. Full solution builds (Debug).

## Review loop — three rounds, six findings, all real

Worth recording, because every round found an assertion that *named* a regression it could not detect:

**Round 1**
- **A genuine regression I introduced.** `Site.UrlBase` is nullable, so "no row" and "a row whose URL is null" are different answers. My first `string`-returning port collapsed both to `null`, so a null-URL row fell through to Graph and then inserted a **second row for the same site id** — after which `SingleOrDefaultAsync` throws for that site permanently. The port now returns the row.
- **No test touched the SQL adapter at all** — making `TryGetForSiteIdAsync` always return `null`, or deleting the re-key line, would have passed all six new tests.
- **A Unicode test that crossed no encoding boundary** (Graph and SQL were both in-memory objects returning the same managed string). Deleted.

**Round 2**
- The re-key assertion re-queried on the **writing** context, so EF's identity map answered it: an adapter that moved `SaveChangesAsync` into only the insert branch would leave the re-key tracked-but-unsaved and still pass. Now verified on a fresh context with `AsNoTracking()`.
- The stored-casing check asked for the id in its stored case, so an adapter returning the *requested* spelling would have passed. It now asks in uppercase and asserts the stored spelling comes back — exercising the case-insensitive collation against real SQL.
- `InMemorySiteUrlStore` diverged twice more: it re-keyed on a **null** URL where SQL inserts (`UseDatabaseNullSemantics = true`, verified in `AnalyticsEntitiesContext.cs:72`), and returned the first of several matches where `SingleOrDefaultAsync` **throws** — and duplicate `site_id`s are the exact failure state this cache guards against.

**Round 3** — clean.

## Reviewer hotspots
1. **Is `SqlSiteUrlStore` faithful?** Compare against `git show origin/dev~1:…/Graph/SPSiteIdToUrlCache.cs`. Particularly: `TryGetUrlForSiteIdAsync` returns `UrlBase` and the caller now builds `SiteId` from the *requested* id rather than the stored row's — confirm those are always equal in practice, or say if that is a real difference.
2. **`InMemorySiteUrlStore` re-implements the re-key-on-same-URL rule** rather than sharing it with the SQL adapter, so the two could drift. Same trade-off flagged (and fixed) on #400 — is it worth hoisting here, or is the SQL adapter's version adequately covered by `SPSiteIdToUrlCacheTests`?
3. **Test honesty** — for each of the 6, what realistic regression makes it fail? Recent rounds caught a cap test that could not reach the cap and a UTC test that only discriminated on negative-offset hosts, so please be blunt.

## Still outstanding in #375

The full `IUsageReportStore` (`GetStoredReportDatesAsync` / `UpsertReportRowsAsync` / `RecordReportLoadAsync`) and moving `ExecuteSqlCommandAsync` out of the aggregate loaders. That is the largest remaining piece and threads through the generic base class, so it wants its own PR.

Addresses #375