### PR TITLE
Fix three doc comments that describe the previous implementation (#373 review rounds 3-5)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
@@ -111,9 +111,10 @@ namespace Tests.UnitTests
 
             var allRacers = Task.WhenAll(racers);
             var finished = await Task.WhenAny(allRacers, Task.Delay(TimeSpan.FromSeconds(30)));
-            // Deliberately no using/finally on the barrier: if a racer is stuck, disposing it out from
-            // under that thread would raise ObjectDisposedException on a thread with no handler. Leaking a
-            // Barrier in an already-failing test is the cheaper outcome.
+            // Deliberately no using/finally on the barrier: on the timeout path a racer may still be sitting
+            // in SignalAndWait, and disposing it out from under that racer would fault its task with
+            // ObjectDisposedException - a fault nothing observes, because the timed-out racers are never
+            // awaited. Leaking a Barrier in an already-failing test is the simpler correct outcome.
             Assert.AreSame(allRacers, finished, "A racer did not finish - the init lock may be deadlocked.");
 
             var caches = await allRacers;

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImportCacheProviderTests.cs
@@ -111,10 +111,9 @@ namespace Tests.UnitTests
 
             var allRacers = Task.WhenAll(racers);
             var finished = await Task.WhenAny(allRacers, Task.Delay(TimeSpan.FromSeconds(30)));
-            // Deliberately no using/finally on the barrier: on the timeout path a racer may still be sitting
-            // in SignalAndWait, and disposing it out from under that racer would fault its task with
-            // ObjectDisposedException - a fault nothing observes, because the timed-out racers are never
-            // awaited. Leaking a Barrier in an already-failing test is the simpler correct outcome.
+            // Deliberately no using/finally on the barrier: Barrier.Dispose is not safe against a concurrent
+            // SignalAndWait, and on the timeout path a racer may still be sitting in one. Leaving it to the
+            // GC on an already-failing path is simpler than reasoning about what happens if we don't.
             Assert.AreSame(allRacers, finished, "A racer did not finish - the init lock may be deadlocked.");
 
             var caches = await allRacers;

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotMetadataPrewarmerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotMetadataPrewarmerTests.cs
@@ -21,7 +21,8 @@ namespace Tests.UnitTests
     /// CopilotPrewarmExtractionTests already covers which contexts are extracted and the
     /// <see cref="WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules.CopilotPrewarmPolicy.ShouldPrewarm"/>
     /// predicate in isolation. What could not be observed before, and is covered here, is the behaviour
-    /// around them: that a disabled tenant really makes no outbound call, that a Graph auth failure is
+    /// around them: that a disabled tenant really makes no outbound Copilot file lookup (it still builds the
+    /// loader, which authenticates - the pre-warm is what is skipped), that a Graph auth failure is
     /// survivable and not retried per batch, and that the fan-out stays throttled.
     /// </summary>
     [TestClass]

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotMetadataPrewarmerTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotMetadataPrewarmerTests.cs
@@ -22,8 +22,8 @@ namespace Tests.UnitTests
     /// <see cref="WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules.CopilotPrewarmPolicy.ShouldPrewarm"/>
     /// predicate in isolation. What could not be observed before, and is covered here, is the behaviour
     /// around them: that a disabled tenant really makes no outbound Copilot file lookup (it still builds the
-    /// loader, which authenticates - the pre-warm is what is skipped), that a Graph auth failure is
-    /// survivable and not retried per batch, and that the fan-out stays throttled.
+    /// loader; the pre-warm is what is skipped), that a Graph auth failure is survivable and not retried per
+    /// batch, and that the fan-out stays throttled.
     /// </summary>
     [TestClass]
     public class CopilotMetadataPrewarmerTests

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityStagingWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/IActivityStagingWriter.cs
@@ -63,8 +63,9 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
     }
 
     /// <summary>
-    /// Production <see cref="IActivityStagingWriter"/>: an <c>EFInsertBatch</c> bound to the save's own EF
-    /// context, which is exactly what <c>ActivityReportSqlPersistenceManager</c> built inline before #373.
+    /// Production <see cref="IActivityStagingWriter"/>: an <c>EFInsertBatch</c> constructed from the save
+    /// context's connection string, which is exactly what <c>ActivityReportSqlPersistenceManager</c> built
+    /// inline before #373.
     /// </summary>
     internal sealed class SqlActivityStagingWriter : IActivityStagingWriter
     {


### PR DESCRIPTION
Addresses #373. Third and final follow-up to #417 / #419, closing the multi-model review loop.

**Comment-only. No production behaviour change, no test behaviour change.** Three statements that the earlier review rounds' own fixes left behind, each now factually wrong in `dev`. (It started as two; rounds 4 and 5 of the review loop found the third, and then found that my first correction of it was itself too broad — see the bottom of this description.)

## What is wrong today

**1. `SqlActivityStagingWriter`'s class summary says the batch is "bound to the save's own EF context".**

`EFInsertBatch` extracts `context.Database.Connection.ConnectionString` in its constructor and keeps no reference to the context or its connection; `InsertBatch.SaveToStagingTable` then opens its own creator connection plus one `SqlConnection` per insert chunk. #419 corrected the interface doc and `CreateBatch` but missed this third occurrence, so `dev` currently states the opposite of what the code does — and that statement is load-bearing, because it is the justification for collapsing #373's proposed three-method staging port into one. Found by gpt-5.6-sol in round 3.

**2. The racer test's comment explains a hazard that no longer exists.**

`ImportCache_ConcurrentFirstUse_StillBuildsOnlyOnce` deliberately does not dispose its `Barrier` on the timeout path. The comment justifies that with "would raise `ObjectDisposedException` on a thread with no handler" — true of #417's round-1 design, which ran the racers on raw background `Thread`s where an unhandled exception tears down the test host on .NET Framework. #419 moved them onto `LongRunning` tasks, so that reason no longer describes the implementation. The decision to leak the `Barrier` is still correct, but for a simpler reason that does not depend on TPL exception semantics at all: **`Barrier.Dispose` is not safe against a concurrent `SignalAndWait`**, and on the timeout path a racer may still be in one. The comment now says only that. Found by claude-opus-4.8 in round 3; its replacement wording was corrected again by gpt-5.6-sol in round 4.

## Round 3 was otherwise clean

Three `code-review` agents — claude-opus-4.8, gpt-5.6-sol, grok-4.6 — ran a third round against #419. Beyond the statements above:

- **No production regression introduced by the #373 extraction**, across three rounds and three models — all three independently concluded it is behaviour-identical. To state that precisely rather than flatteringly: gpt-5.6-sol did identify the inherited double-checked initialisation (see below) as a *formal* production race. It is pre-#373 code, it is not introduced here, and it did not block these follow-ups — but "no production defect anywhere" would be the wrong summary of its position.
- The five doc passages rewritten in #419 were each re-verified against the source and found literally true — including the locked-vs-unlocked `ActivityImportCache` member split and the creator/per-chunk connection description in `InsertBatch`.
- The rewritten racer test was confirmed correct on every point it was challenged on: `TaskCreationOptions.LongRunning` does give each racer a dedicated non-pool thread on .NET Framework (so the anti-starvation property survives), `GetAwaiter().GetResult()` on those threads cannot deadlock (no `SynchronizationContext`, and the loser continuations have the whole pool available), and `await allRacers` after `Task.WhenAny` is what surfaces a racer exception.
- The mid-review merges were verified: all three checked `00e9cc5` in round 3, and `7f17dc3` (#419's merge, which had not yet landed at that point) was checked afterwards — every merged blob matches the reviewed commits, with nothing lost, altered or duplicated.

## Still open for a maintainer decision (not addressed here)

The double-checked initialisation in `ActivityImportCacheProvider` and `CopilotMetadataPrewarmer` pre-checks a non-volatile `bool` outside its lock. That is pre-#373 code moved verbatim, so it is not a regression, and the docs now describe it as implementation behaviour rather than a guarantee. Adding `Volatile.Read`/`Volatile.Write` would make it a formal guarantee. All three reviewers agreed it should not block these pure-move follow-ups; they did **not** agree on how to characterise it — claude-opus-4.8 and grok-4.6 see no realistic failure on .NET Framework 4.8 / x64 and call it optional formalisation, while gpt-5.6-sol maintains the fast path genuinely lacks an acquire because the JIT is an independent reordering agent. Worth a maintainer decision; happy to do it as a separate change.

## Rounds 4 and 5 added the third fix, then corrected it twice

A fourth review round on the two-sentence diff above was **not** clean, and nor was a fifth. Both were gpt-5.6-sol; claude-opus-4.8 and grok-4.6 returned clean on each. This is why the PR now touches three files:

- The replacement barrier comment still made a claim about exception *observation* that was wrong in a subtle way — `Task.WhenAll` is created before the timeout, so it **does** observe a racer''s fault and re-parents it; the unobserved fault is `WhenAll`''s own. Rather than rewrite that sentence a fifth time, it now states only what actually matters and is not in dispute: `Barrier.Dispose` is not safe against a concurrent `SignalAndWait`, so on the failing path the barrier is left to the GC.
- `CopilotMetadataPrewarmerTests`'' class summary claimed a tenant with resource resolution disabled "makes no outbound call". It makes no outbound *file lookup* — `GetLoaderAndPrewarmAsync` builds the loader, which authenticates, **before** consulting `ShouldPrewarm`. Corrected, and it now says which part is skipped.

Round 5 then found that the *replacement* for the second of those was itself too broad: it said the loader "authenticates", but `InitClientCredential` only constructs a `ClientSecretCredential` in the default secret mode — no network until a request is actually made; only certificate mode contacts Key Vault. The summary now claims only what the test asserts.

That is four consecutive rounds in which a correction introduced the next round''s inaccuracy, always by asserting more than the test needed. The final wording in each case says strictly less.

## Verification

- Full solution builds clean in Debug on the current `dev` (which now also carries #416 and #419), no new warnings.
- **74/74 pass** across the same set used throughout: the 17 tests from #417 plus `ActivityImporterTests`, `AuditImportFailureHandlingTests`, `AuditTests`, `ActivityStagingRulesTests`, `ActivitySaveConcurrencyPolicyTests`, `ActivityImportCacheWindowTests`, `CopilotPrewarmExtractionTests`, `ActivityReportSetMinMaxTests`, `ActivityReportLoaderTimeoutTests`.
