### PR TITLE
Correct the key-discovery verification guidance, which was wrong

### DIFF
--- a/src/TelemetryService/LESSONS-LEARNED.md
+++ b/src/TelemetryService/LESSONS-LEARNED.md
@@ -99,6 +99,43 @@ When reasoning about what an identity library does at runtime, prefer this over
 reading the library's source. It answers "what did this deployment actually
 send", which is the question that matters.
 
+### …but dependency telemetry redacts query strings
+
+`Data` keeps the *shape* of a URL, not its query values. A request carrying
+`?appid=<guid>` is recorded as `…/openid-configuration?*`, and other callers
+show per-parameter redaction such as `?api-version=2019-08-01&resource=REDACTED`.
+
+Searching `Data` for a literal parameter value therefore finds nothing even when
+the parameter is definitely on the wire. **Test for the presence of `?`, not for
+the parameter.** The most reliable form is a before/after count, which is immune
+to how any individual URL was redacted:
+
+```kusto
+AppDependencies
+| where TimeGenerated > ago(30d)
+| where Target has "login.microsoftonline.com"
+| summarize total = count(), tagged = countif(Data contains "?") by bin(TimeGenerated, 1d)
+```
+
+This cost real time. A verified-working deployment was briefly declared broken
+because the literal `appid=` could not be found in telemetry.
+
+### One token validation produces two different key fetches
+
+Microsoft.Identity.Web runs an independent `ConfigurationManager` through
+`AadIssuerValidator` to resolve the issuer, separate from the one
+`JwtBearerOptions` owns. Both fetch `openid-configuration` and then the JWKS, so
+a single validation emits two near-simultaneous pairs of calls.
+
+Only the `JwtBearerOptions` one is ours to configure. The issuer validator's
+pair will never carry our parameter, and its presence is not a defect. Any check
+that assumes "all discovery calls should look the same" will misfire.
+
+Related: validation short-circuits. A token rejected on audience or issuer may
+never require signing keys, so a probe can produce the issuer validator's fetch
+and nothing else. When forcing key discovery deliberately, the token has to get
+far enough to need a signature check.
+
 ### The EasyAuth sidecar is invisible from inside the app
 
 On Linux, App Service Authentication runs as a **separate container** — the

--- a/src/TelemetryService/README.md
+++ b/src/TelemetryService/README.md
@@ -414,8 +414,8 @@ To verify attribution after deploying:
 
 1. Sign in to the dashboard and load both protected API endpoints, so token
    acquisition and key discovery occur together.
-2. In Application Insights, confirm the outbound dependency URLs carry the
-   parameter:
+2. In Application Insights, confirm the outbound dependency URLs carry a query
+   string:
 
    ```kusto
    AppDependencies
@@ -424,10 +424,34 @@ To verify attribution after deploying:
    | project TimeGenerated, Data, ResultCode
    ```
 
-   Both the `.well-known/openid-configuration` and `discovery/v2.0/keys` calls
-   must include `appid=`. A bare pair means the metadata address was lost — the
-   most likely cause is a Microsoft.Identity.Web upgrade changing the
-   post-configuration order, which `EntraKeyDiscoveryTests` is there to catch.
+   **Do not look for the literal `appid=` — you will not find it.** The
+   dependency exporter redacts query strings, so a tagged request appears as
+   `…/v2.0/.well-known/openid-configuration?*`. Presence of the `?` is the
+   signal; the value is never recorded.
+
+   **Expect a mix of tagged and untagged calls, and do not read the untagged
+   ones as failure.** Microsoft.Identity.Web runs a second, independent
+   `ConfigurationManager` through `AadIssuerValidator` to resolve the issuer,
+   and that one is not ours to configure — it will always fetch without the
+   parameter. A single token validation therefore produces both a tagged pair
+   and a bare pair, side by side.
+
+   So the check is: **does any `openid-configuration` call carry a `?`**. If
+   one does, the metadata address is applied and the matching
+   `discovery/v2.0/keys` call will carry it too, because Entra echoes the
+   parameter into `jwks_uri`. If *none* of them do, over a window in which a
+   token was definitely validated, then the address was lost — the most likely
+   cause is a Microsoft.Identity.Web upgrade changing the post-configuration
+   order, which `EntraKeyDiscoveryTests` is there to catch.
+
+   A useful before/after form, which avoids all of the above ambiguity:
+
+   ```kusto
+   AppDependencies
+   | where TimeGenerated > ago(7d)
+   | where Target has "login.microsoftonline.com"
+   | summarize total = count(), tagged = countif(Data contains "?") by bin(TimeGenerated, 1d)
+   ```
 3. Allow 3–5 days for the compliance pipeline to reflect new telemetry.
 
 Note that key discovery only happens on a cold start or when a cached


### PR DESCRIPTION
Documentation only. Corrects verification guidance introduced with #409 that was actively misleading — following it caused a **working** production deployment to be declared broken.

## What was wrong

The README told the reader to confirm the fix by finding a literal `appid=` in dependency telemetry, and to treat a bare pair of discovery calls as proof the metadata address had been lost. Both statements are false.

**1. Dependency telemetry redacts query strings.** `Data` preserves a URL's shape but not its query values. A request carrying `?appid=<guid>` is recorded as `…/openid-configuration?*`; other callers show per-parameter redaction such as `?api-version=2019-08-01&resource=REDACTED`. Searching for the parameter value finds nothing no matter how correct the deployment is.

The reliable signal is the presence of `?`. Measured on this deployment:

| Window | Discovery calls | Carrying a query string |
| --- | --- | --- |
| 30 days before deploy | 22 | **0** |
| After deploy | 8 | **2** |

The two tagged calls are the `openid-configuration` **and** `discovery/v2.0/keys` pair, confirming `appid` propagates into `jwks_uri` in production exactly as it does against the live endpoints.

**2. There are two independent `ConfigurationManager`s.** Microsoft.Identity.Web resolves the issuer via `AadIssuerValidator`, which runs its own `ConfigurationManager` separate from the one `JwtBearerOptions` owns. Both fetch the configuration document and then the JWKS, so **one** token validation emits **two** near-simultaneous pairs of calls — and only one is ours to configure.

The issuer validator's pair is permanently untagged, and that is correct behaviour. Any check phrased as "all discovery calls should carry the parameter" reports a failure that does not exist. This is what produced the false alarm: the bare pair sits directly alongside the tagged one.

## Changes

- **README** — verification step rewritten: test for `?`, not for `appid=`; expect a mix of tagged and untagged calls and do not read the untagged ones as failure; includes a before/after aggregate query that is immune to redaction.
- **LESSONS-LEARNED** — two new entries under Telemetry covering query-string redaction and the two-`ConfigurationManager` behaviour, plus a note that validation short-circuits (a token rejected on audience or issuer may never need signing keys, so a probe meant to force key discovery must reach a signature check).

## Note

No behaviour change and no change to `EntraKeyDiscovery` or its tests — the code was correct throughout. This only fixes the instructions for confirming it.