### PR TITLE
Graph user pipeline: bulk-write port, batched manager resolution and the delta-commit rule (#371 part 2, #372 part 1)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserPipelinePorts.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserPipelinePorts.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// In-memory <see cref="IUserBulkUpdateWriter"/>. Records a snapshot of every batch handed to it
+    /// so the batching and foreign-key resolution above it can be asserted without a SQL Server
+    /// (#371).
+    /// </summary>
+    /// <remarks>
+    /// The batches are <b>copied</b>, not stored by reference: the production caller wraps the
+    /// <see cref="DataTable"/> in a <c>using</c> and disposes it as soon as this returns, so keeping
+    /// the instance would leave the test asserting against a disposed table.
+    /// </remarks>
+    internal class InMemoryUserBulkUpdateWriter : IUserBulkUpdateWriter
+    {
+        public List<DataTable> Batches { get; } = new List<DataTable>();
+
+        public int TotalRowsWritten => Batches.Sum(b => b.Rows.Count);
+
+        public Task ExecuteAsync(DataTable userUpdates)
+        {
+            Batches.Add(userUpdates.Copy());
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IUserLookupStore"/> seeded with a fixed user population.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CallCount"/> and <see cref="RequestedUpnBatches"/> are what pin the N+1 fix: the
+    /// point of the port is that a whole batch resolves in one call, so a regression that puts the
+    /// lookup back inside the per-user loop shows up as a call count equal to the number of users.
+    /// </remarks>
+    internal class InMemoryUserLookupStore : IUserLookupStore
+    {
+        private readonly Dictionary<string, List<Common.Entities.User>> _byUpn
+            = new Dictionary<string, List<Common.Entities.User>>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>How many times the store has been asked for users.</summary>
+        public int CallCount { get; private set; }
+
+        /// <summary>The UPN set passed to each call, in order.</summary>
+        public List<List<string>> RequestedUpnBatches { get; } = new List<List<string>>();
+
+        public InMemoryUserLookupStore Add(Common.Entities.User user)
+        {
+            if (!_byUpn.TryGetValue(user.UserPrincipalName, out var rows))
+            {
+                rows = new List<Common.Entities.User>();
+                _byUpn[user.UserPrincipalName] = rows;
+            }
+            rows.Add(user);
+            return this;
+        }
+
+        public InMemoryUserLookupStore Add(int id, string upn)
+        {
+            return Add(new Common.Entities.User { ID = id, UserPrincipalName = upn });
+        }
+
+        public Task<IReadOnlyList<Common.Entities.User>> GetUsersByUpnAsync(IReadOnlyCollection<string> upns)
+        {
+            CallCount++;
+            RequestedUpnBatches.Add(upns.ToList());
+
+            var found = new List<Common.Entities.User>();
+            foreach (var upn in upns)
+            {
+                if (_byUpn.TryGetValue(upn, out var rows))
+                {
+                    found.AddRange(rows);
+                }
+            }
+
+            return Task.FromResult<IReadOnlyList<Common.Entities.User>>(found);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IUserLookupStore"/> whose every call fails.
+    /// </summary>
+    /// <remarks>
+    /// Fails via <see cref="Task.FromException"/> rather than throwing synchronously. A synchronous
+    /// throw lands in the caller's <c>catch</c> whether or not the caller awaited the task, so a fake
+    /// built that way cannot detect a dropped <c>await</c> - the bug class behind commit
+    /// <c>560e501</c>. The attempt is recorded before the faulted task is returned so
+    /// "was it attempted?" assertions still hold.
+    /// </remarks>
+    internal class FailingUserLookupStore : IUserLookupStore
+    {
+        public int CallCount { get; private set; }
+
+        public Task<IReadOnlyList<Common.Entities.User>> GetUsersByUpnAsync(IReadOnlyCollection<string> upns)
+        {
+            CallCount++;
+            return Task.FromException<IReadOnlyList<Common.Entities.User>>(
+                new InvalidOperationException("Simulated user lookup failure"));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -54,6 +54,11 @@
     <Compile Include="InstallTests\VNetIntegrationTests.cs" />
     <Compile Include="InstallTests\AppInsightsArmTemplateTests.cs" />
     <Compile Include="UserImportCaseSensitivityTests.cs" />
+    <Compile Include="FakeLoaderClasses\FakeUserPipelinePorts.cs" />
+    <Compile Include="UserBulkUpdateRulesTests.cs" />
+    <Compile Include="UserImportCommitPolicyTests.cs" />
+    <Compile Include="UserManagerResolutionTests.cs" />
+    <Compile Include="UserManagerPrefetchLicenceTests.cs" />
     <Compile Include="UserMetadataMappingRulesTests.cs" />
     <Compile Include="UserMetadataUpdaterBasicTests.cs" />
     <Compile Include="UserMetadataUpdaterInsertTests.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/UserBulkUpdateRulesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserBulkUpdateRulesTests.cs
@@ -1,0 +1,498 @@
+using Common.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text.RegularExpressions;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests for the bulk existing-user update rules: which users make it into a batch, what every
+    /// column gets, and the manager foreign-key precedence chain.
+    ///
+    /// All of this used to live inside <c>UserBatchProcessor</c> next to a <c>SqlConnection</c> and a
+    /// <c>SqlBulkCopy</c>, so none of it could be asserted without a live SQL Server and none of it
+    /// had a test - despite being the write path a ~200,000-user tenant actually takes. See issues
+    /// #371 / #381.
+    /// </summary>
+    [TestClass]
+    public class UserBulkUpdateRulesTests
+    {
+        private const string ManagerAadId = "00000000-0000-0000-0000-0000000000aa";
+        private static readonly DateTime Stamp = new DateTime(2026, 3, 4, 5, 6, 7, DateTimeKind.Unspecified);
+
+        #region Fixtures
+
+        private static GraphUser GraphUserWithEverything()
+        {
+            return new GraphUser
+            {
+                Id = "00000000-0000-0000-0000-000000000001",
+                UserPrincipalName = "jane.doe@contoso.com",
+                Mail = "jane.doe@contoso.com",
+                AccountEnabled = true,
+                PostalCode = "SW1A 1AA",
+                Department = "Engineering",
+                JobTitle = "Principal Engineer",
+                OfficeLocation = "London",
+                UsageLocation = "GB",
+                Country = "United Kingdom",
+                State = "Greater London",
+                CompanyName = "Contoso",
+            };
+        }
+
+        /// <summary>Lookup maps where every name in <see cref="GraphUserWithEverything"/> has a saved row.</summary>
+        private static LookupEntityMaps SavedLookupsForEverything()
+        {
+            var maps = new LookupEntityMaps();
+            maps.Departments["Engineering"] = new UserDepartment { ID = 11, Name = "Engineering" };
+            maps.JobTitles["Principal Engineer"] = new UserJobTitle { ID = 12, Name = "Principal Engineer" };
+            maps.OfficeLocations["London"] = new UserOfficeLocation { ID = 13, Name = "London" };
+            maps.UsageLocations["GB"] = new UserUsageLocation { ID = 14, Name = "GB" };
+            maps.Countries["United Kingdom"] = new CountryOrRegion { ID = 15, Name = "United Kingdom" };
+            maps.StatesOrProvinces["Greater London"] = new StateOrProvince { ID = 16, Name = "Greater London" };
+            maps.CompanyNames["Contoso"] = new CompanyName { ID = 17, Name = "Contoso" };
+            return maps;
+        }
+
+        private static Dictionary<string, Common.Entities.User> UsersByUpn(params Common.Entities.User[] users)
+        {
+            var d = new Dictionary<string, Common.Entities.User>(StringComparer.OrdinalIgnoreCase);
+            foreach (var u in users) d[u.UserPrincipalName] = u;
+            return d;
+        }
+
+        private static Dictionary<string, Common.Entities.User> UsersByAadId(params Common.Entities.User[] users)
+        {
+            var d = new Dictionary<string, Common.Entities.User>(StringComparer.OrdinalIgnoreCase);
+            foreach (var u in users) d[u.AzureAdId] = u;
+            return d;
+        }
+
+        private static Dictionary<string, GraphUser> GraphUsersByAadId(params GraphUser[] users)
+        {
+            var d = new Dictionary<string, GraphUser>(StringComparer.OrdinalIgnoreCase);
+            foreach (var u in users) d[u.Id] = u;
+            return d;
+        }
+
+        private static GraphUser WithManager(GraphUser user, string managerAadId)
+        {
+            user.ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = managerAadId } };
+            return user;
+        }
+
+        private static DataRow SingleRowFor(GraphUser graphUser, LookupEntityMaps maps, Common.Entities.User dbUser)
+        {
+            var table = UserBulkUpdateRules.BuildUpdateTable(
+                new List<GraphUser> { graphUser },
+                maps,
+                UsersByAadId(),
+                UsersByUpn(dbUser),
+                GraphUsersByAadId(),
+                Stamp);
+
+            Assert.AreEqual(1, table.Rows.Count, "Expected exactly one row for one mapped user.");
+            return table.Rows[0];
+        }
+
+        #endregion
+
+        #region Table shape - the three copies of the column list must agree
+
+        [TestMethod]
+        public void UserBulkUpdate_DataTableShape_MatchesTheDeclaredColumnList()
+        {
+            var table = UserBulkUpdateRules.CreateUpdateTable();
+
+            CollectionAssert.AreEqual(
+                UserBulkUpdateRules.UpdateTableColumns.ToArray(),
+                table.Columns.Cast<DataColumn>().Select(c => c.ColumnName).ToArray(),
+                "The batch table's columns must match UpdateTableColumns exactly, in order - " +
+                "SqlUserBulkUpdateWriter maps them positionally from that same list.");
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_TempTableDdl_DeclaresExactlyTheColumnsTheBatchCarries()
+        {
+            // The temp table, the DataTable and the SqlBulkCopy mappings used to be three
+            // independently maintained lists of the same fourteen names. Adding a column to one and
+            // forgetting the others is a runtime failure inside a customer import, so pin them here.
+            //
+            // Matched as whole identifiers, not substrings: "id" occurs inside azure_ad_id,
+            // department_id, manager_id and six others, so a substring check would stay green even
+            // if the join-key column were deleted from the DDL outright.
+            CollectionAssert.AreEquivalent(
+                UserBulkUpdateRules.UpdateTableColumns.ToArray(),
+                DeclaredTempTableColumns(SqlUserBulkUpdateWriter.CREATE_TEMP_TABLE_SQL),
+                "#user_updates must declare exactly the columns the batch carries - no more, no fewer.");
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_UpdateStatement_WritesEveryColumnExceptTheJoinKey()
+        {
+            var assignments = Assignments(SqlUserBulkUpdateWriter.UPDATE_FROM_TEMP_SQL);
+
+            CollectionAssert.AreEquivalent(
+                UserBulkUpdateRules.UpdateTableColumns.Where(c => c != "id").ToArray(),
+                assignments.Select(a => a.Target).ToArray(),
+                "The UPDATE ... FROM JOIN must assign every batch column except the join key - a column " +
+                "the batch carries but the statement never writes is silently dropped.");
+
+            // Checking only the target would let u.mail = t.postalcode through: every column would
+            // still be assigned, from the wrong source.
+            var crossed = assignments.Where(a => a.Target != a.Source).ToArray();
+            Assert.AreEqual(0, crossed.Length,
+                "Each column must be written from the batch column of the same name. Crossed: " +
+                string.Join(", ", crossed.Select(a => $"u.{a.Target} = t.{a.Source}")));
+
+            StringAssert.Contains(SqlUserBulkUpdateWriter.UPDATE_FROM_TEMP_SQL, "ON u.id = t.id",
+                "'id' is the join key, not an updated column.");
+        }
+
+        /// <summary>Column identifiers declared by the CREATE TABLE, taken from the start of each line.</summary>
+        private static string[] DeclaredTempTableColumns(string createTableSql)
+        {
+            var body = createTableSql.Substring(createTableSql.IndexOf('(') + 1);
+            return Regex.Matches(body, @"^\s*(?<name>[a-z_][a-z0-9_]*)\s+(INT|BIT|DATETIME|NVARCHAR)",
+                    RegexOptions.Multiline | RegexOptions.IgnoreCase)
+                .Cast<Match>()
+                .Select(m => m.Groups["name"].Value)
+                .ToArray();
+        }
+
+        /// <summary>The "u.x = t.y" pairs in the UPDATE's SET clause.</summary>
+        private static (string Target, string Source)[] Assignments(string updateSql)
+        {
+            // Only the SET clause: the ON clause also matches "u.x = t.x", and counting the join key
+            // as an assignment would hide a column the statement never actually writes.
+            var setStart = updateSql.IndexOf("SET ", System.StringComparison.Ordinal);
+            var fromStart = updateSql.IndexOf("FROM dbo.users", System.StringComparison.Ordinal);
+            var setClause = updateSql.Substring(setStart, fromStart - setStart);
+
+            return Regex.Matches(setClause, @"u\.(?<target>[a-z_][a-z0-9_]*)\s*=\s*t\.(?<source>[a-z_][a-z0-9_]*)")
+                .Cast<Match>()
+                .Select(m => (Target: m.Groups["target"].Value, Source: m.Groups["source"].Value))
+                .ToArray();
+        }
+
+        #endregion
+
+        #region Column mapping
+
+        [TestMethod]
+        public void UserBulkUpdate_MapsDirectFieldsAndResolvedForeignKeys()
+        {
+            var dbUser = new Common.Entities.User { ID = 42, UserPrincipalName = "jane.doe@contoso.com" };
+            var row = SingleRowFor(GraphUserWithEverything(), SavedLookupsForEverything(), dbUser);
+
+            Assert.AreEqual(42, row["id"]);
+            Assert.AreEqual("00000000-0000-0000-0000-000000000001", row["azure_ad_id"]);
+            Assert.AreEqual(true, row["account_enabled"]);
+            Assert.AreEqual("jane.doe@contoso.com", row["mail"]);
+            Assert.AreEqual("SW1A 1AA", row["postalcode"]);
+            Assert.AreEqual(11, row["department_id"]);
+            Assert.AreEqual(12, row["job_title_id"]);
+            Assert.AreEqual(13, row["office_location_id"]);
+            Assert.AreEqual(14, row["usage_location_id"]);
+            Assert.AreEqual(15, row["country_or_region_id"]);
+            Assert.AreEqual(16, row["state_or_province_id"]);
+            Assert.AreEqual(17, row["company_name_id"]);
+            Assert.AreEqual(Stamp, row["last_updated"]);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_NonAsciiLookupValues_ResolveWithoutMangling()
+        {
+            // Display names, departments, offices and company names are customer text and are
+            // routinely non-Latin. The lookup maps are keyed by the normalised name, so a mapping
+            // change that mangled the characters would silently resolve every one of them to NULL.
+            // (UPNs are excluded on purpose - Entra restricts them to ASCII.)
+            var graphUser = GraphUserWithEverything();
+            graphUser.Department = "Καλημέρα κόσμε";
+            graphUser.JobTitle = "Μηχανικός Λογισμικού";
+            graphUser.OfficeLocation = "Αθήνα";
+            graphUser.Country = "Ελλάδα";
+            graphUser.State = "Αττική";
+            graphUser.CompanyName = "Κόντοσο";
+
+            var maps = SavedLookupsForEverything();
+            maps.Departments["Καλημέρα κόσμε"] = new UserDepartment { ID = 21, Name = "Καλημέρα κόσμε" };
+            maps.JobTitles["Μηχανικός Λογισμικού"] = new UserJobTitle { ID = 22, Name = "Μηχανικός Λογισμικού" };
+            maps.OfficeLocations["Αθήνα"] = new UserOfficeLocation { ID = 23, Name = "Αθήνα" };
+            maps.Countries["Ελλάδα"] = new CountryOrRegion { ID = 24, Name = "Ελλάδα" };
+            maps.StatesOrProvinces["Αττική"] = new StateOrProvince { ID = 25, Name = "Αττική" };
+            maps.CompanyNames["Κόντοσο"] = new CompanyName { ID = 26, Name = "Κόντοσο" };
+
+            var dbUser = new Common.Entities.User { ID = 42, UserPrincipalName = "jane.doe@contoso.com" };
+            var row = SingleRowFor(graphUser, maps, dbUser);
+
+            Assert.AreEqual(21, row["department_id"]);
+            Assert.AreEqual(22, row["job_title_id"]);
+            Assert.AreEqual(23, row["office_location_id"]);
+            Assert.AreEqual(24, row["country_or_region_id"]);
+            Assert.AreEqual(25, row["state_or_province_id"]);
+            Assert.AreEqual(26, row["company_name_id"]);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_ValueGraphNoLongerReports_ClearsTheForeignKey()
+        {
+            // Graph sending nothing means "clear it", exactly as the EF path does - the pipeline
+            // deliberately nulls the lookup rather than leaving the previous value in place.
+            var graphUser = GraphUserWithEverything();
+            graphUser.Department = null;
+            graphUser.JobTitle = "   ";
+
+            var dbUser = new Common.Entities.User { ID = 42, UserPrincipalName = "jane.doe@contoso.com" };
+            var row = SingleRowFor(graphUser, SavedLookupsForEverything(), dbUser);
+
+            Assert.AreEqual(DBNull.Value, row["department_id"]);
+            Assert.AreEqual(DBNull.Value, row["job_title_id"], "A whitespace-only value normalises away and must clear the lookup.");
+            Assert.AreEqual(13, row["office_location_id"], "Only the values Graph stopped reporting should be cleared.");
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_NullDirectFields_AreWrittenAsDbNullNotEmptyStrings()
+        {
+            var graphUser = GraphUserWithEverything();
+            graphUser.Mail = null;
+            graphUser.PostalCode = null;
+            graphUser.Id = null;
+            graphUser.AccountEnabled = null;
+
+            var dbUser = new Common.Entities.User { ID = 42, UserPrincipalName = "jane.doe@contoso.com" };
+            var row = SingleRowFor(graphUser, SavedLookupsForEverything(), dbUser);
+
+            Assert.AreEqual(DBNull.Value, row["mail"]);
+            Assert.AreEqual(DBNull.Value, row["postalcode"]);
+            Assert.AreEqual(DBNull.Value, row["azure_ad_id"]);
+            Assert.AreEqual(DBNull.Value, row["account_enabled"]);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_OverLengthLookupValue_UsesTheSameCapAsTheMappingRule()
+        {
+            var longDepartment = new string('D', UserMetadataMappingRules.LookupNameMaxLength + 50);
+            var capped = UserMetadataMappingRules.NormaliseLookupName(longDepartment);
+            Assert.AreEqual(UserMetadataMappingRules.LookupNameMaxLength, capped.Length,
+                "Precondition: the mapping rule caps the value.");
+
+            var graphUser = GraphUserWithEverything();
+            graphUser.Department = longDepartment;
+
+            var maps = SavedLookupsForEverything();
+            maps.Departments[capped] = new UserDepartment { ID = 99, Name = capped };
+
+            var dbUser = new Common.Entities.User { ID = 42, UserPrincipalName = "jane.doe@contoso.com" };
+            var row = SingleRowFor(graphUser, maps, dbUser);
+
+            Assert.AreEqual(99, row["department_id"],
+                "The batch must look the lookup up under the capped name, or every over-length value silently clears its column.");
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_UnsavedLookupEntity_ResolvesToDbNull()
+        {
+            // A lookup that has not been through SaveChanges has ID == 0, which is not a usable
+            // foreign key - writing it would violate the FK constraint.
+            var maps = SavedLookupsForEverything();
+            maps.Departments["Engineering"] = new UserDepartment { ID = 0, Name = "Engineering" };
+
+            var dbUser = new Common.Entities.User { ID = 42, UserPrincipalName = "jane.doe@contoso.com" };
+            var row = SingleRowFor(GraphUserWithEverything(), maps, dbUser);
+
+            Assert.AreEqual(DBNull.Value, row["department_id"]);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_LastUpdated_IsTheSuppliedStampOnEveryRow()
+        {
+            var a = new GraphUser { Id = "a", UserPrincipalName = "a@contoso.com" };
+            var b = new GraphUser { Id = "b", UserPrincipalName = "b@contoso.com" };
+
+            var table = UserBulkUpdateRules.BuildUpdateTable(
+                new List<GraphUser> { a, b },
+                new LookupEntityMaps(),
+                UsersByAadId(),
+                UsersByUpn(
+                    new Common.Entities.User { ID = 1, UserPrincipalName = "a@contoso.com" },
+                    new Common.Entities.User { ID = 2, UserPrincipalName = "b@contoso.com" }),
+                GraphUsersByAadId(),
+                Stamp);
+
+            Assert.AreEqual(2, table.Rows.Count);
+            foreach (DataRow row in table.Rows)
+            {
+                Assert.AreEqual(Stamp, row["last_updated"]);
+            }
+        }
+
+        #endregion
+
+        #region Which users make it into the batch
+
+        [TestMethod]
+        public void UserBulkUpdate_UserWithNoUpn_IsSkipped()
+        {
+            var table = UserBulkUpdateRules.BuildUpdateTable(
+                new List<GraphUser> { new GraphUser { Id = "x", UserPrincipalName = null } },
+                new LookupEntityMaps(), UsersByAadId(), UsersByUpn(), GraphUsersByAadId(), Stamp);
+
+            Assert.AreEqual(0, table.Rows.Count);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_UserWithNoMatchingDbRow_IsSkipped()
+        {
+            // The UPDATE joins on the primary key, so a Graph user with no users row has nothing to
+            // update. Emitting a row would just be a batch entry that matches nothing.
+            var table = UserBulkUpdateRules.BuildUpdateTable(
+                new List<GraphUser> { GraphUserWithEverything() },
+                SavedLookupsForEverything(), UsersByAadId(), UsersByUpn(), GraphUsersByAadId(), Stamp);
+
+            Assert.AreEqual(0, table.Rows.Count);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_DbUserWithNoIdYet_IsSkipped()
+        {
+            var unsaved = new Common.Entities.User { ID = 0, UserPrincipalName = "jane.doe@contoso.com" };
+
+            var table = UserBulkUpdateRules.BuildUpdateTable(
+                new List<GraphUser> { GraphUserWithEverything() },
+                SavedLookupsForEverything(), UsersByAadId(), UsersByUpn(unsaved), GraphUsersByAadId(), Stamp);
+
+            Assert.AreEqual(0, table.Rows.Count);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_EmptyBatch_ProducesAnEmptyTableWithTheRightShape()
+        {
+            var table = UserBulkUpdateRules.BuildUpdateTable(
+                new List<GraphUser>(), new LookupEntityMaps(), UsersByAadId(), UsersByUpn(), GraphUsersByAadId(), Stamp);
+
+            Assert.AreEqual(0, table.Rows.Count);
+            Assert.AreEqual(UserBulkUpdateRules.UpdateTableColumns.Count, table.Columns.Count);
+        }
+
+        #endregion
+
+        #region Manager precedence chain
+
+        [TestMethod]
+        public void ManagerResolution_PrefersTheDbUserFoundByEntraId()
+        {
+            var managerByAadId = new Common.Entities.User { ID = 7, AzureAdId = ManagerAadId, UserPrincipalName = "boss@contoso.com" };
+            var differentManagerByUpn = new Common.Entities.User { ID = 8, UserPrincipalName = "boss@contoso.com" };
+            var managerGraphUser = new GraphUser { Id = ManagerAadId, UserPrincipalName = "boss@contoso.com" };
+
+            var resolved = UserBulkUpdateRules.ResolveManagerId(
+                ManagerAadId,
+                UsersByAadId(managerByAadId),
+                UsersByUpn(differentManagerByUpn),
+                GraphUsersByAadId(managerGraphUser));
+
+            Assert.AreEqual(7, resolved, "The Entra-id match must win over the UPN fallback.");
+        }
+
+        [TestMethod]
+        public void ManagerResolution_FallsBackToTheGraphBatchUpnThenTheDbUpnMap()
+        {
+            var managerGraphUser = new GraphUser { Id = ManagerAadId, UserPrincipalName = "boss@contoso.com" };
+            var managerByUpn = new Common.Entities.User { ID = 8, UserPrincipalName = "boss@contoso.com" };
+
+            var resolved = UserBulkUpdateRules.ResolveManagerId(
+                ManagerAadId,
+                UsersByAadId(),                       // no Entra-id match
+                UsersByUpn(managerByUpn),
+                GraphUsersByAadId(managerGraphUser));
+
+            Assert.AreEqual(8, resolved);
+        }
+
+        [TestMethod]
+        public void ManagerResolution_NoManagerReportedByGraph_ClearsTheColumn()
+        {
+            var resolved = UserBulkUpdateRules.ResolveManagerId(
+                null, UsersByAadId(), UsersByUpn(), GraphUsersByAadId());
+
+            Assert.AreEqual(DBNull.Value, resolved);
+        }
+
+        [TestMethod]
+        public void ManagerResolution_ManagerNotInTheBatchOrTheDatabase_ClearsTheColumn()
+        {
+            var resolved = UserBulkUpdateRules.ResolveManagerId(
+                ManagerAadId, UsersByAadId(), UsersByUpn(), GraphUsersByAadId());
+
+            Assert.AreEqual(DBNull.Value, resolved);
+        }
+
+        [TestMethod]
+        public void ManagerResolution_ManagerNotSavedYet_ClearsTheColumnRatherThanWritingZero()
+        {
+            // manager_id is a foreign key; 0 is not a users row, so an unsaved manager must produce
+            // NULL rather than a constraint violation.
+            var unsavedByAadId = new Common.Entities.User { ID = 0, AzureAdId = ManagerAadId, UserPrincipalName = "boss@contoso.com" };
+            var unsavedByUpn = new Common.Entities.User { ID = 0, UserPrincipalName = "boss@contoso.com" };
+            var managerGraphUser = new GraphUser { Id = ManagerAadId, UserPrincipalName = "boss@contoso.com" };
+
+            var resolved = UserBulkUpdateRules.ResolveManagerId(
+                ManagerAadId,
+                UsersByAadId(unsavedByAadId),
+                UsersByUpn(unsavedByUpn),
+                GraphUsersByAadId(managerGraphUser));
+
+            Assert.AreEqual(DBNull.Value, resolved);
+        }
+
+        [TestMethod]
+        public void ManagerResolution_ManagerInTheGraphBatchWithNoUpn_ClearsTheColumn()
+        {
+            var managerGraphUser = new GraphUser { Id = ManagerAadId, UserPrincipalName = null };
+
+            var resolved = UserBulkUpdateRules.ResolveManagerId(
+                ManagerAadId, UsersByAadId(), UsersByUpn(), GraphUsersByAadId(managerGraphUser));
+
+            Assert.AreEqual(DBNull.Value, resolved);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_ManagerIdReachesTheRow()
+        {
+            // The chain above is only useful if BuildUpdateTable actually calls it for the user's
+            // own manager id rather than, say, always writing NULL.
+            var graphUser = WithManager(GraphUserWithEverything(), ManagerAadId);
+            var manager = new Common.Entities.User { ID = 7, AzureAdId = ManagerAadId, UserPrincipalName = "boss@contoso.com" };
+            var dbUser = new Common.Entities.User { ID = 42, UserPrincipalName = "jane.doe@contoso.com" };
+
+            var table = UserBulkUpdateRules.BuildUpdateTable(
+                new List<GraphUser> { graphUser },
+                SavedLookupsForEverything(),
+                UsersByAadId(manager),
+                UsersByUpn(dbUser),
+                GraphUsersByAadId(),
+                Stamp);
+
+            Assert.AreEqual(1, table.Rows.Count);
+            Assert.AreEqual(7, table.Rows[0]["manager_id"]);
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_UserWhoseManagerWasRemoved_ClearsManagerId()
+        {
+            var graphUser = GraphUserWithEverything();   // no ManagerInfo entries
+            var dbUser = new Common.Entities.User { ID = 42, UserPrincipalName = "jane.doe@contoso.com" };
+            var row = SingleRowFor(graphUser, SavedLookupsForEverything(), dbUser);
+
+            Assert.AreEqual(DBNull.Value, row["manager_id"]);
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/UserImportCommitPolicyTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserImportCommitPolicyTests.cs
@@ -1,0 +1,169 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests for the delta-commit ordering rule (#372) and for the bulk-write port (#371).
+    ///
+    /// The ordering rule is the single most consequential invariant in the Graph user import:
+    /// Graph's <c>/users/delta</c> token is a promise that everything up to that point has been
+    /// dealt with, so committing it after a partial cycle makes Graph stop reporting those users
+    /// and the missing data is invisible until somebody notices absent users.
+    ///
+    /// The end-to-end behaviour already had tests - the database-backed
+    /// <c>UserMetadataUpdater_SuccessfulImport_DeltaTokenCommitted</c> and
+    /// <c>UserMetadataUpdater_LicenseProcessingThrows_DeltaTokenNotAdvanced</c>. What had none was
+    /// the rule itself, because until now there was no rule: the invariant was a side effect of an
+    /// exception propagating out of the orchestration method.
+    /// </summary>
+    [TestClass]
+    public class UserImportCommitPolicyTests
+    {
+        private static UserImportPhaseResults AllSucceeded()
+        {
+            return new UserImportPhaseResults
+            {
+                InsertPhaseSucceeded = true,
+                UpdatePhaseSucceeded = true,
+                LicenceRefreshSucceeded = true,
+            };
+        }
+
+        [TestMethod]
+        public void UserImport_AllPhasesSucceed_CommitsDeltaToken()
+        {
+            Assert.IsTrue(UserImportCommitPolicy.ShouldCommitDelta(AllSucceeded()));
+        }
+
+        [TestMethod]
+        public void UserImport_InsertPhaseFails_DoesNotCommitDeltaToken()
+        {
+            var results = AllSucceeded();
+            results.InsertPhaseSucceeded = false;
+
+            Assert.IsFalse(UserImportCommitPolicy.ShouldCommitDelta(results),
+                "Users that failed to insert must be reoffered by Graph on the next cycle.");
+        }
+
+        [TestMethod]
+        public void UserImport_UpdatePhaseFails_DoesNotCommitDeltaToken()
+        {
+            var results = AllSucceeded();
+            results.UpdatePhaseSucceeded = false;
+
+            Assert.IsFalse(UserImportCommitPolicy.ShouldCommitDelta(results),
+                "Users whose metadata update failed must be reoffered by Graph on the next cycle.");
+        }
+
+        [TestMethod]
+        public void UserImport_LicenceRefreshFails_DoesNotCommitDeltaToken()
+        {
+            var results = AllSucceeded();
+            results.LicenceRefreshSucceeded = false;
+
+            Assert.IsFalse(UserImportCommitPolicy.ShouldCommitDelta(results),
+                "A failed licence refresh must not be sealed in by a committed delta token.");
+        }
+
+        [TestMethod]
+        public void UserImport_NothingRanYet_DoesNotCommitDeltaToken()
+        {
+            // The default state. A cycle that fell over before any phase completed must never
+            // advance the token.
+            Assert.IsFalse(UserImportCommitPolicy.ShouldCommitDelta(new UserImportPhaseResults()));
+        }
+
+        [TestMethod]
+        public void UserImport_OnlyAllThreePhasesTogether_CommitTheDeltaToken()
+        {
+            // Exhaustive truth table. The single-phase tests above name the three failures an
+            // operator would recognise; this covers the combinations too, so a rewrite that
+            // accidentally checked only two of the three flags cannot pass.
+            var committed = new List<string>();
+            foreach (var insert in new[] { false, true })
+                foreach (var update in new[] { false, true })
+                    foreach (var licence in new[] { false, true })
+                    {
+                        var results = new UserImportPhaseResults
+                        {
+                            InsertPhaseSucceeded = insert,
+                            UpdatePhaseSucceeded = update,
+                            LicenceRefreshSucceeded = licence,
+                        };
+
+                        if (UserImportCommitPolicy.ShouldCommitDelta(results))
+                        {
+                            committed.Add($"insert={insert} update={update} licence={licence}");
+                        }
+                    }
+
+            CollectionAssert.AreEqual(
+                new[] { "insert=True update=True licence=True" }, committed,
+                "Exactly one of the eight states may commit the delta token: the one where every phase succeeded.");
+        }
+    }
+
+    /// <summary>
+    /// Tests for <see cref="IUserBulkUpdateWriter"/> and its SQL adapter (#371). The adapter is the
+    /// original <c>SqlConnection</c> + <c>SqlBulkCopy</c> code relocated unchanged, so what is worth
+    /// pinning here is the contract around it: an empty batch must not open a connection, and the
+    /// column mappings must be driven by the same list the batch is built from.
+    /// </summary>
+    [TestClass]
+    public class UserBulkUpdateWriterTests
+    {
+        /// <summary>Points at nothing. Any attempt to connect fails rather than reaching a real server.</summary>
+        private const string UnreachableConnectionString =
+            "Data Source=(localdb)\\NoSuchInstanceForTests;Initial Catalog=NoSuchDb;Integrated Security=true;Connect Timeout=1";
+
+        [TestMethod]
+        public async Task UserBulkUpdate_EmptyBatch_PerformsNoWrite()
+        {
+            // If this ever starts opening a connection it will fail against an unreachable server,
+            // which is exactly the signal we want: an import cycle with nothing to update must not
+            // pay for a connection, a temp table and an UPDATE.
+            var writer = new SqlUserBulkUpdateWriter(UnreachableConnectionString);
+
+            await writer.ExecuteAsync(UserBulkUpdateRules.CreateUpdateTable());
+        }
+
+        [TestMethod]
+        public void UserBulkUpdate_WriterWithoutAConnectionString_IsRejected()
+        {
+            Assert.ThrowsException<System.ArgumentNullException>(() => new SqlUserBulkUpdateWriter(null));
+            Assert.ThrowsException<System.ArgumentNullException>(() => new SqlUserBulkUpdateWriter(string.Empty));
+        }
+
+        [TestMethod]
+        public async Task UserBulkUpdate_WriterSnapshotsTheBatch_RatherThanKeepingTheCallersTable()
+        {
+            var writer = new InMemoryUserBulkUpdateWriter();
+            var table = UserBulkUpdateRules.CreateUpdateTable();
+            var row = table.NewRow();
+            row["id"] = 7;
+            row["last_updated"] = System.DateTime.Now;
+            table.Rows.Add(row);
+
+            using (table)
+            {
+                await writer.ExecuteAsync(table);
+            }
+
+            // The production caller wraps each batch in a using block and reuses nothing, so a fake
+            // that stored the caller's table by reference would report whatever the caller left
+            // behind. Disposing a DataTable does not clear its rows, so proving the snapshot is
+            // real needs both an identity check and a mutation of the original.
+            Assert.AreNotSame(table, writer.Batches[0], "The writer must record its own copy of the batch.");
+            table.Rows.Clear();
+
+            Assert.AreEqual(1, writer.Batches.Count);
+            Assert.AreEqual(1, writer.TotalRowsWritten, "Clearing the caller's table must not empty what the writer recorded.");
+            Assert.AreEqual(7, writer.Batches[0].Rows[0]["id"]);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/UserManagerPrefetchLicenceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserManagerPrefetchLicenceTests.cs
@@ -1,0 +1,164 @@
+using Common.Entities;
+using Common.Entities.Config;
+using DataUtils;
+using Microsoft.Graph.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Database-backed regression test for the manager prefetch added in #371.
+    ///
+    /// The prefetch (<c>ManagerPrefetchCache</c> / <c>SqlUserLookupStore</c>) loads a batch's
+    /// managers with tracking at the start of the batch, before the batch's own users are attached.
+    /// EF identity resolution therefore lets a prefetched entity win over the <c>AsNoTracking</c>
+    /// snapshot the pipeline was about to attach - which is fine only for as long as the prefetched
+    /// entity is at least as complete.
+    ///
+    /// It is not automatically: <c>UserMetadataUpdater</c> loads its snapshots with
+    /// <c>Include(u =&gt; u.LicenseLookups)</c> on the per-user licence path, proxies are disabled
+    /// and <c>User.LicenseLookups</c> is a plain non-virtual list, so there is no lazy load to fill
+    /// it in afterwards. A prefetch without that <c>Include</c> hands
+    /// <c>UserLicenseProcessor.ProcessUserLicenses</c> an empty licence collection, it deletes none
+    /// of the user's existing rows before re-adding them, and <c>SaveChanges</c> fails on the unique
+    /// <c>(license_type_id, user_id)</c> index.
+    ///
+    /// Found by review, not by the pre-existing suite - none of its licence tests happened to make a
+    /// user the manager of another user in the same batch.
+    /// </summary>
+    [TestClass]
+    public class UserManagerPrefetchLicenceTests
+    {
+        [TestMethod]
+        public async Task ManagerPrefetch_ManagerIsAlsoUpdatedInTheSameBatch_KeepsItsLicenceGraph()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var config = new AppConfig();
+
+            // Guid, not DateTime.Now.Ticks: Ticks only advances every ~15ms on .NET Framework, so
+            // two fixtures starting close together can collide.
+            var tag = Guid.NewGuid().ToString("N");
+            var managerUpn = $"prefetchmanager{tag}@test.com";
+            var reportUpn = $"prefetchreport{tag}@test.com";
+            var managerAadId = Guid.NewGuid().ToString();
+            var reportAadId = Guid.NewGuid().ToString();
+
+            await RemoveTestUsers(managerUpn, reportUpn);
+            try
+            {
+                var manager = new GraphUser
+                {
+                    UserPrincipalName = managerUpn,
+                    Id = managerAadId,
+                    AccountEnabled = true,
+                    Mail = managerUpn,
+                };
+                var report = new GraphUser
+                {
+                    UserPrincipalName = reportUpn,
+                    Id = reportAadId,
+                    AccountEnabled = true,
+                    Mail = reportUpn,
+                    // This is what puts the manager into the batch's prefetch set.
+                    ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = managerAadId } },
+                };
+
+                // fakeSkus: null forces the per-user licence path, which is the one that reads
+                // dbUser.LicenseLookups. Both users hold the same licence on both runs, so the
+                // second run must delete and re-add rather than add a duplicate.
+                var licences = new Dictionary<string, List<LicenseDetails>>
+                {
+                    { managerAadId, new List<LicenseDetails> { new LicenseDetails { SkuId = Guid.NewGuid(), SkuPartNumber = "ENTERPRISEPACK" } } },
+                    { reportAadId, new List<LicenseDetails> { new LicenseDetails { SkuId = Guid.NewGuid(), SkuPartNumber = "ENTERPRISEPACK" } } },
+                };
+
+                var fakeLoader = new FakeUserMetadataLoader(
+                    new List<GraphUser> { manager, report },
+                    fakeSkus: null,
+                    fakeUsersBySku: null,
+                    fakeLicenseDetails: licences);
+
+                // Run 1 inserts both users and gives each a licence.
+                await new UserMetadataUpdater(logger, config, fakeLoader).InsertAndUpdateDatabaseFromExternalUsers();
+
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    Assert.AreEqual(1, await CountLicences(db, managerUpn), "Precondition: run 1 gives the manager one licence.");
+                    Assert.AreEqual(1, await CountLicences(db, reportUpn), "Precondition: run 1 gives the report one licence.");
+                }
+
+                // Run 2 takes the existing-user path, where the batch's users are attached one at a
+                // time from AsNoTracking snapshots - so this is the run where a prefetched manager
+                // can shadow one. Pre-fix this throws a duplicate-key DbUpdateException.
+                await new UserMetadataUpdater(logger, config, fakeLoader).InsertAndUpdateDatabaseFromExternalUsers();
+
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    Assert.AreEqual(1, await CountLicences(db, managerUpn),
+                        "The manager is prefetched AND updated in the same batch; its existing licence row must be replaced, not duplicated.");
+                    Assert.AreEqual(1, await CountLicences(db, reportUpn),
+                        "The report is not prefetched and must be unaffected.");
+
+                    var reportRow = await db.users.AsNoTracking().FirstOrDefaultAsync(u => u.UserPrincipalName == reportUpn);
+                    var managerRow = await db.users.AsNoTracking().FirstOrDefaultAsync(u => u.UserPrincipalName == managerUpn);
+                    Assert.IsNotNull(reportRow);
+                    Assert.IsNotNull(managerRow);
+                    Assert.AreEqual(managerRow.ID, reportRow.ManagerId,
+                        "The manager relationship must still be resolved through the prefetch.");
+                }
+            }
+            finally
+            {
+                await RemoveTestUsers(managerUpn, reportUpn);
+            }
+        }
+
+        private static async Task<int> CountLicences(AnalyticsEntitiesContext db, string upn)
+        {
+            return await db.UserLicenseTypeLookups.CountAsync(l => l.User.UserPrincipalName == upn);
+        }
+
+        /// <summary>
+        /// Deletes on the exact UPNs recorded before the first write - never a substring LIKE, which
+        /// can either reach another fixture's rows or silently match nothing and leak every run. The
+        /// worktree's catalogs are not reset between runs.
+        /// </summary>
+        private static async Task RemoveTestUsers(params string[] upns)
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var users = await db.users
+                    .Include(u => u.LicenseLookups)
+                    .Where(u => upns.Contains(u.UserPrincipalName))
+                    .ToListAsync();
+
+                if (users.Count == 0)
+                {
+                    return;
+                }
+
+                // Clear the manager self-reference first: the FK would otherwise block the delete.
+                foreach (var user in users)
+                {
+                    user.ManagerId = null;
+                    user.Manager = null;
+                }
+                await db.SaveChangesAsync();
+
+                foreach (var user in users)
+                {
+                    db.UserLicenseTypeLookups.RemoveRange(user.LicenseLookups);
+                }
+                db.users.RemoveRange(users);
+                await db.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/UserManagerResolutionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserManagerResolutionTests.cs
@@ -1,0 +1,320 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests for the batched manager resolution introduced by #371.
+    ///
+    /// <c>UserDataMapper.UpdateUserManager</c> resolves a user's manager through a five-branch
+    /// precedence chain, and its fourth branch went to the database <b>per user</b>. On a first
+    /// import that is the branch nearly every user takes - the insert-enrichment phase builds its
+    /// Entra-id dictionary from pre-existing users only - so a brand new ~200,000-user tenant
+    /// issued up to 200,000 individual <c>SELECT ... WHERE user_name = @p</c> round trips in a
+    /// single cycle. These tests pin the replacement: one chunked query per batch.
+    ///
+    /// Zero SQL Server and zero Graph dependency.
+    /// </summary>
+    [TestClass]
+    public class UserManagerResolutionTests
+    {
+        private static GraphUser User(string upn, string aadId, string managerAadId = null)
+        {
+            var user = new GraphUser { Id = aadId, UserPrincipalName = upn };
+            if (managerAadId != null)
+            {
+                user.ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = managerAadId } };
+            }
+            return user;
+        }
+
+        private static Dictionary<string, GraphUser> ByAadId(params GraphUser[] users)
+        {
+            var d = new Dictionary<string, GraphUser>(StringComparer.OrdinalIgnoreCase);
+            foreach (var u in users) d[u.Id] = u;
+            return d;
+        }
+
+        #region Which UPNs a batch needs
+
+        [TestMethod]
+        public void ManagerPrefetch_CollectsTheUpnOfEachManagerReferencedByTheBatch()
+        {
+            var bossA = User("boss.a@contoso.com", "aad-boss-a");
+            var bossB = User("boss.b@contoso.com", "aad-boss-b");
+            var batch = new[]
+            {
+                User("one@contoso.com", "aad-1", "aad-boss-a"),
+                User("two@contoso.com", "aad-2", "aad-boss-b"),
+            };
+
+            var upns = ManagerResolutionRules.CollectManagerUpnsToPrefetch(batch, ByAadId(bossA, bossB));
+
+            CollectionAssert.AreEquivalent(new[] { "boss.a@contoso.com", "boss.b@contoso.com" }, upns);
+        }
+
+        [TestMethod]
+        public void ManagerPrefetch_SharedManager_IsRequestedOnlyOnce()
+        {
+            // The realistic shape: a few hundred reports under one manager. Without the de-dup the
+            // "one query per batch" claim would still send one parameter per user and hit SQL
+            // Server's 2,100-parameter limit far sooner than the chunk size suggests.
+            var boss = User("boss@contoso.com", "aad-boss");
+            var batch = Enumerable.Range(0, 500)
+                .Select(i => User($"user{i}@contoso.com", $"aad-{i}", "aad-boss"))
+                .ToList();
+
+            var upns = ManagerResolutionRules.CollectManagerUpnsToPrefetch(batch, ByAadId(boss));
+
+            Assert.AreEqual(1, upns.Count, "500 reports under one manager is one UPN to look up, not 500.");
+            Assert.AreEqual("boss@contoso.com", upns[0]);
+        }
+
+        [TestMethod]
+        public void ManagerPrefetch_SharedManagerDifferingOnlyByCase_IsRequestedOnlyOnce()
+        {
+            var bossLower = User("boss@contoso.com", "aad-boss-1");
+            var bossUpper = User("BOSS@contoso.com", "aad-boss-2");
+            var batch = new[]
+            {
+                User("one@contoso.com", "aad-1", "aad-boss-1"),
+                User("two@contoso.com", "aad-2", "aad-boss-2"),
+            };
+
+            var upns = ManagerResolutionRules.CollectManagerUpnsToPrefetch(batch, ByAadId(bossLower, bossUpper));
+
+            Assert.AreEqual(1, upns.Count,
+                "SQL Server's default collation is case-insensitive, so two casings are one row - de-dup must be too.");
+        }
+
+        [TestMethod]
+        public void ManagerPrefetch_UsersWithNoManager_ContributeNothing()
+        {
+            var batch = new[] { User("one@contoso.com", "aad-1"), User("two@contoso.com", "aad-2") };
+
+            var upns = ManagerResolutionRules.CollectManagerUpnsToPrefetch(batch, ByAadId());
+
+            Assert.AreEqual(0, upns.Count);
+        }
+
+        [TestMethod]
+        public void ManagerPrefetch_ManagerNotInTheGraphBatch_ContributesNothing()
+        {
+            // The database-by-UPN branch reads the UPN off the cached Graph user, so a manager who
+            // is not in the batch can never reach it and prefetching them would be wasted work.
+            var batch = new[] { User("one@contoso.com", "aad-1", "aad-unknown-boss") };
+
+            var upns = ManagerResolutionRules.CollectManagerUpnsToPrefetch(batch, ByAadId());
+
+            Assert.AreEqual(0, upns.Count);
+        }
+
+        [TestMethod]
+        public void ManagerPrefetch_ManagerWithNoUpn_ContributesNothing()
+        {
+            var boss = User(null, "aad-boss");
+            var batch = new[] { User("one@contoso.com", "aad-1", "aad-boss") };
+
+            var upns = ManagerResolutionRules.CollectManagerUpnsToPrefetch(batch, ByAadId(boss));
+
+            Assert.AreEqual(0, upns.Count);
+        }
+
+        #endregion
+
+        #region Indexing what came back
+
+        [TestMethod]
+        public void ManagerPrefetch_DuplicateUpnRows_ResolveToTheLowestId()
+        {
+            // dbo.users has no unique constraint on user_name and real databases do contain
+            // duplicates - which is why UserCache.Load orders by id and takes the first. The
+            // prefetch has to agree with it, or a duplicated manager would resolve to a different
+            // row depending on which code path asked.
+            var index = ManagerResolutionRules.IndexByUpn(new[]
+            {
+                new Common.Entities.User { ID = 90, UserPrincipalName = "boss@contoso.com" },
+                new Common.Entities.User { ID = 12, UserPrincipalName = "boss@contoso.com" },
+                new Common.Entities.User { ID = 45, UserPrincipalName = "boss@contoso.com" },
+            });
+
+            Assert.AreEqual(1, index.Count);
+            Assert.AreEqual(12, index["boss@contoso.com"].ID);
+        }
+
+        [TestMethod]
+        public void ManagerPrefetch_IndexIsCaseInsensitive()
+        {
+            var index = ManagerResolutionRules.IndexByUpn(new[]
+            {
+                new Common.Entities.User { ID = 5, UserPrincipalName = "Boss@Contoso.com" },
+            });
+
+            Assert.IsTrue(index.TryGetValue("boss@contoso.com", out var found));
+            Assert.AreEqual(5, found.ID);
+        }
+
+        [TestMethod]
+        public void ManagerPrefetch_RowsWithNoUpn_AreSkippedRatherThanThrowing()
+        {
+            var index = ManagerResolutionRules.IndexByUpn(new[]
+            {
+                new Common.Entities.User { ID = 1, UserPrincipalName = null },
+                new Common.Entities.User { ID = 2, UserPrincipalName = "" },
+                new Common.Entities.User { ID = 3, UserPrincipalName = "boss@contoso.com" },
+            });
+
+            Assert.AreEqual(1, index.Count);
+            Assert.IsTrue(index.ContainsKey("boss@contoso.com"));
+        }
+
+        #endregion
+
+        #region The N+1 guard
+
+        [TestMethod]
+        public async Task ManagerPrefetch_ResolvesTheWholeBatchInOneLookup_NotOnePerUser()
+        {
+            // 300 users, 300 distinct managers: the cache must ask the store exactly once, with all
+            // 300 UPNs, and answer every subsequent lookup without going back.
+            //
+            // What this pins is the cache, not the call sites - a regression that removed the
+            // PrefetchManagersForBatchAsync call from UserBatchProcessor or UserInsertProcessor
+            // would leave it green. That wiring is covered by the database-backed
+            // UserMetadataUpdater* tests, which exercise the real batch loops.
+            const int userCount = 300;
+
+            var managers = Enumerable.Range(0, userCount)
+                .Select(i => User($"boss{i}@contoso.com", $"aad-boss-{i}"))
+                .ToList();
+            var batch = Enumerable.Range(0, userCount)
+                .Select(i => User($"user{i}@contoso.com", $"aad-{i}", $"aad-boss-{i}"))
+                .ToList();
+
+            var store = new InMemoryUserLookupStore();
+            for (var i = 0; i < userCount; i++)
+            {
+                store.Add(1000 + i, $"boss{i}@contoso.com");
+            }
+
+            var cache = new ManagerPrefetchCache(store);
+            await cache.LoadForBatchAsync(batch, ByAadId(managers.ToArray()));
+
+            Assert.AreEqual(1, store.CallCount,
+                $"{userCount} users must cost ONE store call, whatever the batch size.");
+            Assert.AreEqual(userCount, store.RequestedUpnBatches[0].Count);
+            Assert.AreEqual(userCount, cache.Count);
+
+            for (var i = 0; i < userCount; i++)
+            {
+                Assert.IsTrue(cache.TryGet($"boss{i}@contoso.com", out var manager), $"boss{i} should be cached");
+                Assert.AreEqual(1000 + i, manager.ID);
+            }
+            Assert.AreEqual(1, store.CallCount, "Reading the cache must not go back to the store.");
+        }
+
+        [TestMethod]
+        public async Task ManagerPrefetch_ManagerMissingFromTheDatabase_IsSimplyAbsent()
+        {
+            // A miss has to fall through to the existing per-user query (which then creates the
+            // placeholder user), so the cache must report "not found" rather than a null entry.
+            var boss = User("boss@contoso.com", "aad-boss");
+            var batch = new[] { User("one@contoso.com", "aad-1", "aad-boss") };
+
+            var cache = new ManagerPrefetchCache(new InMemoryUserLookupStore());
+            await cache.LoadForBatchAsync(batch, ByAadId(boss));
+
+            Assert.AreEqual(0, cache.Count);
+            Assert.IsFalse(cache.TryGet("boss@contoso.com", out var manager));
+            Assert.IsNull(manager);
+        }
+
+        [TestMethod]
+        public async Task ManagerPrefetch_NoManagersInTheBatch_DoesNotTouchTheStore()
+        {
+            var store = new InMemoryUserLookupStore();
+            var cache = new ManagerPrefetchCache(store);
+
+            await cache.LoadForBatchAsync(new[] { User("one@contoso.com", "aad-1") }, ByAadId());
+
+            Assert.AreEqual(0, store.CallCount, "A batch with no managers has nothing to look up.");
+        }
+
+        [TestMethod]
+        public async Task ManagerPrefetch_EachBatchReplacesThePreviousOne()
+        {
+            // Load-bearing: the entities are tracked by the import's context and every batch ends by
+            // detaching them, so carrying a manager over into the next batch would hand EF a
+            // detached entity and it would try to INSERT the manager.
+            var bossA = User("boss.a@contoso.com", "aad-boss-a");
+            var bossB = User("boss.b@contoso.com", "aad-boss-b");
+            var store = new InMemoryUserLookupStore().Add(1, "boss.a@contoso.com").Add(2, "boss.b@contoso.com");
+            var cache = new ManagerPrefetchCache(store);
+
+            await cache.LoadForBatchAsync(new[] { User("one@contoso.com", "aad-1", "aad-boss-a") }, ByAadId(bossA, bossB));
+            Assert.IsTrue(cache.TryGet("boss.a@contoso.com", out _));
+
+            await cache.LoadForBatchAsync(new[] { User("two@contoso.com", "aad-2", "aad-boss-b") }, ByAadId(bossA, bossB));
+
+            Assert.IsTrue(cache.TryGet("boss.b@contoso.com", out _), "The new batch's manager should be cached.");
+            Assert.IsFalse(cache.TryGet("boss.a@contoso.com", out _),
+                "The previous batch's manager must be dropped - it is detached by now.");
+        }
+
+        [TestMethod]
+        public async Task ManagerPrefetch_BatchWithNothingToLookUp_StillClearsThePreviousBatch()
+        {
+            // The case the test above cannot reach: when a batch has no managers the store is never
+            // called, so nothing overwrites the cache. Without an explicit reset the previous
+            // batch's entities would survive - and by now the import has detached them, so handing
+            // one to EF would make it try to INSERT the manager.
+            var boss = User("boss.a@contoso.com", "aad-boss-a");
+            var store = new InMemoryUserLookupStore().Add(1, "boss.a@contoso.com");
+            var cache = new ManagerPrefetchCache(store);
+
+            await cache.LoadForBatchAsync(new[] { User("one@contoso.com", "aad-1", "aad-boss-a") }, ByAadId(boss));
+            Assert.AreEqual(1, cache.Count, "Precondition: the first batch populated the cache.");
+
+            await cache.LoadForBatchAsync(new[] { User("two@contoso.com", "aad-2") }, ByAadId(boss));
+
+            Assert.AreEqual(0, cache.Count, "A batch with no managers must leave the cache empty, not stale.");
+            Assert.IsFalse(cache.TryGet("boss.a@contoso.com", out _));
+            Assert.AreEqual(1, store.CallCount, "Precondition: the second batch never reached the store.");
+        }
+
+        [TestMethod]
+        public async Task ManagerPrefetch_WithNoLookupStore_StaysEmptySoTheOriginalQueryIsUsed()
+        {
+            var boss = User("boss@contoso.com", "aad-boss");
+            var cache = new ManagerPrefetchCache(null);
+
+            await cache.LoadForBatchAsync(new[] { User("one@contoso.com", "aad-1", "aad-boss") }, ByAadId(boss));
+
+            Assert.AreEqual(0, cache.Count);
+            Assert.IsFalse(cache.TryGet("boss@contoso.com", out _));
+        }
+
+        [TestMethod]
+        public async Task ManagerPrefetch_StoreFailure_SurfacesToTheCaller()
+        {
+            // The fake fails as a faulted Task rather than throwing synchronously, so this also
+            // proves the prefetch is awaited: a dropped await would leave the exception unobserved
+            // and this test would fail.
+            var boss = User("boss@contoso.com", "aad-boss");
+            var store = new FailingUserLookupStore();
+            var cache = new ManagerPrefetchCache(store);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                cache.LoadForBatchAsync(new[] { User("one@contoso.com", "aad-1", "aad-boss") }, ByAadId(boss)));
+
+            Assert.AreEqual(1, store.CallCount);
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/IUserBulkUpdateWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/IUserBulkUpdateWriter.cs
@@ -1,0 +1,29 @@
+using System.Data;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Write port for the existing-user metadata bulk update: hands a fully-resolved batch of
+    /// <c>dbo.users</c> rows to storage and returns once they have been applied.
+    /// </summary>
+    /// <remarks>
+    /// Extracted from <c>UserBatchProcessor</c> for issues #371 / #381 so the batching, the
+    /// foreign-key resolution and the shape of the <see cref="DataTable"/> can be tested with zero
+    /// SQL Server dependency. The production implementation,
+    /// <see cref="SqlUserBulkUpdateWriter"/>, is the original <c>SqlConnection</c> +
+    /// <c>SqlBulkCopy</c> + temp-table code <b>relocated verbatim</b> - it is deliberately not
+    /// rewritten.
+    ///
+    /// Internal because <c>UserBatchProcessor</c> is internal;
+    /// <c>InternalsVisibleTo("Tests.UnitTests")</c> makes it reachable from the test project.
+    /// </remarks>
+    internal interface IUserBulkUpdateWriter
+    {
+        /// <summary>
+        /// Applies one batch of user updates. The table's columns are the ones described by
+        /// <see cref="UserBulkUpdateRules.CreateUpdateTable"/>; an empty table is a no-op.
+        /// </summary>
+        Task ExecuteAsync(DataTable userUpdates);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/IUserLookupStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/IUserLookupStore.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Read port for resolving <c>dbo.users</c> rows by user principal name in bulk.
+    /// </summary>
+    /// <remarks>
+    /// Exists to remove the per-user database round-trip in the manager-resolution fallback chain
+    /// (#371): <c>UserDataMapper</c> used to issue one
+    /// <c>db.users.FirstOrDefaultAsync(u =&gt; u.UserPrincipalName == managerUpn)</c> per user whose
+    /// manager could not be resolved from the in-memory dictionaries. During insert enrichment that
+    /// happens whenever a manager is inserted in a <b>later</b> batch than their report: the
+    /// dictionary starts from pre-existing users and each batch adds its own users before
+    /// processing them, so a manager from an earlier or the current batch is found, and one from a
+    /// later batch is not. Graph does not order the delta by reporting line, so on the first import
+    /// of a large tenant that is a substantial share of everyone who has a manager - on the order
+    /// of tens of thousands of individual queries per cycle at the ~200,000-user design target.
+    /// Resolving a whole batch in one chunked <c>Contains(...)</c> query makes it one query per
+    /// batch instead.
+    ///
+    /// Implementations must return entities that are <b>tracked</b> by the same context the caller
+    /// is saving through, because the caller assigns them straight to a navigation property; a
+    /// detached instance would make EF try to INSERT the manager and fail on a duplicate key. That
+    /// is why the port hands back entities rather than ids. They must also carry the user's licence
+    /// lookups: a returned entity can win EF identity resolution over a snapshot the caller was
+    /// about to attach, so it has to be at least as complete - see <see cref="SqlUserLookupStore"/>.
+    ///
+    /// Internal because its collaborators are internal; <c>InternalsVisibleTo("Tests.UnitTests")</c>
+    /// makes it reachable from the test project.
+    /// </remarks>
+    internal interface IUserLookupStore
+    {
+        /// <summary>
+        /// Returns the users whose <c>user_name</c> matches one of <paramref name="upns"/>. UPNs with
+        /// no row are simply absent from the result. Matching is case-insensitive, as SQL Server's
+        /// default code-first collation (<c>Latin1_General_CI_AS</c>) makes it.
+        /// </summary>
+        Task<IReadOnlyList<Common.Entities.User>> GetUsersByUpnAsync(IReadOnlyCollection<string> upns);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/ManagerPrefetchCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/ManagerPrefetchCache.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// The managers referenced by the batch currently being processed, loaded in one query.
+    /// </summary>
+    /// <remarks>
+    /// This is the fix for the manager-resolution N+1 called out in #371. The database-by-UPN
+    /// branch of <c>UserDataMapper.UpdateUserManager</c> is reached whenever a manager cannot be
+    /// resolved from the in-memory dictionaries. During insert enrichment that means a manager
+    /// inserted in a <b>later</b> batch than their report - the dictionary starts from pre-existing
+    /// users and each batch adds its own before processing them - and Graph does not order the
+    /// delta by reporting line, so on the first import of a large tenant it is a substantial share
+    /// of everyone who has a manager. One chunked query per batch replaces those round trips.
+    ///
+    /// Scope is deliberately one batch. The entities are tracked by the import's context and every
+    /// batch ends by detaching them, so a cache kept across batches would hand out detached
+    /// entities and EF would try to INSERT the manager. <see cref="LoadForBatchAsync"/> therefore
+    /// replaces the contents on every call rather than accumulating.
+    ///
+    /// With no lookup store it stays permanently empty, which leaves the original per-user query in
+    /// place - that is what the <c>UserDataMapper</c> constructor overload without a store gets.
+    /// </remarks>
+    internal class ManagerPrefetchCache
+    {
+        private readonly IUserLookupStore _userLookupStore;
+        private Dictionary<string, Common.Entities.User> _byUpn = ManagerResolutionRules.IndexByUpn(new Common.Entities.User[0]);
+
+        /// <param name="userLookupStore">May be null, in which case the cache never loads anything.</param>
+        public ManagerPrefetchCache(IUserLookupStore userLookupStore)
+        {
+            _userLookupStore = userLookupStore;
+        }
+
+        /// <summary>How many managers the last <see cref="LoadForBatchAsync"/> resolved.</summary>
+        public int Count => _byUpn.Count;
+
+        /// <summary>
+        /// Replaces the cache with the managers this batch might need to look up by UPN.
+        /// </summary>
+        public async Task LoadForBatchAsync(IEnumerable<GraphUser> batch, IDictionary<string, GraphUser> graphUsersByAadId)
+        {
+            _byUpn = ManagerResolutionRules.IndexByUpn(new Common.Entities.User[0]);
+
+            if (_userLookupStore == null)
+            {
+                return;
+            }
+
+            var upns = ManagerResolutionRules.CollectManagerUpnsToPrefetch(batch, graphUsersByAadId);
+            if (upns.Count == 0)
+            {
+                return;
+            }
+
+            var managers = await _userLookupStore.GetUsersByUpnAsync(upns);
+            _byUpn = ManagerResolutionRules.IndexByUpn(managers);
+        }
+
+        /// <summary>Case-insensitive, matching SQL Server's default code-first collation.</summary>
+        public bool TryGet(string upn, out Common.Entities.User manager)
+        {
+            return _byUpn.TryGetValue(upn, out manager);
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/REFACTORING_SUMMARY.md
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/REFACTORING_SUMMARY.md
@@ -120,3 +120,28 @@ Potential areas for further enhancement:
 ## Namespace Convention
 
 All files in the `Graph\User` folder use the namespace `WebJob.Office365ActivityImporter.Engine.Graph` (not `...Graph.User`). This follows the existing convention in the project.
+
+## Ports and rules (issues #371 / #372)
+
+A second pass split the remaining SQL and Graph coupling out of the helper classes above, so the
+decisions they make can be asserted without a database. Adapters are behaviour-preserving
+relocations, not rewrites.
+
+### Pure rules — `Graph\User\Rules\`
+| Class | Extracted from | What it owns |
+|---|---|---|
+| `UserMetadataMappingRules` | `UserDataMapper.UpdateUserMetadata` | Normalising the seven de-normalised lookup values, deciding which ones to clear, and the four direct fields |
+| `UserBulkUpdateRules` | `UserBatchProcessor.BuildUpdateDataTable` | The bulk-update batch's shape, per-column values and the manager foreign-key precedence chain |
+| `ManagerResolutionRules` | `UserDataMapper.UpdateUserManager` | Which manager UPNs a batch needs to look up, and how duplicate UPN rows are resolved |
+| `UserImportCommitPolicy` | `UserMetadataUpdater.InsertAndUpdateDatabaseFromExternalUsers` | The delta token is committed only after every phase succeeded |
+
+### Ports and adapters
+| Port | Production adapter | Purpose |
+|---|---|---|
+| `IUserBulkUpdateWriter` | `SqlUserBulkUpdateWriter` | The `SqlConnection` + `SqlBulkCopy` + `#user_updates` temp table, moved out of `UserBatchProcessor` unchanged |
+| `IUserLookupStore` | `SqlUserLookupStore` | Resolves a whole batch's users by UPN in one chunked `Contains(...)` query, replacing a per-user `FirstOrDefaultAsync` |
+| `IAnalyticsDbContextFactory` | `DefaultAnalyticsDbContextFactory` | `UserMetadataUpdater` no longer news up its own `AnalyticsEntitiesContext` |
+
+`ManagerPrefetchCache` holds one batch's managers between the store and `UserDataMapper`. Its scope is
+deliberately a single batch: the entities are tracked by the import's context, and every batch ends by
+detaching them.

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/ManagerResolutionRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/ManagerResolutionRules.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// The pure parts of manager resolution: which manager user principal names a batch will need to
+    /// look up in the database, and how the loaded rows are indexed.
+    ///
+    /// Extracted for issues #371 / #381. The precedence chain in <c>UserDataMapper</c> had no test of
+    /// any kind, and its last-but-one branch issued a database query <b>per user</b>; deciding the
+    /// batch's lookup set up front is what turns that into one query per batch. Everything here runs
+    /// with zero SQL Server and zero Graph dependency.
+    /// </summary>
+    internal static class ManagerResolutionRules
+    {
+        /// <summary>
+        /// Returns the distinct UPNs of the managers referenced by <paramref name="batch"/> that could
+        /// reach the database-by-UPN branch of the resolution chain.
+        /// </summary>
+        /// <remarks>
+        /// A manager only reaches that branch when Graph reported a manager id for the user
+        /// <i>and</i> that manager is present in the current Graph batch <i>and</i> has a UPN - the
+        /// branch reads the UPN off the cached Graph user. Anything else can never produce a query, so
+        /// prefetching it would be wasted work.
+        ///
+        /// The result is deliberately a superset of what the chain actually queries: whether the
+        /// earlier in-memory branches hit depends on dictionary state that changes as the batch is
+        /// processed, so it cannot be decided up front. Over-fetching costs nothing extra - it is the
+        /// same single query either way - and under-fetching would silently reintroduce a per-user
+        /// query.
+        ///
+        /// Comparison is case-insensitive because that is how both the Graph user dictionary and SQL
+        /// Server's default collation behave.
+        /// </remarks>
+        public static List<string> CollectManagerUpnsToPrefetch(
+            IEnumerable<GraphUser> batch,
+            IDictionary<string, GraphUser> graphUsersByAadId)
+        {
+            var upns = new List<string>();
+            if (batch == null || graphUsersByAadId == null)
+            {
+                return upns;
+            }
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var graphUser in batch)
+            {
+                var managerAadId = UserMetadataMappingRules.BuildPlan(graphUser).ManagerAadId;
+                if (managerAadId == null)
+                {
+                    continue;
+                }
+
+                if (graphUsersByAadId.TryGetValue(managerAadId, out var managerGraphUser) &&
+                    !string.IsNullOrEmpty(managerGraphUser.UserPrincipalName) &&
+                    seen.Add(managerGraphUser.UserPrincipalName))
+                {
+                    upns.Add(managerGraphUser.UserPrincipalName);
+                }
+            }
+
+            return upns;
+        }
+
+        /// <summary>
+        /// Indexes loaded users by UPN for the prefetch cache.
+        /// </summary>
+        /// <remarks>
+        /// <c>dbo.users</c> has no unique constraint on <c>user_name</c> and real databases do contain
+        /// duplicates, which is why <c>UserCache.Load</c> orders by id and takes the first rather than
+        /// using <c>SingleOrDefaultAsync</c>. This keeps the lowest id for the same reason, so the
+        /// prefetch resolves a duplicated UPN to the same row the rest of the pipeline does. Users
+        /// with no UPN are skipped.
+        /// </remarks>
+        public static Dictionary<string, Common.Entities.User> IndexByUpn(IEnumerable<Common.Entities.User> users)
+        {
+            var byUpn = new Dictionary<string, Common.Entities.User>(StringComparer.OrdinalIgnoreCase);
+            foreach (var user in users)
+            {
+                if (string.IsNullOrEmpty(user.UserPrincipalName))
+                {
+                    continue;
+                }
+
+                if (!byUpn.TryGetValue(user.UserPrincipalName, out var existing) || user.ID < existing.ID)
+                {
+                    byUpn[user.UserPrincipalName] = user;
+                }
+            }
+
+            return byUpn;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserBulkUpdateRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserBulkUpdateRules.cs
@@ -1,0 +1,197 @@
+﻿using Common.Entities;
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Holds entity-reference dictionaries for each lookup type used by the bulk user update.
+    /// Entity IDs are valid after the context has been saved.
+    /// </summary>
+    /// <remarks>
+    /// Moved out of <c>UserBatchProcessor</c> (where it was a nested type) so
+    /// <see cref="UserBulkUpdateRules"/> can be used without a database context. Behaviour and
+    /// contents are unchanged.
+    /// </remarks>
+    internal class LookupEntityMaps
+    {
+        public Dictionary<string, UserDepartment> Departments = new Dictionary<string, UserDepartment>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, UserJobTitle> JobTitles = new Dictionary<string, UserJobTitle>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, UserOfficeLocation> OfficeLocations = new Dictionary<string, UserOfficeLocation>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, UserUsageLocation> UsageLocations = new Dictionary<string, UserUsageLocation>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, CountryOrRegion> Countries = new Dictionary<string, CountryOrRegion>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, StateOrProvince> StatesOrProvinces = new Dictionary<string, StateOrProvince>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, CompanyName> CompanyNames = new Dictionary<string, CompanyName>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The pure rules behind the bulk existing-user update: which <c>dbo.users</c> rows go into the
+    /// batch, what value each column gets, and how a manager's foreign key is resolved.
+    ///
+    /// Extracted from <c>UserBatchProcessor.BuildUpdateDataTable</c> for issues #371 / #381. It was
+    /// previously interleaved with <c>SqlConnection</c> / <c>SqlBulkCopy</c>, so none of it could be
+    /// asserted without a live SQL Server - and the manager precedence chain in particular had no
+    /// test at all. Everything here runs with zero SQL Server and zero Graph dependency.
+    /// </summary>
+    internal static class UserBulkUpdateRules
+    {
+        /// <summary>
+        /// The columns of the bulk-update batch, in order. <see cref="SqlUserBulkUpdateWriter"/>
+        /// generates its <c>SqlBulkCopy</c> column mappings from this list; the <see cref="DataTable"/>
+        /// built here and the <c>#user_updates</c> temp table are still spelled out separately, and are
+        /// pinned against it by <c>UserBulkUpdateRulesTests</c>. Before the extraction the same fourteen
+        /// names appeared in three independently maintained places with nothing checking they agreed.
+        /// </summary>
+        public static readonly IReadOnlyList<string> UpdateTableColumns = new[]
+        {
+            "id",
+            "azure_ad_id",
+            "account_enabled",
+            "mail",
+            "postalcode",
+            "department_id",
+            "job_title_id",
+            "office_location_id",
+            "usage_location_id",
+            "country_or_region_id",
+            "state_or_province_id",
+            "company_name_id",
+            "manager_id",
+            "last_updated",
+        };
+
+        /// <summary>Creates the empty batch table with the column names and CLR types the writer expects.</summary>
+        public static DataTable CreateUpdateTable()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("id", typeof(int));
+            dt.Columns.Add("azure_ad_id", typeof(string));
+            dt.Columns.Add("account_enabled", typeof(bool));
+            dt.Columns.Add("mail", typeof(string));
+            dt.Columns.Add("postalcode", typeof(string));
+            dt.Columns.Add("department_id", typeof(int));
+            dt.Columns.Add("job_title_id", typeof(int));
+            dt.Columns.Add("office_location_id", typeof(int));
+            dt.Columns.Add("usage_location_id", typeof(int));
+            dt.Columns.Add("country_or_region_id", typeof(int));
+            dt.Columns.Add("state_or_province_id", typeof(int));
+            dt.Columns.Add("company_name_id", typeof(int));
+            dt.Columns.Add("manager_id", typeof(int));
+            dt.Columns.Add("last_updated", typeof(DateTime));
+            return dt;
+        }
+
+        /// <summary>
+        /// Builds one bulk-update batch.
+        /// </summary>
+        /// <param name="lastUpdated">
+        /// The value stamped into <c>users.last_updated</c> for every row. Supplied by the caller,
+        /// which still reads <c>DateTime.Now</c> - note that is local time, not UTC. #371 suggests
+        /// moving it behind <c>IClock</c>, but <c>IClock</c> only exposes <c>UtcNow</c>, so doing so
+        /// would change every stored value on a non-UTC host. That is a behavioural change and is
+        /// deliberately out of scope here, exactly as it was for the mapping rules in #371 part 1.
+        /// </param>
+        /// <remarks>
+        /// A Graph user with no UPN, or whose UPN has no saved <c>dbo.users</c> row, is skipped: the
+        /// update joins on the primary key, so there is nothing to update.
+        ///
+        /// No null guards - the code this replaced dereferenced these arguments directly, and the
+        /// resulting <see cref="NullReferenceException"/> is operator-facing telemetry.
+        /// </remarks>
+        public static DataTable BuildUpdateTable(
+            List<GraphUser> graphUsers,
+            LookupEntityMaps maps,
+            Dictionary<string, Common.Entities.User> dbUsersByAadId,
+            Dictionary<string, Common.Entities.User> dbUsersByUpn,
+            Dictionary<string, GraphUser> graphUsersByAadId,
+            DateTime lastUpdated)
+        {
+            var dt = CreateUpdateTable();
+
+            foreach (var graphUser in graphUsers)
+            {
+                var upn = graphUser.UserPrincipalName;
+                if (string.IsNullOrEmpty(upn))
+                    continue;
+
+                // Find the DB user to get the PK
+                if (!dbUsersByUpn.TryGetValue(upn, out var dbUser) || dbUser.ID == 0)
+                    continue;
+
+                // Same mapping rule the EF path uses, so the two write paths cannot drift (#371).
+                var plan = UserMetadataMappingRules.BuildPlan(graphUser);
+
+                var row = dt.NewRow();
+                row["id"] = dbUser.ID;
+                row["azure_ad_id"] = (object)plan.AzureAdId ?? DBNull.Value;
+                row["account_enabled"] = plan.AccountEnabled.HasValue ? (object)plan.AccountEnabled.Value : DBNull.Value;
+                row["mail"] = (object)plan.Mail ?? DBNull.Value;
+                row["postalcode"] = (object)plan.PostalCode ?? DBNull.Value;
+                row["department_id"] = ResolveLookupId(plan.DepartmentName, maps.Departments);
+                row["job_title_id"] = ResolveLookupId(plan.JobTitleName, maps.JobTitles);
+                row["office_location_id"] = ResolveLookupId(plan.OfficeLocationName, maps.OfficeLocations);
+                row["usage_location_id"] = ResolveLookupId(plan.UsageLocationName, maps.UsageLocations);
+                row["country_or_region_id"] = ResolveLookupId(plan.CountryName, maps.Countries);
+                row["state_or_province_id"] = ResolveLookupId(plan.StateOrProvinceName, maps.StatesOrProvinces);
+                row["company_name_id"] = ResolveLookupId(plan.CompanyName, maps.CompanyNames);
+                row["manager_id"] = ResolveManagerId(plan.ManagerAadId, dbUsersByAadId, dbUsersByUpn, graphUsersByAadId);
+                row["last_updated"] = lastUpdated;
+
+                dt.Rows.Add(row);
+            }
+
+            return dt;
+        }
+
+        /// <summary>
+        /// Turns an already-normalised lookup name into the foreign key to store, or
+        /// <see cref="DBNull"/> when the value is absent or the lookup row has not been saved yet
+        /// (<c>ID == 0</c>), which clears the column.
+        /// </summary>
+        public static object ResolveLookupId<T>(string normalisedName, Dictionary<string, T> map) where T : AbstractEFEntityWithName
+        {
+            if (!string.IsNullOrEmpty(normalisedName) && map.TryGetValue(normalisedName, out var entity) && entity.ID > 0)
+                return entity.ID;
+            return DBNull.Value;
+        }
+
+        /// <summary>
+        /// The manager foreign-key precedence chain for the bulk path, in order:
+        /// <list type="number">
+        /// <item>the manager's Entra id is already in the DB-users-by-AAD-id map;</item>
+        /// <item>otherwise look the manager up in the current Graph batch by Entra id, take its UPN
+        /// and find that UPN in the DB-users-by-UPN map;</item>
+        /// <item>otherwise leave the column NULL, which clears any previously stored manager.</item>
+        /// </list>
+        /// A user Graph reports no manager for also clears the column. In every case the candidate
+        /// must already be saved (<c>ID &gt; 0</c>), because the value becomes a foreign key.
+        /// </summary>
+        /// <param name="managerAadId">
+        /// The manager's Entra object id from <see cref="UserMetadataMappingRules.BuildPlan"/>, or
+        /// null when Graph reported no manager.
+        /// </param>
+        public static object ResolveManagerId(
+            string managerAadId,
+            Dictionary<string, Common.Entities.User> dbUsersByAadId,
+            Dictionary<string, Common.Entities.User> dbUsersByUpn,
+            Dictionary<string, GraphUser> graphUsersByAadId)
+        {
+            if (managerAadId == null)
+                return DBNull.Value;
+
+            if (dbUsersByAadId.TryGetValue(managerAadId, out var manager) && manager.ID > 0)
+                return manager.ID;
+
+            if (graphUsersByAadId != null &&
+                graphUsersByAadId.TryGetValue(managerAadId, out var mgrGraph) &&
+                !string.IsNullOrEmpty(mgrGraph.UserPrincipalName) &&
+                dbUsersByUpn.TryGetValue(mgrGraph.UserPrincipalName, out var mgrByUpn) && mgrByUpn.ID > 0)
+            {
+                return mgrByUpn.ID;
+            }
+
+            return DBNull.Value;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserImportCommitPolicy.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/Rules/UserImportCommitPolicy.cs
@@ -1,0 +1,59 @@
+﻿namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Which phases of one Graph user import cycle completed successfully.
+    /// </summary>
+    /// <remarks>
+    /// A phase is "succeeded" only once it has finished without throwing. A phase that did not run
+    /// at all - the licence refresh when the tenant does not grant <c>Organization.Read.All</c>, so
+    /// licences are handled per user inside the update phase instead - also counts as succeeded,
+    /// because there is no outstanding work it could have skipped.
+    /// </remarks>
+    public sealed class UserImportPhaseResults
+    {
+        /// <summary>New users were inserted and enriched with metadata.</summary>
+        public bool InsertPhaseSucceeded { get; set; }
+
+        /// <summary>Existing users had their metadata updated (bulk-SQL or per-entity path).</summary>
+        public bool UpdatePhaseSucceeded { get; set; }
+
+        /// <summary>
+        /// The tenant-wide licence refresh finished, or no licence refresh was required this cycle.
+        /// </summary>
+        public bool LicenceRefreshSucceeded { get; set; }
+    }
+
+    /// <summary>
+    /// The ordering guarantee that matters most in the Graph user import: the delta token is only
+    /// persisted after the insert, update and licence phases have <b>all</b> succeeded.
+    /// </summary>
+    /// <remarks>
+    /// Extracted for issues #372 / #381. Graph's <c>/users/delta</c> token is a promise that the
+    /// caller has dealt with everything up to that point; committing it after a partial cycle makes
+    /// Graph stop reporting those users, so the work is not retried and the missing data is
+    /// invisible until somebody notices absent users.
+    ///
+    /// The end-to-end behaviour is already covered by the database-backed
+    /// <c>UserMetadataUpdater_SuccessfulImport_DeltaTokenCommitted</c> and
+    /// <c>UserMetadataUpdater_LicenseProcessingThrows_DeltaTokenNotAdvanced</c>. What had no test
+    /// was the <i>rule</i>, because there was no rule to test: the guarantee was a side effect of an
+    /// exception propagating out of the orchestration method. The update phase already sits inside a
+    /// <c>try</c>/<c>catch</c> that logs and rethrows, and deleting that one <c>throw</c> would have
+    /// been enough to start committing a delta token for a failed cycle.
+    ///
+    /// Making it an explicit, checked decision means the safe answer survives that edit: a phase
+    /// whose failure is swallowed leaves its flag false, and the token is not committed.
+    /// </remarks>
+    public static class UserImportCommitPolicy
+    {
+        /// <summary>
+        /// True only when every phase of the cycle succeeded.
+        /// </summary>
+        public static bool ShouldCommitDelta(UserImportPhaseResults results)
+        {
+            return results.InsertPhaseSucceeded
+                && results.UpdatePhaseSucceeded
+                && results.LicenceRefreshSucceeded;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserBulkUpdateWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserBulkUpdateWriter.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// SQL Server implementation of <see cref="IUserBulkUpdateWriter"/>: creates a session temp
+    /// table, <c>SqlBulkCopy</c>s the batch into it, runs a single <c>UPDATE ... FROM JOIN</c> and
+    /// drops the temp table again.
+    /// </summary>
+    /// <remarks>
+    /// This is <c>UserBatchProcessor.ExecuteBulkUpdate</c> moved here unchanged (#371): same
+    /// connection handling, same temp-table DDL, same column mappings, same batch size and
+    /// timeouts. Nothing about the bulk-copy strategy is being altered - it is only being taken out
+    /// of the batching logic so that logic becomes testable.
+    ///
+    /// The temp table is <c>#user_updates</c>, i.e. session-scoped, so every step must run on the
+    /// same open <see cref="SqlConnection"/>.
+    /// </remarks>
+    internal class SqlUserBulkUpdateWriter : IUserBulkUpdateWriter
+    {
+        private readonly string _connectionString;
+
+        public SqlUserBulkUpdateWriter(string connectionString)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+            _connectionString = connectionString;
+        }
+
+        public async Task ExecuteAsync(DataTable userUpdates)
+        {
+            if (userUpdates.Rows.Count == 0)
+                return;
+
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                await connection.OpenAsync();
+
+                using (var cmd = new SqlCommand(CREATE_TEMP_TABLE_SQL, connection))
+                {
+                    cmd.CommandTimeout = 600;
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                using (var bulkCopy = new SqlBulkCopy(connection))
+                {
+                    bulkCopy.DestinationTableName = "#user_updates";
+                    bulkCopy.BatchSize = 10000;
+                    bulkCopy.BulkCopyTimeout = 600;
+
+                    foreach (var column in UserBulkUpdateRules.UpdateTableColumns)
+                    {
+                        bulkCopy.ColumnMappings.Add(column, column);
+                    }
+
+                    await bulkCopy.WriteToServerAsync(userUpdates);
+                }
+
+                using (var cmd = new SqlCommand(UPDATE_FROM_TEMP_SQL, connection))
+                {
+                    cmd.CommandTimeout = 600;
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                using (var cmd = new SqlCommand("DROP TABLE #user_updates", connection))
+                {
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+
+        internal const string CREATE_TEMP_TABLE_SQL = @"
+            CREATE TABLE #user_updates (
+                id              INT          NOT NULL,
+                azure_ad_id     NVARCHAR(450) NULL,
+                account_enabled BIT           NULL,
+                mail            NVARCHAR(450) NULL,
+                postalcode      NVARCHAR(50)  NULL,
+                department_id   INT           NULL,
+                job_title_id    INT           NULL,
+                office_location_id INT        NULL,
+                usage_location_id  INT        NULL,
+                country_or_region_id INT      NULL,
+                state_or_province_id INT      NULL,
+                company_name_id INT           NULL,
+                manager_id      INT           NULL,
+                last_updated    DATETIME      NOT NULL
+            )";
+
+        internal const string UPDATE_FROM_TEMP_SQL = @"
+            UPDATE u
+            SET u.azure_ad_id            = t.azure_ad_id,
+                u.account_enabled        = t.account_enabled,
+                u.mail                   = t.mail,
+                u.postalcode             = t.postalcode,
+                u.department_id          = t.department_id,
+                u.job_title_id           = t.job_title_id,
+                u.office_location_id     = t.office_location_id,
+                u.usage_location_id      = t.usage_location_id,
+                u.country_or_region_id   = t.country_or_region_id,
+                u.state_or_province_id   = t.state_or_province_id,
+                u.company_name_id        = t.company_name_id,
+                u.manager_id             = t.manager_id,
+                u.last_updated           = t.last_updated
+            FROM dbo.users u
+            INNER JOIN #user_updates t ON u.id = t.id";
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserLookupStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserLookupStore.cs
@@ -1,0 +1,80 @@
+﻿using Common.Entities;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Entity Framework implementation of <see cref="IUserLookupStore"/>, reading through the same
+    /// context the user import is writing with so the entities it returns are tracked.
+    /// </summary>
+    internal class SqlUserLookupStore : IUserLookupStore
+    {
+        /// <summary>
+        /// How many UPNs go into one <c>IN (...)</c> list. SQL Server allows 2,100 parameters per
+        /// command, and EF6 sends each element of a <c>Contains</c> list as its own parameter, so
+        /// this has to stay comfortably below that. 1,000 is the size the rest of the user pipeline
+        /// already uses for the same reason (see the reload loop in <c>UserMetadataUpdater</c>).
+        /// </summary>
+        public const int UpnChunkSize = 1000;
+
+        private readonly AnalyticsEntitiesContext _db;
+        private readonly int _chunkSize;
+
+        public SqlUserLookupStore(AnalyticsEntitiesContext db) : this(db, UpnChunkSize) { }
+
+        public SqlUserLookupStore(AnalyticsEntitiesContext db, int chunkSize)
+        {
+            if (chunkSize < 1) throw new ArgumentOutOfRangeException(nameof(chunkSize));
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _chunkSize = chunkSize;
+        }
+
+        public async Task<IReadOnlyList<Common.Entities.User>> GetUsersByUpnAsync(IReadOnlyCollection<string> upns)
+        {
+            var results = new List<Common.Entities.User>(upns.Count);
+            if (upns.Count == 0)
+            {
+                return results;
+            }
+
+            // GetRange rather than Skip().Take() - Skip() on a List walks past every prior element,
+            // so chunking N items in slices of K costs O(N^2/K).
+            var all = upns as List<string> ?? upns.ToList();
+            for (var i = 0; i < all.Count; i += _chunkSize)
+            {
+                var chunk = all.GetRange(i, Math.Min(_chunkSize, all.Count - i));
+
+                // Tracked on purpose: callers assign the result to a navigation property.
+                //
+                // LicenseLookups is included deliberately, and it is load-bearing rather than
+                // decoration. In the per-user licence path (no Organization.Read.All) the batch's
+                // own users are AsNoTracking snapshots loaded WITH their licences, and they are
+                // attached one at a time as the batch is processed. If this query tracks one of
+                // them first - a manager who is also a subject of the same batch -
+                // GetOrAttachUser returns this instance instead, and EF will not populate a
+                // navigation property it was never asked to load: proxies are disabled and
+                // User.LicenseLookups is a plain non-virtual List initialised empty, so there is
+                // no lazy load to rescue it. ProcessUserLicenses would then delete none of the
+                // user's existing licence rows before re-adding them, and SaveChanges would fail
+                // on the unique (license_type_id, user_id) index. Loading the licences here keeps
+                // this instance at least as complete as the snapshot it can shadow.
+                //
+                // No LOWER() on the column - the default code-first collation is already
+                // case-insensitive, and lowering it would make the predicate non-SARGable and
+                // scan the whole table instead of seeking the user_name index.
+                var loaded = await _db.users
+                    .Where(u => chunk.Contains(u.UserPrincipalName))
+                    .Include(u => u.LicenseLookups)
+                    .ToListAsync();
+
+                results.AddRange(loaded);
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserBatchProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserBatchProcessor.cs
@@ -2,9 +2,7 @@ using Common.Entities;
 using DataUtils;
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Data.Entity;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -26,6 +24,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// <summary>
         /// Process existing users in batches to reduce memory pressure
         /// </summary>
+        /// <param name="prepareBatch">
+        /// Called once with each batch before it is processed, so the caller can resolve everything
+        /// the batch will need in bulk - in production that is <c>UserDataMapper</c> prefetching the
+        /// batch's managers in a single query instead of one query per user (#371). Optional; pass
+        /// null to skip.
+        /// </param>
         public async Task<int> ProcessExistingUsersInBatches(
             AnalyticsEntitiesContext db,
             List<GraphUser> allActiveGraphUsers,
@@ -33,6 +37,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             Dictionary<string, Common.Entities.User> dbUsersByUpn,
             Dictionary<string, Common.Entities.User> dbUsersByAadId,
             Func<GraphUser, Common.Entities.User, Task> updateAction,
+            Func<List<GraphUser>, Task> prepareBatch,
             int batchSize = DEFAULT_BATCH_SIZE)
         {
             _logger.LogInformation($"User import - updating {userUpnsToProcess.Count.ToString("N0")} existing users in batches...");
@@ -47,6 +52,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             {
                 var batchCount = Math.Min(batchSize, batchedGraphUsers.Count - i);
                 var batch = batchedGraphUsers.GetRange(i, batchCount);
+
+                if (prepareBatch != null)
+                {
+                    await prepareBatch(batch);
+                }
 
                 // CRITICAL: Ensure all entities in the dictionaries that might be referenced
                 // by this batch are properly attached BEFORE processing
@@ -234,6 +244,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// Pre-warms all lookup caches then builds a DataTable with resolved FK IDs,
         /// bulk-copies to a temp table, and executes a single UPDATE ... FROM JOIN.
         /// </summary>
+        /// <param name="bulkUpdateWriter">
+        /// Where each resolved batch is written. In production this is
+        /// <see cref="SqlUserBulkUpdateWriter"/>, which is the original <c>SqlBulkCopy</c> code
+        /// relocated unchanged; injecting it lets the batching and foreign-key resolution above be
+        /// tested without a SQL Server (#371).
+        /// </param>
         public async Task<int> BulkUpdateExistingUsers(
             AnalyticsEntitiesContext db,
             List<GraphUser> allActiveGraphUsers,
@@ -241,7 +257,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             Dictionary<string, Common.Entities.User> dbUsersByUpn,
             Dictionary<string, Common.Entities.User> dbUsersByAadId,
             Dictionary<string, GraphUser> graphUsersByAadId,
-            UserMetadataCache userMetaCache)
+            UserMetadataCache userMetaCache,
+            IUserBulkUpdateWriter bulkUpdateWriter)
         {
             var graphUsersToUpdate = new List<GraphUser>(userUpnsToProcess.Count);
             foreach (var u in allActiveGraphUsers)
@@ -265,7 +282,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             db.ChangeTracker.DetectChanges();
             await db.SaveChangesAsync();
 
-            var connectionString = db.Database.Connection.ConnectionString;
             int totalProcessed = 0;
             const int BULK_BATCH_SIZE = 50000;
 
@@ -274,9 +290,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 var batchCount = Math.Min(BULK_BATCH_SIZE, graphUsersToUpdate.Count - i);
                 var batch = graphUsersToUpdate.GetRange(i, batchCount);
 
-                using (var dataTable = BuildUpdateDataTable(batch, lookupMaps, dbUsersByAadId, dbUsersByUpn, graphUsersByAadId))
+                // Read per batch, exactly as the inlined table builder used to: on a tenant large
+                // enough to need more than one batch the later batches carry a later last_updated.
+                // Local time, not UTC - see the note on UserBulkUpdateRules.BuildUpdateTable.
+                var now = DateTime.Now;
+
+                using (var dataTable = UserBulkUpdateRules.BuildUpdateTable(
+                    batch, lookupMaps, dbUsersByAadId, dbUsersByUpn, graphUsersByAadId, now))
                 {
-                    await ExecuteBulkUpdate(connectionString, dataTable);
+                    await bulkUpdateWriter.ExecuteAsync(dataTable);
                 }
 
                 totalProcessed += batchCount;
@@ -343,202 +365,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
         private static void AddNormalized(string raw, HashSet<string> set)
         {
-            var name = StringUtils.EnsureMaxLength(raw?.Trim(), 100);
-            if (!string.IsNullOrEmpty(name))
+            // Same normalisation the mapping rule applies, so the pre-warmed cache keys and the
+            // foreign keys resolved later cannot drift apart (#371).
+            var name = UserMetadataMappingRules.NormaliseLookupName(raw);
+            if (name != null)
                 set.Add(name);
-        }
-
-        private DataTable BuildUpdateDataTable(
-            List<GraphUser> graphUsers,
-            LookupEntityMaps maps,
-            Dictionary<string, Common.Entities.User> dbUsersByAadId,
-            Dictionary<string, Common.Entities.User> dbUsersByUpn,
-            Dictionary<string, GraphUser> graphUsersByAadId)
-        {
-            var dt = new DataTable();
-            dt.Columns.Add("id", typeof(int));
-            dt.Columns.Add("azure_ad_id", typeof(string));
-            dt.Columns.Add("account_enabled", typeof(bool));
-            dt.Columns.Add("mail", typeof(string));
-            dt.Columns.Add("postalcode", typeof(string));
-            dt.Columns.Add("department_id", typeof(int));
-            dt.Columns.Add("job_title_id", typeof(int));
-            dt.Columns.Add("office_location_id", typeof(int));
-            dt.Columns.Add("usage_location_id", typeof(int));
-            dt.Columns.Add("country_or_region_id", typeof(int));
-            dt.Columns.Add("state_or_province_id", typeof(int));
-            dt.Columns.Add("company_name_id", typeof(int));
-            dt.Columns.Add("manager_id", typeof(int));
-            dt.Columns.Add("last_updated", typeof(DateTime));
-
-            var now = DateTime.Now;
-
-            foreach (var graphUser in graphUsers)
-            {
-                var upn = graphUser.UserPrincipalName;
-                if (string.IsNullOrEmpty(upn))
-                    continue;
-
-                // Find the DB user to get the PK
-                if (!dbUsersByUpn.TryGetValue(upn, out var dbUser) || dbUser.ID == 0)
-                    continue;
-
-                var row = dt.NewRow();
-                row["id"] = dbUser.ID;
-                row["azure_ad_id"] = (object)graphUser.Id ?? DBNull.Value;
-                row["account_enabled"] = graphUser.AccountEnabled.HasValue ? (object)graphUser.AccountEnabled.Value : DBNull.Value;
-                row["mail"] = (object)graphUser.Mail ?? DBNull.Value;
-                row["postalcode"] = (object)graphUser.PostalCode ?? DBNull.Value;
-                row["department_id"] = ResolveLookupId(graphUser.Department, maps.Departments);
-                row["job_title_id"] = ResolveLookupId(graphUser.JobTitle, maps.JobTitles);
-                row["office_location_id"] = ResolveLookupId(graphUser.OfficeLocation, maps.OfficeLocations);
-                row["usage_location_id"] = ResolveLookupId(graphUser.UsageLocation, maps.UsageLocations);
-                row["country_or_region_id"] = ResolveLookupId(graphUser.Country, maps.Countries);
-                row["state_or_province_id"] = ResolveLookupId(graphUser.State, maps.StatesOrProvinces);
-                row["company_name_id"] = ResolveLookupId(graphUser.CompanyName, maps.CompanyNames);
-                row["manager_id"] = ResolveManagerId(graphUser, dbUsersByAadId, dbUsersByUpn, graphUsersByAadId);
-                row["last_updated"] = now;
-
-                dt.Rows.Add(row);
-            }
-
-            return dt;
-        }
-
-        private static object ResolveLookupId<T>(string rawValue, Dictionary<string, T> map) where T : AbstractEFEntityWithName
-        {
-            var name = StringUtils.EnsureMaxLength(rawValue?.Trim(), 100);
-            if (!string.IsNullOrEmpty(name) && map.TryGetValue(name, out var entity) && entity.ID > 0)
-                return entity.ID;
-            return DBNull.Value;
-        }
-
-        private static object ResolveManagerId(
-            GraphUser graphUser,
-            Dictionary<string, Common.Entities.User> dbUsersByAadId,
-            Dictionary<string, Common.Entities.User> dbUsersByUpn,
-            Dictionary<string, GraphUser> graphUsersByAadId)
-        {
-            if (graphUser.DefaultManagerInfo?.Id == null)
-                return DBNull.Value;
-
-            var mgrAadId = graphUser.DefaultManagerInfo.Id;
-
-            if (dbUsersByAadId.TryGetValue(mgrAadId, out var manager) && manager.ID > 0)
-                return manager.ID;
-
-            if (graphUsersByAadId != null &&
-                graphUsersByAadId.TryGetValue(mgrAadId, out var mgrGraph) &&
-                !string.IsNullOrEmpty(mgrGraph.UserPrincipalName) &&
-                dbUsersByUpn.TryGetValue(mgrGraph.UserPrincipalName, out var mgrByUpn) && mgrByUpn.ID > 0)
-            {
-                return mgrByUpn.ID;
-            }
-
-            return DBNull.Value;
-        }
-
-        private static async Task ExecuteBulkUpdate(string connectionString, DataTable dataTable)
-        {
-            if (dataTable.Rows.Count == 0)
-                return;
-
-            using (var connection = new SqlConnection(connectionString))
-            {
-                await connection.OpenAsync();
-
-                using (var cmd = new SqlCommand(CREATE_TEMP_TABLE_SQL, connection))
-                {
-                    cmd.CommandTimeout = 600;
-                    await cmd.ExecuteNonQueryAsync();
-                }
-
-                using (var bulkCopy = new SqlBulkCopy(connection))
-                {
-                    bulkCopy.DestinationTableName = "#user_updates";
-                    bulkCopy.BatchSize = 10000;
-                    bulkCopy.BulkCopyTimeout = 600;
-
-                    bulkCopy.ColumnMappings.Add("id", "id");
-                    bulkCopy.ColumnMappings.Add("azure_ad_id", "azure_ad_id");
-                    bulkCopy.ColumnMappings.Add("account_enabled", "account_enabled");
-                    bulkCopy.ColumnMappings.Add("mail", "mail");
-                    bulkCopy.ColumnMappings.Add("postalcode", "postalcode");
-                    bulkCopy.ColumnMappings.Add("department_id", "department_id");
-                    bulkCopy.ColumnMappings.Add("job_title_id", "job_title_id");
-                    bulkCopy.ColumnMappings.Add("office_location_id", "office_location_id");
-                    bulkCopy.ColumnMappings.Add("usage_location_id", "usage_location_id");
-                    bulkCopy.ColumnMappings.Add("country_or_region_id", "country_or_region_id");
-                    bulkCopy.ColumnMappings.Add("state_or_province_id", "state_or_province_id");
-                    bulkCopy.ColumnMappings.Add("company_name_id", "company_name_id");
-                    bulkCopy.ColumnMappings.Add("manager_id", "manager_id");
-                    bulkCopy.ColumnMappings.Add("last_updated", "last_updated");
-
-                    await bulkCopy.WriteToServerAsync(dataTable);
-                }
-
-                using (var cmd = new SqlCommand(UPDATE_FROM_TEMP_SQL, connection))
-                {
-                    cmd.CommandTimeout = 600;
-                    await cmd.ExecuteNonQueryAsync();
-                }
-
-                using (var cmd = new SqlCommand("DROP TABLE #user_updates", connection))
-                {
-                    await cmd.ExecuteNonQueryAsync();
-                }
-            }
-        }
-
-        private const string CREATE_TEMP_TABLE_SQL = @"
-            CREATE TABLE #user_updates (
-                id              INT          NOT NULL,
-                azure_ad_id     NVARCHAR(450) NULL,
-                account_enabled BIT           NULL,
-                mail            NVARCHAR(450) NULL,
-                postalcode      NVARCHAR(50)  NULL,
-                department_id   INT           NULL,
-                job_title_id    INT           NULL,
-                office_location_id INT        NULL,
-                usage_location_id  INT        NULL,
-                country_or_region_id INT      NULL,
-                state_or_province_id INT      NULL,
-                company_name_id INT           NULL,
-                manager_id      INT           NULL,
-                last_updated    DATETIME      NOT NULL
-            )";
-
-        private const string UPDATE_FROM_TEMP_SQL = @"
-            UPDATE u
-            SET u.azure_ad_id            = t.azure_ad_id,
-                u.account_enabled        = t.account_enabled,
-                u.mail                   = t.mail,
-                u.postalcode             = t.postalcode,
-                u.department_id          = t.department_id,
-                u.job_title_id           = t.job_title_id,
-                u.office_location_id     = t.office_location_id,
-                u.usage_location_id      = t.usage_location_id,
-                u.country_or_region_id   = t.country_or_region_id,
-                u.state_or_province_id   = t.state_or_province_id,
-                u.company_name_id        = t.company_name_id,
-                u.manager_id             = t.manager_id,
-                u.last_updated           = t.last_updated
-            FROM dbo.users u
-            INNER JOIN #user_updates t ON u.id = t.id";
-
-        /// <summary>
-        /// Holds entity-reference dictionaries for each lookup type.
-        /// Entity IDs are valid after the context has been saved.
-        /// </summary>
-        internal class LookupEntityMaps
-        {
-            public Dictionary<string, UserDepartment> Departments = new Dictionary<string, UserDepartment>(StringComparer.OrdinalIgnoreCase);
-            public Dictionary<string, UserJobTitle> JobTitles = new Dictionary<string, UserJobTitle>(StringComparer.OrdinalIgnoreCase);
-            public Dictionary<string, UserOfficeLocation> OfficeLocations = new Dictionary<string, UserOfficeLocation>(StringComparer.OrdinalIgnoreCase);
-            public Dictionary<string, UserUsageLocation> UsageLocations = new Dictionary<string, UserUsageLocation>(StringComparer.OrdinalIgnoreCase);
-            public Dictionary<string, CountryOrRegion> Countries = new Dictionary<string, CountryOrRegion>(StringComparer.OrdinalIgnoreCase);
-            public Dictionary<string, StateOrProvince> StatesOrProvinces = new Dictionary<string, StateOrProvince>(StringComparer.OrdinalIgnoreCase);
-            public Dictionary<string, CompanyName> CompanyNames = new Dictionary<string, CompanyName>(StringComparer.OrdinalIgnoreCase);
         }
 
         #endregion

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
@@ -15,12 +15,33 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     {
         private readonly AnalyticsLogger _logger;
         private readonly UserMetadataCache _userMetaCache;
+        private readonly ManagerPrefetchCache _managerPrefetch;
         private Dictionary<string, GraphUser> _graphUsersByAadId;
 
+        /// <summary>
+        /// Constructor without a lookup store: manager resolution falls back to the original
+        /// per-user database query. Kept so existing call sites and tests do not have to change.
+        /// </summary>
         public UserDataMapper(AnalyticsLogger logger, UserMetadataCache userMetaCache)
+        {
+            // Deliberately not chained to the overload below: a constructor initialiser runs before
+            // the body, so chaining would move the store's own argument checks ahead of these and
+            // change which ParamName a caller sees.
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _userMetaCache = userMetaCache ?? throw new ArgumentNullException(nameof(userMetaCache));
+            _managerPrefetch = new ManagerPrefetchCache(null);
+        }
+
+        /// <param name="userLookupStore">
+        /// Used by <see cref="PrefetchManagersForBatchAsync"/> to resolve a whole batch's managers in
+        /// one query instead of one query per user (#371).
+        /// </param>
+        public UserDataMapper(AnalyticsLogger logger, UserMetadataCache userMetaCache, IUserLookupStore userLookupStore)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _userMetaCache = userMetaCache ?? throw new ArgumentNullException(nameof(userMetaCache));
+            if (userLookupStore == null) throw new ArgumentNullException(nameof(userLookupStore));
+            _managerPrefetch = new ManagerPrefetchCache(userLookupStore);
         }
 
         /// <summary>
@@ -42,6 +63,27 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     _graphUsersByAadId[graphUser.Id] = graphUser;
                 }
             }
+        }
+
+        /// <summary>
+        /// Loads every manager the given batch might have to look up by UPN, in a single query, so
+        /// the resolution chain below does not have to go to the database once per user.
+        /// </summary>
+        /// <remarks>
+        /// This is the fix for the N+1 called out in #371. The database-by-UPN branch of
+        /// <see cref="UpdateUserManager"/> is reached whenever a manager cannot be resolved from the
+        /// in-memory dictionaries - during insert enrichment, a manager inserted in a later batch
+        /// than their report. One chunked query per batch replaces those round trips.
+        ///
+        /// Call once per batch, before processing it: the entities returned are tracked by the
+        /// import's context and every batch ends by detaching them, so a cache kept across batches
+        /// would hand out detached entities. Each call therefore replaces the previous contents.
+        /// A no-op when no lookup store was supplied, which leaves the original per-user query in
+        /// place.
+        /// </remarks>
+        public async Task PrefetchManagersForBatchAsync(IEnumerable<GraphUser> batch)
+        {
+            await _managerPrefetch.LoadForBatchAsync(batch, _graphUsersByAadId);
         }
 
         /// <summary>
@@ -234,12 +276,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                             // CRITICAL FIX: First try to find the manager in the database by UPN
                             // The AAD ID lookup might have failed due to mismatched/null AAD IDs,
                             // but the user might still exist in the database.
+                            //
+                            // Served from the batch prefetch when one was loaded
+                            // (PrefetchManagersForBatchAsync), which is what stops this being a
+                            // query per user at 200k-user scale (#371). The prefetch runs on the
+                            // same context, so the entity is tracked exactly as the query below
+                            // would return it. The query is still the fallback: it covers managers
+                            // created part-way through the batch, and the case where no lookup
+                            // store was supplied at all.
+                            //
                             // Drop LOWER() from the column predicate - the default code-first
                             // collation (Latin1_General_CI_AS) is case-insensitive, so leaving
                             // the column un-lowered keeps the predicate SARGable and lets the
                             // index on user_name be used.
-                            dbManager = await db.users
-                                .FirstOrDefaultAsync(u => u.UserPrincipalName == managerUpn);
+                            if (!_managerPrefetch.TryGet(managerUpn, out dbManager))
+                            {
+                                dbManager = await db.users
+                                    .FirstOrDefaultAsync(u => u.UserPrincipalName == managerUpn);
+                            }
 
                             if (dbManager != null)
                             {
@@ -299,7 +353,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             if (user.ID == 0 && !string.IsNullOrEmpty(user.UserPrincipalName))
             {
                 var upn = user.UserPrincipalName;
-                var existingUser = await db.users.FirstOrDefaultAsync(u => u.UserPrincipalName == upn);
+                // Served from the batch prefetch where possible, for the same reason as the manager
+                // branch above: this ran once per user with an unsaved template entity (#371).
+                if (!_managerPrefetch.TryGet(upn, out var existingUser))
+                {
+                    existingUser = await db.users.FirstOrDefaultAsync(u => u.UserPrincipalName == upn);
+                }
                 if (existingUser != null)
                 {
                     // Found the user in DB - use the tracked version

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserInsertProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserInsertProcessor.cs
@@ -85,6 +85,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 readUserSkus,
                 METADATA_BATCH_SIZE,
                 userMetaCache,
+                dataMapper,
                 updateAction);
 
             _logger.LogInformation($"User import - Phase 2: Metadata enrichment completed for {insertedDbUsers.Count.ToString("N0")} new users");
@@ -182,6 +183,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             bool readUserSkus,
             int batchSize,
             UserMetadataCache userMetaCache,
+            UserDataMapper dataMapper,
             Func<AnalyticsEntitiesContext, GraphUser, List<GraphUser>, List<Common.Entities.User>, Common.Entities.User, bool, Dictionary<string, Common.Entities.User>, Task> updateAction)
         {
             var enrichedUsers = new List<Common.Entities.User>(insertedUserUpns.Count);
@@ -247,6 +249,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 }
 
                 // Update metadata for each user
+                //
+                // Resolve this batch's managers in ONE query first. Without it the manager
+                // resolution chain falls through to a per-user database lookup for every manager
+                // that is not already in dbUsersByAadId - which, since that dictionary is seeded
+                // from pre-existing users and then grows a batch at a time, means every manager
+                // who happens to be inserted in a later batch than their report. Graph does not
+                // order the delta by reporting line, so on a first import that is a large share of
+                // everyone who has a manager (#371).
+                var batchGraphUsers = new List<GraphUser>(batchUsers.Count);
+                foreach (var dbUser in batchUsers)
+                {
+                    if (!string.IsNullOrEmpty(dbUser.UserPrincipalName) && graphUsersByUpn.TryGetValue(dbUser.UserPrincipalName, out var batchGraphUser))
+                    {
+                        batchGraphUsers.Add(batchGraphUser);
+                    }
+                }
+                await dataMapper.PrefetchManagersForBatchAsync(batchGraphUsers);
+
                 foreach (var dbUser in batchUsers)
                 {
                     if (!string.IsNullOrEmpty(dbUser.UserPrincipalName) && graphUsersByUpn.TryGetValue(dbUser.UserPrincipalName, out var graphUser))

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -21,6 +21,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
         private UserMetadataCache _userMetaCache;
         private readonly IUserMetadataLoader _userLoader;
+        private readonly IAnalyticsDbContextFactory _contextFactory;
         private UserBatchProcessor _batchProcessor;
         private UserInsertProcessor _insertProcessor;
         private UserLicenseProcessor _licenseProcessor;
@@ -48,6 +49,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             var graphServiceClient = GraphServiceClientFactory.CreateWithTimeout(creds, TimeSpan.FromHours(1));
 
             _userLoader = new GraphUserLoader(manualGraphCallClient, deltaProvider, _logger, graphServiceClient);
+            _contextFactory = DefaultAnalyticsDbContextFactory.Instance;
             InitializeHelpers();
         }
 
@@ -55,9 +57,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// Constructor with injectable user loader for testing and alternate implementations
         /// </summary>
         public UserMetadataUpdater(AnalyticsLogger logger, AppConfig settings, IUserMetadataLoader userLoader)
+            : this(logger, settings, userLoader, DefaultAnalyticsDbContextFactory.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Constructor with an injectable user loader and database context factory (#372).
+        /// </summary>
+        public UserMetadataUpdater(AnalyticsLogger logger, AppConfig settings, IUserMetadataLoader userLoader, IAnalyticsDbContextFactory contextFactory)
             : base(logger, settings)
         {
             _userLoader = userLoader;
+            _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
             InitializeHelpers();
         }
 
@@ -77,14 +88,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         public async Task InsertAndUpdateDatabaseFromExternalUsers()
         {
             const int BATCH_SIZE = 500;
+            var phaseResults = new UserImportPhaseResults();
 
-            using (var db = new AnalyticsEntitiesContext())
+            using (var db = _contextFactory.Create())
             {
                 db.Configuration.AutoDetectChangesEnabled = false;
 
                 _userMetaCache = new UserMetadataCache(db);
                 _licenseProcessor = new UserLicenseProcessor(_logger, _userLoader, _userMetaCache);
-                _dataMapper = new UserDataMapper(_logger, _userMetaCache);
+                _dataMapper = new UserDataMapper(_logger, _userMetaCache, new SqlUserLookupStore(db));
 
                 _logger.LogInformation($"{DateTime.Now.ToShortTimeString()} User import - start");
 
@@ -137,6 +149,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
                 // Insert any user we've not seen so far
                 var insertedDbUsers = await InsertMissingUsers(db, allActiveGraphUsers, graphMentionedExistingDbUsers, skus == null);
+                phaseResults.InsertPhaseSucceeded = true;
                 _logger.LogInformation($"User import - Insert phase completed. {insertedDbUsers.Count.ToString("N0")} new users inserted.");
 
                 // Reload newly inserted users WITH TRACKING and update dictionaries
@@ -248,7 +261,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                             dbUsersByUpn,
                             dbUsersByAadId,
                             _dataMapper.GraphUsersByAadId,
-                            _userMetaCache);
+                            _userMetaCache,
+                            new SqlUserBulkUpdateWriter(db.Database.Connection.ConnectionString));
                     }
                     else
                     {
@@ -259,8 +273,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                             dbUsersByUpn,
                             dbUsersByAadId,
                             async (graphUser, dbUser) => await UpdateDbUserWithGraphData(db, graphUser, allActiveGraphUsers, new List<Common.Entities.User>(), dbUser, true, dbUsersByAadId),
+                            // Resolve the whole batch's managers in one query rather than one per
+                            // user - see UserDataMapper.PrefetchManagersForBatchAsync (#371).
+                            batch => _dataMapper.PrefetchManagersForBatchAsync(batch),
                             BATCH_SIZE);
                     }
+                    phaseResults.UpdatePhaseSucceeded = true;
                     _logger.LogInformation($"User import - Completed metadata update for {existingUsersUpdated.ToString("N0")} existing users");
                 }
                 catch (Exception ex)
@@ -326,6 +344,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
                     db.ChangeTracker.DetectChanges();
                     await db.SaveChangesAsync();
+                    phaseResults.LicenceRefreshSucceeded = true;
+                }
+                else
+                {
+                    // No separate licence phase runs at all when tenant SKUs are unavailable:
+                    // ProcessUserLicenses already ran per user inside the update phase above, so
+                    // there is no outstanding licence work that committing the delta could skip.
+                    // Set inside the branch rather than after it so that a catch added around the
+                    // work above would leave the flag false, exactly as it would for the other two
+                    // phases.
+                    phaseResults.LicenceRefreshSucceeded = true;
                 }
 
                 _logger.LogInformation($"{DateTime.Now.ToShortTimeString()} User import - complete. Inserted {insertedDbUsers.Count.ToString("N0")} new users, updated metadata for {existingUsersUpdated.ToString("N0")} existing users (from {allActiveGraphUsers.Count.ToString("N0")} Graph users)");
@@ -337,7 +366,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 // effect, so the failed users will be retried on the next import
                 // cycle instead of being skipped because Graph already considers
                 // them "seen".
-                await _userLoader.CommitDeltaTokenAsync();
+                //
+                // The check is explicit rather than implied by that control flow so the
+                // guarantee survives someone adding a catch: see UserImportCommitPolicy (#372).
+                if (UserImportCommitPolicy.ShouldCommitDelta(phaseResults))
+                {
+                    await _userLoader.CommitDeltaTokenAsync();
+                }
+                else
+                {
+                    _logger.LogWarning("User import - NOT committing the Graph delta token: at least one import phase did not complete. " +
+                        "The same users will be reprocessed on the next cycle rather than being skipped.");
+                }
 
                 // Final cleanup
                 dbUsersByUpn.Clear();
@@ -372,7 +412,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
             if (_dataMapper == null)
             {
-                _dataMapper = new UserDataMapper(_logger, _userMetaCache);
+                _dataMapper = new UserDataMapper(_logger, _userMetaCache, new SqlUserLookupStore(db));
             }
             if (_licenseProcessor == null)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -228,7 +228,15 @@
     <Compile Include="Graph\UserActivityLastImportedRedisSingleDateLoader.cs" />
     <Compile Include="Graph\User\GraphUserGroupsCache.cs" />
     <Compile Include="Graph\User\GraphUserLoader.cs" />
+    <Compile Include="Graph\User\IUserBulkUpdateWriter.cs" />
+    <Compile Include="Graph\User\IUserLookupStore.cs" />
     <Compile Include="Graph\User\IUserMetadataLoader.cs" />
+    <Compile Include="Graph\User\ManagerPrefetchCache.cs" />
+    <Compile Include="Graph\User\Rules\ManagerResolutionRules.cs" />
+    <Compile Include="Graph\User\Rules\UserBulkUpdateRules.cs" />
+    <Compile Include="Graph\User\Rules\UserImportCommitPolicy.cs" />
+    <Compile Include="Graph\User\SqlUserBulkUpdateWriter.cs" />
+    <Compile Include="Graph\User\SqlUserLookupStore.cs" />
     <Compile Include="Graph\User\UserBatchProcessor.cs" />
     <Compile Include="Graph\User\Rules\UserMetadataMappingRules.cs" />
     <Compile Include="Graph\User\UserDataMapper.cs" />


### PR DESCRIPTION
Continues the ports-and-adapters work on the Graph user import (#381). Part 1 of #371 (PR #407) pulled out the pure mapping rules; this takes the remaining two halves of #371 plus the delta-ordering rule and the orchestration seam from #372.

**Behaviour is unchanged.** Every adapter is a relocation of existing code, not a rewrite — in particular `InsertBatch<T>` and `SqlBulkCopy` are untouched.

---

## #371 part 2

### `IUserBulkUpdateWriter` / `SqlUserBulkUpdateWriter`

The `SqlConnection`, the `#user_updates` temp-table DDL, the `SqlBulkCopy` and the `UPDATE ... FROM JOIN` move out of `UserBatchProcessor` **verbatim** — same 10,000-row bulk-copy batch size, same 600s command and bulk-copy timeouts, same statement order (create temp table → bulk copy → update → drop). `UserBatchProcessor` keeps the batching and foreign-key resolution, which are now testable without a SQL Server.

The only change inside the adapter is that the fourteen `ColumnMappings.Add(x, x)` calls became a loop over `UserBulkUpdateRules.UpdateTableColumns` — see the drift note below.

### `UserBulkUpdateRules` (pure)

`BuildUpdateDataTable`, `ResolveLookupId` and `ResolveManagerId`, plus `LookupEntityMaps`, which was a nested type inside `UserBatchProcessor` and had to come out for the rule to be usable without a context.

Two de-duplications fall out of this, both behaviour-identical:

* the batch now maps through `UserMetadataMappingRules.BuildPlan`, so the bulk-SQL path and the EF path share **one** mapping rule instead of two copies;
* `PreWarmLookupCaches.AddNormalized` now calls `NormaliseLookupName` rather than repeating `EnsureMaxLength(x?.Trim(), 100)`. That was the third copy, and a drift between the *pre-warm* key and the *resolve* key would have silently nulled every affected foreign key rather than failing.

`UpdateTableColumns` is now the list the `SqlBulkCopy` mappings are generated from, and the one the other two — `CreateUpdateTable` and `CREATE_TEMP_TABLE_SQL` — are *pinned against* by tests. The DDL is still hand-written SQL, so it is checked by parsing its column identifiers and comparing the set both ways; a substring check would not do, because `"id"` occurs inside `azure_ad_id`, `department_id` and seven others, and deleting the join-key column outright would have gone unnoticed. (An earlier revision of this PR had exactly that weakness; it was caught by review and the mutation now fails the test.)

### `IUserLookupStore` / `SqlUserLookupStore` / `ManagerPrefetchCache` — the N+1

`UserDataMapper.UpdateUserManager` resolved the fourth branch of its precedence chain with one `db.users.FirstOrDefaultAsync(u => u.UserPrincipalName == managerUpn)` **per user**, and `EnsureUserIsTrackedAsync` had a second one for unsaved template entities. Both are now served from a per-batch prefetch that resolves the whole batch in one chunked `Contains(...)` query (1,000 UPNs per chunk, `GetRange` slicing).

Four things make this behaviour-preserving rather than merely faster, and they are the parts worth reviewing hardest:

1. **The original query remains as the fallback.** `UserCache.GetOrCreateNewResource(..., commitChangeOnSaveNew: true)` calls `SaveChangesAsync` immediately, so a placeholder manager created part-way through a batch is committed mid-batch. A prefetch miss therefore still goes to the database and still finds it.
2. **The prefetch runs on the same `AnalyticsEntitiesContext`** with tracking on, so the entity it returns is the same identity-map instance `FirstOrDefaultAsync` would have returned. A detached instance assigned to `dbUser.Manager` would make EF try to INSERT the manager and fail on a duplicate key.
3. **The prefetch loads `LicenseLookups`.** A prefetched entity can win EF identity resolution over the `AsNoTracking` snapshot the pipeline was about to attach, so it has to be at least as complete as that snapshot. On the per-user licence path the snapshots are loaded with `Include(u => u.LicenseLookups)`; proxies are disabled and `User.LicenseLookups` is a plain non-virtual list, so there is no lazy load to fill it in later. Without the `Include`, a manager who is also a subject of the same batch reaches `ProcessUserLicenses` with an empty licence collection, `RemoveRange` deletes nothing, the same licences are re-added and `SaveChanges` fails on the unique `(license_type_id, user_id)` index. **This was found by the review loop, not by the existing suite** — no existing licence test happens to make one user the manager of another in the same batch. `UserManagerPrefetchLicenceTests` now covers it, and fails if the `Include` is removed.
4. **The cache is scoped to exactly one batch.** Every batch ends with `DetachAllEntitiesExceptLookups`, so a cache that outlived a batch would hand EF a detached entity. `LoadForBatchAsync` resets unconditionally, including on the paths where the store is never called — there is a test specifically for that, because the obvious test passes even without the reset.

`dbo.users` has no unique constraint on `user_name`, so `ManagerResolutionRules.IndexByUpn` resolves a duplicated UPN to the **lowest id**, matching `UserCache.Load`'s `OrderBy(t => t.ID).FirstOrDefaultAsync()`.

---

## #372 part 1

### `UserImportCommitPolicy` (pure) + `UserImportPhaseResults`

The delta token is committed only after the insert, update and licence phases have **all** succeeded. The end-to-end behaviour is already covered by the existing DB-backed `UserMetadataUpdater_SuccessfulImport_DeltaTokenCommitted` and `UserMetadataUpdater_LicenseProcessingThrows_DeltaTokenNotAdvanced`; what had no test was the *rule*, because there was no rule — the guarantee was a side effect of an exception propagating out of `InsertAndUpdateDatabaseFromExternalUsers`. There is already a `try`/`catch` around the update phase that logs and rethrows, and deleting that one `throw` would have been enough to start committing a delta token for a failed cycle, after which Graph stops reporting those users and the missing data is invisible until somebody notices absent users.

Each flag is set *inside* the construct that could swallow its phase's failure — the update flag inside the `try`, and the licence flag inside each branch of `if (skus != null)` rather than after it — so a `catch` added to any phase leaves that flag false, the token uncommitted, and a warning logged.

"No licence phase ran" counts as success: when the tenant does not grant `Organization.Read.All`, `ProcessUserLicenses` already ran per user inside the update phase, so there is no outstanding licence work to skip.

The guard is vacuously true today, because every failure path still throws out of the method before reaching it. That is deliberate and is the point: it converts an invariant that only holds by control flow into one that is checked.

### `IAnalyticsDbContextFactory` in `UserMetadataUpdater`

Stops the orchestrator calling `new AnalyticsEntitiesContext()` inline (#368's seam). The three-argument constructor is kept as a **delegating overload** and the new parameter is required on the four-argument one, per #381's convention — a trailing optional parameter would have been binary-breaking.

### Not included: the licence persistence port

#395 (issue #392) is open against exactly that code and already introduces `IUserLicenseStore` / `SqlUserLicenseStore` / `UserLicenseAssignmentDelta`, which is #372's licence seam under a different name. Landing a second version here would collide head-on in `UserLicenseProcessor.ProcessSKUsForAllUsers`. `ILicenseNameResolver` is deferred with it, since it needs the same constructor. This PR deliberately does not touch `UserLicenseProcessor.cs` or `GraphUserLoader.cs`; the only overlap with #395 is comment text in `UserMetadataUpdater.cs` lines ~273–330, which is textually disjoint from the regions changed here.

---

## Scale — at the ~200,000-user design target

The manager N+1 is worst on a **first import**. `UserInsertProcessor.EnrichInsertedUsersWithMetadata` seeds its Entra-id dictionary from pre-existing users and then grows it a batch at a time — each batch's tracked users are added *before* that batch is processed, and entries persist across batches. So the per-user query fires for exactly the managers who are inserted in a **later** batch than their report. Graph does not order `/users/delta` by reporting line, so on a first import that is a large share of everyone who has a manager: on the order of tens of thousands of individual `SELECT ... WHERE user_name = @p` round trips per cycle at the 200,000-user design target, on top of the row-loads the importer already does.

An earlier draft of this description said "nearly every user" and "up to 200,000 queries". That is the theoretical worst case (every manager ordered after every report), not the expected shape; the corrected figure above is what the code actually does. Issue #371 asks for a measured before/after query count — that needs a synthetic-scale harness and is **not** included here, so treat the estimate as an estimate.

It is now **one query per 500-user batch** — roughly 400 for the same tenant — with the batch's manager UPNs de-duplicated first. That de-dup matters twice over: 500 reports under one manager is one UPN rather than 500, which also keeps the parameter count well inside SQL Server's 2,100-parameter limit that EF6's `Contains` translation spends one parameter per element of.

No new anti-patterns were introduced, and the existing ones were preserved rather than reintroduced:

* chunking uses `GetRange`, never `Skip().Take()`;
* no `.ToLower()` reaches an indexed column — the new `Contains` predicate is left un-lowered so it stays SARGable against the `user_name` index;
* the `OrdinalIgnoreCase` dictionaries are keyed by the original string, with no per-lookup `.ToLower()` allocation;
* no 200k-entry dictionary is rebuilt inside a per-batch loop — `ManagerPrefetchCache` holds at most one batch's managers.

One deliberate non-change: `users.last_updated` is still stamped with `DateTime.Now` (local, not UTC) and is still re-read **per 50,000-row bulk batch**, so a tenant large enough to need more than one batch still gets a later stamp on the later batches. `IClock` only exposes `UtcNow`, so moving it would change every stored value on a non-UTC host — the same reasoning that deferred it in #407. It is now passed into the rule as a parameter, which is what makes the rule pure.

---

## Tests

**48 new tests. 47 of them need no SQL Server, Graph, Redis or Service Bus at all;** the 48th is a database-backed regression test, because the defect it guards is an EF identity-resolution problem that cannot be reproduced without a context.

| Class | Count | Covers |
|---|---|---|
| `UserBulkUpdateRulesTests` | 22 | batch shape, per-column mapping, the three-list agreement, which users are skipped, and every branch of the manager precedence chain |
| `UserManagerResolutionTests` | 16 | which UPNs a batch needs, duplicate-UPN indexing, per-batch reset, and the N+1 guard |
| `UserImportCommitPolicyTests` | 6 | one test per phase, the default state, and the full eight-state truth table |
| `UserBulkUpdateWriterTests` | 3 | an empty batch performs no write; a missing connection string is rejected |
| `UserManagerPrefetchLicenceTests` | 1 | **DB-backed.** A manager who is also updated in the same batch keeps its licence graph (see #371 point 3 above) |

New fakes in `Tests.UnitTests/FakeLoaderClasses/FakeUserPipelinePorts.cs`: `InMemoryUserBulkUpdateWriter` (which **copies** each batch, because the production caller wraps the `DataTable` in a `using` and disposes it before any assertion runs), `InMemoryUserLookupStore` (records call count and the UPN set per call), and `FailingUserLookupStore` (fails via `Task.FromException`, never a synchronous throw, so a dropped `await` is detectable — the bug class of `560e501`).

The N+1 guard is `ManagerPrefetch_ResolvesTheWholeBatchInOneLookup_NotOnePerUser`: 300 users with 300 distinct managers must cost **one** store call carrying all 300 UPNs, and reading the cache afterwards must not go back to the store. To be precise about what it does *not* pin: it drives `ManagerPrefetchCache` directly, so it guards the cache's batching, not the `UserBatchProcessor` / `UserInsertProcessor` call sites. Removing those calls would leave it green — that wiring is covered by the DB-backed `UserMetadataUpdater*` suite and by the new `UserManagerPrefetchLicenceTests`.

### Mutation testing

Fifteen mutations were run against the load-bearing tests. Each failed the intended test, and only that test:

| # | Mutation | Failed |
|---|---|---|
| 1 | drop the per-batch cache reset | `ManagerPrefetch_BatchWithNothingToLookUp_StillClearsThePreviousBatch` |
| 2 | lose the manager UPN de-dup | the two `SharedManager_IsRequestedOnlyOnce` tests |
| 3 | index duplicate UPNs by highest id | `ManagerPrefetch_DuplicateUpnRows_ResolveToTheLowestId` |
| 4 | skip the Entra-id branch of the manager chain | `ManagerResolution_PrefersTheDbUserFoundByEntraId`, `UserBulkUpdate_ManagerIdReachesTheRow` |
| 5 | drop the unsaved-lookup `ID > 0` guard | `UserBulkUpdate_UnsavedLookupEntity_ResolvesToDbNull` |
| 6 | drop the empty-batch short circuit | `UserBulkUpdate_EmptyBatch_PerformsNoWrite` |
| 7 | commit policy requires ANY phase, not ALL | all four negative commit-policy tests |
| 8 | rename a batch column so the three lists drift | the shape test plus 9 row tests |
| 9 | resolve the lookup from the raw Graph value, skipping normalisation | `UserBulkUpdate_OverLengthLookupValue_UsesTheSameCapAsTheMappingRule` |
| 10 | delete the join-key column from the temp-table DDL | `UserBulkUpdate_TempTableDdl_DeclaresExactlyTheColumnsTheBatchCarries` |
| 11 | delete one column assignment from the UPDATE | `UserBulkUpdate_UpdateStatement_WritesEveryColumnExceptTheJoinKey` |
| 12 | commit policy ignores the licence phase | the licence-fail test and the truth table |
| 13 | fake writer stores the caller's table by reference | `UserBulkUpdate_WriterSnapshotsTheBatch_RatherThanKeepingTheCallersTable` |
| 14 | drop `Include(LicenseLookups)` from the prefetch | `ManagerPrefetch_ManagerIsAlsoUpdatedInTheSameBatch_KeepsItsLicenceGraph` |
| 15 | make the UPDATE write one column from the wrong source column | `UserBulkUpdate_UpdateStatement_WritesEveryColumnExceptTheJoinKey` |

Mutation 1 is the reason `ManagerPrefetch_BatchWithNothingToLookUp_StillClearsThePreviousBatch` exists at all: the obvious "each batch replaces the previous one" test passes without the reset, because the second batch's own load overwrites the dictionary anyway. Only a batch with *nothing to look up* reaches the line.

Mutations 10–15 were added across two review rounds; see below.

### Pre-existing tests

The behaviour-identical evidence is the 76 pre-existing user-pipeline tests — `UserMetadataUpdater{Basic,Insert,License,Manager,Metadata,Performance}Tests`, `UserImportCaseSensitivityTests`, `UserImportTests`, `UserLookupTests`, `DBLookupCacheDuplicateKeyErrorTests`, `LookupCacheBatchProcessingTests`, `PerfRegressionTests` — all of which are DB-backed and all of which pass unchanged.

Full suite: **1374 passed / 12 failed (1,387 discovered)**, the 12 being the documented pre-existing environment failures (Graph and cognitive credentials against placeholder config, and the four installer tests needing `InstallTests/TestConfigs/InstallerTestConfig.json`, which is not in the repo) - the same 12 as the pre-change baseline, so no regressions.

---

## Reviewer hotspots

1. **`UserDataMapper.UpdateUserManager`** — is the prefetch-then-fallback genuinely equivalent to the old unconditional query? The argument rests on the fallback still being there and on the prefetch returning tracked entities from the same context.
2. **`ProcessExistingUsersInBatches`** — the prefetch now tracks a batch's managers *before* `GetOrAttachUser` runs. `GetOrAttachUser` already checks the change tracker before attaching, and already had to handle a manager attached by the step above it, so this is not a new situation; but it is the place where the reasoning is subtlest.
3. **`SqlUserBulkUpdateWriter`'s column-mapping loop** — mechanically identical to the fourteen explicit `Add` calls given the same names and order, and pinned by tests, but it is the one line inside the "relocated verbatim" adapter that is not literally verbatim.
4. **The extra `Include(u => u.LicenseLookups)` in `SqlUserLookupStore`** — it fixes the identity-resolution problem described above, but it does load more per batch (up to one batch of managers' licence rows). On the per-user licence path the pipeline already holds every user's licences in memory, so this is a small addition, but it is a deliberate cost.

## Known limitation, not fixed here

The `FirstOrDefaultAsync` fallback in `UserDataMapper.UpdateUserManager` still loads a manager **without** its licence lookups, so the same identity-resolution hazard exists on that path — as it did before this PR. It is pre-existing and out of scope; the prefetch now covers the overwhelming majority of cases, and widening the fallback query would be a behavioural change of its own. Worth a follow-up issue.

Addresses #371
Addresses #372
