### PR TITLE
Correct five over-broad claims from #417 and make its racer test host-safe (#373 follow-up)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
@@ -88,40 +88,39 @@ namespace Tests.UnitTests
             // exists. Without the init lock each of them would run the (expensive, whole-window)
             // audit_events query.
             //
-            // Dedicated threads plus a Barrier rather than Task.Run: the ThreadPool injects threads slowly
-            // once its minimum is exhausted, so pool-scheduled racers can end up arriving hundreds of
-            // milliseconds apart and never actually race. The barrier releases all eight at the same
-            // instant, and the first load then holds them for 250ms.
+            // LongRunning tasks plus a Barrier rather than plain Task.Run: the ThreadPool injects threads
+            // slowly once its minimum is exhausted, so pool-scheduled racers can arrive hundreds of
+            // milliseconds apart and never actually race. LongRunning gives each racer a dedicated thread
+            // while still surfacing its exceptions through the returned Task - a raw Thread would let an
+            // unhandled exception tear down the whole test host.
             const int racerCount = 8;
             var loader = new FakeActivityImportCacheLoader { LoadDuration = TimeSpan.FromMilliseconds(250) };
             var provider = new ActivityImportCacheProvider(loader, new RecordingLogger());
             var window = PerRunWindow();
 
-            var caches = new ActivityImportCache[racerCount];
-            var threads = new Thread[racerCount];
-            using (var startLine = new Barrier(racerCount))
-            {
-                for (int i = 0; i < racerCount; i++)
-                {
-                    var index = i;
-                    threads[i] = new Thread(() =>
+            var startLine = new Barrier(racerCount);
+            var racers = Enumerable.Range(0, racerCount)
+                .Select(_ => Task.Factory.StartNew(
+                    () =>
                     {
                         startLine.SignalAndWait();
-                        caches[index] = provider.GetForWindowAsync(window).GetAwaiter().GetResult();
-                    })
-                    { IsBackground = true };
-                    threads[i].Start();
-                }
+                        return provider.GetForWindowAsync(window).GetAwaiter().GetResult();
+                    },
+                    CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default))
+                .ToArray();
 
-                foreach (var thread in threads)
-                {
-                    Assert.IsTrue(thread.Join(TimeSpan.FromSeconds(30)), "A racer did not finish - the init lock may be deadlocked.");
-                }
-            }
+            var allRacers = Task.WhenAll(racers);
+            var finished = await Task.WhenAny(allRacers, Task.Delay(TimeSpan.FromSeconds(30)));
+            // Deliberately no using/finally on the barrier: if a racer is stuck, disposing it out from
+            // under that thread would raise ObjectDisposedException on a thread with no handler. Leaking a
+            // Barrier in an already-failing test is the cheaper outcome.
+            Assert.AreSame(allRacers, finished, "A racer did not finish - the init lock may be deadlocked.");
+
+            var caches = await allRacers;
+            startLine.Dispose();
 
             Assert.AreEqual(1, loader.LoadCount, "Concurrent first callers must not each build the cache.");
             Assert.IsTrue(caches.All(c => c != null && ReferenceEquals(c, caches[0])), "All concurrent callers must get the same cache instance.");
-            await Task.CompletedTask;
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -94,10 +94,11 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// than in a chained constructor initialiser. That is deliberate ordering-insurance: a chained
         /// <c>: this(new SqlThing(appConfig...), ...)</c> evaluates the adapter's constructor <i>before</i>
         /// this body's <c>new UserGroupsFilterModel(appConfig.UserGroupsFilter)</c>. It makes no difference
-        /// today - none of the production adapters below validates or dereferences what it is handed, so a
-        /// null <c>appConfig</c> still raises the same <see cref="NullReferenceException"/> at the same
-        /// point either way - but it means adding a guard to one of those adapters later cannot silently
-        /// change which exception an existing caller sees.
+        /// today - neither adapter that is handed <c>appConfig</c> (<see cref="GraphCopilotMetadataLoaderFactory"/>
+        /// and <see cref="SaveSessionFactory"/>) validates or dereferences it in its constructor, so a null
+        /// <c>appConfig</c> still raises the same <see cref="NullReferenceException"/> at the same point
+        /// either way - but it means adding such a guard later cannot silently change which exception an
+        /// existing caller sees.
         /// </summary>
         internal ActivityReportSqlPersistenceManager(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache, ILogger logger, AppConfig appConfig,
             int maxConcurrentSaves, bool usePerBatchDedupCache, IClock clock,

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
@@ -14,7 +14,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
 {
     /// <summary>
     /// What one staging pass produced: the statistics for the batch and the events it handed to the
-    /// staging batch, which the metadata pass then tries to match against the rows the merge created.
+    /// staging batch, which the metadata pass then tries to match against the rows present in
+    /// <c>audit_events</c> after the merge.
     /// </summary>
     internal sealed class ActivityStagingPassResult
     {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityImportCacheProvider.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityImportCacheProvider.cs
@@ -104,13 +104,21 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
         /// cache is keyed by event id, so a single full-window load is equivalent to the old per-batch
         /// [Min,Max] loads - without the massive redundancy.
         ///
-        /// Concurrent callers are serialised by a single-permit lock, so the load happens once and a failed
-        /// load leaves the flag clear so the next batch retries. The pre-check outside the lock is an
-        /// ordinary (non-volatile) read of <c>_runImportCacheBuilt</c>, and the reference is published before
-        /// the flag is set - this is the pre-#373 code moved verbatim, and it is safe under the .NET
-        /// Framework memory model on the x86/x64 platforms this runs on, where stores are not reordered with
-        /// stores nor loads with loads. <see cref="ActivityImportCache"/> is itself internally locked, so the
-        /// shared cache is safe once handed out.
+        /// Concurrent callers are serialised by a single-permit lock, so the load happens once, and a load
+        /// that throws leaves the flag clear so the next batch retries.
+        ///
+        /// The pre-check outside the lock is an ordinary (non-volatile) read of <c>_runImportCacheBuilt</c>,
+        /// with the reference published before the flag is set. That is the pre-#373 code moved verbatim and
+        /// it has always worked on the deployed runtime (.NET Framework on x86/x64), but it relies on
+        /// implementation behaviour rather than a guarantee the ECMA memory model makes - an ordinary read
+        /// is not an acquire. Making it a formal guarantee means <c>Volatile.Read</c>/<c>Volatile.Write</c>,
+        /// which is a change to inherited code and therefore out of scope for this extraction. A caller that
+        /// lost the race simply takes the lock and re-checks.
+        ///
+        /// Note <see cref="ActivityImportCache"/> locks the de-duplication members this path uses
+        /// (<c>HaveSeenInProcessedOrIgnoredEvents</c>, <c>RememberProcessedEvent</c>,
+        /// <c>RememberNewlyIgnoredEvent</c>, <c>ProcessedIdCount</c>) - not every member on it - which is what
+        /// makes sharing one cache across concurrent batches safe here.
         ///
         /// Once built, later calls return the same cache and their window argument is ignored.
         /// </summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityStagingWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityStagingWriter.cs
@@ -16,6 +16,14 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
     /// <c>EFInsertBatch&lt;AuditLogTempEntity&gt;</c>, and <c>InsertBatch&lt;T&gt;</c> keeps its row-by-row
     /// implementation per project convention.
     ///
+    /// Why one <c>LoadAndMergeAsync</c> rather than #373's proposed separate create / load / merge calls:
+    /// <c>InsertBatch.SaveToStagingTable</c> opens one connection, creates the staging table on it, fans the
+    /// row inserts out over separate per-chunk connections, then runs the merge back on the original - and
+    /// holds that original connection open throughout, which is what keeps the (Release-configuration)
+    /// <c>##</c> global temp table alive and visible to the chunk connections and to the merge. Splitting
+    /// that across three port calls would break the table's lifetime or force the port to hold connection
+    /// state.
+    ///
     /// Internal because <see cref="AuditLogTempEntity"/> is internal;
     /// <c>InternalsVisibleTo("Tests.UnitTests")</c> makes it reachable from the test project.
     /// </summary>
@@ -23,8 +31,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
     {
         /// <summary>
         /// Start one save batch. Created per save (not per manager) because the underlying
-        /// <c>InsertBatch</c> is bound to the context/connection this save runs on and owns that save's row
-        /// list.
+        /// <c>InsertBatch</c> takes its connection string from the context this save runs on and owns that
+        /// save's row list.
         /// </summary>
         IActivityStagingBatch CreateBatch(AnalyticsEntitiesContext db);
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ICopilotMetadataLoaderFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ICopilotMetadataLoaderFactory.cs
@@ -109,8 +109,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
         /// "tried", so a broken Graph auth costs one attempt and one warning per cycle rather than per batch.
         ///
         /// Concurrent callers are serialised by a single-permit lock; the pre-check outside it is the same
-        /// non-volatile flag read as the pre-#373 code, moved verbatim (see the note on
-        /// <c>ActivityImportCacheProvider</c>).
+        /// ordinary (non-volatile) flag read as the pre-#373 code, moved verbatim - see the note on
+        /// <c>ActivityImportCacheProvider</c> for why that is left as-is rather than made a formal guarantee.
         /// </summary>
         private async Task<ICopilotMetadataLoader> GetSharedLoaderAsync()
         {


### PR DESCRIPTION
Addresses #373. Follow-up to #417 (part 2 of 2), which merged while round 2 of its multi-model review loop was still running — these fixes did not make it into that merge.

**No production behaviour change.** Every item here is an inaccurate doc claim or a robustness flaw in a test that #417's own round-1 fixes introduced. Each was verified against the source before being acted on.

## Where this came from

Three `code-review` agents (claude-opus-4.8, gpt-5.6-sol, grok-4.6) ran two rounds against #417. **Neither round found a production defect** — all three independently concluded the extraction is behaviour-identical. Round 1's findings landed in #417 as `fb21fd4`. Round 2's are here.

## Doc claims narrowed

| Claim as merged | Why it is wrong | Now says |
|---|---|---|
| The double-checked init is "safe under the .NET Framework memory model on the x86/x64 platforms this runs on" | x86/x64 hardware does not reorder store/store or load/load, but the **JIT is an independent reordering agent** and an ordinary read is not an acquire. That is implementation behaviour, not a guarantee. | Implementation behaviour on the deployed runtime, with the reason the fix is out of scope |
| "`ActivityImportCache` is itself internally locked" | Only partly. `HaveSeenInProcessedOrIgnoredEvents`, `RememberProcessedEvent`, `RememberNewlyIgnoredEvent`, `ProcessedIdCount` and `AddProcessedID` take the lock; **`GetIds`, `OrgUrlCache` and `AnonymisedUserNameCache` do not.** | Names the de-dup members this path actually uses |
| "none of the production adapters below validates or dereferences what it is handed" | False for two of them: `ActivityImportCacheProvider` guards its loader and `CopilotMetadataPrewarmer` guards its factory. | The narrower claim the argument actually needs — neither adapter handed `appConfig` validates or dereferences `appConfig` — naming both |
| The metadata pass matches "the rows the merge created" | Two concurrent batches can both stage an id the other has not yet remembered; the merge's `NOT EXISTS` means the second batch's metadata pass matches a row the **first** merge inserted. | "rows present in `audit_events` after the merge" |
| `IActivityStagingWriter`: the batch is "bound to the context/connection" | `EFInsertBatch` keeps the context's connection **string**, and `InsertBatch` fans the row inserts out over a **separate `SqlConnection` per chunk** while holding the creating connection open. | Describes it accurately — and it is a *stronger* argument for collapsing #373's proposed three port methods into one, since it is that held-open connection which keeps the (Release-configuration) `##` global temp table alive for the chunk connections and the merge |

Reviewers disagreed on the first row: claude-opus-4.8 and grok-4.6 both judged the merged wording accurate; gpt-5.6-sol did not. The wording here is the conservative reading. **The code is deliberately unchanged** — the double-checked pattern is inherited verbatim from before #373, so it is not a regression, and #381 scopes that work to a pure move. If you would rather have `Volatile.Read`/`Volatile.Write`, say so and it is a two-line change; it is a formal-correctness improvement, not a bug fix.

## Test robustness

`ImportCache_ConcurrentFirstUse_StillBuildsOnlyOnce` was changed in #417's round 1 to run its eight racers on raw background `Thread`s, to escape ThreadPool thread injection staggering them so far apart they never actually race. That fix introduced two problems of its own:

- an **unhandled exception on a raw background thread terminates the test host** on .NET Framework, and the delegate had no capture;
- on the `Join`-timeout path the `using` block **disposed the `Barrier` while racers could still be inside `SignalAndWait`**, which is precisely the failure the timeout exists to diagnose.

Now uses `Task.Factory.StartNew(..., TaskCreationOptions.LongRunning)` — still a dedicated thread each, so the anti-starvation property is kept — and awaits `Task.WhenAny(all, 30s)`, which surfaces racer exceptions through the returned `Task`. The `Barrier` is only disposed on the healthy path; leaking one in an already-failing test is cheaper than tearing down the host.

## Verification

- Full solution builds clean in Debug on the current `dev`, no new warnings.
- **74/74 pass** across the same set #417 used: the 17 tests from that PR plus `ActivityImporterTests`, `AuditImportFailureHandlingTests`, `AuditTests`, `ActivityStagingRulesTests`, `ActivitySaveConcurrencyPolicyTests`, `ActivityImportCacheWindowTests`, `CopilotPrewarmExtractionTests`, `ActivityReportSetMinMaxTests`, `ActivityReportLoaderTimeoutTests`.
- The rewritten racer test was **re-mutation-checked**: removing the cache init lock still fails it, and now with `LoadCount == 8` rather than merely `> 1`.

## Reviewer note

The only judgement call worth a second opinion is the memory-model one above — whether to leave the inherited non-volatile fast path alone (as here) or add `Volatile.Read`/`Volatile.Write` now.
