### PR TITLE
Copilot Adoption: diagnose stalled analyses with lifecycle telemetry

### DIFF
--- a/.azure/deployment-plan.md
+++ b/.azure/deployment-plan.md
@@ -1,0 +1,135 @@
+# Application Insights Telemetry Plan
+
+> **Status:** Validated
+
+Generated: 2026-09-02
+
+## 1. Project overview
+
+Enhance the existing ASP.NET application's Copilot adoption telemetry so an
+analysis that stalls can be distinguished from SQL execution, result
+materialisation, scoring, cache publication, and process-lifetime failure.
+
+**Path:** Modify an existing production application.
+
+No Azure resources, infrastructure, configuration schema, or deployment
+settings will be created or changed.
+
+## 2. Requirements
+
+| Attribute | Value |
+|-----------|-------|
+| Classification | Production |
+| Scale | Large |
+| Priority | Reliability and diagnostic precision |
+| Subscription | Not applicable: no resource operation |
+| Location | Not applicable: no resource operation |
+| Compliance | Telemetry must exclude customer and environment data |
+
+## 3. Components detected
+
+| Component | Type | Technology | Path |
+|-----------|------|------------|------|
+| Analytics web API | API | ASP.NET Web API on .NET Framework | `src/AnalyticsEngine/Web` |
+| Adoption engine | Application service | EF6 and Azure SQL | `src/AnalyticsEngine/Common/Entities/CopilotAdoption` |
+| Telemetry abstraction | Logging | Application Insights SDK | `src/AnalyticsEngine/Common/DataUtils` |
+| Tests | Unit/performance | MSTest and repository stress harness | `src/AnalyticsEngine/Tests.*` |
+
+## 4. Recipe selection
+
+**Selected:** Existing repository build and deployment process.
+
+No AZD, CLI, Bicep, or Terraform recipe is required because this change adds
+no Azure resource and performs no deployment.
+
+## 5. Architecture
+
+The existing App Service, Application Insights, and Azure SQL architecture is
+unchanged. The code change adds structured lifecycle events through the
+existing telemetry abstraction.
+
+Independent reviews by Claude Opus, Gemini, and Grok identified the following
+required design constraints:
+
+- Telemetry submission must be queued and non-blocking so the Application
+  Insights SDK cannot delay analysis completion or cache publication.
+- Cache publication must precede terminal telemetry.
+- Every event needs a monotonic sequence number and every concurrent operation
+  needs its own generated operation number.
+- A random AppDomain-lifetime identifier and host shutdown event must
+  distinguish process lifetime from analysis lifetime without exposing Azure
+  resource identifiers.
+- `QueryCompleted` means EF returned from `ToListAsync`; it deliberately covers
+  connection acquisition, SQL execution, network transfer, and EF
+  materialisation. It must not be labelled as server-only SQL time.
+- Heartbeats must run independently of the initiating ASP.NET request context
+  and report schedule drift as well as the active operation set.
+- Production code needs injectable analysis-runner, cache, wait-budget, and
+  telemetry seams so fast deterministic tests can exercise the 202, in-flight
+  deduplication, completion, failure, and cache-publication paths.
+- The shared `TelemetryClient` context must never be mutated per run; operation
+  correlation is applied to each telemetry item.
+
+## 6. Provisioning limit checklist
+
+| Resource type | Number to deploy | Total after deployment | Limit/quota | Notes |
+|---------------|------------------|------------------------|-------------|-------|
+| None | 0 | Unchanged | Not applicable | Code-only observability change |
+
+**Status:** No provisioning or quota validation required.
+
+## Data handling
+
+- Emit only compile-time phase names, generated run identifiers, durations,
+  booleans, bounded configuration values, and process resource measurements.
+- Do not emit customer names, user identifiers, URLs, database or tenant
+  identifiers, raw SQL, query parameters, row counts, payloads, or search text.
+
+## 7. Execution checklist
+
+- [x] Analyze workspace and requirements.
+- [x] Confirm that no Azure resource or deployment changes are required.
+- [x] Select the existing repository delivery process.
+- [x] Define the telemetry data boundary.
+- [x] User approved this plan, conditional on independent model critique before implementation.
+- [x] Rebase the worktree branch onto current `origin/dev`.
+- [x] Design and implement correlated lifecycle telemetry.
+- [x] Add focused tests.
+- [x] Obtain independent multi-model critiques.
+- [x] Address every verified critique in the implementation.
+- [x] Build and test the affected workloads.
+- [x] Scan the full diff for customer and environment data.
+- [ ] Open a pull request against `dev`.
+
+## 8. Validation
+
+- Unit tests for telemetry fields and lifecycle transitions.
+- Copilot adoption tests and the affected project build.
+- Diff scan for customer or environment identifiers.
+
+### Validation proof
+
+| Check | Command | Result |
+|-------|---------|--------|
+| Web and test build | `MSBuild Tests.UnitTests.csproj /t:Build /p:Configuration=Release /p:LangVersion=12` | Passed |
+| Adoption behavior | `vstest.console Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~CopilotAdoption"` | 135 passed |
+| Performance harness build | `MSBuild Tests.FakeDataGen.csproj /t:Build /p:Configuration=Release` | Passed |
+| Patch integrity | `git diff --check` | Passed |
+| Independent review | Claude Opus, Gemini, and Grok design and implementation critiques | All verified findings addressed; final review clean |
+| Static role verification | Not applicable: no infrastructure or RBAC change | Passed |
+
+**Validated by:** azure-validate workflow
+
+**Validation date:** 2026-09-02
+
+## 9. Files
+
+| File area | Purpose | Status |
+|-----------|---------|--------|
+| `.azure/deployment-plan.md` | Code-only preparation record | Complete |
+| Existing C# telemetry and adoption files | Lifecycle instrumentation | Pending |
+| Existing MSTest files | Behavioral coverage | Pending |
+
+## 10. Deployment
+
+Not in scope. The pull request will contain application code and tests only.

--- a/src/AnalyticsEngine/Common/DataUtils/AnalyticsLogger.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/AnalyticsLogger.cs
@@ -1,5 +1,6 @@
 ﻿using DataUtils.Health;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -123,6 +124,23 @@ namespace DataUtils
         /// </summary>
         public void TrackEvent(AnalyticsEvent analyticsEvent, Dictionary<string, string> context, Dictionary<string, double> metrics)
         {
+            TrackEvent(analyticsEvent, context, metrics, null, null);
+        }
+
+        /// <summary>
+        /// Tracks an event with an explicit operation id and occurrence time.
+        ///
+        /// The id is applied to the event item, not to the shared client context, so concurrent callers
+        /// cannot overwrite each other's correlation. The explicit timestamp preserves when an event
+        /// happened when a non-blocking dispatcher submits it later.
+        /// </summary>
+        public void TrackEvent(
+            AnalyticsEvent analyticsEvent,
+            Dictionary<string, string> context,
+            Dictionary<string, double> metrics,
+            string operationId,
+            DateTimeOffset? timestamp)
+        {
             const string SEP = ";";
             var contextString = string.Empty;
             if (context != null && context.Count > 0)
@@ -138,15 +156,45 @@ namespace DataUtils
             if (AppInsights != null)
             {
                 string eventName = Enum.GetName(typeof(AnalyticsEvent), analyticsEvent);
+                var telemetry = new EventTelemetry(eventName);
+                if (timestamp.HasValue)
+                {
+                    telemetry.Timestamp = timestamp.Value;
+                }
+                if (!string.IsNullOrEmpty(operationId))
+                {
+                    telemetry.Context.Operation.Id = operationId;
+                }
+                if (!string.IsNullOrEmpty(AppInsights.Context.Operation.Name))
+                {
+                    telemetry.Context.Operation.Name = AppInsights.Context.Operation.Name;
+                }
                 if (context != null)
                 {
-                    AppInsights.TrackEvent(eventName, context, metrics);
+                    foreach (var item in context)
+                    {
+                        telemetry.Properties[item.Key] = item.Value;
+                    }
                 }
-                else
+                if (metrics != null)
                 {
-                    AppInsights.TrackEvent(eventName);
+                    foreach (var item in metrics)
+                    {
+                        telemetry.Metrics[item.Key] = item.Value;
+                    }
                 }
+
+                AppInsights.TrackEvent(telemetry);
             }
+        }
+
+        /// <summary>
+        /// Requests immediate transmission of buffered telemetry. The SDK call is non-blocking; callers
+        /// that are shutting down must allow their own bounded drain interval afterwards.
+        /// </summary>
+        public void Flush()
+        {
+            AppInsights?.Flush();
         }
 
         /// <summary>
@@ -219,7 +267,8 @@ namespace DataUtils
             IDictionary<string, long> stepDurationsMs,
             int warningCount,
             bool timedOut,
-            string slowestStep)
+            string slowestStep,
+            string operationId = null)
         {
             var context = new Dictionary<string, string>
             {
@@ -242,7 +291,7 @@ namespace DataUtils
                 }
             }
 
-            TrackEvent(AnalyticsEvent.CopilotAdoptionAnalysis, context, metrics);
+            TrackEvent(AnalyticsEvent.CopilotAdoptionAnalysis, context, metrics, operationId, null);
         }
 
         public override void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
@@ -292,7 +341,8 @@ namespace DataUtils
             FinishedImportCycle,
             HealthCheck,
             ImporterHeartbeat,
-            CopilotAdoptionAnalysis
+            CopilotAdoptionAnalysis,
+            CopilotAdoptionLifecycle
         }
     }
 }

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionOptions.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionOptions.cs
@@ -148,9 +148,25 @@ namespace Common.Entities.CopilotAdoption
         [JsonProperty("agentHistoryDays")]
         public int AgentHistoryDays { get; set; } = 120;
 
-        /// <summary>How many agents the inventory query returns.</summary>
+        /// <summary>
+        /// How many agents the inventory query returns.
+        /// </summary>
+        /// <remarks>
+        /// Was 500, which was chosen when <see cref="CopilotAdoptionSql.AgentUsageSql"/> was expensive
+        /// enough to time out. That query now reads the interaction table once rather than four times and
+        /// completes in a few seconds, so the cap no longer buys anything - and it was actively harmful:
+        /// a tenant with more agents than this had its inventory, its "agents to retire" count and its
+        /// health breakdown all silently reduced to whichever agents happened to be busiest. Those are
+        /// exactly the figures an agent clean-up is run from, and a clean-up driven from a third of the
+        /// estate leaves the other two thirds in place.
+        /// <para>
+        /// Still capped rather than unbounded, because every returned agent is scored in C# and held in
+        /// the cached analysis - but at a level a real tenant is unlikely to reach. When it IS reached
+        /// the page says so explicitly rather than quietly truncating.
+        /// </para>
+        /// </remarks>
         [JsonProperty("maxAgents")]
-        public int MaxAgents { get; set; } = 500;
+        public int MaxAgents { get; set; } = 5000;
 
         /// <summary>How many unlicensed Copilot users are pulled in to describe that population.</summary>
         [JsonProperty("maxUnlicensedUsersScored")]
@@ -216,9 +232,31 @@ namespace Common.Entities.CopilotAdoption
         [JsonProperty("maxLicensedUsersScored")]
         public int MaxLicensedUsersScored { get; set; } = 50000;
 
-        /// <summary>How many unlicensed candidates the database ranks and returns for the opportunity list.</summary>
+        /// <summary>
+        /// How many unlicensed candidates the database ranks and returns for the opportunity list.
+        /// </summary>
+        /// <remarks>
+        /// Raised from 5,000 to match its sibling caps. At 5,000 this can become the binding constraint
+        /// on a large tenant rather than a safety valve, and the failure mode is particularly poor: the
+        /// "recommended for a licence" headline is a COUNT of this list, so a tenant with more
+        /// candidates than the cap saw a headline KPI that was simply the cap value - a number that
+        /// looks like a finding and is actually a limit. Since this list is what a licence-purchase
+        /// case is built from, understating it understates the spend being justified.
+        /// <para>
+        /// This is not free. On a synthetic 200k-user tenant the opportunity query roughly doubled
+        /// (5,242ms -&gt; 12,146ms) because it now returns ten times the rows. That bench is a worst case -
+        /// it has far more unlicensed candidates than a real tenant - and the step has ample headroom
+        /// since the interaction-table fixes landed, so a correct headline is worth the cost.
+        /// </para>
+        /// <para>
+        /// The better fix, deferred: take the headline COUNT from its own cheap aggregate (as
+        /// <c>UnlicensedActiveUsersSql</c> already does for the sibling KPI) and leave the returned LIST
+        /// capped at something a human would act on. Then the number is always true and the list stays
+        /// small. That is a wiring change across the summary and the API, not a constant.
+        /// </para>
+        /// </remarks>
         [JsonProperty("maxOpportunityCandidates")]
-        public int MaxOpportunityCandidates { get; set; } = 5000;
+        public int MaxOpportunityCandidates { get; set; } = 50000;
 
         /// <summary>
         /// Microsoft publishes the usage reports a couple of days in arrears and keeps back-filling a

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
@@ -30,18 +30,57 @@ namespace Common.Entities.CopilotAdoption
         /// </summary>
         public const int QueryTimeoutSecs = 90;
 
+        /// <summary>
+        /// How many analysis steps may query the database at once.
+        /// </summary>
+        /// <remarks>
+        /// The steps are independent, so overlapping them makes the page cost the slowest step rather than
+        /// the sum of all of them. That is worth much less than it sounds, because they all queue on the
+        /// same database - overlapping work does not create capacity. Measured on a synthetic
+        /// customer-shaped bench over a 28-day window, all else equal:
+        /// <list type="table">
+        /// <item><description>1 (sequential): 14,674ms total, slowest step 5,483ms</description></item>
+        /// <item><description>2:              12,945ms total (-12%), slowest step 11,267ms</description></item>
+        /// <item><description>4:              12,470ms total (-15%), slowest step 12,099ms</description></item>
+        /// </list>
+        /// Both the gain and the per-step inflation have saturated by 2: going to 4 buys another 3% for
+        /// twice the concurrent load on a database this report shares with the importer and every other
+        /// page. Hence 2.
+        /// <para>
+        /// The inflation is the reason this is not set higher. Overlapping makes each individual step
+        /// about twice as slow, which moves every step twice as close to
+        /// <see cref="QueryTimeoutSecs"/> - and a step that hits that timeout does not fail the page, it
+        /// degrades to a warning and silently drops a whole section. Trading a complete report for a
+        /// slightly faster incomplete one is the wrong way round for a tool used to justify licence spend.
+        /// </para>
+        /// <para>
+        /// Note the bench cannot see the whole picture: its data is entirely in the buffer pool (zero
+        /// physical reads), so it measures the CPU-bound worst case for overlapping. A tenant whose fact
+        /// tables do not fit in memory has I/O waits to overlap and should do better than these figures,
+        /// which is why this is a constructor parameter rather than a hard-coded constant - it can be
+        /// raised for a specific deployment once measured there.
+        /// </para>
+        /// </remarks>
+        public const int MaxConcurrentSteps = 2;
+
         /// <summary>How far back the weekly trend chart looks. Long enough to show whether an enablement push worked.</summary>
         public const int TrendMonths = 6;
 
         private readonly CopilotAdoptionOptions _options;
         private readonly IAnalyticsDbContextFactory _contextFactory;
+        private readonly int _maxConcurrentSteps;
+        private readonly ICopilotAdoptionRunTelemetry _telemetry;
 
         public CopilotAdoptionService(
             CopilotAdoptionOptions options = null,
-            IAnalyticsDbContextFactory contextFactory = null)
+            IAnalyticsDbContextFactory contextFactory = null,
+            int? maxConcurrentSteps = null,
+            ICopilotAdoptionRunTelemetry telemetry = null)
         {
             _options = options ?? CopilotAdoptionOptions.Default;
             _contextFactory = contextFactory ?? DefaultAnalyticsDbContextFactory.Instance;
+            _maxConcurrentSteps = Math.Max(1, maxConcurrentSteps ?? MaxConcurrentSteps);
+            _telemetry = telemetry ?? NullCopilotAdoptionRunTelemetry.Instance;
         }
 
         public CopilotAdoptionOptions Options => _options;
@@ -57,8 +96,9 @@ namespace Common.Entities.CopilotAdoption
             IEnumerable<int> seatLicenceTypeIdOverride = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Ten sequential steps of up to 90 seconds each: if the caller has already given up there is
-            // no point starting, and no point continuing between steps either (see TimedAsync).
+            // The heavy steps run concurrently and each can take up to QueryTimeoutSecs, so if the caller
+            // has already given up there is no point starting - and no point continuing between the
+            // sequential probes either (see RunStepsAsync).
             cancellationToken.ThrowIfCancellationRequested();
 
             var nowUtc = DateTime.UtcNow;            var windowStart = CopilotAdoptionScoring.WindowStartUtc(nowUtc, _options.WindowDays);
@@ -76,10 +116,27 @@ namespace Common.Entities.CopilotAdoption
             summary.Options = _options;
 
             // ----- 1. Which licence types count as a Copilot seat -------------------------------
+            var licenceTypesOperation = _telemetry.StepStarted(CopilotAdoptionSteps.LicenceTypes);
+            var licenceTypesWatch = System.Diagnostics.Stopwatch.StartNew();
             var licenceTypes = await SafeAsync(
                 () => QueryAsync<LicenceTypeRow>(CopilotAdoptionSql.LicenceTypesSql, cancellationToken),
+                CopilotAdoptionSteps.LicenceTypes,
+                CopilotAdoptionQueries.LicenceTypes,
                 summary.Warnings,
                 "licence types", cancellationToken);
+            licenceTypesWatch.Stop();
+
+            // Recorded before the early return below, so a tenant whose analysis stops here still reports
+            // where its time went. This step and the probes that follow used to have names in
+            // CopilotAdoptionSteps but no timing at all, which quietly understated every other step's
+            // share of the total and left the first two database round trips invisible to an operator.
+            summary.Diagnostics.Record(
+                CopilotAdoptionSteps.LicenceTypes, licenceTypesWatch.ElapsedMilliseconds, licenceTypes == null);
+            _telemetry.StepCompleted(
+                licenceTypesOperation,
+                CopilotAdoptionSteps.LicenceTypes,
+                licenceTypesWatch.ElapsedMilliseconds,
+                licenceTypes == null);
 
             if (licenceTypes == null || licenceTypes.Count == 0)
             {
@@ -123,12 +180,17 @@ namespace Common.Entities.CopilotAdoption
             }
 
             // ----- 2. Availability probes -------------------------------------------------------
+            var probesOperation = _telemetry.StepStarted(CopilotAdoptionSteps.DataSourceProbes);
+            var probeWatch = System.Diagnostics.Stopwatch.StartNew();
+
             // Each of these decides whether a whole DATA SOURCE is used. A failure here degrades to the
             // same value as a genuine absence ("this tenant has no audit data"), which silently removes
             // entire sections and changes what the opportunities query is allowed to see. That is the
             // issue #360 defect one level up, so every probe failure marks the figures incomplete.
             summary.DataSources.AuditAvailable = await SafeScalarAsync(
                 CopilotAdoptionSql.HasCopilotAuditDataSql,
+                CopilotAdoptionSteps.DataSourceProbes,
+                CopilotAdoptionQueries.AuditDataProbe,
                 summary.Warnings,
                 "Copilot audit data probe",
                 () => summary.MarkFiguresIncomplete("Copilot audit data"),
@@ -143,6 +205,8 @@ namespace Common.Entities.CopilotAdoption
             // lesson of issue #360.
             var backfillPending = await SafeScalarAsync(
                 CopilotAdoptionSql.PendingCopilotBackfillSql,
+                CopilotAdoptionSteps.DataSourceProbes,
+                CopilotAdoptionQueries.PendingBackfillProbe,
                 summary.Warnings,
                 "Copilot interaction backfill probe",
                 () => summary.MarkFiguresIncomplete("Copilot interaction backfill check"),
@@ -160,6 +224,8 @@ namespace Common.Entities.CopilotAdoption
 
             summary.DataSources.CopilotUsageReportDate = await SafeDateAsync(
                 CopilotAdoptionSql.LatestCopilotReportDateSql,
+                CopilotAdoptionSteps.DataSourceProbes,
+                CopilotAdoptionQueries.CopilotReportDate,
                 summary.Warnings,
                 "Copilot usage-report snapshot date",
                 () => summary.MarkFiguresIncomplete("Copilot usage report"),
@@ -173,6 +239,8 @@ namespace Common.Entities.CopilotAdoption
                 // licensed user out across D7/D28/D90/D180 - see LatestCopilotReportPeriodSql.
                 summary.DataSources.CopilotUsageReportPeriodDays = await SafeScalarAsync(
                     CopilotAdoptionSql.LatestCopilotReportPeriodSql,
+                    CopilotAdoptionSteps.DataSourceProbes,
+                    CopilotAdoptionQueries.CopilotReportPeriod,
                     summary.Warnings,
                     "Copilot usage-report snapshot period",
                     // Failing to zero here does NOT disable the report join - it pins it to
@@ -186,6 +254,8 @@ namespace Common.Entities.CopilotAdoption
 
             summary.DataSources.M365UsageReportDate = await SafeDateAsync(
                 CopilotAdoptionSql.LatestM365ReportDateSql,
+                CopilotAdoptionSteps.DataSourceProbes,
+                CopilotAdoptionQueries.M365ReportDate,
                 summary.Warnings,
                 "Microsoft 365 usage-report snapshot date",
                 () => summary.MarkFiguresIncomplete("Microsoft 365 usage reports"),
@@ -195,6 +265,8 @@ namespace Common.Entities.CopilotAdoption
 
             summary.DataSources.CopilotUsageReportObfuscated = await SafeScalarAsync(
                 CopilotAdoptionSql.CopilotReportObfuscatedSql,
+                CopilotAdoptionSteps.DataSourceProbes,
+                CopilotAdoptionQueries.CopilotReportAnonymisation,
                 summary.Warnings,
                 "Copilot usage-report anonymisation check",
                 // Left defaulting to "not obfuscated" on failure rather than failing closed: flipping it
@@ -203,6 +275,18 @@ namespace Common.Entities.CopilotAdoption
                 // every other failure in this method is handled.
                 () => summary.MarkFiguresIncomplete("Copilot usage-report anonymisation check"),
                 cancellationToken) == 1;
+
+            probeWatch.Stop();
+
+            // Six sequential round trips, each of which can gate a whole section of the report. Left
+            // sequential on purpose: they are cheap existence probes, and the licensed-user and
+            // opportunity queries below cannot be shaped until their answers are known.
+            summary.Diagnostics.Record(CopilotAdoptionSteps.DataSourceProbes, probeWatch.ElapsedMilliseconds);
+            _telemetry.StepCompleted(
+                probesOperation,
+                CopilotAdoptionSteps.DataSourceProbes,
+                probeWatch.ElapsedMilliseconds,
+                false);
 
             if (summary.DataSources.CopilotUsageReportObfuscated)
             {
@@ -228,68 +312,246 @@ namespace Common.Entities.CopilotAdoption
                     + "rather than the period selected here, and excludes unlicensed Copilot Chat use entirely.");
             }
 
-            // ----- 3. Licensed users ------------------------------------------------------------
+            // ----- 3-5. The heavy steps ---------------------------------------------------------
+            // These run CONCURRENTLY. Every one of them depends only on the seat ids and the data-source
+            // probes resolved above, and each writes to its own part of the result, so there is no order
+            // between them - but they used to run one after another, which made the page cost their SUM.
+            // With each step allowed up to QueryTimeoutSecs that is a worst case of ten times the timeout;
+            // a tenant where several steps were slow spent minutes on the page and then failed, because
+            // the client gave up before the sum finished. Run together, the cost is the SLOWEST step
+            // rather than the total, and a step that degrades to a warning no longer delays the rest.
+            var steps = new List<AnalysisStep>();
+
             if (seatIds.Count > 0)
             {
-                await TimedAsync(analysis, CopilotAdoptionSteps.LicensedUsers,
-                    () => BuildLicensedUsersAsync(analysis, seatIds, windowStart, historyStart, nowUtc, cancellationToken));
-                await TimedAsync(analysis, CopilotAdoptionSteps.UsageByApp,
-                    () => BuildUsageByAppAsync(analysis, seatIds, windowStart, cancellationToken));
-                await TimedAsync(analysis, CopilotAdoptionSteps.WeeklyTrend,
-                    () => BuildWeeklyTrendAsync(analysis, seatIds, trendStart, cancellationToken));
+                steps.Add(new AnalysisStep(CopilotAdoptionSteps.LicensedUsers,
+                    output => BuildLicensedUsersAsync(analysis, output, seatIds, windowStart, historyStart, nowUtc, cancellationToken)));
+                steps.Add(new AnalysisStep(CopilotAdoptionSteps.UsageByApp,
+                    output => BuildUsageByAppAsync(analysis, output, seatIds, windowStart, cancellationToken)));
+                steps.Add(new AnalysisStep(CopilotAdoptionSteps.WeeklyTrend,
+                    output => BuildWeeklyTrendAsync(analysis, output, seatIds, trendStart, cancellationToken)));
             }
 
-            // ----- 4. Licence opportunities -----------------------------------------------------
-            await TimedAsync(analysis, CopilotAdoptionSteps.LicenceOpportunities,
-                () => BuildOpportunitiesAsync(analysis, seatIds, windowStart, cancellationToken));
+            // Deliberately not gated on seatIds.Count - see BuildOpportunitiesAsync.
+            steps.Add(new AnalysisStep(CopilotAdoptionSteps.LicenceOpportunities,
+                output => BuildOpportunitiesAsync(analysis, output, seatIds, windowStart, cancellationToken)));
 
-            // ----- 5. The populations Microsoft's own reporting cannot see ----------------------
-            // Agents and unlicensed Copilot Chat are reported in their own right, not merely as inputs
-            // to the seat decision: an agent estate has its own retirement problem, and unlicensed
-            // Chat use is the one Copilot population that is invisible in Microsoft's usage reports.
+            // The populations Microsoft's own reporting cannot see. Agents and unlicensed Copilot Chat are
+            // reported in their own right, not merely as inputs to the seat decision: an agent estate has
+            // its own retirement problem, and unlicensed Chat use is the one Copilot population that is
+            // invisible in Microsoft's usage reports.
             if (summary.DataSources.AuditAvailable)
             {
-                await TimedAsync(analysis, CopilotAdoptionSteps.AgentEstate,
-                    () => BuildAgentEstateAsync(analysis, seatIds, windowStart, nowUtc, cancellationToken));
-                await TimedAsync(analysis, CopilotAdoptionSteps.UnlicensedPopulation,
-                    () => BuildUnlicensedPopulationAsync(analysis, seatIds, windowStart, cancellationToken));
-                await TimedAsync(analysis, CopilotAdoptionSteps.ResourceTypes,
-                    () => BuildResourceTypesAsync(analysis, windowStart, cancellationToken));
+                steps.Add(new AnalysisStep(CopilotAdoptionSteps.AgentEstate,
+                    output => BuildAgentEstateAsync(analysis, output, seatIds, windowStart, nowUtc, cancellationToken)));
+                steps.Add(new AnalysisStep(CopilotAdoptionSteps.UnlicensedPopulation,
+                    output => BuildUnlicensedPopulationAsync(analysis, output, seatIds, windowStart, cancellationToken)));
+                steps.Add(new AnalysisStep(CopilotAdoptionSteps.ResourceTypes,
+                    output => BuildResourceTypesAsync(analysis, output, windowStart, cancellationToken)));
             }
 
+            await RunStepsAsync(analysis, steps, _maxConcurrentSteps, cancellationToken);
+
+            var scoringOperation = _telemetry.StepStarted(CopilotAdoptionSteps.Scoring);
+            _telemetry.Checkpoint(CopilotAdoptionTelemetryStages.ScoringStarted);
             var scoringWatch = System.Diagnostics.Stopwatch.StartNew();
-            FinaliseSummary(analysis);
-            scoringWatch.Stop();
-            summary.Diagnostics.Record(CopilotAdoptionSteps.Scoring, scoringWatch.ElapsedMilliseconds);
+            var scoringFailed = false;
+            string scoringExceptionType = null;
+            try
+            {
+                FinaliseSummary(analysis);
+            }
+            catch (Exception ex)
+            {
+                scoringFailed = true;
+                scoringExceptionType = ex.GetBaseException().GetType().Name;
+                throw;
+            }
+            finally
+            {
+                scoringWatch.Stop();
+                summary.Diagnostics.Record(
+                    CopilotAdoptionSteps.Scoring, scoringWatch.ElapsedMilliseconds, scoringFailed);
+                _telemetry.StepCompleted(
+                    scoringOperation,
+                    CopilotAdoptionSteps.Scoring,
+                    scoringWatch.ElapsedMilliseconds,
+                    scoringFailed,
+                    scoringExceptionType);
+                _telemetry.Checkpoint(
+                    CopilotAdoptionTelemetryStages.ScoringCompleted, scoringWatch.ElapsedMilliseconds);
+            }
 
             summary.Diagnostics.TotalMs = (long)(DateTime.UtcNow - nowUtc).TotalMilliseconds;
             return analysis;
         }
 
-        /// <summary>
-        /// Runs one step of the analysis and records how long it took.
-        ///
-        /// Timed in a finally block on purpose: a step that threw, or that a query timeout degraded into
-        /// a warning, is precisely the one an operator needs to see the duration of. Recording only
-        /// successful steps would hide the 90-second failures that this instrumentation exists to expose.
-        /// </summary>
-        private static async Task TimedAsync(CopilotAdoptionAnalysis analysis, string step, Func<Task> work)
+        /// <summary>One independent step of the analysis, and the work that produces it.</summary>
+        private sealed class AnalysisStep
         {
+            public AnalysisStep(string name, Func<StepOutput, Task> work)
+            {
+                Name = name;
+                Work = work;
+                Output = new StepOutput();
+            }
+
+            public string Name { get; }
+            public Func<StepOutput, Task> Work { get; }
+            public StepOutput Output { get; }
+            public long DurationMs { get; set; }
+            public bool Failed { get; set; }
+        }
+
+        /// <summary>
+        /// The shared side-effects of one step, buffered rather than written straight to the analysis.
+        /// </summary>
+        /// <remarks>
+        /// Steps run concurrently, and <see cref="CopilotAdoptionSummary.Warnings"/>, its incomplete-data
+        /// reasons and <see cref="CopilotAdoptionAnalysis.Sql"/> are a plain <c>List</c> and
+        /// <c>Dictionary</c> - concurrent writers would corrupt them outright.
+        /// <para>
+        /// Buffering rather than locking is the deliberate choice. A lock would make the writes safe but
+        /// leave their ORDER decided by whichever query happened to finish first, so the same tenant would
+        /// get its caveats in a different order on every load. The workbook export exists to be run before
+        /// and after an enablement programme and diffed, and that comparison must not fill up with
+        /// reordering noise. Merging these buffers in step order instead reproduces exactly the order the
+        /// old sequential implementation produced.
+        /// </para>
+        /// <para>
+        /// Everything else a step writes is a property it alone owns (its own rows, its own chart, its own
+        /// counters), so those stay direct writes to the analysis.
+        /// </para>
+        /// </remarks>
+        private sealed class StepOutput
+        {
+            /// <summary>Warnings raised by this step, in the order it raised them.</summary>
+            public List<string> Warnings { get; } = new List<string>();
+
+            /// <summary>The queries this step ran, for the SQL tab.</summary>
+            public Dictionary<string, string> Sql { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            /// <summary>Datasets this step could not complete. Merged through MarkFiguresIncomplete.</summary>
+            public List<string> IncompleteReasons { get; } = new List<string>();
+
+            /// <summary>
+            /// Whether any query in this step failed or timed out.
+            /// </summary>
+            /// <remarks>
+            /// Recorded separately from the warnings because a step's warnings are not all failures -
+            /// "the agent inventory was capped" is informational - and because SafeAsync turns a failed
+            /// query into a warning and returns null, which means the step's own try/catch never sees an
+            /// exception. Without this, a query that timed out was reported in the diagnostics as having
+            /// succeeded, indistinguishable from one that was simply fast. That is not academic: during
+            /// development a syntactically broken query showed up in the performance harness as a step
+            /// that got 6.5x faster, because it failed instantly and the failure was invisible.
+            /// </remarks>
+            public bool QueryFailed { get; private set; }
+
+            /// <summary>Records that a query in this step failed. See <see cref="QueryFailed"/>.</summary>
+            public void MarkQueryFailed()
+            {
+                QueryFailed = true;
+            }
+
+            /// <summary>Buffered equivalent of <see cref="CopilotAdoptionSummary.MarkFiguresIncomplete"/>.</summary>
+            public void MarkIncomplete(string dataset)
+            {
+                if (!string.IsNullOrWhiteSpace(dataset) && !IncompleteReasons.Contains(dataset))
+                {
+                    IncompleteReasons.Add(dataset);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Runs the independent steps concurrently, then merges their buffered side-effects in step order.
+        /// </summary>
+        /// <remarks>
+        /// Bounded by <see cref="MaxConcurrentSteps"/>. Unbounded concurrency would fire every heavy query
+        /// at the database at once, which on a tier-capped Azure SQL database is a good way to turn one
+        /// slow report into a whole-database stall that also hits the importer and every other page.
+        /// <para>
+        /// The merge happens even when a step throws. Only a cancellation or an outright bug gets this far
+        /// (a query failure is already degraded to a warning by SafeAsync), but if one step faults the
+        /// warnings the others produced are still the honest description of what was gathered.
+        /// </para>
+        /// </remarks>
+        private async Task RunStepsAsync(
+            CopilotAdoptionAnalysis analysis, List<AnalysisStep> steps, int maxConcurrency, CancellationToken cancellationToken)
+        {
+            if (steps.Count == 0) return;
+
+            using (var gate = new SemaphoreSlim(Math.Min(Math.Max(1, maxConcurrency), steps.Count)))
+            {
+                var running = steps.Select(step => RunOneStepAsync(step, gate, cancellationToken)).ToArray();
+
+                try
+                {
+                    await Task.WhenAll(running);
+                }
+                finally
+                {
+                    // In step order, NOT completion order - see StepOutput.
+                    foreach (var step in steps)
+                    {
+                        analysis.Summary.Diagnostics.Record(step.Name, step.DurationMs, step.Failed);
+
+                        foreach (var warning in step.Output.Warnings)
+                        {
+                            analysis.Summary.Warnings.Add(warning);
+                        }
+
+                        foreach (var reason in step.Output.IncompleteReasons)
+                        {
+                            analysis.Summary.MarkFiguresIncomplete(reason);
+                        }
+
+                        foreach (var entry in step.Output.Sql)
+                        {
+                            analysis.Sql[entry.Key] = entry.Value;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>Runs and times one step, holding a slot in the concurrency gate while it works.</summary>
+        private async Task RunOneStepAsync(
+            AnalysisStep step, SemaphoreSlim gate, CancellationToken cancellationToken)
+        {
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            var operationId = _telemetry.StepStarted(step.Name);
             var watch = System.Diagnostics.Stopwatch.StartNew();
-            var failed = false;
+            string exceptionType = null;
             try
             {
-                await work();
+                await step.Work(step.Output);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                failed = true;
+                step.Failed = true;
+                exceptionType = ex.GetBaseException().GetType().Name;
                 throw;
             }
             finally
             {
                 watch.Stop();
-                analysis.Summary.Diagnostics.Record(step, watch.ElapsedMilliseconds, failed);
+                step.DurationMs = watch.ElapsedMilliseconds;
+
+                // A query that failed or timed out was degraded to a warning by SafeAsync rather than
+                // thrown, so the catch above never fires for it. Without this the diagnostics would
+                // report the step as successful - see StepOutput.QueryFailed.
+                if (step.Output.QueryFailed) step.Failed = true;
+
+                _telemetry.StepCompleted(
+                    operationId,
+                    step.Name,
+                    step.DurationMs,
+                    step.Failed,
+                    exceptionType);
+                gate.Release();
             }
         }
 
@@ -304,6 +566,7 @@ namespace Common.Entities.CopilotAdoption
         /// </summary>
         private async Task BuildAgentEstateAsync(
             CopilotAdoptionAnalysis analysis,
+            StepOutput output,
             List<int> seatIds,
             DateTime windowStart,
             DateTime nowUtc,
@@ -327,11 +590,13 @@ namespace Common.Entities.CopilotAdoption
                 { "@historyFrom", agentHistoryStart },
                 { "@maxRows", _options.MaxAgents },
             };
-            analysis.Sql["agents"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+            output.Sql["agents"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
 
             var rows = await SafeAsync(
                 () => QueryAsync<AgentUsageQueryRow>(sql, cancellationToken, ToSqlParameters(parameters)),
-                summary.Warnings,
+                CopilotAdoptionSteps.AgentEstate,
+                CopilotAdoptionQueries.AgentUsage,
+                output,
                 "Copilot agent usage", cancellationToken);
 
             if (rows == null) return;
@@ -344,7 +609,7 @@ namespace Common.Entities.CopilotAdoption
 
             if (analysis.Agents.Count >= _options.MaxAgents)
             {
-                summary.Warnings.Add(
+                output.Warnings.Add(
                     $"The agent inventory was capped at {_options.MaxAgents} agents, so the agent figures are "
                     + "a floor rather than a total.");
             }
@@ -355,11 +620,13 @@ namespace Common.Entities.CopilotAdoption
                 { "@from", windowStart },
                 { "@top", _options.TopSegments },
             };
-            analysis.Sql["agentsByDepartment"] = CopilotAdoptionSql.ForDisplay(byDeptSql, byDeptParameters);
+            output.Sql["agentsByDepartment"] = CopilotAdoptionSql.ForDisplay(byDeptSql, byDeptParameters);
 
             var byDept = await SafeAsync(
                 () => QueryAsync<CategoryQueryRow>(byDeptSql, cancellationToken, ToSqlParameters(byDeptParameters)),
-                summary.Warnings,
+                CopilotAdoptionSteps.AgentEstate,
+                CopilotAdoptionQueries.AgentUsageByDepartment,
+                output,
                 "agent usage by department", cancellationToken);
 
             if (byDept != null)
@@ -380,6 +647,7 @@ namespace Common.Entities.CopilotAdoption
         /// </summary>
         private async Task BuildUnlicensedPopulationAsync(
             CopilotAdoptionAnalysis analysis,
+            StepOutput output,
             List<int> seatIds,
             DateTime windowStart,
             CancellationToken cancellationToken)
@@ -392,11 +660,13 @@ namespace Common.Entities.CopilotAdoption
                 { "@from", windowStart },
                 { "@maxRows", _options.MaxUnlicensedUsersScored },
             };
-            analysis.Sql["unlicensedUsage"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+            output.Sql["unlicensedUsage"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
 
             var rows = await SafeAsync(
                 () => QueryAsync<UnlicensedUsageQueryRow>(sql, cancellationToken, ToSqlParameters(parameters)),
-                summary.Warnings,
+                CopilotAdoptionSteps.UnlicensedPopulation,
+                CopilotAdoptionQueries.UnlicensedUsage,
+                output,
                 "unlicensed Copilot usage", cancellationToken);
 
             if (rows != null)
@@ -406,7 +676,7 @@ namespace Common.Entities.CopilotAdoption
 
                 if (summary.Unlicensed.Truncated)
                 {
-                    summary.Warnings.Add(
+                    output.Warnings.Add(
                         $"Unlicensed Copilot usage was capped at {_options.MaxUnlicensedUsersScored} users, so "
                         + "those figures are a floor rather than a total.");
                 }
@@ -418,11 +688,13 @@ namespace Common.Entities.CopilotAdoption
                 { "@from", windowStart },
                 { "@top", _options.TopSegments },
             };
-            analysis.Sql["unlicensedUsageByApp"] = CopilotAdoptionSql.ForDisplay(appSql, appParameters);
+            output.Sql["unlicensedUsageByApp"] = CopilotAdoptionSql.ForDisplay(appSql, appParameters);
 
             var apps = await SafeAsync(
                 () => QueryAsync<CategoryQueryRow>(appSql, cancellationToken, ToSqlParameters(appParameters)),
-                summary.Warnings,
+                CopilotAdoptionSteps.UnlicensedPopulation,
+                CopilotAdoptionQueries.UnlicensedUsageByApp,
+                output,
                 "unlicensed Copilot usage by app", cancellationToken);
 
             if (apps != null)
@@ -440,6 +712,7 @@ namespace Common.Entities.CopilotAdoption
         /// </summary>
         private async Task BuildResourceTypesAsync(
             CopilotAdoptionAnalysis analysis,
+            StepOutput output,
             DateTime windowStart,
             CancellationToken cancellationToken)
         {
@@ -449,11 +722,13 @@ namespace Common.Entities.CopilotAdoption
                 { "@from", windowStart },
                 { "@top", _options.TopSegments },
             };
-            analysis.Sql["resourceTypes"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+            output.Sql["resourceTypes"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
 
             var rows = await SafeAsync(
                 () => QueryAsync<CategoryQueryRow>(sql, cancellationToken, ToSqlParameters(parameters)),
-                analysis.Summary.Warnings,
+                CopilotAdoptionSteps.ResourceTypes,
+                CopilotAdoptionQueries.ResourceTypes,
+                output,
                 "Copilot accessed resource types", cancellationToken);
 
             if (rows == null) return;
@@ -469,6 +744,7 @@ namespace Common.Entities.CopilotAdoption
 
         private async Task BuildLicensedUsersAsync(
             CopilotAdoptionAnalysis analysis,
+            StepOutput output,
             List<int> seatIds,
             DateTime windowStart,
             DateTime historyStart,
@@ -481,18 +757,20 @@ namespace Common.Entities.CopilotAdoption
             // only way to name every seat SKU a user holds (a user can hold more than one), and it
             // gives an exact licensed-user count that is not subject to the detail query's row cap.
             var assignmentsSql = CopilotAdoptionSql.SeatAssignmentsSql(seatIds);
-            analysis.Sql["seatAssignments"] = assignmentsSql;
+            output.Sql["seatAssignments"] = assignmentsSql;
 
             var assignments = await SafeAsync(
                 () => QueryAsync<SeatAssignmentRow>(assignmentsSql, cancellationToken),
-                summary.Warnings,
+                CopilotAdoptionSteps.LicensedUsers,
+                CopilotAdoptionQueries.SeatAssignments,
+                output,
                 "Copilot licence assignments", cancellationToken);
 
             if (assignments == null)
             {
                 // The seat count comes from here. Falling through with an empty list would report zero
                 // licensed users - indistinguishable from a tenant that genuinely has none.
-                summary.MarkFiguresIncomplete("Copilot licence assignments");
+                output.MarkIncomplete("Copilot licence assignments");
                 assignments = new List<SeatAssignmentRow>();
             }
 
@@ -512,7 +790,9 @@ namespace Common.Entities.CopilotAdoption
 
             var coworkAgentIds = await SafeAsync(
                 () => QueryAsync<IntValueRow>(CopilotAdoptionSql.CoworkAgentIdsSql, cancellationToken),
-                summary.Warnings,
+                CopilotAdoptionSteps.LicensedUsers,
+                CopilotAdoptionQueries.CoworkAgentLookup,
+                output,
                 "Cowork agent lookup", cancellationToken) ?? new List<IntValueRow>();
 
             var coworkIds = coworkAgentIds.Select(r => r.Value).ToList();
@@ -530,11 +810,13 @@ namespace Common.Entities.CopilotAdoption
                 parameters["@copilotReportPeriodDays"] = summary.DataSources.CopilotUsageReportPeriodDays;
             }
 
-            analysis.Sql["licensedUsers"] = CopilotAdoptionSql.ForDisplay(detailSql, parameters);
+            output.Sql["licensedUsers"] = CopilotAdoptionSql.ForDisplay(detailSql, parameters);
 
             var rows = await SafeAsync(
                 () => QueryAsync<LicensedUserUsageRow>(detailSql, cancellationToken, ToSqlParameters(parameters)),
-                summary.Warnings,
+                CopilotAdoptionSteps.LicensedUsers,
+                CopilotAdoptionQueries.LicensedUserDetail,
+                output,
                 "licensed user detail", cancellationToken);
 
             if (rows == null)
@@ -542,13 +824,13 @@ namespace Common.Entities.CopilotAdoption
                 // Every rate, funnel stage, band and segment on the page is computed from this list. An
                 // empty one renders as "nobody uses Copilot", which is the most damaging thing this tool
                 // could say incorrectly.
-                summary.MarkFiguresIncomplete("licensed user detail");
+                output.MarkIncomplete("licensed user detail");
                 return;
             }
 
             if (rows.Count >= _options.MaxLicensedUsersScored)
             {
-                summary.Warnings.Add(
+                output.Warnings.Add(
                     $"Only the first {_options.MaxLicensedUsersScored:N0} licensed users were analysed. "
                     + "The figures below therefore describe that subset, not the whole tenant.");
             }
@@ -574,6 +856,7 @@ namespace Common.Entities.CopilotAdoption
 
         private async Task BuildUsageByAppAsync(
             CopilotAdoptionAnalysis analysis,
+            StepOutput output,
             List<int> seatIds,
             DateTime windowStart,
             CancellationToken cancellationToken)
@@ -589,11 +872,13 @@ namespace Common.Entities.CopilotAdoption
                 { "@from", windowStart },
                 { "@top", _options.TopSegments },
             };
-            analysis.Sql["usageByApp"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+            output.Sql["usageByApp"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
 
             var rows = await SafeAsync(
                 () => QueryAsync<CategoryQueryRow>(sql, cancellationToken, ToSqlParameters(parameters)),
-                analysis.Summary.Warnings,
+                CopilotAdoptionSteps.UsageByApp,
+                CopilotAdoptionQueries.LicensedUsageByApp,
+                output,
                 "Copilot usage by app", cancellationToken);
 
             if (rows == null) return;
@@ -605,6 +890,7 @@ namespace Common.Entities.CopilotAdoption
 
         private async Task BuildWeeklyTrendAsync(
             CopilotAdoptionAnalysis analysis,
+            StepOutput output,
             List<int> seatIds,
             DateTime trendStart,
             CancellationToken cancellationToken)
@@ -616,16 +902,20 @@ namespace Common.Entities.CopilotAdoption
 
             var coworkAgentIds = await SafeAsync(
                 () => QueryAsync<IntValueRow>(CopilotAdoptionSql.CoworkAgentIdsSql, cancellationToken),
-                analysis.Summary.Warnings,
+                CopilotAdoptionSteps.WeeklyTrend,
+                CopilotAdoptionQueries.CoworkAgentLookup,
+                output,
                 "Cowork agent lookup", cancellationToken) ?? new List<IntValueRow>();
 
             var sql = CopilotAdoptionSql.WeeklyAdoptionTrendSql(seatIds, coworkAgentIds.Select(r => r.Value));
             var parameters = new Dictionary<string, object> { { "@trendFrom", trendStart } };
-            analysis.Sql["weeklyTrend"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+            output.Sql["weeklyTrend"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
 
             var rows = await SafeAsync(
                 () => QueryAsync<NamedWeekRow>(sql, cancellationToken, ToSqlParameters(parameters)),
-                analysis.Summary.Warnings,
+                CopilotAdoptionSteps.WeeklyTrend,
+                CopilotAdoptionQueries.WeeklyTrend,
+                output,
                 "weekly adoption trend", cancellationToken);
 
             if (rows == null) return;
@@ -660,6 +950,7 @@ namespace Common.Entities.CopilotAdoption
 
         private async Task BuildOpportunitiesAsync(
             CopilotAdoptionAnalysis analysis,
+            StepOutput output,
             List<int> seatIds,
             DateTime windowStart,
             CancellationToken cancellationToken)
@@ -673,16 +964,18 @@ namespace Common.Entities.CopilotAdoption
             if (summary.DataSources.AuditAvailable)
             {
                 var unlicensedSql = CopilotAdoptionSql.UnlicensedActiveUsersSql(seatIds);
-                analysis.Sql["unlicensedActiveUsers"] = CopilotAdoptionSql.ForDisplay(
+                output.Sql["unlicensedActiveUsers"] = CopilotAdoptionSql.ForDisplay(
                     unlicensedSql, new Dictionary<string, object> { { "@from", windowStart } });
 
                 summary.UnlicensedActiveUsers = await SafeScalarAsync(
                     unlicensedSql,
-                    summary.Warnings,
+                    CopilotAdoptionSteps.LicenceOpportunities,
+                    CopilotAdoptionQueries.UnlicensedActiveUsers,
+                    output,
                     "unlicensed Copilot users",
                     // Published as a headline KPI, and zero is a meaningful answer here - so a failure that
                     // reads as zero is indistinguishable from "nobody uses Copilot without a licence".
-                    () => summary.MarkFiguresIncomplete("unlicensed Copilot users"),
+                    () => output.MarkIncomplete("unlicensed Copilot users"),
                     cancellationToken,
                     new SqlParameter("@from", windowStart));
             }
@@ -692,7 +985,7 @@ namespace Common.Entities.CopilotAdoption
 
             if (!includeAudit && !includeM365)
             {
-                summary.Warnings.Add(
+                output.Warnings.Add(
                     "Licence opportunities need either the Copilot audit import or the Microsoft 365 usage "
                     + "reports. Neither has data, so no candidates can be identified.");
                 return;
@@ -713,11 +1006,13 @@ namespace Common.Entities.CopilotAdoption
                 parameters["@m365ReportDate"] = summary.DataSources.M365UsageReportDate.Value;
             }
 
-            analysis.Sql["licenceOpportunities"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
+            output.Sql["licenceOpportunities"] = CopilotAdoptionSql.ForDisplay(sql, parameters);
 
             var rows = await SafeAsync(
                 () => QueryAsync<UnlicensedUserSignalRow>(sql, cancellationToken, ToSqlParameters(parameters)),
-                summary.Warnings,
+                CopilotAdoptionSteps.LicenceOpportunities,
+                CopilotAdoptionQueries.LicenceOpportunities,
+                output,
                 "licence opportunities", cancellationToken);
 
             if (rows == null)
@@ -725,13 +1020,13 @@ namespace Common.Entities.CopilotAdoption
                 // RecommendedForLicence is published as a headline KPI and the opportunity list drives a
                 // whole tab and a CSV export. This is one of the queries that times out at the median on a
                 // large tenant, so a silent empty list here reads as "nobody is worth a licence".
-                summary.MarkFiguresIncomplete("licence opportunities");
+                output.MarkIncomplete("licence opportunities");
                 return;
             }
 
             if (!includeM365)
             {
-                summary.Warnings.Add(
+                output.Warnings.Add(
                     "The Microsoft 365 usage reports are not available, so licence candidates are ranked only "
                     + "on unlicensed Copilot Chat use. Heavy Microsoft 365 users who have never tried Copilot "
                     + "will not appear.");
@@ -1253,18 +1548,27 @@ namespace Common.Entities.CopilotAdoption
         /// Runs a query, turning any failure into a warning on the result. One heavy query timing out
         /// should cost that one chart, not the whole licence review.
         /// </summary>
-        private static async Task<List<T>> SafeAsync<T>(
+        private async Task<List<T>> SafeAsync<T>(
             Func<Task<List<T>>> query,
+            string step,
+            string queryName,
             List<string> warnings,
             string description,
             CancellationToken cancellationToken)
         {
+            var operationId = _telemetry.QueryStarted(step, queryName);
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            var failed = false;
+            string exceptionType = null;
             try
             {
                 return await query();
             }
             catch (Exception ex)
             {
+                failed = true;
+                exceptionType = ex.GetBaseException().GetType().Name;
+
                 // Cancellation is decided by the TOKEN, not by the exception type. A token-triggered
                 // abort surfaces from EF6 / SqlClient as any of TaskCanceledException, SqlException
                 // ("Operation cancelled by user") or InvalidOperationException, so type-matching here
@@ -1291,16 +1595,78 @@ namespace Common.Entities.CopilotAdoption
                 warnings.Add($"Could not load {description}: {InnermostMessage(ex)}");
                 return null;
             }
+            finally
+            {
+                watch.Stop();
+                _telemetry.QueryCompleted(
+                    operationId,
+                    step,
+                    queryName,
+                    watch.ElapsedMilliseconds,
+                    failed,
+                    exceptionType);
+            }
+        }
+
+        /// <summary>
+        /// As above, for a step running in the concurrent phase: also records that the query failed, so
+        /// the step's diagnostics say so instead of reporting a silent degradation as a success.
+        /// </summary>
+        private async Task<List<T>> SafeAsync<T>(
+            Func<Task<List<T>>> query,
+            string step,
+            string queryName,
+            StepOutput output,
+            string description,
+            CancellationToken cancellationToken)
+        {
+            // SafeAsync returns null exactly when it swallowed a failure, which is what makes this work
+            // without every call site having to remember to report it.
+            var rows = await SafeAsync(
+                query, step, queryName, output.Warnings, description, cancellationToken);
+            if (rows == null) output.MarkQueryFailed();
+            return rows;
         }
 
         private async Task<int> SafeScalarAsync(
             string sql,
+            string step,
+            string queryName,
             List<string> warnings,
             string description,
             CancellationToken cancellationToken,
             params SqlParameter[] parameters)
         {
-            return await SafeScalarAsync(sql, warnings, description, null, cancellationToken, parameters);
+            return await SafeScalarAsync(
+                sql, step, queryName, warnings, description, null, cancellationToken, parameters);
+        }
+
+        /// <summary>Step-scoped <see cref="SafeScalarAsync(string, List{string}, string, Action, CancellationToken, SqlParameter[])"/>.</summary>
+        private async Task<int> SafeScalarAsync(
+            string sql,
+            string step,
+            string queryName,
+            StepOutput output,
+            string description,
+            Action onFailure,
+            CancellationToken cancellationToken,
+            params SqlParameter[] parameters)
+        {
+            var rows = await SafeAsync(
+                () => QueryAsync<int?>(sql, cancellationToken, parameters),
+                step,
+                queryName,
+                output,
+                description,
+                cancellationToken);
+
+            if (rows == null)
+            {
+                onFailure?.Invoke();
+                return 0;
+            }
+
+            return rows.FirstOrDefault() ?? 0;
         }
 
         /// <summary>
@@ -1314,6 +1680,8 @@ namespace Common.Entities.CopilotAdoption
         /// </remarks>
         private async Task<int> SafeScalarAsync(
             string sql,
+            string step,
+            string queryName,
             List<string> warnings,
             string description,
             Action onFailure,
@@ -1322,6 +1690,8 @@ namespace Common.Entities.CopilotAdoption
         {
             var rows = await SafeAsync(
                 () => QueryAsync<int?>(sql, cancellationToken, parameters),
+                step,
+                queryName,
                 warnings,
                 description,
                 cancellationToken);
@@ -1337,12 +1707,15 @@ namespace Common.Entities.CopilotAdoption
 
         private async Task<DateTime?> SafeDateAsync(
             string sql,
+            string step,
+            string queryName,
             List<string> warnings,
             string description,
             CancellationToken cancellationToken,
             params SqlParameter[] parameters)
         {
-            return await SafeDateAsync(sql, warnings, description, null, cancellationToken, parameters);
+            return await SafeDateAsync(
+                sql, step, queryName, warnings, description, null, cancellationToken, parameters);
         }
 
         /// <summary>
@@ -1356,6 +1729,8 @@ namespace Common.Entities.CopilotAdoption
         /// </remarks>
         private async Task<DateTime?> SafeDateAsync(
             string sql,
+            string step,
+            string queryName,
             List<string> warnings,
             string description,
             Action onFailure,
@@ -1364,6 +1739,8 @@ namespace Common.Entities.CopilotAdoption
         {
             var rows = await SafeAsync(
                 () => QueryAsync<DateTime?>(sql, cancellationToken, parameters),
+                step,
+                queryName,
                 warnings,
                 description,
                 cancellationToken);

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
@@ -746,61 +746,58 @@ namespace Common.Entities.CopilotAdoption
             var seats = IdList(seatLicenceTypeIds);
 
             return
+                "SET NOCOUNT ON;\r\n" +
+                "IF OBJECT_ID('tempdb..#agent_grain') IS NOT NULL DROP TABLE #agent_grain;\r\n" +
+                "\r\n" +
                 "WITH SeatUsers AS (\r\n" +
                 "    SELECT DISTINCT ul.user_id AS user_id\r\n" +
                 $"    FROM dbo.user_license_type_lookups AS ul WHERE ul.license_type_id IN ({seats})\r\n" +
-                "),\r\n" +
-                // One projected pass, then a separate grouping per distinct set. Four distinct counts in
-                // one grouping made SQL Server spool the input and process each separately: 6.0M of this
-                // query's 6.4M logical reads were that spool, and it ran for 128s against a 90s timeout.
-                // See LicensedUsersSql for the full measurement.
-                "AgentUse AS (\r\n" +
-                "    SELECT c.agent_id AS agent_id,\r\n" +
-                "           c.user_id AS user_id,\r\n" +
-                "           c.time_stamp AS time_stamp,\r\n" +
-                "           ISNULL(c.app_host, '(unknown)') AS app_host,\r\n" +
-                "           CASE WHEN seats.user_id IS NOT NULL THEN 1 ELSE 0 END AS IsLicensed\r\n" +
-                "    FROM dbo.copilot_chats AS c\r\n" +
-                "    LEFT JOIN SeatUsers AS seats ON seats.user_id = c.user_id\r\n" +
-                "    WHERE c.time_stamp >= @historyFrom\r\n" +
-                // Redundant against the inner join to copilot_agents below, but it lets the optimiser
-                // eliminate the (usually large) majority of Copilot interactions that carry no agent
-                // before it does any joining, rather than discovering it during the join.
-                "      AND c.agent_id IS NOT NULL\r\n" +
-                "),\r\n" +
-                "Totals AS (\r\n" +
-                "    SELECT agent_id,\r\n" +
-                "           COUNT_BIG(*) AS Interactions,\r\n" +
+                ")\r\n" +
+                // ONE pass over copilot_chats, collapsed to one row per (agent, user, day, app) and
+                // MATERIALISED, because everything below needs to read it four different ways.
+                //
+                // This was a CTE called AgentUse that four aggregates then selected from, with a comment
+                // claiming it was "one projected pass". It was not: SQL Server does not materialise a CTE,
+                // it expands it at every reference, so the 120-day scan happened four times over. A
+                // representative large-data A/B showed fewer fact-table reads, no spool, lower CPU and
+                // lower elapsed time. Exact environment measurements remain out-of-band. Row-for-row
+                // equivalence was proven with EXCEPT in both directions.
+                //
+                // A temp table rather than another CTE on purpose. Rolling the four aggregates up with
+                // COUNT(DISTINCT) over a single CTE was also tried and was 4.6x WORSE: it reintroduced
+                // exactly the spool the original four-CTE shape had been written to avoid. Materialising
+                // once is what gets both - no repeated scan AND no spool.
+                //
+                // Caveat for whoever benchmarks this next: the current synthetic generator produces
+                // roughly one grain row per interaction. When the grain does not compress there is nothing
+                // to gain from materialising it, so fix that data shape before using the synthetic bench
+                // to judge this query.
+                "SELECT c.agent_id AS agent_id,\r\n" +
+                "       c.user_id AS user_id,\r\n" +
+                "       CAST(c.time_stamp AS date) AS active_date,\r\n" +
+                "       ISNULL(c.app_host, '(unknown)') AS app_host,\r\n" +
+                // Licensing is a property of the user, so it is constant within the group.
+                "       MAX(CASE WHEN seats.user_id IS NOT NULL THEN 1 ELSE 0 END) AS IsLicensed,\r\n" +
+                "       COUNT_BIG(*) AS Interactions,\r\n" +
                 // Window-scoped as well as history-scoped. The inventory needs the long view to spot a
                 // dormant agent, but the headline "interactions per agent user" divides by a user count
                 // that is scoped to the reporting period - mixing the two inflates that KPI by the ratio
                 // of the windows (roughly 4x at the defaults).
-                "           COUNT_BIG(CASE WHEN time_stamp >= @from THEN 1 END) AS WindowInteractions,\r\n" +
-                "           MIN(time_stamp) AS FirstUsedUtc,\r\n" +
-                "           MAX(time_stamp) AS LastUsedUtc\r\n" +
-                "    FROM AgentUse GROUP BY agent_id\r\n" +
-                "),\r\n" +
-                "AgentUsers AS (\r\n" +
-                // COUNT(user_id), not COUNT(*). The old COUNT(DISTINCT au.user_id) skipped NULL users
-                // implicitly; grouping by (agent_id, user_id) puts unattributed events into their own
-                // NULL group, which COUNT(*) would count as a person. That matters because Users is not
-                // just displayed - it is the adoption threshold (AgentMinUsers, default 3), so a single
-                // unattributed interaction could flip an agent from Review to Keep.
-                "    SELECT agent_id, COUNT(user_id) AS Users, SUM(IsLicensed) AS LicensedUsers\r\n" +
-                "    FROM (SELECT agent_id, user_id, MAX(IsLicensed) AS IsLicensed\r\n" +
-                "          FROM AgentUse GROUP BY agent_id, user_id) AS u\r\n" +
-                "    GROUP BY agent_id\r\n" +
-                "),\r\n" +
-                "AgentDays AS (\r\n" +
-                "    SELECT agent_id, COUNT(*) AS ActiveDays\r\n" +
-                "    FROM (SELECT DISTINCT agent_id, CAST(time_stamp AS date) AS active_date FROM AgentUse) AS d\r\n" +
-                "    GROUP BY agent_id\r\n" +
-                "),\r\n" +
-                "AgentApps AS (\r\n" +
-                "    SELECT agent_id, COUNT(*) AS AppsUsed\r\n" +
-                "    FROM (SELECT DISTINCT agent_id, app_host FROM AgentUse) AS a\r\n" +
-                "    GROUP BY agent_id\r\n" +
-                ")\r\n" +
+                "       COUNT_BIG(CASE WHEN c.time_stamp >= @from THEN 1 END) AS WindowInteractions,\r\n" +
+                "       MIN(c.time_stamp) AS FirstUsedUtc,\r\n" +
+                "       MAX(c.time_stamp) AS LastUsedUtc\r\n" +
+                "INTO #agent_grain\r\n" +
+                "FROM dbo.copilot_chats AS c\r\n" +
+                "LEFT JOIN SeatUsers AS seats ON seats.user_id = c.user_id\r\n" +
+                "WHERE c.time_stamp >= @historyFrom\r\n" +
+                // Redundant against the inner join to copilot_agents below, but it lets the optimiser
+                // eliminate the (usually large) majority of Copilot interactions that carry no agent
+                // before it does any joining, rather than discovering it during the join.
+                "  AND c.agent_id IS NOT NULL\r\n" +
+                "GROUP BY c.agent_id, c.user_id, CAST(c.time_stamp AS date), ISNULL(c.app_host, '(unknown)')\r\n" +
+                "OPTION (RECOMPILE);\r\n" +
+                "\r\n" +
+                // Every aggregate below now reads the small grain table instead of copilot_chats.
                 "SELECT TOP (@maxRows)\r\n" +
                 "       ag.id AS AgentId,\r\n" +
                 "       ISNULL(ag.name, '(unnamed agent)') AS Name,\r\n" +
@@ -814,16 +811,34 @@ namespace Common.Entities.CopilotAdoption
                 "       ISNULL(a.AppsUsed, 0) AS AppsUsed,\r\n" +
                 "       t.FirstUsedUtc AS FirstUsedUtc,\r\n" +
                 "       t.LastUsedUtc AS LastUsedUtc\r\n" +
-                "FROM Totals AS t\r\n" +
+                "FROM (SELECT agent_id,\r\n" +
+                "             SUM(Interactions) AS Interactions,\r\n" +
+                "             SUM(WindowInteractions) AS WindowInteractions,\r\n" +
+                "             MIN(FirstUsedUtc) AS FirstUsedUtc,\r\n" +
+                "             MAX(LastUsedUtc) AS LastUsedUtc\r\n" +
+                "      FROM #agent_grain GROUP BY agent_id) AS t\r\n" +
                 "JOIN dbo.copilot_agents AS ag ON ag.id = t.agent_id\r\n" +
-                "LEFT JOIN AgentUsers AS u ON u.agent_id = t.agent_id\r\n" +
-                "LEFT JOIN AgentDays AS d ON d.agent_id = t.agent_id\r\n" +
-                "LEFT JOIN AgentApps AS a ON a.agent_id = t.agent_id\r\n" +
+                // COUNT(user_id), not COUNT(*). Grouping by (agent_id, user_id) puts unattributed events
+                // into their own NULL group, which COUNT(*) would count as a person. That matters because
+                // Users is not just displayed - it is the adoption threshold (AgentMinUsers, default 3),
+                // so a single unattributed interaction could flip an agent from Review to Keep.
+                "LEFT JOIN (SELECT agent_id, COUNT(user_id) AS Users, SUM(IsLicensed) AS LicensedUsers\r\n" +
+                "           FROM (SELECT agent_id, user_id, MAX(IsLicensed) AS IsLicensed\r\n" +
+                "                 FROM #agent_grain GROUP BY agent_id, user_id) AS x\r\n" +
+                "           GROUP BY agent_id) AS u ON u.agent_id = t.agent_id\r\n" +
+                "LEFT JOIN (SELECT agent_id, COUNT(*) AS ActiveDays\r\n" +
+                "           FROM (SELECT DISTINCT agent_id, active_date FROM #agent_grain) AS y\r\n" +
+                "           GROUP BY agent_id) AS d ON d.agent_id = t.agent_id\r\n" +
+                "LEFT JOIN (SELECT agent_id, COUNT(*) AS AppsUsed\r\n" +
+                "           FROM (SELECT DISTINCT agent_id, app_host FROM #agent_grain) AS z\r\n" +
+                "           GROUP BY agent_id) AS a ON a.agent_id = t.agent_id\r\n" +
                 // ag.id breaks ties deterministically. Without it, TOP truncates the tie region at the cap
                 // arbitrarily, so which agents survive varies between runs - the sibling capped queries in this
                 // file (LicensedUsersSql, LicenceOpportunitiesSql) both carry a unique tie-break for the same reason.
                 "ORDER BY Interactions DESC, ag.id\r\n" +
-                "OPTION (RECOMPILE);";
+                "OPTION (RECOMPILE);\r\n" +
+                "\r\n" +
+                "DROP TABLE #agent_grain;";
         }
 
         /// <summary>
@@ -857,11 +872,12 @@ namespace Common.Entities.CopilotAdoption
         public static string UnlicensedUsageRowsSql(IEnumerable<int> seatLicenceTypeIds)
         {
             return
-                // Grouped to one row per (user, day/app/agent) set separately, then rolled up. Asking for
-                // the three distinct counts in a single grouping made SQL Server spool the input and
-                // process each distinct separately: 8.1M of this query's 8.4M logical reads were that
-                // spool, and it ran for 131s against a 90s timeout. See LicensedUsersSql for the full
-                // measurement and the reasoning.
+                // The window's unlicensed interactions, read ONCE. This used to be a CTE that four
+                // separate aggregates selected from - see the note on the grain table below for what that
+                // cost and what it was measured at.
+                "SET NOCOUNT ON;\r\n" +
+                "IF OBJECT_ID('tempdb..#unlicensed_grain') IS NOT NULL DROP TABLE #unlicensed_grain;\r\n" +
+                "\r\n" +
                 "WITH Unlicensed AS (\r\n" +
                 "    SELECT c.user_id AS user_id,\r\n" +
                 "           c.time_stamp AS time_stamp,\r\n" +
@@ -877,26 +893,31 @@ namespace Common.Entities.CopilotAdoption
                 "      )\r\n" +
                 // Kept in step with UnlicensedActiveUsersSql - this is the detail behind that count.
                 ExcludeGuestsByUserId("c.user_id", "      ") +
-                "),\r\n" +
-                "Totals AS (\r\n" +
-                "    SELECT user_id, COUNT_BIG(*) AS Interactions, MAX(time_stamp) AS LastInteractionUtc\r\n" +
-                "    FROM Unlicensed GROUP BY user_id\r\n" +
-                "),\r\n" +
-                "Days AS (\r\n" +
-                "    SELECT user_id, COUNT(*) AS ActiveDays\r\n" +
-                "    FROM (SELECT DISTINCT user_id, CAST(time_stamp AS date) AS active_date FROM Unlicensed) AS d\r\n" +
-                "    GROUP BY user_id\r\n" +
-                "),\r\n" +
-                "Apps AS (\r\n" +
-                "    SELECT user_id, COUNT(*) AS AppsUsed\r\n" +
-                "    FROM (SELECT DISTINCT user_id, app_host FROM Unlicensed) AS a\r\n" +
-                "    GROUP BY user_id\r\n" +
-                "),\r\n" +
-                "Agents AS (\r\n" +
-                "    SELECT user_id, COUNT(*) AS AgentsUsed\r\n" +
-                "    FROM (SELECT DISTINCT user_id, agent_id FROM Unlicensed WHERE agent_id IS NOT NULL) AS g\r\n" +
-                "    GROUP BY user_id\r\n" +
                 ")\r\n" +
+                // ONE pass over copilot_chats, collapsed to one row per (user, day, app, agent) and
+                // MATERIALISED, because the four aggregates below each need to read it differently.
+                //
+                // The Unlicensed CTE was previously selected from by four separate aggregates. SQL Server
+                // does not materialise a CTE - it expands it at every reference - so the window scan, and
+                // both of the NOT EXISTS lookups above, ran four times over. A representative large-data
+                // A/B showed substantially fewer reads and lower elapsed time; exact environment
+                // measurements remain out-of-band. The improvement was larger than the repeated reference
+                // alone accounts for because the repeated shape also pushed the optimiser into a worse
+                // plan for the licence and guest lookups. The new shape was verified row-for-row identical
+                // with EXCEPT in both directions.
+                //
+                // See AgentUsageSql for why this is a temp table rather than another CTE.
+                "SELECT user_id,\r\n" +
+                "       CAST(time_stamp AS date) AS active_date,\r\n" +
+                "       app_host,\r\n" +
+                "       agent_id,\r\n" +
+                "       COUNT_BIG(*) AS Interactions,\r\n" +
+                "       MAX(time_stamp) AS LastInteractionUtc\r\n" +
+                "INTO #unlicensed_grain\r\n" +
+                "FROM Unlicensed\r\n" +
+                "GROUP BY user_id, CAST(time_stamp AS date), app_host, agent_id\r\n" +
+                "OPTION (RECOMPILE);\r\n" +
+                "\r\n" +
                 "SELECT TOP (@maxRows)\r\n" +
                 "       t.user_id AS UserId,\r\n" +
                 "       ISNULL(NULLIF(LTRIM(RTRIM(dept.name)), ''), '') AS Department,\r\n" +
@@ -905,16 +926,27 @@ namespace Common.Entities.CopilotAdoption
                 "       ISNULL(a.AppsUsed, 0) AS AppsUsed,\r\n" +
                 "       ISNULL(g.AgentsUsed, 0) AS AgentsUsed,\r\n" +
                 "       t.LastInteractionUtc AS LastInteractionUtc\r\n" +
-                "FROM Totals AS t\r\n" +
-                "LEFT JOIN Days AS d ON d.user_id = t.user_id\r\n" +
-                "LEFT JOIN Apps AS a ON a.user_id = t.user_id\r\n" +
-                "LEFT JOIN Agents AS g ON g.user_id = t.user_id\r\n" +
+                "FROM (SELECT user_id, SUM(Interactions) AS Interactions,\r\n" +
+                "             MAX(LastInteractionUtc) AS LastInteractionUtc\r\n" +
+                "      FROM #unlicensed_grain GROUP BY user_id) AS t\r\n" +
+                "LEFT JOIN (SELECT user_id, COUNT(*) AS ActiveDays\r\n" +
+                "           FROM (SELECT DISTINCT user_id, active_date FROM #unlicensed_grain) AS x\r\n" +
+                "           GROUP BY user_id) AS d ON d.user_id = t.user_id\r\n" +
+                "LEFT JOIN (SELECT user_id, COUNT(*) AS AppsUsed\r\n" +
+                "           FROM (SELECT DISTINCT user_id, app_host FROM #unlicensed_grain) AS y\r\n" +
+                "           GROUP BY user_id) AS a ON a.user_id = t.user_id\r\n" +
+                "LEFT JOIN (SELECT user_id, COUNT(*) AS AgentsUsed\r\n" +
+                "           FROM (SELECT DISTINCT user_id, agent_id FROM #unlicensed_grain\r\n" +
+                "                 WHERE agent_id IS NOT NULL) AS z\r\n" +
+                "           GROUP BY user_id) AS g ON g.user_id = t.user_id\r\n" +
                 "LEFT JOIN dbo.users AS u ON u.id = t.user_id\r\n" +
                 "LEFT JOIN dbo.user_departments AS dept ON dept.id = u.department_id\r\n" +
                 // Deterministic truncation - see the note in AgentUsageSql. This one matters more: when the cap
                 // bites, FinaliseUnlicensed derives the habit distribution from whichever rows survived.
                 "ORDER BY Interactions DESC, t.user_id\r\n" +
-                "OPTION (RECOMPILE);";
+                "OPTION (RECOMPILE);\r\n" +
+                "\r\n" +
+                "DROP TABLE #unlicensed_grain;";
         }
 
         /// <summary>
@@ -1017,6 +1049,20 @@ namespace Common.Entities.CopilotAdoption
         /// missing week is ambiguous between "no data" and "no usage" - but that is a reporting decision,
         /// not something to slip in with a performance fix.
         /// </para>
+        /// <para>
+        /// The seat and guest lookups are joined AFTER the aggregate, not per chat row. Both answer a
+        /// question about the user rather than the interaction, so per-row evaluation recomputed the same
+        /// answer for every interaction a user had in the week. Measured on a synthetic customer-shaped
+        /// bench, at a step concurrency of 1, comparing the two shapes over the same data:
+        /// <list type="table">
+        /// <item><description>6-month window:  5,551ms -&gt; 2,322ms elapsed (2.4x), CPU 21.1s -&gt; 12.5s</description></item>
+        /// <item><description>12-month window: 11,523ms -&gt; 4,643ms elapsed (2.5x), CPU 44.7s -&gt; 24.7s</description></item>
+        /// </list>
+        /// Logical reads are unchanged (within 1%) because the same index pages are read either way - the
+        /// saving is join and aggregation CPU, which is the resource that actually runs out on a
+        /// tier-capped database. Verified row-for-row identical against the previous query with EXCEPT in
+        /// both directions.
+        /// </para>
         /// </remarks>
         public static string WeeklyAdoptionTrendSql(IEnumerable<int> seatLicenceTypeIds, IEnumerable<int> coworkAgentIds)
         {
@@ -1037,28 +1083,45 @@ namespace Common.Entities.CopilotAdoption
                 // that spool, and it ran for 315s against a 90s timeout. Grouping by (week, user) once
                 // removes every distinct: a user is licensed or not for the whole week, so MAX() over the
                 // flag is exactly the same answer, and the roll-up below is then a trivial SUM.
-                "WeekUser AS (\r\n" +
+                //
+                // This first pass touches NOTHING but copilot_chats. Whether a user holds a seat and
+                // whether they are a guest are properties of the USER, not of the interaction, so joining
+                // those two lookups here - as this query used to - evaluated them once per chat row to
+                // produce an answer that is identical for every row the user appears in. The joins moved
+                // below the aggregate instead, where they run once per (week, user).
+                "ChatWeekUser AS (\r\n" +
                 $"    SELECT {week} AS WeekStart,\r\n" +
                 "           c.user_id AS user_id,\r\n" +
-                "           MAX(CASE WHEN seats.user_id IS NOT NULL THEN 1 ELSE 0 END) AS IsLicensed,\r\n" +
-                // Carried as a flag rather than filtered in the WHERE clause: the licensed series must
-                // keep counting a guest that somehow holds a seat (that is a real licence being spent),
-                // while the unlicensed series must exclude guests to agree with the headline count and
-                // the candidate list. One LEFT JOIN on the users PK, so the single-pass shape that this
-                // query was rewritten into (see above) is preserved.
-                "           MAX(CASE WHEN guest_check.user_name LIKE " + GuestUserNamePattern +
-                " THEN 1 ELSE 0 END) AS IsGuest,\r\n" +
-                "           MAX(CASE WHEN seats.user_id IS NOT NULL\r\n" +
-                $"                     AND ({cowork}) THEN 1 ELSE 0 END) AS IsCowork,\r\n" +
+                $"           MAX(CASE WHEN ({cowork}) THEN 1 ELSE 0 END) AS CoworkRow,\r\n" +
                 "           MAX(CASE WHEN c.agent_id IS NOT NULL THEN 1 ELSE 0 END) AS UsedAgent,\r\n" +
-                "           COUNT_BIG(CASE WHEN seats.user_id IS NOT NULL THEN 1 END) AS LicensedInteractions,\r\n" +
-                "           COUNT_BIG(CASE WHEN seats.user_id IS NULL THEN 1 END) AS UnlicensedInteractions\r\n" +
+                "           COUNT_BIG(*) AS Interactions\r\n" +
                 "    FROM dbo.copilot_chats AS c\r\n" +
-                "    LEFT JOIN SeatUsers AS seats ON seats.user_id = c.user_id\r\n" +
-                "    LEFT JOIN dbo.users AS guest_check ON guest_check.id = c.user_id\r\n" +
                 "    WHERE c.time_stamp >= @trendFrom\r\n" +
                 "      AND c.user_id IS NOT NULL\r\n" +
                 $"    GROUP BY {week}, c.user_id\r\n" +
+                "),\r\n" +
+                // The per-user lookups, now once per (week, user) instead of once per interaction.
+                "WeekUser AS (\r\n" +
+                "    SELECT wu.WeekStart AS WeekStart,\r\n" +
+                "           CASE WHEN seats.user_id IS NOT NULL THEN 1 ELSE 0 END AS IsLicensed,\r\n" +
+                // Carried as a flag rather than filtered in the WHERE clause: the licensed series must
+                // keep counting a guest that somehow holds a seat (that is a real licence being spent),
+                // while the unlicensed series must exclude guests to agree with the headline count and
+                // the candidate list.
+                "           CASE WHEN guest_check.user_name LIKE " + GuestUserNamePattern +
+                " THEN 1 ELSE 0 END AS IsGuest,\r\n" +
+                // Cowork is "a licensed user who used Cowork". Licensing is constant across the week, so
+                // ANDing it after the aggregate gives the same answer as testing it on every row.
+                "           CASE WHEN seats.user_id IS NOT NULL\r\n" +
+                "                 AND wu.CoworkRow = 1 THEN 1 ELSE 0 END AS IsCowork,\r\n" +
+                "           wu.UsedAgent AS UsedAgent,\r\n" +
+                // Likewise the two interaction counts: the old conditional COUNT_BIGs tested a condition
+                // that is the same for every row of the group, so they are just the group's count or zero.
+                "           CASE WHEN seats.user_id IS NOT NULL THEN wu.Interactions ELSE 0 END AS LicensedInteractions,\r\n" +
+                "           CASE WHEN seats.user_id IS NULL THEN wu.Interactions ELSE 0 END AS UnlicensedInteractions\r\n" +
+                "    FROM ChatWeekUser AS wu\r\n" +
+                "    LEFT JOIN SeatUsers AS seats ON seats.user_id = wu.user_id\r\n" +
+                "    LEFT JOIN dbo.users AS guest_check ON guest_check.id = wu.user_id\r\n" +
                 "),\r\n" +
                 "Weekly AS (\r\n" +
                 "    SELECT WeekStart,\r\n" +

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionTelemetry.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionTelemetry.cs
@@ -1,0 +1,120 @@
+using System;
+
+namespace Common.Entities.CopilotAdoption
+{
+    /// <summary>
+    /// Non-blocking observer for one Copilot adoption analysis.
+    ///
+    /// Implementations must never perform network I/O on the calling thread and must never throw. The
+    /// analysis calls this at the boundaries needed to distinguish a database/EF wait from projection,
+    /// scoring and cache publication without exposing SQL, parameters or tenant-derived values.
+    /// </summary>
+    public interface ICopilotAdoptionRunTelemetry
+    {
+        long StepStarted(string step);
+
+        void StepCompleted(
+            long operationId,
+            string step,
+            long durationMs,
+            bool failed,
+            string exceptionType = null);
+
+        long QueryStarted(string step, string query);
+
+        void QueryCompleted(
+            long operationId,
+            string step,
+            string query,
+            long durationMs,
+            bool failed,
+            string exceptionType = null);
+
+        void Checkpoint(string stage, long durationMs = 0);
+    }
+
+    /// <summary>No-op telemetry used outside the web application and by existing callers.</summary>
+    public sealed class NullCopilotAdoptionRunTelemetry : ICopilotAdoptionRunTelemetry
+    {
+        public static readonly NullCopilotAdoptionRunTelemetry Instance =
+            new NullCopilotAdoptionRunTelemetry();
+
+        private NullCopilotAdoptionRunTelemetry()
+        {
+        }
+
+        public long StepStarted(string step) => 0;
+
+        public void StepCompleted(
+            long operationId,
+            string step,
+            long durationMs,
+            bool failed,
+            string exceptionType = null)
+        {
+        }
+
+        public long QueryStarted(string step, string query) => 0;
+
+        public void QueryCompleted(
+            long operationId,
+            string step,
+            string query,
+            long durationMs,
+            bool failed,
+            string exceptionType = null)
+        {
+        }
+
+        public void Checkpoint(string stage, long durationMs = 0)
+        {
+        }
+    }
+
+    /// <summary>Stable lifecycle stage names used by Application Insights queries.</summary>
+    public static class CopilotAdoptionTelemetryStages
+    {
+        public const string Started = "Started";
+        public const string QueryStarted = "QueryStarted";
+        public const string QueryCompleted = "QueryCompleted";
+        public const string QueryFailed = "QueryFailed";
+        public const string StepStarted = "StepStarted";
+        public const string StepCompleted = "StepCompleted";
+        public const string StepFailed = "StepFailed";
+        public const string ScoringStarted = "ScoringStarted";
+        public const string ScoringCompleted = "ScoringCompleted";
+        public const string ServiceReturned = "ServiceReturned";
+        public const string CachePublished = "CachePublished";
+        public const string CompletionTelemetryReturned = "CompletionTelemetryReturned";
+        public const string Failed = "Failed";
+        public const string Heartbeat = "Heartbeat";
+        public const string HostStopping = "HostStopping";
+    }
+
+    /// <summary>
+    /// Stable, compile-time query names. Values describe query purpose only; they never include SQL,
+    /// parameters, database identifiers or tenant data.
+    /// </summary>
+    public static class CopilotAdoptionQueries
+    {
+        public const string LicenceTypes = "LicenceTypes";
+        public const string AuditDataProbe = "AuditDataProbe";
+        public const string PendingBackfillProbe = "PendingBackfillProbe";
+        public const string CopilotReportDate = "CopilotReportDate";
+        public const string CopilotReportPeriod = "CopilotReportPeriod";
+        public const string M365ReportDate = "M365ReportDate";
+        public const string CopilotReportAnonymisation = "CopilotReportAnonymisation";
+        public const string SeatAssignments = "SeatAssignments";
+        public const string CoworkAgentLookup = "CoworkAgentLookup";
+        public const string LicensedUserDetail = "LicensedUserDetail";
+        public const string LicensedUsageByApp = "LicensedUsageByApp";
+        public const string WeeklyTrend = "WeeklyTrend";
+        public const string UnlicensedActiveUsers = "UnlicensedActiveUsers";
+        public const string LicenceOpportunities = "LicenceOpportunities";
+        public const string AgentUsage = "AgentUsage";
+        public const string AgentUsageByDepartment = "AgentUsageByDepartment";
+        public const string UnlicensedUsage = "UnlicensedUsage";
+        public const string UnlicensedUsageByApp = "UnlicensedUsageByApp";
+        public const string ResourceTypes = "ResourceTypes";
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -94,6 +94,7 @@
     <Compile Include="CopilotAdoption\CopilotAdoptionService.cs" />
     <Compile Include="CopilotAdoption\CopilotAdoptionSql.cs" />
     <Compile Include="CopilotAdoption\CopilotAdoptionSummaryModels.cs" />
+    <Compile Include="CopilotAdoption\CopilotAdoptionTelemetry.cs" />
     <Compile Include="CopilotAdoption\CopilotAdoptionUnlicensedModels.cs" />
     <Compile Include="CopilotAdoption\CopilotAdoptionUserModels.cs" />
     <Compile Include="CopilotAdoption\CopilotAdoptionWorkbook.cs" />

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
@@ -40,6 +40,8 @@ namespace Tests.FakeDataGen
                 ctx => RunStressTest(new ActivityApiDbStressTest(), ctx)),
             new MenuItem("Copilot event import stress test", MenuCategory.StressTest,
                 ctx => RunStressTest(new CopilotStressTest(), ctx)),
+            new MenuItem("Copilot Adoption page performance test (read-only, before/after)", MenuCategory.StressTest,
+                ctx => RunStressTest(new CopilotAdoptionPerfTest(), ctx)),
             new MenuItem("Power Platform event import stress test", MenuCategory.StressTest,
                 ctx => RunStressTest(new PowerPlatformStressTest(), ctx)),
             new MenuItem("Sent email importer stress test", MenuCategory.StressTest,
@@ -76,7 +78,7 @@ namespace Tests.FakeDataGen
             {
                 Console.WriteLine("No SQL connection string provided.");
                 Console.WriteLine("Stress tests that don't need SQL will still run; everything else will be disabled.");
-                Console.WriteLine("Usage: Tests.FakeDataGen.exe \"<SQL Connection String>\" [--run <copilot|activityapi|activityapidb|powerplatform|sentemail|useractivity>]");
+                Console.WriteLine("Usage: Tests.FakeDataGen.exe \"<SQL Connection String>\" [--run <copilot|copilotadoption|activityapi|activityapidb|powerplatform|sentemail|useractivity>]");
             }
             Console.WriteLine();
 
@@ -227,6 +229,7 @@ namespace Tests.FakeDataGen
             new Dictionary<string, Func<BaseStressTest>>(StringComparer.OrdinalIgnoreCase)
             {
                 { "copilot", () => new CopilotStressTest() },
+                { "copilotadoption", () => new CopilotAdoptionPerfTest() },
                 { "activityapi", () => new ActivityAPIStressTest() },
                 { "activityapidb", () => new ActivityApiDbStressTest() },
                 { "powerplatform", () => new PowerPlatformStressTest() },

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotAdoptionPerfTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotAdoptionPerfTest.cs
@@ -1,0 +1,540 @@
+using Common.Entities;
+using Common.Entities.CopilotAdoption;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.FakeDataGen.StressTests
+{
+    /// <summary>
+    /// Measures how long the Copilot Adoption page actually takes, by running the REAL
+    /// <see cref="CopilotAdoptionService"/> end to end against whatever database the connection string
+    /// points at, and reporting the per-step breakdown.
+    ///
+    /// <para>
+    /// <b>Why this exists.</b> Issue #360 was raised because the page timed out on a large tenant, and the
+    /// release that fixed the two slowest queries (Stable build 1810) did not make it fast enough - the
+    /// page still spends minutes "Analysing Copilot adoption...". Optimising it further needs a number that
+    /// can be produced before a change and again after it, on the same data, without a customer in the
+    /// loop. That is all this test is.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>It runs the real service on purpose.</b> Copying the SQL into a benchmark script measures a
+    /// snapshot that silently rots the moment someone edits <see cref="CopilotAdoptionSql"/>. Driving
+    /// <see cref="CopilotAdoptionService.AnalyseAsync"/> means this test measures whatever the product
+    /// actually does today, including the C# scoring step, which no SQL-only benchmark would catch.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>What it reports.</b> The service already times every step into
+    /// <see cref="CopilotAdoptionDiagnostics"/> - the same instrumentation the page and App Insights use -
+    /// so this reports that, per window, as a median over several runs. Those step names are compile-time
+    /// constants and every value is a duration, so the output carries no tenant data and is safe to paste
+    /// into a PR or an issue.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Reading the result.</b> The steps run SEQUENTIALLY, so the total is their sum and the slowest
+    /// step is the only one worth optimising first. A step at or near <c>QueryTimeoutSecs</c> did not take
+    /// that long - it FAILED, and the analysis carried on with an empty result. Those are flagged rather
+    /// than averaged in silently, because a fast run made of failed steps is not an improvement.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Data.</b> This test never generates anything - point it at a database seeded by
+    /// <see cref="UserActivityStressTest"/> (which scales to a large tenant) or at a restored copy. It is
+    /// read-only apart from the schema check the host performs, so it is safe to re-run.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Before/after workflow.</b> Run it, keep the JSON it writes, make the change, run it again with
+    /// <c>COPILOTPERF_BASELINE</c> pointing at the first file: it prints a per-step delta and fails the run
+    /// if the total regressed by more than the tolerance. That is the loop this test is for.
+    /// </para>
+    /// </summary>
+    public class CopilotAdoptionPerfTest : BaseStressTest
+    {
+        private const int DefaultRepeats = 3;
+
+        /// <summary>
+        /// Windows the page offers. The window drives how much of copilot_chats each query reads, so a fix
+        /// that only helps the default 28-day window is not a fix.
+        /// </summary>
+        private static readonly int[] DefaultWindows = { 7, 28, 90, 180 };
+
+        /// <summary>
+        /// A step this close to the query timeout almost certainly failed rather than completed. Kept as a
+        /// fraction so it tracks <see cref="CopilotAdoptionOptions.QueryTimeoutSecs"/> if that changes.
+        /// </summary>
+        private const double TimeoutSuspicionFraction = 0.95;
+
+        protected override StressTestResult Execute()
+        {
+            Console.WriteLine("\n=== Copilot Adoption Performance Test ===\n");
+
+            var connectionString = ConnectionString;
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("This test measures real queries and needs a connection string on the command line.");
+                Console.ResetColor();
+                return new StressTestResult
+                {
+                    Success = false,
+                    Message = "No connection string provided - CopilotAdoptionPerfTest requires SQL.",
+                };
+            }
+
+            int repeats = GetIntegerInput(
+                "Timed runs per window (medians reported; a cold run is done first and discarded)",
+                DefaultRepeats, 1, 25, "COPILOTPERF_REPEATS");
+
+            bool allWindows = GetBooleanInput(
+                "Measure every window (7/28/90/180)? N measures 28 only",
+                true, "COPILOTPERF_ALLWINDOWS");
+
+            int concurrent = GetIntegerInput(
+                "Simultaneous callers per measurement (proves the shared-analysis cache dedupes; 1 = off)",
+                1, 1, 50, "COPILOTPERF_CONCURRENT");
+
+            // The steps are independent, so they can overlap - but they all queue on the same database, so
+            // overlapping them does not automatically make the page faster. 1 reproduces the old strictly
+            // sequential behaviour, which is what this has to be measured against.
+            int maxConcurrentSteps = GetIntegerInput(
+                "Analysis steps allowed to query at once (1 = strictly sequential, the pre-parallel behaviour)",
+                CopilotAdoptionService.MaxConcurrentSteps, 1, 16, "COPILOTPERF_MAXSTEPS");
+
+            var windows = allWindows ? DefaultWindows : new[] { 28 };
+
+            Console.WriteLine($"Step concurrency: {maxConcurrentSteps}");
+
+            _memoryMonitor.Start();
+            var overallWatch = Stopwatch.StartNew();
+            var runs = new List<WindowResult>();
+            long stepsMeasured = 0;
+
+            foreach (var windowDays in windows)
+            {
+                var result = MeasureWindow(connectionString, windowDays, repeats, concurrent, maxConcurrentSteps);
+                if (result == null)
+                {
+                    return new StressTestResult
+                    {
+                        Success = false,
+                        Message = $"The analysis threw for the {windowDays}-day window - see the exception above.",
+                        Duration = overallWatch.Elapsed,
+                    };
+                }
+
+                runs.Add(result);
+                stepsMeasured += result.Steps.Count;
+                _memoryMonitor.UpdatePeak();
+            }
+
+            overallWatch.Stop();
+            _memoryMonitor.Stop();
+
+            PrintReport(runs);
+
+            var outputPath = WriteJson(runs);
+            var regression = CompareToBaseline(runs);
+
+            var slowest = runs.OrderByDescending(r => r.TotalMedianMs).FirstOrDefault();
+            var anyFailed = runs.Any(r => r.Steps.Any(s => s.Failed || s.LooksLikeTimeout));
+
+            var message = slowest == null
+                ? "No windows measured."
+                : $"Slowest window: {slowest.WindowDays}d at {slowest.TotalMedianMs:N0} ms"
+                  + $" (worst step {slowest.SlowestStepName} at {slowest.SlowestStepMs:N0} ms)."
+                  + (anyFailed ? " WARNING: at least one step failed or hit the query timeout - see above." : string.Empty)
+                  + (outputPath != null ? $" Results: {outputPath}" : string.Empty)
+                  + (regression != null ? $" {regression}" : string.Empty);
+
+            return new StressTestResult
+            {
+                // A run whose steps failed is not a pass, however fast it was: the whole point of #360 was
+                // that a failed query rendered as a confident, empty answer.
+                Success = !anyFailed && regression == null,
+                Message = message,
+                ItemsProcessed = stepsMeasured,
+                Duration = overallWatch.Elapsed,
+                InitialMemoryBytes = _memoryMonitor.InitialMemoryBytes,
+                PeakMemoryBytes = _memoryMonitor.PeakMemoryBytes,
+                FinalMemoryBytes = _memoryMonitor.CurrentMemoryBytes,
+            };
+        }
+
+        /// <summary>
+        /// Runs one window: a discarded cold run, then <paramref name="repeats"/> timed runs, reported as
+        /// medians. Medians rather than means because a single scheduling hiccup on a shared dev box
+        /// otherwise dominates the number, which is also why the repo's SQL benchmarks are medians.
+        /// </summary>
+        private WindowResult MeasureWindow(
+            string connectionString, int windowDays, int repeats, int concurrent, int maxConcurrentSteps)
+        {
+            Console.WriteLine($"--- {windowDays}-day window ---");
+
+            var options = CopilotAdoptionOptions.Default;
+            options.WindowDays = windowDays;
+
+            IAnalyticsDbContextFactory contextFactory =
+                new NoMigrateContextFactory(connectionString);
+
+            try
+            {
+                // Cold run, discarded: it pays for the EF model build, the connection pool and a cold
+                // buffer pool, none of which a user on a warm site experiences.
+                Console.Write("  cold run (discarded)... ");
+                var cold = RunOnce(options, contextFactory, concurrent, maxConcurrentSteps);
+                Console.WriteLine($"{cold.TotalMs:N0} ms");
+
+                var timed = new List<CopilotAdoptionDiagnostics>();
+                for (var i = 1; i <= repeats; i++)
+                {
+                    Console.Write($"  run {i}/{repeats}... ");
+                    var diagnostics = RunOnce(options, contextFactory, concurrent, maxConcurrentSteps);
+                    timed.Add(diagnostics);
+                    Console.WriteLine($"{diagnostics.TotalMs:N0} ms");
+                }
+
+                return Summarise(windowDays, timed);
+            }
+            catch (Exception ex)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"  FAILED: {ex.Message}");
+                Console.ResetColor();
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// One measured analysis. When <paramref name="concurrent"/> is above 1 the same analysis is asked
+        /// for by that many callers at once and the FIRST result is timed, reproducing several people
+        /// opening the page together. The web layer caches a shared Task so they should cost the same as
+        /// one - if this number scales with the caller count, that de-duplication has broken.
+        /// </summary>
+        private static CopilotAdoptionDiagnostics RunOnce(
+            CopilotAdoptionOptions options,
+            IAnalyticsDbContextFactory contextFactory,
+            int concurrent,
+            int maxConcurrentSteps)
+        {
+            var watch = Stopwatch.StartNew();
+
+            if (concurrent <= 1)
+            {
+                var single = new CopilotAdoptionService(options, contextFactory, maxConcurrentSteps)
+                    .AnalyseAsync(null, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+
+                watch.Stop();
+                return WithTotal(single, watch.ElapsedMilliseconds);
+            }
+
+            var tasks = Enumerable.Range(0, concurrent)
+                .Select(_ => new CopilotAdoptionService(options, contextFactory, maxConcurrentSteps)
+                    .AnalyseAsync(null, CancellationToken.None))
+                .ToArray();
+
+            Task.WaitAll(tasks);
+            watch.Stop();
+
+            return WithTotal(tasks[0].GetAwaiter().GetResult(), watch.ElapsedMilliseconds);
+        }
+
+        /// <summary>
+        /// The service records per-step times; the wall clock around the whole call is measured here so the
+        /// total includes anything the steps do not (model materialisation, serialisation of results).
+        /// </summary>
+        private static CopilotAdoptionDiagnostics WithTotal(CopilotAdoptionAnalysis analysis, long totalMs)
+        {
+            var diagnostics = analysis?.Summary?.Diagnostics ?? new CopilotAdoptionDiagnostics();
+            diagnostics.TotalMs = totalMs;
+            return diagnostics;
+        }
+
+        /// <summary>
+        /// Creates contexts against the benchmark database WITHOUT enabling automatic migration.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not <see cref="ConnectionStringAnalyticsDbContextFactory"/>, which passes
+        /// <c>autoUpdate: true</c> and therefore installs
+        /// <c>MigrateDatabaseToLatestVersion</c>. A measurement harness must never alter the schema of
+        /// the database it is measuring - the numbers would describe a database nobody has, and pointing
+        /// this test at a restored copy of a customer database would silently start migrating it.
+        /// </remarks>
+        private sealed class NoMigrateContextFactory : IAnalyticsDbContextFactory
+        {
+            private readonly string _connectionString;
+
+            public NoMigrateContextFactory(string connectionString)
+            {
+                _connectionString = connectionString;
+            }
+
+            public AnalyticsEntitiesContext Create()
+            {
+                return new AnalyticsEntitiesContext(_connectionString, true, false);
+            }
+        }
+
+        private static WindowResult Summarise(int windowDays, List<CopilotAdoptionDiagnostics> runs)
+        {
+            var timeoutMs = CopilotAdoptionService.QueryTimeoutSecs * 1000L * TimeoutSuspicionFraction;
+
+            var steps = runs
+                .SelectMany(r => r.Steps)
+                .GroupBy(s => s.Step, StringComparer.Ordinal)
+                .Select(g => new StepResult
+                {
+                    Step = g.Key,
+                    MedianMs = Median(g.Select(s => s.DurationMs)),
+                    MaxMs = g.Max(s => s.DurationMs),
+                    Failed = g.Any(s => s.Failed),
+                    LooksLikeTimeout = g.Any(s => s.DurationMs >= timeoutMs),
+                })
+                .OrderByDescending(s => s.MedianMs)
+                .ToList();
+
+            var slowest = steps.FirstOrDefault();
+
+            return new WindowResult
+            {
+                WindowDays = windowDays,
+                Runs = runs.Count,
+                TotalMedianMs = Median(runs.Select(r => r.TotalMs)),
+                TotalMaxMs = runs.Max(r => r.TotalMs),
+                QueryTimeoutSecs = CopilotAdoptionService.QueryTimeoutSecs,
+                Steps = steps,
+                SlowestStepName = slowest?.Step,
+                SlowestStepMs = slowest?.MedianMs ?? 0,
+            };
+        }
+
+        private static long Median(IEnumerable<long> values)
+        {
+            var sorted = values.OrderBy(v => v).ToList();
+            if (sorted.Count == 0) return 0;
+            return sorted.Count % 2 == 1
+                ? sorted[sorted.Count / 2]
+                : (sorted[(sorted.Count / 2) - 1] + sorted[sorted.Count / 2]) / 2;
+        }
+
+        private static void PrintReport(List<WindowResult> runs)
+        {
+            Console.WriteLine("\n=== Copilot Adoption timings (medians) ===\n");
+
+            foreach (var window in runs)
+            {
+                Console.WriteLine($"{window.WindowDays}-day window - total {window.TotalMedianMs:N0} ms"
+                                  + $" (worst run {window.TotalMaxMs:N0} ms, {window.Runs} run(s))");
+                Console.WriteLine("  step                        median ms      max ms   share");
+                Console.WriteLine("  ------------------------  -----------  ----------  ------");
+
+                foreach (var step in window.Steps)
+                {
+                    var share = window.TotalMedianMs > 0
+                        ? (100.0 * step.MedianMs / window.TotalMedianMs)
+                        : 0;
+
+                    var flag = step.Failed ? "  FAILED"
+                             : step.LooksLikeTimeout ? "  ~TIMEOUT"
+                             : string.Empty;
+
+                    if (!string.IsNullOrEmpty(flag)) Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine($"  {step.Step,-24}  {step.MedianMs,11:N0}  {step.MaxMs,10:N0}  {share,5:F1}%{flag}");
+                    if (!string.IsNullOrEmpty(flag)) Console.ResetColor();
+                }
+
+                Console.WriteLine();
+            }
+
+            var worst = runs.OrderByDescending(r => r.TotalMedianMs).FirstOrDefault();
+            if (worst != null)
+            {
+                // Steps overlap, so the shares above are shares of WALL CLOCK and can sum to well over
+                // 100%. That gap is the useful number: sum-of-steps is how much database work the report
+                // costs, while the total is how long the person waited. Printing both stops a reader
+                // concluding that overlapping the steps removed work when it only hid it - and if the two
+                // are close, the steps are not actually overlapping and the database is the constraint.
+                var stepSum = worst.Steps.Sum(s => s.MedianMs);
+                var overlap = worst.TotalMedianMs > 0 ? (double)stepSum / worst.TotalMedianMs : 0;
+
+                Console.WriteLine($"Worst window {worst.WindowDays}d: waited {worst.TotalMedianMs:N0} ms for"
+                                  + $" {stepSum:N0} ms of step time ({overlap:F2}x overlap).");
+                Console.WriteLine($"Optimise '{worst.SlowestStepName}' first ({worst.SlowestStepMs:N0} ms) -"
+                                  + " it alone sets the floor for the whole page.\n");
+            }
+
+            if (runs.Any(r => r.Steps.Any(s => s.LooksLikeTimeout || s.Failed)))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("At least one step FAILED or sat at the query timeout. Those steps returned"
+                                  + " nothing, so the totals above understate the real work - fix the failure"
+                                  + " before reading these as a benchmark.\n");
+                Console.ResetColor();
+            }
+        }
+
+        /// <summary>
+        /// Writes the run to JSON so a later run can diff against it. Contains only step names, durations
+        /// and counts, so it is safe to attach to an issue or PR.
+        /// </summary>
+        private static string WriteJson(List<WindowResult> runs)
+        {
+            try
+            {
+                var dir = Environment.GetEnvironmentVariable("COPILOTPERF_OUTDIR");
+                if (string.IsNullOrWhiteSpace(dir)) dir = Path.GetTempPath();
+                Directory.CreateDirectory(dir);
+
+                var path = Path.Combine(
+                    dir, $"copilot-adoption-perf-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json");
+
+                File.WriteAllText(path, JsonConvert.SerializeObject(runs, Formatting.Indented));
+                Console.WriteLine($"Results written to {path}");
+                return path;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"(could not write results JSON: {ex.Message})");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Diffs against a previous run when <c>COPILOTPERF_BASELINE</c> names one. Returns null when the
+        /// run is acceptable, or a description of the regression - which the caller turns into a failure,
+        /// so this can gate a change rather than just describe it.
+        /// </summary>
+        private static string CompareToBaseline(List<WindowResult> runs)
+        {
+            var baselinePath = Environment.GetEnvironmentVariable("COPILOTPERF_BASELINE");
+            if (string.IsNullOrWhiteSpace(baselinePath)) return null;
+
+            if (!File.Exists(baselinePath))
+            {
+                Console.WriteLine($"(baseline '{baselinePath}' not found - skipping comparison)");
+                return null;
+            }
+
+            var tolerance = 0.10;
+            var toleranceEnv = Environment.GetEnvironmentVariable("COPILOTPERF_TOLERANCE");
+            if (!string.IsNullOrWhiteSpace(toleranceEnv)
+                && double.TryParse(toleranceEnv, out var parsed) && parsed > 0)
+            {
+                tolerance = parsed;
+            }
+
+            List<WindowResult> baseline;
+            try
+            {
+                baseline = JsonConvert.DeserializeObject<List<WindowResult>>(File.ReadAllText(baselinePath));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"(could not read baseline: {ex.Message})");
+                return null;
+            }
+
+            if (baseline == null || baseline.Count == 0) return null;
+
+            Console.WriteLine($"=== Comparison against {Path.GetFileName(baselinePath)} ===\n");
+            Console.WriteLine("  window       before ms      after ms     change");
+            Console.WriteLine("  --------  ------------  ------------  ---------");
+
+            string regression = null;
+
+            foreach (var after in runs)
+            {
+                var before = baseline.FirstOrDefault(b => b.WindowDays == after.WindowDays);
+                if (before == null) continue;
+
+                var delta = before.TotalMedianMs == 0
+                    ? 0
+                    : (double)(after.TotalMedianMs - before.TotalMedianMs) / before.TotalMedianMs;
+
+                var worse = delta > tolerance;
+                if (worse) Console.ForegroundColor = ConsoleColor.Red;
+                else if (delta < -tolerance) Console.ForegroundColor = ConsoleColor.Green;
+
+                Console.WriteLine($"  {after.WindowDays,6}d  {before.TotalMedianMs,12:N0}  "
+                                  + $"{after.TotalMedianMs,12:N0}  {delta * 100,8:F1}%");
+                Console.ResetColor();
+
+                if (worse)
+                {
+                    regression = $"REGRESSION: the {after.WindowDays}-day window went from "
+                               + $"{before.TotalMedianMs:N0} ms to {after.TotalMedianMs:N0} ms "
+                               + $"({delta * 100:F1}%, tolerance {tolerance * 100:F0}%).";
+                }
+            }
+
+            Console.WriteLine();
+
+            // Per-step deltas for the default window, which is where a change usually shows up first.
+            var afterDefault = runs.FirstOrDefault(r => r.WindowDays == 28);
+            var beforeDefault = baseline.FirstOrDefault(r => r.WindowDays == 28);
+            if (afterDefault != null && beforeDefault != null)
+            {
+                Console.WriteLine("  per-step, 28-day window:");
+                foreach (var step in afterDefault.Steps)
+                {
+                    var was = beforeDefault.Steps.FirstOrDefault(s => s.Step == step.Step);
+                    if (was == null) continue;
+
+                    var delta = step.MedianMs - was.MedianMs;
+                    var sign = delta > 0 ? "+" : string.Empty;
+                    Console.WriteLine($"    {step.Step,-24}  {was.MedianMs,9:N0} -> {step.MedianMs,9:N0} ms"
+                                      + $"  ({sign}{delta:N0})");
+                }
+                Console.WriteLine();
+            }
+
+            if (regression != null)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine(regression);
+                Console.ResetColor();
+            }
+
+            return regression;
+        }
+
+        /// <summary>One measured reporting window. Serialised as the before/after baseline.</summary>
+        private class WindowResult
+        {
+            public int WindowDays { get; set; }
+            public int Runs { get; set; }
+            public long TotalMedianMs { get; set; }
+            public long TotalMaxMs { get; set; }
+            public int QueryTimeoutSecs { get; set; }
+            public string SlowestStepName { get; set; }
+            public long SlowestStepMs { get; set; }
+            public List<StepResult> Steps { get; set; } = new List<StepResult>();
+        }
+
+        /// <summary>One step of the analysis, aggregated across the timed runs.</summary>
+        private class StepResult
+        {
+            public string Step { get; set; }
+            public long MedianMs { get; set; }
+            public long MaxMs { get; set; }
+            public bool Failed { get; set; }
+
+            /// <summary>
+            /// At or above <see cref="TimeoutSuspicionFraction"/> of the query timeout. Such a step almost
+            /// certainly failed and returned nothing rather than genuinely taking that long, so treating it
+            /// as a timing would flatter the result.
+            /// </summary>
+            public bool LooksLikeTimeout { get; set; }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -64,6 +64,7 @@
     <Compile Include="StressTests\ActivityAPIStressTest.cs" />
     <Compile Include="StressTests\ActivityApiDbStressTest.cs" />
     <Compile Include="StressTests\BaseStressTest.cs" />
+    <Compile Include="StressTests\CopilotAdoptionPerfTest.cs" />
     <Compile Include="StressTests\CopilotStressTest.cs" />
     <Compile Include="StressTests\MemoryMonitor.cs" />
     <Compile Include="StressTests\PowerPlatformStressTest.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionTelemetryTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionTelemetryTests.cs
@@ -1,0 +1,640 @@
+extern alias AnalyticsWeb;
+
+using Common.Entities.CopilotAdoption;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AdoptionCache = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionAnalysisCache;
+using AdoptionCoordinator = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionAnalysisCoordinator;
+using AdoptionEvent = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionLifecycleEvent;
+using AdoptionFailure = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionFailureEvent;
+using AdoptionHeartbeatFactory = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionHeartbeatFactory;
+using AdoptionRunner = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionAnalysisRunner;
+using AdoptionRunTelemetry = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionRunTelemetry;
+using AdoptionSink = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionEventSink;
+using AdoptionCompletion = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionCompletionEvent;
+using AdoptionQueuedSink = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.QueuedCopilotAdoptionEventSink;
+using AdoptionWriter = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionTelemetryWriter;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class CopilotAdoptionTelemetryTests
+    {
+        private static readonly HashSet<string> AllowedDimensions =
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                "SchemaVersion",
+                "Stage",
+                "RunId",
+                "InstanceId",
+                "WindowDays",
+                "HasSeatOverride",
+                "SynchronizationContext",
+                "Step",
+                "Query",
+                "Outcome",
+                "ExceptionType",
+                "ActiveOperations",
+                "ShutdownReason",
+            };
+
+        private static readonly HashSet<string> AllowedMeasurements =
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                "Sequence",
+                "ElapsedMs",
+                "AppDomainId",
+                "AppDomainUptimeMs",
+                "DroppedEvents",
+                "OperationId",
+                "DurationMs",
+                "HeartbeatDriftMs",
+                "ProcessWorkingSetBytes",
+                "ManagedHeapBytes",
+                "Gen0Collections",
+                "Gen1Collections",
+                "Gen2Collections",
+                "ThreadPoolAvailableWorkers",
+                "ThreadPoolAvailableCompletionPorts",
+            };
+
+        [TestMethod]
+        public void LifecycleEvents_AreCorrelatedSequencedAndPrivacyAllowListed()
+        {
+            var sink = new RecordingSink();
+            var heartbeat = new ManualHeartbeatFactory();
+            var telemetry = NewTelemetry(sink, heartbeat);
+
+            var step = telemetry.StepStarted(CopilotAdoptionSteps.LicensedUsers);
+            var firstQuery = telemetry.QueryStarted(
+                CopilotAdoptionSteps.LicensedUsers,
+                CopilotAdoptionQueries.CoworkAgentLookup);
+            var secondQuery = telemetry.QueryStarted(
+                CopilotAdoptionSteps.WeeklyTrend,
+                CopilotAdoptionQueries.CoworkAgentLookup);
+
+            heartbeat.Trigger();
+            var bothActive = sink.Events.Last(
+                item => item.Stage == CopilotAdoptionTelemetryStages.Heartbeat);
+            StringAssert.Contains(bothActive.ActiveOperations, firstQuery + ":");
+            StringAssert.Contains(bothActive.ActiveOperations, secondQuery + ":");
+
+            telemetry.QueryCompleted(
+                firstQuery,
+                CopilotAdoptionSteps.LicensedUsers,
+                CopilotAdoptionQueries.CoworkAgentLookup,
+                10,
+                false);
+            heartbeat.Trigger();
+            var oneActive = sink.Events.Last(
+                item => item.Stage == CopilotAdoptionTelemetryStages.Heartbeat);
+            Assert.IsFalse(oneActive.ActiveOperations.Contains(firstQuery + ":"));
+            StringAssert.Contains(oneActive.ActiveOperations, secondQuery + ":");
+
+            telemetry.QueryCompleted(
+                secondQuery,
+                CopilotAdoptionSteps.WeeklyTrend,
+                CopilotAdoptionQueries.CoworkAgentLookup,
+                20,
+                true,
+                nameof(TimeoutException));
+            telemetry.StepCompleted(
+                step,
+                CopilotAdoptionSteps.LicensedUsers,
+                30,
+                false);
+
+            var countBeforeDispose = sink.Events.Count;
+            telemetry.Dispose();
+            heartbeat.Trigger();
+            Assert.AreEqual(
+                countBeforeDispose,
+                sink.Events.Count,
+                "disposing a completed run must stop its heartbeat");
+
+            var events = sink.Events;
+            Assert.IsTrue(events.Count > 0);
+            Assert.AreEqual(1, events.Select(item => item.RunId).Distinct().Count());
+            Assert.AreEqual("00000000000000000000000000000001", events[0].InstanceId);
+            CollectionAssert.AreEqual(
+                Enumerable.Range(1, events.Count).Select(value => (long)value).ToArray(),
+                events.Select(item => item.Sequence).ToArray(),
+                "sequence numbers must make missing or reordered telemetry visible");
+
+            foreach (var telemetryEvent in events)
+            {
+                Assert.IsTrue(
+                    telemetryEvent.Dimensions().Keys.All(AllowedDimensions.Contains),
+                    "an unreviewed custom dimension was added");
+                Assert.IsTrue(
+                    telemetryEvent.Measurements().Keys.All(AllowedMeasurements.Contains),
+                    "an unreviewed custom measurement was added");
+            }
+
+            var failedQuery = events.Single(
+                item => item.Stage == CopilotAdoptionTelemetryStages.QueryFailed);
+            Assert.AreEqual(nameof(TimeoutException), failedQuery.ExceptionType);
+        }
+
+        [TestMethod]
+        public async Task ConcurrentColdRequests_ShareOneRunThenReadThePublishedCache()
+        {
+            var order = new ConcurrentQueue<string>();
+            var sink = new RecordingSink(order);
+            var heartbeat = new ManualHeartbeatFactory();
+            var runner = new ControllableRunner();
+            var cache = new InMemoryAnalysisCache(order);
+            var coordinator = NewCoordinator(runner, cache, sink, heartbeat);
+            var ids = new List<int>();
+
+            var firstPolls = Enumerable.Range(0, 3)
+                .Select(_ => coordinator.TryGetAsync(
+                    28,
+                    ids,
+                    TimeSpan.FromMilliseconds(40),
+                    CancellationToken.None))
+                .ToArray();
+
+            await Task.WhenAll(firstPolls);
+
+            Assert.AreEqual(1, runner.CallCount, "three cold endpoints must start one analysis");
+            Assert.IsTrue(firstPolls.All(task => task.Result == null));
+
+            var analysis = new CopilotAdoptionAnalysis();
+            runner.Complete(analysis);
+            var completed = await coordinator.TryGetAsync(
+                28,
+                ids,
+                TimeSpan.FromSeconds(2),
+                CancellationToken.None);
+            var cached = await coordinator.GetAsync(28, ids);
+
+            Assert.AreSame(analysis, completed);
+            Assert.AreSame(analysis, cached);
+            Assert.AreEqual(1, runner.CallCount);
+            Assert.AreEqual(1, cache.SetCount);
+            Assert.AreEqual(
+                1,
+                sink.Events.Count(
+                    item => item.Stage == CopilotAdoptionTelemetryStages.CachePublished));
+
+            var ordered = order.ToArray();
+            Assert.IsTrue(
+                Array.IndexOf(ordered, "CacheSet")
+                < Array.IndexOf(ordered, CopilotAdoptionTelemetryStages.CachePublished),
+                "the result must be published before any terminal telemetry");
+        }
+
+        [TestMethod]
+        public async Task CachePublication_IsNotBlockedByCompletionTelemetry()
+        {
+            var sink = new RecordingSink { BlockCompletion = true };
+            var heartbeat = new ManualHeartbeatFactory();
+            var runner = new ControllableRunner();
+            var cache = new InMemoryAnalysisCache();
+            var coordinator = NewCoordinator(runner, cache, sink, heartbeat);
+            var analysis = new CopilotAdoptionAnalysis();
+
+            var first = coordinator.GetAsync(28, new List<int>());
+            runner.Complete(analysis);
+
+            Assert.IsTrue(
+                sink.CompletionEntered.Wait(TimeSpan.FromSeconds(2)),
+                "the fake must block the completion telemetry path");
+            Assert.AreEqual(1, cache.SetCount, "cache publication must happen first");
+
+            var second = await coordinator.GetAsync(28, new List<int>());
+            Assert.AreSame(
+                analysis,
+                second,
+                "a new poll must read the cache while completion telemetry is blocked");
+
+            sink.ReleaseCompletion.Set();
+            Assert.AreSame(analysis, await first);
+        }
+
+        [TestMethod]
+        public async Task FailedRun_IsEvictedAndTheNextRequestRetries()
+        {
+            var sink = new RecordingSink();
+            var heartbeat = new ManualHeartbeatFactory();
+            var runner = new SequencedRunner(
+                Task.FromException<CopilotAdoptionAnalysis>(
+                    new InvalidOperationException("sensitive-value")),
+                Task.FromResult(new CopilotAdoptionAnalysis()));
+            var cache = new InMemoryAnalysisCache();
+            var coordinator = NewCoordinator(runner, cache, sink, heartbeat);
+
+            try
+            {
+                await coordinator.GetAsync(28, new List<int>());
+                Assert.Fail("the first run should fail");
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            var recovered = await coordinator.GetAsync(28, new List<int>());
+
+            Assert.IsNotNull(recovered);
+            Assert.AreEqual(2, runner.CallCount, "a faulted generation must not stay in-flight");
+            Assert.AreEqual(1, cache.SetCount);
+            var failure = sink.Events.Single(
+                item => item.Stage == CopilotAdoptionTelemetryStages.Failed);
+            Assert.AreEqual(nameof(InvalidOperationException), failure.ExceptionType);
+            Assert.IsFalse(
+                string.Join("|", failure.Dimensions().Values).Contains("sensitive-value"));
+        }
+
+        [TestMethod]
+        public async Task TelemetryFactoryFailure_DoesNotStopOrPoisonTheAnalysis()
+        {
+            var runner = new SequencedRunner(
+                Task.FromException<CopilotAdoptionAnalysis>(
+                    new InvalidOperationException("first analysis failed")),
+                Task.FromResult(new CopilotAdoptionAnalysis()));
+            var cache = new InMemoryAnalysisCache();
+            var coordinator = new AdoptionCoordinator(
+                runner,
+                cache,
+                (window, hasOverride) => throw new InvalidOperationException(
+                    "telemetry construction failed"),
+                TimeSpan.FromMinutes(10));
+
+            try
+            {
+                await coordinator.GetAsync(28, new List<int>());
+                Assert.Fail("the first fake analysis should fail");
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            var recovered = await coordinator.GetAsync(28, new List<int>());
+
+            Assert.IsNotNull(recovered);
+            Assert.AreEqual(
+                2,
+                runner.CallCount,
+                "telemetry construction must not leave a faulted generation in-flight");
+            Assert.AreEqual(1, cache.SetCount);
+        }
+
+        [TestMethod]
+        public void QueuedSink_DoesNotBlockTheCallerWhenTheWriterBlocks()
+        {
+            var writer = new BlockingWriter();
+            var sink = new AdoptionQueuedSink(() => writer);
+            var completion = new AdoptionCompletion
+            {
+                RunId = "00000000000000000000000000000002",
+                WindowDays = 28,
+                Steps = new Dictionary<string, long>(),
+            };
+            var submitted = LifecycleEvent(
+                CopilotAdoptionTelemetryStages.CompletionTelemetryReturned,
+                completion.RunId);
+
+            var watch = Stopwatch.StartNew();
+            sink.TrackCompletion(completion, submitted);
+            watch.Stop();
+
+            Assert.IsTrue(watch.Elapsed < TimeSpan.FromMilliseconds(250));
+            Assert.IsTrue(writer.CompletionEntered.Wait(TimeSpan.FromSeconds(2)));
+            Assert.IsFalse(
+                writer.Events.Any(
+                    item => item.Stage
+                            == CopilotAdoptionTelemetryStages.CompletionTelemetryReturned),
+                "the boundary event must only be submitted after legacy completion telemetry returns");
+
+            Thread.Sleep(30);
+            writer.ReleaseCompletion.Set();
+            Assert.IsTrue(
+                SpinWait.SpinUntil(
+                    () => writer.Events.Any(
+                        item => item.Stage
+                                == CopilotAdoptionTelemetryStages.CompletionTelemetryReturned),
+                    TimeSpan.FromSeconds(2)));
+            var returned = writer.Events.Single(
+                item => item.Stage
+                        == CopilotAdoptionTelemetryStages.CompletionTelemetryReturned);
+            Assert.IsTrue(returned.DurationMs >= 20);
+
+            sink.Shutdown(TimeSpan.FromSeconds(2));
+        }
+
+        [TestMethod]
+        public void QueuedSink_RetriesAfterTransientWriterConstructionFailure()
+        {
+            var writer = new BlockingWriter();
+            writer.ReleaseCompletion.Set();
+            var attempts = 0;
+            var sink = new AdoptionQueuedSink(() =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                {
+                    throw new InvalidOperationException("transient setup failure");
+                }
+                return writer;
+            });
+
+            sink.Track(LifecycleEvent(
+                CopilotAdoptionTelemetryStages.Started,
+                "00000000000000000000000000000003"));
+            sink.Track(LifecycleEvent(
+                CopilotAdoptionTelemetryStages.Heartbeat,
+                "00000000000000000000000000000003"));
+
+            Assert.IsTrue(
+                SpinWait.SpinUntil(
+                    () => writer.Events.Any(
+                        item => item.Stage == CopilotAdoptionTelemetryStages.Heartbeat),
+                    TimeSpan.FromSeconds(2)));
+            Assert.AreEqual(2, attempts);
+            Assert.AreEqual(1, sink.DroppedEvents);
+
+            sink.Shutdown(TimeSpan.FromSeconds(2));
+        }
+
+        private static AdoptionCoordinator NewCoordinator(
+            AdoptionRunner runner,
+            AdoptionCache cache,
+            RecordingSink sink,
+            ManualHeartbeatFactory heartbeat)
+        {
+            return new AdoptionCoordinator(
+                runner,
+                cache,
+                (window, hasOverride) => NewTelemetry(
+                    sink,
+                    heartbeat,
+                    window,
+                    hasOverride),
+                TimeSpan.FromMinutes(10));
+        }
+
+        private static AdoptionRunTelemetry NewTelemetry(
+            AdoptionSink sink,
+            AdoptionHeartbeatFactory heartbeat,
+            int windowDays = 28,
+            bool hasOverride = false)
+        {
+            return new AdoptionRunTelemetry(
+                sink,
+                windowDays,
+                hasOverride,
+                "00000000000000000000000000000001",
+                1,
+                Stopwatch.StartNew(),
+                heartbeat,
+                TimeSpan.FromSeconds(30));
+        }
+
+        private static AdoptionEvent LifecycleEvent(string stage, string runId)
+        {
+            return new AdoptionEvent
+            {
+                OccurredUtc = DateTimeOffset.UtcNow,
+                Stage = stage,
+                RunId = runId,
+                InstanceId = "00000000000000000000000000000001",
+                WindowDays = 28,
+                Sequence = 1,
+                Gen0Collections = -1,
+                Gen1Collections = -1,
+                Gen2Collections = -1,
+                ThreadPoolAvailableWorkers = -1,
+                ThreadPoolAvailableCompletionPorts = -1,
+            };
+        }
+
+        private sealed class RecordingSink : AdoptionSink
+        {
+            private readonly object _gate = new object();
+            private readonly ConcurrentQueue<string> _order;
+            private readonly List<AdoptionEvent> _events = new List<AdoptionEvent>();
+
+            public RecordingSink(ConcurrentQueue<string> order = null)
+            {
+                _order = order;
+            }
+
+            public bool BlockCompletion { get; set; }
+            public ManualResetEventSlim CompletionEntered { get; } =
+                new ManualResetEventSlim(false);
+            public ManualResetEventSlim ReleaseCompletion { get; } =
+                new ManualResetEventSlim(false);
+            public int DroppedEvents => 0;
+
+            public List<AdoptionEvent> Events
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        return _events.ToList();
+                    }
+                }
+            }
+
+            public void Track(AdoptionEvent telemetryEvent)
+            {
+                lock (_gate)
+                {
+                    _events.Add(telemetryEvent);
+                }
+                _order?.Enqueue(telemetryEvent.Stage);
+            }
+
+            public void TrackCompletion(
+                AdoptionCompletion completion,
+                AdoptionEvent submittedEvent)
+            {
+                CompletionEntered.Set();
+                if (BlockCompletion)
+                {
+                    ReleaseCompletion.Wait(TimeSpan.FromSeconds(5));
+                }
+                Track(submittedEvent);
+            }
+
+            public bool TrackFailure(
+                AdoptionFailure failure,
+                AdoptionEvent failureEvent)
+            {
+                Track(failureEvent);
+                return true;
+            }
+
+            public void Shutdown(TimeSpan timeout)
+            {
+            }
+        }
+
+        private sealed class ManualHeartbeatFactory : AdoptionHeartbeatFactory
+        {
+            private Action _heartbeat;
+            private bool _disposed;
+
+            public IDisposable Start(Action heartbeat, TimeSpan interval)
+            {
+                _heartbeat = heartbeat;
+                _disposed = false;
+                return new CallbackDisposable(() => _disposed = true);
+            }
+
+            public void Trigger()
+            {
+                if (!_disposed) _heartbeat?.Invoke();
+            }
+        }
+
+        private sealed class CallbackDisposable : IDisposable
+        {
+            private readonly Action _dispose;
+
+            public CallbackDisposable(Action dispose)
+            {
+                _dispose = dispose;
+            }
+
+            public void Dispose()
+            {
+                _dispose();
+            }
+        }
+
+        private sealed class InMemoryAnalysisCache : AdoptionCache
+        {
+            private readonly object _gate = new object();
+            private readonly Dictionary<string, CopilotAdoptionAnalysis> _items =
+                new Dictionary<string, CopilotAdoptionAnalysis>(StringComparer.Ordinal);
+            private readonly ConcurrentQueue<string> _order;
+
+            public InMemoryAnalysisCache(ConcurrentQueue<string> order = null)
+            {
+                _order = order;
+            }
+
+            public int SetCount { get; private set; }
+
+            public bool TryGet(string key, out CopilotAdoptionAnalysis analysis)
+            {
+                lock (_gate)
+                {
+                    return _items.TryGetValue(key, out analysis);
+                }
+            }
+
+            public void Set(string key, CopilotAdoptionAnalysis analysis, TimeSpan ttl)
+            {
+                lock (_gate)
+                {
+                    _items[key] = analysis;
+                    SetCount++;
+                }
+                _order?.Enqueue("CacheSet");
+            }
+        }
+
+        private sealed class ControllableRunner : AdoptionRunner
+        {
+            private readonly TaskCompletionSource<CopilotAdoptionAnalysis> _completion =
+                new TaskCompletionSource<CopilotAdoptionAnalysis>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _callCount;
+
+            public int CallCount => Volatile.Read(ref _callCount);
+
+            public Task<CopilotAdoptionAnalysis> RunAsync(
+                int windowDays,
+                List<int> seatLicenceTypeIds,
+                ICopilotAdoptionRunTelemetry telemetry)
+            {
+                Interlocked.Increment(ref _callCount);
+                return _completion.Task;
+            }
+
+            public void Complete(CopilotAdoptionAnalysis analysis)
+            {
+                _completion.SetResult(analysis);
+            }
+        }
+
+        private sealed class SequencedRunner : AdoptionRunner
+        {
+            private readonly ConcurrentQueue<Task<CopilotAdoptionAnalysis>> _responses;
+            private int _callCount;
+
+            public SequencedRunner(params Task<CopilotAdoptionAnalysis>[] responses)
+            {
+                _responses = new ConcurrentQueue<Task<CopilotAdoptionAnalysis>>(responses);
+            }
+
+            public int CallCount => Volatile.Read(ref _callCount);
+
+            public Task<CopilotAdoptionAnalysis> RunAsync(
+                int windowDays,
+                List<int> seatLicenceTypeIds,
+                ICopilotAdoptionRunTelemetry telemetry)
+            {
+                Interlocked.Increment(ref _callCount);
+                if (!_responses.TryDequeue(out var response))
+                {
+                    throw new InvalidOperationException("No fake response configured.");
+                }
+                return response;
+            }
+        }
+
+        private sealed class BlockingWriter : AdoptionWriter
+        {
+            private readonly object _gate = new object();
+            private readonly List<AdoptionEvent> _events = new List<AdoptionEvent>();
+
+            public ManualResetEventSlim CompletionEntered { get; } =
+                new ManualResetEventSlim(false);
+            public ManualResetEventSlim ReleaseCompletion { get; } =
+                new ManualResetEventSlim(false);
+
+            public List<AdoptionEvent> Events
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        return _events.ToList();
+                    }
+                }
+            }
+
+            public void Write(AdoptionEvent telemetryEvent)
+            {
+                lock (_gate)
+                {
+                    _events.Add(telemetryEvent);
+                }
+            }
+
+            public void WriteCompletion(AdoptionCompletion completion)
+            {
+                CompletionEntered.Set();
+                ReleaseCompletion.Wait(TimeSpan.FromSeconds(5));
+            }
+
+            public void WriteFailure(AdoptionFailure failure)
+            {
+            }
+
+            public void Flush()
+            {
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -178,6 +178,7 @@
     <Compile Include="PowerPlatformAdminActivityRecordParseTests.cs" />
     <Compile Include="ProfilingStoredProcedureTests.cs" />
     <Compile Include="CopilotAdoptionSqlIntegrationTests.cs" />
+    <Compile Include="CopilotAdoptionTelemetryTests.cs" />
     <Compile Include="CopilotAdoptionTests.cs" />
     <Compile Include="CopilotAdoptionWorkbookTests.cs" />
     <Compile Include="ReportsAPIControllerTests.cs" />

--- a/src/AnalyticsEngine/Web/Controllers/CopilotAdoptionAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/CopilotAdoptionAPIController.cs
@@ -3,17 +3,16 @@ using Common.Entities.Config;
 using Common.Entities.CopilotAdoption;
 using DataUtils;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.Caching;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Web.AnalyticsWeb.Models.CopilotAdoption;
 
 namespace Web.AnalyticsWeb.Controllers
 {
@@ -47,15 +46,6 @@ namespace Web.AnalyticsWeb.Controllers
     [RoutePrefix("api/CopilotAdoption")]
     public class CopilotAdoptionAPIController : ApiController
     {
-        private const string CacheKeyPrefix = "CopilotAdoption::Analysis::";
-
-        /// <summary>
-        /// How long a completed analysis is reused. Long enough that working through the list - sorting,
-        /// filtering, exporting - never re-runs the queries, short enough that a refresh after an import
-        /// shows new data. The imports themselves run far less often than this.
-        /// </summary>
-        private const int CacheMinutes = 10;
-
         /// <summary>Windows the UI offers. Anything else is snapped to the nearest, so a hand-edited URL cannot force a year-long scan.</summary>
         private static readonly int[] AllowedWindowDays = { 7, 28, 90, 180 };
 
@@ -67,6 +57,18 @@ namespace Web.AnalyticsWeb.Controllers
         /// single request from materialising an entire directory into one HTTP response.
         /// </summary>
         private const int MaxCsvRows = 100000;
+
+        public CopilotAdoptionAPIController()
+            : this(CopilotAdoptionAnalysisCoordinator.Default)
+        {
+        }
+
+        internal CopilotAdoptionAPIController(CopilotAdoptionAnalysisCoordinator coordinator)
+        {
+            Coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
+        }
+
+        internal CopilotAdoptionAnalysisCoordinator Coordinator { get; }
 
         #region Availability
 
@@ -172,10 +174,10 @@ namespace Web.AnalyticsWeb.Controllers
         /// </summary>
         /// <remarks>
         /// Task.WhenAny rather than a cancellable await: the analysis is shared between callers, so one
-        /// caller giving up must not cancel it for everyone else. The task is left running and observed on
-        /// completion by the continuation in <see cref="GetAnalysisAsync"/>.
+        /// caller giving up must not cancel it for everyone else. The task is left running in the shared
+        /// <see cref="CopilotAdoptionAnalysisCoordinator"/>.
         /// </remarks>
-        private static async Task<CopilotAdoptionAnalysis> TryGetAnalysisAsync(
+        private async Task<CopilotAdoptionAnalysis> TryGetAnalysisAsync(
             int windowDays, string seatLicenceTypeIds, CancellationToken cancellationToken)
         {
             return await TryGetAnalysisAsync(windowDays, seatLicenceTypeIds, FirstResponseBudget, cancellationToken);
@@ -185,19 +187,14 @@ namespace Web.AnalyticsWeb.Controllers
         /// As above, but with an explicit wait budget. Exports use a much longer one - see
         /// <see cref="ExportWaitBudget"/>.
         /// </summary>
-        private static async Task<CopilotAdoptionAnalysis> TryGetAnalysisAsync(
+        private async Task<CopilotAdoptionAnalysis> TryGetAnalysisAsync(
             int windowDays, string seatLicenceTypeIds, TimeSpan budget, CancellationToken cancellationToken)
         {
-            var task = GetAnalysisAsync(windowDays, seatLicenceTypeIds, cancellationToken);
-
-            if (task.IsCompleted)
-            {
-                return await task;   // rethrows a genuine failure, as before
-            }
-
-            var finished = await Task.WhenAny(task, Task.Delay(budget, cancellationToken));
-
-            return finished == task ? await task : null;
+            return await Coordinator.TryGetAsync(
+                NormaliseWindowDays(windowDays),
+                ParseIds(seatLicenceTypeIds),
+                budget,
+                cancellationToken);
         }
 
         /// <summary>
@@ -578,235 +575,6 @@ namespace Web.AnalyticsWeb.Controllers
             };
 
             return response;
-        }
-
-        #endregion
-
-        #region Analysis cache
-
-        /// <summary>
-        /// The cached analysis for this window and licence override, running it if necessary.
-        ///
-        /// The <see cref="Task{T}"/> itself is cached, not its result, so several requests arriving
-        /// while the first analysis is still running all await the same execution instead of each
-        /// starting their own scan of the Copilot audit history. A failed analysis is evicted so the
-        /// next request retries rather than serving a cached error for ten minutes.
-        /// </summary>
-        /// <remarks>
-        /// Two details are load-bearing.
-        /// <para>
-        /// The work is wrapped in a <see cref="Lazy{T}"/> and only the winner of
-        /// <c>AddOrGetExisting</c> is evaluated. Starting the task first and then racing to insert it does
-        /// not share anything: a C# async method runs eagerly, so the loser has already issued its queries
-        /// and "abandoning" it only discards the result. Two concurrent first hits meant two full scans of
-        /// the audit history - and the SPA loads summary, filters and SQL concurrently on a cold page.
-        /// </para>
-        /// <para>
-        /// The shared execution deliberately does NOT take the caller's <see cref="CancellationToken"/>.
-        /// The token is bound to one HTTP request, so an admin navigating away would cancel the analysis
-        /// that every other waiter is awaiting.
-        /// </para>
-        /// </remarks>
-        /// <summary>
-        /// Analyses currently RUNNING, keyed the same way as the cache.
-        /// </summary>
-        /// <remarks>
-        /// Separate from <see cref="MemoryCache"/> on purpose. The cache entry's absolute expiry starts when
-        /// the entry is INSERTED, which is before the analysis has run - so a 10-minute entry holding an
-        /// analysis that takes seven minutes is only reusable for three, and an analysis that takes longer
-        /// than the expiry would be evicted while still running. The next request would then start a SECOND
-        /// full analysis against an already-struggling database, and so on for as long as anyone kept
-        /// polling. Polling makes that far more likely to happen, so it has to be fixed here (issue #360).
-        ///
-        /// In-flight runs therefore live here, with no expiry, and only the finished RESULT is put in the
-        /// cache - with its lifetime starting at completion, which is what the 10 minutes was always meant
-        /// to mean.
-        /// </remarks>
-        private static readonly ConcurrentDictionary<string, Lazy<Task<CopilotAdoptionAnalysis>>> _inFlight =
-            new ConcurrentDictionary<string, Lazy<Task<CopilotAdoptionAnalysis>>>(StringComparer.Ordinal);
-
-        private static Task<CopilotAdoptionAnalysis> GetAnalysisAsync(
-            int windowDays,
-            string seatLicenceTypeIds,
-            CancellationToken cancellationToken)
-        {
-            var window = NormaliseWindowDays(windowDays);
-            var overrideIds = ParseIds(seatLicenceTypeIds);
-            var cacheKey = CacheKeyPrefix + window + "::"
-                           + (overrideIds.Count == 0 ? "auto" : string.Join(",", overrideIds.OrderBy(i => i)));
-
-            // A completed result, still inside its 10 minutes.
-            var cached = MemoryCache.Default.Get(cacheKey) as CopilotAdoptionAnalysis;
-            if (cached != null)
-            {
-                return Task.FromResult(cached);
-            }
-
-            // A run already under way - join it rather than starting another.
-            var candidate = new Lazy<Task<CopilotAdoptionAnalysis>>(() =>
-            {
-                var options = CopilotAdoptionOptions.Default;
-                options.WindowDays = window;
-
-                var service = new CopilotAdoptionService(options);
-                return RunAndReportAsync(service, overrideIds, window);
-            }, LazyThreadSafetyMode.ExecutionAndPublication);
-
-            // GetOrAdd is atomic, and because the Lazy has not been evaluated yet the loser costs nothing -
-            // no query is issued for it.
-            var effective = _inFlight.GetOrAdd(cacheKey, candidate);
-
-            if (ReferenceEquals(effective, candidate))
-            {
-                // We won the race to create the entry. Re-check the result cache BEFORE evaluating the Lazy:
-                // between the miss above and here, an earlier run could have completed and published its
-                // result, and starting a second multi-minute analysis on top of a perfectly good one is
-                // exactly what this whole mechanism exists to prevent.
-                var justPublished = MemoryCache.Default.Get(cacheKey) as CopilotAdoptionAnalysis;
-                if (justPublished != null)
-                {
-                    RemoveInFlight(cacheKey, candidate);
-                    return Task.FromResult(justPublished);
-                }
-
-                var startedTask = effective.Value;
-
-                // Only the caller that actually started this run attaches the completion handling, so a
-                // hundred polls do not attach a hundred continuations to the same task.
-                startedTask.ContinueWith(
-                    completed =>
-                    {
-                        if (completed.IsFaulted)
-                        {
-                            // Reading .Exception is what actually OBSERVES the fault. Testing IsFaulted
-                            // alone leaves it unobserved if every caller has given up polling by now.
-                            var ignored = completed.Exception;
-                        }
-                        else if (!completed.IsCanceled)
-                        {
-                            // Publish BEFORE removing the in-flight entry, so there is no instant where the
-                            // key is absent from both stores and a concurrent caller would start again.
-                            MemoryCache.Default.Set(
-                                cacheKey, completed.Result, DateTimeOffset.UtcNow.AddMinutes(CacheMinutes));
-                        }
-
-                        // Generation-safe: ConcurrentDictionary's ICollection.Remove compares key AND value,
-                        // so this can only ever remove our own entry, never a newer run that replaced it.
-                        RemoveInFlight(cacheKey, candidate);
-                    },
-                    TaskContinuationOptions.ExecuteSynchronously);
-
-                return startedTask;
-            }
-
-            return effective.Value;
-        }
-
-        /// <summary>Removes an in-flight entry only if it is still the one we put there.</summary>
-        private static void RemoveInFlight(string cacheKey, Lazy<Task<CopilotAdoptionAnalysis>> ours)
-        {
-            var current = _inFlight as ICollection<KeyValuePair<string, Lazy<Task<CopilotAdoptionAnalysis>>>>;
-            current.Remove(new KeyValuePair<string, Lazy<Task<CopilotAdoptionAnalysis>>>(cacheKey, ours));
-        }
-
-        /// <summary>
-        /// Runs the analysis and reports how it went to App Insights.
-        ///
-        /// Deliberately inside the cache's Lazy factory, so exactly one event is emitted per actual
-        /// analysis rather than one per HTTP request. A cache hit does no work and should not look in
-        /// telemetry as though it did - otherwise the p95 would be dominated by cached reads and the
-        /// slow runs, which are the entire point of measuring, would disappear into the average.
-        /// </summary>
-        private static async Task<CopilotAdoptionAnalysis> RunAndReportAsync(
-            CopilotAdoptionService service, List<int> overrideIds, int windowDays)
-        {
-            try
-            {
-                var analysis = await service.AnalyseAsync(
-                    overrideIds.Count == 0 ? null : overrideIds, CancellationToken.None);
-
-                TrackAnalysis(analysis, windowDays);
-                return analysis;
-            }
-            catch (Exception ex)
-            {
-                // Previously TrackAnalysis sat after the await with no try/catch, so an analysis that threw
-                // reported NOTHING - no event, and no exception either, because the web application has no
-                // Application Insights request/exception collection of its own. That combination is what
-                // made issue #360 so hard to diagnose: a failing page with no telemetry at all.
-                TrackAnalysisFailure(ex, windowDays);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Reports an analysis that failed outright. Never throws: telemetry must not be the reason a
-        /// request behaves differently.
-        /// </summary>
-        private static void TrackAnalysisFailure(Exception ex, int windowDays)
-        {
-            try
-            {
-                var config = new AppConfig();
-                var logger = new AnalyticsLogger(
-                    config.AppInsightsConnectionString, nameof(CopilotAdoptionAPIController));
-
-                logger.TrackException(ex);
-                logger.LogError(
-                    $"Copilot adoption analysis failed for a {windowDays}-day window: "
-                    + $"{ex.GetBaseException().Message}");
-
-                // One shared analysis can have many requests awaiting it, and each will rethrow this very
-                // instance. Marking it here stops the Web API exception logger reporting the same
-                // failure once more per waiting request.
-                WebExceptionTelemetry.MarkReported(ex);
-            }
-            catch (Exception)
-            {
-                // Deliberately swallowed - see above.
-            }
-        }
-
-        /// <summary>
-        /// Emits the <c>CopilotAdoptionAnalysis</c> event. Never throws: telemetry must not be the
-        /// reason a request behaves differently, which is the same rule the workbook endpoint follows.
-        /// </summary>
-        private static void TrackAnalysis(CopilotAdoptionAnalysis analysis, int windowDays)
-        {
-            try
-            {
-                var diagnostics = analysis?.Summary?.Diagnostics;
-                if (diagnostics == null) return;
-
-                var steps = new Dictionary<string, long>();
-                foreach (var step in diagnostics.Steps)
-                {
-                    // Last write wins; a step runs once per analysis, so a collision would be a bug.
-                    steps[step.Step] = step.DurationMs;
-                }
-
-                // A step that reached the command timeout is the signal that matters: the query was
-                // abandoned and its figures degraded to a warning rather than an error, so nothing
-                // else in the request tells anyone the report is incomplete.
-                var timeoutMs = CopilotAdoptionService.QueryTimeoutSecs * 1000L;
-                var timedOut = diagnostics.Steps.Any(s => s.DurationMs >= timeoutMs);
-
-                var config = new AppConfig();
-                var logger = new AnalyticsLogger(
-                    config.AppInsightsConnectionString, nameof(CopilotAdoptionAPIController));
-
-                logger.TrackCopilotAdoptionAnalysis(
-                    windowDays,
-                    diagnostics.TotalMs,
-                    steps,
-                    analysis.Summary.Warnings.Count,
-                    timedOut,
-                    diagnostics.SlowestStep?.Step);
-            }
-            catch (Exception)
-            {
-                // Swallowed on purpose - see the workbook endpoint for the same reasoning.
-            }
         }
 
         #endregion

--- a/src/AnalyticsEngine/Web/Global.asax.cs
+++ b/src/AnalyticsEngine/Web/Global.asax.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Web;
 using System.Web.Http;
 using System.Web.Mvc;
+using System.Web.Hosting;
 using System.Web.Routing;
+using System.Web.SessionState;
+using Web.AnalyticsWeb.Models.CopilotAdoption;
 
 namespace Web.AnalyticsWeb
 {
@@ -16,11 +20,32 @@ namespace Web.AnalyticsWeb
         }
         protected void Application_PostAuthorizeRequest()
         {
-            System.Web.HttpContext.Current.SetSessionStateBehavior(System.Web.SessionState.SessionStateBehavior.Required);
-        }
-
-        protected void Session_Start(object sender, EventArgs e)
-        {
+            // ASP.NET session state is DISABLED deliberately - do not set this back to Required.
+            //
+            // Nothing in this solution reads or writes Session or TempData; sign-in is OIDC and is held
+            // in an auth cookie, not in session. Requiring session state therefore bought nothing, and
+            // cost a great deal: SessionStateModule takes an EXCLUSIVE per-session lock for the whole of
+            // every request that requires session state, so every request carrying one browser's
+            // ASP.NET_SessionId cookie is processed strictly one at a time.
+            //
+            // That is invisible on fast pages and fatal on slow ones. The Copilot Adoption SPA polls
+            // three endpoints concurrently, and each poll parks for up to
+            // CopilotAdoptionAPIController.FirstResponseBudget waiting for the shared analysis. Serialised,
+            // the site can only answer ONE poll per budget while three arrive every budget, so the queue
+            // grows without bound: response times climb by a whole budget per round until the client's
+            // polling ceiling gives up and reports the analysis as "taking longer than expected" - which
+            // is never what has actually gone wrong. A browser trace of the failure shows the signature
+            // plainly: consecutive responses spaced exactly one budget apart, on separate connections,
+            // with near-zero stalled time, so it is the server serialising and not the browser queueing.
+            //
+            // Reproduced with three concurrent requests to an async handler with a 2s budget:
+            // Required + a declared Session_Start = 6,287ms with handler starts 2s apart (one at a time);
+            // Disabled = 2,146ms with all three starting together.
+            //
+            // The declared (empty) Session_Start that used to live in this class mattered too: declaring
+            // it is what made ASP.NET persist the new session and issue the cookie that the requests then
+            // contended over. With no session there is nothing to start, so it has gone with it.
+            HttpContext.Current.SetSessionStateBehavior(SessionStateBehavior.Disabled);
         }
 
         protected void Application_BeginRequest(object sender, EventArgs e)
@@ -39,12 +64,9 @@ namespace Web.AnalyticsWeb
             WebExceptionTelemetry.Report(Server?.GetLastError(), "AspNet pipeline");
         }
 
-        protected void Session_End(object sender, EventArgs e)
-        {
-        }
-
         protected void Application_End(object sender, EventArgs e)
         {
+            CopilotAdoptionTelemetryHost.Shutdown(HostingEnvironment.ShutdownReason.ToString());
         }
     }
 }

--- a/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionAnalysisCoordinator.cs
+++ b/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionAnalysisCoordinator.cs
@@ -1,0 +1,227 @@
+using Common.Entities;
+using Common.Entities.CopilotAdoption;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Caching;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Web.AnalyticsWeb.Models.CopilotAdoption
+{
+    internal interface ICopilotAdoptionAnalysisRunner
+    {
+        Task<CopilotAdoptionAnalysis> RunAsync(
+            int windowDays,
+            List<int> seatLicenceTypeIds,
+            ICopilotAdoptionRunTelemetry telemetry);
+    }
+
+    internal sealed class CopilotAdoptionAnalysisRunner : ICopilotAdoptionAnalysisRunner
+    {
+        public Task<CopilotAdoptionAnalysis> RunAsync(
+            int windowDays,
+            List<int> seatLicenceTypeIds,
+            ICopilotAdoptionRunTelemetry telemetry)
+        {
+            var options = CopilotAdoptionOptions.Default;
+            options.WindowDays = windowDays;
+
+            var service = new CopilotAdoptionService(
+                options,
+                DefaultAnalyticsDbContextFactory.Instance,
+                telemetry: telemetry);
+            return service.AnalyseAsync(
+                seatLicenceTypeIds.Count == 0 ? null : seatLicenceTypeIds,
+                CancellationToken.None);
+        }
+    }
+
+    internal interface ICopilotAdoptionAnalysisCache
+    {
+        bool TryGet(string key, out CopilotAdoptionAnalysis analysis);
+
+        void Set(string key, CopilotAdoptionAnalysis analysis, TimeSpan ttl);
+    }
+
+    internal sealed class MemoryCopilotAdoptionAnalysisCache : ICopilotAdoptionAnalysisCache
+    {
+        public static readonly MemoryCopilotAdoptionAnalysisCache Instance =
+            new MemoryCopilotAdoptionAnalysisCache();
+
+        public bool TryGet(string key, out CopilotAdoptionAnalysis analysis)
+        {
+            analysis = MemoryCache.Default.Get(key) as CopilotAdoptionAnalysis;
+            return analysis != null;
+        }
+
+        public void Set(string key, CopilotAdoptionAnalysis analysis, TimeSpan ttl)
+        {
+            MemoryCache.Default.Set(
+                key,
+                analysis,
+                new CacheItemPolicy
+                {
+                    AbsoluteExpiration = DateTimeOffset.UtcNow.Add(ttl),
+                });
+        }
+    }
+
+    /// <summary>
+    /// Owns the completed-result cache and single in-flight analysis per scope.
+    ///
+    /// The ports are deliberately instance-scoped so tests can exercise the real wait/deduplication/
+    /// publication policy without SQL, Application Insights, wall-clock 20-second waits or shared
+    /// <see cref="MemoryCache.Default"/> state.
+    /// </summary>
+    internal sealed class CopilotAdoptionAnalysisCoordinator
+    {
+        private const string CacheKeyPrefix = "CopilotAdoption::Analysis::";
+
+        public static readonly CopilotAdoptionAnalysisCoordinator Default =
+            new CopilotAdoptionAnalysisCoordinator(
+                new CopilotAdoptionAnalysisRunner(),
+                MemoryCopilotAdoptionAnalysisCache.Instance,
+                CopilotAdoptionTelemetryHost.Start,
+                TimeSpan.FromMinutes(10));
+
+        private readonly ConcurrentDictionary<string, Lazy<Task<CopilotAdoptionAnalysis>>> _inFlight =
+            new ConcurrentDictionary<string, Lazy<Task<CopilotAdoptionAnalysis>>>(StringComparer.Ordinal);
+        private readonly ICopilotAdoptionAnalysisRunner _runner;
+        private readonly ICopilotAdoptionAnalysisCache _cache;
+        private readonly Func<int, bool, ICopilotAdoptionAnalysisTelemetry> _telemetryFactory;
+        private readonly TimeSpan _cacheTtl;
+
+        public CopilotAdoptionAnalysisCoordinator(
+            ICopilotAdoptionAnalysisRunner runner,
+            ICopilotAdoptionAnalysisCache cache,
+            Func<int, bool, ICopilotAdoptionAnalysisTelemetry> telemetryFactory,
+            TimeSpan cacheTtl)
+        {
+            _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _telemetryFactory = telemetryFactory ?? throw new ArgumentNullException(nameof(telemetryFactory));
+            _cacheTtl = cacheTtl;
+        }
+
+        public async Task<CopilotAdoptionAnalysis> TryGetAsync(
+            int windowDays,
+            List<int> seatLicenceTypeIds,
+            TimeSpan waitBudget,
+            CancellationToken cancellationToken)
+        {
+            var task = GetAsync(windowDays, seatLicenceTypeIds);
+            if (task.IsCompleted) return await task;
+
+            var finished = await Task.WhenAny(task, Task.Delay(waitBudget, cancellationToken));
+            return finished == task ? await task : null;
+        }
+
+        internal Task<CopilotAdoptionAnalysis> GetAsync(
+            int windowDays,
+            List<int> seatLicenceTypeIds)
+        {
+            var ids = seatLicenceTypeIds ?? new List<int>();
+            var cacheKey = CacheKey(windowDays, ids);
+
+            if (_cache.TryGet(cacheKey, out var cached))
+            {
+                return Task.FromResult(cached);
+            }
+
+            Lazy<Task<CopilotAdoptionAnalysis>> candidate = null;
+            candidate = new Lazy<Task<CopilotAdoptionAnalysis>>(
+                () => RunAndPublishAsync(cacheKey, candidate, windowDays, ids),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+
+            var effective = _inFlight.GetOrAdd(cacheKey, candidate);
+            if (ReferenceEquals(effective, candidate))
+            {
+                // A previous generation may have published between the first miss and GetOrAdd.
+                if (_cache.TryGet(cacheKey, out var justPublished))
+                {
+                    RemoveInFlight(cacheKey, candidate);
+                    return Task.FromResult(justPublished);
+                }
+            }
+
+            return effective.Value;
+        }
+
+        internal static string CacheKey(int windowDays, IEnumerable<int> seatLicenceTypeIds)
+        {
+            var ids = (seatLicenceTypeIds ?? Enumerable.Empty<int>())
+                .Distinct()
+                .OrderBy(id => id)
+                .ToList();
+            return CacheKeyPrefix + windowDays + "::"
+                   + (ids.Count == 0 ? "auto" : string.Join(",", ids));
+        }
+
+        private async Task<CopilotAdoptionAnalysis> RunAndPublishAsync(
+            string cacheKey,
+            Lazy<Task<CopilotAdoptionAnalysis>> generation,
+            int windowDays,
+            List<int> seatLicenceTypeIds)
+        {
+            ICopilotAdoptionAnalysisTelemetry telemetry =
+                NullCopilotAdoptionAnalysisTelemetry.Instance;
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+
+            try
+            {
+                try
+                {
+                    telemetry = _telemetryFactory(
+                        windowDays, seatLicenceTypeIds.Count > 0)
+                        ?? NullCopilotAdoptionAnalysisTelemetry.Instance;
+                }
+                catch (Exception)
+                {
+                    // Telemetry is best-effort. A construction failure must not poison this in-flight
+                    // generation or stop the analysis from running.
+                }
+
+                var analysis = await _runner.RunAsync(
+                    windowDays,
+                    seatLicenceTypeIds,
+                    telemetry).ConfigureAwait(false);
+                var serviceDurationMs = watch.ElapsedMilliseconds;
+
+                // Publish first. A blocked or broken telemetry channel must never keep the page polling
+                // after the analysis has already produced a valid result.
+                _cache.Set(cacheKey, analysis, _cacheTtl);
+
+                telemetry.Checkpoint(
+                    CopilotAdoptionTelemetryStages.ServiceReturned, serviceDurationMs);
+                telemetry.Checkpoint(
+                    CopilotAdoptionTelemetryStages.CachePublished, watch.ElapsedMilliseconds);
+                telemetry.QueueCompletion(analysis);
+                return analysis;
+            }
+            catch (Exception ex)
+            {
+                telemetry.QueueFailure(ex);
+                throw;
+            }
+            finally
+            {
+                RemoveInFlight(cacheKey, generation);
+                telemetry.Dispose();
+            }
+        }
+
+        private void RemoveInFlight(
+            string cacheKey,
+            Lazy<Task<CopilotAdoptionAnalysis>> generation)
+        {
+            var entries = _inFlight
+                as ICollection<KeyValuePair<string, Lazy<Task<CopilotAdoptionAnalysis>>>>;
+            entries.Remove(
+                new KeyValuePair<string, Lazy<Task<CopilotAdoptionAnalysis>>>(
+                    cacheKey,
+                    generation));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionTelemetry.cs
+++ b/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionTelemetry.cs
@@ -1,0 +1,976 @@
+using Common.Entities.Config;
+using Common.Entities.CopilotAdoption;
+using DataUtils;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+
+namespace Web.AnalyticsWeb.Models.CopilotAdoption
+{
+    internal sealed class CopilotAdoptionLifecycleEvent
+    {
+        public const string SchemaVersion = "1";
+
+        public DateTimeOffset OccurredUtc { get; set; }
+        public string Stage { get; set; }
+        public string RunId { get; set; }
+        public string InstanceId { get; set; }
+        public int WindowDays { get; set; }
+        public bool HasSeatOverride { get; set; }
+        public string Step { get; set; }
+        public string Query { get; set; }
+        public string Outcome { get; set; }
+        public string ExceptionType { get; set; }
+        public string ActiveOperations { get; set; }
+        public string SynchronizationContext { get; set; }
+        public string ShutdownReason { get; set; }
+        public long Sequence { get; set; }
+        public long OperationId { get; set; }
+        public long ElapsedMs { get; set; }
+        public long DurationMs { get; set; }
+        public long HeartbeatDriftMs { get; set; }
+        public long ProcessWorkingSetBytes { get; set; }
+        public long ManagedHeapBytes { get; set; }
+        public int Gen0Collections { get; set; }
+        public int Gen1Collections { get; set; }
+        public int Gen2Collections { get; set; }
+        public int ThreadPoolAvailableWorkers { get; set; }
+        public int ThreadPoolAvailableCompletionPorts { get; set; }
+        public int AppDomainId { get; set; }
+        public long AppDomainUptimeMs { get; set; }
+        public int DroppedEvents { get; set; }
+
+        public Dictionary<string, string> Dimensions()
+        {
+            var result = new Dictionary<string, string>
+            {
+                { "SchemaVersion", SchemaVersion },
+                { "Stage", Stage },
+                { "RunId", RunId },
+                { "InstanceId", InstanceId },
+                { "WindowDays", WindowDays.ToString(CultureInfo.InvariantCulture) },
+                { "HasSeatOverride", HasSeatOverride ? "true" : "false" },
+                { "SynchronizationContext", SynchronizationContext ?? "None" },
+            };
+
+            AddIfPresent(result, "Step", Step);
+            AddIfPresent(result, "Query", Query);
+            AddIfPresent(result, "Outcome", Outcome);
+            AddIfPresent(result, "ExceptionType", ExceptionType);
+            AddIfPresent(result, "ActiveOperations", ActiveOperations);
+            AddIfPresent(result, "ShutdownReason", ShutdownReason);
+            return result;
+        }
+
+        public Dictionary<string, double> Measurements()
+        {
+            var result = new Dictionary<string, double>
+            {
+                { "Sequence", Sequence },
+                { "ElapsedMs", ElapsedMs },
+                { "AppDomainId", AppDomainId },
+                { "AppDomainUptimeMs", AppDomainUptimeMs },
+                { "DroppedEvents", DroppedEvents },
+            };
+
+            if (OperationId > 0) result.Add("OperationId", OperationId);
+            if (HasDuration(Stage)) result.Add("DurationMs", DurationMs);
+            if (HeartbeatDriftMs > 0) result.Add("HeartbeatDriftMs", HeartbeatDriftMs);
+            if (ProcessWorkingSetBytes > 0) result.Add("ProcessWorkingSetBytes", ProcessWorkingSetBytes);
+            if (ManagedHeapBytes > 0) result.Add("ManagedHeapBytes", ManagedHeapBytes);
+            if (Gen0Collections >= 0) result.Add("Gen0Collections", Gen0Collections);
+            if (Gen1Collections >= 0) result.Add("Gen1Collections", Gen1Collections);
+            if (Gen2Collections >= 0) result.Add("Gen2Collections", Gen2Collections);
+            if (ThreadPoolAvailableWorkers >= 0)
+            {
+                result.Add("ThreadPoolAvailableWorkers", ThreadPoolAvailableWorkers);
+            }
+            if (ThreadPoolAvailableCompletionPorts >= 0)
+            {
+                result.Add("ThreadPoolAvailableCompletionPorts", ThreadPoolAvailableCompletionPorts);
+            }
+
+            return result;
+        }
+
+        private static void AddIfPresent(IDictionary<string, string> target, string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value)) target.Add(key, value);
+        }
+
+        private static bool HasDuration(string stage)
+        {
+            return stage == CopilotAdoptionTelemetryStages.QueryCompleted
+                   || stage == CopilotAdoptionTelemetryStages.QueryFailed
+                   || stage == CopilotAdoptionTelemetryStages.StepCompleted
+                   || stage == CopilotAdoptionTelemetryStages.StepFailed
+                   || stage == CopilotAdoptionTelemetryStages.ScoringCompleted
+                   || stage == CopilotAdoptionTelemetryStages.ServiceReturned
+                   || stage == CopilotAdoptionTelemetryStages.CachePublished
+                   || stage == CopilotAdoptionTelemetryStages.CompletionTelemetryReturned;
+        }
+    }
+
+    internal sealed class CopilotAdoptionCompletionEvent
+    {
+        public string RunId { get; set; }
+        public int WindowDays { get; set; }
+        public long TotalMs { get; set; }
+        public IDictionary<string, long> Steps { get; set; }
+        public int WarningCount { get; set; }
+        public bool TimedOut { get; set; }
+        public string SlowestStep { get; set; }
+    }
+
+    internal sealed class CopilotAdoptionFailureEvent
+    {
+        public string RunId { get; set; }
+        public int WindowDays { get; set; }
+        public Exception Exception { get; set; }
+    }
+
+    internal interface ICopilotAdoptionEventSink
+    {
+        int DroppedEvents { get; }
+
+        void Track(CopilotAdoptionLifecycleEvent telemetryEvent);
+
+        void TrackCompletion(
+            CopilotAdoptionCompletionEvent completion,
+            CopilotAdoptionLifecycleEvent submittedEvent);
+
+        bool TrackFailure(
+            CopilotAdoptionFailureEvent failure,
+            CopilotAdoptionLifecycleEvent failureEvent);
+
+        void Shutdown(TimeSpan timeout);
+    }
+
+    internal interface ICopilotAdoptionTelemetryWriter
+    {
+        void Write(CopilotAdoptionLifecycleEvent telemetryEvent);
+
+        void WriteCompletion(CopilotAdoptionCompletionEvent completion);
+
+        void WriteFailure(CopilotAdoptionFailureEvent failure);
+
+        void Flush();
+    }
+
+    internal sealed class AppInsightsCopilotAdoptionTelemetryWriter : ICopilotAdoptionTelemetryWriter
+    {
+        private readonly AnalyticsLogger _logger;
+
+        public AppInsightsCopilotAdoptionTelemetryWriter(string connectionString)
+        {
+            _logger = new AnalyticsLogger(
+                connectionString, nameof(Controllers.CopilotAdoptionAPIController));
+        }
+
+        public void Write(CopilotAdoptionLifecycleEvent telemetryEvent)
+        {
+            _logger.TrackEvent(
+                AnalyticsLogger.AnalyticsEvent.CopilotAdoptionLifecycle,
+                telemetryEvent.Dimensions(),
+                telemetryEvent.Measurements(),
+                telemetryEvent.RunId,
+                telemetryEvent.OccurredUtc);
+        }
+
+        public void WriteCompletion(CopilotAdoptionCompletionEvent completion)
+        {
+            _logger.TrackCopilotAdoptionAnalysis(
+                completion.WindowDays,
+                completion.TotalMs,
+                completion.Steps,
+                completion.WarningCount,
+                completion.TimedOut,
+                completion.SlowestStep,
+                completion.RunId);
+        }
+
+        public void WriteFailure(CopilotAdoptionFailureEvent failure)
+        {
+            _logger.TrackException(failure.Exception);
+            _logger.LogError(
+                $"Copilot adoption analysis failed ({failure.Exception.GetBaseException().GetType().Name}).");
+        }
+
+        public void Flush()
+        {
+            _logger.Flush();
+        }
+    }
+
+    /// <summary>
+    /// Bounded, non-blocking hand-off to Application Insights.
+    ///
+    /// The worker owns all SDK calls. A blocked telemetry channel can stop this thread, but it can never
+    /// stop the analysis task or delay cache publication.
+    /// </summary>
+    internal sealed class QueuedCopilotAdoptionEventSink : ICopilotAdoptionEventSink
+    {
+        private const int Capacity = 1024;
+
+        private readonly BlockingCollection<SinkItem> _queue =
+            new BlockingCollection<SinkItem>(new ConcurrentQueue<SinkItem>(), Capacity);
+        private readonly Func<ICopilotAdoptionTelemetryWriter> _writerFactory;
+        private readonly Thread _worker;
+        private int _droppedEvents;
+        private int _stopping;
+
+        public QueuedCopilotAdoptionEventSink(Func<ICopilotAdoptionTelemetryWriter> writerFactory)
+        {
+            _writerFactory = writerFactory ?? throw new ArgumentNullException(nameof(writerFactory));
+            _worker = new Thread(Drain)
+            {
+                IsBackground = true,
+                Name = "CopilotAdoptionTelemetry",
+            };
+            _worker.Start();
+        }
+
+        public int DroppedEvents => Volatile.Read(ref _droppedEvents);
+
+        public void Track(CopilotAdoptionLifecycleEvent telemetryEvent)
+        {
+            TryAdd(SinkItem.Lifecycle(telemetryEvent));
+        }
+
+        public void TrackCompletion(
+            CopilotAdoptionCompletionEvent completion,
+            CopilotAdoptionLifecycleEvent submittedEvent)
+        {
+            TryAdd(SinkItem.Completion(completion, submittedEvent));
+        }
+
+        public bool TrackFailure(
+            CopilotAdoptionFailureEvent failure,
+            CopilotAdoptionLifecycleEvent failureEvent)
+        {
+            return TryAdd(SinkItem.Failure(failure, failureEvent));
+        }
+
+        public void Shutdown(TimeSpan timeout)
+        {
+            if (Interlocked.Exchange(ref _stopping, 1) != 0) return;
+
+            _queue.CompleteAdding();
+            if (Thread.CurrentThread != _worker)
+            {
+                _worker.Join(timeout);
+            }
+        }
+
+        private bool TryAdd(SinkItem item)
+        {
+            try
+            {
+                if (item != null
+                    && Volatile.Read(ref _stopping) == 0
+                    && _queue.TryAdd(item))
+                {
+                    return true;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // CompleteAdding raced this enqueue during AppDomain shutdown.
+            }
+
+            Interlocked.Increment(ref _droppedEvents);
+            return false;
+        }
+
+        private void Drain()
+        {
+            ICopilotAdoptionTelemetryWriter writer = null;
+            try
+            {
+                foreach (var item in _queue.GetConsumingEnumerable())
+                {
+                    if (writer == null)
+                    {
+                        try
+                        {
+                            writer = _writerFactory();
+                        }
+                        catch (Exception ex)
+                        {
+                            Interlocked.Increment(ref _droppedEvents);
+                            Console.WriteLine(
+                                $"Copilot adoption telemetry writer could not start ({ex.GetBaseException().GetType().Name}).");
+                            continue;
+                        }
+                    }
+
+                    try
+                    {
+                        item.Write(writer);
+                    }
+                    catch (Exception ex)
+                    {
+                        Interlocked.Increment(ref _droppedEvents);
+                        Console.WriteLine(
+                            $"Copilot adoption telemetry write failed ({ex.GetBaseException().GetType().Name}).");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(
+                    $"Copilot adoption telemetry worker stopped ({ex.GetBaseException().GetType().Name}).");
+            }
+            finally
+            {
+                try
+                {
+                    writer?.Flush();
+                    Thread.Sleep(1000);
+                }
+                catch (Exception)
+                {
+                    // The process is already stopping; telemetry must never obstruct shutdown.
+                }
+            }
+        }
+
+        private sealed class SinkItem
+        {
+            private readonly CopilotAdoptionLifecycleEvent _lifecycle;
+            private readonly CopilotAdoptionCompletionEvent _completion;
+            private readonly CopilotAdoptionFailureEvent _failure;
+            private readonly CopilotAdoptionLifecycleEvent _submitted;
+
+            private SinkItem(
+                CopilotAdoptionLifecycleEvent lifecycle,
+                CopilotAdoptionCompletionEvent completion,
+                CopilotAdoptionFailureEvent failure,
+                CopilotAdoptionLifecycleEvent submitted)
+            {
+                _lifecycle = lifecycle;
+                _completion = completion;
+                _failure = failure;
+                _submitted = submitted;
+            }
+
+            public static SinkItem Lifecycle(CopilotAdoptionLifecycleEvent telemetryEvent) =>
+                new SinkItem(telemetryEvent, null, null, null);
+
+            public static SinkItem Completion(
+                CopilotAdoptionCompletionEvent completion,
+                CopilotAdoptionLifecycleEvent submitted) =>
+                new SinkItem(null, completion, null, submitted);
+
+            public static SinkItem Failure(
+                CopilotAdoptionFailureEvent failure,
+                CopilotAdoptionLifecycleEvent failureEvent) =>
+                new SinkItem(failureEvent, null, failure, null);
+
+            public void Write(ICopilotAdoptionTelemetryWriter writer)
+            {
+                if (_lifecycle != null) writer.Write(_lifecycle);
+                if (_completion != null)
+                {
+                    var watch = Stopwatch.StartNew();
+                    writer.WriteCompletion(_completion);
+                    watch.Stop();
+                    _submitted.OccurredUtc = DateTimeOffset.UtcNow;
+                    _submitted.DurationMs = watch.ElapsedMilliseconds;
+                    writer.Write(_submitted);
+                    writer.Flush();
+                }
+                if (_failure != null)
+                {
+                    writer.WriteFailure(_failure);
+                    writer.Flush();
+                }
+            }
+        }
+    }
+
+    internal interface ICopilotAdoptionHeartbeatFactory
+    {
+        IDisposable Start(Action heartbeat, TimeSpan interval);
+    }
+
+    internal sealed class DedicatedThreadHeartbeatFactory : ICopilotAdoptionHeartbeatFactory
+    {
+        public static readonly DedicatedThreadHeartbeatFactory Instance =
+            new DedicatedThreadHeartbeatFactory();
+
+        public IDisposable Start(Action heartbeat, TimeSpan interval) =>
+            new DedicatedThreadHeartbeat(heartbeat, interval);
+
+        private sealed class DedicatedThreadHeartbeat : IDisposable
+        {
+            private readonly Action _heartbeat;
+            private readonly TimeSpan _interval;
+            private readonly ManualResetEventSlim _stop = new ManualResetEventSlim(false);
+            private readonly Thread _thread;
+            private int _disposed;
+
+            public DedicatedThreadHeartbeat(Action heartbeat, TimeSpan interval)
+            {
+                _heartbeat = heartbeat ?? throw new ArgumentNullException(nameof(heartbeat));
+                _interval = interval;
+                _thread = new Thread(Run)
+                {
+                    IsBackground = true,
+                    Name = "CopilotAdoptionHeartbeat",
+                };
+                _thread.Start();
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+                _stop.Set();
+                if (Thread.CurrentThread != _thread
+                    && _thread.Join(TimeSpan.FromSeconds(1)))
+                {
+                    _stop.Dispose();
+                }
+            }
+
+            private void Run()
+            {
+                while (!_stop.Wait(_interval))
+                {
+                    _heartbeat();
+                }
+            }
+        }
+    }
+
+    internal interface ICopilotAdoptionAnalysisTelemetry :
+        ICopilotAdoptionRunTelemetry,
+        IDisposable
+    {
+        string RunId { get; }
+
+        void QueueCompletion(CopilotAdoptionAnalysis analysis);
+
+        bool QueueFailure(Exception exception);
+
+        void HostStopping(string reason);
+    }
+
+    internal sealed class NullCopilotAdoptionAnalysisTelemetry :
+        ICopilotAdoptionAnalysisTelemetry
+    {
+        public static readonly NullCopilotAdoptionAnalysisTelemetry Instance =
+            new NullCopilotAdoptionAnalysisTelemetry();
+
+        public string RunId => string.Empty;
+
+        public long StepStarted(string step) => 0;
+
+        public void StepCompleted(
+            long operationId,
+            string step,
+            long durationMs,
+            bool failed,
+            string exceptionType = null)
+        {
+        }
+
+        public long QueryStarted(string step, string query) => 0;
+
+        public void QueryCompleted(
+            long operationId,
+            string step,
+            string query,
+            long durationMs,
+            bool failed,
+            string exceptionType = null)
+        {
+        }
+
+        public void Checkpoint(string stage, long durationMs = 0)
+        {
+        }
+
+        public void QueueCompletion(CopilotAdoptionAnalysis analysis)
+        {
+        }
+
+        public bool QueueFailure(Exception exception) => false;
+
+        public void HostStopping(string reason)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    internal sealed class CopilotAdoptionRunTelemetry : ICopilotAdoptionAnalysisTelemetry
+    {
+        public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
+
+        private readonly ICopilotAdoptionEventSink _sink;
+        private readonly Stopwatch _watch = Stopwatch.StartNew();
+        private readonly Stopwatch _appDomainWatch;
+        private readonly ConcurrentDictionary<long, ActiveOperation> _active =
+            new ConcurrentDictionary<long, ActiveOperation>();
+        private readonly object _emitGate = new object();
+        private readonly Action<CopilotAdoptionRunTelemetry> _onDispose;
+        private readonly int _appDomainId;
+        private readonly long _heartbeatIntervalMs;
+        private readonly IDisposable _heartbeat;
+        private long _sequence;
+        private long _operationId;
+        private long _lastHeartbeatMs;
+        private int _disposed;
+
+        public CopilotAdoptionRunTelemetry(
+            ICopilotAdoptionEventSink sink,
+            int windowDays,
+            bool hasSeatOverride,
+            string instanceId,
+            int appDomainId,
+            Stopwatch appDomainWatch,
+            ICopilotAdoptionHeartbeatFactory heartbeatFactory,
+            TimeSpan heartbeatInterval,
+            Action<CopilotAdoptionRunTelemetry> onDispose = null)
+        {
+            _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+            WindowDays = windowDays;
+            HasSeatOverride = hasSeatOverride;
+            InstanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
+            _appDomainId = appDomainId;
+            _appDomainWatch = appDomainWatch ?? throw new ArgumentNullException(nameof(appDomainWatch));
+            _heartbeatIntervalMs = Math.Max(1, (long)heartbeatInterval.TotalMilliseconds);
+            _onDispose = onDispose;
+            RunId = Guid.NewGuid().ToString("N");
+
+            Emit(CopilotAdoptionTelemetryStages.Started, includeRuntime: true);
+            _heartbeat = (heartbeatFactory ?? DedicatedThreadHeartbeatFactory.Instance)
+                .Start(Heartbeat, heartbeatInterval);
+        }
+
+        public string RunId { get; }
+        public string InstanceId { get; }
+        public int WindowDays { get; }
+        public bool HasSeatOverride { get; }
+
+        public long StepStarted(string step)
+        {
+            var id = NextOperationId();
+            _active[id] = new ActiveOperation("Step", step, null);
+            Emit(CopilotAdoptionTelemetryStages.StepStarted, step: step, operationId: id);
+            return id;
+        }
+
+        public void StepCompleted(
+            long operationId,
+            string step,
+            long durationMs,
+            bool failed,
+            string exceptionType = null)
+        {
+            _active.TryRemove(operationId, out _);
+            Emit(
+                failed ? CopilotAdoptionTelemetryStages.StepFailed : CopilotAdoptionTelemetryStages.StepCompleted,
+                step,
+                outcome: failed ? "Failed" : "Succeeded",
+                exceptionType: exceptionType,
+                operationId: operationId,
+                durationMs: durationMs);
+        }
+
+        public long QueryStarted(string step, string query)
+        {
+            var id = NextOperationId();
+            _active[id] = new ActiveOperation("Query", step, query);
+            Emit(
+                CopilotAdoptionTelemetryStages.QueryStarted,
+                step,
+                query,
+                operationId: id);
+            return id;
+        }
+
+        public void QueryCompleted(
+            long operationId,
+            string step,
+            string query,
+            long durationMs,
+            bool failed,
+            string exceptionType = null)
+        {
+            _active.TryRemove(operationId, out _);
+            Emit(
+                failed ? CopilotAdoptionTelemetryStages.QueryFailed : CopilotAdoptionTelemetryStages.QueryCompleted,
+                step,
+                query,
+                failed ? "Failed" : "Succeeded",
+                exceptionType,
+                operationId,
+                durationMs,
+                includeRuntime: true);
+        }
+
+        public void Checkpoint(string stage, long durationMs = 0)
+        {
+            Emit(stage, durationMs: durationMs, includeRuntime: IsTerminal(stage));
+        }
+
+        public void QueueCompletion(CopilotAdoptionAnalysis analysis)
+        {
+            var diagnostics = analysis?.Summary?.Diagnostics;
+            if (diagnostics == null) return;
+
+            var steps = diagnostics.Steps.ToDictionary(
+                step => step.Step,
+                step => step.DurationMs,
+                StringComparer.Ordinal);
+            var timeoutMs = CopilotAdoptionService.QueryTimeoutSecs * 1000L;
+
+            var completion = new CopilotAdoptionCompletionEvent
+            {
+                RunId = RunId,
+                WindowDays = WindowDays,
+                TotalMs = diagnostics.TotalMs,
+                Steps = steps,
+                WarningCount = analysis.Summary.Warnings.Count,
+                TimedOut = diagnostics.Steps.Any(step => step.DurationMs >= timeoutMs),
+                SlowestStep = diagnostics.SlowestStep?.Step,
+            };
+
+            var submitted = CreateEvent(
+                CopilotAdoptionTelemetryStages.CompletionTelemetryReturned,
+                outcome: "Succeeded",
+                includeRuntime: true);
+            TryTrackCompletion(completion, submitted);
+        }
+
+        public bool QueueFailure(Exception exception)
+        {
+            var failureEvent = CreateEvent(
+                CopilotAdoptionTelemetryStages.Failed,
+                outcome: "Failed",
+                exceptionType: exception?.GetBaseException().GetType().Name,
+                activeOperations: ActiveOperations(),
+                includeRuntime: true);
+            return TryTrackFailure(
+                new CopilotAdoptionFailureEvent
+                {
+                    RunId = RunId,
+                    WindowDays = WindowDays,
+                    Exception = exception,
+                },
+                failureEvent);
+        }
+
+        public void HostStopping(string reason)
+        {
+            Emit(
+                CopilotAdoptionTelemetryStages.HostStopping,
+                outcome: "Interrupted",
+                activeOperations: ActiveOperations(),
+                shutdownReason: reason,
+                includeRuntime: true);
+        }
+
+        public void EmitHeartbeat()
+        {
+            Heartbeat();
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            _heartbeat.Dispose();
+            _onDispose?.Invoke(this);
+        }
+
+        private void Heartbeat()
+        {
+            if (Volatile.Read(ref _disposed) != 0) return;
+
+            var elapsed = _watch.ElapsedMilliseconds;
+            var previous = Interlocked.Exchange(ref _lastHeartbeatMs, elapsed);
+            var drift = previous == 0
+                ? Math.Max(0, elapsed - _heartbeatIntervalMs)
+                : Math.Max(0, elapsed - previous - _heartbeatIntervalMs);
+
+            Emit(
+                CopilotAdoptionTelemetryStages.Heartbeat,
+                activeOperations: ActiveOperations(),
+                heartbeatDriftMs: drift,
+                includeRuntime: true);
+        }
+
+        private long NextOperationId() => Interlocked.Increment(ref _operationId);
+
+        private string ActiveOperations()
+        {
+            return string.Join(
+                ",",
+                _active
+                    .OrderBy(item => item.Key)
+                    .Select(item => item.Value.Display(item.Key)));
+        }
+
+        private void Emit(
+            string stage,
+            string step = null,
+            string query = null,
+            string outcome = null,
+            string exceptionType = null,
+            long operationId = 0,
+            long durationMs = 0,
+            string activeOperations = null,
+            string shutdownReason = null,
+            long heartbeatDriftMs = 0,
+            bool includeRuntime = false)
+        {
+            TryTrack(CreateEvent(
+                stage,
+                step,
+                query,
+                outcome,
+                exceptionType,
+                operationId,
+                durationMs,
+                activeOperations,
+                shutdownReason,
+                heartbeatDriftMs,
+                includeRuntime));
+        }
+
+        private void TryTrack(CopilotAdoptionLifecycleEvent telemetryEvent)
+        {
+            try
+            {
+                _sink.Track(telemetryEvent);
+            }
+            catch (Exception)
+            {
+                // Observability must never alter analysis behavior.
+            }
+        }
+
+        private void TryTrackCompletion(
+            CopilotAdoptionCompletionEvent completion,
+            CopilotAdoptionLifecycleEvent submitted)
+        {
+            try
+            {
+                _sink.TrackCompletion(completion, submitted);
+            }
+            catch (Exception)
+            {
+                // Observability must never alter analysis behavior.
+            }
+        }
+
+        private bool TryTrackFailure(
+            CopilotAdoptionFailureEvent failure,
+            CopilotAdoptionLifecycleEvent failureEvent)
+        {
+            try
+            {
+                return _sink.TrackFailure(failure, failureEvent);
+            }
+            catch (Exception)
+            {
+                // Observability must never alter analysis behavior.
+                return false;
+            }
+        }
+
+        private CopilotAdoptionLifecycleEvent CreateEvent(
+            string stage,
+            string step = null,
+            string query = null,
+            string outcome = null,
+            string exceptionType = null,
+            long operationId = 0,
+            long durationMs = 0,
+            string activeOperations = null,
+            string shutdownReason = null,
+            long heartbeatDriftMs = 0,
+            bool includeRuntime = false)
+        {
+            lock (_emitGate)
+            {
+                var telemetryEvent = new CopilotAdoptionLifecycleEvent
+                {
+                    OccurredUtc = DateTimeOffset.UtcNow,
+                    Stage = stage,
+                    RunId = RunId,
+                    InstanceId = InstanceId,
+                    WindowDays = WindowDays,
+                    HasSeatOverride = HasSeatOverride,
+                    Step = step,
+                    Query = query,
+                    Outcome = outcome,
+                    ExceptionType = exceptionType,
+                    ActiveOperations = activeOperations,
+                    SynchronizationContext =
+                        SynchronizationContext.Current?.GetType().Name ?? "None",
+                    ShutdownReason = shutdownReason,
+                    Sequence = Interlocked.Increment(ref _sequence),
+                    OperationId = operationId,
+                    ElapsedMs = _watch.ElapsedMilliseconds,
+                    DurationMs = durationMs,
+                    HeartbeatDriftMs = heartbeatDriftMs,
+                    AppDomainId = _appDomainId,
+                    AppDomainUptimeMs = _appDomainWatch.ElapsedMilliseconds,
+                    DroppedEvents = _sink.DroppedEvents,
+                    Gen0Collections = -1,
+                    Gen1Collections = -1,
+                    Gen2Collections = -1,
+                    ThreadPoolAvailableWorkers = -1,
+                    ThreadPoolAvailableCompletionPorts = -1,
+                };
+
+                if (includeRuntime) PopulateRuntime(telemetryEvent);
+                return telemetryEvent;
+            }
+        }
+
+        private static bool IsTerminal(string stage)
+        {
+            return stage == CopilotAdoptionTelemetryStages.ServiceReturned
+                   || stage == CopilotAdoptionTelemetryStages.CachePublished
+                   || stage == CopilotAdoptionTelemetryStages.Failed;
+        }
+
+        private static void PopulateRuntime(CopilotAdoptionLifecycleEvent telemetryEvent)
+        {
+            telemetryEvent.ManagedHeapBytes = GC.GetTotalMemory(false);
+            telemetryEvent.Gen0Collections = GC.CollectionCount(0);
+            telemetryEvent.Gen1Collections = GC.CollectionCount(1);
+            telemetryEvent.Gen2Collections = GC.CollectionCount(2);
+            ThreadPool.GetAvailableThreads(
+                out var availableWorkers,
+                out var availableCompletionPorts);
+            telemetryEvent.ThreadPoolAvailableWorkers = availableWorkers;
+            telemetryEvent.ThreadPoolAvailableCompletionPorts = availableCompletionPorts;
+
+            try
+            {
+                using (var process = Process.GetCurrentProcess())
+                {
+                    telemetryEvent.ProcessWorkingSetBytes = process.WorkingSet64;
+                }
+            }
+            catch (Exception)
+            {
+                // Runtime counters are supporting evidence only; their absence must not affect the run.
+            }
+        }
+
+        private sealed class ActiveOperation
+        {
+            public ActiveOperation(string kind, string step, string query)
+            {
+                Kind = kind;
+                Step = step;
+                Query = query;
+            }
+
+            public string Kind { get; }
+            public string Step { get; }
+            public string Query { get; }
+
+            public string Display(long id)
+            {
+                return string.IsNullOrEmpty(Query)
+                    ? $"{id}:{Kind}:{Step}"
+                    : $"{id}:{Kind}:{Step}:{Query}";
+            }
+        }
+    }
+
+    internal static class CopilotAdoptionTelemetryHost
+    {
+        private static readonly string InstanceId = Guid.NewGuid().ToString("N");
+        private static readonly int AppDomainId = AppDomain.CurrentDomain.Id;
+        private static readonly Stopwatch Uptime = Stopwatch.StartNew();
+        private static readonly ConcurrentDictionary<string, CopilotAdoptionRunTelemetry> ActiveRuns =
+            new ConcurrentDictionary<string, CopilotAdoptionRunTelemetry>(StringComparer.Ordinal);
+        private static readonly object SinkGate = new object();
+        private static ICopilotAdoptionEventSink _sink;
+
+        public static ICopilotAdoptionAnalysisTelemetry Start(
+            int windowDays,
+            bool hasSeatOverride)
+        {
+            try
+            {
+                var sink = GetSink();
+                if (sink == null) return NullCopilotAdoptionAnalysisTelemetry.Instance;
+
+                CopilotAdoptionRunTelemetry run = null;
+                run = new CopilotAdoptionRunTelemetry(
+                    sink,
+                    windowDays,
+                    hasSeatOverride,
+                    InstanceId,
+                    AppDomainId,
+                    Uptime,
+                    DedicatedThreadHeartbeatFactory.Instance,
+                    CopilotAdoptionRunTelemetry.DefaultHeartbeatInterval,
+                    completed => ActiveRuns.TryRemove(completed.RunId, out _));
+                ActiveRuns.TryAdd(run.RunId, run);
+                return run;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(
+                    $"Copilot adoption telemetry could not start ({ex.GetBaseException().GetType().Name}).");
+                return NullCopilotAdoptionAnalysisTelemetry.Instance;
+            }
+        }
+
+        public static void Shutdown(string reason)
+        {
+            foreach (var run in ActiveRuns.Values)
+            {
+                run.HostStopping(reason);
+                run.Dispose();
+            }
+
+            ICopilotAdoptionEventSink sink;
+            lock (SinkGate)
+            {
+                sink = _sink;
+            }
+            sink?.Shutdown(TimeSpan.FromSeconds(2));
+        }
+
+        private static ICopilotAdoptionEventSink GetSink()
+        {
+            if (_sink != null) return _sink;
+
+            lock (SinkGate)
+            {
+                if (_sink != null) return _sink;
+
+                try
+                {
+                    _sink = new QueuedCopilotAdoptionEventSink(
+                        () => new AppInsightsCopilotAdoptionTelemetryWriter(
+                            new AppConfig().AppInsightsConnectionString));
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(
+                        $"Copilot adoption telemetry sink could not start ({ex.GetBaseException().GetType().Name}).");
+                }
+
+                return _sink;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -231,6 +231,8 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Models\AuthTeamRequest.cs" />
+    <Compile Include="Models\CopilotAdoption\CopilotAdoptionAnalysisCoordinator.cs" />
+    <Compile Include="Models\CopilotAdoption\CopilotAdoptionTelemetry.cs" />
     <Compile Include="Models\InstallLogModels.cs" />
     <Compile Include="Models\ProfilingStatusModels.cs" />
     <Compile Include="Models\ReportsModels.cs" />


### PR DESCRIPTION
## Summary

Adds privacy-safe, correlated lifecycle telemetry for Copilot Adoption analyses that continue returning `202` after their database work appears to have ended. It also carries the already-tested large-tenant request/query fixes so the diagnostics instrument the runtime currently under evaluation rather than the older sequential implementation.

## Implementation

- Emits `CopilotAdoptionLifecycle` events for analysis start, EF query return, concurrent step completion, scoring, service return, cache publication, completion telemetry return, failure, heartbeat, and AppDomain shutdown.
- Correlates each run and concurrent operation with generated identifiers, monotonic sequence numbers, original occurrence timestamps, active-operation snapshots, heartbeat drift, managed heap/GC, working set, and thread-pool availability.
- Uses compile-time step/query names only. It never emits SQL, parameters, result counts, identities, tenant/resource/database identifiers, URLs, payloads, search text, or exception messages.
- Moves single-flight caching behind injectable runner/cache seams and publishes a valid analysis before any terminal telemetry. A blocked Application Insights SDK therefore cannot keep callers polling.
- Submits telemetry through a bounded background worker with retryable writer construction and bounded shutdown flushing. Telemetry startup failure falls back to a no-op observer and cannot poison the in-flight cache.
- Preserves the existing `CopilotAdoptionAnalysis` completion event and correlates it with the lifecycle stream.
- Keeps the Web API exception logger as the failure backstop even when the telemetry queue rejects or later loses an event.
- Includes the existing performance harness, session-state concurrency correction, bounded parallel analysis, and measured query-shape changes from the test branch; environment-specific measurements have been removed from code and commit history.

## Diagnostic interpretation

For a stalled run, the last lifecycle event and heartbeat now distinguish:

- query requested but EF never returned;
- EF returned but step projection did not finish;
- concurrent step still active;
- scoring did not finish;
- service returned but cache publication failed;
- cache published but legacy completion telemetry blocked;
- AppDomain shutdown interrupted an active run;
- telemetry queue pressure or writer startup failure.

`QueryCompleted` deliberately means the full EF `ToListAsync` boundary returned (connection acquisition + SQL + network + materialisation), not server-only SQL time. Query Store remains the source for server execution time.

## Validation

- Release build: Web and unit-test projects
- Copilot Adoption test slice: 135 passed
- Performance harness: Release build passed
- Three-model design critique and three-model implementation review; verified findings were fixed and the final review was clean
- Staged secret scan and explicit sensitive-value scan passed

## Risk and compatibility

- No database migration, configuration-schema change, Azure resource change, or new dependency.
- Existing completion-event name and measurements remain available for saved queries.
- Lifecycle event volume is bounded and no event is emitted per HTTP poll.
- This PR adds observability and preserves current analysis behavior; durable precomputation and watchdog cancellation remain separate follow-up work.

## Reviewer hotspots

- `CopilotAdoptionAnalysisCoordinator`: cache-before-telemetry ordering and generation-safe eviction.
- `CopilotAdoptionTelemetry`: bounded dispatcher, heartbeat lifecycle, event allow-list, and AppDomain shutdown.
- `CopilotAdoptionService`: query/step boundary placement under concurrent execution.