### PR TITLE
Extract IUsageReportStore from the daily and weekly usage-report loaders (#375 part 3)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
+using UnitTests.FakeLoaderClasses;
 
 namespace Tests.UnitTests
 {
@@ -261,9 +262,10 @@ namespace Tests.UnitTests
         public async Task DailyActivityLoader_SkippedDates_AreNotRequestedFromGraph()
         {
             // The whole point of the finalized-date rule: a skipped day costs no (often slow) paged download.
-            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
-            var yesterday = DateTime.UtcNow.Date.AddDays(-1);
-            var twoDaysAgo = DateTime.UtcNow.Date.AddDays(-2);
+            var now = new DateTime(2026, 6, 20, 11, 15, 0, DateTimeKind.Utc);
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance) { Clock = new FixedClock(now) };
+            var yesterday = now.Date.AddDays(-1);
+            var twoDaysAgo = now.Date.AddDays(-2);
             loader.PagesByDate[yesterday] = new List<FakeUserActivityDetail> { Page(UserA, 1) };
             loader.PagesByDate[twoDaysAgo] = new List<FakeUserActivityDetail> { Page(UserA, 2) };
 
@@ -277,20 +279,62 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public async Task DailyActivityLoader_NoCompletedImportPhase_DoesNotEvenAskStorage()
+        {
+            // Until a usage-report phase completes, stored rows may be from an interrupted save, so there
+            // is nothing to ask about - and asking would cost a scan of the biggest table for nothing.
+            var now = new DateTime(2026, 6, 20, 11, 15, 0, DateTimeKind.Utc);
+            var inspector = new FakeUsageReportStorageInspector();
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(StoredRow(now.Date.AddDays(-6), UserAId, 1));
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
+            {
+                Clock = new FixedClock(now),
+                StorageInspector = inspector,
+                ReportStore = store,
+            };
+
+            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: null);
+
+            Assert.AreEqual(0, skip.Count);
+            Assert.AreEqual(0, store.ExistenceProbes.Count);
+            Assert.AreEqual(0, store.RangeScans.Count);
+            Assert.AreEqual(0, inspector.IndexQuestionsAsked.Count, "The index question is only worth asking if something could be skipped.");
+        }
+
+        [TestMethod]
+        public void DailyActivityLoader_DefaultClock_IsTheSystemClock()
+        {
+            // The injected clock must be an opt-in for tests only: production reads DateTime.UtcNow exactly
+            // as it did before, so the import window is unchanged.
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+
+            Assert.AreSame(SystemClock.Instance, loader.Clock);
+            Assert.IsTrue(Math.Abs((DateTime.UtcNow - loader.Clock.UtcNow).TotalSeconds) < 5,
+                "The default clock must report the real UTC time.");
+        }
+
+        [TestMethod]
         public async Task DailyActivityLoader_IndexedTable_ProbesEachCandidateDateInsteadOfScanning()
         {
             // With a date-leading index the scan is one bounded seek per candidate date; a DISTINCT over
             // the range would still touch every user's row for every date (millions at 200k users).
+            //
+            // The clock is FIXED: the loader reads "now" itself, so a test asserting exact window bounds
+            // against its own DateTime.UtcNow would disagree with the loader whenever the two reads
+            // straddle UTC midnight.
+            var now = new DateTime(2026, 6, 20, 11, 15, 0, DateTimeKind.Utc);
+            var today = now.Date;
             var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
             {
+                Clock = new FixedClock(now),
                 StorageInspector = new FakeUsageReportStorageInspector(hasLeadingDateIndex: true),
             };
-            var today = DateTime.UtcNow.Date;
             var stored = today.AddDays(-6);
             var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>().Seed(StoredRow(stored, UserAId, 1));
             loader.ReportStore = store;
 
-            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: DateTime.UtcNow);
+            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: now);
 
             Assert.AreEqual(0, store.RangeScans.Count, "The indexed branch must not fall back to a range scan.");
             CollectionAssert.AreEqual(
@@ -303,18 +347,20 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task DailyActivityLoader_UnindexedTable_UsesOneRangeScanForTheWholeWindow()
         {
+            var now = new DateTime(2026, 6, 20, 11, 15, 0, DateTimeKind.Utc);
+            var today = now.Date;
             var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
             {
+                Clock = new FixedClock(now),
                 StorageInspector = new FakeUsageReportStorageInspector(hasLeadingDateIndex: false),
             };
-            var today = DateTime.UtcNow.Date;
             var storedInWindow = today.AddDays(-6);
             var storedTooRecent = today.AddDays(-1);
             var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
                 .Seed(StoredRow(storedInWindow, UserAId, 1), StoredRow(storedTooRecent, UserBId, 1));
             loader.ReportStore = store;
 
-            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: DateTime.UtcNow);
+            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: now);
 
             Assert.AreEqual(0, store.ExistenceProbes.Count, "Without a date-leading index each probe would scan the table.");
             Assert.AreEqual(1, store.RangeScans.Count, "One scan for the whole window, not one per date.");
@@ -322,28 +368,6 @@ namespace Tests.UnitTests
             Assert.AreEqual(today.AddDays(-3), store.RangeScans[0].Item2);
             CollectionAssert.AreEqual(new[] { storedInWindow }, skip.ToArray(),
                 "A stored date inside the 3-day mutability window can still change in Graph and must be re-imported.");
-        }
-
-        [TestMethod]
-        public async Task DailyActivityLoader_NoCompletedImportPhase_DoesNotEvenAskStorage()
-        {
-            // Until a usage-report phase completes, stored rows may be from an interrupted save, so there
-            // is nothing to ask about - and asking would cost a scan of the biggest table for nothing.
-            var inspector = new FakeUsageReportStorageInspector();
-            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
-                .Seed(StoredRow(DateTime.UtcNow.Date.AddDays(-6), UserAId, 1));
-            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
-            {
-                StorageInspector = inspector,
-                ReportStore = store,
-            };
-
-            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: null);
-
-            Assert.AreEqual(0, skip.Count);
-            Assert.AreEqual(0, store.ExistenceProbes.Count);
-            Assert.AreEqual(0, store.RangeScans.Count);
-            Assert.AreEqual(0, inspector.IndexQuestionsAsked.Count, "The index question is only worth asking if something could be skipped.");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
@@ -1,0 +1,360 @@
+using Common.Entities.LookupCaches;
+using DataUtils;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The Graph daily usage-report save loop and finalized-date scan, driven entirely through the
+    /// <c>IUsageReportStore</c> port extracted by issue #375. Zero SQL Server, zero Graph, zero HTTP.
+    ///
+    /// <para>
+    /// This loop had no unit tests at all before: the (date, lookup) upsert, the dirty check that decides
+    /// whether a re-fetched finalized day costs an UPDATE, the batch boundary that keeps EF6 from
+    /// OutOfMemory-ing at 200k users, and the two skip-scan query shapes were all only reachable through a
+    /// live database.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class DailyActivityLoaderTests
+    {
+        private const string UserA = "alice@contoso.com";
+        private const string UserB = "bob@contoso.com";
+        private const int UserAId = 11;
+        private const int UserBId = 22;
+
+        private static readonly DateTime Day1 = new DateTime(2026, 5, 10);
+        private static readonly DateTime Day2 = new DateTime(2026, 5, 11);
+
+        private static ConcurrentLookupDbIdsCache SeededIdCache()
+        {
+            // Pre-seeded so lookup resolution never needs the DB-backed lookup cache. Keyed by the report
+            // ENTITY type and the RAW LookupFieldValue, exactly as ResolveLookupIdAsync does.
+            var cache = new ConcurrentLookupDbIdsCache();
+            cache.AddOrUpdateForName<FakeUserUsageActivityLog>(UserA, UserAId);
+            cache.AddOrUpdateForName<FakeUserUsageActivityLog>(UserB, UserBId);
+            return cache;
+        }
+
+        private static FakeUserActivityDetail Page(string upn, int thingCount, string lastActivity = null)
+            => new FakeUserActivityDetail { UserPrincipalName = upn, ThingCount = thingCount, LastActivityDateString = lastActivity };
+
+        private static FakeUserUsageActivityLog StoredRow(DateTime date, int userId, int thingCount, DateTime? lastActivity = null)
+            => new FakeUserUsageActivityLog { ID = userId * 1000, Date = date, UserID = userId, ThingCount = thingCount, LastActivityDate = lastActivity };
+
+        // Runs the save loop against an in-memory store, with no context and no lookup-cache DB access.
+        private static async Task<InMemoryUsageReportStore<FakeUserUsageActivityLog>> SaveAsync(
+            InMemoryDailyActivityLoader loader, InMemoryUsageReportStore<FakeUserUsageActivityLog> store)
+        {
+            loader.ReportStore = store;
+            await loader.SaveLoadedReportsToSql(SeededIdCache(), new UserCache(null));
+            return store;
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_RunsWithFakeSourceAndFakeStore_WithoutSqlOrGraph()
+        {
+            // Day 1's key deliberately carries a TIME: Graph pages are keyed by DateTime.UtcNow.AddDays(-n),
+            // so the loop must truncate to the date both for the stored value and for the existing-row lookup.
+            var day1WithTime = Day1.AddHours(13).AddMinutes(37);
+
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            loader.LoadedReportPages[day1WithTime] = new List<FakeUserActivityDetail> { Page(UserA, 5), Page(UserB, 7) };
+            loader.LoadedReportPages[Day2] = new List<FakeUserActivityDetail> { Page(UserA, 9) };
+
+            var store = await SaveAsync(loader, new InMemoryUsageReportStore<FakeUserUsageActivityLog>());
+
+            Assert.AreEqual(3, store.Stored.Count, "Every report row with a resolvable lookup should be inserted.");
+            Assert.AreEqual(0, store.Updated.Count, "Nothing was stored beforehand, so nothing can be an update.");
+            Assert.AreEqual(3, loader.LastSaveDbWriteCount);
+
+            var day1A = store.Stored.Single(r => r.Date == Day1 && r.UserID == UserAId);
+            Assert.AreEqual(5, day1A.ThingCount, "Report-specific metadata must reach the stored row.");
+            Assert.AreEqual(9, store.Stored.Single(r => r.Date == Day2 && r.UserID == UserAId).ThingCount);
+
+            // Each day is read and released on its own, which is what bounds EF's change tracker.
+            CollectionAssert.AreEquivalent(new[] { Day1, Day2 }, store.RowsLoadedForDates.ToArray(),
+                "The existing-row query must use the DATE, not the page key's timestamp.");
+            Assert.AreEqual(2, store.ReleaseCount);
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_UnchangedExistingRow_IsNotRewritten()
+        {
+            // The dominant cost of a re-import at large-tenant scale: a finalized day re-fetched by the
+            // recent-window rule is almost always identical to what is stored, so it must cost no UPDATE.
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail> { Page(UserA, 5) };
+
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(StoredRow(Day1, UserAId, thingCount: 5));
+
+            await SaveAsync(loader, store);
+
+            Assert.AreEqual(0, store.Updated.Count, "An identical row must not be rewritten.");
+            Assert.AreEqual(0, store.Inserted.Count, "The stored row must be reused, not duplicated.");
+            Assert.AreEqual(0, loader.LastSaveDbWriteCount);
+            Assert.AreEqual(0, store.SaveCount, "With nothing to write there is nothing to flush.");
+            Assert.AreEqual(1, store.Stored.Count);
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_ChangedExistingRow_IsUpdatedNotDuplicated()
+        {
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail> { Page(UserA, 42) };
+
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(StoredRow(Day1, UserAId, thingCount: 5));
+
+            await SaveAsync(loader, store);
+
+            Assert.AreEqual(1, store.Updated.Count, "A changed row must be written.");
+            Assert.AreEqual(0, store.Inserted.Count, "The (date, lookup) row already exists - updating it must not insert a second one.");
+            Assert.AreEqual(1, store.Stored.Count);
+            Assert.AreEqual(42, store.Stored[0].ThingCount);
+            Assert.AreEqual(1, loader.LastSaveDbWriteCount);
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_EmptyLastActivityDate_LeavesTheStoredValueAlone()
+        {
+            // Three different Graph shapes for lastActivityDate, asserted against an EXISTING row that
+            // already holds a date - on a new row "left alone" and "set to null" are indistinguishable.
+            var stored = new DateTime(2026, 1, 2);
+
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail> { Page(UserA, 5, lastActivity: "") };
+
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(StoredRow(Day1, UserAId, thingCount: 5, lastActivity: stored));
+
+            await SaveAsync(loader, store);
+
+            Assert.AreEqual(stored, store.Stored[0].LastActivityDate,
+                "An empty lastActivityDate means 'Graph said nothing', which must not erase what is stored.");
+            Assert.AreEqual(0, loader.LastSaveDbWriteCount, "Nothing changed, so there is nothing to write.");
+            Assert.AreEqual(0, store.SaveCount);
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_ValidLastActivityDate_IsParsed_InvalidIsNulled()
+        {
+            // The invalid case is asserted against an EXISTING row that already holds a date: on a new row
+            // "nulled" and "never set" both read as null, so it would pass even if the null-out were removed.
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail>
+            {
+                Page(UserA, 1, lastActivity: "2026-05-04"),
+                Page(UserB, 2, lastActivity: "04/05/2026"),   // right day, wrong format - Graph only ever sends ISO
+            };
+
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(StoredRow(Day1, UserBId, thingCount: 2, lastActivity: new DateTime(2026, 1, 2)));
+
+            await SaveAsync(loader, store);
+
+            Assert.AreEqual(new DateTime(2026, 5, 4), store.Stored.Single(r => r.UserID == UserAId).LastActivityDate);
+            Assert.IsNull(store.Stored.Single(r => r.UserID == UserBId).LastActivityDate,
+                "An unparseable lastActivityDate must overwrite the stored value with null, not be guessed at or ignored.");
+            Assert.AreEqual(1, store.Updated.Count, "Nulling the stored date is a real change and must be written.");
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_RowWithNoLookupIdentifier_IsSkipped()
+        {
+            // Graph sends a null userPrincipalName when report anonymisation is on. Such a row cannot be
+            // matched to a lookup, and must be dropped rather than taken down the resolve path.
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail>
+            {
+                Page(null, 1),
+                Page("   ", 2),
+                Page(UserA, 3),
+            };
+
+            var store = await SaveAsync(loader, new InMemoryUsageReportStore<FakeUserUsageActivityLog>());
+
+            Assert.AreEqual(1, store.Stored.Count, "Only the row with a usable identifier should be saved.");
+            Assert.AreEqual(UserAId, store.Stored[0].UserID);
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_OutOfScopeUser_IsSkipped()
+        {
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
+            {
+                InScopeRule = upn => upn == UserA,
+            };
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail> { Page(UserA, 1), Page(UserB, 2) };
+
+            var store = await SaveAsync(loader, new InMemoryUsageReportStore<FakeUserUsageActivityLog>());
+
+            Assert.AreEqual(1, store.Stored.Count, "The group filter must exclude the out-of-scope user's row.");
+            Assert.AreEqual(UserAId, store.Stored[0].UserID);
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_FlushesOnceTheBatchIsFull_AndAgainForTheRemainder()
+        {
+            // The batch boundary is why a 200k-user tenant does not OutOfMemory EF6: without it every
+            // pending row across every date is built into one command tree.
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance) { SaveBatchSize = 2 };
+            var idCache = new ConcurrentLookupDbIdsCache();
+            var pages = new List<FakeUserActivityDetail>();
+            for (var user = 1; user <= 5; user++)
+            {
+                var upn = $"user{user}@contoso.com";
+                idCache.AddOrUpdateForName<FakeUserUsageActivityLog>(upn, user);
+                pages.Add(Page(upn, user));
+            }
+            loader.LoadedReportPages[Day1] = pages;
+
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>();
+            loader.ReportStore = store;
+            await loader.SaveLoadedReportsToSql(idCache, new UserCache(null));
+
+            Assert.AreEqual(3, store.SaveCount, "5 writes at a batch size of 2 is two full batches plus the remainder.");
+            Assert.AreEqual(5, store.Stored.Count);
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_SaveLoopRunsEntirelyInsideOneBulkWriteScope()
+        {
+            // EF6 change auto-detection off is what keeps adding a day's rows O(n) instead of O(n^2); no
+            // row-count assertion would notice it being dropped.
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail> { Page(UserA, 1) };
+            loader.LoadedReportPages[Day2] = new List<FakeUserActivityDetail> { Page(UserA, 2) };
+
+            var store = await SaveAsync(loader, new InMemoryUsageReportStore<FakeUserUsageActivityLog>());
+
+            Assert.AreEqual(1, store.BulkWriteScopesOpened, "One scope for the whole save, not one per day.");
+            Assert.AreEqual(1, store.BulkWriteScopesDisposed, "The scope must be left, or the context stays in bulk mode.");
+            Assert.IsTrue(store.AllWritesInsideBulkScope, "Every add, dirty check and flush must happen inside the scope.");
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_SaveThrowing_StillLeavesTheBulkWriteScope()
+        {
+            // The scope is left on the failure path too - the context may be reused by the next report.
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail> { Page(UserA, 1) };
+
+            var store = new ThrowOnSaveUsageReportStore();
+            loader.ReportStore = store;
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => loader.SaveLoadedReportsToSql(SeededIdCache(), new UserCache(null)));
+
+            Assert.AreEqual(1, store.BulkWriteScopesOpened);
+            Assert.AreEqual(1, store.BulkWriteScopesDisposed, "A failed save must still restore change auto-detection.");
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_SkippedDates_AreNotRequestedFromGraph()
+        {
+            // The whole point of the finalized-date rule: a skipped day costs no (often slow) paged download.
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
+            var yesterday = DateTime.UtcNow.Date.AddDays(-1);
+            var twoDaysAgo = DateTime.UtcNow.Date.AddDays(-2);
+            loader.PagesByDate[yesterday] = new List<FakeUserActivityDetail> { Page(UserA, 1) };
+            loader.PagesByDate[twoDaysAgo] = new List<FakeUserActivityDetail> { Page(UserA, 2) };
+
+            await loader.PopulateLoadedReportPagesFromGraph(daysBackMax: 3, datesToSkip: new HashSet<DateTime> { twoDaysAgo });
+
+            CollectionAssert.DoesNotContain(loader.GraphRequests, twoDaysAgo, "A skipped date must not be downloaded.");
+            CollectionAssert.Contains(loader.GraphRequests, yesterday, "A non-skipped date must still be downloaded.");
+            Assert.IsFalse(loader.LoadedReportPages.Keys.Any(k => k.Date == twoDaysAgo),
+                "A skipped date must not appear as a loaded (and therefore savable) page.");
+            Assert.IsTrue(loader.LoadedReportPages.Keys.Any(k => k.Date == yesterday));
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_IndexedTable_ProbesEachCandidateDateInsteadOfScanning()
+        {
+            // With a date-leading index the scan is one bounded seek per candidate date; a DISTINCT over
+            // the range would still touch every user's row for every date (millions at 200k users).
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
+            {
+                StorageInspector = new FakeUsageReportStorageInspector(hasLeadingDateIndex: true),
+            };
+            var today = DateTime.UtcNow.Date;
+            var stored = today.AddDays(-6);
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>().Seed(StoredRow(stored, UserAId, 1));
+            loader.ReportStore = store;
+
+            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: DateTime.UtcNow);
+
+            Assert.AreEqual(0, store.RangeScans.Count, "The indexed branch must not fall back to a range scan.");
+            CollectionAssert.AreEqual(
+                Enumerable.Range(0, 7).Select(i => today.AddDays(-10 + i)).ToArray(),
+                store.ExistenceProbes.ToArray(),
+                "Every candidate date from the window start up to the 3-day mutability cutoff should be probed, oldest first.");
+            CollectionAssert.AreEqual(new[] { stored }, skip.ToArray(), "Only dates that actually have rows can be skipped.");
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_UnindexedTable_UsesOneRangeScanForTheWholeWindow()
+        {
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
+            {
+                StorageInspector = new FakeUsageReportStorageInspector(hasLeadingDateIndex: false),
+            };
+            var today = DateTime.UtcNow.Date;
+            var storedInWindow = today.AddDays(-6);
+            var storedTooRecent = today.AddDays(-1);
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(StoredRow(storedInWindow, UserAId, 1), StoredRow(storedTooRecent, UserBId, 1));
+            loader.ReportStore = store;
+
+            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: DateTime.UtcNow);
+
+            Assert.AreEqual(0, store.ExistenceProbes.Count, "Without a date-leading index each probe would scan the table.");
+            Assert.AreEqual(1, store.RangeScans.Count, "One scan for the whole window, not one per date.");
+            Assert.AreEqual(today.AddDays(-10), store.RangeScans[0].Item1);
+            Assert.AreEqual(today.AddDays(-3), store.RangeScans[0].Item2);
+            CollectionAssert.AreEqual(new[] { storedInWindow }, skip.ToArray(),
+                "A stored date inside the 3-day mutability window can still change in Graph and must be re-imported.");
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_NoCompletedImportPhase_DoesNotEvenAskStorage()
+        {
+            // Until a usage-report phase completes, stored rows may be from an interrupted save, so there
+            // is nothing to ask about - and asking would cost a scan of the biggest table for nothing.
+            var inspector = new FakeUsageReportStorageInspector();
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(StoredRow(DateTime.UtcNow.Date.AddDays(-6), UserAId, 1));
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
+            {
+                StorageInspector = inspector,
+                ReportStore = store,
+            };
+
+            var skip = await loader.GetFinalizedStoredDatesToSkipAsync(null, daysBackMax: 10, lastSuccessfulImport: null);
+
+            Assert.AreEqual(0, skip.Count);
+            Assert.AreEqual(0, store.ExistenceProbes.Count);
+            Assert.AreEqual(0, store.RangeScans.Count);
+            Assert.AreEqual(0, inspector.IndexQuestionsAsked.Count, "The index question is only worth asking if something could be skipped.");
+        }
+
+        /// <summary>
+        /// Store whose flush always fails, for the "the bulk-write scope is left even on failure" case.
+        /// Fails as a FAULTED TASK, never a synchronous throw: a synchronous throw would be caught even by
+        /// a caller that forgot to await, so it could not tell the two apart.
+        /// </summary>
+        private sealed class ThrowOnSaveUsageReportStore : InMemoryUsageReportStore<FakeUserUsageActivityLog>
+        {
+            public override Task SaveChangesAsync()
+                => Task.FromException(new InvalidOperationException("Simulated flush failure."));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
@@ -306,12 +306,12 @@ namespace Tests.UnitTests
         public void DailyActivityLoader_DefaultClock_IsTheSystemClock()
         {
             // The injected clock must be an opt-in for tests only: production reads DateTime.UtcNow exactly
-            // as it did before, so the import window is unchanged.
+            // as it did before, so the import window is unchanged. Identity is the whole assertion - that
+            // SystemClock reports UTC is already pinned by ClockAndContextFactoryTests.SystemClock_ReturnsUtcKind,
+            // and re-checking it here against a tolerance would only add a preemption flake.
             var loader = new InMemoryDailyActivityLoader(NullLogger.Instance);
 
             Assert.AreSame(SystemClock.Instance, loader.Clock);
-            Assert.IsTrue(Math.Abs((DateTime.UtcNow - loader.Clock.UtcNow).TotalSeconds) < 5,
-                "The default clock must report the real UTC time.");
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryDailyActivityLoader.cs
@@ -1,0 +1,87 @@
+using Common.Entities;
+using Common.Entities.ActivityReports;
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// Report row for the in-memory daily-loader tests. Derives from the real
+    /// <see cref="UserRelatedAbstractUsageActivity"/> so the lookup id is the MAPPED <c>user_id</c> column
+    /// (as in production) rather than an unmapped property, which is what makes the dirty check
+    /// representative. See issue #375.
+    /// </summary>
+    [Table("fake_user_activity_log")]
+    public class FakeUserUsageActivityLog : UserRelatedAbstractUsageActivity
+    {
+        [Column("thing_count")]
+        public int ThingCount { get; set; }
+    }
+
+    /// <summary>A Graph report page for <see cref="FakeUserUsageActivityLog"/>.</summary>
+    public class FakeUserActivityDetail : AbstractUserActivityUserDetailWithUpn
+    {
+        [JsonProperty("thingCount")]
+        public int ThingCount { get; set; }
+    }
+
+    /// <summary>
+    /// Concrete <see cref="AbstractDailyActivityLoader{,,,}"/> whose Graph paging and storage are both
+    /// supplied by the test, so the entire save loop - the lookup/scope filters, the (date, lookup) upsert,
+    /// the LastActivityDate parse, the dirty check, the batch boundary and the per-day release - runs with
+    /// zero SQL Server and zero HTTP. See issue #375.
+    ///
+    /// <para>
+    /// <c>GetTable</c> returns null and the context passed to the base is null; both are safe ONLY because
+    /// callers set <c>ReportStore</c> (and, where relevant, <c>StorageInspector</c>), which short-circuits
+    /// the <c>?? new Sql...(db)</c> defaults so neither adapter is ever constructed.
+    /// </para>
+    /// </summary>
+    public class InMemoryDailyActivityLoader
+        : AbstractUserDailyActivityLoader<FakeUserUsageActivityLog, FakeUserActivityDetail>
+    {
+        public InMemoryDailyActivityLoader(ILogger logger)
+            : base(null, new MockUserGroupsCache(null, logger), new UserGroupsFilterModel(null), logger)
+        {
+        }
+
+        /// <summary>Canned Graph pages, keyed by the DATE (time component ignored) they answer for.</summary>
+        public Dictionary<DateTime, List<FakeUserActivityDetail>> PagesByDate { get; }
+            = new Dictionary<DateTime, List<FakeUserActivityDetail>>();
+
+        /// <summary>Every date actually requested from "Graph", in order.</summary>
+        public List<DateTime> GraphRequests { get; } = new List<DateTime>();
+
+        /// <summary>Optional scope filter, standing in for the Entra group-membership check.</summary>
+        public Func<string, bool> InScopeRule { get; set; }
+
+        public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/thisReportDoesNotExist";
+
+        public override DbSet<FakeUserUsageActivityLog> GetTable(AnalyticsEntitiesContext context) => null;
+
+        protected override Task<List<FakeUserActivityDetail>> LoadReportPageForDateFromGraph(DateTime date)
+        {
+            GraphRequests.Add(date.Date);
+            PagesByDate.TryGetValue(date.Date, out var page);
+            return Task.FromResult(page ?? new List<FakeUserActivityDetail>());
+        }
+
+        protected override Task<bool> IdInScope(string lookupId)
+            => Task.FromResult(InScopeRule == null || InScopeRule(lookupId));
+
+        protected override void PopulateReportSpecificMetadata(FakeUserUsageActivityLog todaysLog, FakeUserActivityDetail page)
+        {
+            todaysLog.ThingCount = page.ThingCount;
+        }
+
+        protected override long CountActivity(FakeUserActivityDetail activityPage) => activityPage.ThingCount;
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemorySharePointSiteUsageStore.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemorySharePointSiteUsageStore.cs
@@ -1,0 +1,135 @@
+using Common.Entities;
+using Common.Entities.Entities.UsageReports;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="ISharePointSiteUsageStore"/> - the sites and weekly-stats tables replaced by
+    /// lists, so the weekly SharePoint save loop (day-of-week gate, "only newer than stored", existing-site
+    /// FK reuse, new-site creation and reuse within one run) can be asserted with no SQL Server. See #375.
+    ///
+    /// <para>
+    /// Two things it mirrors on purpose:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>Site keys are assigned ON COMMIT, not on add - so does EF, and a test that read the key
+    /// before the commit would be testing the fake rather than the loader.</item>
+    /// <item>A stats row added with only its <c>Site</c> navigation set gets its <c>SiteId</c> filled from
+    /// that site's newly-assigned key at commit, which is what EF does with the FK.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Note what it does NOT do: it does not match sites by URL. The case-insensitive URL matching lives
+    /// in the loader's own dictionaries, so a fake that also matched by URL could hide a loader that had
+    /// stopped doing it.
+    /// </para>
+    /// </summary>
+    public class InMemorySharePointSiteUsageStore : ISharePointSiteUsageStore
+    {
+        private readonly List<Site> _sites = new List<Site>();
+        private readonly List<SharePointSitesFileWeeklyStats> _stats = new List<SharePointSitesFileWeeklyStats>();
+        private readonly List<Site> _pendingSites = new List<Site>();
+        private readonly List<SharePointSitesFileWeeklyStats> _pendingStats = new List<SharePointSitesFileWeeklyStats>();
+
+        private int _nextSiteId = 1;
+
+        /// <summary>Committed sites, in insertion order.</summary>
+        public IReadOnlyList<Site> Sites => _sites;
+
+        /// <summary>Committed weekly stats rows, in insertion order.</summary>
+        public IReadOnlyList<SharePointSitesFileWeeklyStats> WeeklyStats => _stats;
+
+        /// <summary>How many times the whole-sites read ran. Must be once per save, never once per site.</summary>
+        public int SitesReadCount { get; private set; }
+
+        /// <summary>How many times the grouped latest-week read ran. Must be once per save.</summary>
+        public int LatestWeekReadCount { get; private set; }
+
+        /// <summary>How many times the loader committed.</summary>
+        public int CommitCount { get; private set; }
+
+        public int BulkWriteBegun { get; private set; }
+        public int BulkWriteEnded { get; private set; }
+
+        /// <summary>True while a bulk-write scope is open.</summary>
+        public bool BulkWriteOpen { get; private set; }
+
+        /// <summary>Seed a committed site and return it (with its assigned key).</summary>
+        public Site SeedSite(string urlBase)
+        {
+            var site = new Site { ID = _nextSiteId++, UrlBase = urlBase };
+            _sites.Add(site);
+            return site;
+        }
+
+        /// <summary>Seed a committed weekly-stats row for an already-seeded site.</summary>
+        public InMemorySharePointSiteUsageStore SeedWeek(Site site, DateTime? weekEnding)
+        {
+            _stats.Add(new SharePointSitesFileWeeklyStats { Site = site, SiteId = site.ID, ForWeekEnding = weekEnding });
+            return this;
+        }
+
+        public Task<IReadOnlyList<StoredSite>> GetAllSitesAsync()
+        {
+            SitesReadCount++;
+            IReadOnlyList<StoredSite> sites = _sites.Select(s => new StoredSite(s.ID, s.UrlBase)).ToList();
+            return Task.FromResult(sites);
+        }
+
+        public Task<IReadOnlyList<SiteLatestStoredWeek>> GetLatestStoredWeekPerSiteAsync()
+        {
+            LatestWeekReadCount++;
+            IReadOnlyList<SiteLatestStoredWeek> latest = _stats
+                .GroupBy(s => s.SiteId)
+                .Select(g => new SiteLatestStoredWeek(g.Key, g.Max(s => s.ForWeekEnding)))
+                .ToList();
+            return Task.FromResult(latest);
+        }
+
+        public void AddSite(Site site) => _pendingSites.Add(site);
+
+        public void AddWeeklyStats(SharePointSitesFileWeeklyStats stats) => _pendingStats.Add(stats);
+
+        public Task CommitAsync()
+        {
+            CommitCount++;
+
+            foreach (var site in _pendingSites)
+            {
+                site.ID = _nextSiteId++;
+                _sites.Add(site);
+            }
+            _pendingSites.Clear();
+
+            foreach (var stats in _pendingStats)
+            {
+                // EF fills the FK from the attached principal; do the same so SiteId is assertable.
+                if (stats.Site != null)
+                {
+                    stats.SiteId = stats.Site.ID;
+                }
+                _stats.Add(stats);
+            }
+            _pendingStats.Clear();
+
+            return Task.CompletedTask;
+        }
+
+        public void BeginBulkWrite()
+        {
+            BulkWriteBegun++;
+            BulkWriteOpen = true;
+        }
+
+        public void EndBulkWrite()
+        {
+            BulkWriteEnded++;
+            BulkWriteOpen = false;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryUsageReportStore.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryUsageReportStore.cs
@@ -1,0 +1,257 @@
+using Common.Entities.ActivityReports;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="IUsageReportStore{TReportDbType}"/> - the daily usage-report table replaced by
+    /// a list, so the whole finalized-date scan and the whole save loop (upsert, dirty check, batch
+    /// boundary, per-day detach) can be asserted with no SQL Server. See issue #375.
+    ///
+    /// <para>
+    /// It deliberately mirrors four things about the EF6 adapter rather than being merely convenient,
+    /// because a lenient fake would let a broken refactor pass:
+    /// </para>
+    /// <list type="number">
+    /// <item>The dirty check compares against a snapshot taken WHEN THE ROW WAS HANDED OUT, not against
+    /// the row itself. Comparing an object with itself is always "unchanged", which is how a dirty-check
+    /// test can pass by reference identity and prove nothing.</item>
+    /// <item><see cref="MarkUpdatedIfChanged"/> on a row that is queued for INSERT throws, because EF6's
+    /// <c>DbEntityEntry.OriginalValues</c> throws for an entity in the <c>Added</c> state. That is a real,
+    /// pre-existing edge of the save loop (two Graph rows for the same new lookup on one date) and the
+    /// fake must not paper over it.</item>
+    /// <item><see cref="ReleaseSavedRows"/> DISCARDS anything still queued, because detaching an unsaved
+    /// entity in EF6 drops the pending insert. A refactor that released before the final flush would
+    /// silently lose a day's rows, and this is what catches it.</item>
+    /// <item>A successful save resets the snapshot, so an unchanged row saved twice is only written once.</item>
+    /// </list>
+    /// </summary>
+    public class InMemoryUsageReportStore<TReportDbType> : IUsageReportStore<TReportDbType>
+        where TReportDbType : AbstractUsageActivityLog
+    {
+        private readonly List<TReportDbType> _stored = new List<TReportDbType>();
+        private readonly List<TReportDbType> _pendingInserts = new List<TReportDbType>();
+        private readonly List<TReportDbType> _pendingUpdates = new List<TReportDbType>();
+
+        // Reference-keyed: these entities do not override Equals, exactly like EF's identity map.
+        private readonly Dictionary<TReportDbType, Dictionary<string, object>> _snapshots
+            = new Dictionary<TReportDbType, Dictionary<string, object>>();
+
+        /// <summary>Everything committed so far, in insertion order.</summary>
+        public IReadOnlyList<TReportDbType> Stored => _stored;
+
+        /// <summary>Dates the bounded existence probe was asked about, in order.</summary>
+        public List<DateTime> ExistenceProbes { get; } = new List<DateTime>();
+
+        /// <summary>Ranges the fallback scan was asked about, in order.</summary>
+        public List<Tuple<DateTime, DateTime>> RangeScans { get; } = new List<Tuple<DateTime, DateTime>>();
+
+        /// <summary>Dates a day's rows were loaded for, in order.</summary>
+        public List<DateTime> RowsLoadedForDates { get; } = new List<DateTime>();
+
+        /// <summary>How many times the loader flushed. Pins the batch boundary.</summary>
+        public int SaveCount { get; private set; }
+
+        /// <summary>Rows committed as INSERTs, in order.</summary>
+        public List<TReportDbType> Inserted { get; } = new List<TReportDbType>();
+
+        /// <summary>Rows committed as UPDATEs, in order (a row saved twice appears twice).</summary>
+        public List<TReportDbType> Updated { get; } = new List<TReportDbType>();
+
+        /// <summary>How many times per-day rows were released.</summary>
+        public int ReleaseCount { get; private set; }
+
+        /// <summary>How many bulk-write scopes were opened, and how many of those were disposed.</summary>
+        public int BulkWriteScopesOpened { get; private set; }
+        public int BulkWriteScopesDisposed { get; private set; }
+
+        /// <summary>
+        /// False if any add / dirty-check / flush happened outside a bulk-write scope. Removing the
+        /// scope would make bulk saves O(n^2) again, which no row-count assertion would notice.
+        /// </summary>
+        public bool AllWritesInsideBulkScope { get; private set; } = true;
+
+        private int _openScopes;
+
+        /// <summary>Pre-populate a committed row (no snapshot: it has not been handed out yet).</summary>
+        public InMemoryUsageReportStore<TReportDbType> Seed(params TReportDbType[] rows)
+        {
+            _stored.AddRange(rows);
+            return this;
+        }
+
+        public Task<bool> HasAnyRowForDateAsync(DateTime date)
+        {
+            ExistenceProbes.Add(date);
+            return Task.FromResult(_stored.Any(r => r.Date == date));
+        }
+
+        public Task<IReadOnlyList<DateTime>> GetStoredDatesInRangeAsync(DateTime fromInclusive, DateTime toExclusive)
+        {
+            RangeScans.Add(Tuple.Create(fromInclusive, toExclusive));
+            IReadOnlyList<DateTime> dates = _stored
+                .Where(r => r.Date >= fromInclusive && r.Date < toExclusive)
+                .Select(r => r.Date)
+                .Distinct()
+                .ToList();
+            return Task.FromResult(dates);
+        }
+
+        public Task<IReadOnlyList<TReportDbType>> GetRowsForDateAsync(DateTime date)
+        {
+            RowsLoadedForDates.Add(date);
+            var rows = _stored.Where(r => r.Date == date).ToList();
+            foreach (var row in rows)
+            {
+                _snapshots[row] = SnapshotMappedValues(row);
+            }
+            return Task.FromResult<IReadOnlyList<TReportDbType>>(rows);
+        }
+
+        public void AddRow(TReportDbType row)
+        {
+            NoteWrite();
+            _pendingInserts.Add(row);
+        }
+
+        public bool MarkUpdatedIfChanged(TReportDbType row)
+        {
+            NoteWrite();
+
+            if (_pendingInserts.Contains(row))
+            {
+                // Matches EF6: DbEntityEntry.OriginalValues throws for an entity in the Added state.
+                throw new InvalidOperationException(
+                    "Cannot get original values for an entity in the Added state - the row is queued for insert and has never been loaded.");
+            }
+
+            if (!_snapshots.TryGetValue(row, out var original))
+            {
+                throw new InvalidOperationException(
+                    "The row was never handed out by GetRowsForDateAsync (or has been released), so it has no original values.");
+            }
+
+            var current = SnapshotMappedValues(row);
+            if (!HasChanged(original, current))
+            {
+                return false;
+            }
+
+            if (!_pendingUpdates.Contains(row))
+            {
+                _pendingUpdates.Add(row);
+            }
+            return true;
+        }
+
+        public virtual Task SaveChangesAsync()
+        {
+            NoteWrite();
+            SaveCount++;
+
+            foreach (var row in _pendingInserts)
+            {
+                _stored.Add(row);
+                Inserted.Add(row);
+                // Committed rows become tracked-and-clean, as an EF Added entity does after SaveChanges.
+                _snapshots[row] = SnapshotMappedValues(row);
+            }
+            _pendingInserts.Clear();
+
+            foreach (var row in _pendingUpdates)
+            {
+                Updated.Add(row);
+                _snapshots[row] = SnapshotMappedValues(row);
+            }
+            _pendingUpdates.Clear();
+
+            return Task.CompletedTask;
+        }
+
+        public void ReleaseSavedRows()
+        {
+            ReleaseCount++;
+
+            // Detaching in EF6 drops anything not yet saved. Mirroring that is what makes a "released
+            // before the final flush" refactor show up as missing rows rather than as a silent pass.
+            _pendingInserts.Clear();
+            _pendingUpdates.Clear();
+            _snapshots.Clear();
+        }
+
+        public IDisposable BeginBulkWrite()
+        {
+            BulkWriteScopesOpened++;
+            _openScopes++;
+            return new Scope(this);
+        }
+
+        private void NoteWrite()
+        {
+            if (_openScopes == 0)
+            {
+                AllWritesInsideBulkScope = false;
+            }
+        }
+
+        private sealed class Scope : IDisposable
+        {
+            private readonly InMemoryUsageReportStore<TReportDbType> _owner;
+            private bool _disposed;
+
+            internal Scope(InMemoryUsageReportStore<TReportDbType> owner) => _owner = owner;
+
+            public void Dispose()
+            {
+                if (_disposed) return;
+                _disposed = true;
+                _owner._openScopes--;
+                _owner.BulkWriteScopesDisposed++;
+            }
+        }
+
+        private static bool HasChanged(Dictionary<string, object> original, Dictionary<string, object> current)
+            => current.Any(kv => !object.Equals(original[kv.Key], kv.Value));
+
+        /// <summary>
+        /// The values EF6 would put in its original/current snapshots: readable AND writable public
+        /// scalar properties that are not <c>[NotMapped]</c>. That excludes navigation properties (not
+        /// scalar), computed properties such as <c>IsSavedToDB</c> (no setter) and
+        /// <c>AssociatedLookupId</c> (<c>[NotMapped]</c> - it is a facade over the mapped FK column,
+        /// which IS included).
+        /// </summary>
+        private static Dictionary<string, object> SnapshotMappedValues(TReportDbType row)
+        {
+            var values = new Dictionary<string, object>();
+            foreach (var property in row.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!property.CanRead || !property.CanWrite) continue;
+                if (property.GetIndexParameters().Length > 0) continue;
+                if (property.GetCustomAttribute<NotMappedAttribute>() != null) continue;
+                if (!IsMappedScalar(property.PropertyType)) continue;
+
+                values[property.Name] = property.GetValue(row);
+            }
+            return values;
+        }
+
+        private static bool IsMappedScalar(Type type)
+        {
+            var underlying = Nullable.GetUnderlyingType(type) ?? type;
+            return underlying.IsPrimitive
+                || underlying.IsEnum
+                || underlying == typeof(string)
+                || underlying == typeof(decimal)
+                || underlying == typeof(DateTime)
+                || underlying == typeof(DateTimeOffset)
+                || underlying == typeof(TimeSpan)
+                || underlying == typeof(Guid);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/SharePointSiteUsageStoreTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SharePointSiteUsageStoreTests.cs
@@ -1,0 +1,233 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The weekly SharePoint site-usage save loop, driven entirely through the
+    /// <c>ISharePointSiteUsageStore</c> port extracted by issue #375. Zero SQL Server, zero Graph.
+    ///
+    /// <para>
+    /// The same guarantees are also covered end-to-end against a real database in
+    /// <c>GraphUsageReportImportTests</c>; these run without one, and additionally pin the two things a
+    /// row-count assertion cannot see - that storage is read ONCE rather than once per site, and that a
+    /// site row with no URL is never used as a key.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class SharePointSiteUsageStoreTests
+    {
+        // 2024-02-25 is a Sunday; 2024-02-18 the Sunday before.
+        private static readonly DateTime ThisSunday = new DateTime(2024, 2, 25);
+        private static readonly DateTime LastSunday = new DateTime(2024, 2, 18);
+
+        private static SharePointSitesWeeklyUsageReportLoader LoaderOver(InMemorySharePointSiteUsageStore store)
+            => new SharePointSitesWeeklyUsageReportLoader(store, null, NullLogger.Instance, null);
+
+        private static SharePointSiteUsageDetail Report(string url, DateTime refreshDate, int fileCount = 0)
+            => new SharePointSiteUsageDetail { SiteUrl = url, FileCount = fileCount, ReportRefreshDate = refreshDate };
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_SavesStaleAndNewSites_SkipsAlreadyCurrent_WithoutSql()
+        {
+            var store = new InMemorySharePointSiteUsageStore();
+            var stale = store.SeedSite("https://contoso.sharepoint.com/sites/stale");
+            var current = store.SeedSite("https://contoso.sharepoint.com/sites/current");
+            store.SeedWeek(stale, LastSunday).SeedWeek(current, ThisSunday);
+
+            var loader = LoaderOver(store);
+            var saved = await loader.SaveLoadedReportsIfRefreshOnDay(DayOfWeek.Sunday, new List<SharePointSiteUsageDetail>
+            {
+                Report("https://contoso.sharepoint.com/sites/stale", ThisSunday, fileCount: 10),
+                Report("https://contoso.sharepoint.com/sites/current", ThisSunday, fileCount: 20),
+                Report("https://contoso.sharepoint.com/sites/brand-new", ThisSunday, fileCount: 30),
+                // Saturday - outside the refresh day, so it must be ignored entirely.
+                Report("https://contoso.sharepoint.com/sites/brand-new", new DateTime(2024, 2, 24), fileCount: 99),
+            });
+
+            Assert.AreEqual(2, saved, "The stale existing site and the brand-new site; not the already-current one, not the Saturday row.");
+            Assert.AreEqual(1, store.CommitCount, "One commit for the whole run, not one per site.");
+
+            // The stale site's new week must reuse the EXISTING site key, not create a second site row.
+            var staleRows = store.WeeklyStats.Where(s => s.SiteId == stale.ID).ToList();
+            Assert.AreEqual(2, staleRows.Count, "The stale site should now hold the old and the new week.");
+            Assert.AreEqual(10, staleRows.Single(r => r.ForWeekEnding == ThisSunday).FileCount);
+
+            Assert.AreEqual(1, store.WeeklyStats.Count(s => s.SiteId == current.ID),
+                "A site already stored for this week must not get a duplicate row.");
+
+            var newSite = store.Sites.SingleOrDefault(s => s.UrlBase == "https://contoso.sharepoint.com/sites/brand-new");
+            Assert.IsNotNull(newSite, "An unknown site URL should create the site.");
+            var newRows = store.WeeklyStats.Where(s => s.SiteId == newSite.ID).ToList();
+            Assert.AreEqual(1, newRows.Count, "The Saturday row must not have produced a second week.");
+            Assert.AreEqual(30, newRows[0].FileCount);
+        }
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_MatchesExistingSiteUrlCaseInsensitively_WithoutSql()
+        {
+            // Graph can return the site URL in a different case. SQL Server's collation is case-insensitive,
+            // so treating the two as different sites would insert a duplicate the database then sees as one.
+            var storedUrl = "https://contoso.sharepoint.com/sites/CaseTest";
+            var store = new InMemorySharePointSiteUsageStore();
+            var site = store.SeedSite(storedUrl);
+            store.SeedWeek(site, LastSunday);
+
+            var saved = await LoaderOver(store).SaveLoadedReportsIfRefreshOnDay(
+                DayOfWeek.Sunday,
+                new List<SharePointSiteUsageDetail> { Report(storedUrl.ToUpperInvariant(), ThisSunday) });
+
+            Assert.AreEqual(1, saved);
+            Assert.AreEqual(1, store.Sites.Count, "A case-differing report URL must reuse the existing site, not create a duplicate.");
+            Assert.AreEqual(2, store.WeeklyStats.Count(s => s.SiteId == site.ID));
+        }
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_CaseDifferingStoredWeek_StillCountsAsAlreadyCurrent()
+        {
+            // The other half of case-insensitivity, and the half a "no duplicate site" assertion cannot
+            // see: the LAST STORED WEEK lookup must match case-insensitively too, or the same week is
+            // saved again on every run.
+            var storedUrl = "https://contoso.sharepoint.com/sites/CaseTest";
+            var store = new InMemorySharePointSiteUsageStore();
+            var site = store.SeedSite(storedUrl);
+            store.SeedWeek(site, ThisSunday);
+
+            var saved = await LoaderOver(store).SaveLoadedReportsIfRefreshOnDay(
+                DayOfWeek.Sunday,
+                new List<SharePointSiteUsageDetail> { Report(storedUrl.ToUpperInvariant(), ThisSunday) });
+
+            Assert.AreEqual(0, saved, "This week is already stored for that site, whatever case the report used.");
+            Assert.AreEqual(1, store.WeeklyStats.Count);
+            Assert.AreEqual(0, store.CommitCount, "Nothing to save means nothing to commit.");
+        }
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_TwoSitesSharingAUrl_UseTheirGreatestStoredWeek()
+        {
+            // Duplicate site rows for one URL exist in the wild. The last stored week for that URL is the
+            // GREATEST across them. Seeded so that the LAST row read holds the OLDER week: taking whichever
+            // row happens to be read last would re-save a week that is already held.
+            var url = "https://contoso.sharepoint.com/sites/shared";
+            var store = new InMemorySharePointSiteUsageStore();
+            var upToDate = store.SeedSite(url);
+            var behind = store.SeedSite(url.ToUpperInvariant());
+            store.SeedWeek(upToDate, ThisSunday).SeedWeek(behind, LastSunday);
+
+            var saved = await LoaderOver(store).SaveLoadedReportsIfRefreshOnDay(
+                DayOfWeek.Sunday,
+                new List<SharePointSiteUsageDetail> { Report(url, ThisSunday) });
+
+            Assert.AreEqual(0, saved, "The greatest stored week across the duplicate sites already covers this report.");
+            Assert.AreEqual(1, store.WeeklyStats.Count(s => s.ForWeekEnding == ThisSunday));
+        }
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_DuplicateNewSiteInSameRun_CreatesOneSite_WithoutSql()
+        {
+            var url = "https://contoso.sharepoint.com/sites/dup";
+            var store = new InMemorySharePointSiteUsageStore();
+
+            var saved = await LoaderOver(store).SaveLoadedReportsIfRefreshOnDay(
+                DayOfWeek.Sunday,
+                new List<SharePointSiteUsageDetail> { Report(url, ThisSunday, 1), Report(url, ThisSunday, 2) });
+
+            Assert.AreEqual(2, saved);
+            Assert.AreEqual(1, store.Sites.Count, "Two rows for the same new URL must map to a single created site.");
+            Assert.AreEqual(2, store.WeeklyStats.Count(s => s.SiteId == store.Sites[0].ID),
+                "Both weekly rows should attach to the one site.");
+        }
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_SiteRowWithNoUrl_IsNeverUsedAsAKey()
+        {
+            // Site.UrlBase is nullable, and issue #375 part 2 (PR #410) shipped a regression from treating
+            // "no URL" and "no site" as the same answer. A null-URL site must not be keyed on, and must not
+            // be picked up by a report row that happens to carry no URL either.
+            var store = new InMemorySharePointSiteUsageStore();
+            var urlless = store.SeedSite(null);
+            store.SeedWeek(urlless, LastSunday);
+
+            var saved = await LoaderOver(store).SaveLoadedReportsIfRefreshOnDay(
+                DayOfWeek.Sunday,
+                new List<SharePointSiteUsageDetail> { Report("https://contoso.sharepoint.com/sites/real", ThisSunday) });
+
+            Assert.AreEqual(1, saved);
+            Assert.AreEqual(2, store.Sites.Count, "The URL-less site must be left alone and a real site created.");
+            Assert.AreEqual(0, store.WeeklyStats.Count(s => s.SiteId == urlless.ID && s.ForWeekEnding == ThisSunday),
+                "The new week must not be attached to the URL-less site.");
+        }
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_ReadsStorageOncePerRun_NotOncePerSite()
+        {
+            // The per-site top-1 query this replaced was the dominant cost of the import (~1 query/site).
+            // Reintroducing it would still produce correct rows, so only a call count catches it.
+            var store = new InMemorySharePointSiteUsageStore();
+            var reports = new List<SharePointSiteUsageDetail>();
+            for (var i = 0; i < 50; i++)
+            {
+                var site = store.SeedSite($"https://contoso.sharepoint.com/sites/site{i}");
+                store.SeedWeek(site, LastSunday);
+                reports.Add(Report($"https://contoso.sharepoint.com/sites/site{i}", ThisSunday, i));
+            }
+
+            var saved = await LoaderOver(store).SaveLoadedReportsIfRefreshOnDay(DayOfWeek.Sunday, reports);
+
+            Assert.AreEqual(50, saved);
+            Assert.AreEqual(1, store.SitesReadCount, "Sites must be pre-loaded once, not queried per site.");
+            Assert.AreEqual(1, store.LatestWeekReadCount, "The latest stored week must come from ONE grouped query.");
+            Assert.AreEqual(1, store.CommitCount);
+        }
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_BulkWriteScopeIsClosedEvenWhenNothingIsSaved()
+        {
+            // Storage may be reused by the next report, so the change-tracking change has to be undone
+            // whether or not the run wrote anything.
+            var store = new InMemorySharePointSiteUsageStore();
+            var site = store.SeedSite("https://contoso.sharepoint.com/sites/current");
+            store.SeedWeek(site, ThisSunday);
+
+            var saved = await LoaderOver(store).SaveLoadedReportsIfRefreshOnDay(
+                DayOfWeek.Sunday,
+                new List<SharePointSiteUsageDetail> { Report("https://contoso.sharepoint.com/sites/current", ThisSunday) });
+
+            Assert.AreEqual(0, saved);
+            Assert.AreEqual(1, store.BulkWriteBegun);
+            Assert.AreEqual(1, store.BulkWriteEnded);
+            Assert.IsFalse(store.BulkWriteOpen, "The bulk-write scope must be closed even when nothing was saved.");
+        }
+
+        [TestMethod]
+        public async Task SharePointSitesUsage_GreekSiteUrl_RoundTripsUnchanged()
+        {
+            // SharePoint site URLs are unrestricted free text and routinely non-Latin. The URL is the key
+            // the whole import matches on, so it must survive verbatim into the created site row.
+            var greekUrl = "https://contoso.sharepoint.com/sites/Καλημέρα-κόσμε";
+            var store = new InMemorySharePointSiteUsageStore();
+
+            var saved = await LoaderOver(store).SaveLoadedReportsIfRefreshOnDay(
+                DayOfWeek.Sunday,
+                new List<SharePointSiteUsageDetail> { Report(greekUrl, ThisSunday, 3) });
+
+            Assert.AreEqual(1, saved);
+            Assert.AreEqual(greekUrl, store.Sites.Single().UrlBase);
+        }
+
+        [TestMethod]
+        public void SharePointSitesUsage_ConstructingWithoutStorage_FailsImmediately()
+        {
+            // A null store would otherwise surface much later as a NullReferenceException inside the save
+            // loop, after the whole report had been downloaded from Graph.
+            Assert.ThrowsException<ArgumentNullException>(
+                () => new SharePointSitesWeeklyUsageReportLoader((ISharePointSiteUsageStore)null, null, NullLogger.Instance, null));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -146,6 +146,9 @@
     <Compile Include="FakeLoaderClasses\FakeUsageReportStorageInspector.cs" />
     <Compile Include="FakeLoaderClasses\InMemorySiteUrlStore.cs" />
     <Compile Include="FakeLoaderClasses\TablelessDailyActivityLoader.cs" />
+    <Compile Include="FakeLoaderClasses\InMemoryDailyActivityLoader.cs" />
+    <Compile Include="FakeLoaderClasses\InMemorySharePointSiteUsageStore.cs" />
+    <Compile Include="FakeLoaderClasses\InMemoryUsageReportStore.cs" />
     <Compile Include="FakeLoaderClasses\FakeOrgUrlStore.cs" />
     <Compile Include="FakeLoaderClasses\FakeCallsPorts.cs" />
     <Compile Include="FakeLoaderClasses\FakeTeamsPorts.cs" />
@@ -265,6 +268,8 @@
     <Compile Include="UserGroupsCacheTests.cs" />
     <Compile Include="UserGroupsFilterModelTests.cs" />
     <Compile Include="SiteIdToUrlCacheTests.cs" />
+    <Compile Include="DailyActivityLoaderTests.cs" />
+    <Compile Include="SharePointSiteUsageStoreTests.cs" />
     <Compile Include="UsageReportRefreshPolicyTests.cs" />
     <Compile Include="UserImportTests.cs" />
     <Compile Include="UserLookupTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -4,12 +4,8 @@ using DataUtils;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
-using System.Data.SqlClient;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Rules;
@@ -74,6 +70,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             => StorageInspector ?? new SqlUsageReportStorageInspector(db);
 
         /// <summary>
+        /// Reads and writes for this report's table. Injectable so the whole finalized-date scan and the
+        /// entire save loop - the upsert, the scope/lookup filters, the dirty check, the batch boundary -
+        /// can be exercised without SQL Server (#375); defaults to the EF adapter over whichever context
+        /// the caller passes in.
+        /// </summary>
+        public IUsageReportStore<TReportDbType> ReportStore { get; set; }
+
+        // Note the `??`: when a store is injected, the right-hand side is never evaluated, so GetTable(db)
+        // is not called and a null context is never dereferenced.
+        private IUsageReportStore<TReportDbType> StoreFor(AnalyticsEntitiesContext db)
+            => ReportStore ?? new SqlUsageReportStore<TReportDbType>(db, GetTable(db));
+
+        /// <summary>
         /// The set of dates within the [now-daysBackMax, now) import window that are already stored in SQL, old
         /// enough that Graph will no longer change them, and covered by a previously completed import phase. These
         /// can be skipped entirely on the next import - no re-download, no re-write. Dates within the recent window
@@ -97,7 +106,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 return new HashSet<DateTime>();
             }
 
-            var table = GetTable(db);
+            var store = StoreFor(db);
             if (await HasLeadingDateIndexAsync(db))
             {
                 // The window contains at most 25 finalized dates. DISTINCT over an indexed range
@@ -106,7 +115,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 var storedFinalizedDates = new HashSet<DateTime>();
                 foreach (var date in UsageReportRefreshPolicy.EnumerateSkipCandidates(window))
                 {
-                    if (await table.AnyAsync(activity => activity.Date == date))
+                    if (await store.HasAnyRowForDateAsync(date))
                     {
                         storedFinalizedDates.Add(date);
                     }
@@ -117,13 +126,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 
             // Some account/group report tables have no date-leading index. Repeated existence
             // probes would each scan the table, so use one range scan until an index is available.
-            var windowStart = window.WindowStartUtc;
-            var safeCutoff = window.SafeCutoffUtc;
-            var scannedDates = await table
-                .Where(activity => activity.Date >= windowStart && activity.Date < safeCutoff)
-                .Select(activity => activity.Date)
-                .Distinct()
-                .ToListAsync();
+            var scannedDates = await store.GetStoredDatesInRangeAsync(window.WindowStartUtc, window.SafeCutoffUtc);
 
             return new HashSet<DateTime>(scannedDates.Select(date => date.Date));
         }
@@ -235,16 +238,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             // O(n) instead of O(n^2). AssociatedLookupId is [NotMapped] (it maps to UserID / YammerGroupID per
             // subclass), so existing rows can only be filtered in SQL by the mapped Date column - we key them by
             // lookup id in memory.
-            var autoDetectWasEnabled = db.Configuration.AutoDetectChangesEnabled;
-            db.Configuration.AutoDetectChangesEnabled = false;
-            try
+            var store = StoreFor(db);
+            using (store.BeginBulkWrite())
             {
                 foreach (var dateTime in LoadedReportPages.Keys)
                 {
                     // This day's existing rows, tracked (so updates go through the identity map without attach
                     // conflicts), keyed in memory by the [NotMapped] AssociatedLookupId.
                     var existingByLookupId = new Dictionary<int, TReportDbType>();
-                    foreach (var existingRow in await GetTable(db).Where(t => t.Date == dateTime.Date).ToListAsync())
+                    foreach (var existingRow in await store.GetRowsForDateAsync(dateTime.Date))
                     {
                         // Graph returns one row per lookup per date; last wins if the DB somehow has duplicates.
                         existingByLookupId[existingRow.AssociatedLookupId] = existingRow;
@@ -311,16 +313,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                         bool willWrite;
                         if (isNewLog)
                         {
-                            GetTable(db).Add(dateRequestedLog);
+                            store.AddRow(dateRequestedLog);
                             willWrite = true;
                         }
                         else
                         {
-                            willWrite = HasMappedValueChanged(db.Entry(dateRequestedLog));
-                            if (willWrite)
-                            {
-                                db.Entry(dateRequestedLog).State = EntityState.Modified;
-                            }
+                            willWrite = store.MarkUpdatedIfChanged(dateRequestedLog);
                         }
 
                         i++;
@@ -330,7 +328,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                             pendingChanges++;
                             if (pendingChanges >= SaveBatchSize)
                             {
-                                await db.SaveChangesAsync();
+                                await store.SaveChangesAsync();
                                 pendingChanges = 0;
                             }
                         }
@@ -338,16 +336,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 
                     if (pendingChanges > 0)
                     {
-                        await db.SaveChangesAsync();
+                        await store.SaveChangesAsync();
                     }
 
                     // Release this day's tracked rows before moving to the next day.
-                    DetachReportLogEntities(db);
+                    store.ReleaseSavedRows();
                 }
-            }
-            finally
-            {
-                db.Configuration.AutoDetectChangesEnabled = autoDetectWasEnabled;
             }
 
             LastSaveDbWriteCount = dbWrites;
@@ -386,36 +380,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 }
             }
             return lookupId.Value;
-        }
-
-        // Detach the day's saved usage-log entities so the EF6 change tracker (and the memory it holds) is
-        // released before the next day. Lookup entities (users/groups) are intentionally left tracked so the
-        // shared id cache keeps working.
-        private static void DetachReportLogEntities(AnalyticsEntitiesContext db)
-        {
-            foreach (var entry in db.ChangeTracker.Entries<AbstractUsageActivityLog>().ToList())
-            {
-                entry.State = EntityState.Detached;
-            }
-        }
-
-        // True if any mapped scalar value on the tracked entity differs from the value originally loaded from the
-        // DB. Compares the EF6 original/current value snapshots directly so it works with
-        // AutoDetectChangesEnabled = false (auto-detect is deliberately off to keep bulk saves O(n)). Navigation
-        // properties and [NotMapped] members (e.g. AssociatedLookupId) are not in these snapshots, so only real
-        // column changes trigger an UPDATE.
-        private static bool HasMappedValueChanged(DbEntityEntry entry)
-        {
-            var current = entry.CurrentValues;
-            var original = entry.OriginalValues;
-            foreach (var propertyName in current.PropertyNames)
-            {
-                if (!object.Equals(original[propertyName], current[propertyName]))
-                {
-                    return true;
-                }
-            }
-            return false;
         }
 
         protected virtual Task<bool> IdInScope(string lookupId)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -83,6 +83,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             => ReportStore ?? new SqlUsageReportStore<TReportDbType>(db, GetTable(db));
 
         /// <summary>
+        /// Source of "now" for the import window and the finalized-date scan. Defaults to
+        /// <see cref="SystemClock"/>, i.e. <c>DateTime.UtcNow</c>, so behaviour is unchanged; injectable
+        /// (#368/#375) so a test asserting exact window bounds cannot disagree with the loader's own clock
+        /// read when the two straddle UTC midnight.
+        /// </summary>
+        public IClock Clock { get; set; } = SystemClock.Instance;
+
+        /// <summary>
         /// The set of dates within the [now-daysBackMax, now) import window that are already stored in SQL, old
         /// enough that Graph will no longer change them, and covered by a previously completed import phase. These
         /// can be skipped entirely on the next import - no re-download, no re-write. Dates within the recent window
@@ -97,7 +105,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             DateTime? lastSuccessfulImport)
         {
             var window = UsageReportRefreshPolicy.ResolveSkipWindow(
-                daysBackMax, lastSuccessfulImport, RefreshableRecentDays, DateTime.UtcNow);
+                daysBackMax, lastSuccessfulImport, RefreshableRecentDays, Clock.UtcNow);
 
             if (!window.CanSkipAnyDate)
             {
@@ -162,8 +170,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 // Example: Message: {"error":{"code":"InvalidArgument","message":"Invalid date value specified: $DateTime.Now. Only support data for the past 28 days."}}
                 var daysBack = (daysBackIdx + 1) * -1;
                 // Graph Usage Reports API operates in UTC; DateTime.Now on a non-UTC server
-                // produces the wrong date bucket near midnight.
-                var dt = DateTime.UtcNow.AddDays(daysBack);
+                // produces the wrong date bucket near midnight. Read per iteration, as before.
+                var dt = Clock.UtcNow.AddDays(daysBack);
 
                 // Finalized days we already hold don't change in Graph - skip the (often slow) paged download entirely.
                 if (datesToSkip != null && datesToSkip.Contains(dt.Date))

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractAggregateWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractAggregateWeeklyUsageReportLoader.cs
@@ -1,4 +1,3 @@
-using Common.Entities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -8,17 +7,16 @@ using System.Threading.Tasks;
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
 {
     /// <summary>
-    /// A usage report loader that only loads/saves on a specific day of the week. Has SQL and Graph dependencies. 
+    /// A usage report loader that only loads/saves on a specific day of the week. Has Graph (and, via a
+    /// store port, storage) dependencies.
     /// </summary>
     public abstract class GraphAndSqlAggregateWeeklyUsageReportLoader<T> : AbstractAggregateWeeklyUsageReportLoader<T> where T : BaseAggregateItemStats
     {
         protected readonly ManualGraphCallClient _client;
-        protected readonly AnalyticsEntitiesContext _context;
 
-        protected GraphAndSqlAggregateWeeklyUsageReportLoader(AnalyticsEntitiesContext db, ManualGraphCallClient client, ILogger logger) : base(logger)
+        protected GraphAndSqlAggregateWeeklyUsageReportLoader(ManualGraphCallClient client, ILogger logger) : base(logger)
         {
             _client = client;
-            _context = db;
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/ISharePointSiteUsageStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/ISharePointSiteUsageStore.cs
@@ -1,0 +1,146 @@
+using Common.Entities;
+using Common.Entities.Entities.UsageReports;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
+{
+    /// <summary>A site row as the weekly SharePoint usage import needs it: just the key and the URL.</summary>
+    public sealed class StoredSite
+    {
+        public StoredSite(int id, string urlBase)
+        {
+            Id = id;
+            UrlBase = urlBase;
+        }
+
+        public int Id { get; }
+
+        /// <summary>
+        /// Nullable, exactly as the column is. The import discards null-URL sites rather than keying on
+        /// them - see <c>SharePointSitesWeeklyUsageReportLoader.BeginSaveAsync</c>, and issue #375 part 2,
+        /// where collapsing "no URL" into "no row" duplicated site rows.
+        /// </summary>
+        public string UrlBase { get; }
+    }
+
+    /// <summary>The most recent stored week for one site.</summary>
+    public sealed class SiteLatestStoredWeek
+    {
+        public SiteLatestStoredWeek(int siteId, DateTime? latestWeekEnding)
+        {
+            SiteId = siteId;
+            LatestWeekEnding = latestWeekEnding;
+        }
+
+        public int SiteId { get; }
+
+        /// <summary>Nullable because <c>week_ending</c> is - a stored row need not carry a week.</summary>
+        public DateTime? LatestWeekEnding { get; }
+    }
+
+    /// <summary>
+    /// Storage for the weekly SharePoint site usage report - the EF reads and writes
+    /// <c>SharePointSitesWeeklyUsageReportLoader</c> used to perform against
+    /// <c>AnalyticsEntitiesContext</c> inline. See issue #375.
+    ///
+    /// <para>
+    /// Both reads are deliberately whole-table and pre-loaded once: the save loop must do ZERO per-site
+    /// round-trips. The previous per-site top-1 query was the dominant cost of this import on a large
+    /// tenant, at roughly one query per site.
+    /// </para>
+    /// </summary>
+    public interface ISharePointSiteUsageStore
+    {
+        /// <summary>Every known site, untracked. Includes sites with a null URL; the caller filters.</summary>
+        Task<IReadOnlyList<StoredSite>> GetAllSitesAsync();
+
+        /// <summary>The latest stored week per site, in ONE grouped query rather than one query per site.</summary>
+        Task<IReadOnlyList<SiteLatestStoredWeek>> GetLatestStoredWeekPerSiteAsync();
+
+        /// <summary>Queue an insert for a site discovered by this report run.</summary>
+        void AddSite(Site site);
+
+        /// <summary>
+        /// Queue an insert for a weekly stats row. When <see cref="SharePointSitesFileWeeklyStats.Site"/>
+        /// is set instead of <see cref="SharePointSitesFileWeeklyStats.SiteId"/>, the store is responsible
+        /// for inserting that site first and filling the FK.
+        /// </summary>
+        void AddWeeklyStats(SharePointSitesFileWeeklyStats stats);
+
+        /// <summary>Commit everything queued.</summary>
+        Task CommitAsync();
+
+        /// <summary>
+        /// Enter the bulk-add phase. For the EF adapter this turns change auto-detection off, without
+        /// which adding tens of thousands of rows to the context is O(n^2).
+        /// </summary>
+        void BeginBulkWrite();
+
+        /// <summary>
+        /// Leave the bulk-add phase. Called from a <c>finally</c> so it runs even when nothing was saved,
+        /// because the context may be reused afterwards.
+        /// </summary>
+        void EndBulkWrite();
+    }
+
+    /// <summary>
+    /// EF6 <see cref="ISharePointSiteUsageStore"/>. Both queries, both adds, the commit and the
+    /// change-tracking toggle are the ones that were inline in
+    /// <c>SharePointSitesWeeklyUsageReportLoader</c>, moved unchanged (issue #375).
+    /// </summary>
+    public sealed class SqlSharePointSiteUsageStore : ISharePointSiteUsageStore
+    {
+        private readonly AnalyticsEntitiesContext _db;
+
+        public SqlSharePointSiteUsageStore(AnalyticsEntitiesContext db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+
+        public async Task<IReadOnlyList<StoredSite>> GetAllSitesAsync()
+        {
+            // Lightweight projection, not tracked - the save loop only needs the key and the URL.
+            var existingSites = await _db.sites.AsNoTracking()
+                .Select(s => new { s.ID, s.UrlBase })
+                .ToListAsync();
+
+            return existingSites.Select(s => new StoredSite(s.ID, s.UrlBase)).ToList();
+        }
+
+        public async Task<IReadOnlyList<SiteLatestStoredWeek>> GetLatestStoredWeekPerSiteAsync()
+        {
+            var latestPerSite = await _db.SharePointSiteStats
+                .GroupBy(s => s.SiteId)
+                .Select(g => new { SiteId = g.Key, Latest = g.Max(s => s.ForWeekEnding) })
+                .ToListAsync();
+
+            return latestPerSite.Select(r => new SiteLatestStoredWeek(r.SiteId, r.Latest)).ToList();
+        }
+
+        // Added (tracked) and attached via the stats row's navigation property, so EF inserts the site and
+        // fills the FK itself - no second round-trip to discover the new key.
+        public void AddSite(Site site) => _db.sites.Add(site);
+
+        public void AddWeeklyStats(SharePointSitesFileWeeklyStats stats) => _db.SharePointSiteStats.Add(stats);
+
+        public async Task CommitAsync()
+        {
+            // Auto-detect is off during the bulk add; run it once here so the pending inserts are picked up.
+            _db.ChangeTracker.DetectChanges();
+            await _db.SaveChangesAsync();
+        }
+
+        public void BeginBulkWrite() => _db.Configuration.AutoDetectChangesEnabled = false;
+
+        /// <summary>
+        /// Restores auto-detection to ON rather than to whatever it was before, which is what this loader
+        /// has always done. (The daily loaders restore the captured value instead; that difference is
+        /// pre-existing and is preserved deliberately - see issue #381, no behavioural change.)
+        /// </summary>
+        public void EndBulkWrite() => _db.Configuration.AutoDetectChangesEnabled = true;
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/ISharePointSiteUsageStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/ISharePointSiteUsageStore.cs
@@ -9,37 +9,52 @@ using System.Threading.Tasks;
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
 {
     /// <summary>A site row as the weekly SharePoint usage import needs it: just the key and the URL.</summary>
+    /// <remarks>
+    /// Settable properties and a parameterless constructor on purpose: this is what lets the EF adapter
+    /// project straight into it (<c>Select(s =&gt; new StoredSite { ... })</c>) instead of materialising an
+    /// anonymous type and then copying every row into a second list. On a tenant with tens of thousands
+    /// of sites that copy is pure garbage.
+    /// </remarks>
     public sealed class StoredSite
     {
+        public StoredSite()
+        {
+        }
+
         public StoredSite(int id, string urlBase)
         {
             Id = id;
             UrlBase = urlBase;
         }
 
-        public int Id { get; }
+        public int Id { get; set; }
 
         /// <summary>
         /// Nullable, exactly as the column is. The import discards null-URL sites rather than keying on
         /// them - see <c>SharePointSitesWeeklyUsageReportLoader.BeginSaveAsync</c>, and issue #375 part 2,
         /// where collapsing "no URL" into "no row" duplicated site rows.
         /// </summary>
-        public string UrlBase { get; }
+        public string UrlBase { get; set; }
     }
 
     /// <summary>The most recent stored week for one site.</summary>
+    /// <remarks>Projectable for the same reason as <see cref="StoredSite"/>.</remarks>
     public sealed class SiteLatestStoredWeek
     {
+        public SiteLatestStoredWeek()
+        {
+        }
+
         public SiteLatestStoredWeek(int siteId, DateTime? latestWeekEnding)
         {
             SiteId = siteId;
             LatestWeekEnding = latestWeekEnding;
         }
 
-        public int SiteId { get; }
+        public int SiteId { get; set; }
 
         /// <summary>Nullable because <c>week_ending</c> is - a stored row need not carry a week.</summary>
-        public DateTime? LatestWeekEnding { get; }
+        public DateTime? LatestWeekEnding { get; set; }
     }
 
     /// <summary>
@@ -103,22 +118,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
 
         public async Task<IReadOnlyList<StoredSite>> GetAllSitesAsync()
         {
-            // Lightweight projection, not tracked - the save loop only needs the key and the URL.
-            var existingSites = await _db.sites.AsNoTracking()
-                .Select(s => new { s.ID, s.UrlBase })
+            // Lightweight projection, not tracked - the save loop only needs the key and the URL. Projected
+            // straight into the DTO so the whole table is materialised ONCE, not copied into a second list.
+            return await _db.sites.AsNoTracking()
+                .Select(s => new StoredSite { Id = s.ID, UrlBase = s.UrlBase })
                 .ToListAsync();
-
-            return existingSites.Select(s => new StoredSite(s.ID, s.UrlBase)).ToList();
         }
 
         public async Task<IReadOnlyList<SiteLatestStoredWeek>> GetLatestStoredWeekPerSiteAsync()
         {
-            var latestPerSite = await _db.SharePointSiteStats
+            return await _db.SharePointSiteStats
                 .GroupBy(s => s.SiteId)
-                .Select(g => new { SiteId = g.Key, Latest = g.Max(s => s.ForWeekEnding) })
+                .Select(g => new SiteLatestStoredWeek { SiteId = g.Key, LatestWeekEnding = g.Max(s => s.ForWeekEnding) })
                 .ToListAsync();
-
-            return latestPerSite.Select(r => new SiteLatestStoredWeek(r.SiteId, r.Latest)).ToList();
         }
 
         // Added (tracked) and attached via the stats row's navigation property, so EF inserts the site and

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/SharePointSitesWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/SharePointSitesWeeklyUsageReportLoader.cs
@@ -3,8 +3,6 @@ using Common.Entities.Entities.UsageReports;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
@@ -15,6 +13,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
     public class SharePointSitesWeeklyUsageReportLoader : GraphAndSqlAggregateWeeklyUsageReportLoader<SharePointSiteUsageDetail>
     {
         private readonly SPSiteIdToUrlCache _sPSiteIdToUrlCache;
+        private readonly ISharePointSiteUsageStore _store;
 
         // Bulk-loaded once in BeginSaveAsync so the per-site save loop needs no DB round-trips:
         private Dictionary<string, DateTime?> _lastStoredWeekByUrl;   // existing latest week_ending per site URL
@@ -22,8 +21,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
         private Dictionary<string, Site> _newSitesByUrl;              // sites created during this run (reused for repeats)
 
         public SharePointSitesWeeklyUsageReportLoader(AnalyticsEntitiesContext db, ManualGraphCallClient client, ILogger logger, SPSiteIdToUrlCache sPSiteIdToUrlCache)
-            : base(db, client, logger)
+            : this(new SqlSharePointSiteUsageStore(db), client, logger, sPSiteIdToUrlCache)
         {
+        }
+
+        /// <summary>
+        /// As above, with storage supplied (issue #375). The context-taking constructor is kept as a
+        /// delegating overload so no call site changes.
+        /// </summary>
+        public SharePointSitesWeeklyUsageReportLoader(ISharePointSiteUsageStore store, ManualGraphCallClient client, ILogger logger, SPSiteIdToUrlCache sPSiteIdToUrlCache)
+            : base(client, logger)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
             _sPSiteIdToUrlCache = sPSiteIdToUrlCache;
         }
 
@@ -65,27 +74,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
         protected override async Task BeginSaveAsync(IReadOnlyList<SharePointSiteUsageDetail> allItems)
         {
             // All known sites (lightweight projection, not tracked) keyed by URL.
-            var existingSites = await _context.sites.AsNoTracking()
-                .Select(s => new { s.ID, s.UrlBase })
-                .ToListAsync();
+            var existingSites = await _store.GetAllSitesAsync();
 
             _existingSiteIdByUrl = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             var urlBySiteId = new Dictionary<int, string>();
             foreach (var s in existingSites)
             {
+                // A site with no URL cannot be keyed by one. Dropping it here is what keeps "no URL"
+                // and "no site" from collapsing into the same answer further down.
                 if (!string.IsNullOrEmpty(s.UrlBase))
                 {
-                    _existingSiteIdByUrl[s.UrlBase] = s.ID;
-                    urlBySiteId[s.ID] = s.UrlBase;
+                    _existingSiteIdByUrl[s.UrlBase] = s.Id;
+                    urlBySiteId[s.Id] = s.UrlBase;
                 }
             }
 
             // Latest stored week per site in ONE grouped query (replaces the per-site top-1 query that
             // previously ran once per site - the dominant cost of this import at ~1 query/site).
-            var latestPerSite = await _context.SharePointSiteStats
-                .GroupBy(s => s.SiteId)
-                .Select(g => new { SiteId = g.Key, Latest = g.Max(s => s.ForWeekEnding) })
-                .ToListAsync();
+            var latestPerSite = await _store.GetLatestStoredWeekPerSiteAsync();
 
             _lastStoredWeekByUrl = new Dictionary<string, DateTime?>(StringComparer.OrdinalIgnoreCase);
             foreach (var row in latestPerSite)
@@ -95,21 +101,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
                     // Keep the greatest week across any sites resolving to the same URL (matches the previous
                     // OrderByDescending(ForWeekEnding).First() semantics).
                     if (!_lastStoredWeekByUrl.TryGetValue(url, out var existing)
-                        || (row.Latest.HasValue && (!existing.HasValue || row.Latest.Value > existing.Value)))
+                        || (row.LatestWeekEnding.HasValue && (!existing.HasValue || row.LatestWeekEnding.Value > existing.Value)))
                     {
-                        _lastStoredWeekByUrl[url] = row.Latest;
+                        _lastStoredWeekByUrl[url] = row.LatestWeekEnding;
                     }
                 }
             }
 
             _newSitesByUrl = new Dictionary<string, Site>(StringComparer.OrdinalIgnoreCase);
-            _context.Configuration.AutoDetectChangesEnabled = false;
+            _store.BeginBulkWrite();
         }
 
         protected override Task EndSaveAsync()
         {
             // Always restore, even when nothing was saved, since the context may be reused.
-            _context.Configuration.AutoDetectChangesEnabled = true;
+            _store.EndBulkWrite();
             return Task.CompletedTask;
         }
 
@@ -123,12 +129,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
             return Task.FromResult(lastStored);
         }
 
-        protected override async Task CommitAllChanges()
-        {
-            // Auto-detect is off during the bulk add; run it once here so the pending inserts are picked up.
-            _context.ChangeTracker.DetectChanges();
-            await _context.SaveChangesAsync();
-        }
+        protected override Task CommitAllChanges() => _store.CommitAsync();
 
         protected override Task AddItemToSaveList(SharePointSiteUsageDetail item)
         {
@@ -162,12 +163,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
             {
                 // Brand-new site: add it (tracked) and attach via navigation so EF inserts it and fills the FK.
                 var site = new Site { UrlBase = item.SiteUrl };
-                _context.sites.Add(site);
+                _store.AddSite(site);
                 _newSitesByUrl[item.SiteUrl] = site;
                 newLog.Site = site;
             }
 
-            _context.SharePointSiteStats.Add(newLog);
+            _store.AddWeeklyStats(newLog);
             return Task.CompletedTask;
         }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs
@@ -1,0 +1,177 @@
+using Common.Entities;
+using Common.Entities.ActivityReports;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
+{
+    /// <summary>
+    /// Storage for ONE daily Graph usage-report table - the reads and writes
+    /// <c>AbstractDailyActivityLoader</c> used to perform against <c>AnalyticsEntitiesContext</c> inline.
+    /// See issue #375.
+    ///
+    /// <para>
+    /// The shape is deliberately day-scoped and incremental rather than the
+    /// "hand me every stored date / hand me every row" shape issue #375 sketched. The loader reads and
+    /// commits ONE DAY AT A TIME, dirty-checks each existing row and flushes every
+    /// <c>SaveBatchSize</c> writes, precisely because a ~200k-user tenant times 28 days is enough rows
+    /// to OutOfMemory EF6 when they are built into a single command tree (observed on a 7GB P2v2). A
+    /// coarser port would have forced that behaviour back out again, so the seam follows the batching
+    /// instead of fighting it.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TReportDbType">The EF entity for this report's table.</typeparam>
+    public interface IUsageReportStore<TReportDbType> where TReportDbType : AbstractUsageActivityLog
+    {
+        /// <summary>
+        /// Is there at least one stored row for this date? A bounded existence probe, used when the table
+        /// has a date-leading index so the finalized-date scan costs one index seek per candidate date.
+        /// </summary>
+        Task<bool> HasAnyRowForDateAsync(DateTime date);
+
+        /// <summary>
+        /// The distinct stored dates in <c>[fromInclusive, toExclusive)</c> - one range scan, used when
+        /// the table has no date-leading index and repeated existence probes would each scan it.
+        /// Values come back exactly as stored; the caller normalises.
+        /// </summary>
+        Task<IReadOnlyList<DateTime>> GetStoredDatesInRangeAsync(DateTime fromInclusive, DateTime toExclusive);
+
+        /// <summary>
+        /// Every stored row for one date, TRACKED, so that updates to them go through the change tracker
+        /// rather than needing an attach.
+        /// </summary>
+        Task<IReadOnlyList<TReportDbType>> GetRowsForDateAsync(DateTime date);
+
+        /// <summary>Queue an insert for a row that has no stored counterpart.</summary>
+        void AddRow(TReportDbType row);
+
+        /// <summary>
+        /// Queue an update for a row returned by <see cref="GetRowsForDateAsync"/>, but only when a mapped
+        /// value on it actually differs from what was loaded. Returns whether it will be written.
+        ///
+        /// <para>
+        /// This is the dominant cost of the import at scale: finalized days that the recent-window rule
+        /// re-fetches are almost always byte-identical to what is stored, so skipping those UPDATEs is
+        /// what keeps a re-import cheap. The check and the "mark it" are one call so the two can never
+        /// drift apart.
+        /// </para>
+        /// </summary>
+        bool MarkUpdatedIfChanged(TReportDbType row);
+
+        /// <summary>Commit everything queued since the last commit.</summary>
+        Task SaveChangesAsync();
+
+        /// <summary>
+        /// Release the usage-log rows held since the last call, so a 28-day import does not accumulate
+        /// every day's rows. Lookup entities (users / groups) are deliberately NOT released - the shared
+        /// id cache still needs them.
+        /// </summary>
+        void ReleaseSavedRows();
+
+        /// <summary>
+        /// Enter a bulk-write scope, restoring whatever was changed when disposed. For the SQL adapter
+        /// that means turning EF6 change auto-detection off, without which adding a day's rows is
+        /// O(n^2) - and restoring the PREVIOUS value, not a hard-coded "on", because the context may
+        /// have been handed in with it already off.
+        /// </summary>
+        IDisposable BeginBulkWrite();
+    }
+
+    /// <summary>
+    /// EF6/SQL Server <see cref="IUsageReportStore{TReportDbType}"/>. Every query, the dirty check, the
+    /// detach sweep and the change-tracking toggle are the ones that were inline in
+    /// <c>AbstractDailyActivityLoader</c>, moved unchanged (issue #375).
+    /// </summary>
+    public sealed class SqlUsageReportStore<TReportDbType> : IUsageReportStore<TReportDbType>
+        where TReportDbType : AbstractUsageActivityLog
+    {
+        private readonly AnalyticsEntitiesContext _db;
+        private readonly DbSet<TReportDbType> _table;
+
+        public SqlUsageReportStore(AnalyticsEntitiesContext db, DbSet<TReportDbType> table)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+        }
+
+        public Task<bool> HasAnyRowForDateAsync(DateTime date)
+            => _table.AnyAsync(activity => activity.Date == date);
+
+        public async Task<IReadOnlyList<DateTime>> GetStoredDatesInRangeAsync(DateTime fromInclusive, DateTime toExclusive)
+        {
+            return await _table
+                .Where(activity => activity.Date >= fromInclusive && activity.Date < toExclusive)
+                .Select(activity => activity.Date)
+                .Distinct()
+                .ToListAsync();
+        }
+
+        public async Task<IReadOnlyList<TReportDbType>> GetRowsForDateAsync(DateTime date)
+            => await _table.Where(t => t.Date == date).ToListAsync();
+
+        public void AddRow(TReportDbType row) => _table.Add(row);
+
+        public bool MarkUpdatedIfChanged(TReportDbType row)
+        {
+            var entry = _db.Entry(row);
+            if (!HasMappedValueChanged(entry))
+            {
+                return false;
+            }
+
+            // Auto-detect is off inside the bulk-write scope, so state the change explicitly.
+            entry.State = EntityState.Modified;
+            return true;
+        }
+
+        public Task SaveChangesAsync() => _db.SaveChangesAsync();
+
+        public void ReleaseSavedRows()
+        {
+            foreach (var entry in _db.ChangeTracker.Entries<AbstractUsageActivityLog>().ToList())
+            {
+                entry.State = EntityState.Detached;
+            }
+        }
+
+        public IDisposable BeginBulkWrite() => new AutoDetectChangesSuspension(_db);
+
+        // True if any mapped scalar value on the tracked entity differs from the value originally loaded from the
+        // DB. Compares the EF6 original/current value snapshots directly so it works with
+        // AutoDetectChangesEnabled = false (auto-detect is deliberately off to keep bulk saves O(n)). Navigation
+        // properties and [NotMapped] members (e.g. AssociatedLookupId) are not in these snapshots, so only real
+        // column changes trigger an UPDATE.
+        private static bool HasMappedValueChanged(DbEntityEntry entry)
+        {
+            var current = entry.CurrentValues;
+            var original = entry.OriginalValues;
+            foreach (var propertyName in current.PropertyNames)
+            {
+                if (!object.Equals(original[propertyName], current[propertyName]))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private sealed class AutoDetectChangesSuspension : IDisposable
+        {
+            private readonly AnalyticsEntitiesContext _db;
+            private readonly bool _wasEnabled;
+
+            internal AutoDetectChangesSuspension(AnalyticsEntitiesContext db)
+            {
+                _db = db;
+                _wasEnabled = db.Configuration.AutoDetectChangesEnabled;
+                db.Configuration.AutoDetectChangesEnabled = false;
+            }
+
+            public void Dispose() => _db.Configuration.AutoDetectChangesEnabled = _wasEnabled;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Graph\Teams\TeamTokenManager.cs" />
     <Compile Include="Graph\UsageReports\AbstractDailyActivityLoader.cs" />
     <Compile Include="Graph\UsageReports\IUsageReportStorageInspector.cs" />
+    <Compile Include="Graph\UsageReports\IUsageReportStore.cs" />
     <Compile Include="Graph\UsageReports\Rules\UsageReportRefreshPolicy.cs" />
     <Compile Include="Graph\Calls\CallQueueProcessor.cs" />
     <Compile Include="Graph\Calls\CallRecordAdapters.cs" />
@@ -204,6 +205,7 @@
     <Compile Include="Graph\UsageReports\ActivityReportLoader.cs" />
     <Compile Include="Graph\UsageReports\Aggregate\AbstractAggregateWeeklyUsageReportLoader.cs" />
     <Compile Include="Graph\UsageReports\Aggregate\AbstractModels.cs" />
+    <Compile Include="Graph\UsageReports\Aggregate\ISharePointSiteUsageStore.cs" />
     <Compile Include="Graph\UsageReports\Aggregate\SharePointSiteUsageDetail.cs" />
     <Compile Include="Graph\UsageReports\Aggregate\SharePointSitesWeeklyUsageReportLoader.cs" />
     <Compile Include="Graph\UsageReports\Copilot\CopilotReportRequest.cs" />


### PR DESCRIPTION
Part 3 of #375, and the last of its store seams. Parts 1 ([#404](https://github.com/pnp/Microsoft365-Analytics-Insights/pull/404)) and 2 ([#410](https://github.com/pnp/Microsoft365-Analytics-Insights/pull/410)) extracted `UsageReportRefreshPolicy` / `IUsageReportStorageInspector` and `ISiteUrlStore`. This removes the remaining inline EF from **both** usage-report loaders: neither now issues an EF query or write itself. (The weekly loader no longer holds an `AnalyticsEntitiesContext` at all. The daily loader still *receives* one per call from `GraphImporter` and hands it to the adapters — `GetTable(db)`, `StoreFor(db)`, `InspectorFor(db)` — so it is not context-free, just query-free.)

**Behaviour is identical.** Every query, `Add`, dirty check, flush, detach and change-tracking toggle is the statement that was already there, relocated into an adapter. No log text, log order or log number changes. No schema, migration or index changes. No call-site changes.

## Why this was its own PR

The seam threads through the generic base class `AbstractDailyActivityLoader<TReportDbType, TUserActivityUserDetail, TLookupType, CACHETYPE>`, which every one of the ten concrete daily loaders derives from — bolting it onto part 2 would have made that diff unreviewable.

## What moved

### `IUsageReportStore<TReportDbType>` + `SqlUsageReportStore<TReportDbType>`
`WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs`

Covers everything `AbstractDailyActivityLoader` did against `AnalyticsEntitiesContext`:

| Port member | Was |
|---|---|
| `HasAnyRowForDateAsync` | `table.AnyAsync(a => a.Date == date)` (indexed branch) |
| `GetStoredDatesInRangeAsync` | `.Where(range).Select(Date).Distinct().ToListAsync()` (fallback branch) |
| `GetRowsForDateAsync` | `GetTable(db).Where(t => t.Date == dateTime.Date).ToListAsync()` |
| `AddRow` | `GetTable(db).Add(...)` |
| `MarkUpdatedIfChanged` | `HasMappedValueChanged(db.Entry(x))` + `Entry(x).State = Modified` |
| `SaveChangesAsync` | `db.SaveChangesAsync()` |
| `ReleaseSavedRows` | `ChangeTracker.Entries<AbstractUsageActivityLog>()` → `Detached` |
| `BeginBulkWrite` | `AutoDetectChangesEnabled` capture/false/restore `try…finally` |

Injected the same way part 1 injected the inspector — a settable `ReportStore` property that short-circuits a `?? new SqlUsageReportStore<T>(db, GetTable(db))` default, so no constructor signature changes and nothing binary-breaking.

### `ISharePointSiteUsageStore` + `SqlSharePointSiteUsageStore`
`WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/ISharePointSiteUsageStore.cs`

Covers the weekly aggregate loader: the `AsNoTracking()` sites projection, the **one** grouped latest-week-per-site query, both `Add`s, `DetectChanges()` + `SaveChangesAsync()`, and the bulk-write toggle. `GraphAndSqlAggregateWeeklyUsageReportLoader<T>` no longer holds an `AnalyticsEntitiesContext`; `SharePointSitesWeeklyUsageReportLoader` keeps its `(db, client, logger, cache)` constructor as a **delegating overload** that builds the SQL adapter, so `GraphImporter` and the four pre-existing DB-backed tests are untouched.

Two pre-existing performance properties are preserved verbatim and are now covered by call-count assertions rather than only by comment: reads happen **once per run, never once per site**, and the `_existingSiteIdByUrl` / `_lastStoredWeekByUrl` dictionaries stay `OrdinalIgnoreCase`.

### On the port shape

Deliberately **day-scoped and incremental**, not the `GetStoredReportDatesAsync(reportName)` / `UpsertReportRowsAsync(rows)` shape #375 sketched. The loader reads and commits one day at a time and flushes every `SaveBatchSize` writes precisely because ~200k users × 28 days OOMs EF6 as a single command tree (observed on a 7GB P2v2). A coarser port would have forced that behaviour back out, which #381 forbids. The interface is EF-shaped because the batching *is* the behaviour being preserved.

## `ExecuteSqlCommandAsync`

The task for this part was worded as "move `ExecuteSqlCommandAsync` out of the aggregate loaders". Verified against history rather than taken at face value: the only `ExecuteSqlCommandAsync` in this area was in `AbstractDailyActivityLoader` (the columnstore `REORGANIZE`, #375's `:203`), and **part 1 already relocated it** into `SqlUsageReportStorageInspector`. `git show 34da30e~1` confirms the aggregate loaders never contained one. After this PR there is no raw SQL and no inline EF query or write left in either loader. (The daily loader still calls its own `GetTable(db)` accessor to hand the `DbSet<T>` to the adapter — that is the remaining EF contact, and it is deliberate.)

## Tests — 25 new, zero SQL Server / zero Graph / zero HTTP

`Tests.UnitTests/DailyActivityLoaderTests.cs` (15). **This save loop had no unit tests at all**: the `(date, lookup)` upsert, the dirty check that decides whether a re-fetched finalized day costs an `UPDATE`, the batch boundary, the null-lookup and group-scope filters, `LastActivityDate` parsing, the per-day release, and both skip-scan query shapes were only reachable through a live database.

`Tests.UnitTests/SharePointSiteUsageStoreTests.cs` (10). The weekly save loop without a database, including:
- the case-insensitive URL guarantee in **both** directions — the site match *and* the last-stored-week match (only the first was covered before, and a wrong comparer on the second re-saves the same week every run without ever duplicating a site);
- the greatest-week-across-duplicate-sites rule, seeded so that "take whichever row was read last" gives the wrong answer;
- **a site row with a `NULL url_base` is never used as a key** — the same "no row vs. row with a null value" class of bug that #410's review caught.

New fakes: `InMemoryUsageReportStore<T>`, `InMemorySharePointSiteUsageStore`, `InMemoryDailyActivityLoader`. `InMemoryUsageReportStore` mirrors four EF6 behaviours on purpose rather than being merely convenient, because a lenient fake would let a broken refactor pass:
1. the dirty check compares against a snapshot taken **when the row was handed out**, not against the row itself (which can only ever compare equal — the reference-identity failure mode);
2. `MarkUpdatedIfChanged` **throws** for a row queued for insert, because EF6's `DbEntityEntry.OriginalValues` throws in the `Added` state;
3. `ReleaseSavedRows` **discards** anything unsaved, because detaching in EF6 drops a pending insert;
4. a successful save resets the snapshot.

## Mutation-checked

Every load-bearing test was proven able to fail. Eleven production lines were broken on purpose, the run repeated, and the line restored:

| Mutation | Test(s) that failed |
|---|---|
| dirty check always writes | `UnchangedExistingRow_IsNotRewritten` |
| `.Date` truncation dropped | `RunsWithFakeSourceAndFakeStore_WithoutSqlOrGraph` |
| batch boundary removed | `FlushesOnceTheBatchIsFull_AndAgainForTheRemainder` |
| release moved **before** the final flush | 6 tests — rows silently lost |
| bulk-write scope never disposed | both bulk-scope tests |
| skip-date filter disabled | `SkippedDates_AreNotRequestedFromGraph` |
| index branch inverted | both skip-scan shape tests |
| invalid-date null-out removed | `ValidLastActivityDate_IsParsed_InvalidIsNulled` |
| null-URL site guard removed | `SiteRowWithNoUrl_IsNeverUsedAsAKey` |
| greatest-week → last-wins | `TwoSitesSharingAUrl_UseTheirGreatestStoredWeek` |
| `OrdinalIgnoreCase` → `Ordinal` | both case-insensitivity tests |

Two tests were rewritten during this step because they *could not fail*: `EmptyLastActivityDate…` asserted `Updated.Count` (which the fake leaves at 0 even when the loader forces a write) and now asserts `LastSaveDbWriteCount`; `ValidLastActivityDate_IsParsed_InvalidIsNulled` asserted the null on a **new** row, where "nulled" and "never set" are indistinguishable, and now asserts it against an existing row that already holds a date.

## Reviewer hotspots

- **`BeginBulkWrite` semantics differ between the two loaders, on purpose.** The daily store restores the *captured* value; the aggregate store restores to `true` unconditionally. That asymmetry is pre-existing (`EndSaveAsync` has always hard-coded `AutoDetectChangesEnabled = true`) and is preserved rather than "fixed", per #381.
- **The `?? new Sql…(db, GetTable(db))` default.** The right-hand side is only evaluated when no store is injected, which is what makes a null context safe in the fakes. Same trick part 1 used for the inspector.
- **`SqlSharePointSiteUsageStore` null-guards its context in the delegating constructor**, so a `null` db now throws `ArgumentNullException` at construction where it previously NRE'd later inside `BeginSaveAsync`. Consistent with `SqlSiteUrlStore` and `SqlUsageReportStorageInspector` from parts 1 and 2; no production path passes null.
- **`protected readonly AnalyticsEntitiesContext _context` and the `(db, client, logger)` constructor were removed** from the public abstract `GraphAndSqlAggregateWeeklyUsageReportLoader<T>`, rather than left dangling and null. It has exactly one subclass and no other reader anywhere in the solution. To be precise about the cost: removing a `protected` member from a public type is **binary**-breaking as well as source-breaking — an already-compiled external subclass would get `MissingMethodException`/`MissingFieldException`. Accepted deliberately: this assembly is consumed only by the web-job and the test project, it is not a published library, and keeping the shims would mean a permanently-null `_context` field that the next subclass would fall into.
- **Pre-existing edge preserved, not fixed:** two Graph rows for the same *new* lookup on one date reach `MarkUpdatedIfChanged` with the entity in the `Added` state, where EF6's `OriginalValues` throws. That is how the code behaves today (`db.Entry(addedEntity).OriginalValues`); the fake reproduces it rather than papering over it. Worth a follow-up issue, out of scope here.

## Verification

Full solution builds (Debug).

**Area suite:** 55 tests across `DailyActivityLoaderTests`, `SharePointSiteUsageStoreTests`, `GraphUsageReportImportTests`, `UsageReportRefreshPolicyTests`, `UsageReportTableNameTests` and `SiteIdToUrlCacheTests` — **54 passed, 1 failed**. (Note `UsageReportRefreshPolicyTests.cs` contains a *second* `[TestClass]`, `UsageReportTableNameTests`; an earlier run of this section filtered on five class names and therefore missed its 4 tests.)

**Full suite (re-run on HEAD):** **1351 passed / 12 failed / 1 skipped** out of 1364. The 12 failures are exactly the documented pre-existing environment failures — eight needing real Graph/cognitive credentials (including `SharePointSitesUsageLoaderTest`, which dies on the local placeholder config with `AADSTS90002: Tenant '00000000-0000-0000-0000-000000000002' not found`) and four needing `InstallerTestConfig.json`. (That file *is* tracked in git, at `Tests.UnitTests/InstallTests/TestConfigs/`, but the old-style project does not mark it as content, so it is never copied to `bin\Debug\InstallTests\TestConfigs\` where `VNetIntegrationTests` looks for it.) The skip is the env-gated `ActivityApi_ColdWarm_LoadTest`. **No regressions.**

Addresses #375. Part of #381.

## Review round 1 (multi-model)

Three reviewers (`claude-opus-4.8`, `gpt-5.6-sol`, `grok-4.6`) went at this independently. Nobody found a behavioural difference in the refactor itself; the findings were a test-flake, an allocation regression I introduced in the new adapter, and three inaccurate claims in this body. All fixed in `99a7442`:

1. **Three tests could fail at UTC midnight.** They computed expected dates from their own `DateTime.UtcNow` while the loader read `DateTime.UtcNow` again internally. `AbstractDailyActivityLoader` now takes an `IClock` (the seam merged by #368), defaulting to `SystemClock.Instance` so production is unchanged, and both of its clock reads go through it — the Graph-window read staying *inside* the day loop exactly as before. Mutation-checked, and measured rather than assumed — the two reads are in different methods, so no single revert fails all three: reverting the skip-window read fails `IndexedTable` and `UnindexedTable` (2 tests); reverting the Graph-window read fails `SkippedDates` (1 test); only reverting both fails all three. A 15th test pins that the default really is `SystemClock`.
2. **`SqlSharePointSiteUsageStore` allocated ~2N objects per whole-table read** — it materialised into anonymous types and then copied every row into a second list, which the original loader did not do. Both reads now project straight into the DTOs. Verified the SQL is byte-for-byte the same shape by printing `IQueryable.ToString()`: `SELECT [Extent1].[id], [Extent1].[url_base] FROM [dbo].[sites]` and `SELECT … FROM (SELECT [site_id] AS [K1], MAX([week_ending]) AS [A1] FROM [dbo].[sharepoint_sites_file_stats_log] GROUP BY [site_id]) …` — still a two-column projection and a server-side `GROUP BY`/`MAX`, no client-side evaluation. The three DB-backed `SharePointSitesUsageLoader_*` tests still pass.
3. **Three claims in this body were wrong** and have been corrected above: the "neither loader touches `AnalyticsEntitiesContext`" overstatement, "source-breaking only" (it is binary-breaking too), and the "50 tests" count.

Total mutations proven: **13** (11 in the original round, plus both clock sites).
## Review round 2

Same three reviewers, re-run against `99a7442`. Nobody found a behavioural difference; one code finding and four inaccurate claims of mine. Fixed in `9af4feb`:

- **Dropped a redundant, flake-prone assertion.** `DailyActivityLoader_DefaultClock_IsTheSystemClock` also asserted the default clock's `UtcNow` was within five seconds of `DateTime.UtcNow`. That cannot fail independently of the `AreSame` check (`SystemClock.UtcNow` just returns `DateTime.UtcNow`) but *can* fail if the thread is preempted between the two reads — no discriminating power, real flake. Removed; `ClockAndContextFactoryTests.SystemClock_ReturnsUtcKind` already covers that `SystemClock` reports UTC.
- **Corrected the clock mutation claim** (see above): measured, not inferred — 2 tests / 1 test, not "either site fails all three".
- **Corrected "no EF call left in either loader"** to "no raw SQL and no inline EF query or write", since `StoreFor` still calls `GetTable(db)`.
- **Corrected the `InstallerTestConfig.json` explanation**: the file *is* tracked in git; it is simply never copied to the test output directory.
- **Re-ran the full suite on HEAD** rather than quoting the pre-`99a7442` figure: **1351 / 12 / 1 of 1364** (was 1350 / 12 / 1 of 1363 before the added test).

Total mutations proven: **13** — the 11 in the table above, plus the two clock sites checked individually.