### PR TITLE
Split ActivityReportSqlPersistenceManager into testable collaborators (#373 part 2)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
@@ -1,0 +1,136 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The audit-log de-duplication cache lifecycle, split out of ActivityReportSqlPersistenceManager by
+    /// issue #373 part 2. Runs with zero SQL Server: the only thing that touched the database was the load
+    /// itself, and that is now <see cref="IActivityImportCacheLoader"/>.
+    ///
+    /// What is being pinned here is one of the two operator safety-valves this class carries -
+    /// <c>AUDIT_PERBATCH_DEDUP_CACHE</c> - plus the build-once-per-cycle optimisation it exists to undo.
+    /// </summary>
+    [TestClass]
+    public class ActivityImportCacheProviderTests
+    {
+        private static readonly DateTime Now = new DateTime(2026, 3, 1, 9, 30, 0, DateTimeKind.Utc);
+
+        private static AbstractAuditLogContent Event(DateTime createdUtc)
+            => new AzureADAuditLogContent { Id = Guid.NewGuid(), UserId = "someone@contoso.onmicrosoft.com", CreationTime = createdUtc };
+
+        private static ActivityDedupCacheWindow PerRunWindow(int daysBeforeNowToDownload = 3)
+            => ActivityImportCacheWindow.Resolve(usePerBatchDedupCache: false, oldestContentUtc: Now.AddHours(-1),
+                newestContentUtc: Now, daysBeforeNowToDownload: daysBeforeNowToDownload, nowUtc: Now);
+
+        private static ActivityDedupCacheWindow PerBatchWindow(DateTime oldestUtc, DateTime newestUtc)
+            => ActivityImportCacheWindow.Resolve(usePerBatchDedupCache: true, oldestContentUtc: oldestUtc,
+                newestContentUtc: newestUtc, daysBeforeNowToDownload: 3, nowUtc: Now);
+
+        [TestMethod]
+        public async Task ImportCache_PerRunScope_IsBuiltOnceAndReusedByEveryBatch()
+        {
+            var loader = new FakeActivityImportCacheLoader();
+            var provider = new ActivityImportCacheProvider(loader, new RecordingLogger());
+            var window = PerRunWindow();
+
+            var first = await provider.GetForWindowAsync(window);
+            var second = await provider.GetForWindowAsync(window);
+            var third = await provider.GetForWindowAsync(window);
+
+            Assert.AreEqual(1, loader.LoadCount,
+                "The run-scoped cache must be loaded from audit_events ONCE per import cycle, not once per save batch.");
+            Assert.AreSame(first, second, "Every batch of the cycle must share one cache, so ids remembered by one batch are seen by the next.");
+            Assert.AreSame(first, third);
+
+            // ...and over the whole download window, not the batch's own [oldest, newest] span.
+            Assert.AreEqual(window.FromUtc, loader.Loads[0].FromUtc);
+            Assert.AreEqual(window.ToUtc, loader.Loads[0].ToUtc);
+        }
+
+        [TestMethod]
+        public async Task ImportCache_PerBatchSafetyValve_RebuildsForEveryBatchOverThatBatchsOwnSpan()
+        {
+            // AUDIT_PERBATCH_DEDUP_CACHE=true. The valve exists so an operator can restore the pre-#373
+            // per-batch behaviour without a redeploy, so it must genuinely reload for each batch AND use
+            // each batch's own span - not the cycle-wide window.
+            var loader = new FakeActivityImportCacheLoader();
+            var provider = new ActivityImportCacheProvider(loader, new RecordingLogger());
+
+            var batchOne = PerBatchWindow(Now.AddHours(-5), Now.AddHours(-4));
+            var batchTwo = PerBatchWindow(Now.AddHours(-2), Now.AddHours(-1));
+
+            var first = await provider.GetForWindowAsync(batchOne);
+            var second = await provider.GetForWindowAsync(batchTwo);
+
+            Assert.AreEqual(2, loader.LoadCount, "With the safety-valve on, every batch rebuilds the cache.");
+            Assert.AreNotSame(first, second, "Each batch gets its own cache instance under the safety-valve.");
+
+            Assert.AreEqual(Now.AddHours(-5), loader.Loads[0].FromUtc);
+            Assert.AreEqual(Now.AddHours(-4), loader.Loads[0].ToUtc);
+            Assert.AreEqual(Now.AddHours(-2), loader.Loads[1].FromUtc);
+            Assert.AreEqual(Now.AddHours(-1), loader.Loads[1].ToUtc);
+        }
+
+        [TestMethod]
+        public async Task ImportCache_ConcurrentFirstUse_StillBuildsOnlyOnce()
+        {
+            // In concurrent-save mode several batches enter the save path at once, all before the cache
+            // exists. Without the init lock each of them would run the (expensive, whole-window)
+            // audit_events query.
+            var loader = new FakeActivityImportCacheLoader { LoadDuration = TimeSpan.FromMilliseconds(250) };
+            var provider = new ActivityImportCacheProvider(loader, new RecordingLogger());
+            var window = PerRunWindow();
+
+            var racers = Enumerable.Range(0, 8)
+                .Select(_ => Task.Run(async () => await provider.GetForWindowAsync(window)))
+                .ToArray();
+            var caches = await Task.WhenAll(racers);
+
+            Assert.AreEqual(1, loader.LoadCount, "Concurrent first callers must not each build the cache.");
+            Assert.IsTrue(caches.All(c => ReferenceEquals(c, caches[0])), "All concurrent callers must get the same cache instance.");
+        }
+
+        [TestMethod]
+        public async Task ImportCache_PerRunBuild_LogsTheIdCountAndWindowOnce()
+        {
+            // Operator-facing telemetry: #381 forbids changing log text or the numbers inside it, and this
+            // line is how an operator sees whether the per-cycle cache is working.
+            var logger = new RecordingLogger();
+            var loader = new FakeActivityImportCacheLoader
+            {
+                SeedCache = cache =>
+                {
+                    cache.RememberProcessedEvent(Event(Now.AddHours(-1)));
+                    cache.RememberProcessedEvent(Event(Now.AddHours(-2)));
+                    cache.RememberProcessedEvent(Event(Now.AddHours(-3)));
+                }
+            };
+            var provider = new ActivityImportCacheProvider(loader, logger);
+            var window = PerRunWindow(daysBeforeNowToDownload: 3);
+
+            await provider.GetForWindowAsync(window);
+            await provider.GetForWindowAsync(window);
+
+            var buildLines = logger.Entries
+                .Where(e => e.Message.Contains("built run dedup cache from audit_events"))
+                .ToList();
+
+            Assert.AreEqual(1, buildLines.Count, "The build line must be logged once per cycle, not once per batch.");
+            Assert.AreEqual(Microsoft.Extensions.Logging.LogLevel.Information, buildLines[0].Level);
+            StringAssert.Contains(buildLines[0].Message, "(3 already-processed id(s)",
+                "The count comes from ActivityImportCache.ProcessedIdCount - the ids actually loaded.");
+            // daysBeforeNowToDownload 3 + the one-day lower margin.
+            StringAssert.Contains(buildLines[0].Message, $"{window.DaysBack}-day window");
+            Assert.AreEqual(4, window.DaysBack, "Precondition: the reported window is the download window plus its lower margin.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
@@ -86,17 +87,41 @@ namespace Tests.UnitTests
             // In concurrent-save mode several batches enter the save path at once, all before the cache
             // exists. Without the init lock each of them would run the (expensive, whole-window)
             // audit_events query.
+            //
+            // Dedicated threads plus a Barrier rather than Task.Run: the ThreadPool injects threads slowly
+            // once its minimum is exhausted, so pool-scheduled racers can end up arriving hundreds of
+            // milliseconds apart and never actually race. The barrier releases all eight at the same
+            // instant, and the first load then holds them for 250ms.
+            const int racerCount = 8;
             var loader = new FakeActivityImportCacheLoader { LoadDuration = TimeSpan.FromMilliseconds(250) };
             var provider = new ActivityImportCacheProvider(loader, new RecordingLogger());
             var window = PerRunWindow();
 
-            var racers = Enumerable.Range(0, 8)
-                .Select(_ => Task.Run(async () => await provider.GetForWindowAsync(window)))
-                .ToArray();
-            var caches = await Task.WhenAll(racers);
+            var caches = new ActivityImportCache[racerCount];
+            var threads = new Thread[racerCount];
+            using (var startLine = new Barrier(racerCount))
+            {
+                for (int i = 0; i < racerCount; i++)
+                {
+                    var index = i;
+                    threads[i] = new Thread(() =>
+                    {
+                        startLine.SignalAndWait();
+                        caches[index] = provider.GetForWindowAsync(window).GetAwaiter().GetResult();
+                    })
+                    { IsBackground = true };
+                    threads[i].Start();
+                }
+
+                foreach (var thread in threads)
+                {
+                    Assert.IsTrue(thread.Join(TimeSpan.FromSeconds(30)), "A racer did not finish - the init lock may be deadlocked.");
+                }
+            }
 
             Assert.AreEqual(1, loader.LoadCount, "Concurrent first callers must not each build the cache.");
-            Assert.IsTrue(caches.All(c => ReferenceEquals(c, caches[0])), "All concurrent callers must get the same cache instance.");
+            Assert.IsTrue(caches.All(c => c != null && ReferenceEquals(c, caches[0])), "All concurrent callers must get the same cache instance.");
+            await Task.CompletedTask;
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivitySavePipelineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivitySavePipelineTests.cs
@@ -1,0 +1,254 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The audit-log save batch's staging pass - de-duplicate, scope-check, build the staging rows, then
+    /// load + merge - as split out of ActivityReportSqlPersistenceManager by issue #373 part 2.
+    ///
+    /// Zero SQL Server: the staging table is reached only through <see cref="IActivityStagingWriter"/>, and
+    /// the org-URL whitelist and user-groups filter were already injectable. ActivityStagingRulesTests
+    /// covers the per-event decision; this covers what the batch does WITH those decisions - the
+    /// operator-facing <c>ImportStat</c> counters and log line, the phase timings, and which staging table
+    /// the merge is pointed at in serial versus sharded mode.
+    /// </summary>
+    [TestClass]
+    public class ActivitySavePipelineTests
+    {
+        private const string InScopeUpn = "in@contoso.onmicrosoft.com";
+        private const string OutOfScopeUpn = "out@contoso.onmicrosoft.com";
+        private static readonly DateTime Created = new DateTime(2026, 3, 1, 9, 30, 0, DateTimeKind.Utc);
+
+        private static SharePointAuditLogContent SpEvent(string upn, string objectId = "https://contoso.sharepoint.com/sites/x/a.docx", Guid? id = null)
+            => new SharePointAuditLogContent
+            {
+                Id = id ?? Guid.NewGuid(),
+                UserId = upn,
+                CreationTime = Created,
+                Workload = ActivityImportConstants.WORKLOAD_SP,
+                Operation = "FileAccessed",
+                ObjectId = objectId,
+                SiteUrl = "https://contoso.sharepoint.com/sites/x",
+                SourceFileName = "a.docx",
+                SourceFileExtension = "docx",
+                ItemType = "File",
+                EventData = "<event/>"
+            };
+
+        private static ActivityReportSet SetOf(params AbstractAuditLogContent[] events)
+        {
+            var set = new WebActivityReportSet();
+            set.AddRange(events);
+            return set;
+        }
+
+        /// <summary>
+        /// A groups cache + filter pair where <see cref="InScopeUpn"/> matches and <see cref="OutOfScopeUpn"/>
+        /// does not. Note UserGroupsCache treats "user has no groups at all" as a match, so the excluded user
+        /// must be given a non-matching group rather than none.
+        /// </summary>
+        private static MockUserGroupsCache GroupsCache()
+            => new MockUserGroupsCache(new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                { InScopeUpn, new List<string> { "Finance" } },
+                { OutOfScopeUpn, new List<string> { "Legal" } }
+            }, NullLoggerShim.Instance);
+
+        private static ActivityStagingPass PassFor(AuditFilterConfig filterConfig, ILogger logger)
+            => new ActivityStagingPass(filterConfig, GroupsCache(), new Common.Entities.Config.UserGroupsFilterModel("Finance"), logger);
+
+        [TestMethod]
+        public async Task SavePipeline_EachOutcomeIsStagedAndCountedCorrectly()
+        {
+            var imported = SpEvent(InScopeUpn);
+            var userOutOfScope = SpEvent(OutOfScopeUpn);
+            var urlOutOfScope = SpEvent(InScopeUpn, "https://other-tenant.sharepoint.com/sites/y/b.docx");
+            var alreadyProcessed = SpEvent(InScopeUpn);
+            var repeatOfImported = SpEvent(InScopeUpn, id: imported.Id);
+
+            var cache = ActivityImportCache.GetEmptyCache();
+            cache.RememberProcessedEvent(alreadyProcessed);
+
+            var logger = new RecordingLogger();
+            var filter = new PredicateAuditFilterConfig(e => !ReferenceEquals(e, urlOutOfScope));
+            var writer = new InMemoryActivityStagingWriter();
+            var batch = writer.CreateBatch(null);
+
+            var result = await PassFor(filter, logger).RunAsync(
+                SetOf(imported, userOutOfScope, urlOutOfScope, alreadyProcessed, repeatOfImported),
+                cache, batch, stagingTableName: null, mergeLock: null);
+
+            Assert.AreEqual(5, result.Stats.Total, "Total counts everything the batch was handed.");
+            Assert.AreEqual(1, result.Stats.Imported);
+            Assert.AreEqual(1, result.Stats.UsersOutOfScope);
+            Assert.AreEqual(1, result.Stats.URLsOutOfScope);
+
+            // Deliberately zero: an event skipped by the de-duplication cache (or repeated inside the set)
+            // increments NO counter at all. That is long-standing behaviour, not an oversight of the split -
+            // ActivityStagingRules returns SaveResultEnum.NotSaved for it and the caller's counter block is
+            // guarded by !IsDuplicate. Changing it would change an operator-facing number.
+            Assert.AreEqual(0, result.Stats.ProcessedAlready);
+
+            Assert.AreEqual(1, writer.LastBatch.Rows.Count, "Only the in-scope, in-filter, not-yet-seen event may be staged.");
+            Assert.AreEqual(imported.Id, writer.LastBatch.Rows[0].Id);
+
+            CollectionAssert.AreEquivalent(new List<AbstractAuditLogContent> { imported }, result.SavedToSql.ToList(),
+                "Only staged events go to the metadata pass - anything else has no audit_events row to attach metadata to.");
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_UserOutsideGroupsFilter_LogsTheOperatorLineNamingTheUser()
+        {
+            var logger = new RecordingLogger();
+            var writer = new InMemoryActivityStagingWriter();
+            var batch = writer.CreateBatch(null);
+
+            await PassFor(new AllowAllFilterConfig(), logger).RunAsync(
+                SetOf(SpEvent(OutOfScopeUpn), SpEvent(InScopeUpn)),
+                ActivityImportCache.GetEmptyCache(), batch, stagingTableName: null, mergeLock: null);
+
+            var skipLines = logger.Entries.Where(e => e.Message.StartsWith("Skipping activity report for user")).ToList();
+            Assert.AreEqual(1, skipLines.Count, "Exactly the one filtered user is reported.");
+            Assert.AreEqual(LogLevel.Information, skipLines[0].Level);
+            Assert.AreEqual($"Skipping activity report for user '{OutOfScopeUpn}' - not in user groups filter", skipLines[0].Message);
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_SerialMode_MergesTheSharedStagingTableWithNoMergeLock()
+        {
+            var writer = new InMemoryActivityStagingWriter();
+            var batch = writer.CreateBatch(null);
+
+            await PassFor(new AllowAllFilterConfig(), new RecordingLogger()).RunAsync(
+                SetOf(SpEvent(InScopeUpn)), ActivityImportCache.GetEmptyCache(), batch,
+                stagingTableName: null, mergeLock: null);
+
+            var merged = writer.LastBatch;
+            Assert.AreEqual(1, merged.MergeCount);
+            Assert.IsNull(merged.LastStagingTableName,
+                "No override means InsertBatch uses the entity's [TempTableName] - the single shared staging table.");
+            Assert.IsNull(merged.LastMergeLock,
+                "On the serial path the whole save is already serialised by the static save semaphore, so no merge lock is passed.");
+            Assert.AreEqual(10000, merged.LastInsertsPerThread,
+                "The production staging fan-out size. Asserted as a literal, not against the constant, so changing the constant is a visible change.");
+
+            StringAssert.Contains(merged.LastMergeSql, ActivityImportConstants.STAGING_TABLE_ACTIVITY);
+            Assert.IsFalse(merged.LastMergeSql.Contains("${STAGING_TABLE_ACTIVITY}"),
+                "Every placeholder in the merge script must be substituted, or the merge is invalid SQL.");
+            Assert.AreEqual(1, merged.RowCountAtMerge, "The staged rows must be in the batch before the merge runs, not after.");
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_ShardedMode_PointsTheMergeAtTheShardAndHandsDownTheSharedWriteLock()
+        {
+            // Deliberately NOT ActivitySaveConcurrencyPolicy.NewShardedStagingTableName(): in Release builds
+            // the shared table name is a prefix of the sharded one, so a generated name could not tell the
+            // two apart. The generator itself is covered by ActivitySaveConcurrencyPolicyTests.
+            const string shard = "##unit_test_activity_shard_a1b2c3";
+            var sharedWriteLock = new SemaphoreSlim(1, 1);
+            var writer = new InMemoryActivityStagingWriter();
+            var batch = writer.CreateBatch(null);
+
+            await PassFor(new AllowAllFilterConfig(), new RecordingLogger()).RunAsync(
+                SetOf(SpEvent(InScopeUpn)), ActivityImportCache.GetEmptyCache(), batch,
+                stagingTableName: shard, mergeLock: sharedWriteLock);
+
+            var merged = writer.LastBatch;
+            Assert.AreEqual(shard, merged.LastStagingTableName, "Each concurrent save must load into its OWN staging table.");
+            Assert.AreSame(sharedWriteLock, merged.LastMergeLock,
+                "The merge writes shared lookup/fact tables, so the save's shared-write lock must reach it.");
+
+            StringAssert.Contains(merged.LastMergeSql, shard, "The merge must read the shard this save just loaded...");
+            Assert.IsFalse(merged.LastMergeSql.Contains(ActivityImportConstants.STAGING_TABLE_ACTIVITY),
+                "...and must not touch the shared staging table another save may be loading.");
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_StagingRowCarriesTheEventsOwnUserAndUrlUnchanged()
+        {
+            // A staging row that took the wrong UPN, or mangled a non-Latin URL, would corrupt users/urls on
+            // the merge - and both are customer text, so neither may be normalised here.
+            const string greekUrl = "https://contoso.sharepoint.com/sites/x/Καλημέρα κόσμε.docx";
+            var log = SpEvent(InScopeUpn, greekUrl);
+            var writer = new InMemoryActivityStagingWriter();
+            var batch = writer.CreateBatch(null);
+
+            await PassFor(new AllowAllFilterConfig(), new RecordingLogger()).RunAsync(
+                SetOf(log), ActivityImportCache.GetEmptyCache(), batch, stagingTableName: null, mergeLock: null);
+
+            var row = writer.LastBatch.Rows.Single();
+            Assert.AreEqual(log.Id, row.Id);
+            Assert.AreEqual(InScopeUpn, row.UserName, "The staging row's user_name is the event's own UserId.");
+            Assert.AreEqual(greekUrl, row.ObjectId, "A Unicode URL inside the column width must reach SQL byte-for-byte.");
+            Assert.AreEqual(log.CreationTime, row.TimeStamp);
+            Assert.AreEqual(ActivityImportConstants.WORKLOAD_SP, row.Workload);
+            Assert.AreEqual("a.docx", row.FileName);
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_SlowScopeCheck_IsChargedToTheDedupPhaseNotTheMerge()
+        {
+            // The two halves of the crossed pair below exist because a single "is a timing recorded?" test
+            // would pass even if the two phases were swapped.
+            const int slowMs = 400;
+            var writer = new InMemoryActivityStagingWriter();
+            var batch = writer.CreateBatch(null);
+            var slowFilter = new PredicateAuditFilterConfig(e => { Thread.Sleep(slowMs); return true; });
+
+            var sw = Stopwatch.StartNew();
+            var result = await PassFor(slowFilter, new RecordingLogger()).RunAsync(
+                SetOf(SpEvent(InScopeUpn)), ActivityImportCache.GetEmptyCache(), batch,
+                stagingTableName: null, mergeLock: null);
+            sw.Stop();
+
+            Assert.IsTrue(sw.ElapsedMilliseconds >= slowMs * 0.75, "Precondition: the pass really did take the injected delay.");
+            Assert.IsTrue(result.Stats.SaveDedupMs >= slowMs * 0.75,
+                $"The scope check happens in the dedup phase; SaveDedupMs was {result.Stats.SaveDedupMs}.");
+            Assert.IsTrue(result.Stats.SaveMergeMs < slowMs * 0.75,
+                $"...and must not be charged to the merge; SaveMergeMs was {result.Stats.SaveMergeMs}.");
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_SlowMerge_IsChargedToTheMergePhaseNotTheDedup()
+        {
+            const int slowMs = 400;
+            var writer = new InMemoryActivityStagingWriter { OnMerge = () => Task.Delay(slowMs) };
+            var batch = writer.CreateBatch(null);
+
+            var sw = Stopwatch.StartNew();
+            var result = await PassFor(new AllowAllFilterConfig(), new RecordingLogger()).RunAsync(
+                SetOf(SpEvent(InScopeUpn)), ActivityImportCache.GetEmptyCache(), batch,
+                stagingTableName: null, mergeLock: null);
+            sw.Stop();
+
+            Assert.IsTrue(sw.ElapsedMilliseconds >= slowMs * 0.75, "Precondition: the pass really did take the injected delay.");
+            Assert.IsTrue(result.Stats.SaveMergeMs >= slowMs * 0.75,
+                $"The staging load + merge is the merge phase; SaveMergeMs was {result.Stats.SaveMergeMs}.");
+            Assert.IsTrue(result.Stats.SaveDedupMs < slowMs * 0.75,
+                $"...and must not be charged to the dedup phase; SaveDedupMs was {result.Stats.SaveDedupMs}.");
+        }
+
+        /// <summary>MockUserGroupsCache takes an ILogger; these tests do not assert on its output.</summary>
+        private class NullLoggerShim : ILogger
+        {
+            public static readonly NullLoggerShim Instance = new NullLoggerShim();
+            public IDisposable BeginScope<TState>(TState state) => new Scope();
+            public bool IsEnabled(LogLevel logLevel) => false;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) { }
+            private class Scope : IDisposable { public void Dispose() { } }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivitySavePipelineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivitySavePipelineTests.cs
@@ -106,7 +106,7 @@ namespace Tests.UnitTests
             Assert.AreEqual(imported.Id, writer.LastBatch.Rows[0].Id);
 
             CollectionAssert.AreEquivalent(new List<AbstractAuditLogContent> { imported }, result.SavedToSql.ToList(),
-                "Only staged events go to the metadata pass - anything else has no audit_events row to attach metadata to.");
+                "Only staged events are offered to the metadata pass - the others were never sent to the staging table, so the merge cannot have created a row for them.");
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotMetadataPrewarmerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotMetadataPrewarmerTests.cs
@@ -1,0 +1,175 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The Copilot Graph pre-warm that runs before the audit-log save takes the SQL lock, split out of
+    /// ActivityReportSqlPersistenceManager by issue #373 part 2. Zero Graph, zero SQL Server: the Graph
+    /// client is now built by <see cref="ICopilotMetadataLoaderFactory"/>.
+    ///
+    /// CopilotPrewarmExtractionTests already covers which contexts are extracted and the
+    /// <see cref="WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules.CopilotPrewarmPolicy.ShouldPrewarm"/>
+    /// predicate in isolation. What could not be observed before, and is covered here, is the behaviour
+    /// around them: that a disabled tenant really makes no outbound call, that a Graph auth failure is
+    /// survivable and not retried per batch, and that the fan-out stays throttled.
+    /// </summary>
+    [TestClass]
+    public class CopilotMetadataPrewarmerTests
+    {
+        private const string FileContextA = "https://contoso.sharepoint.com/sites/x/Καλημέρα κόσμε.docx";
+        private const string FileContextB = "https://contoso.sharepoint.com/sites/x/b.docx";
+
+        private static CopilotAuditLogContent CopilotEvent(string upn, params string[] fileContextIds)
+            => new CopilotAuditLogContent
+            {
+                Id = Guid.NewGuid(),
+                UserId = upn,
+                CreationTime = new DateTime(2026, 3, 1, 9, 30, 0, DateTimeKind.Utc),
+                CopilotEventData = new CopilotEventData
+                {
+                    Contexts = fileContextIds.Select(id => new Context { Id = id, Type = "file" }).ToList()
+                }
+            };
+
+        private static List<AbstractAuditLogContent> Activities(params AbstractAuditLogContent[] events)
+            => events.ToList();
+
+        [TestMethod]
+        public async Task Prewarm_CopilotResourceResolutionDisabled_MakesNoGraphFileLookups()
+        {
+            // A tenant that has turned Copilot resource resolution off stages every Copilot event
+            // agent-metadata-only, so the serial pass never asks Graph for a file. Warming would be pure
+            // outbound Graph traffic for a cache nothing reads - and on a Copilot-heavy tenant that is
+            // thousands of calls per cycle against a tenant that deliberately opted out.
+            var graph = new RecordingCopilotMetadataLoader();
+            var prewarmer = new CopilotMetadataPrewarmer(new FakeCopilotMetadataLoaderFactory(graph), new RecordingLogger());
+
+            var loader = await prewarmer.GetLoaderAndPrewarmAsync(
+                Activities(CopilotEvent("a@contoso.com", FileContextA), CopilotEvent("b@contoso.com", FileContextB)),
+                resolveCopilotResourceMetadata: false);
+
+            Assert.AreEqual(0, graph.FileLookups.Count, "Resolution is disabled: nothing may be pre-resolved from Graph.");
+            Assert.AreSame(graph, loader, "The loader is still returned - the SaveSession is given it either way.");
+        }
+
+        [TestMethod]
+        public async Task Prewarm_CopilotResourceResolutionEnabled_ResolvesEachDistinctContextOnceWithItsOwnUpn()
+        {
+            var graph = new RecordingCopilotMetadataLoader();
+            var prewarmer = new CopilotMetadataPrewarmer(new FakeCopilotMetadataLoaderFactory(graph), new RecordingLogger());
+
+            var loader = await prewarmer.GetLoaderAndPrewarmAsync(
+                Activities(
+                    CopilotEvent("a@contoso.com", FileContextA),
+                    CopilotEvent("b@contoso.com", FileContextB),
+                    CopilotEvent("c@contoso.com", FileContextA),      // same file as the first event
+                    new SharePointAuditLogContent { Id = Guid.NewGuid(), UserId = "d@contoso.com" }),   // not a Copilot event at all
+                resolveCopilotResourceMetadata: true);
+
+            Assert.AreSame(graph, loader);
+            Assert.AreEqual(2, graph.FileLookups.Count,
+                "A context seen twice in a batch costs one Graph round-trip, not two - and a non-Copilot event costs none.");
+
+            var byContext = graph.FileLookups.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Assert.AreEqual("a@contoso.com", byContext[FileContextA], "The first event to claim a context supplies the UPN Graph is asked with.");
+            Assert.AreEqual("b@contoso.com", byContext[FileContextB]);
+        }
+
+        [TestMethod]
+        public async Task Prewarm_LoaderFactoryFails_ReturnsNullAndWarnsAndSkipsThePrewarm()
+        {
+            // Building the run-scoped loader is best-effort: with no Graph credentials the import must
+            // continue, with each SaveSession falling back to building its own loader.
+            var factory = FakeCopilotMetadataLoaderFactory.FailingWith(new InvalidOperationException("no Graph creds"));
+            var logger = new RecordingLogger();
+            var prewarmer = new CopilotMetadataPrewarmer(factory, logger);
+
+            var loader = await prewarmer.GetLoaderAndPrewarmAsync(
+                Activities(CopilotEvent("a@contoso.com", FileContextA)),
+                resolveCopilotResourceMetadata: true);
+
+            Assert.IsNull(loader, "A failed build must degrade to null, not throw out of the save path.");
+
+            var warnings = logger.Entries.Where(e => e.Level == LogLevel.Warning).ToList();
+            Assert.AreEqual(1, warnings.Count);
+            Assert.AreEqual("Could not build a run-scoped Copilot metadata loader; falling back to per-batch loaders.", warnings[0].Message);
+            Assert.IsInstanceOfType(warnings[0].Exception, typeof(InvalidOperationException),
+                "The cause must reach the log, not just the fact that something failed.");
+        }
+
+        [TestMethod]
+        public async Task Prewarm_LoaderIsBuiltAtMostOncePerCycle_EvenWhenTheFactoryFailed()
+        {
+            // Every save batch calls this. Retrying a broken Graph auth per batch would cost an
+            // authentication round-trip - and a warning line - for each of the cycle's batches.
+            var okFactory = new FakeCopilotMetadataLoaderFactory(new RecordingCopilotMetadataLoader());
+            var okPrewarmer = new CopilotMetadataPrewarmer(okFactory, new RecordingLogger());
+            var batch = Activities(CopilotEvent("a@contoso.com", FileContextA));
+
+            await okPrewarmer.GetLoaderAndPrewarmAsync(batch, resolveCopilotResourceMetadata: true);
+            await okPrewarmer.GetLoaderAndPrewarmAsync(batch, resolveCopilotResourceMetadata: true);
+            Assert.AreEqual(1, okFactory.CreateCallCount, "The successful loader is built once and reused for the whole cycle.");
+
+            var badFactory = FakeCopilotMetadataLoaderFactory.FailingWith(new InvalidOperationException("no Graph creds"));
+            var badLogger = new RecordingLogger();
+            var badPrewarmer = new CopilotMetadataPrewarmer(badFactory, badLogger);
+
+            await badPrewarmer.GetLoaderAndPrewarmAsync(batch, resolveCopilotResourceMetadata: true);
+            await badPrewarmer.GetLoaderAndPrewarmAsync(batch, resolveCopilotResourceMetadata: true);
+            Assert.AreEqual(1, badFactory.CreateCallCount, "A FAILED build must not be retried on the next batch either.");
+            Assert.AreEqual(1, badLogger.Entries.Count(e => e.Level == LogLevel.Warning), "...and must therefore warn only once.");
+        }
+
+        [TestMethod]
+        public async Task Prewarm_OneContextFailingInGraph_DoesNotStopTheOthers()
+        {
+            // The prewarm is an optimisation; the authoritative resolution and its error reporting happen in
+            // the serial ProcessExtendedProperties pass. One unresolvable file must not abort the batch.
+            var graph = new RecordingCopilotMetadataLoader();
+            graph.FailForContextIds.Add(FileContextA);
+            var logger = new RecordingLogger();
+            var prewarmer = new CopilotMetadataPrewarmer(new FakeCopilotMetadataLoaderFactory(graph), logger);
+
+            await prewarmer.GetLoaderAndPrewarmAsync(
+                Activities(CopilotEvent("a@contoso.com", FileContextA), CopilotEvent("b@contoso.com", FileContextB)),
+                resolveCopilotResourceMetadata: true);
+
+            Assert.AreEqual(2, graph.FileLookups.Count, "Both contexts are still attempted.");
+            Assert.AreEqual(1, logger.Entries.Count(e => e.Level == LogLevel.Debug),
+                "The failure is recorded at Debug - it is not an operator-actionable error here.");
+            Assert.AreEqual(0, logger.Entries.Count(e => e.Level == LogLevel.Error || e.Level == LogLevel.Warning));
+        }
+
+        [TestMethod]
+        public async Task Prewarm_FanOutIsThrottled_ButStillConcurrent()
+        {
+            // The pre-warm runs OUTSIDE the SQL lock precisely so it can overlap, but an unbounded fan-out
+            // over a large batch would burst Graph and get the tenant throttled.
+            var graph = new RecordingCopilotMetadataLoader { FileLookupDuration = TimeSpan.FromMilliseconds(60) };
+            var prewarmer = new CopilotMetadataPrewarmer(new FakeCopilotMetadataLoaderFactory(graph), new RecordingLogger());
+
+            var events = Enumerable.Range(0, 24)
+                .Select(i => (AbstractAuditLogContent)CopilotEvent($"u{i}@contoso.com", $"https://contoso.sharepoint.com/sites/x/f{i}.docx"))
+                .ToList();
+
+            await prewarmer.GetLoaderAndPrewarmAsync(events, resolveCopilotResourceMetadata: true);
+
+            Assert.AreEqual(24, graph.FileLookups.Count);
+            Assert.IsTrue(graph.PeakConcurrentFileLookups > 1,
+                $"The pre-warm must actually overlap its Graph calls; peak concurrency was {graph.PeakConcurrentFileLookups}.");
+            Assert.IsTrue(graph.PeakConcurrentFileLookups <= CopilotMetadataPrewarmer.PrewarmConcurrency,
+                $"The fan-out must stay within {CopilotMetadataPrewarmer.PrewarmConcurrency}; peak concurrency was {graph.PeakConcurrentFileLookups}.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotMetadataPrewarmerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotMetadataPrewarmerTests.cs
@@ -156,7 +156,7 @@ namespace Tests.UnitTests
         {
             // The pre-warm runs OUTSIDE the SQL lock precisely so it can overlap, but an unbounded fan-out
             // over a large batch would burst Graph and get the tenant throttled.
-            var graph = new RecordingCopilotMetadataLoader { FileLookupDuration = TimeSpan.FromMilliseconds(60) };
+            var graph = new RecordingCopilotMetadataLoader { FileLookupDuration = TimeSpan.FromMilliseconds(150) };
             var prewarmer = new CopilotMetadataPrewarmer(new FakeCopilotMetadataLoaderFactory(graph), new RecordingLogger());
 
             var events = Enumerable.Range(0, 24)
@@ -168,8 +168,11 @@ namespace Tests.UnitTests
             Assert.AreEqual(24, graph.FileLookups.Count);
             Assert.IsTrue(graph.PeakConcurrentFileLookups > 1,
                 $"The pre-warm must actually overlap its Graph calls; peak concurrency was {graph.PeakConcurrentFileLookups}.");
-            Assert.IsTrue(graph.PeakConcurrentFileLookups <= CopilotMetadataPrewarmer.PrewarmConcurrency,
-                $"The fan-out must stay within {CopilotMetadataPrewarmer.PrewarmConcurrency}; peak concurrency was {graph.PeakConcurrentFileLookups}.");
+            // Asserted as the literal cap, not against CopilotMetadataPrewarmer.PrewarmConcurrency: comparing
+            // the observed peak to the very constant that sizes the semaphore cannot fail when that constant
+            // changes, which is exactly the value an operator would care about.
+            Assert.IsTrue(graph.PeakConcurrentFileLookups <= 8,
+                $"The fan-out must stay within 8 concurrent Graph lookups; peak concurrency was {graph.PeakConcurrentFileLookups}.");
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeActivityPersistencePorts.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeActivityPersistencePorts.cs
@@ -1,0 +1,310 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using Common.Entities;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="IActivityStagingWriter"/>: hands out recording batches instead of an
+    /// <c>EFInsertBatch</c>, so the audit-log save path's staging + merge decisions can be asserted with no
+    /// SQL Server. See issue #373.
+    ///
+    /// Internal because the staging entity it carries is internal.
+    /// </summary>
+    internal class InMemoryActivityStagingWriter : IActivityStagingWriter
+    {
+        private readonly object _lock = new object();
+
+        public List<InMemoryActivityStagingBatch> Batches { get; } = new List<InMemoryActivityStagingBatch>();
+
+        /// <summary>Optional hook run inside the merge, e.g. to make the merge phase measurably slow.</summary>
+        public Func<Task> OnMerge { get; set; }
+
+        public InMemoryActivityStagingBatch LastBatch
+        {
+            get { lock (_lock) { return Batches.Count == 0 ? null : Batches[Batches.Count - 1]; } }
+        }
+
+        public IActivityStagingBatch CreateBatch(AnalyticsEntitiesContext db)
+        {
+            var batch = new InMemoryActivityStagingBatch { OnMerge = OnMerge };
+            lock (_lock) { Batches.Add(batch); }
+            return batch;
+        }
+    }
+
+    /// <summary>
+    /// Records everything one save batch staged and exactly how the merge was invoked - which staging table
+    /// the merge SQL was pointed at, and whether the shared-write lock was handed down to it.
+    /// </summary>
+    internal class InMemoryActivityStagingBatch : IActivityStagingBatch
+    {
+        private readonly object _lock = new object();
+
+        public List<AuditLogTempEntity> Rows { get; } = new List<AuditLogTempEntity>();
+
+        /// <summary>How many times the batch was merged (production: exactly once per save).</summary>
+        public int MergeCount { get; private set; }
+
+        /// <summary>The merge script as it was actually handed to SQL, with the table name substituted.</summary>
+        public string LastMergeSql { get; private set; }
+
+        /// <summary>
+        /// The staging-table override. <c>null</c> means the shared table named by the entity's
+        /// <c>[TempTableName]</c> attribute - i.e. the default serial path.
+        /// </summary>
+        public string LastStagingTableName { get; private set; }
+
+        /// <summary>
+        /// The shared-write lock passed down to the merge, or <c>null</c> on the serial path. Kept as the
+        /// instance (not a bool) so a test can assert it is the SAME semaphore the save was given.
+        /// </summary>
+        public SemaphoreSlim LastMergeLock { get; private set; }
+
+        public int LastInsertsPerThread { get; private set; }
+
+        /// <summary>Rows staged at the moment the merge ran, so a later mutation cannot fake it.</summary>
+        public int RowCountAtMerge { get; private set; }
+
+        public Func<Task> OnMerge { get; set; }
+
+        public void AddRow(AuditLogTempEntity row)
+        {
+            lock (_lock) { Rows.Add(row); }
+        }
+
+        public async Task<int> LoadAndMergeAsync(int insertsPerThread, string mergeSql, string stagingTableName, SemaphoreSlim mergeLock)
+        {
+            lock (_lock)
+            {
+                MergeCount++;
+                LastInsertsPerThread = insertsPerThread;
+                LastMergeSql = mergeSql;
+                LastStagingTableName = stagingTableName;
+                LastMergeLock = mergeLock;
+                RowCountAtMerge = Rows.Count;
+            }
+
+            if (OnMerge != null)
+            {
+                await OnMerge();
+            }
+
+            return RowCountAtMerge;
+        }
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IActivityImportCacheLoader"/>. Records every window it was asked to load so a
+    /// test can tell a run-scoped (whole-window, built once) load from the per-batch safety-valve's
+    /// rebuild-every-batch behaviour. See issue #373.
+    /// </summary>
+    public class FakeActivityImportCacheLoader : IActivityImportCacheLoader
+    {
+        private readonly object _lock = new object();
+        private readonly List<CacheLoad> _loads = new List<CacheLoad>();
+
+        /// <summary>A single load request.</summary>
+        public class CacheLoad
+        {
+            public DateTime FromUtc { get; set; }
+            public DateTime ToUtc { get; set; }
+        }
+
+        /// <summary>Optional: how long each load "takes", to exercise the build-once locking.</summary>
+        public TimeSpan LoadDuration { get; set; } = TimeSpan.Zero;
+
+        /// <summary>Optional: seeds the cache each load returns (e.g. to give it a non-zero id count).</summary>
+        public Action<ActivityImportCache> SeedCache { get; set; }
+
+        public IReadOnlyList<CacheLoad> Loads
+        {
+            get { lock (_lock) { return _loads.ToArray(); } }
+        }
+
+        public int LoadCount
+        {
+            get { lock (_lock) { return _loads.Count; } }
+        }
+
+        public ActivityImportCache Load(DateTime fromUtc, DateTime toUtc)
+        {
+            lock (_lock) { _loads.Add(new CacheLoad { FromUtc = fromUtc, ToUtc = toUtc }); }
+            if (LoadDuration > TimeSpan.Zero)
+            {
+                Thread.Sleep(LoadDuration);
+            }
+            var cache = ActivityImportCache.GetEmptyCache();
+            SeedCache?.Invoke(cache);
+            return cache;
+        }
+    }
+
+    /// <summary>
+    /// In-memory <see cref="ICopilotMetadataLoaderFactory"/>. Can be made to fail, which is the realistic
+    /// case (no Graph credentials), and counts how many times it was asked - the run-scoped loader must be
+    /// built at most once per import cycle even when it fails.
+    /// </summary>
+    public class FakeCopilotMetadataLoaderFactory : ICopilotMetadataLoaderFactory
+    {
+        private readonly ICopilotMetadataLoader _loader;
+        private readonly Exception _failWith;
+        private int _createCallCount;
+
+        public FakeCopilotMetadataLoaderFactory(ICopilotMetadataLoader loader)
+        {
+            _loader = loader;
+        }
+
+        /// <summary>
+        /// A factory that fails. The failure is returned as a FAULTED TASK rather than thrown
+        /// synchronously: a synchronous throw would land in the caller's catch block whether or not the
+        /// caller awaited it, so it could not detect a dropped <c>await</c>.
+        /// </summary>
+        public static FakeCopilotMetadataLoaderFactory FailingWith(Exception ex)
+        {
+            return new FakeCopilotMetadataLoaderFactory(null, ex);
+        }
+
+        private FakeCopilotMetadataLoaderFactory(ICopilotMetadataLoader loader, Exception failWith)
+        {
+            _loader = loader;
+            _failWith = failWith;
+        }
+
+        public int CreateCallCount => Interlocked.CompareExchange(ref _createCallCount, 0, 0);
+
+        public Task<ICopilotMetadataLoader> CreateAsync()
+        {
+            Interlocked.Increment(ref _createCallCount);
+            if (_failWith != null)
+            {
+                return Task.FromException<ICopilotMetadataLoader>(_failWith);
+            }
+            return Task.FromResult(_loader);
+        }
+    }
+
+    /// <summary>
+    /// In-memory <see cref="ICopilotMetadataLoader"/> that records every Graph lookup it was asked for,
+    /// including the peak number running at once - which is what the pre-warm's concurrency cap controls.
+    /// </summary>
+    public class RecordingCopilotMetadataLoader : ICopilotMetadataLoader
+    {
+        private readonly object _lock = new object();
+        private readonly List<KeyValuePair<string, string>> _fileLookups = new List<KeyValuePair<string, string>>();
+        private int _inFlight;
+        private int _peakInFlight;
+
+        /// <summary>Optional: how long each file lookup "takes", so concurrency is observable.</summary>
+        public TimeSpan FileLookupDuration { get; set; } = TimeSpan.Zero;
+
+        /// <summary>Optional: context ids whose lookup fails (as a faulted task, not a synchronous throw).</summary>
+        public HashSet<string> FailForContextIds { get; } = new HashSet<string>();
+
+        /// <summary>(contextId, eventUpn) pairs, in the order the lookups started.</summary>
+        public IReadOnlyList<KeyValuePair<string, string>> FileLookups
+        {
+            get { lock (_lock) { return _fileLookups.ToArray(); } }
+        }
+
+        public int PeakConcurrentFileLookups
+        {
+            get { lock (_lock) { return _peakInFlight; } }
+        }
+
+        public async Task<SpoDocumentFileInfo> GetSpoFileInfo(string copilotId, string eventUpn)
+        {
+            lock (_lock)
+            {
+                _fileLookups.Add(new KeyValuePair<string, string>(copilotId, eventUpn));
+                _inFlight++;
+                if (_inFlight > _peakInFlight) _peakInFlight = _inFlight;
+            }
+            try
+            {
+                bool fail;
+                lock (_lock) { fail = FailForContextIds.Contains(copilotId); }
+                if (fail)
+                {
+                    // Faulted task, never a synchronous throw - see FakeCopilotMetadataLoaderFactory.
+                    await Task.FromException<SpoDocumentFileInfo>(new InvalidOperationException($"Graph lookup failed for {copilotId}"));
+                }
+                if (FileLookupDuration > TimeSpan.Zero)
+                {
+                    await Task.Delay(FileLookupDuration);
+                }
+                return new SpoDocumentFileInfo { Url = copilotId };
+            }
+            finally
+            {
+                lock (_lock) { _inFlight--; }
+            }
+        }
+
+        public Task<MeetingMetadata> GetMeetingInfo(string threadId, string userGuid) => Task.FromResult(new MeetingMetadata());
+
+        public Task<string> GetUserIdFromUpn(string userPrincipalName) => Task.FromResult(Guid.Empty.ToString());
+    }
+
+    /// <summary>
+    /// <see cref="AuditFilterConfig"/> driven by a predicate, so a test can put specific events outside the
+    /// org-URL whitelist without loading org_urls from SQL.
+    /// </summary>
+    public class PredicateAuditFilterConfig : AuditFilterConfig
+    {
+        private readonly Func<AbstractAuditLogContent, bool> _inScope;
+
+        public PredicateAuditFilterConfig(Func<AbstractAuditLogContent, bool> inScope)
+        {
+            _inScope = inScope;
+        }
+
+        public override bool InScope(AbstractAuditLogContent content) => _inScope(content);
+    }
+
+    /// <summary>Minimal <see cref="ILogger"/> that records level, formatted message and exception.</summary>
+    public class RecordingLogger : ILogger
+    {
+        public class Entry
+        {
+            public LogLevel Level { get; set; }
+            public string Message { get; set; }
+            public Exception Exception { get; set; }
+        }
+
+        private readonly object _lock = new object();
+        private readonly List<Entry> _entries = new List<Entry>();
+
+        public IReadOnlyList<Entry> Entries
+        {
+            get { lock (_lock) { return _entries.ToArray(); } }
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => new NoopScope();
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            lock (_lock)
+            {
+                _entries.Add(new Entry { Level = logLevel, Message = formatter(state, exception), Exception = exception });
+            }
+        }
+
+        private class NoopScope : IDisposable
+        {
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="CopilotAuditLogContentSchemaTests.cs" />
     <Compile Include="CopilotEventManagerAccessedResourcesTests.cs" />
     <Compile Include="CopilotEventManagerEdgeCaseTests.cs" />
+    <Compile Include="CopilotMetadataPrewarmerTests.cs" />
     <Compile Include="CopilotPrewarmExtractionTests.cs" />
     <Compile Include="CopilotEventManagerSaveTests.cs" />
     <Compile Include="CopilotTestBase.cs" />
@@ -121,11 +122,13 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActivityImportCacheProviderTests.cs" />
     <Compile Include="ActivityImportCacheWindowTests.cs" />
     <Compile Include="ActivityImporterTests.cs" />
     <Compile Include="ActivityReportLoaderTimeoutTests.cs" />
     <Compile Include="ActivityReportSetMinMaxTests.cs" />
     <Compile Include="ActivitySaveConcurrencyPolicyTests.cs" />
+    <Compile Include="ActivitySavePipelineTests.cs" />
     <Compile Include="ActivityStagingRulesTests.cs" />
     <Compile Include="AppInsightsConnectionStringParserTests.cs" />
     <Compile Include="AppInsightsKqlGetWhereStringTests.cs" />
@@ -161,6 +164,7 @@
     <Compile Include="InsertBatchOverWidthTests.cs" />
     <Compile Include="AppInsightsImportTests.cs" />
     <Compile Include="CopilotAuditEventManagerStagingTests.cs" />
+    <Compile Include="FakeLoaderClasses\FakeActivityPersistencePorts.cs" />
     <Compile Include="FakeLoaderClasses\InMemoryStagingWriters.cs" />
     <Compile Include="PowerPlatformAuditEventManagerStagingTests.cs" />
     <Compile Include="ClockAndContextFactoryTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -90,11 +90,14 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// <see cref="IActivityStagingWriter"/> carries the internal staging entity;
         /// <c>InternalsVisibleTo("Tests.UnitTests")</c> makes it reachable from the tests.
         ///
-        /// A <c>null</c> collaborator means "build the production adapter". That is how the public
-        /// constructors above keep the original field-initialisation order: <c>appConfig</c> is still
-        /// dereferenced (and still throws a <see cref="NullReferenceException"/> if it is null) before any
-        /// adapter is constructed, rather than a chained <c>: this(new SqlThing(appConfig...), ...)</c>
-        /// moving an adapter's own validation in front of it.
+        /// A <c>null</c> collaborator means "build the production adapter", constructed in the body rather
+        /// than in a chained constructor initialiser. That is deliberate ordering-insurance: a chained
+        /// <c>: this(new SqlThing(appConfig...), ...)</c> evaluates the adapter's constructor <i>before</i>
+        /// this body's <c>new UserGroupsFilterModel(appConfig.UserGroupsFilter)</c>. It makes no difference
+        /// today - none of the production adapters below validates or dereferences what it is handed, so a
+        /// null <c>appConfig</c> still raises the same <see cref="NullReferenceException"/> at the same
+        /// point either way - but it means adding a guard to one of those adapters later cannot silently
+        /// change which exception an existing caller sees.
         /// </summary>
         internal ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig,
             int maxConcurrentSaves, bool usePerBatchDedupCache, IClock clock,

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -4,7 +4,6 @@ using Common.Entities.Config;
 using DataUtils;
 using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
-using Microsoft.Graph;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -15,11 +14,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 using WebJob.Office365ActivityImporter.Engine.Graph.User;
-using WebJob.Office365ActivityImporter.Engine.Properties;
 
 namespace WebJob.Office365ActivityImporter.Engine
 {
@@ -29,13 +28,20 @@ namespace WebJob.Office365ActivityImporter.Engine
     /// </summary>
     public class ActivityReportSqlPersistenceManager : IActivityReportPersistenceManager
     {
-        private readonly AuditFilterConfig _filterConfig;
-        private readonly UserGroupsCache _userGroupsCache;
         private readonly ILogger _logger;
         private readonly AppConfig _appConfig;
         private readonly IClock _clock;
         private string _defaultConnectionString = null;
-        private UserGroupsFilterModel _userGroupsFilter = null;
+
+        // --- Collaborators (issue #373 part 2) ---------------------------------------------------------
+        // The four jobs this adapter used to do inline, each now behind its own seam so the decisions around
+        // them can be asserted without SQL Server or Graph. The production adapters are still constructed
+        // here by default, so no call site changes.
+        private readonly IActivityImportCacheProvider _cacheProvider;
+        private readonly IActivityStagingWriter _stagingWriter;
+        private readonly CopilotMetadataPrewarmer _copilotPrewarmer;
+        private readonly ISaveSessionFactory _saveSessionFactory;
+        private readonly ActivityStagingPass _stagingPass;
 
         /// <summary>
         /// Process-wide gate that serializes writes to the staging tables. Intentionally <c>static</c> so that
@@ -49,40 +55,19 @@ namespace WebJob.Office365ActivityImporter.Engine
         // --- Concurrent-save mode (opt-in; _maxConcurrentSaves > 1) ------------------------------------
         // When enabled, each CommitAll uses its OWN sharded staging table so multiple saves can build +
         // load their staging table in parallel (bounded by _saveConcurrencyGate). The parts that write
-        // SHARED tables - the merge (lookup + fact inserts) and the metadata pass (webs/sites, etc.) -
-        // are still serialised across all saves by _sharedWriteSemaphore, so there is no shared-table
-        // race. Default is 1, which preserves the original strictly-serial behaviour exactly (single
-        // static _sqlSaveSemaphore, no sharding).
+        // SHARED tables - the merge (lookup + fact inserts) and the metadata pass (webs/sites, etc.) - are
+        // still serialised across all saves by _sharedWriteSemaphore, so there is no shared-table race.
+        // Default is 1, which preserves the original strictly-serial behaviour exactly (single static
+        // _sqlSaveSemaphore, no sharding).
         private readonly int _maxConcurrentSaves;
         private readonly SemaphoreSlim _saveConcurrencyGate;
         private static readonly SemaphoreSlim _sharedWriteSemaphore = new SemaphoreSlim(1, 1);
 
         // --- Run-scoped dedup cache (perf: build ONCE per cycle, not per batch) -------------------------
-        // The set of audit-event ids already imported/ignored within the download window. This manager is
-        // created once per import cycle, so the cache is built ONCE (lazily, for the whole window) and kept
-        // current in-memory as each batch saves - replacing the old behaviour of re-querying audit_events on
-        // every CommitAll. A 2000-event batch's [Min,Max] CreationTime spans almost the entire window (events
-        // download out-of-order across ~130 threads), so the per-batch query materialised ~the whole in-window
-        // audit_events set on EVERY batch: the dominant cost, and a large memory spike, at scale. Correctness
-        // is unchanged - the same ids are cached (full window, keyed by id) and the merge SQL's NOT EXISTS
-        // guards remain the authoritative cross-instance/cross-cycle dedup backstop. ActivityImportCache is
-        // internally thread-safe, so one instance is shared safely across concurrent saves.
-        //   _usePerBatchDedupCache is an ops safety-valve (app setting AUDIT_PERBATCH_DEDUP_CACHE=true) that
-        //   restores the old per-batch build without a redeploy; default false = new per-cycle behaviour.
+        // _usePerBatchDedupCache is an ops safety-valve (app setting AUDIT_PERBATCH_DEDUP_CACHE=true) that
+        // restores the old per-batch cache build without a redeploy; default false = per-cycle behaviour.
+        // The lifecycle itself lives in ActivityImportCacheProvider.
         private readonly bool _usePerBatchDedupCache;
-        private ActivityImportCache _runImportCache;
-        private bool _runImportCacheBuilt;
-        private readonly SemaphoreSlim _runImportCacheInitLock = new SemaphoreSlim(1, 1);
-
-        // Run-scoped Copilot Graph metadata loader, shared across every batch so its Graph caches (resolved
-        // files, users, sites, and unresolvable contexts) persist for the whole import instead of being rebuilt
-        // per batch. Lazily built once; best-effort (null on failure -> each SaveSession falls back to its own).
-        private ICopilotMetadataLoader _sharedCopilotLoader;
-        private bool _sharedCopilotLoaderTried;
-        private readonly SemaphoreSlim _sharedLoaderInitLock = new SemaphoreSlim(1, 1);
-
-        // How many Copilot file contexts to resolve concurrently while pre-warming the cache (outside the SQL lock).
-        private const int PrewarmConcurrency = 8;
 
         public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves = 1, bool usePerBatchDedupCache = false)
             : this(filterConfig, userGroupsCache, logger, appConfig, maxConcurrentSaves, usePerBatchDedupCache, null)
@@ -96,19 +81,43 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// compiled caller.
         /// </summary>
         public ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig, int maxConcurrentSaves, bool usePerBatchDedupCache, IClock clock)
+            : this(filterConfig, userGroupsCache, logger, appConfig, maxConcurrentSaves, usePerBatchDedupCache, clock, null, null, null, null)
         {
-            _filterConfig = filterConfig;
-            _userGroupsCache = userGroupsCache;
+        }
+
+        /// <summary>
+        /// The collaborator constructor (issue #373 part 2). <c>internal</c> because
+        /// <see cref="IActivityStagingWriter"/> carries the internal staging entity;
+        /// <c>InternalsVisibleTo("Tests.UnitTests")</c> makes it reachable from the tests.
+        ///
+        /// A <c>null</c> collaborator means "build the production adapter". That is how the public
+        /// constructors above keep the original field-initialisation order: <c>appConfig</c> is still
+        /// dereferenced (and still throws a <see cref="NullReferenceException"/> if it is null) before any
+        /// adapter is constructed, rather than a chained <c>: this(new SqlThing(appConfig...), ...)</c>
+        /// moving an adapter's own validation in front of it.
+        /// </summary>
+        internal ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig,
+            int maxConcurrentSaves, bool usePerBatchDedupCache, IClock clock,
+            IActivityImportCacheProvider cacheProvider, IActivityStagingWriter stagingWriter,
+            ICopilotMetadataLoaderFactory copilotMetadataLoaderFactory, ISaveSessionFactory saveSessionFactory)
+        {
             _logger = logger;
             _appConfig = appConfig;
             _clock = clock ?? SystemClock.Instance;
-            _userGroupsFilter = new UserGroupsFilterModel(appConfig.UserGroupsFilter);
+            var userGroupsFilter = new UserGroupsFilterModel(appConfig.UserGroupsFilter);
             _maxConcurrentSaves = ActivitySaveConcurrencyPolicy.NormaliseMaxConcurrentSaves(maxConcurrentSaves);
             _usePerBatchDedupCache = usePerBatchDedupCache;
             if (ActivitySaveConcurrencyPolicy.UseShardedStaging(_maxConcurrentSaves))
             {
                 _saveConcurrencyGate = new SemaphoreSlim(_maxConcurrentSaves, _maxConcurrentSaves);
             }
+
+            _stagingPass = new ActivityStagingPass(filterConfig, userGroupsCache, userGroupsFilter, logger);
+            _cacheProvider = cacheProvider ?? new ActivityImportCacheProvider(SqlActivityImportCacheLoader.Instance, logger);
+            _stagingWriter = stagingWriter ?? new SqlActivityStagingWriter(logger);
+            _copilotPrewarmer = new CopilotMetadataPrewarmer(
+                copilotMetadataLoaderFactory ?? new GraphCopilotMetadataLoaderFactory(logger, appConfig), logger);
+            _saveSessionFactory = saveSessionFactory ?? new SaveSessionFactory(logger, appConfig);
         }
 
         /// <summary>
@@ -120,14 +129,12 @@ namespace WebJob.Office365ActivityImporter.Engine
             {
                 // Build the dedup cache ONCE per cycle (shared, kept current in-memory) instead of
                 // re-querying audit_events for every batch. The per-batch reload materialised ~the whole
-                // in-window event set each time because a batch spans nearly the whole window. See the field
-                // comment on _runImportCache. The AUDIT_PERBATCH_DEDUP_CACHE safety-valve restores the old path.
+                // in-window event set each time because a batch spans nearly the whole window. See
+                // ActivityImportCacheProvider. The AUDIT_PERBATCH_DEDUP_CACHE safety-valve restores the old path.
                 var cacheWindow = ActivityImportCacheWindow.Resolve(_usePerBatchDedupCache, activities.OldestContent,
                     activities.NewestContent, _appConfig.DaysBeforeNowToDownload, _clock.UtcNow);
 
-                var cache = cacheWindow.Scope == ActivityDedupCacheScope.PerBatch
-                    ? ActivityImportCache.GetAndBuildNewCache(cacheWindow.FromUtc, cacheWindow.ToUtc)
-                    : await GetOrBuildRunImportCacheAsync(cacheWindow);
+                var cache = await _cacheProvider.GetForWindowAsync(cacheWindow);
 
                 // Read default connection-string
                 if (string.IsNullOrEmpty(_defaultConnectionString))
@@ -158,14 +165,10 @@ namespace WebJob.Office365ActivityImporter.Engine
             // Copilot file events it calls Graph (network). Resolving those ahead of time - overlapping across
             // batches and within a batch - turns the in-lock calls into cache hits, so the lock is held only for
             // SQL work, not network round-trips.
-            // Skip the prewarm entirely when Copilot resource resolution is disabled - the save path makes no
-            // Graph resource calls in that mode (every Copilot event is staged agent-metadata-only), so there
-            // is nothing to warm.
-            var sharedLoader = await GetSharedCopilotLoaderAsync();
-            if (CopilotPrewarmPolicy.ShouldPrewarm(sharedLoader != null, _appConfig.ResolveCopilotResourceMetadata))
-            {
-                await PrewarmCopilotFileMetadataAsync(activities, sharedLoader);
-            }
+            // The prewarm is skipped entirely when Copilot resource resolution is disabled - the save path makes
+            // no Graph resource calls in that mode (every Copilot event is staged agent-metadata-only), so there
+            // is nothing to warm. See CopilotMetadataPrewarmer / CopilotPrewarmPolicy.
+            var sharedLoader = await _copilotPrewarmer.GetLoaderAndPrewarmAsync(activities, _appConfig.ResolveCopilotResourceMetadata);
 
             if (!ActivitySaveConcurrencyPolicy.UseShardedStaging(_maxConcurrentSaves))
             {
@@ -219,113 +222,6 @@ namespace WebJob.Office365ActivityImporter.Engine
         }
 
         /// <summary>
-        /// Lazily build the run-scoped dedup cache ONCE per import cycle (this manager is created per cycle),
-        /// over the window resolved by <see cref="ActivityImportCacheWindow"/>. Every event processed this
-        /// cycle has a CreationTime inside that window (the API only serves it there) and the cache is keyed by
-        /// event id, so a single full-window load is equivalent to the old per-batch [Min,Max] loads - without
-        /// the massive redundancy. Kept current thereafter in-memory by RememberProcessedEvent /
-        /// RememberNewlyIgnoredEvent as batches save. Thread-safe (double-checked init + a thread-safe cache).
-        ///
-        /// The window is supplied by the caller (resolved on entry to CommitAll) rather than computed here, so
-        /// the rule is a pure function of the clock and the configured download window. Once built, later
-        /// calls return the same cache and their window argument is ignored.
-        /// </summary>
-        private async Task<ActivityImportCache> GetOrBuildRunImportCacheAsync(ActivityDedupCacheWindow window)
-        {
-            if (_runImportCacheBuilt) return _runImportCache;
-            await _runImportCacheInitLock.WaitAsync();
-            try
-            {
-                if (!_runImportCacheBuilt)
-                {
-                    var sw = System.Diagnostics.Stopwatch.StartNew();
-                    var built = ActivityImportCache.GetAndBuildNewCache(window.FromUtc, window.ToUtc);
-                    sw.Stop();
-
-                    _logger.LogInformation($"Audit events import: built run dedup cache from audit_events in " +
-                        $"{sw.Elapsed.TotalSeconds.ToString("n1")}s ({built.ProcessedIdCount.ToString("n0")} already-processed id(s), " +
-                        $"{window.DaysBack}-day window) - reused across all save batches this cycle instead of reloading per batch.");
-
-                    _runImportCache = built;
-                    _runImportCacheBuilt = true;
-                }
-            }
-            finally
-            {
-                _runImportCacheInitLock.Release();
-            }
-            return _runImportCache;
-        }
-
-        /// <summary>
-        /// Lazily build the run-scoped Copilot metadata loader (once). Best-effort: on any failure (e.g. no Graph
-        /// creds in a test) returns null and callers fall back to the per-session loader. Thread-safe.
-        /// </summary>
-        private async Task<ICopilotMetadataLoader> GetSharedCopilotLoaderAsync()
-        {
-            if (_sharedCopilotLoaderTried)
-            {
-                return _sharedCopilotLoader;
-            }
-            await _sharedLoaderInitLock.WaitAsync();
-            try
-            {
-                if (!_sharedCopilotLoaderTried)
-                {
-                    try
-                    {
-                        var auth = new GraphAppIndentityOAuthContext(_logger, _appConfig.ClientID, _appConfig.TenantGUID.ToString(), _appConfig.ClientSecret, _appConfig.KeyVaultUrl, _appConfig.UseClientCertificate);
-                        await auth.InitClientCredential();
-                        _sharedCopilotLoader = new GraphFileMetadataLoader(new GraphServiceClient(auth.Creds), _logger);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Could not build a run-scoped Copilot metadata loader; falling back to per-batch loaders.");
-                        _sharedCopilotLoader = null;
-                    }
-                    _sharedCopilotLoaderTried = true;
-                }
-            }
-            finally
-            {
-                _sharedLoaderInitLock.Release();
-            }
-            return _sharedCopilotLoader;
-        }
-
-        /// <summary>
-        /// Resolve the file metadata for this batch's Copilot file contexts concurrently, warming the shared
-        /// loader's cache. Errors are swallowed - the authoritative resolution + logging happens in the serial
-        /// ProcessExtendedProperties pass (this only pre-populates the cache).
-        /// </summary>
-        private async Task PrewarmCopilotFileMetadataAsync(ActivityReportSet activities, ICopilotMetadataLoader loader)
-        {
-            var fileContexts = CopilotPrewarmPolicy.ExtractFileContexts(activities);
-            if (fileContexts.Count == 0) return;
-
-            using (var throttle = new SemaphoreSlim(PrewarmConcurrency))
-            {
-                var tasks = fileContexts.Select(async kvp =>
-                {
-                    await throttle.WaitAsync();
-                    try
-                    {
-                        await loader.GetSpoFileInfo(kvp.Key, kvp.Value);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogDebug(ex, "Copilot metadata prewarm failed for context {ctx} (will retry in the serial pass)", kvp.Key);
-                    }
-                    finally
-                    {
-                        throttle.Release();
-                    }
-                });
-                await Task.WhenAll(tasks);
-            }
-        }
-
-        /// <summary>
         /// The distinct (fileContextId -> eventUpn) map to pre-resolve for a batch. Thin wrapper kept so
         /// existing call sites and tests are unaffected; the rule itself lives in
         /// <see cref="CopilotPrewarmPolicy.ExtractFileContexts"/>.
@@ -338,70 +234,12 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// </summary>
         private async Task<ImportStat> SaveToSqlAllTheThings(ActivityReportSet activities, AnalyticsEntitiesContext db, SqlConnection con, ActivityImportCache cache, ICopilotMetadataLoader sharedCopilotLoader, string stagingTableName, SemaphoreSlim mergeLock)
         {
-            var listOfActivitiesSavedToSQL = new ConcurrentBag<AbstractAuditLogContent>();
-            var logsToInsert = new EFInsertBatch<AuditLogTempEntity>(db, _logger);
-            // Sequential dedup within this set: a HashSet gives O(1) Contains. The previous
-            // ConcurrentBag.Contains was O(n) per row (an O(n^2) scan over a large activity set).
-            var processedIds = new HashSet<Guid>();
-            var stats = new ImportStat() { Total = activities.Count };
-
-            // Phase timing, surfaced per cycle so operators can see where the save time actually goes: the
-            // in-memory dedup + scope check, the SQL staging-load + merge, and the EF metadata pass. Aggregated
-            // (summed) across batches in ImportStat.AddStats; in concurrent-save mode the merge/metadata are
-            // serialised by mergeLock so their summed times approximate the real serialised wall-time.
-            var swDedup = System.Diagnostics.Stopwatch.StartNew();
-
-            // Hoisted out of the loop: all three capture only loop-invariant state, and Roslyn does not
-            // cache capturing lambdas, so building them per event would allocate three delegates for every
-            // one of the batch's events.
-            Func<AbstractAuditLogContent, bool> urlInScope = log => _filterConfig.InScope(log);
-            Func<string, Task<bool>> userInGroupsFilter = upn => _userGroupsCache.IsInGroupsFilter(upn, _userGroupsFilter);
-            Action<AbstractAuditLogContent> stageRow = log => logsToInsert.Rows.Add(new AuditLogTempEntity(log, log.UserId));
-
-            foreach (var abtractLog in activities)
-            {
-                // Don't insert duplicates in same set. The decision itself (dedup -> URL scope -> user
-                // scope, plus what gets remembered where) lives in ActivityStagingRules so it can be
-                // asserted with no SQL and no Graph; see issue #373.
-                var decision = await ActivityStagingRules.DecideAndRememberAsync(
-                    abtractLog, processedIds, cache, urlInScope, userInGroupsFilter, stageRow);
-
-                if (!decision.IsDuplicate)
-                {
-                    var result = decision.Result;
-                    if (result == SaveResultEnum.UserOutOfScope)
-                    {
-                        _logger.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
-                    }
-
-                    // Update stats
-                    if (result == SaveResultEnum.Imported)
-                    {
-                        stats.Imported++;
-                        listOfActivitiesSavedToSQL.Add(abtractLog);
-                    }
-                    else if (result == SaveResultEnum.ProcessedAlready) stats.ProcessedAlready++;
-                    else if (result == SaveResultEnum.UrlOutOfScope) stats.URLsOutOfScope++;
-                    else if (result == SaveResultEnum.UserOutOfScope) stats.UsersOutOfScope++;
-                    else _logger.LogError($"Unexpected log result for log {abtractLog.Id}");
-                }
-            }
-            swDedup.Stop();
-            stats.SaveDedupMs = swDedup.Elapsed.TotalMilliseconds;
-
-            // Merge data
-#if DEBUG
-            Console.WriteLine("\nDEBUG: Merging activity staging table...");
-#endif
-            // Merge to normal tables. In concurrent mode each save has its own sharded staging table
-            // (stagingTableName) and mergeLock serialises ONLY the merge (which writes shared lookup/fact
-            // tables); the parallel staging LOAD inside SaveToStagingTable runs unlocked.
-            var effectiveStagingTable = ActivitySaveConcurrencyPolicy.EffectiveStagingTableName(stagingTableName);
-            var mergeSQL = Resources.Insert_Activity_from_Staging_Table.Replace("${STAGING_TABLE_ACTIVITY}", effectiveStagingTable);
-            var swMerge = System.Diagnostics.Stopwatch.StartNew();
-            await logsToInsert.SaveToStagingTable(10000, mergeSQL, stagingTableName, mergeLock);
-            swMerge.Stop();
-            stats.SaveMergeMs = swMerge.Elapsed.TotalMilliseconds;
+            // Dedup + scope check + staging-row build, then the staging load and merge. All of it lives in
+            // ActivityStagingPass, which reaches SQL only through IActivityStagingBatch, so the batch's
+            // counters, log lines and merge wiring can be asserted without a database (issue #373).
+            var stagingBatch = _stagingWriter.CreateBatch(db);
+            var staged = await _stagingPass.RunAsync(activities, cache, stagingBatch, stagingTableName, mergeLock);
+            var stats = staged.Stats;
 
             #region Add Extra Metadata
 
@@ -411,7 +249,7 @@ namespace WebJob.Office365ActivityImporter.Engine
             if (mergeLock != null) await mergeLock.WaitAsync();
             try
             {
-                await SaveMetadataAsync(db, listOfActivitiesSavedToSQL, sharedCopilotLoader, stats);
+                await SaveMetadataAsync(db, staged.SavedToSql, sharedCopilotLoader, stats);
             }
             finally
             {
@@ -433,8 +271,7 @@ namespace WebJob.Office365ActivityImporter.Engine
         {
             // Add metadata the traditional way with EF. By now should have all the sites saved.
             // Pass the run-scoped Copilot loader so per-event Graph resolution hits the cache warmed above.
-            var saveSession = new SaveSession(_logger, db, _appConfig, sharedCopilotLoader);
-            await saveSession.Init();
+            var saveSession = await _saveSessionFactory.CreateAsync(db, sharedCopilotLoader);
 
             int metaSaveIdx = 0, changesMadeCount = 0;
             double copilotResolveMs = 0;   // per-event Copilot resolution time (the Graph file/meeting calls)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
@@ -1,0 +1,161 @@
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
+using WebJob.Office365ActivityImporter.Engine.Properties;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
+{
+    /// <summary>
+    /// What one staging pass produced: the statistics for the batch and the events that were actually
+    /// staged, which the metadata pass then reads back from SQL.
+    /// </summary>
+    internal sealed class ActivityStagingPassResult
+    {
+        internal ActivityStagingPassResult(ImportStat stats, ConcurrentBag<AbstractAuditLogContent> savedToSql)
+        {
+            Stats = stats;
+            SavedToSql = savedToSql;
+        }
+
+        /// <summary>
+        /// Totals plus the <c>SaveDedupMs</c> / <c>SaveMergeMs</c> phase timings. The metadata-phase timings
+        /// are filled in afterwards by the caller.
+        /// </summary>
+        public ImportStat Stats { get; }
+
+        /// <summary>
+        /// The events handed to the staging table, in the order the pass added them. A
+        /// <see cref="ConcurrentBag{T}"/> rather than a list purely because that is what this pass has always
+        /// produced, and the metadata pass's enumeration order therefore stays as it was.
+        /// </summary>
+        public ConcurrentBag<AbstractAuditLogContent> SavedToSql { get; }
+    }
+
+    /// <summary>
+    /// The SQL-facing half of an audit-log save batch: run every event through
+    /// <see cref="ActivityStagingRules"/>, build its staging row, then load the staging table and merge it
+    /// into the normal tables.
+    ///
+    /// Lifted out of <c>ActivityReportSqlPersistenceManager.SaveToSqlAllTheThings</c> by issue #373. Nothing
+    /// here touches EF: the staging table is reached through <see cref="IActivityStagingBatch"/>, the
+    /// org-URL whitelist and the user-groups filter through the collaborators the manager already held. That
+    /// makes the batch's operator-facing outputs - the <c>ImportStat</c> counters, the "not in user groups
+    /// filter" line, the merge SQL and which staging table it targets, and whether the shared-write lock is
+    /// taken - assertable with no SQL Server and no Graph.
+    ///
+    /// Stateless between calls (everything is per-<see cref="RunAsync"/>), so one instance is shared by every
+    /// batch of a cycle, including concurrent ones.
+    /// </summary>
+    internal sealed class ActivityStagingPass
+    {
+        /// <summary>
+        /// Rows per parallel staging-insert thread. The production value, unchanged; the actual thread count
+        /// is capped by <c>InsertBatchConcurrency.MaxConcurrentThreads</c>.
+        /// </summary>
+        public const int StagingInsertsPerThread = 10000;
+
+        private readonly AuditFilterConfig _filterConfig;
+        private readonly UserGroupsCache _userGroupsCache;
+        private readonly UserGroupsFilterModel _userGroupsFilter;
+        private readonly ILogger _logger;
+
+        /// <remarks>
+        /// Deliberately no null guards: the manager did not validate these either, and it dereferences them
+        /// during the save. Adding an <c>ArgumentNullException</c> here would move a
+        /// <c>NullReferenceException</c> raised mid-save to a different exception raised at construction -
+        /// an operator-visible change, not an extraction.
+        /// </remarks>
+        public ActivityStagingPass(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache,
+            UserGroupsFilterModel userGroupsFilter, ILogger logger)
+        {
+            _filterConfig = filterConfig;
+            _userGroupsCache = userGroupsCache;
+            _userGroupsFilter = userGroupsFilter;
+            _logger = logger;
+        }
+
+        /// <param name="stagingTableName">
+        /// This save's sharded staging table, or <c>null</c> for the default serial path's shared table.
+        /// </param>
+        /// <param name="mergeLock">
+        /// Serialises only the merge (which writes shared lookup / fact tables) in concurrent-save mode;
+        /// <c>null</c> on the serial path, where the whole save is already serialised.
+        /// </param>
+        public async Task<ActivityStagingPassResult> RunAsync(ActivityReportSet activities, ActivityImportCache cache,
+            IActivityStagingBatch batch, string stagingTableName, SemaphoreSlim mergeLock)
+        {
+            var listOfActivitiesSavedToSQL = new ConcurrentBag<AbstractAuditLogContent>();
+            // Sequential dedup within this set: a HashSet gives O(1) Contains. The previous
+            // ConcurrentBag.Contains was O(n) per row (an O(n^2) scan over a large activity set).
+            var processedIds = new HashSet<Guid>();
+            var stats = new ImportStat() { Total = activities.Count };
+
+            // Phase timing, surfaced per cycle so operators can see where the save time actually goes: the
+            // in-memory dedup + scope check, the SQL staging-load + merge, and the EF metadata pass. Aggregated
+            // (summed) across batches in ImportStat.AddStats; in concurrent-save mode the merge/metadata are
+            // serialised by mergeLock so their summed times approximate the real serialised wall-time.
+            var swDedup = System.Diagnostics.Stopwatch.StartNew();
+
+            // Hoisted out of the loop: all three capture only loop-invariant state, and Roslyn does not
+            // cache capturing lambdas, so building them per event would allocate three delegates for every
+            // one of the batch's events.
+            Func<AbstractAuditLogContent, bool> urlInScope = log => _filterConfig.InScope(log);
+            Func<string, Task<bool>> userInGroupsFilter = upn => _userGroupsCache.IsInGroupsFilter(upn, _userGroupsFilter);
+            Action<AbstractAuditLogContent> stageRow = log => batch.AddRow(new AuditLogTempEntity(log, log.UserId));
+
+            foreach (var abtractLog in activities)
+            {
+                // Don't insert duplicates in same set. The decision itself (dedup -> URL scope -> user
+                // scope, plus what gets remembered where) lives in ActivityStagingRules so it can be
+                // asserted with no SQL and no Graph; see issue #373.
+                var decision = await ActivityStagingRules.DecideAndRememberAsync(
+                    abtractLog, processedIds, cache, urlInScope, userInGroupsFilter, stageRow);
+
+                if (!decision.IsDuplicate)
+                {
+                    var result = decision.Result;
+                    if (result == SaveResultEnum.UserOutOfScope)
+                    {
+                        _logger.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
+                    }
+
+                    // Update stats
+                    if (result == SaveResultEnum.Imported)
+                    {
+                        stats.Imported++;
+                        listOfActivitiesSavedToSQL.Add(abtractLog);
+                    }
+                    else if (result == SaveResultEnum.ProcessedAlready) stats.ProcessedAlready++;
+                    else if (result == SaveResultEnum.UrlOutOfScope) stats.URLsOutOfScope++;
+                    else if (result == SaveResultEnum.UserOutOfScope) stats.UsersOutOfScope++;
+                    else _logger.LogError($"Unexpected log result for log {abtractLog.Id}");
+                }
+            }
+            swDedup.Stop();
+            stats.SaveDedupMs = swDedup.Elapsed.TotalMilliseconds;
+
+            // Merge data
+#if DEBUG
+            Console.WriteLine("\nDEBUG: Merging activity staging table...");
+#endif
+            // Merge to normal tables. In concurrent mode each save has its own sharded staging table
+            // (stagingTableName) and mergeLock serialises ONLY the merge (which writes shared lookup/fact
+            // tables); the parallel staging LOAD inside the batch runs unlocked.
+            var effectiveStagingTable = ActivitySaveConcurrencyPolicy.EffectiveStagingTableName(stagingTableName);
+            var mergeSQL = Resources.Insert_Activity_from_Staging_Table.Replace("${STAGING_TABLE_ACTIVITY}", effectiveStagingTable);
+            var swMerge = System.Diagnostics.Stopwatch.StartNew();
+            await batch.LoadAndMergeAsync(StagingInsertsPerThread, mergeSQL, stagingTableName, mergeLock);
+            swMerge.Stop();
+            stats.SaveMergeMs = swMerge.Elapsed.TotalMilliseconds;
+
+            return new ActivityStagingPassResult(stats, listOfActivitiesSavedToSQL);
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
@@ -13,8 +13,8 @@ using WebJob.Office365ActivityImporter.Engine.Properties;
 namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
 {
     /// <summary>
-    /// What one staging pass produced: the statistics for the batch and the events that were actually
-    /// staged, which the metadata pass then reads back from SQL.
+    /// What one staging pass produced: the statistics for the batch and the events it handed to the
+    /// staging batch, which the metadata pass then tries to match against the rows the merge created.
     /// </summary>
     internal sealed class ActivityStagingPassResult
     {
@@ -31,9 +31,14 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
         public ImportStat Stats { get; }
 
         /// <summary>
-        /// The events handed to the staging table, in the order the pass added them. A
-        /// <see cref="ConcurrentBag{T}"/> rather than a list purely because that is what this pass has always
-        /// produced, and the metadata pass's enumeration order therefore stays as it was.
+        /// The events handed to the staging batch. Note this is what was <i>offered</i> to SQL, not
+        /// necessarily what reached <c>audit_events</c>: <c>InsertBatch</c> skips any row whose value is
+        /// wider than its staging column (see issue #122 / #127), which is why the metadata pass tolerates
+        /// an event having no saved row.
+        ///
+        /// A <see cref="ConcurrentBag{T}"/> rather than a list purely because that is what this pass has
+        /// always produced, so the metadata pass's (unordered) enumeration behaves exactly as it did -
+        /// <see cref="ConcurrentBag{T}"/> makes no insertion-order guarantee.
         /// </summary>
         public ConcurrentBag<AbstractAuditLogContent> SavedToSql { get; }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityImportCacheProvider.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityImportCacheProvider.cs
@@ -102,8 +102,15 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
         /// Lazily build the run-scoped cache ONCE, over the window resolved on entry to the save. Every event
         /// processed this cycle has a CreationTime inside that window (the API only serves it there) and the
         /// cache is keyed by event id, so a single full-window load is equivalent to the old per-batch
-        /// [Min,Max] loads - without the massive redundancy. Thread-safe (double-checked init around a
-        /// single-permit lock; <see cref="ActivityImportCache"/> is itself internally thread-safe).
+        /// [Min,Max] loads - without the massive redundancy.
+        ///
+        /// Concurrent callers are serialised by a single-permit lock, so the load happens once and a failed
+        /// load leaves the flag clear so the next batch retries. The pre-check outside the lock is an
+        /// ordinary (non-volatile) read of <c>_runImportCacheBuilt</c>, and the reference is published before
+        /// the flag is set - this is the pre-#373 code moved verbatim, and it is safe under the .NET
+        /// Framework memory model on the x86/x64 platforms this runs on, where stores are not reordered with
+        /// stores nor loads with loads. <see cref="ActivityImportCache"/> is itself internally locked, so the
+        /// shared cache is safe once handed out.
         ///
         /// Once built, later calls return the same cache and their window argument is ignored.
         /// </summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityImportCacheProvider.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityImportCacheProvider.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
+{
+    /// <summary>
+    /// Read port for the audit-log de-duplication cache: the one place that queries <c>audit_events</c> and
+    /// <c>ignored_audit_events</c> to find out which event ids have already been seen.
+    ///
+    /// Split out by issue #373 so the cache <i>lifecycle</i> (build once per cycle, or once per batch under
+    /// the <c>AUDIT_PERBATCH_DEDUP_CACHE</c> safety-valve) can be asserted without SQL Server. The load is
+    /// deliberately synchronous because <see cref="ActivityImportCache.GetAndBuildNewCache(DateTime, DateTime)"/>
+    /// is - wrapping it in a Task would change when the caller's thread blocks.
+    /// </summary>
+    public interface IActivityImportCacheLoader
+    {
+        /// <summary>
+        /// Load every already-processed (imported or ignored) event id whose timestamp falls in
+        /// [<paramref name="fromUtc"/>, <paramref name="toUtc"/>].
+        /// </summary>
+        ActivityImportCache Load(DateTime fromUtc, DateTime toUtc);
+    }
+
+    /// <summary>
+    /// Production <see cref="IActivityImportCacheLoader"/>. A one-line adapter over the existing static
+    /// factory, which is what makes that factory's <c>new AnalyticsEntitiesContext()</c> substitutable.
+    /// </summary>
+    public sealed class SqlActivityImportCacheLoader : IActivityImportCacheLoader
+    {
+        public static readonly SqlActivityImportCacheLoader Instance = new SqlActivityImportCacheLoader();
+
+        public ActivityImportCache Load(DateTime fromUtc, DateTime toUtc)
+        {
+            return ActivityImportCache.GetAndBuildNewCache(fromUtc, toUtc);
+        }
+    }
+
+    /// <summary>
+    /// Hands a save batch the de-duplication cache it should use, per
+    /// <see cref="ActivityImportCacheWindow.Resolve"/>'s decision.
+    /// </summary>
+    public interface IActivityImportCacheProvider
+    {
+        /// <summary>
+        /// The cache for one save batch. For <see cref="ActivityDedupCacheScope.PerBatch"/> this is a fresh
+        /// cache over the batch's own span; for <see cref="ActivityDedupCacheScope.PerRun"/> it is the
+        /// single run-scoped cache, built on first use and returned unchanged thereafter.
+        /// </summary>
+        Task<ActivityImportCache> GetForWindowAsync(ActivityDedupCacheWindow window);
+    }
+
+    /// <summary>
+    /// The de-duplication cache lifecycle for one import cycle, lifted out of
+    /// <c>ActivityReportSqlPersistenceManager</c> by issue #373.
+    ///
+    /// One instance per import cycle (the persistence manager is itself created per cycle), so the
+    /// run-scoped cache is built ONCE for the whole download window instead of being re-queried for every
+    /// save batch. That matters at scale: a 2000-event batch's [Min,Max] CreationTime spans almost the whole
+    /// window because events download out-of-order across ~130 threads, so the old per-batch load
+    /// materialised ~the entire in-window <c>audit_events</c> set on every single batch.
+    ///
+    /// Correctness is unchanged - the same ids end up cached (full window, keyed by id), the cache is kept
+    /// current in memory by <c>RememberProcessedEvent</c> / <c>RememberNewlyIgnoredEvent</c> as batches
+    /// commit, and the merge SQL's <c>NOT EXISTS</c> guards remain the authoritative cross-instance /
+    /// cross-cycle backstop.
+    ///
+    /// <see cref="ActivityDedupCacheScope.PerBatch"/> is the <c>AUDIT_PERBATCH_DEDUP_CACHE</c> operator
+    /// safety-valve: it restores the old per-batch build without a redeploy.
+    /// </summary>
+    public sealed class ActivityImportCacheProvider : IActivityImportCacheProvider
+    {
+        private readonly IActivityImportCacheLoader _loader;
+        private readonly ILogger _logger;
+
+        private ActivityImportCache _runImportCache;
+        private bool _runImportCacheBuilt;
+        private readonly SemaphoreSlim _runImportCacheInitLock = new SemaphoreSlim(1, 1);
+
+        public ActivityImportCacheProvider(IActivityImportCacheLoader loader, ILogger logger)
+        {
+            if (loader == null) throw new ArgumentNullException(nameof(loader));
+            _loader = loader;
+            _logger = logger;
+        }
+
+        public async Task<ActivityImportCache> GetForWindowAsync(ActivityDedupCacheWindow window)
+        {
+            if (window == null) throw new ArgumentNullException(nameof(window));
+
+            if (window.Scope == ActivityDedupCacheScope.PerBatch)
+            {
+                return _loader.Load(window.FromUtc, window.ToUtc);
+            }
+
+            return await GetOrBuildRunImportCacheAsync(window);
+        }
+
+        /// <summary>
+        /// Lazily build the run-scoped cache ONCE, over the window resolved on entry to the save. Every event
+        /// processed this cycle has a CreationTime inside that window (the API only serves it there) and the
+        /// cache is keyed by event id, so a single full-window load is equivalent to the old per-batch
+        /// [Min,Max] loads - without the massive redundancy. Thread-safe (double-checked init around a
+        /// single-permit lock; <see cref="ActivityImportCache"/> is itself internally thread-safe).
+        ///
+        /// Once built, later calls return the same cache and their window argument is ignored.
+        /// </summary>
+        private async Task<ActivityImportCache> GetOrBuildRunImportCacheAsync(ActivityDedupCacheWindow window)
+        {
+            if (_runImportCacheBuilt) return _runImportCache;
+            await _runImportCacheInitLock.WaitAsync();
+            try
+            {
+                if (!_runImportCacheBuilt)
+                {
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    var built = _loader.Load(window.FromUtc, window.ToUtc);
+                    sw.Stop();
+
+                    _logger.LogInformation($"Audit events import: built run dedup cache from audit_events in " +
+                        $"{sw.Elapsed.TotalSeconds.ToString("n1")}s ({built.ProcessedIdCount.ToString("n0")} already-processed id(s), " +
+                        $"{window.DaysBack}-day window) - reused across all save batches this cycle instead of reloading per batch.");
+
+                    _runImportCache = built;
+                    _runImportCacheBuilt = true;
+                }
+            }
+            finally
+            {
+                _runImportCacheInitLock.Release();
+            }
+            return _runImportCache;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityStagingWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityStagingWriter.cs
@@ -1,0 +1,95 @@
+using Common.Entities;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
+{
+    /// <summary>
+    /// Write port for the audit-log staging table: the SQL half of a save batch (create the staging table,
+    /// bulk-load the staged rows into it, then run the merge into the normal tables).
+    ///
+    /// Extracted by issue #373 so the decisions around it - which staging table the merge is pointed at, the
+    /// merge SQL that is built, and whether the shared-write lock is taken - can be asserted with no SQL
+    /// Server. The SQL itself is unchanged: the adapter wraps the existing
+    /// <c>EFInsertBatch&lt;AuditLogTempEntity&gt;</c>, and <c>InsertBatch&lt;T&gt;</c> keeps its row-by-row
+    /// implementation per project convention.
+    ///
+    /// Internal because <see cref="AuditLogTempEntity"/> is internal;
+    /// <c>InternalsVisibleTo("Tests.UnitTests")</c> makes it reachable from the test project.
+    /// </summary>
+    internal interface IActivityStagingWriter
+    {
+        /// <summary>
+        /// Start one save batch. Created per save (not per manager) because the underlying
+        /// <c>InsertBatch</c> is bound to the context/connection this save runs on and owns that save's row
+        /// list.
+        /// </summary>
+        IActivityStagingBatch CreateBatch(AnalyticsEntitiesContext db);
+    }
+
+    /// <summary>
+    /// The staged rows for one save batch, plus the load+merge that commits them.
+    /// </summary>
+    internal interface IActivityStagingBatch
+    {
+        /// <summary>Add one row to the staging batch. Nothing is sent to SQL until the merge.</summary>
+        void AddRow(AuditLogTempEntity row);
+
+        /// <summary>
+        /// Create + load the staging table and run <paramref name="mergeSql"/> against it.
+        /// </summary>
+        /// <param name="insertsPerThread">Rows per parallel insert thread (the production value is 10,000).</param>
+        /// <param name="stagingTableName">
+        /// The per-save sharded staging table, or <c>null</c> to use the type's own
+        /// <c>[TempTableName]</c> (the single shared staging table used by the default serial path).
+        /// </param>
+        /// <param name="mergeLock">
+        /// When supplied, serialises ONLY the merge - which writes shared lookup / fact tables - while the
+        /// parallel staging load runs unlocked. <c>null</c> on the serial path, where the whole save is
+        /// already serialised.
+        /// </param>
+        /// <returns>Rows affected by the merge, as reported by SQL Server.</returns>
+        Task<int> LoadAndMergeAsync(int insertsPerThread, string mergeSql, string stagingTableName, SemaphoreSlim mergeLock);
+    }
+
+    /// <summary>
+    /// Production <see cref="IActivityStagingWriter"/>: an <c>EFInsertBatch</c> bound to the save's own EF
+    /// context, which is exactly what <c>ActivityReportSqlPersistenceManager</c> built inline before #373.
+    /// </summary>
+    internal sealed class SqlActivityStagingWriter : IActivityStagingWriter
+    {
+        private readonly ILogger _logger;
+
+        public SqlActivityStagingWriter(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public IActivityStagingBatch CreateBatch(AnalyticsEntitiesContext db)
+        {
+            return new SqlActivityStagingBatch(new EFInsertBatch<AuditLogTempEntity>(db, _logger));
+        }
+    }
+
+    /// <summary>
+    /// SQL Server adapter for one save batch. A thin wrapper: the row list and the load+merge are still
+    /// <c>InsertBatch&lt;T&gt;</c>'s.
+    /// </summary>
+    internal sealed class SqlActivityStagingBatch : IActivityStagingBatch
+    {
+        private readonly EFInsertBatch<AuditLogTempEntity> _batch;
+
+        public SqlActivityStagingBatch(EFInsertBatch<AuditLogTempEntity> batch)
+        {
+            if (batch == null) throw new ArgumentNullException(nameof(batch));
+            _batch = batch;
+        }
+
+        public void AddRow(AuditLogTempEntity row) => _batch.Rows.Add(row);
+
+        public Task<int> LoadAndMergeAsync(int insertsPerThread, string mergeSql, string stagingTableName, SemaphoreSlim mergeLock)
+            => _batch.SaveToStagingTable(insertsPerThread, mergeSql, stagingTableName, mergeLock);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ICopilotMetadataLoaderFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ICopilotMetadataLoaderFactory.cs
@@ -1,0 +1,172 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
+{
+    /// <summary>
+    /// Builds the run-scoped Copilot Graph metadata loader. A port purely so that the audit-log persistence
+    /// adapter no longer constructs a Graph client (and therefore no longer needs the network) to decide what
+    /// to pre-warm - see issue #373, which calls this out explicitly.
+    /// </summary>
+    public interface ICopilotMetadataLoaderFactory
+    {
+        /// <summary>
+        /// Authenticate and build a loader. Throwing is a legitimate outcome (no Graph credentials, for
+        /// instance); <see cref="CopilotMetadataPrewarmer"/> owns the best-effort handling of that.
+        /// </summary>
+        Task<ICopilotMetadataLoader> CreateAsync();
+    }
+
+    /// <summary>
+    /// Production <see cref="ICopilotMetadataLoaderFactory"/> - the app-identity Graph client the persistence
+    /// adapter used to build inline.
+    /// </summary>
+    public sealed class GraphCopilotMetadataLoaderFactory : ICopilotMetadataLoaderFactory
+    {
+        private readonly ILogger _logger;
+        private readonly AppConfig _appConfig;
+
+        public GraphCopilotMetadataLoaderFactory(ILogger logger, AppConfig appConfig)
+        {
+            _logger = logger;
+            _appConfig = appConfig;
+        }
+
+        public async Task<ICopilotMetadataLoader> CreateAsync()
+        {
+            var auth = new GraphAppIndentityOAuthContext(_logger, _appConfig.ClientID, _appConfig.TenantGUID.ToString(), _appConfig.ClientSecret, _appConfig.KeyVaultUrl, _appConfig.UseClientCertificate);
+            await auth.InitClientCredential();
+            return new GraphFileMetadataLoader(new GraphServiceClient(auth.Creds), _logger);
+        }
+    }
+
+    /// <summary>
+    /// Owns the run-scoped Copilot metadata loader and the pre-warm pass that fills its Graph caches before
+    /// the save takes the single-permit SQL lock. Lifted out of <c>ActivityReportSqlPersistenceManager</c> by
+    /// issue #373 so both halves can be exercised with no Graph and no SQL Server.
+    ///
+    /// Why the pre-warm exists: the per-event <c>ProcessExtendedProperties</c> pass runs serially inside the
+    /// SQL lock and, for Copilot file events, calls Graph. Resolving those contexts ahead of time - across
+    /// batches and concurrently within a batch - turns the in-lock calls into cache hits, so the lock is held
+    /// for SQL work rather than network round-trips.
+    ///
+    /// One instance per import cycle: the loader is built at most once and its caches (resolved files, users,
+    /// sites and unresolvable contexts) then persist for the whole import instead of being rebuilt per batch.
+    /// </summary>
+    public sealed class CopilotMetadataPrewarmer
+    {
+        /// <summary>
+        /// How many Copilot file contexts to resolve concurrently while pre-warming (outside the SQL lock).
+        /// </summary>
+        public const int PrewarmConcurrency = 8;
+
+        private readonly ICopilotMetadataLoaderFactory _loaderFactory;
+        private readonly ILogger _logger;
+
+        private ICopilotMetadataLoader _sharedCopilotLoader;
+        private bool _sharedCopilotLoaderTried;
+        private readonly SemaphoreSlim _sharedLoaderInitLock = new SemaphoreSlim(1, 1);
+
+        public CopilotMetadataPrewarmer(ICopilotMetadataLoaderFactory loaderFactory, ILogger logger)
+        {
+            if (loaderFactory == null) throw new ArgumentNullException(nameof(loaderFactory));
+            _loaderFactory = loaderFactory;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Get the run-scoped loader and, when <see cref="CopilotPrewarmPolicy.ShouldPrewarm"/> says so,
+        /// pre-resolve this batch's Copilot file contexts into it. Returns the loader (possibly null) for the
+        /// save path to hand to its <c>SaveSession</c>.
+        /// </summary>
+        /// <param name="resolveCopilotResourceMetadata">
+        /// The tenant's <c>ResolveCopilotResourceMetadata</c> setting, read per batch exactly as before. With
+        /// it off the save path makes no Graph resource calls at all, so warming would be pure outbound Graph
+        /// traffic for a cache nothing reads.
+        /// </param>
+        public async Task<ICopilotMetadataLoader> GetLoaderAndPrewarmAsync(IEnumerable<AbstractAuditLogContent> activities, bool resolveCopilotResourceMetadata)
+        {
+            var sharedLoader = await GetSharedLoaderAsync();
+            if (CopilotPrewarmPolicy.ShouldPrewarm(sharedLoader != null, resolveCopilotResourceMetadata))
+            {
+                await PrewarmFileMetadataAsync(activities, sharedLoader);
+            }
+            return sharedLoader;
+        }
+
+        /// <summary>
+        /// Lazily build the run-scoped loader (once). Best-effort: on any failure (e.g. no Graph credentials
+        /// in a test) returns null and callers fall back to the per-session loader. Thread-safe.
+        /// </summary>
+        private async Task<ICopilotMetadataLoader> GetSharedLoaderAsync()
+        {
+            if (_sharedCopilotLoaderTried)
+            {
+                return _sharedCopilotLoader;
+            }
+            await _sharedLoaderInitLock.WaitAsync();
+            try
+            {
+                if (!_sharedCopilotLoaderTried)
+                {
+                    try
+                    {
+                        _sharedCopilotLoader = await _loaderFactory.CreateAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Could not build a run-scoped Copilot metadata loader; falling back to per-batch loaders.");
+                        _sharedCopilotLoader = null;
+                    }
+                    _sharedCopilotLoaderTried = true;
+                }
+            }
+            finally
+            {
+                _sharedLoaderInitLock.Release();
+            }
+            return _sharedCopilotLoader;
+        }
+
+        /// <summary>
+        /// Resolve the file metadata for this batch's Copilot file contexts concurrently, warming the shared
+        /// loader's cache. Errors are swallowed - the authoritative resolution + logging happens in the serial
+        /// ProcessExtendedProperties pass (this only pre-populates the cache).
+        /// </summary>
+        private async Task PrewarmFileMetadataAsync(IEnumerable<AbstractAuditLogContent> activities, ICopilotMetadataLoader loader)
+        {
+            var fileContexts = CopilotPrewarmPolicy.ExtractFileContexts(activities);
+            if (fileContexts.Count == 0) return;
+
+            using (var throttle = new SemaphoreSlim(PrewarmConcurrency))
+            {
+                var tasks = fileContexts.Select(async kvp =>
+                {
+                    await throttle.WaitAsync();
+                    try
+                    {
+                        await loader.GetSpoFileInfo(kvp.Key, kvp.Value);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Copilot metadata prewarm failed for context {ctx} (will retry in the serial pass)", kvp.Key);
+                    }
+                    finally
+                    {
+                        throttle.Release();
+                    }
+                });
+                await Task.WhenAll(tasks);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ICopilotMetadataLoaderFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ICopilotMetadataLoaderFactory.cs
@@ -105,7 +105,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
 
         /// <summary>
         /// Lazily build the run-scoped loader (once). Best-effort: on any failure (e.g. no Graph credentials
-        /// in a test) returns null and callers fall back to the per-session loader. Thread-safe.
+        /// in a test) returns null and callers fall back to the per-session loader. A failure counts as
+        /// "tried", so a broken Graph auth costs one attempt and one warning per cycle rather than per batch.
+        ///
+        /// Concurrent callers are serialised by a single-permit lock; the pre-check outside it is the same
+        /// non-volatile flag read as the pre-#373 code, moved verbatim (see the note on
+        /// <c>ActivityImportCacheProvider</c>).
         /// </summary>
         private async Task<ICopilotMetadataLoader> GetSharedLoaderAsync()
         {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ISaveSessionFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ISaveSessionFactory.cs
@@ -1,0 +1,54 @@
+using ActivityImporter.Engine.ActivityAPI.Copilot;
+using Common.Entities;
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
+{
+    /// <summary>
+    /// Creates the <see cref="SaveSession"/> used by a save batch's metadata pass, replacing the
+    /// <c>new SaveSession(...)</c> + <c>Init()</c> pair that <c>ActivityReportSqlPersistenceManager</c> did
+    /// inline (issue #373).
+    ///
+    /// This is a real seam, not bookkeeping: <c>SaveSession.Init()</c> constructs a
+    /// <c>CopilotAuditEventManager</c> and a <c>PowerPlatformAuditEventManager</c> from the configured
+    /// connection string and - when no shared loader is supplied - authenticates a Graph client. Putting it
+    /// behind a port is what lets a later change substitute the metadata pass's collaborators.
+    /// </summary>
+    public interface ISaveSessionFactory
+    {
+        /// <summary>
+        /// Build and initialise a session bound to <paramref name="db"/>.
+        /// </summary>
+        /// <param name="sharedCopilotLoader">
+        /// The run-scoped Copilot metadata loader, so per-event Graph resolution hits the cache warmed
+        /// outside the SQL lock. Null makes the session build its own (the original behaviour).
+        /// </param>
+        Task<SaveSession> CreateAsync(AnalyticsEntitiesContext db, ICopilotMetadataLoader sharedCopilotLoader);
+    }
+
+    /// <summary>
+    /// Production <see cref="ISaveSessionFactory"/>.
+    /// </summary>
+    public sealed class SaveSessionFactory : ISaveSessionFactory
+    {
+        private readonly ILogger _logger;
+        private readonly AppConfig _appConfig;
+
+        public SaveSessionFactory(ILogger logger, AppConfig appConfig)
+        {
+            _logger = logger;
+            _appConfig = appConfig;
+        }
+
+        public async Task<SaveSession> CreateAsync(AnalyticsEntitiesContext db, ICopilotMetadataLoader sharedCopilotLoader)
+        {
+            // Deliberately not disposed here or by the caller: SaveSession.Dispose() disposes the EF context,
+            // which the save path owns and disposes itself. That is the pre-#373 behaviour.
+            var saveSession = new SaveSession(_logger, db, _appConfig, sharedCopilotLoader);
+            await saveSession.Init();
+            return saveSession;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -79,6 +79,11 @@
     <Compile Include="ActivityAPI\Copilot\SpoGraphClient.cs" />
     <Compile Include="ActivityAPI\Copilot\Models.cs" />
     <Compile Include="ActivityAPI\Copilot\StagingClasses.cs" />
+    <Compile Include="ActivityAPI\Persistence\ActivityStagingPass.cs" />
+    <Compile Include="ActivityAPI\Persistence\IActivityImportCacheProvider.cs" />
+    <Compile Include="ActivityAPI\Persistence\IActivityStagingWriter.cs" />
+    <Compile Include="ActivityAPI\Persistence\ICopilotMetadataLoaderFactory.cs" />
+    <Compile Include="ActivityAPI\Persistence\ISaveSessionFactory.cs" />
     <Compile Include="ActivityAPI\Rules\ActivityImportCacheWindow.cs" />
     <Compile Include="ActivityAPI\Rules\ActivitySaveConcurrencyPolicy.cs" />
     <Compile Include="ActivityAPI\Rules\ActivityStagingRules.cs" />


### PR DESCRIPTION
Addresses #373 (part 2 of 2). Part of #381.

Part 1 (#396) lifted the pure rules out of `ActivityReportSqlPersistenceManager`. This is **part 2: the collaborator split**, so the adapter's remaining jobs each sit behind a seam that can be exercised without SQL Server or Graph.

**Behaviour is identical.** No change to the SQL, the staging schema, the merge script, the concurrency design, the log text, or the numbers inside it. No schema change, no migration, no index change. `InsertBatch<T>` keeps its row-by-row implementation - it is only reached through a port now.

## The two operator safety-valves

`#373` says this class carries two, and both keep working and are now assertable:

| Valve | App setting | Where it lives now | Test |
|---|---|---|---|
| Per-batch de-dup cache | `AUDIT_PERBATCH_DEDUP_CACHE` | `ActivityImportCacheProvider` | `ImportCache_PerBatchSafetyValve_RebuildsForEveryBatchOverThatBatchsOwnSpan` |
| Concurrent saves | `AUDIT_MAX_CONCURRENT_SAVES` | `ActivitySaveConcurrencyPolicy` (part 1) + `ActivityStagingPass` | `SavePipeline_SerialMode_...` / `SavePipeline_ShardedMode_PointsTheMergeAtTheShardAndHandsDownTheSharedWriteLock` |

## What moved

All new files under `WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/`.

| Was (in the manager) | Is now |
|---|---|
| `ActivityImportCache.GetAndBuildNewCache(...)` (static, `new AnalyticsEntitiesContext()`) | `IActivityImportCacheLoader` + `SqlActivityImportCacheLoader` |
| `GetOrBuildRunImportCacheAsync` + the per-batch/per-run ternary in `CommitAll` | `IActivityImportCacheProvider` + `ActivityImportCacheProvider` |
| `new EFInsertBatch<AuditLogTempEntity>(db, _logger)` + `SaveToStagingTable(...)` | `IActivityStagingWriter` / `IActivityStagingBatch` + `SqlActivityStagingWriter` / `SqlActivityStagingBatch` (internal) |
| `GetSharedCopilotLoaderAsync` (built a `GraphServiceClient` inline) + `PrewarmCopilotFileMetadataAsync` | `ICopilotMetadataLoaderFactory` + `GraphCopilotMetadataLoaderFactory`, and `CopilotMetadataPrewarmer` |
| `new SaveSession(_logger, db, _appConfig, loader)` + `await Init()` | `ISaveSessionFactory` + `SaveSessionFactory` |
| The per-event dedup/scope/stage loop and the staging load + merge inside `SaveToSqlAllTheThings` | `ActivityStagingPass` |

`ActivityStagingPass` is the piece that makes the rest testable: it reaches SQL **only** through `IActivityStagingBatch`, so a batch's `ImportStat` counters, its operator log line, its phase timings and its merge wiring can all be asserted with no database. It is stateless between calls (everything is per-`RunAsync`), so one instance is shared by every batch of a cycle, including concurrent ones.

### Deliberate deviation from #373's proposed interface shape

#373 proposed `IActivityStagingWriter` as three methods - `CreateStagingTableAsync` / `LoadAsync` / `MergeAsync`. It is one method here (`LoadAndMergeAsync`), because of how `InsertBatch.SaveToStagingTable` is built: it opens one connection, creates the staging table on it, fans the row inserts out over a **separate `SqlConnection` per chunk**, then runs the merge back on the original - holding that original connection open throughout. That held-open connection is what keeps the staging table alive and visible to the chunk connections and the merge (in Release the default table is the `##` global temp table; in Debug it is the permanent `debug_import_staging_event_lookups`). Three port calls would either break that lifetime or force the port to hold connection state across calls. Collapsing them keeps the existing SQL byte-identical.

Also, `ActivityDedupPolicy` from the issue's sketch is not added: its two proposed members already exist as `ActivityStagingRules.IsAlreadyProcessed` and `AuditFilterConfig.InScope`, both from part 1.

## Wiring

Both existing public constructors are kept as **delegating overloads** - no call site changes (`ProgramTasks.cs`, `ActivityImporterTests`, `ActivityApiDbStressRunner`, `Tests.UnitTests/Program.cs`). The new collaborator constructor is `internal` because `IActivityStagingWriter` carries the internal `AuditLogTempEntity`.

A `null` collaborator on that constructor means "build the production adapter", constructed in the body rather than in a chained initialiser. To be accurate about what that buys: it changes **nothing** today - none of the production adapters validates or dereferences what it is handed, so a null `appConfig` reaches `new UserGroupsFilterModel(appConfig.UserGroupsFilter)` and raises the same `NullReferenceException` either way. It is deliberate ordering-insurance, so that adding a guard to one of those adapters later cannot silently change which exception an existing caller sees. Happy to swap it for required parameters if reviewers prefer.

Consistent with that, `ActivityStagingPass`'s constructor deliberately has **no** null guards: the manager did not validate `filterConfig` / `userGroupsCache` either, and it dereferences them mid-save. An `ArgumentNullException` at construction where there used to be a `NullReferenceException` mid-save is an operator-visible change, not an extraction.

## Tests - 17 new, zero SQL Server / Graph / Redis / Service Bus

**`ActivityImportCacheProviderTests`** (4)
- `ImportCache_PerRunScope_IsBuiltOnceAndReusedByEveryBatch` - one load per cycle, same instance to every batch, over the whole download window rather than the batch span.
- `ImportCache_PerBatchSafetyValve_RebuildsForEveryBatchOverThatBatchsOwnSpan` - the valve reloads per batch **and** uses each batch's own `[oldest, newest]`.
- `ImportCache_ConcurrentFirstUse_StillBuildsOnlyOnce` - 8 concurrent first callers, one load.
- `ImportCache_PerRunBuild_LogsTheIdCountAndWindowOnce` - the operator-facing "built run dedup cache" line, its `ProcessedIdCount` and its `N-day window`, logged once per cycle.

**`CopilotMetadataPrewarmerTests`** (6)
- `Prewarm_CopilotResourceResolutionDisabled_MakesNoGraphFileLookups` - a tenant that opted out must generate **zero** outbound Copilot file lookups (the loader is still returned, because `SaveSession` gets it either way).
- `Prewarm_CopilotResourceResolutionEnabled_ResolvesEachDistinctContextOnceWithItsOwnUpn` - one round-trip per distinct context, keyed with the first claiming event's UPN, and non-Copilot events cost nothing.
- `Prewarm_LoaderFactoryFails_ReturnsNullAndWarnsAndSkipsThePrewarm` - degrades to null with the exact warning, exception included.
- `Prewarm_LoaderIsBuiltAtMostOncePerCycle_EvenWhenTheFactoryFailed` - a **failed** Graph auth is not retried (nor re-warned) on the next batch.
- `Prewarm_OneContextFailingInGraph_DoesNotStopTheOthers` - swallowed at Debug; no Error/Warning.
- `Prewarm_FanOutIsThrottled_ButStillConcurrent` - peak concurrency `> 1` **and** `<= 8` (the literal cap, deliberately not `PrewarmConcurrency`, so raising that constant cannot pass silently).

**`ActivitySavePipelineTests`** (7)
- `SavePipeline_EachOutcomeIsStagedAndCountedCorrectly` - `Total` / `Imported` / `UsersOutOfScope` / `URLsOutOfScope`, only the qualifying event staged and handed to the metadata pass. It also pins that a de-duplicated event increments **nothing** (`ProcessedAlready` stays 0) - long-standing behaviour, see the note below.
- `SavePipeline_UserOutsideGroupsFilter_LogsTheOperatorLineNamingTheUser` - exact message text.
- `SavePipeline_SerialMode_MergesTheSharedStagingTableWithNoMergeLock` - no table override (so `InsertBatch` uses `[TempTableName]`), no merge lock, `10000` inserts per thread, every `${STAGING_TABLE_ACTIVITY}` substituted.
- `SavePipeline_ShardedMode_PointsTheMergeAtTheShardAndHandsDownTheSharedWriteLock` - the merge reads this save's shard, not the shared table, and gets the same `SemaphoreSlim` instance.
- `SavePipeline_StagingRowCarriesTheEventsOwnUserAndUrlUnchanged` - the row's `user_name` is the event's own UPN, and a Greek SharePoint URL reaches SQL unchanged.
- `SavePipeline_SlowScopeCheck_IsChargedToTheDedupPhaseNotTheMerge` / `SavePipeline_SlowMerge_IsChargedToTheMergePhaseNotTheDedup` - a **crossed pair**, so swapping the two phase timings fails both. A single "is a timing recorded?" test would not.

New fakes in `Tests.UnitTests/FakeLoaderClasses/FakeActivityPersistencePorts.cs`: `InMemoryActivityStagingWriter` / `InMemoryActivityStagingBatch`, `FakeActivityImportCacheLoader`, `FakeCopilotMetadataLoaderFactory`, `RecordingCopilotMetadataLoader`, `PredicateAuditFilterConfig`, `RecordingLogger`. Failure fakes fault their `Task` rather than throwing synchronously, so a dropped `await` cannot hide behind the caller's `catch`.

## Verification

- Full solution builds clean in Debug, no new warnings.
- **74 / 74 pass** across the 17 new tests plus the pre-existing tests for this area: `ActivityImporterTests`, `AuditImportFailureHandlingTests`, `AuditTests`, `ActivityStagingRulesTests`, `ActivitySaveConcurrencyPolicyTests`, `ActivityImportCacheWindowTests`, `CopilotPrewarmExtractionTests`, `ActivityReportSetMinMaxTests`, `ActivityReportLoaderTimeoutTests`. The DB-backed `ActivityImporterTests` drive the **real** manager through full saves against LocalDB, with both real and generated audit data - that is the behaviour-identical evidence. To be precise about what that does and does not cover: every real-manager construction in that class uses the four-argument overload, so `maxConcurrentSaves` is `1` and only the **serial** save path is exercised end-to-end against SQL. The sharded/concurrent path is covered by `AuditImportFailureHandlingTests.ConcurrentSaveMode_...` (real orchestration, fake persistence manager), by `ActivitySaveConcurrencyPolicyTests`, and by the new `SavePipeline_ShardedMode_...`; the real-manager concurrent case is the separately gated stress harness, which is not in this 74-test set. Re-run after rebasing onto the current `dev`.
- **Every one of the 17 new tests was mutation-checked.** Over six rounds the production line each test claims to cover was broken on purpose, and in each round *exactly* the predicted set of tests failed and no others: `&& false` on the per-batch branch; the cache init lock removed; the build-once flag removed; `ShouldPrewarm(..., true)`; `_sharedCopilotLoaderTried = false`; `SemaphoreSlim(1)` and then `SemaphoreSlim(int.MaxValue)` instead of `PrewarmConcurrency`; both `try/catch`es defeated; `GetSpoFileInfo` arguments swapped; `EffectiveStagingTableName(null)`; the effective name passed as the override; the two phase timings swapped; `URLsOutOfScope++` -> `UsersOutOfScope++`; a hard-coded UPN on the staging row; and the skip message reworded. The two tests hardened during review were re-checked afterwards and now fail more decisively than before (removing the cache init lock yields `LoadCount == 8`, not merely `> 1`; an unbounded prewarm yields peak concurrency 24 against the literal cap of 8).

Two tests were tightened as a result of that exercise: one asserted `LastInsertsPerThread` against the very constant that produces it (so changing the constant could not fail it - now a literal `10000`), and a `MakesNoGraphCalls` test was too weak to fail on any realistic break, so it was folded into the dedup test as an extra non-Copilot event rather than kept as its own case.

## Performance at 200k-user scale

No new per-event work and no new per-event allocation. The hoisted `urlInScope` / `userInGroupsFilter` / `stageRow` delegates are still built once per batch, not per event; the staged rows are still added to one list owned by `InsertBatch`, with no intermediate copy; the events handed to the metadata pass are still the same `ConcurrentBag`, so its enumeration order is unchanged. Per save batch the split adds one `IActivityStagingBatch` wrapper object; `ActivityStagingPass`, `ActivityImportCacheProvider`, `CopilotMetadataPrewarmer` and `SaveSessionFactory` are each built once per manager (i.e. once per import cycle).

## Reviewer hotspots

1. **`ActivityStagingPass.RunAsync` vs the old `SaveToSqlAllTheThings`** - the biggest move. Worth reading as a literal diff: the statement order, the `#if DEBUG` line, the stopwatch boundaries and the `if/else if` counter chain are intended to be unchanged.
2. **The `null`-means-production collaborator constructor** - see the reasoning above; happy to change it if the ordering argument does not hold up.
3. **`ISaveSessionFactory` has no DB-free test.** It is honest to say so: the metadata pass still needs a real `AnalyticsEntitiesContext` (`db.AuditEventsCommon` / `db.sharepoint_events`) and `ProcessExtendedProperties` takes the concrete `SaveSession`, so making that pass DB-free is a part-3 change, not this one. The factory is covered by the DB-backed `ActivityImporterTests`.
4. **The double-checked init in `ActivityImportCacheProvider` / `CopilotMetadataPrewarmer`** pre-checks a non-volatile `bool` outside the lock, then returns a separately-published reference. This is the pre-#373 code moved verbatim, so it is not a regression, and I left it alone rather than widen a pure-move PR. Reviewers split on how to describe it: x86/x64 hardware does not reorder store/store or load/load, but the JIT is an independent reordering agent and an ordinary read is not an acquire - so the doc comments now call it implementation behaviour rather than a guarantee, which is the conservative reading. **Say the word and I will add `Volatile.Read`/`Volatile.Write`**, here or in a follow-up.
5. **`CommitAllToSQL` still opens a real `SqlConnection`**, so `CommitAll` itself is not DB-free either. Deliberately left alone - abstracting connection creation is a bigger blast radius than this PR should carry.

## Out of scope, noted while reading

`ImportStat.AddStats` accumulates every counter **except** `UsersOutOfScope`, while `ImportStat.ToString()` prints it - so the per-cycle summary always reports `users out of scope: 0` no matter how many events the groups filter excluded. Pre-existing (it predates part 1) and **not** fixed here, because it changes an operator-facing number, which #381 forbids in this PR. Filed as #418.

## Review

Three `code-review` agents (claude-opus-4.8, gpt-5.6-sol, grok-4.6) ran two rounds against this branch. **No reviewer found a production defect in either round** - all three independently concluded the extraction is behaviour-identical. Every finding was an inaccurate claim or a test-strength issue, and each was verified against the source before being acted on:

**Round 1** - `SavedToSql` doc claimed insertion order (`ConcurrentBag` gives none) and that its events reached SQL (`InsertBatch` skips over-width rows); the constructor rationale claimed an exception change that does not happen today; two `Thread-safe` docs were unqualified; `Prewarm_FanOutIsThrottled` asserted against the same constant that sizes the semaphore; `ImportCache_ConcurrentFirstUse` used `Task.Run` and could be staggered by ThreadPool thread injection; and this PR body overstated concurrent coverage.

**Round 2** - the reworded memory-model claim was still stronger than the CLR guarantees; "`ActivityImportCache` is internally locked" was true only of its de-dup members; "none of the adapters validates what it is handed" was false for two of them; "rows the merge created" ignored that a concurrent batch's metadata pass can match a row the *other* merge inserted; the one-connection staging rationale did not match `InsertBatch` (chunk loads use their own connections); and round 1's raw-`Thread` racer test could terminate the test host on an unhandled exception. All fixed in `6abb733`.

Two remaining nits at the end of round 2 were PR-body staleness, corrected above.