### PR TITLE
Graph import: compose sections behind IGraphImportSection instead of new-ing them inline (#376)

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeGraphImportSections.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeGraphImportSections.cs
@@ -1,0 +1,147 @@
+using Common.Entities;
+using Common.Entities.Config;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.Graph.Sections;
+
+namespace UnitTests.FakeLoaderClasses
+{
+    /// <summary>
+    /// A Graph import section that records whether it ran and answers however the test tells it to.
+    /// Lets the <c>GraphImporter</c> orchestration loop be driven with zero SQL Server, Graph, Redis or
+    /// Service Bus (issue #376).
+    /// </summary>
+    public class FakeGraphImportSection : IGraphImportSection
+    {
+        private FakeGraphImportSection(string name, string cadenceKey, int intervalHours)
+        {
+            Name = name;
+            DisabledMessage = $"Skipping {name}";
+            CadenceKey = cadenceKey;
+            IntervalHours = intervalHours;
+        }
+
+        /// <summary>A section the orchestrator must cadence-gate.</summary>
+        public static FakeGraphImportSection Gated(string name, string cadenceKey, int intervalHours)
+            => new FakeGraphImportSection(name, cadenceKey, intervalHours);
+
+        /// <summary>A section with no cadence key, which the orchestrator must run every cycle.</summary>
+        public static FakeGraphImportSection Ungated(string name)
+            => new FakeGraphImportSection(name, null, 0);
+
+        public string Name { get; }
+        public string DisabledMessage { get; set; }
+        public string CadenceKey { get; }
+        public int IntervalHours { get; }
+
+        /// <summary>Whether the tenant has this import switched on. Defaults to on.</summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>What <see cref="RunAsync"/> reports. Ignored when <see cref="FailWith"/> is set.</summary>
+        public bool Result { get; set; } = true;
+
+        /// <summary>
+        /// When set, <see cref="RunAsync"/> returns a FAULTED task rather than throwing synchronously - a
+        /// synchronous throw would land in the caller's catch even if the caller forgot to await, so it
+        /// could not tell a dropped await from a handled failure.
+        /// </summary>
+        public Exception FailWith { get; set; }
+
+        /// <summary>Runs while the section body executes, for asserting ordering / interleaving.</summary>
+        public Action OnRun { get; set; }
+
+        public int RunCount { get; private set; }
+        public bool WasRun => RunCount > 0;
+
+        /// <summary>The <c>ImportTaskSettings</c> instance the orchestrator asked <see cref="IsEnabled"/> about.</summary>
+        public ImportTaskSettings LastEnabledCheckArgument { get; private set; }
+
+        public bool IsEnabled(ImportTaskSettings settings)
+        {
+            LastEnabledCheckArgument = settings;
+            return Enabled;
+        }
+
+        public Task<bool> RunAsync()
+        {
+            RunCount++;
+            OnRun?.Invoke();
+
+            if (FailWith != null) return Task.FromException<bool>(FailWith);
+            return Task.FromResult(Result);
+        }
+    }
+
+    /// <summary>
+    /// Hands the orchestrator a fixed list of sections and records how it was asked for them.
+    /// </summary>
+    public class FakeGraphImportSectionFactory : IGraphImportSectionFactory
+    {
+        private readonly IReadOnlyList<IGraphImportSection> _sections;
+
+        public FakeGraphImportSectionFactory(params IGraphImportSection[] sections)
+        {
+            _sections = sections ?? new IGraphImportSection[0];
+        }
+
+        public int CreateSectionsCallCount { get; private set; }
+        public AppConfig LastSettingsArgument { get; private set; }
+
+        public IReadOnlyList<IGraphImportSection> CreateSections(AppConfig settings)
+        {
+            CreateSectionsCallCount++;
+            LastSettingsArgument = settings;
+            return _sections;
+        }
+    }
+
+    /// <summary>
+    /// <see cref="IImportLastRunStore"/> that records every read and write, so a test can assert not just
+    /// the resulting state but that the orchestrator wrote (or did not write) at all.
+    ///
+    /// Set <see cref="ReadsAlwaysReturnNull"/> to reproduce the documented Redis fail-open contract: a
+    /// <c>RedisImportLastRunStore</c> whose backing cache is unreachable returns null from a read and
+    /// swallows a write, so the section runs rather than being skipped by a cache blip.
+    /// </summary>
+    public class RecordingImportLastRunStore : IImportLastRunStore
+    {
+        private readonly Dictionary<string, DateTime> _lastRuns = new Dictionary<string, DateTime>(StringComparer.Ordinal);
+
+        public List<string> Reads { get; } = new List<string>();
+        public List<KeyValuePair<string, DateTime>> Writes { get; } = new List<KeyValuePair<string, DateTime>>();
+        public List<string> Clears { get; } = new List<string>();
+
+        public bool ReadsAlwaysReturnNull { get; set; }
+        public bool WritesAreSwallowed { get; set; }
+
+        /// <summary>Seeds a last-run time without recording it as a write.</summary>
+        public RecordingImportLastRunStore Seed(string key, DateTime whenUtc)
+        {
+            _lastRuns[key] = whenUtc.ToUniversalTime();
+            return this;
+        }
+
+        public Task<DateTime?> GetLastRunUtc(string key)
+        {
+            Reads.Add(key);
+            if (ReadsAlwaysReturnNull) return Task.FromResult((DateTime?)null);
+            return Task.FromResult(_lastRuns.TryGetValue(key, out var dt) ? (DateTime?)dt : null);
+        }
+
+        public Task SetLastRunUtc(string key, DateTime whenUtc)
+        {
+            Writes.Add(new KeyValuePair<string, DateTime>(key, whenUtc));
+            if (!WritesAreSwallowed) _lastRuns[key] = whenUtc.ToUniversalTime();
+            return Task.CompletedTask;
+        }
+
+        public Task Clear(string key)
+        {
+            Clears.Add(key);
+            _lastRuns.Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphImportOrchestrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphImportOrchestrationTests.cs
@@ -1,0 +1,343 @@
+using Common.Entities;
+using Common.Entities.Config;
+using DataUtils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+using WebJob.Office365ActivityImporter.Engine.Graph.Sections;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Coverage for the <see cref="GraphImporter"/> orchestration loop introduced by issue #376: section
+    /// selection, per-section cadence gating, and the rule that the last-run timestamp is written only when
+    /// the section actually succeeded.
+    ///
+    /// None of these touch SQL Server, Graph, Redis or Service Bus - the sections are fakes, which is the
+    /// whole point of lifting composition out into <see cref="IGraphImportSectionFactory"/>. Before this,
+    /// the only way to find out whether the Teams import had been correctly skipped was to run a real import
+    /// against a real tenant.
+    /// </summary>
+    [TestClass]
+    public class GraphImportOrchestrationTests
+    {
+        private const string FirstSectionCadence = "first-test-section-cadence";
+        private const string SecondSectionCadence = "second-test-section-cadence";
+        private static readonly DateTime Now = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// Settings with the force flags explicitly off. Read explicitly rather than trusting the defaults:
+        /// AppConfig populates itself from the local App.config, so a machine with
+        /// ForceGraphMetadataImport=true would otherwise silently make every gating test pass.
+        /// </summary>
+        private static AppConfig GatingSettings()
+        {
+            return new AppConfig
+            {
+                ForceGraphMetadataImport = false,
+                ImportJobSettings = new ImportTaskSettings(),
+            };
+        }
+
+        private static GraphImporter BuildImporter(AppConfig settings, IImportLastRunStore store, IClock clock, params IGraphImportSection[] sections)
+        {
+            return new GraphImporter(AnalyticsLogger.ConsoleOnlyTracer(), settings,
+                new FakeGraphImportSectionFactory(sections), store, clock);
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_DisabledSection_IsNotRun()
+        {
+            var disabled = FakeGraphImportSection.Gated("Disabled section", FirstSectionCadence, 24);
+            disabled.Enabled = false;
+            var enabled = FakeGraphImportSection.Gated("Enabled section", SecondSectionCadence, 24);
+
+            var store = new RecordingImportLastRunStore();
+            await BuildImporter(GatingSettings(), store, new FixedClock(Now), disabled, enabled)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(0, disabled.RunCount, "A section the tenant has switched off must not run.");
+            Assert.IsFalse(store.Reads.Contains(FirstSectionCadence), "A disabled section must not even be looked up in the cadence store.");
+            Assert.AreEqual(1, enabled.RunCount, "Disabling one section must not stop the others.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_EnabledSectionWithinCadenceWindow_IsSkipped()
+        {
+            var section = FakeGraphImportSection.Gated("Gated section", FirstSectionCadence, 24);
+            var store = new RecordingImportLastRunStore().Seed(FirstSectionCadence, Now.AddHours(-23));
+
+            await BuildImporter(GatingSettings(), store, new FixedClock(Now), section)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(0, section.RunCount, "23h into a 24h window the section must be skipped.");
+            Assert.AreEqual(0, store.Writes.Count, "A skipped section must not re-stamp its last-run time.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_EnabledSectionOutsideCadenceWindow_IsRun()
+        {
+            var section = FakeGraphImportSection.Gated("Gated section", FirstSectionCadence, 24);
+            var store = new RecordingImportLastRunStore().Seed(FirstSectionCadence, Now.AddHours(-25));
+
+            await BuildImporter(GatingSettings(), store, new FixedClock(Now), section)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(1, section.RunCount, "25h into a 24h window the section is due.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_ForceGraphMetadataImport_BypassesCadenceGateForEverySection()
+        {
+            var first = FakeGraphImportSection.Gated("First", FirstSectionCadence, 24);
+            var second = FakeGraphImportSection.Gated("Second", SecondSectionCadence, 24);
+
+            // Both ran a minute ago, so without the force flag neither would be due.
+            var store = new RecordingImportLastRunStore()
+                .Seed(FirstSectionCadence, Now.AddMinutes(-1))
+                .Seed(SecondSectionCadence, Now.AddMinutes(-1));
+
+            var settings = GatingSettings();
+            settings.ForceGraphMetadataImport = true;
+
+            await BuildImporter(settings, store, new FixedClock(Now), first, second).GetAndSaveAllGraphData(settings);
+
+            Assert.AreEqual(1, first.RunCount, "ForceGraphMetadataImport must bypass the gate.");
+            Assert.AreEqual(1, second.RunCount, "ForceGraphMetadataImport must bypass the gate for EVERY section, not just the first.");
+            Assert.AreEqual(2, store.Writes.Count, "A forced run still re-stamps the gate, so the next cycle is throttled normally again.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_IntervalHoursZero_RunsEveryCycleAndRecordsNoLastRunTime()
+        {
+            var section = FakeGraphImportSection.Gated("Ungated by interval", FirstSectionCadence, 0);
+
+            // Seeded as having run this very instant: with gating disabled that must not matter.
+            var store = new RecordingImportLastRunStore().Seed(FirstSectionCadence, Now);
+
+            var importer = BuildImporter(GatingSettings(), store, new FixedClock(Now), section);
+            await importer.GetAndSaveAllGraphData(GatingSettings());
+            await importer.GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(2, section.RunCount, "IntervalHours 0 disables gating, so the section runs every cycle.");
+            Assert.AreEqual(0, store.Writes.Count,
+                "With gating disabled there is no window to protect, so writing a last-run time is pointless cache traffic on every cycle.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_SectionReturnsFalse_DoesNotRecordLastRunTime()
+        {
+            var section = FakeGraphImportSection.Gated("Failing section", FirstSectionCadence, 24);
+            section.Result = false;
+
+            var store = new RecordingImportLastRunStore();
+            await BuildImporter(GatingSettings(), store, new FixedClock(Now), section)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(1, section.RunCount);
+            Assert.AreEqual(0, store.Writes.Count,
+                "Stamping the gate after a failure would idle a broken import for a whole interval - issue #285.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_SectionReturnsFalse_StillRunsSubsequentSections()
+        {
+            var failing = FakeGraphImportSection.Gated("Failing section", FirstSectionCadence, 24);
+            failing.Result = false;
+            var later = FakeGraphImportSection.Gated("Later section", SecondSectionCadence, 24);
+
+            await BuildImporter(GatingSettings(), new RecordingImportLastRunStore(), new FixedClock(Now), failing, later)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(1, later.RunCount,
+                "A section reporting failure must not unwind the loop - that is why these sections return bool instead of throwing.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_SectionThrows_UnwindsAndSkipsTheSectionsAfterIt()
+        {
+            // Documents CURRENT behaviour rather than the behaviour #376 proposed. GraphImporter has never
+            // isolated a throwing section - ProgramTasks.GetGraphTeamsAndUserData catches only ODataError -
+            // and adding isolation here would quietly downgrade a hard failure to a logged warning. That is a
+            // behavioural change and belongs in its own issue; this test pins today's contract so the change
+            // cannot happen by accident.
+            var throwing = FakeGraphImportSection.Gated("Throwing section", FirstSectionCadence, 24);
+            throwing.FailWith = new InvalidOperationException("section blew up");
+            var later = FakeGraphImportSection.Gated("Later section", SecondSectionCadence, 24);
+
+            var store = new RecordingImportLastRunStore();
+            var importer = BuildImporter(GatingSettings(), store, new FixedClock(Now), throwing, later);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => importer.GetAndSaveAllGraphData(GatingSettings()));
+
+            Assert.AreEqual(1, throwing.RunCount);
+            Assert.AreEqual(0, later.RunCount, "The exception unwinds out of the loop, so later sections are skipped this cycle.");
+            Assert.AreEqual(0, store.Writes.Count, "A section that threw must not be recorded as having run.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_SectionSucceeds_RecordsLastRunTimeFromInjectedClock()
+        {
+            var section = FakeGraphImportSection.Gated("Gated section", FirstSectionCadence, 24);
+            var store = new RecordingImportLastRunStore();
+
+            await BuildImporter(GatingSettings(), store, new FixedClock(Now), section)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(1, store.Writes.Count);
+            Assert.AreEqual(FirstSectionCadence, store.Writes[0].Key);
+            Assert.AreEqual(Now, store.Writes[0].Value, "The stamp must come from the injected clock, not from wall time.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_CadenceGate_UsesInjectedClock_NotWallClock()
+        {
+            // Named in issue #368 but never written, because GraphImporter could not be constructed without a
+            // Graph client until #376. The injected clock is set 30 days in the PAST, and each section is
+            // seeded so that wall time and the injected clock disagree about whether it is due - so an
+            // implementation that read DateTime.UtcNow would get BOTH answers wrong, in both directions.
+            var injectedNow = DateTime.UtcNow.AddDays(-30);
+
+            var due = FakeGraphImportSection.Gated("Due by the injected clock", FirstSectionCadence, 24);
+            var notDue = FakeGraphImportSection.Gated("Not due by the injected clock", SecondSectionCadence, 24);
+
+            var store = new RecordingImportLastRunStore()
+                // 25h before the injected now (due), but ~31 days before wall time - which would also be due,
+                // so this one only proves the loop still runs things.
+                .Seed(FirstSectionCadence, injectedNow.AddHours(-25))
+                // 1h before the injected now (NOT due), but ~30 days before wall time, which WOULD be due.
+                // This is the discriminating case: reading DateTime.UtcNow here runs a section that must be
+                // skipped, re-crawling a whole tenant's Teams every cycle.
+                .Seed(SecondSectionCadence, injectedNow.AddHours(-1));
+
+            await BuildImporter(GatingSettings(), store, new FixedClock(injectedNow), due, notDue)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(1, due.RunCount, "25h before the injected 'now' is outside a 24h window.");
+            Assert.AreEqual(0, notDue.RunCount,
+                "1h before the injected 'now' is inside a 24h window - wall-clock time says otherwise, and must not be consulted.");
+
+            Assert.AreEqual(1, store.Writes.Count);
+            Assert.AreEqual(injectedNow, store.Writes[0].Value, "The recorded run time must be the injected instant, not wall time.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_LastRunStoreReadsFailOpenToNull_SectionStillRuns()
+        {
+            // RedisImportLastRunStore returns null when the cache is unreachable, deliberately, so a cache
+            // blip can never skip an import. This pins the orchestrator's half of that contract.
+            var recentlyRan = FakeGraphImportSection.Gated("Gated section", FirstSectionCadence, 24);
+            var workingStore = new RecordingImportLastRunStore().Seed(FirstSectionCadence, Now.AddMinutes(-1));
+
+            await BuildImporter(GatingSettings(), workingStore, new FixedClock(Now), recentlyRan)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(0, recentlyRan.RunCount, "Control: with a working store, a section that just ran is skipped.");
+
+            var sameSection = FakeGraphImportSection.Gated("Gated section", FirstSectionCadence, 24);
+            var failOpenStore = new RecordingImportLastRunStore { ReadsAlwaysReturnNull = true, WritesAreSwallowed = true };
+            failOpenStore.Seed(FirstSectionCadence, Now.AddMinutes(-1));
+
+            await BuildImporter(GatingSettings(), failOpenStore, new FixedClock(Now), sameSection)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(1, sameSection.RunCount, "With the same seeded timestamp but an unreachable cache, the import must still run.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_UngatedSection_RunsEveryCycleAndNeverTouchesTheLastRunStore()
+        {
+            // The activity/usage-report phase is the real case: it owns its own once-a-day throttle via
+            // ISingleDateStore, so routing it through the cadence store would double-gate it.
+            var section = FakeGraphImportSection.Ungated("Usage reports");
+            var store = new RecordingImportLastRunStore();
+
+            var importer = BuildImporter(GatingSettings(), store, new FixedClock(Now), section);
+            await importer.GetAndSaveAllGraphData(GatingSettings());
+            await importer.GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(2, section.RunCount);
+            Assert.AreEqual(0, store.Reads.Count, "A section with no cadence key must not be looked up in the cadence store.");
+            Assert.AreEqual(0, store.Writes.Count, "...nor written to it.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_UngatedSectionReturnsFalse_StillRunsSubsequentSections()
+        {
+            // "Throttled, nothing imported" is the ordinary answer from the usage-report phase, and it must
+            // not stop the Copilot / Teams / sent-email sections that come after it.
+            var throttled = FakeGraphImportSection.Ungated("Usage reports");
+            throttled.Result = false;
+            var later = FakeGraphImportSection.Gated("Teams import", FirstSectionCadence, 24);
+
+            await BuildImporter(GatingSettings(), new RecordingImportLastRunStore(), new FixedClock(Now), throttled, later)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(1, throttled.RunCount);
+            Assert.AreEqual(1, later.RunCount);
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_RunsSectionsInFactoryOrder()
+        {
+            // Order is behaviour: the two cheap tenant-aggregate Copilot reports are deliberately ahead of the
+            // per-user one, and user metadata is ahead of everything that joins to the users table.
+            var order = new List<string>();
+            var sections = new[] { "first", "second", "third" }
+                .Select(name =>
+                {
+                    var s = FakeGraphImportSection.Ungated(name);
+                    s.OnRun = () => order.Add(name);
+                    return s;
+                })
+                .ToArray();
+
+            await BuildImporter(GatingSettings(), new RecordingImportLastRunStore(), new FixedClock(Now), sections)
+                .GetAndSaveAllGraphData(GatingSettings());
+
+            CollectionAssert.AreEqual(new[] { "first", "second", "third" }, order,
+                "Sections must run in the order the factory returns them.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_SelectsSectionsUsingTheSettingsPassedToGetAndSaveAllGraphData()
+        {
+            // GetAndSaveAllGraphData takes an AppConfig argument AND the class holds one. In production they
+            // are the same object, so a refactor that quietly started reading the field instead would look
+            // fine in every real run - and change which flags select the sections for anyone who does not
+            // pass the same instance.
+            var section = FakeGraphImportSection.Ungated("Any section");
+            var factory = new FakeGraphImportSectionFactory(section);
+
+            var fieldSettings = GatingSettings();
+            var argumentSettings = GatingSettings();
+            Assert.AreNotSame(fieldSettings, argumentSettings, "Sanity: the two settings objects must be distinct for this test to mean anything.");
+
+            var importer = new GraphImporter(AnalyticsLogger.ConsoleOnlyTracer(), fieldSettings, factory, new RecordingImportLastRunStore(), new FixedClock(Now));
+            await importer.GetAndSaveAllGraphData(argumentSettings);
+
+            Assert.AreSame(argumentSettings, factory.LastSettingsArgument, "The factory must be given the per-cycle settings argument.");
+            Assert.AreSame(argumentSettings.ImportJobSettings, section.LastEnabledCheckArgument, "Section selection must use the per-cycle settings argument.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_BuildsItsSectionsOncePerCycle()
+        {
+            // Sections hold per-cycle state (the shared Graph client and user-group caches), so they must be
+            // rebuilt each cycle rather than cached on the importer.
+            var factory = new FakeGraphImportSectionFactory(FakeGraphImportSection.Ungated("Any section"));
+            var importer = new GraphImporter(AnalyticsLogger.ConsoleOnlyTracer(), GatingSettings(), factory,
+                new RecordingImportLastRunStore(), new FixedClock(Now));
+
+            await importer.GetAndSaveAllGraphData(GatingSettings());
+            await importer.GetAndSaveAllGraphData(GatingSettings());
+
+            Assert.AreEqual(2, factory.CreateSectionsCallCount);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphImportOrchestrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphImportOrchestrationTests.cs
@@ -4,7 +4,9 @@ using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
@@ -24,6 +26,7 @@ namespace Tests.UnitTests
     /// against a real tenant.
     /// </summary>
     [TestClass]
+    [DoNotParallelize]
     public class GraphImportOrchestrationTests
     {
         private const string FirstSectionCadence = "first-test-section-cadence";
@@ -48,6 +51,23 @@ namespace Tests.UnitTests
         {
             return new GraphImporter(AnalyticsLogger.ConsoleOnlyTracer(), settings,
                 new FakeGraphImportSectionFactory(sections), store, clock);
+        }
+
+        private static async Task<string> CaptureConsole(Func<Task> action)
+        {
+            var captured = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(captured);
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            return captured.ToString();
         }
 
         [TestMethod]
@@ -136,12 +156,17 @@ namespace Tests.UnitTests
             section.Result = false;
 
             var store = new RecordingImportLastRunStore();
-            await BuildImporter(GatingSettings(), store, new FixedClock(Now), section)
-                .GetAndSaveAllGraphData(GatingSettings());
+            var output = await CaptureConsole(() => BuildImporter(GatingSettings(), store, new FixedClock(Now), section)
+                .GetAndSaveAllGraphData(GatingSettings()));
 
             Assert.AreEqual(1, section.RunCount);
             Assert.AreEqual(0, store.Writes.Count,
                 "Stamping the gate after a failure would idle a broken import for a whole interval - issue #285.");
+            Assert.IsFalse(output.Contains("New event '" + nameof(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport) + "'"),
+                "A section that returned false must not report itself as successfully finished.");
+            StringAssert.Contains(output,
+                "Failing section did not complete successfully; it will be retried on the next cycle.",
+                "The trace must name the section and make clear that it will retry.");
         }
 
         [TestMethod]
@@ -173,11 +198,23 @@ namespace Tests.UnitTests
             var store = new RecordingImportLastRunStore();
             var importer = BuildImporter(GatingSettings(), store, new FixedClock(Now), throwing, later);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => importer.GetAndSaveAllGraphData(GatingSettings()));
+            var console = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(console);
+            try
+            {
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => importer.GetAndSaveAllGraphData(GatingSettings()));
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
 
             Assert.AreEqual(1, throwing.RunCount);
             Assert.AreEqual(0, later.RunCount, "The exception unwinds out of the loop, so later sections are skipped this cycle.");
             Assert.AreEqual(0, store.Writes.Count, "A section that threw must not be recorded as having run.");
+            Assert.IsFalse(console.ToString().Contains("New event '" + nameof(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport) + "'"),
+                "A section that threw must not report itself as successfully finished.");
         }
 
         [TestMethod]
@@ -192,6 +229,25 @@ namespace Tests.UnitTests
             Assert.AreEqual(1, store.Writes.Count);
             Assert.AreEqual(FirstSectionCadence, store.Writes[0].Key);
             Assert.AreEqual(Now, store.Writes[0].Value, "The stamp must come from the injected clock, not from wall time.");
+        }
+
+        [TestMethod]
+        public async Task GraphImporter_SuccessfulSections_ReportFinishedEventsWithTheirNames()
+        {
+            var gated = FakeGraphImportSection.Gated("Gated telemetry section", FirstSectionCadence, 24);
+            var ungated = FakeGraphImportSection.Ungated("Ungated telemetry section");
+
+            var output = await CaptureConsole(() => BuildImporter(
+                    GatingSettings(), new RecordingImportLastRunStore(), new FixedClock(Now), gated, ungated)
+                .GetAndSaveAllGraphData(GatingSettings()));
+
+            var finishedEvents = Regex.Matches(output,
+                "New event '" + nameof(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport) + "'").Count;
+            Assert.AreEqual(2, finishedEvents, "Each successful section must emit one completion event.");
+            StringAssert.Contains(output, "context=Gated telemetry section:",
+                "The gated completion event must identify the section in Application Insights.");
+            StringAssert.Contains(output, "context=Ungated telemetry section:",
+                "The ungated completion event must identify the section in Application Insights.");
         }
 
         [TestMethod]
@@ -275,11 +331,17 @@ namespace Tests.UnitTests
             throttled.Result = false;
             var later = FakeGraphImportSection.Gated("Teams import", FirstSectionCadence, 24);
 
-            await BuildImporter(GatingSettings(), new RecordingImportLastRunStore(), new FixedClock(Now), throttled, later)
-                .GetAndSaveAllGraphData(GatingSettings());
+            var output = await CaptureConsole(() => BuildImporter(
+                    GatingSettings(), new RecordingImportLastRunStore(), new FixedClock(Now), throttled, later)
+                .GetAndSaveAllGraphData(GatingSettings()));
 
             Assert.AreEqual(1, throttled.RunCount);
             Assert.AreEqual(1, later.RunCount);
+            Assert.AreEqual(1, Regex.Matches(output,
+                    "New event '" + nameof(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport) + "'").Count,
+                "Only the later successful section must report completion.");
+            Assert.IsFalse(output.Contains("Usage reports did not complete successfully"),
+                "The ungated usage-report path uses false for its ordinary throttle result and must not warn.");
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphImportSectionCompositionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphImportSectionCompositionTests.cs
@@ -1,0 +1,224 @@
+using Common.Entities;
+using Common.Entities.Config;
+using DataUtils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+using WebJob.Office365ActivityImporter.Engine.Graph.Sections;
+using WebJob.Office365ActivityImporter.Engine.Graph.Teams;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Pins what <see cref="ProductionGraphImportSectionFactory"/> composes: which sections exist, in what
+    /// order, which <c>ImportJobSettings</c> flag switches each one on, which cadence key and interval it
+    /// carries, and the exact "Skipping ..." line an operator greps for.
+    ///
+    /// This is the evidence that lifting the section bodies out of <c>GraphImporter</c> (issue #376) changed
+    /// nothing an operator can observe. It runs offline: the factory builds a Graph client and user-group
+    /// cache but neither touches the network until a call is actually made, and the section bodies are
+    /// lambdas that are never invoked here.
+    /// </summary>
+    [TestClass]
+    public class GraphImportSectionCompositionTests
+    {
+        private static AppConfig SettingsWithDistinctIntervals()
+        {
+            // Deliberately distinct so a section reading the wrong interval property fails rather than
+            // matching by coincidence.
+            return new AppConfig
+            {
+                ImportJobSettings = new ImportTaskSettings(),
+                GraphMetadataImportIntervalHours = 11,
+                GraphCopilotUsageReportsIntervalHours = 22,
+                GraphTeamsImportIntervalHours = 33,
+                CopilotInteractionHistoryIntervalHours = 44,
+                UserGroupsFilter = "Pilot Group;Καλημέρα κόσμε",
+                DaysBeforeNowToDownload = 9,
+            };
+        }
+
+        private static ProductionGraphImportSectionFactory BuildFactory(AppConfig settings, ActivityReportsImport activityReports)
+        {
+            return new ProductionGraphImportSectionFactory(
+                AnalyticsLogger.ConsoleOnlyTracer(),
+                settings,
+                graphAppIndentityOAuthContext: null,
+                graphClient: null,
+                sentEmailMailboxSkipList: null,
+                activityReportsImport: activityReports,
+                dbContextFactory: null,
+                clock: null);
+        }
+
+        private static ActivityReportsImport NeverCalled()
+        {
+            return (days, client, cache, filter) => throw new AssertFailedException("The activity-report phase must not run while sections are merely being composed.");
+        }
+
+        [TestMethod]
+        public void ProductionSections_AreTheSixSectionsInTheOriginalOrder()
+        {
+            var sections = BuildFactory(SettingsWithDistinctIntervals(), NeverCalled())
+                .CreateSections(SettingsWithDistinctIntervals());
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "User metadata refresh",
+                    "Usage reports",
+                    "Copilot usage reports",
+                    "Teams import",
+                    "Sent emails import",
+                    "Copilot interaction history import",
+                },
+                sections.Select(s => s.Name).ToArray(),
+                "Section order is behaviour: user metadata runs before everything that joins to the users table, "
+                + "and the cheap tenant-aggregate Copilot reports run before the per-user one.");
+        }
+
+        [TestMethod]
+        public void ProductionSections_KeepTheOriginalSkippedMessages()
+        {
+            // These lines are what an operator greps the WebJob log for when an import "isn't running".
+            var expected = new Dictionary<string, string>
+            {
+                { "User metadata refresh", "Skipping user metadata import" },
+                { "Usage reports", "Skipping usage reports import" },
+                { "Copilot usage reports", "Skipping Graph Copilot usage reports import" },
+                { "Teams import", "Skipping Teams import" },
+                { "Sent emails import", "Skipping sent emails import" },
+                { "Copilot interaction history import", "Skipping Copilot interaction history import" },
+            };
+
+            foreach (var section in BuildFactory(SettingsWithDistinctIntervals(), NeverCalled()).CreateSections(SettingsWithDistinctIntervals()))
+            {
+                Assert.AreEqual(expected[section.Name], section.DisabledMessage, $"Wrong 'skipping' message for {section.Name}.");
+            }
+        }
+
+        [TestMethod]
+        public void ProductionSections_CarryTheOriginalCadenceKeysAndIntervals()
+        {
+            var settings = SettingsWithDistinctIntervals();
+            var sections = BuildFactory(settings, NeverCalled()).CreateSections(settings).ToDictionary(s => s.Name);
+
+            AssertGated(sections["User metadata refresh"], "GraphUsersMetadataLastImported", 11);
+            AssertGated(sections["Copilot usage reports"], "GraphCopilotUsageReportsLastImported", 22);
+            AssertGated(sections["Teams import"], "GraphTeamsLastImported", 33);
+            AssertGated(sections["Copilot interaction history import"], "CopilotInteractionHistoryLastImported", 44);
+
+            // The activity/usage-report phase throttles itself via ISingleDateStore, and the sent-email
+            // import has never been gated at all. Giving either a cadence key would double-gate it.
+            AssertUngated(sections["Usage reports"]);
+            AssertUngated(sections["Sent emails import"]);
+        }
+
+        private static void AssertGated(IGraphImportSection section, string expectedKey, int expectedIntervalHours)
+        {
+            Assert.AreEqual(expectedKey, section.CadenceKey, $"{section.Name} must keep its Redis cadence key - operators clear these by hand.");
+            Assert.AreEqual(expectedIntervalHours, section.IntervalHours, $"{section.Name} is reading the wrong interval setting.");
+        }
+
+        private static void AssertUngated(IGraphImportSection section)
+        {
+            Assert.IsNull(section.CadenceKey, $"{section.Name} must not be cadence-gated.");
+        }
+
+        [TestMethod]
+        public void ProductionSections_EachMapToExactlyOneImportSettingFlag()
+        {
+            // One flag at a time, deliberately: turning several on at once would let two crossed mappings
+            // both read as correct.
+            var flags = new List<Tuple<string, Action<ImportTaskSettings>>>
+            {
+                Tuple.Create<string, Action<ImportTaskSettings>>("User metadata refresh", s => s.GraphUsersMetadata = true),
+                Tuple.Create<string, Action<ImportTaskSettings>>("Usage reports", s => s.GraphUsageReports = true),
+                Tuple.Create<string, Action<ImportTaskSettings>>("Copilot usage reports", s => s.GraphCopilotUsageReports = true),
+                Tuple.Create<string, Action<ImportTaskSettings>>("Teams import", s => s.GraphTeams = true),
+                Tuple.Create<string, Action<ImportTaskSettings>>("Sent emails import", s => s.SentEmails = true),
+                Tuple.Create<string, Action<ImportTaskSettings>>("Copilot interaction history import", s => s.CopilotInteractionHistory = true),
+            };
+
+            var sections = BuildFactory(SettingsWithDistinctIntervals(), NeverCalled()).CreateSections(SettingsWithDistinctIntervals());
+
+            var allOff = new ImportTaskSettings();
+            CollectionAssert.AreEqual(new string[0], sections.Where(s => s.IsEnabled(allOff)).Select(s => s.Name).ToArray(),
+                "With every import flag off, no section may run.");
+
+            foreach (var flag in flags)
+            {
+                var settings = new ImportTaskSettings();
+                flag.Item2(settings);
+
+                CollectionAssert.AreEqual(new[] { flag.Item1 }, sections.Where(s => s.IsEnabled(settings)).Select(s => s.Name).ToArray(),
+                    $"Turning on only the flag for '{flag.Item1}' must enable exactly that section.");
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageReportSection_PassesTheDaysWindowAndTheConfiguredUserGroupsFilter()
+        {
+            // Guards the one place the section list reads the per-cycle settings ARGUMENT rather than the
+            // factory's own AppConfig, plus that the user-group filter is really built from configuration.
+            var fieldSettings = SettingsWithDistinctIntervals();
+            var argumentSettings = SettingsWithDistinctIntervals();
+            argumentSettings.DaysBeforeNowToDownload = 42;
+            argumentSettings.UserGroupsFilter = "ignored - the filter comes from the factory's settings";
+
+            int observedDays = -1;
+            List<string> observedPatterns = null;
+
+            var factory = BuildFactory(fieldSettings, (days, client, cache, filter) =>
+            {
+                observedDays = days;
+                observedPatterns = filter.Patterns;
+                return Task.FromResult(true);
+            });
+
+            var usageReports = factory.CreateSections(argumentSettings).Single(s => s.Name == "Usage reports");
+
+            Assert.AreEqual(-1, observedDays, "Composing the sections must not run any of them.");
+
+            Assert.IsTrue(await usageReports.RunAsync());
+            Assert.AreEqual(42, observedDays, "The days window comes from the settings passed to GetAndSaveAllGraphData.");
+            CollectionAssert.AreEqual(new[] { "Pilot Group", "Καλημέρα κόσμε" }, observedPatterns,
+                "The user-group filter is parsed from configuration - including non-Latin group names.");
+        }
+
+        [TestMethod]
+        public void TeamTokenManager_HoldsNoProcessWideState()
+        {
+            // TeamTokenManager used to keep a static Lazy<Dictionary<O365Team, RefreshOAuthToken>> keyed by
+            // object identity. O365Team overrides neither Equals nor GetHashCode and GetRefreshToken has a
+            // single call site that always passes a freshly-constructed team, so the lookup could never hit -
+            // it only leaked a fully-populated O365Team per team per cycle for the life of the process, and
+            // raced, because the Teams crawl runs teams in parallel. Removing it is what issue #376 is for;
+            // this stops it coming back.
+            var statics = typeof(TeamTokenManager)
+                .GetFields(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+                .Where(f => !f.IsLiteral)   // const is fine; a static field is not
+                .Select(f => f.Name)
+                .ToArray();
+
+            CollectionAssert.AreEqual(new string[0], statics,
+                "TeamTokenManager must hold no process-wide state. Found: " + string.Join(", ", statics));
+        }
+
+        [TestMethod]
+        public void O365Team_UsesReferenceEquality()
+        {
+            // The premise of the test above: identical teams are still different dictionary keys, which is
+            // why the removed cache could never produce a hit. If O365Team ever gains value equality this
+            // will fail, and the reasoning in TeamTokenManager's summary will need revisiting.
+            Assert.AreEqual(typeof(object), typeof(O365Team).GetMethod("GetHashCode").DeclaringType,
+                "O365Team does not override GetHashCode, so it is compared by reference.");
+            Assert.AreEqual(typeof(object), typeof(O365Team).GetMethod("Equals", new[] { typeof(object) }).DeclaringType,
+                "O365Team does not override Equals, so it is compared by reference.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
 using WebJob.Office365ActivityImporter.Engine;
 
 namespace Tests.UnitTests
@@ -157,9 +158,26 @@ namespace Tests.UnitTests
             // Asserted against ShouldRun itself, so the two can never drift apart.
             var lastUtc = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
 
-            foreach (var last in new[] { lastUtc, lastUtc.ToLocalTime(), DateTime.SpecifyKind(lastUtc, DateTimeKind.Unspecified).ToLocalTime() })
+            // The same instant in all three kinds the store can hand back. Utc and Local are what the two
+            // ISingleDateStore implementations actually produce; Unspecified is what an offset-less string in
+            // Redis parses to - a bare local wall-clock reading, which is why ToUniversalTime() treating
+            // Unspecified as local is the right reading of it.
+            //
+            // Note SpecifyKind(lastUtc, Unspecified).ToLocalTime() would NOT do: ToLocalTime treats
+            // Unspecified as UTC, so it just yields the Local value again.
+            var representations = new[]
+            {
+                lastUtc,
+                lastUtc.ToLocalTime(),
+                DateTime.SpecifyKind(lastUtc.ToLocalTime(), DateTimeKind.Unspecified),
+            };
+
+            foreach (var last in representations)
             {
                 var nextRun = ActivityReportsCadenceGate.NextRunUtc(last, OneDay);
+
+                Assert.AreEqual(lastUtc.Add(OneDay), nextRun,
+                    $"All three representations are the same instant, so they must announce the same threshold ({last.Kind}).");
 
                 Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(last, OneDay, nextRun.AddTicks(-1)),
                     $"One tick before the announced time the gate must still be shut ({last.Kind}).");
@@ -168,6 +186,10 @@ namespace Tests.UnitTests
                 Assert.IsTrue(ActivityReportsCadenceGate.ShouldRun(last, OneDay, nextRun.AddTicks(1)),
                     $"One tick after the announced time the gate must be open ({last.Kind}).");
             }
+
+            CollectionAssert.AreEqual(new[] { DateTimeKind.Utc, DateTimeKind.Local, DateTimeKind.Unspecified },
+                representations.Select(d => d.Kind).ToArray(),
+                "Sanity: the three fixtures must really be three different kinds, or two thirds of this test is a duplicate.");
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
@@ -178,6 +178,13 @@ namespace Tests.UnitTests
             {
                 var nextRun = ActivityReportsCadenceGate.NextRunUtc(last, OneDay);
 
+                // Kind, not just ticks: on a host at UTC all three fixtures have identical ticks, so an
+                // implementation that skipped the conversion would satisfy every value assertion below.
+                // ToUniversalTime() always yields Utc; DateTime.Add preserves the input's Kind - so this is
+                // the one assertion here that discriminates on every host, including a UTC CI runner.
+                Assert.AreEqual(DateTimeKind.Utc, nextRun.Kind,
+                    $"NextRunUtc must return a UTC instant whatever kind it was given ({last.Kind}).");
+
                 Assert.AreEqual(lastUtc.Add(OneDay), nextRun,
                     $"All three representations are the same instant, so they must announce the same threshold ({last.Kind}).");
 

--- a/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using WebJob.Office365ActivityImporter.Engine;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Coverage for the two pure rules lifted out of the import composition roots by issue #376:
+    /// <see cref="ImportRuntimeOptions"/> (the audit-import environment-variable safety valves, previously
+    /// parsed inline in <c>ProgramTasks.DownloadActivityData</c>) and
+    /// <see cref="ActivityReportsCadenceGate"/> (the once-a-day throttle on the activity/usage-report phase,
+    /// previously an inline <c>DateTime.Now</c> subtraction in <c>GraphImporter</c>).
+    ///
+    /// Zero SQL Server, Graph, Redis and Service Bus, and no environment variables are read or written -
+    /// the raw value is passed in, so these tests cannot disturb a parallel test host's environment.
+    /// </summary>
+    [TestClass]
+    public class ImportRuntimeOptionsTests
+    {
+        [TestMethod]
+        public void RuntimeOptions_MaxConcurrentSavesUnset_DefaultsToOne()
+        {
+            Assert.AreEqual(1, ImportRuntimeOptions.ResolveMaxConcurrentSaves(null));
+            Assert.AreEqual(1, ImportRuntimeOptions.ResolveMaxConcurrentSaves(string.Empty));
+            Assert.AreEqual(1, ImportRuntimeOptions.ResolveMaxConcurrentSaves("   "));
+        }
+
+        [TestMethod]
+        public void RuntimeOptions_MaxConcurrentSavesInvalid_DefaultsToOne()
+        {
+            foreach (var bad in new[] { "yes", "true", "4x", "2.5", string.Empty, "-3", "0", "1" })
+            {
+                Assert.AreEqual(1, ImportRuntimeOptions.ResolveMaxConcurrentSaves(bad),
+                    $"'{bad}' must leave the strictly-serial default: this valve can only ever turn concurrency ON, "
+                    + "so a typo must never be able to stop the importer saving.");
+            }
+        }
+
+        [TestMethod]
+        public void RuntimeOptions_MaxConcurrentSavesValid_IsHonoured()
+        {
+            Assert.AreEqual(2, ImportRuntimeOptions.ResolveMaxConcurrentSaves("2"));
+            Assert.AreEqual(8, ImportRuntimeOptions.ResolveMaxConcurrentSaves("8"));
+            Assert.AreEqual(4, ImportRuntimeOptions.ResolveMaxConcurrentSaves("  4  "),
+                "App Service settings routinely carry stray whitespace. (This pins the accepted input shape rather "
+                + "than the Trim() call, which int.TryParse's NumberStyles.Integer already tolerates.)");
+        }
+
+        [TestMethod]
+        public void RuntimeOptions_PerBatchDedupCache_AcceptsOneAndTrueCaseInsensitively()
+        {
+            foreach (var on in new[] { "1", "true", "True", "TRUE", "  true  ", " 1 " })
+            {
+                Assert.IsTrue(ImportRuntimeOptions.ResolveUsePerBatchDedupCache(on), $"'{on}' must enable the per-batch dedup cache.");
+            }
+        }
+
+        [TestMethod]
+        public void RuntimeOptions_PerBatchDedupCache_IsOffForAnythingElse()
+        {
+            foreach (var off in new[] { null, string.Empty, "   ", "0", "false", "False", "yes", "on", "2", "truthy", "11" })
+            {
+                Assert.IsFalse(ImportRuntimeOptions.ResolveUsePerBatchDedupCache(off),
+                    $"'{off ?? "<null>"}' must leave the per-cycle cache in place.");
+            }
+        }
+
+        private static readonly TimeSpan OneDay = TimeSpan.FromDays(1);
+
+        [TestMethod]
+        public void ActivityReportsGate_NeverImported_Runs()
+        {
+            Assert.IsTrue(ActivityReportsCadenceGate.ShouldRun(null, OneDay, new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc)),
+                "A fresh install, or a database with no activity data, must import immediately.");
+        }
+
+        [TestMethod]
+        public void ActivityReportsGate_AtExactlyTheWindow_DoesNotRun()
+        {
+            var last = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+
+            Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(last, OneDay, last.Add(OneDay)),
+                "The original comparison was strictly greater-than; at exactly 24h the phase still waits.");
+            Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(last, OneDay, last.Add(OneDay).AddTicks(-1)));
+            Assert.IsTrue(ActivityReportsCadenceGate.ShouldRun(last, OneDay, last.Add(OneDay).AddTicks(1)));
+        }
+
+        [TestMethod]
+        public void ActivityReportsGate_UsesTheSuppliedNow_NotWallClock()
+        {
+            // The stored timestamp is 30 days old by wall time - which would always be "due" - but only one
+            // hour old by the supplied clock.
+            var wallishLast = DateTime.UtcNow.AddDays(-30);
+            var suppliedNow = wallishLast.AddHours(1);
+
+            Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(wallishLast, OneDay, suppliedNow),
+                "The gate must compare against the instant it is given, never DateTime.Now/UtcNow.");
+        }
+
+        [TestMethod]
+        public void ActivityReportsGate_TreatsALocalStoredTimestampAsAnInstant()
+        {
+            // Both ISingleDateStore implementations stamp DateTime.Now, so the value read back has
+            // DateTimeKind.Local. The gate must convert it to UTC before subtracting; the old inline
+            // expression instead subtracted a local reading from DateTime.Now, which is the wall-clock
+            // difference rather than the elapsed time.
+            var lastUtc = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+            var offset = TimeZoneInfo.Local.GetUtcOffset(lastUtc);
+
+            if (Math.Abs(offset.TotalHours) < 1)
+            {
+                // On a host at (or within an hour of) UTC, a local and a UTC representation of the same
+                // instant have the same raw value, so no assertion here can tell the two apart. Say so
+                // rather than passing vacuously - this discriminates on any host an hour or more off UTC.
+                Assert.Inconclusive($"Host UTC offset is {offset}; local-vs-UTC handling is unobservable here.");
+            }
+
+            var lastLocal = lastUtc.ToLocalTime();
+            Assert.AreEqual(DateTimeKind.Local, lastLocal.Kind);
+
+            // 25h really elapsed. Skipping the conversion would read this as 25h minus the host offset,
+            // which is inside the window on any host east of UTC.
+            Assert.IsTrue(ActivityReportsCadenceGate.ShouldRun(lastLocal, OneDay, lastUtc.AddHours(25)),
+                "25 hours have really passed, whatever the host's timezone.");
+
+            // 23h really elapsed. Skipping the conversion would read this as 23h minus the host offset,
+            // which is outside the window on any host west of UTC.
+            Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(lastLocal, OneDay, lastUtc.AddHours(23)),
+                "Only 23 hours have really passed, whatever the host's timezone.");
+        }
+
+        [TestMethod]
+        public void ActivityReportsGate_LeavesAUtcStoredTimestampAlone()
+        {
+            var lastUtc = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+
+            Assert.IsTrue(ActivityReportsCadenceGate.ShouldRun(lastUtc, OneDay, lastUtc.AddHours(25)));
+            Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(lastUtc, OneDay, lastUtc.AddHours(23)));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
@@ -104,29 +104,70 @@ namespace Tests.UnitTests
             // DateTimeKind.Local. The gate must convert it to UTC before subtracting; the old inline
             // expression instead subtracted a local reading from DateTime.Now, which is the wall-clock
             // difference rather than the elapsed time.
-            var lastUtc = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
-            var offset = TimeZoneInfo.Local.GetUtcOffset(lastUtc);
-
-            if (Math.Abs(offset.TotalHours) < 1)
-            {
-                // On a host at (or within an hour of) UTC, a local and a UTC representation of the same
-                // instant have the same raw value, so no assertion here can tell the two apart. Say so
-                // rather than passing vacuously - this discriminates on any host an hour or more off UTC.
-                Assert.Inconclusive($"Host UTC offset is {offset}; local-vs-UTC handling is unobservable here.");
-            }
-
+            //
+            // Mid-June, deliberately: far from a DST transition in either hemisphere, so ToLocalTime() and
+            // ToUniversalTime() round-trip through an unambiguous offset.
+            var lastUtc = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
             var lastLocal = lastUtc.ToLocalTime();
             Assert.AreEqual(DateTimeKind.Local, lastLocal.Kind);
 
-            // 25h really elapsed. Skipping the conversion would read this as 25h minus the host offset,
-            // which is inside the window on any host east of UTC.
-            Assert.IsTrue(ActivityReportsCadenceGate.ShouldRun(lastLocal, OneDay, lastUtc.AddHours(25)),
-                "25 hours have really passed, whatever the host's timezone.");
+            // DateTime subtraction ignores Kind, so this is exactly the skew an implementation that forgot
+            // the conversion would introduce: it would test `elapsed > minWait + skew` instead of
+            // `elapsed > minWait`.
+            var skew = lastLocal - lastUtc;
+            if (skew == TimeSpan.Zero)
+            {
+                // On a host at UTC a local and a UTC representation of the same instant have identical
+                // ticks, so no assertion can tell the two apart. Say so rather than passing vacuously.
+                Assert.Inconclusive("Host is at UTC; local-vs-UTC handling is unobservable here.");
+            }
 
-            // 23h really elapsed. Skipping the conversion would read this as 23h minus the host offset,
-            // which is outside the window on any host west of UTC.
-            Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(lastLocal, OneDay, lastUtc.AddHours(23)),
-                "Only 23 hours have really passed, whatever the host's timezone.");
+            // Sweep the window on a 30-minute grid rather than picking two points either side of it. Two
+            // points only discriminate when the host offset exceeds the slack chosen, which is how an
+            // earlier version of this test passed vacuously at exactly UTC-1.
+            for (var halfHours = 0; halfHours <= 96; halfHours++)
+            {
+                var elapsed = TimeSpan.FromMinutes(30 * halfHours);
+                AssertGateAgreesWithRealElapsedTime(lastUtc, lastLocal, elapsed, skew);
+            }
+
+            // ...and one point chosen from the skew itself, which discriminates for ANY non-zero offset,
+            // in either direction, however small - so this test does not quietly depend on the host's
+            // offset happening to land on the grid. The EXPECTED answer is still real elapsed time versus
+            // the window; only the sample point is derived from the skew.
+            //
+            // At minWait + skew/2 the correct answer is "run" when skew is positive and "wait" when it is
+            // negative, and an implementation missing the conversion gives the opposite in both cases.
+            AssertGateAgreesWithRealElapsedTime(lastUtc, lastLocal, OneDay + TimeSpan.FromTicks(skew.Ticks / 2), skew);
+        }
+
+        private static void AssertGateAgreesWithRealElapsedTime(DateTime lastUtc, DateTime lastLocal, TimeSpan elapsed, TimeSpan skew)
+        {
+            Assert.AreEqual(elapsed > OneDay, ActivityReportsCadenceGate.ShouldRun(lastLocal, OneDay, lastUtc.Add(elapsed)),
+                $"After {elapsed} of real elapsed time the gate must give the same answer for a local-kind "
+                + $"stored timestamp as for a UTC one (host skew {skew}).");
+        }
+
+        [TestMethod]
+        public void ActivityReportsGate_NextRunUtc_IsExactlyWhenTheGateOpens()
+        {
+            // The "will import again after ..." line an operator reads must name the instant the gate
+            // actually opens. Adding minWait to the stored LOCAL value instead - which is what the code did
+            // before the gate moved to UTC - reports an hour out across a daylight-saving transition.
+            // Asserted against ShouldRun itself, so the two can never drift apart.
+            var lastUtc = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+            foreach (var last in new[] { lastUtc, lastUtc.ToLocalTime(), DateTime.SpecifyKind(lastUtc, DateTimeKind.Unspecified).ToLocalTime() })
+            {
+                var nextRun = ActivityReportsCadenceGate.NextRunUtc(last, OneDay);
+
+                Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(last, OneDay, nextRun.AddTicks(-1)),
+                    $"One tick before the announced time the gate must still be shut ({last.Kind}).");
+                Assert.IsFalse(ActivityReportsCadenceGate.ShouldRun(last, OneDay, nextRun),
+                    $"At exactly the announced time the gate is still shut - the comparison is strictly greater-than ({last.Kind}).");
+                Assert.IsTrue(ActivityReportsCadenceGate.ShouldRun(last, OneDay, nextRun.AddTicks(1)),
+                    $"One tick after the announced time the gate must be open ({last.Kind}).");
+            }
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
@@ -160,10 +160,11 @@ namespace Tests.UnitTests
             // is what makes the word "after" in that message honest.
             var lastUtc = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
 
-            // The same instant in all three kinds the store can hand back. Utc and Local are what the two
-            // ISingleDateStore implementations actually produce; Unspecified is what an offset-less string in
-            // Redis parses to - a bare local wall-clock reading, which is why ToUniversalTime() treating
-            // Unspecified as local is the right reading of it.
+            // The same instant in all three kinds the gate accepts. `Local` is what both ISingleDateStore
+            // implementations actually produce (each stamps DateTime.Now). `Utc` and `Unspecified` reach the
+            // gate only from a value the standard composition did not write - a Z-suffixed or an offset-less
+            // Redis string, or a custom ISingleDateStore. An offset-less string is a bare local wall-clock
+            // reading, which is why ToUniversalTime() treating Unspecified as local is the right reading.
             //
             // Note SpecifyKind(lastUtc, Unspecified).ToLocalTime() would NOT do: ToLocalTime treats
             // Unspecified as UTC, so it just yields the Local value again.

--- a/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ImportRuntimeOptionsTests.cs
@@ -150,12 +150,14 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void ActivityReportsGate_NextRunUtc_IsExactlyWhenTheGateOpens()
+        public void ActivityReportsGate_NextRunUtc_IsTheLastInstantTheGateIsStillShut()
         {
-            // The "will import again after ..." line an operator reads must name the instant the gate
-            // actually opens. Adding minWait to the stored LOCAL value instead - which is what the code did
+            // The "will import again after ..." line an operator reads must name the threshold the gate
+            // actually uses. Adding minWait to the stored LOCAL value instead - which is what the code did
             // before the gate moved to UTC - reports an hour out across a daylight-saving transition.
-            // Asserted against ShouldRun itself, so the two can never drift apart.
+            // Asserted against ShouldRun itself, so the two can never drift apart. Note the announced instant
+            // is the last one at which the gate is STILL SHUT: the comparison is strictly greater-than, which
+            // is what makes the word "after" in that message honest.
             var lastUtc = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
 
             // The same instant in all three kinds the store can hand back. Utc and Local are what the two

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -156,6 +156,10 @@
     <Compile Include="FakeLoaderClasses\InMemoryUsageReportStore.cs" />
     <Compile Include="FakeLoaderClasses\FakeOrgUrlStore.cs" />
     <Compile Include="FakeLoaderClasses\FakeCallsPorts.cs" />
+    <Compile Include="FakeLoaderClasses\FakeGraphImportSections.cs" />
+    <Compile Include="GraphImportOrchestrationTests.cs" />
+    <Compile Include="GraphImportSectionCompositionTests.cs" />
+    <Compile Include="ImportRuntimeOptionsTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeTeamsPorts.cs" />
     <Compile Include="OrgUrlStoreTests.cs" />
     <Compile Include="FakeLoaderClasses\FixedClock.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityReportsCadenceGate.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityReportsCadenceGate.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace WebJob.Office365ActivityImporter.Engine
+{
+    /// <summary>
+    /// Pure decision logic for the once-a-day throttle on the activity/usage-report phase, factored out so it
+    /// can be unit tested without Redis (issue #376). The sibling of <see cref="ImportCadenceGate"/>, which
+    /// gates the per-section Graph imports.
+    ///
+    /// <para>
+    /// <b>Why this takes a UTC "now" while the stored timestamp may be local.</b> Both
+    /// <see cref="ISingleDateStore"/> implementations stamp <c>DateTime.Now</c> - <c>InMemorySingleDateStore</c>
+    /// stores it directly, and <c>RedisSingleDateLoader</c> round-trips it through <c>"o"</c> format, which
+    /// keeps the offset - so <paramref name="lastImported"/> comes back with <see cref="DateTimeKind.Local"/>.
+    /// The original comparison was <c>DateTime.Now.Subtract(lastImported) &gt; minWait</c>: local minus local.
+    /// That is right in the ordinary case and wrong across a daylight-saving transition, where subtracting two
+    /// local wall-clock readings gives the wall-clock difference rather than the elapsed time - so twice a year
+    /// the phase either re-ran an hour early or waited an hour too long.
+    /// </para>
+    /// <para>
+    /// Normalising to UTC compares the two <i>instants</i>, which is what "has a day passed?" actually means,
+    /// and lets the caller supply the clock (<see cref="DataUtils.IClock"/>) instead of reading wall time.
+    /// <see cref="DateTime.ToUniversalTime"/> is a no-op on a <see cref="DateTimeKind.Utc"/> value and treats
+    /// <see cref="DateTimeKind.Unspecified"/> as local - which is exactly how the previous expression treated
+    /// an offset-less value parsed out of Redis.
+    /// </para>
+    /// </summary>
+    public static class ActivityReportsCadenceGate
+    {
+        /// <summary>
+        /// Whether the activity/usage-report phase is due to run.
+        /// </summary>
+        /// <param name="lastImported">
+        /// When the phase last completed, as returned by <see cref="ISingleDateStore.GetLastDT"/>, or null if
+        /// it never has (or no store is configured). Local, UTC and unspecified kinds are all accepted.
+        /// </param>
+        /// <param name="minWait">Minimum time between runs.</param>
+        /// <param name="nowUtc">Current time (UTC), from the injected clock.</param>
+        public static bool ShouldRun(DateTime? lastImported, TimeSpan minWait, DateTime nowUtc)
+        {
+            if (lastImported == null) return true;
+
+            // Strictly greater than, matching the original expression: at exactly minWait the phase waits.
+            return nowUtc.Subtract(lastImported.Value.ToUniversalTime()) > minWait;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityReportsCadenceGate.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityReportsCadenceGate.cs
@@ -43,5 +43,17 @@ namespace WebJob.Office365ActivityImporter.Engine
             // Strictly greater than, matching the original expression: at exactly minWait the phase waits.
             return nowUtc.Subtract(lastImported.Value.ToUniversalTime()) > minWait;
         }
+
+        /// <summary>
+        /// The instant (UTC) at which <see cref="ShouldRun"/> starts returning true for
+        /// <paramref name="lastImported"/>. Exists so the "will import again after ..." message an operator
+        /// reads is derived from the same arithmetic as the decision: adding <paramref name="minWait"/> to the
+        /// stored LOCAL value instead would report a wall-clock time that is an hour out from the real
+        /// threshold across a daylight-saving transition.
+        /// </summary>
+        public static DateTime NextRunUtc(DateTime lastImported, TimeSpan minWait)
+        {
+            return lastImported.ToUniversalTime().Add(minWait);
+        }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityReportsCadenceGate.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityReportsCadenceGate.cs
@@ -45,11 +45,13 @@ namespace WebJob.Office365ActivityImporter.Engine
         }
 
         /// <summary>
-        /// The instant (UTC) at which <see cref="ShouldRun"/> starts returning true for
-        /// <paramref name="lastImported"/>. Exists so the "will import again after ..." message an operator
-        /// reads is derived from the same arithmetic as the decision: adding <paramref name="minWait"/> to the
-        /// stored LOCAL value instead would report a wall-clock time that is an hour out from the real
-        /// threshold across a daylight-saving transition.
+        /// The last instant (UTC) at which the gate is still shut for <paramref name="lastImported"/>:
+        /// <see cref="ShouldRun"/> is false at this instant and true one tick later, matching the
+        /// strictly-greater-than comparison and the word "after" in the operator-facing log line.
+        ///
+        /// Exists so that message is derived from the same arithmetic as the decision: adding
+        /// <paramref name="minWait"/> to the stored LOCAL value instead would report a wall-clock time that
+        /// is an hour out from the real threshold across a daylight-saving transition.
         /// </summary>
         public static DateTime NextRunUtc(DateTime lastImported, TimeSpan minWait)
         {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -1,7 +1,6 @@
 using Common.Entities;
 using Common.Entities.ActivityReports;
 using Common.Entities.Config;
-using Common.Entities.Entities.UsageReports;
 using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
@@ -11,56 +10,78 @@ using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
-using WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHistory;
 using WebJob.Office365ActivityImporter.Engine.Graph.Email;
-using WebJob.Office365ActivityImporter.Engine.Graph.Teams;
+using WebJob.Office365ActivityImporter.Engine.Graph.Sections;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate;
-using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot;
 using WebJob.Office365ActivityImporter.Engine.Graph.User;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
     /// <summary>
-    /// Reads and saves all data read from Graph
+    /// Orchestrates the Graph import: selects the enabled sections, applies the per-section cadence gate and
+    /// records the last-run time. It does not build any of them - composition lives behind
+    /// <see cref="IGraphImportSectionFactory"/> (issue #376), which is what makes this loop testable with fake
+    /// sections and no SQL Server, Graph, Redis or Service Bus.
     /// </summary>
     public class GraphImporter : AbstractApiLoader
     {
-        private readonly UserGroupsCache _userGroupsCache;
-        private readonly GraphAppIndentityOAuthContext _graphAppIndentityOAuthContext;
         private readonly GraphServiceClient _graphClient;
         // Two independent markers: one proves the usage-report phase completed (so finalized dates can be
         // skipped safely), the other gates how often the non-fresh Graph sections re-run.
         private readonly ISingleDateStore _activityReportsLastImportedStore;
         private readonly IImportLastRunStore _lastRunStore;
-        // Negative cache of users with no Exchange mailbox, so the sent-email import stops re-checking
-        // them (and logging a 404) on every cycle. Must be process-lifetime, hence injected.
-        private readonly ISentEmailMailboxSkipList _sentEmailMailboxSkipList;
+
+        private readonly IGraphImportSectionFactory _sectionFactory;
 
         private readonly IClock _clock;
 
+        /// <summary>
+        /// Production constructor: builds the <see cref="ProductionGraphImportSectionFactory"/> that holds all
+        /// the section wiring. Kept at its original signature so no call site breaks.
+        /// </summary>
+        /// <param name="userGroupsCache">
+        /// Unused, and was unused before this change too - it was stored in a field that nothing read. The
+        /// usage-report and Copilot sections use a <c>GraphUserGroupsCache</c> the factory builds over its own
+        /// <c>ManualGraphCallClient</c>, which is not the same instance the caller passes here. Kept on the
+        /// signature so no call site breaks.
+        /// </param>
         public GraphImporter(AnalyticsLogger logger, UserGroupsCache userGroupsCache, GraphAppIndentityOAuthContext graphAppIndentityOAuthContext, GraphServiceClient graphClient, AppConfig settings, ISingleDateStore activityReportsLastImportedStore = null, IImportLastRunStore lastRunStore = null, ISentEmailMailboxSkipList sentEmailMailboxSkipList = null, IClock clock = null)
             : base(logger, settings)
         {
             _clock = clock ?? SystemClock.Instance;
-            _userGroupsCache = userGroupsCache;
-            _graphAppIndentityOAuthContext = graphAppIndentityOAuthContext;
             _graphClient = graphClient;
             _activityReportsLastImportedStore = activityReportsLastImportedStore;
 
             // Defensive: a per-instance in-memory store still works (just doesn't persist the gate
             // across cycles). Production passes the process-lifetime store hoisted in Program.cs.
             _lastRunStore = lastRunStore ?? new InMemoryImportLastRunStore();
-            _sentEmailMailboxSkipList = sentEmailMailboxSkipList ?? new InMemorySentEmailMailboxSkipList();
+
+            _sectionFactory = new ProductionGraphImportSectionFactory(
+                logger,
+                settings,
+                graphAppIndentityOAuthContext,
+                graphClient,
+                sentEmailMailboxSkipList ?? new InMemorySentEmailMailboxSkipList(),
+                GetAndSaveActivityReportsMultiThreaded,
+                DefaultAnalyticsDbContextFactory.Instance,
+                _clock);
         }
 
-        // Keys for the per-section "last run" timestamps used to daily-gate the non-fresh Graph imports.
-        // Stored verbatim (unprefixed) in Redis db 0, so they can be cleared manually with e.g.
-        // `redis-cli DEL GraphUsersMetadataLastImported`.
-        private const string GraphUsersMetadataLastImportedKey = "GraphUsersMetadataLastImported";
-        private const string GraphTeamsLastImportedKey = "GraphTeamsLastImported";
-        private const string GraphCopilotUsageReportsLastImportedKey = "GraphCopilotUsageReportsLastImported";
-        private const string CopilotInteractionHistoryLastImportedKey = "CopilotInteractionHistoryLastImported";
+        /// <summary>
+        /// Orchestration-only constructor: the sections are supplied, so nothing here touches Graph, SQL or
+        /// Redis. Separate from the production constructor rather than another optional parameter on it,
+        /// because a trailing optional argument is baked in by the calling compiler and so is binary-breaking
+        /// for already-compiled callers.
+        /// </summary>
+        public GraphImporter(AnalyticsLogger logger, AppConfig settings, IGraphImportSectionFactory sectionFactory, IImportLastRunStore lastRunStore, IClock clock)
+            : base(logger, settings)
+        {
+            _clock = clock ?? SystemClock.Instance;
+            _sectionFactory = sectionFactory ?? throw new ArgumentNullException(nameof(sectionFactory));
+            _lastRunStore = lastRunStore ?? new InMemoryImportLastRunStore();
+        }
+
 
         /// <summary>
         /// Runs a "non-fresh" Graph import section at most once per <paramref name="intervalHours"/>.
@@ -68,20 +89,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// configured, otherwise in-memory) so the gate survives the per-cycle recreation of this
         /// importer. An interval of 0 disables the gate (runs every cycle); <c>ForceGraphMetadataImport</c>
         /// bypasses it for one run. Redis failures are fail-open (the section still runs).
-        /// </summary>
-        private Task RunGraphSectionIfDueAsync(string key, int intervalHours, string sectionName, Func<Task> sectionWork)
-        {
-            return RunGraphSectionIfDueAsync(key, intervalHours, sectionName, async () =>
-            {
-                await sectionWork();
-                return true;
-            });
-        }
-
-        /// <summary>
-        /// As above, for a section that reports success itself instead of throwing. Returning false records
-        /// the section as not done, so the cadence gate lets it retry next cycle, without an exception
-        /// unwinding out of <see cref="GetAndSaveAllGraphData"/> and skipping the sections that come after it.
+        ///
+        /// The section reports success itself instead of throwing. Returning false records the section as not
+        /// done, so the cadence gate lets it retry next cycle, without an exception unwinding out of
+        /// <see cref="GetAndSaveAllGraphData"/> and skipping the sections that come after it.
         /// </summary>
         private async Task RunGraphSectionIfDueAsync(string key, int intervalHours, string sectionName, Func<Task<bool>> sectionWork)
         {
@@ -125,236 +136,53 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
         }
 
+        /// <summary>
+        /// Runs a section that is not cadence-gated: it either has no throttle at all or owns one of its own,
+        /// as the activity/usage-report phase does. There is deliberately no "did not complete" warning here -
+        /// for that phase, returning false is the ordinary "throttled, nothing to do" answer and would warn on
+        /// every cycle inside the window.
+        /// </summary>
+        private async Task RunUngatedSectionAsync(IGraphImportSection section)
+        {
+            var timer = new JobTimer(_logger, section.Name);
+            timer.Start();
+
+            if (await section.RunAsync())
+            {
+                timer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
+            }
+        }
 
         /// <summary>
-        /// Main entry-point
+        /// Main entry-point. Runs every enabled section in factory order.
+        ///
+        /// A section that returns false is recorded as not done and the following sections still run. A
+        /// section that <b>throws</b> unwinds out of here and the sections after it are skipped for this
+        /// cycle - that is the long-standing behaviour and is left unchanged: adding per-section exception
+        /// isolation would silently convert a hard failure into a logged warning, which is a behavioural
+        /// change and belongs in its own issue.
         /// </summary>
         public async Task GetAndSaveAllGraphData(AppConfig settings)
         {
-            var httpClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _logger);
-            var userGroupsFilter = new UserGroupsFilterModel(_settings.UserGroupsFilter);
-
-            var graphUserGroupsCache = new GraphUserGroupsCache(httpClient, _logger);
-
-            if (settings.ImportJobSettings.GraphUsersMetadata)
+            foreach (var section in _sectionFactory.CreateSections(settings))
             {
-                await RunGraphSectionIfDueAsync(GraphUsersMetadataLastImportedKey, _settings.GraphMetadataImportIntervalHours, "User metadata refresh", async () =>
+                if (!section.IsEnabled(settings.ImportJobSettings))
                 {
-                    // Update Graph users first
-                    var userUpdater = new UserMetadataUpdater(_logger, _settings, _graphAppIndentityOAuthContext.Creds, httpClient);
-                    await userUpdater.InsertAndUpdateDatabaseFromExternalUsers();
-                });
-            }
-            else
-                _logger.LogInformation("Skipping user metadata import", graphUserGroupsCache);
+                    _logger.LogInformation(section.DisabledMessage);
+                    continue;
+                }
 
-
-            using (var db = new AnalyticsEntitiesContext())
-            {
-                if (settings.ImportJobSettings.GraphUsageReports)
+                if (section.CadenceKey != null)
                 {
-                    var usageActivityTimer = new JobTimer(_logger, "Usage reports");
-                    usageActivityTimer.Start();
-
-                    // Global user activity report. Each thread creates own context.
-                    var imported = await GetAndSaveActivityReportsMultiThreaded(settings.DaysBeforeNowToDownload, httpClient, graphUserGroupsCache, userGroupsFilter);
-
-                    // Track finished event 
-                    if (imported)
-                    {
-                        usageActivityTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
-                    }
+                    await RunGraphSectionIfDueAsync(section.CadenceKey, section.IntervalHours, section.Name, section.RunAsync);
                 }
                 else
-                    _logger.LogInformation("Skipping usage reports import", graphUserGroupsCache);
-
-                if (settings.ImportJobSettings.GraphCopilotUsageReports)
                 {
-                    // Refreshed daily by default. Microsoft publishes these reports roughly 48 hours behind,
-                    // so polling more often costs a full re-download and re-process of every licensed user
-                    // and returns the same numbers. This uses its own interval rather than the shared
-                    // non-fresh Graph one, whose High-preset default is "every cycle".
-                    await RunGraphSectionIfDueAsync(GraphCopilotUsageReportsLastImportedKey, _settings.GraphCopilotUsageReportsIntervalHours, "Copilot usage reports",
-                        () => ImportCopilotUsageReports(httpClient, graphUserGroupsCache, userGroupsFilter));
+                    await RunUngatedSectionAsync(section);
                 }
-                else
-                    _logger.LogInformation("Skipping Graph Copilot usage reports import", graphUserGroupsCache);
-
-                if (settings.ImportJobSettings.GraphTeams)
-                {
-                    await RunGraphSectionIfDueAsync(GraphTeamsLastImportedKey, _settings.GraphTeamsImportIntervalHours, "Teams import", async () =>
-                    {
-                        var teamsImporter = new TeamsImporter(_logger, _settings, _graphClient);
-
-                        var teamsConfig = await TeamsCrawlConfig.LoadFromDb(db);
-                        await teamsImporter.RefreshAndSaveAllTeamsData(teamsConfig);
-                    });
-                }
-                else
-                    _logger.LogInformation("Skipping Teams import", graphUserGroupsCache);
-
-                if (settings.ImportJobSettings.SentEmails)
-                {
-                    var sentEmailsTimer = new JobTimer(_logger, "Sent emails import");
-                    sentEmailsTimer.Start();
-
-                    IDeltaTokenStore deltaTokenStore;
-                    if (!string.IsNullOrEmpty(_settings.ConnectionStrings.RedisConnectionString))
-                    {
-                        deltaTokenStore = new RedisDeltaTokenStore(_settings.ConnectionStrings.RedisConnectionString, tenantId: _settings.TenantGUID.ToString(), clientId: _settings.ClientID, clientSecret: _settings.ClientSecret);
-                    }
-                    else
-                    {
-                        deltaTokenStore = new InMemoryDeltaTokenStore();
-                    }
-
-                    var sentEmailImporter = new SentEmailImporter(_logger, _settings, httpClient, deltaTokenStore, _graphAppIndentityOAuthContext, _sentEmailMailboxSkipList);
-                    await sentEmailImporter.ImportSentEmails();
-
-                    sentEmailsTimer.TrackFinishedEventAndStopTimer(AnalyticsLogger.AnalyticsEvent.FinishedSectionImport);
-                }
-                else
-                    _logger.LogInformation("Skipping sent emails import", graphUserGroupsCache);
-
-                if (settings.ImportJobSettings.CopilotInteractionHistory)
-                {
-                    // Cadence-gated like the other non-fresh Graph sections, but for a different reason: this
-                    // one costs a Graph call per in-scope user, so running it every cycle would be expensive
-                    // even for a modest pilot group. Defaults to daily.
-                    //
-                    // Uses the bool overload deliberately. ImportAsync returns null when it declined to run
-                    // (no UserGroupsFilter, or the app registration has no AiEnterpriseInteraction.Read.All
-                    // consent) and sets Error on the run log when it caught one. Reporting those as success
-                    // would stamp the daily gate on a cycle that imported nothing, so enabling the feature
-                    // before admin consent is granted would silently do nothing for another 24 hours.
-                    await RunGraphSectionIfDueAsync(CopilotInteractionHistoryLastImportedKey, _settings.CopilotInteractionHistoryIntervalHours, "Copilot interaction history import", async () =>
-                    {
-                        var interactionImporter = new CopilotInteractionHistoryImporter(
-                            _logger,
-                            _settings,
-                            new GraphAiInteractionSourceLoader(httpClient, _graphAppIndentityOAuthContext, _logger),
-                            InteractionCognitiveEnricherFactory.Create(_settings, _logger),
-                            new GraphPilotGroupMemberResolver(httpClient, _logger),
-                            userGroupsFilter);
-
-                        var interactionLog = await interactionImporter.ImportAsync();
-                        return interactionLog != null && string.IsNullOrEmpty(interactionLog.Error);
-                    });
-                }
-                else
-                    _logger.LogInformation("Skipping Copilot interaction history import", graphUserGroupsCache);
-
             }
         }
 
-
-        /// <summary>
-        /// Imports the three Graph Microsoft 365 Copilot usage reports. Returns true only if all three
-        /// succeeded, so the cadence gate retries next cycle otherwise.
-        ///
-        /// Order is deliberate: the two tenant-aggregate reports go first because they are cheap (a few
-        /// thousand rows whatever the tenant size), need no per-user joins, and are unaffected by the tenant's
-        /// concealed-user-information setting - so even where the per-user report is unusable, the customer
-        /// still gets adoption numbers that line up with the Microsoft 365 admin centre.
-        ///
-        /// Each report is attempted independently, and a failure is logged rather than thrown: a missing
-        /// Reports.Read.All grant or a non-global-cloud tenant (where these endpoints simply don't exist)
-        /// must not take down the Teams and sent-email imports that run after this section. Each report also
-        /// gets its own DbContext so a failed SaveChanges can't poison the next one.
-        /// </summary>
-        private async Task<bool> ImportCopilotUsageReports(ManualGraphCallClient httpClient, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel)
-        {
-            // Same client, throttling and paging as every other Graph usage report in this solution.
-            var reportSource = new GraphCopilotReportSource(httpClient, _logger);
-
-            // First run gets the widest window Graph offers. This is history we cannot get any other way:
-            // the audit pipeline has a hard 7-day retrieval ceiling, so without this backfill a new
-            // install starts with an empty Copilot adoption trend.
-            //
-            // The decision is based on whether a D180 TREND import has ever completed - not on whether any
-            // Copilot row exists. Keying it off "any row" meant a successful summary import alongside a
-            // failed D180 trend permanently downgraded every later run to D28, silently losing the
-            // backfill for good.
-            var backfillDone = await HasCompletedTrendBackfill();
-            var trendPeriod = backfillDone ? CopilotReportRequest.DefaultRefreshPeriod : CopilotReportRequest.MaxHistoryPeriod;
-            if (!backfillDone)
-            {
-                _logger.LogInformation($"No completed Copilot trend backfill on record - requesting the maximum window ({trendPeriod}).");
-            }
-
-            var allSucceeded = true;
-
-            allSucceeded &= await RunCopilotReport("Copilot user-count trend", db =>
-                new CopilotUserCountReportLoader(reportSource, _logger).LoadAndSaveTrendAsync(db, trendPeriod));
-
-            allSucceeded &= await RunCopilotReport("Copilot user-count summary", db =>
-                new CopilotUserCountReportLoader(reportSource, _logger).LoadAndSaveSummaryAsync(db, CopilotReportRequest.DefaultRefreshPeriod));
-
-            allSucceeded &= await RunCopilotReport("Copilot per-user usage detail", db =>
-                new CopilotUsageUserDetailLoader(reportSource, _logger, userGroupsCache, userGroupsFilterModel)
-                    .LoadAndSaveAsync(db, CopilotReportRequest.DefaultRefreshPeriod));
-
-            return allSucceeded;
-        }
-
-        /// <summary>
-        /// True when a maximum-window trend import has previously completed without error, which is what
-        /// proves the one-off history backfill actually landed. Never throws: this is only a decision about
-        /// which window to request, so if the check itself fails the safe answer is "not done" (request the
-        /// wide window) rather than unwinding and skipping the Graph sections that follow.
-        /// </summary>
-        private async Task<bool> HasCompletedTrendBackfill()
-        {
-            try
-            {
-                using (var db = new AnalyticsEntitiesContext())
-                {
-                    return await db.CopilotUsageReportImportLogs.AnyAsync(l =>
-                        l.ReportName == CopilotUsageReportNames.UserCountTrend
-                        && l.ReportPeriod == CopilotReportRequest.MaxHistoryPeriod
-                        && l.Error == null
-                        && l.RowsRead > 0);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"Couldn't check whether the Copilot trend backfill has run ({ex.Message}); assuming it hasn't and requesting the maximum window.");
-                return false;
-            }
-        }
-
-        private async Task<bool> RunCopilotReport(string reportDescription, Func<AnalyticsEntitiesContext, Task<int>> import)
-        {
-            try
-            {
-                using (var db = new AnalyticsEntitiesContext())
-                {
-                    var rows = await import(db);
-                    _logger.LogInformation($"{reportDescription}: wrote {rows.ToString("N0")} row(s) to SQL.");
-                }
-                return true;
-            }
-            catch (GraphHttpException ex)
-            {
-                // Typed so the log names the actual HTTP status. A 403 here is nearly always a missing or
-                // ungranted Reports.Read.All application permission, and saying so beats "an error occurred".
-                var advice = ex.StatusCode == System.Net.HttpStatusCode.Forbidden || ex.StatusCode == System.Net.HttpStatusCode.Unauthorized
-                    ? "Graph refused the call: grant the app registration the Reports.Read.All APPLICATION permission and admin-consent it. "
-                    : "Graph returned an error rather than a report. ";
-
-                _logger.LogError(ex, $"{reportDescription} failed with HTTP {(int)ex.StatusCode} ({ex.StatusCode}): {ex.Message} {advice}" +
-                    "The report was NOT imported and has not been recorded as up to date; it will be retried on the next cycle. " +
-                    "The other Copilot reports and the remaining Graph imports are unaffected.");
-                return false;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"{reportDescription} failed: {ex.Message}. " +
-                    "Check the app registration has the Reports.Read.All application permission granted, and that this is a global-cloud tenant (these reports don't exist in the US Government or 21Vianet clouds). " +
-                    "The other Copilot reports and the remaining Graph imports are unaffected; this one will be retried on the next cycle.");
-                return false;
-            }
-        }
 
         public async Task<bool> GetAndSaveActivityReportsMultiThreaded(int daysBackMax, ManualGraphCallClient client, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel)        {
             var MIN_WAIT = TimeSpan.FromDays(1);
@@ -386,7 +214,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 _logger.LogWarning("No activity-reports throttle store configured - cannot check last import date; will import this cycle.");
             }
 
-            var runImport = (lastImportedDate == null || DateTime.Now.Subtract(lastImportedDate.Value) > MIN_WAIT);
+            // Compare instants, not wall-clock readings: the store stamps DateTime.Now, so lastImportedDate
+            // comes back as a LOCAL time, and the old `DateTime.Now.Subtract(lastImportedDate)` compared two
+            // local readings - which is the wall-clock difference, not the elapsed time, across a DST change.
+            // ActivityReportsCadenceGate normalises to UTC and takes "now" from the injected clock.
+            var runImport = ActivityReportsCadenceGate.ShouldRun(lastImportedDate, MIN_WAIT, _clock.UtcNow);
             if (_settings.ForceUsageReportsImport)
             {
                 _logger.LogInformation("ForceUsageReportsImport=true; bypassing recently-imported gate.");

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -74,10 +74,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// because a trailing optional argument is baked in by the calling compiler and so is binary-breaking
         /// for already-compiled callers.
         ///
-        /// <b>Internal deliberately.</b> An instance built this way can only run
+        /// <b>Internal deliberately.</b> An instance built this way is composed only for
         /// <see cref="GetAndSaveAllGraphData"/>: it has no <see cref="GraphServiceClient"/> and no
-        /// <see cref="ISingleDateStore"/>, so <see cref="GetAndSaveActivityReportsMultiThreaded"/> would throw
-        /// on it. <c>InternalsVisibleTo("Tests.UnitTests")</c> makes it reachable from the test project, which
+        /// <see cref="ISingleDateStore"/>, so the still-public
+        /// <see cref="GetAndSaveActivityReportsMultiThreaded"/> is not supported on it.
+        /// <c>InternalsVisibleTo("Tests.UnitTests")</c> makes it reachable from the test project, which
         /// is its only intended caller; production composes through the constructor above.
         /// </summary>
         internal GraphImporter(AnalyticsLogger logger, AppConfig settings, IGraphImportSectionFactory sectionFactory, IImportLastRunStore lastRunStore, IClock clock)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -73,8 +73,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         /// Redis. Separate from the production constructor rather than another optional parameter on it,
         /// because a trailing optional argument is baked in by the calling compiler and so is binary-breaking
         /// for already-compiled callers.
+        ///
+        /// <b>Internal deliberately.</b> An instance built this way can only run
+        /// <see cref="GetAndSaveAllGraphData"/>: it has no <see cref="GraphServiceClient"/> and no
+        /// <see cref="ISingleDateStore"/>, so <see cref="GetAndSaveActivityReportsMultiThreaded"/> would throw
+        /// on it. <c>InternalsVisibleTo("Tests.UnitTests")</c> makes it reachable from the test project, which
+        /// is its only intended caller; production composes through the constructor above.
         /// </summary>
-        public GraphImporter(AnalyticsLogger logger, AppConfig settings, IGraphImportSectionFactory sectionFactory, IImportLastRunStore lastRunStore, IClock clock)
+        internal GraphImporter(AnalyticsLogger logger, AppConfig settings, IGraphImportSectionFactory sectionFactory, IImportLastRunStore lastRunStore, IClock clock)
             : base(logger, settings)
         {
             _clock = clock ?? SystemClock.Instance;
@@ -346,7 +352,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             else
             {
                 _logger.LogInformation($"Skipping activity reports as have processed recently (less than {MIN_WAIT.TotalHours} hours ago). " +
-                    $"Will import again after {lastImportedDate.Value.Add(MIN_WAIT)}.");
+                    $"Will import again after {ActivityReportsCadenceGate.NextRunUtc(lastImportedDate.Value, MIN_WAIT).ToLocalTime()}.");
                 return false;
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/DelegateGraphImportSection.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/DelegateGraphImportSection.cs
@@ -1,0 +1,67 @@
+using Common.Entities;
+using System;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Sections
+{
+    /// <summary>
+    /// An <see cref="IGraphImportSection"/> whose body is a delegate. The section bodies are lifted verbatim
+    /// out of <c>GraphImporter.GetAndSaveAllGraphData</c>, so keeping them as lambdas in
+    /// <see cref="ProductionGraphImportSectionFactory"/> makes this a pure move rather than six new classes
+    /// that would each need their own review against the original.
+    ///
+    /// Construct via <see cref="Gated"/> / <see cref="Ungated"/> rather than the constructor, so the caller
+    /// cannot accidentally build a gated section with no cadence key (or an ungated one with a key that would
+    /// then never be read).
+    /// </summary>
+    public sealed class DelegateGraphImportSection : IGraphImportSection
+    {
+        private readonly Func<ImportTaskSettings, bool> _isEnabled;
+        private readonly Func<Task<bool>> _run;
+
+        private DelegateGraphImportSection(string name, string disabledMessage, string cadenceKey, int intervalHours,
+            Func<ImportTaskSettings, bool> isEnabled, Func<Task<bool>> run)
+        {
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("A section needs a name.", nameof(name));
+            if (string.IsNullOrWhiteSpace(disabledMessage)) throw new ArgumentException("A section needs a disabled message.", nameof(disabledMessage));
+
+            Name = name;
+            DisabledMessage = disabledMessage;
+            CadenceKey = cadenceKey;
+            IntervalHours = intervalHours;
+            _isEnabled = isEnabled ?? throw new ArgumentNullException(nameof(isEnabled));
+            _run = run ?? throw new ArgumentNullException(nameof(run));
+        }
+
+        /// <summary>
+        /// A section gated to at most once per <paramref name="intervalHours"/> via
+        /// <see cref="IImportLastRunStore"/>.
+        /// </summary>
+        public static DelegateGraphImportSection Gated(string name, string disabledMessage, string cadenceKey,
+            int intervalHours, Func<ImportTaskSettings, bool> isEnabled, Func<Task<bool>> run)
+        {
+            if (string.IsNullOrWhiteSpace(cadenceKey)) throw new ArgumentException("A gated section needs a cadence key.", nameof(cadenceKey));
+            return new DelegateGraphImportSection(name, disabledMessage, cadenceKey, intervalHours, isEnabled, run);
+        }
+
+        /// <summary>
+        /// A section that runs on every cycle it is enabled for, because it either has no throttle at all or
+        /// owns one of its own (the activity/usage-report phase throttles itself via
+        /// <see cref="ISingleDateStore"/>).
+        /// </summary>
+        public static DelegateGraphImportSection Ungated(string name, string disabledMessage,
+            Func<ImportTaskSettings, bool> isEnabled, Func<Task<bool>> run)
+        {
+            return new DelegateGraphImportSection(name, disabledMessage, null, 0, isEnabled, run);
+        }
+
+        public string Name { get; }
+        public string DisabledMessage { get; }
+        public string CadenceKey { get; }
+        public int IntervalHours { get; }
+
+        public bool IsEnabled(ImportTaskSettings settings) => _isEnabled(settings);
+
+        public Task<bool> RunAsync() => _run();
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/IGraphImportSection.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/IGraphImportSection.cs
@@ -1,0 +1,61 @@
+using Common.Entities;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Sections
+{
+    /// <summary>
+    /// One independently-selectable Graph import section (user metadata, usage reports, Teams, sent emails,
+    /// Copilot usage reports, Copilot interaction history).
+    ///
+    /// This is the seam that separates <b>composition</b> from <b>orchestration</b> (issue #376):
+    /// <see cref="GraphImporter"/> knows only how to select, gate and run sections, while everything about
+    /// how a section is built - Graph clients, delta-token stores, DB contexts - lives behind
+    /// <see cref="IGraphImportSectionFactory"/>. The orchestration loop is then testable with fake sections
+    /// and no SQL Server, Graph, Redis or Service Bus.
+    ///
+    /// A section is expected to be <b>cheap to construct</b>: everything it needs is built inside
+    /// <see cref="RunAsync"/>, so a section that is disabled or gated off this cycle costs nothing. That
+    /// matters beyond tidiness - the sent-email section opens a Redis connection while building its delta
+    /// token store, which must not happen on a cycle where the section does not run.
+    /// </summary>
+    public interface IGraphImportSection
+    {
+        /// <summary>
+        /// Operator-facing name, used as the <see cref="DataUtils.JobTimer"/> operation name and in the
+        /// cadence-gate log lines.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Logged verbatim (at information level) when <see cref="IsEnabled"/> is false.
+        /// Kept per-section because the existing messages are not derivable from <see cref="Name"/>.
+        /// </summary>
+        string DisabledMessage { get; }
+
+        /// <summary>
+        /// The <see cref="IImportLastRunStore"/> key used to gate this section to at most once per
+        /// <see cref="IntervalHours"/>, or <c>null</c> for a section that is not cadence-gated (it either
+        /// runs every cycle or owns its own throttle, as the activity/usage-report phase does).
+        /// </summary>
+        string CadenceKey { get; }
+
+        /// <summary>
+        /// Minimum hours between runs. <c>0</c> disables gating. Ignored when <see cref="CadenceKey"/> is null.
+        /// </summary>
+        int IntervalHours { get; }
+
+        /// <summary>
+        /// Whether the tenant has this import switched on.
+        /// </summary>
+        bool IsEnabled(ImportTaskSettings settings);
+
+        /// <summary>
+        /// Runs the section. Returns false when the section did not complete - the orchestrator then neither
+        /// stamps the cadence gate nor emits a "finished section" event, so the section retries next cycle.
+        /// A section that throws is NOT isolated: the exception unwinds out of
+        /// <c>GraphImporter.GetAndSaveAllGraphData</c> and the sections after it are skipped for this cycle.
+        /// That is the pre-existing behaviour and is deliberately left unchanged here.
+        /// </summary>
+        Task<bool> RunAsync();
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/IGraphImportSectionFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/IGraphImportSectionFactory.cs
@@ -1,0 +1,21 @@
+using Common.Entities.Config;
+using System.Collections.Generic;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Sections
+{
+    /// <summary>
+    /// Builds the ordered list of Graph import sections for one import cycle. This is the composition root
+    /// for the Graph import: every <c>new</c> that <see cref="GraphImporter"/> used to do inline lives behind
+    /// this interface (issue #376).
+    ///
+    /// The returned order is the order the sections run in, and it is significant - see
+    /// <see cref="ProductionGraphImportSectionFactory.CreateSections"/>.
+    /// </summary>
+    public interface IGraphImportSectionFactory
+    {
+        /// <param name="settings">
+        /// The settings for this cycle, as passed to <c>GraphImporter.GetAndSaveAllGraphData</c>.
+        /// </param>
+        IReadOnlyList<IGraphImportSection> CreateSections(AppConfig settings);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/ProductionGraphImportSectionFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/ProductionGraphImportSectionFactory.cs
@@ -1,0 +1,332 @@
+using Common.Entities;
+using Common.Entities.Config;
+using Common.Entities.Entities.UsageReports;
+using DataUtils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.Graph.Copilot.InteractionHistory;
+using WebJob.Office365ActivityImporter.Engine.Graph.Email;
+using WebJob.Office365ActivityImporter.Engine.Graph.Teams;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Copilot;
+using WebJob.Office365ActivityImporter.Engine.Graph.User;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Sections
+{
+    /// <summary>
+    /// Runs the activity/usage-report phase. Implemented by
+    /// <c>GraphImporter.GetAndSaveActivityReportsMultiThreaded</c>, which stays where it is because it is a
+    /// public entry point with its own test coverage; the factory only wires it in as a section.
+    /// </summary>
+    public delegate Task<bool> ActivityReportsImport(int daysBackMax, ManualGraphCallClient client,
+        UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel);
+
+    /// <summary>
+    /// The production composition root for the Graph import (issue #376). Every collaborator that
+    /// <c>GraphImporter.GetAndSaveAllGraphData</c> used to <c>new</c> inline is built here, leaving
+    /// <see cref="GraphImporter"/> as a pure orchestrator over <see cref="IGraphImportSection"/>.
+    ///
+    /// Construction is deliberately <b>lazy</b>: <see cref="CreateSections"/> only builds the shared Graph
+    /// client / caches (which the old code also built unconditionally at the top of the method) and the
+    /// section descriptors. Everything else is built inside a section's <c>RunAsync</c>, exactly as before -
+    /// so a disabled or gated-off section still constructs nothing. That is load-bearing for the sent-email
+    /// section, whose <see cref="RedisDeltaTokenStore"/> opens a Redis connection.
+    /// </summary>
+    public class ProductionGraphImportSectionFactory : IGraphImportSectionFactory
+    {
+        // Keys for the per-section "last run" timestamps used to daily-gate the non-fresh Graph imports.
+        // Stored verbatim (unprefixed) in Redis db 0, so they can be cleared manually with e.g.
+        // `redis-cli DEL GraphUsersMetadataLastImported`.
+        public const string GraphUsersMetadataLastImportedKey = "GraphUsersMetadataLastImported";
+        public const string GraphTeamsLastImportedKey = "GraphTeamsLastImported";
+        public const string GraphCopilotUsageReportsLastImportedKey = "GraphCopilotUsageReportsLastImported";
+        public const string CopilotInteractionHistoryLastImportedKey = "CopilotInteractionHistoryLastImported";
+
+        private readonly AnalyticsLogger _logger;
+        private readonly AppConfig _settings;
+        private readonly GraphAppIndentityOAuthContext _graphAppIndentityOAuthContext;
+        private readonly GraphServiceClient _graphClient;
+        private readonly ISentEmailMailboxSkipList _sentEmailMailboxSkipList;
+        private readonly IAnalyticsDbContextFactory _dbContextFactory;
+        private readonly IClock _clock;
+        private readonly ActivityReportsImport _activityReportsImport;
+
+        public ProductionGraphImportSectionFactory(
+            AnalyticsLogger logger,
+            AppConfig settings,
+            GraphAppIndentityOAuthContext graphAppIndentityOAuthContext,
+            GraphServiceClient graphClient,
+            ISentEmailMailboxSkipList sentEmailMailboxSkipList,
+            ActivityReportsImport activityReportsImport,
+            IAnalyticsDbContextFactory dbContextFactory,
+            IClock clock)
+        {
+            // Deliberately no null guards on logger/settings: GraphImporter's own constructor never had them,
+            // and adding them here would move the failure from an NRE inside the import to an
+            // ArgumentNullException at construction - a behavioural change for an operator reading a stack
+            // trace. activityReportsImport is a new collaborator with no prior behaviour to preserve, and a
+            // null one would otherwise surface as an NRE deep inside the usage-report section.
+            _logger = logger;
+            _settings = settings;
+            _graphAppIndentityOAuthContext = graphAppIndentityOAuthContext;
+            _graphClient = graphClient;
+            _sentEmailMailboxSkipList = sentEmailMailboxSkipList;
+            _activityReportsImport = activityReportsImport ?? throw new ArgumentNullException(nameof(activityReportsImport));
+            _dbContextFactory = dbContextFactory ?? DefaultAnalyticsDbContextFactory.Instance;
+            _clock = clock ?? SystemClock.Instance;
+        }
+
+        /// <summary>
+        /// Builds the sections for one import cycle, in the order they must run.
+        /// </summary>
+        /// <param name="settings">
+        /// The per-cycle settings passed to <c>GetAndSaveAllGraphData</c>. In production this is the same
+        /// object as the <see cref="AppConfig"/> given to the constructor; the distinction is preserved
+        /// because the original code read <c>DaysBeforeNowToDownload</c> and the <c>ImportJobSettings</c>
+        /// flags from the method argument and everything else from the field.
+        /// </param>
+        public IReadOnlyList<IGraphImportSection> CreateSections(AppConfig settings)
+        {
+            // Shared across sections and built unconditionally, exactly as before.
+            var httpClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _logger);
+            var userGroupsFilter = new UserGroupsFilterModel(_settings.UserGroupsFilter);
+            var graphUserGroupsCache = new GraphUserGroupsCache(httpClient, _logger);
+
+            return new List<IGraphImportSection>
+            {
+                DelegateGraphImportSection.Gated(
+                    "User metadata refresh",
+                    "Skipping user metadata import",
+                    GraphUsersMetadataLastImportedKey,
+                    _settings.GraphMetadataImportIntervalHours,
+                    s => s.GraphUsersMetadata,
+                    async () =>
+                    {
+                        // Update Graph users first
+                        var userUpdater = new UserMetadataUpdater(_logger, _settings, _graphAppIndentityOAuthContext.Creds, httpClient);
+                        await userUpdater.InsertAndUpdateDatabaseFromExternalUsers();
+                        return true;
+                    }),
+
+                // Not cadence-gated: the activity/usage-report phase owns its own once-a-day throttle via
+                // ISingleDateStore, and reports "did I import" itself.
+                DelegateGraphImportSection.Ungated(
+                    "Usage reports",
+                    "Skipping usage reports import",
+                    s => s.GraphUsageReports,
+                    // Global user activity report. Each thread creates own context.
+                    () => _activityReportsImport(settings.DaysBeforeNowToDownload, httpClient, graphUserGroupsCache, userGroupsFilter)),
+
+                // Refreshed daily by default. Microsoft publishes these reports roughly 48 hours behind,
+                // so polling more often costs a full re-download and re-process of every licensed user
+                // and returns the same numbers. This uses its own interval rather than the shared
+                // non-fresh Graph one, whose High-preset default is "every cycle".
+                DelegateGraphImportSection.Gated(
+                    "Copilot usage reports",
+                    "Skipping Graph Copilot usage reports import",
+                    GraphCopilotUsageReportsLastImportedKey,
+                    _settings.GraphCopilotUsageReportsIntervalHours,
+                    s => s.GraphCopilotUsageReports,
+                    () => ImportCopilotUsageReports(httpClient, graphUserGroupsCache, userGroupsFilter)),
+
+                DelegateGraphImportSection.Gated(
+                    "Teams import",
+                    "Skipping Teams import",
+                    GraphTeamsLastImportedKey,
+                    _settings.GraphTeamsImportIntervalHours,
+                    s => s.GraphTeams,
+                    async () =>
+                    {
+                        var teamsImporter = new TeamsImporter(_logger, _settings, _graphClient);
+
+                        // TeamsCrawlConfig is a detached POCO (two lists of ids), so the context is only
+                        // needed for the load itself. It used to be opened around every section from usage
+                        // reports onwards even though this was its only reader, which held an EF context -
+                        // and its pooled connection - open for the whole multi-hour Graph phase.
+                        TeamsCrawlConfig teamsConfig;
+                        using (var db = _dbContextFactory.Create())
+                        {
+                            teamsConfig = await TeamsCrawlConfig.LoadFromDb(db);
+                        }
+
+                        await teamsImporter.RefreshAndSaveAllTeamsData(teamsConfig);
+                        return true;
+                    }),
+
+                DelegateGraphImportSection.Ungated(
+                    "Sent emails import",
+                    "Skipping sent emails import",
+                    s => s.SentEmails,
+                    async () =>
+                    {
+                        IDeltaTokenStore deltaTokenStore;
+                        if (!string.IsNullOrEmpty(_settings.ConnectionStrings.RedisConnectionString))
+                        {
+                            deltaTokenStore = new RedisDeltaTokenStore(_settings.ConnectionStrings.RedisConnectionString, tenantId: _settings.TenantGUID.ToString(), clientId: _settings.ClientID, clientSecret: _settings.ClientSecret);
+                        }
+                        else
+                        {
+                            deltaTokenStore = new InMemoryDeltaTokenStore();
+                        }
+
+                        // The primary constructor rather than the convenience overload, so the composition
+                        // root supplies the DB context factory instead of the importer defaulting it.
+                        // The remaining arguments are what the convenience overload passes.
+                        var sentEmailImporter = new SentEmailImporter(
+                            _logger,
+                            _settings,
+                            new GraphSentEmailSourceLoader(httpClient, deltaTokenStore, _graphAppIndentityOAuthContext, _logger),
+                            SentEmailSentimentScorerFactory.Create(_settings, _logger),
+                            dbContextFactory: _dbContextFactory,
+                            mailboxSkipList: _sentEmailMailboxSkipList,
+                            noMailboxRetryHours: _settings?.SentEmailNoMailboxRetryHours ?? 0);
+
+                        await sentEmailImporter.ImportSentEmails();
+                        return true;
+                    }),
+
+                // Cadence-gated like the other non-fresh Graph sections, but for a different reason: this
+                // one costs a Graph call per in-scope user, so running it every cycle would be expensive
+                // even for a modest pilot group. Defaults to daily.
+                //
+                // Reports success itself rather than throwing. ImportAsync returns null when it declined to
+                // run (no UserGroupsFilter, or the app registration has no AiEnterpriseInteraction.Read.All
+                // consent) and sets Error on the run log when it caught one. Reporting those as success
+                // would stamp the daily gate on a cycle that imported nothing, so enabling the feature
+                // before admin consent is granted would silently do nothing for another 24 hours.
+                DelegateGraphImportSection.Gated(
+                    "Copilot interaction history import",
+                    "Skipping Copilot interaction history import",
+                    CopilotInteractionHistoryLastImportedKey,
+                    _settings.CopilotInteractionHistoryIntervalHours,
+                    s => s.CopilotInteractionHistory,
+                    async () =>
+                    {
+                        var interactionImporter = new CopilotInteractionHistoryImporter(
+                            _logger,
+                            _settings,
+                            new GraphAiInteractionSourceLoader(httpClient, _graphAppIndentityOAuthContext, _logger),
+                            InteractionCognitiveEnricherFactory.Create(_settings, _logger),
+                            new GraphPilotGroupMemberResolver(httpClient, _logger),
+                            userGroupsFilter,
+                            dbContextFactory: _dbContextFactory,
+                            clock: _clock);
+
+                        var interactionLog = await interactionImporter.ImportAsync();
+                        return interactionLog != null && string.IsNullOrEmpty(interactionLog.Error);
+                    }),
+            };
+        }
+
+        /// <summary>
+        /// Imports the three Graph Microsoft 365 Copilot usage reports. Returns true only if all three
+        /// succeeded, so the cadence gate retries next cycle otherwise.
+        ///
+        /// Order is deliberate: the two tenant-aggregate reports go first because they are cheap (a few
+        /// thousand rows whatever the tenant size), need no per-user joins, and are unaffected by the tenant's
+        /// concealed-user-information setting - so even where the per-user report is unusable, the customer
+        /// still gets adoption numbers that line up with the Microsoft 365 admin centre.
+        ///
+        /// Each report is attempted independently, and a failure is logged rather than thrown: a missing
+        /// Reports.Read.All grant or a non-global-cloud tenant (where these endpoints simply don't exist)
+        /// must not take down the Teams and sent-email imports that run after this section. Each report also
+        /// gets its own DbContext so a failed SaveChanges can't poison the next one.
+        /// </summary>
+        private async Task<bool> ImportCopilotUsageReports(ManualGraphCallClient httpClient, UserGroupsCache userGroupsCache, UserGroupsFilterModel userGroupsFilterModel)
+        {
+            // Same client, throttling and paging as every other Graph usage report in this solution.
+            var reportSource = new GraphCopilotReportSource(httpClient, _logger);
+
+            // First run gets the widest window Graph offers. This is history we cannot get any other way:
+            // the audit pipeline has a hard 7-day retrieval ceiling, so without this backfill a new
+            // install starts with an empty Copilot adoption trend.
+            //
+            // The decision is based on whether a D180 TREND import has ever completed - not on whether any
+            // Copilot row exists. Keying it off "any row" meant a successful summary import alongside a
+            // failed D180 trend permanently downgraded every later run to D28, silently losing the
+            // backfill for good.
+            var backfillDone = await HasCompletedTrendBackfill();
+            var trendPeriod = backfillDone ? CopilotReportRequest.DefaultRefreshPeriod : CopilotReportRequest.MaxHistoryPeriod;
+            if (!backfillDone)
+            {
+                _logger.LogInformation($"No completed Copilot trend backfill on record - requesting the maximum window ({trendPeriod}).");
+            }
+
+            var allSucceeded = true;
+
+            allSucceeded &= await RunCopilotReport("Copilot user-count trend", db =>
+                new CopilotUserCountReportLoader(reportSource, _logger).LoadAndSaveTrendAsync(db, trendPeriod));
+
+            allSucceeded &= await RunCopilotReport("Copilot user-count summary", db =>
+                new CopilotUserCountReportLoader(reportSource, _logger).LoadAndSaveSummaryAsync(db, CopilotReportRequest.DefaultRefreshPeriod));
+
+            allSucceeded &= await RunCopilotReport("Copilot per-user usage detail", db =>
+                new CopilotUsageUserDetailLoader(reportSource, _logger, userGroupsCache, userGroupsFilterModel)
+                    .LoadAndSaveAsync(db, CopilotReportRequest.DefaultRefreshPeriod));
+
+            return allSucceeded;
+        }
+
+        /// <summary>
+        /// True when a maximum-window trend import has previously completed without error, which is what
+        /// proves the one-off history backfill actually landed. Never throws: this is only a decision about
+        /// which window to request, so if the check itself fails the safe answer is "not done" (request the
+        /// wide window) rather than unwinding and skipping the Graph sections that follow.
+        /// </summary>
+        private async Task<bool> HasCompletedTrendBackfill()
+        {
+            try
+            {
+                using (var db = _dbContextFactory.Create())
+                {
+                    return await db.CopilotUsageReportImportLogs.AnyAsync(l =>
+                        l.ReportName == CopilotUsageReportNames.UserCountTrend
+                        && l.ReportPeriod == CopilotReportRequest.MaxHistoryPeriod
+                        && l.Error == null
+                        && l.RowsRead > 0);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Couldn't check whether the Copilot trend backfill has run ({ex.Message}); assuming it hasn't and requesting the maximum window.");
+                return false;
+            }
+        }
+
+        private async Task<bool> RunCopilotReport(string reportDescription, Func<AnalyticsEntitiesContext, Task<int>> import)
+        {
+            try
+            {
+                using (var db = _dbContextFactory.Create())
+                {
+                    var rows = await import(db);
+                    _logger.LogInformation($"{reportDescription}: wrote {rows.ToString("N0")} row(s) to SQL.");
+                }
+                return true;
+            }
+            catch (GraphHttpException ex)
+            {
+                // Typed so the log names the actual HTTP status. A 403 here is nearly always a missing or
+                // ungranted Reports.Read.All application permission, and saying so beats "an error occurred".
+                var advice = ex.StatusCode == System.Net.HttpStatusCode.Forbidden || ex.StatusCode == System.Net.HttpStatusCode.Unauthorized
+                    ? "Graph refused the call: grant the app registration the Reports.Read.All APPLICATION permission and admin-consent it. "
+                    : "Graph returned an error rather than a report. ";
+
+                _logger.LogError(ex, $"{reportDescription} failed with HTTP {(int)ex.StatusCode} ({ex.StatusCode}): {ex.Message} {advice}" +
+                    "The report was NOT imported and has not been recorded as up to date; it will be retried on the next cycle. " +
+                    "The other Copilot reports and the remaining Graph imports are unaffected.");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"{reportDescription} failed: {ex.Message}. " +
+                    "Check the app registration has the Reports.Read.All application permission granted, and that this is a global-cloud tenant (these reports don't exist in the US Government or 21Vianet clouds). " +
+                    "The other Copilot reports and the remaining Graph imports are unaffected; this one will be retried on the next cycle.");
+                return false;
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/ProductionGraphImportSectionFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/ProductionGraphImportSectionFactory.cs
@@ -144,8 +144,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Sections
 
                         // TeamsCrawlConfig is a detached POCO (two lists of ids), so the context is only
                         // needed for the load itself. It used to be opened around every section from usage
-                        // reports onwards even though this was its only reader, which held an EF context -
-                        // and its pooled connection - open for the whole multi-hour Graph phase.
+                        // reports onwards even though this was its only reader, so an EF context and the
+                        // entities it tracked were retained for the whole multi-hour Graph phase to serve one
+                        // query at the start of it.
                         TeamsCrawlConfig teamsConfig;
                         using (var db = _dbContextFactory.Create())
                         {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/ProductionGraphImportSectionFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Sections/ProductionGraphImportSectionFactory.cs
@@ -143,10 +143,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Sections
                         var teamsImporter = new TeamsImporter(_logger, _settings, _graphClient);
 
                         // TeamsCrawlConfig is a detached POCO (two lists of ids), so the context is only
-                        // needed for the load itself. It used to be opened around every section from usage
-                        // reports onwards even though this was its only reader, so an EF context and the
-                        // entities it tracked were retained for the whole multi-hour Graph phase to serve one
-                        // query at the start of it.
+                        // needed for the load itself. It used to be created before the usage-report section
+                        // and disposed after the last section, even though this query - part way through
+                        // that span - was its only reader.
                         TeamsCrawlConfig teamsConfig;
                         using (var db = _dbContextFactory.Create())
                         {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
@@ -3,13 +3,35 @@ using Common.Entities.Models;
 using Common.Entities.Redis;
 using Common.Entities.Redis.Teams;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Graph.Teams;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
+    /// <summary>
+    /// Resolves the per-Team delegated (refresh) OAuth token used to read channel messages, from the Redis
+    /// token cache the Teams sign-up page writes to.
+    ///
+    /// <para>
+    /// This class used to hold a process-wide <c>static Lazy&lt;Dictionary&lt;O365Team, RefreshOAuthToken&gt;&gt;</c>
+    /// "cache". It was removed as part of issue #376 (separating composition from orchestration), and removing
+    /// it changes no observable behaviour, because it could never produce a hit:
+    /// </para>
+    /// <list type="number">
+    /// <item><description><c>O365Team</c> does not override <c>Equals</c>/<c>GetHashCode</c>, so the dictionary
+    /// keyed on it used <b>reference</b> equality.</description></item>
+    /// <item><description><see cref="GetRefreshToken"/> has exactly one call site
+    /// (<c>O365Team.LoadTeamFull</c>), which calls it once against an <c>O365Team</c> it has just constructed -
+    /// so the lookup was always a miss and the add always a new entry.</description></item>
+    /// </list>
+    /// <para>
+    /// What it did do was leak and race. Every crawled team, on every cycle, added a fully-populated
+    /// <c>O365Team</c> (its channels, messages, members and reactions) plus a token to a dictionary that was
+    /// never read and never cleared - for the life of the WebJob process. And the Teams crawl runs teams in
+    /// parallel (<c>TeamsImporter.RefreshAndSaveAllTeamsData</c> via <c>ParallelListProcessor</c>), so that
+    /// unsynchronised <c>Dictionary.Add</c> was a genuine data race.
+    /// </para>
+    /// </summary>
     public class TeamTokenManager
     {
         public TeamTokenManager(O365Team team, AppConfig appConfig, ILogger logger)
@@ -28,17 +50,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         public CacheConnectionManager CacheConnectionManager { get; set; }
         public O365Team Team { get; set; }
 
-        static Lazy<Dictionary<O365Team, RefreshOAuthToken>> _cahedTokens = new Lazy<Dictionary<O365Team, RefreshOAuthToken>>(() => new Dictionary<O365Team, RefreshOAuthToken>());
         public async Task<RefreshOAuthToken> GetRefreshToken(ILogger logger)
         {
             if (CacheConnectionManager == null)
             {
                 // No redis
                 return null;
-            }
-            if (_cahedTokens.Value.ContainsKey(this.Team))
-            {
-                return _cahedTokens.Value[this.Team];
             }
 
             RefreshOAuthToken teamToken = null;
@@ -73,8 +90,6 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 {
                     logger.LogInformation($"Got refresh token for Team '{this.Team.DisplayName}'.");
                 }
-
-                _cahedTokens.Value.Add(this.Team, teamToken);
 
                 return teamToken;
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
@@ -26,11 +26,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </list>
     /// <para>
     /// What it did do was leak and race, for every team that reached the add - Redis configured, and a
-    /// refresh-token entry present for that team. Each such team, on every cycle, added a fully-populated
-    /// <c>O365Team</c> (its channels, messages, members and reactions) plus the token to a dictionary that was
-    /// never read and never cleared, for the life of the WebJob process. And the Teams crawl runs teams in
-    /// parallel (<c>TeamsImporter.RefreshAndSaveAllTeamsData</c> via <c>ParallelListProcessor</c>), so that
-    /// unsynchronised <c>Dictionary.Add</c> was a genuine data race whenever two chunks reached it at once.
+    /// refresh-token entry present for that team. The dictionary retained a <b>reference</b> to each such
+    /// <c>O365Team</c>, and therefore to whatever that object went on to hold, including its channel messages
+    /// and reactions, for the life of the WebJob process - while never being read and never being cleared.
+    /// And the Teams crawl runs teams in parallel (<c>TeamsImporter.RefreshAndSaveAllTeamsData</c> via
+    /// <c>ParallelListProcessor</c>), so that unsynchronised <c>Dictionary.Add</c> was a genuine data race
+    /// whenever two chunks reached it at once.
     /// </para>
     /// </summary>
     public class TeamTokenManager

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamTokenManager.cs
@@ -25,11 +25,12 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// so the lookup was always a miss and the add always a new entry.</description></item>
     /// </list>
     /// <para>
-    /// What it did do was leak and race. Every crawled team, on every cycle, added a fully-populated
-    /// <c>O365Team</c> (its channels, messages, members and reactions) plus a token to a dictionary that was
-    /// never read and never cleared - for the life of the WebJob process. And the Teams crawl runs teams in
+    /// What it did do was leak and race, for every team that reached the add - Redis configured, and a
+    /// refresh-token entry present for that team. Each such team, on every cycle, added a fully-populated
+    /// <c>O365Team</c> (its channels, messages, members and reactions) plus the token to a dictionary that was
+    /// never read and never cleared, for the life of the WebJob process. And the Teams crawl runs teams in
     /// parallel (<c>TeamsImporter.RefreshAndSaveAllTeamsData</c> via <c>ParallelListProcessor</c>), so that
-    /// unsynchronised <c>Dictionary.Add</c> was a genuine data race.
+    /// unsynchronised <c>Dictionary.Add</c> was a genuine data race whenever two chunks reached it at once.
     /// </para>
     /// </summary>
     public class TeamTokenManager

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ImportRuntimeOptions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ImportRuntimeOptions.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace WebJob.Office365ActivityImporter.Engine
+{
+    /// <summary>
+    /// Parsing for the audit-import runtime safety valves, which are environment variables rather than
+    /// installer configuration so they can be flipped on a live App Service without a redeploy.
+    ///
+    /// Extracted from <c>ProgramTasks.DownloadActivityData</c> (issue #376) so the parsing is testable: these
+    /// are the switches an operator reaches for when the import is misbehaving in production, and getting
+    /// "what does AUDIT_PERBATCH_DEDUP_CACHE=yes do?" wrong is the sort of thing that is only discovered
+    /// during an incident.
+    /// </summary>
+    public static class ImportRuntimeOptions
+    {
+        /// <summary>
+        /// The original strictly-serial save. Concurrent-save mode is opt-in.
+        /// </summary>
+        public const int DefaultMaxConcurrentSaves = 1;
+
+        public const string MaxConcurrentSavesEnvVariable = "AUDIT_MAX_CONCURRENT_SAVES";
+        public const string PerBatchDedupCacheEnvVariable = "AUDIT_PERBATCH_DEDUP_CACHE";
+
+        /// <summary>
+        /// How many audit batches may commit in parallel (sharded staging; shared-table writes are still
+        /// serialised). Anything that is not a whole number greater than 1 - unset, blank, non-numeric,
+        /// zero or negative - leaves the strictly-serial default, deliberately: this valve can only ever
+        /// turn concurrency <i>on</i>, so a typo cannot stop the importer saving.
+        /// </summary>
+        public static int ResolveMaxConcurrentSaves(string rawEnvValue)
+        {
+            if (!string.IsNullOrWhiteSpace(rawEnvValue)
+                && int.TryParse(rawEnvValue.Trim(), out int parsed)
+                && parsed > 1)
+            {
+                return parsed;
+            }
+
+            return DefaultMaxConcurrentSaves;
+        }
+
+        /// <summary>
+        /// Whether to rebuild the de-dup cache for every batch (the pre-optimisation behaviour) instead of
+        /// once per cycle. Accepts "1" or "true" in any casing, with surrounding whitespace ignored;
+        /// everything else means off.
+        /// </summary>
+        public static bool ResolveUsePerBatchDedupCache(string rawEnvValue)
+        {
+            if (string.IsNullOrWhiteSpace(rawEnvValue)) return false;
+
+            var trimmed = rawEnvValue.Trim();
+            return trimmed == "1" || trimmed.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -102,6 +102,12 @@
     <Compile Include="Constants.cs" />
     <Compile Include="ActivityImportCache.cs" />
     <Compile Include="ImportLastRunStore.cs" />
+    <Compile Include="ImportRuntimeOptions.cs" />
+    <Compile Include="ActivityReportsCadenceGate.cs" />
+    <Compile Include="Graph\Sections\IGraphImportSection.cs" />
+    <Compile Include="Graph\Sections\IGraphImportSectionFactory.cs" />
+    <Compile Include="Graph\Sections\DelegateGraphImportSection.cs" />
+    <Compile Include="Graph\Sections\ProductionGraphImportSectionFactory.cs" />
     <Compile Include="Entities\BaseUser.cs" />
     <Compile Include="Entities\ChatReactions.cs" />
     <Compile Include="Entities\Serialisation\BaseSerialisationClasses.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -148,12 +148,11 @@ namespace WebJob.Office365ActivityImporter
                 // Concurrent-save mode is opt-in and OFF by default (1 = the original strictly-serial save).
                 // Set AUDIT_MAX_CONCURRENT_SAVES > 1 to let batches commit in parallel (sharded staging;
                 // shared-table writes still serialised). Validate in a non-production environment before use.
-                int maxConcurrentSaves = 1;
-                var concurrentSavesEnv = Environment.GetEnvironmentVariable("AUDIT_MAX_CONCURRENT_SAVES");
-                if (!string.IsNullOrWhiteSpace(concurrentSavesEnv) && int.TryParse(concurrentSavesEnv.Trim(), out int parsedConcurrentSaves) && parsedConcurrentSaves > 1)
+                var maxConcurrentSaves = ImportRuntimeOptions.ResolveMaxConcurrentSaves(
+                    Environment.GetEnvironmentVariable(ImportRuntimeOptions.MaxConcurrentSavesEnvVariable));
+                if (maxConcurrentSaves > ImportRuntimeOptions.DefaultMaxConcurrentSaves)
                 {
-                    maxConcurrentSaves = parsedConcurrentSaves;
-                    _logger.LogInformation($"Activity import: concurrent-save mode enabled (AUDIT_MAX_CONCURRENT_SAVES={maxConcurrentSaves}).");
+                    _logger.LogInformation($"Activity import: concurrent-save mode enabled ({ImportRuntimeOptions.MaxConcurrentSavesEnvVariable}={maxConcurrentSaves}).");
                 }
 
                 var importer = new ActivityWebImporter(_settings, _logger, MAX_IMPORTS_PER_BATCH, maxConcurrentSaves);
@@ -162,13 +161,11 @@ namespace WebJob.Office365ActivityImporter
                 // audit_events for every batch, which materialised ~the whole in-window event set each time -
                 // the dominant save cost at scale). Set AUDIT_PERBATCH_DEDUP_CACHE=true to restore the old
                 // per-batch build without a redeploy if the new path ever misbehaves.
-                bool usePerBatchDedupCache = false;
-                var perBatchCacheEnv = Environment.GetEnvironmentVariable("AUDIT_PERBATCH_DEDUP_CACHE");
-                if (!string.IsNullOrWhiteSpace(perBatchCacheEnv) &&
-                    (perBatchCacheEnv.Trim() == "1" || perBatchCacheEnv.Trim().Equals("true", StringComparison.OrdinalIgnoreCase)))
+                var usePerBatchDedupCache = ImportRuntimeOptions.ResolveUsePerBatchDedupCache(
+                    Environment.GetEnvironmentVariable(ImportRuntimeOptions.PerBatchDedupCacheEnvVariable));
+                if (usePerBatchDedupCache)
                 {
-                    usePerBatchDedupCache = true;
-                    _logger.LogWarning("Activity import: per-batch dedup cache ENABLED (AUDIT_PERBATCH_DEDUP_CACHE) - reverts the per-cycle cache optimisation; expect slower saves on large tables.");
+                    _logger.LogWarning($"Activity import: per-batch dedup cache ENABLED ({ImportRuntimeOptions.PerBatchDedupCacheEnvVariable}) - reverts the per-cycle cache optimisation; expect slower saves on large tables.");
                 }
 
                 var sqlAdaptor = new ActivityReportSqlPersistenceManager(spFilterList, _graphUserGroupsCache, _logger, _settings, maxConcurrentSaves, usePerBatchDedupCache);


### PR DESCRIPTION
# GraphImporter: separate composition from orchestration via `IGraphImportSection` (#376)

Addresses #376. Part of the ports & adapters initiative tracked by #381, and the last of its code tasks.

## Why

`GraphImporter` was both the orchestrator for every Graph import section and the thing that `new`ed each
section's collaborators inline, so the orchestration rules had **no test and none was possible** — the only
way to find out whether the Teams import had been correctly gated off this cycle was to run a real import
against a real tenant. The rules that were trapped there are subtle and load-bearing:

- which sections run for a given `ImportJobSettings`;
- the per-section cadence gate and its interaction with `ForceGraphMetadataImport`;
- that the last-run timestamp is stamped **only** on success and **only** when gating is active — the rule
  that stops a permanently failing section from idling for a whole interval while emitting a healthy
  "finished section" event every cycle (#285);
- that a section reporting failure must not unwind the loop and skip the sections after it.

## What changed

### New seam (`WebJob.Office365ActivityImporter.Engine/Graph/Sections/`)

| Type | Role |
|---|---|
| `IGraphImportSection` | `Name`, `DisabledMessage`, `CadenceKey`, `IntervalHours`, `IsEnabled(ImportTaskSettings)`, `Task<bool> RunAsync()` |
| `IGraphImportSectionFactory` | `IReadOnlyList<IGraphImportSection> CreateSections(AppConfig settings)` |
| `DelegateGraphImportSection` | section whose body is a delegate; built via `Gated(...)` / `Ungated(...)` |
| `ProductionGraphImportSectionFactory` | the composition root — every `new` that used to be inline |

`GraphImporter.GetAndSaveAllGraphData` is now a ~20-line loop: ask the factory for the sections, skip the
disabled ones (logging the same line as before), route each remaining one through either the cadence gate or
the plain timer path. `ImportCopilotUsageReports` / `HasCompletedTrendBackfill` / `RunCopilotReport` moved to
the factory with them, since they are all composition. The class shrank from 633 to ~400 lines, and about
150 of what is left is `GetAndSaveActivityReportsMultiThreaded` (see *Deliberately not done*).

`GraphImporter` keeps its original constructor, which builds the production factory, so **no call site
changes**. A second, `internal` constructor takes the factory, last-run store and clock — a separate overload
rather than another trailing optional parameter, which would be binary-breaking for already-compiled callers.
It is `internal` (reachable from `Tests.UnitTests` via the existing `InternalsVisibleTo`) because an instance
built that way is composed only for `GetAndSaveAllGraphData`: it has no `GraphServiceClient` and no
`ISingleDateStore`, so the still-public `GetAndSaveActivityReportsMultiThreaded` is not supported on it.

### Two paths, not one

The gated and ungated paths are deliberately kept distinct rather than unified behind `IntervalHours == 0`.
Merging them would have added the gated path's `"{section} did not complete successfully"` warning to the
activity/usage-report phase, where returning `false` is the ordinary *"throttled, nothing to do"* answer —
so an untouched tenant would have logged a warning on every cycle inside its 24-hour window.

### `ImportRuntimeOptions`

The two audit-import environment-variable safety valves (`AUDIT_MAX_CONCURRENT_SAVES`,
`AUDIT_PERBATCH_DEDUP_CACHE`) were parsed inline in the middle of `ProgramTasks.DownloadActivityData`. They
are now a pure `ImportRuntimeOptions` with the parsing preserved exactly, including that the concurrency
valve can only ever turn concurrency *on* — so a typo cannot stop the importer saving.

## Behaviour preservation

Section bodies are lifted **verbatim**. What is asserted by test rather than by eye:

- the six sections exist, in the original order;
- each carries its original `JobTimer` name, its original `"Skipping ..."` log line (what operators grep
  for), its original Redis cadence key (what operators `DEL` by hand) and reads the right interval setting;
- each maps to exactly one `ImportJobSettings` flag — checked one flag at a time, so two crossed mappings
  cannot both read as correct;
- construction stays lazy: composing the sections runs none of them. That matters — the sent-email section
  opens a Redis connection while building its delta-token store, and must not do so on a cycle it is gated
  off.

Two knock-on details worth a reviewer's eye:

1. **The outer `AnalyticsEntitiesContext` is gone.** It was created before the usage-report section and
   disposed after the last section, but its only reader was `TeamsCrawlConfig.LoadFromDb(db)` part-way
   through that span, which returns a detached POCO (two lists of ids). The Teams section now opens its own
   context via `IAnalyticsDbContextFactory` for that one load. (Two earlier drafts of this bullet over-claimed
   and were corrected by reviewers: EF6 opens and closes the connection per query when the caller has not
   opened it explicitly, so no pooled connection was being held, and the query is in the middle of the span,
   not at its start.)
2. **`SentEmailImporter` and `CopilotInteractionHistoryImporter` are now given their
   `IAnalyticsDbContextFactory` by the composition root** (and `CopilotInteractionHistoryImporter` its
   `IClock` — `SentEmailImporter` has no clock seam) instead of defaulting them internally. In production
   those are the same `DefaultAnalyticsDbContextFactory.Instance` / `SystemClock.Instance` the constructors
   would have picked, so this is identical at runtime — it just makes them substitutable.

`_logger.LogInformation("Skipping ...", graphUserGroupsCache)` lost its stray second argument. The message
has no format placeholder and `AnalyticsLogger.Log<TState>` only uses `formatter(state, exception)`, so the
rendered line is byte-identical.

## Two deliberate changes

### 1. `GraphImporter.cs:389` read `DateTime.Now` — now an instant comparison off the injected clock

`#368` left this alone because `IClock` exposes only `UtcNow` and converting it blind would have shifted the
comparison by the host's UTC offset. **The comparison was local-vs-local and therefore right in the ordinary
case:** both `ISingleDateStore` implementations stamp `DateTime.Now`, and `RedisSingleDateLoader` round-trips
it through `"o"` format with `RoundtripKind`, so the value read back is `DateTimeKind.Local`.

It is wrong across a daylight-saving transition, where subtracting two local wall-clock readings gives the
wall-clock difference rather than the elapsed time — twice a year the usage-report phase either re-ran an
hour early or waited an hour too long.

**Chosen: convert the comparison, not widen the port.** The two values are *instants*; normalising to UTC is
the only way to compare them correctly, and `ToUniversalTime()` is a no-op on a `Utc` value and treats
`Unspecified` as local — exactly how the old expression treated an offset-less value parsed out of Redis.
Widening `IClock` with a local `Now` would have preserved the DST bug and given every future rule two
sources of truth for "now" to choose between. The logic is now the pure `ActivityReportsCadenceGate`,
alongside the existing `ImportCadenceGate`.

For the `Local`-kind values the standard composition actually produces, this is bit-for-bit the same decision
outside a DST transition: `ActivityReportsLastImportedStoreFactory` builds one of the two built-in stores and
both stamp `DateTime.Now`. It is **not** identical for a `Utc`-kind value — which would need a different
`ISingleDateStore` on the public `GraphImporter` constructor, a caller using the public
`RedisSingleDateLoader.SaveDT(DateTime)` overload with a UTC value, or a hand-written `Z`-suffixed Redis
value — where the old raw subtraction was skewed by the host's offset and the new one is correct. The `>`
(not `>=`) boundary is preserved and tested.

The `"Will import again after ..."` line in the skip branch moved with it, to
`ActivityReportsCadenceGate.NextRunUtc(last, MIN_WAIT).ToLocalTime()`. It still prints a local time, and for
a `Local`-kind stored value the same one, except across a DST transition — where it previously named a
wall-clock time an hour away from the real threshold. `NextRunUtc` returns the **last instant the gate is
still shut** (the comparison is strictly greater-than, which is what makes the word "after" honest), and
`ActivityReportsGate_NextRunUtc_IsTheLastInstantTheGateIsStillShut` asserts that against `ShouldRun` itself
one tick either side, for all three `DateTimeKind`s, so the message and the decision cannot drift apart
again. (Found by a reviewer: the gate moved to UTC but the message had not.)

### 2. `TeamTokenManager`'s process-wide `static` token cache — deleted

`#377` left it as out of scope. It was `static Lazy<Dictionary<O365Team, RefreshOAuthToken>>` keyed by
`O365Team`, and **it could never produce a hit**:

- `O365Team` overrides neither `Equals` nor `GetHashCode`, so the dictionary used reference equality
  (asserted by `O365Team_UsesReferenceEquality`);
- `GetRefreshToken` has exactly one call site — `O365Team.LoadTeamFull` — which calls it once, against an
  `O365Team` it constructed three statements earlier.

So every lookup missed and every add was new. What it *did* do was leak and race — for every team that
reached the add, meaning Redis configured and a refresh-token entry present for that team. The dictionary
retained a **reference** to each such `O365Team`, and therefore to whatever that object went on to hold,
including its channel messages and reactions, for the life of the WebJob process, while never being read and
never being cleared; and because `TeamsImporter.RefreshAndSaveAllTeamsData` crawls teams in parallel via
`ParallelListProcessor`, that unsynchronised `Dictionary.Add` was a genuine data race on a non-thread-safe
collection whenever two chunks reached it at once.

Removing it is behaviour-preserving in the observable sense and removes the leak and the race.
`TeamTokenManager_HoldsNoProcessWideState` stops it coming back.

## Tests

35 new tests, all with **zero SQL Server, Graph, Redis and Service Bus**, in three files:

- `GraphImportOrchestrationTests` (17) — the loop: disabled sections, inside/outside the cadence window,
  `ForceGraphMetadataImport`, `IntervalHours == 0`, "returns false ⇒ no stamp", "returns false ⇒ later
  sections still run", "throws ⇒ unwinds", "succeeds ⇒ stamp comes from the injected clock", Redis fail-open,
  ungated sections never touching the cadence store, factory ordering, and which `AppConfig` instance selects
  the sections. Includes `GraphImporter_CadenceGate_UsesInjectedClock_NotWallClock`, named in #368 and never
  writable until now.
- `GraphImportSectionCompositionTests` (7) — the production section list, described above.
- `ImportRuntimeOptionsTests` (11) — the two env-var valves and `ActivityReportsCadenceGate`.

### Mutation evidence

Each load-bearing assertion was proved by breaking the behaviour, watching the named test fail, restoring,
and watching it pass. 21 mutations, 21 caught:

| Mutation | Caught by |
|---|---|
| `ActivityReportsCadenceGate.ShouldRun` drops `.ToUniversalTime()` | `ActivityReportsGate_TreatsALocalStoredTimestampAsAnInstant` |
| `ActivityReportsCadenceGate.NextRunUtc` drops `.ToUniversalTime()` | `ActivityReportsGate_NextRunUtc_IsTheLastInstantTheGateIsStillShut` |
| gate uses `>=` instead of `>` | `ActivityReportsGate_AtExactlyTheWindow_DoesNotRun` |
| cadence gate reads `DateTime.UtcNow` instead of `_clock.UtcNow` | `GraphImporter_CadenceGate_UsesInjectedClock_NotWallClock` |
| last-run stamped even with gating disabled (`intervalHours > 0` dropped) | `GraphImporter_IntervalHoursZero_RunsEveryCycleAndRecordsNoLastRunTime` |
| last-run stamped after a failure (`succeeded` dropped) | `GraphImporter_SectionReturnsFalse_DoesNotRecordLastRunTime` |
| ungated sections routed through the cadence store | `GraphImporter_UngatedSection_RunsEveryCycleAndNeverTouchesTheLastRunStore` |
| per-section exception isolation added (`try { } catch { }` round the body) | `GraphImporter_SectionThrows_UnwindsAndSkipsTheSectionsAfterIt` |
| section selection reads the field `AppConfig`, not the argument | `GraphImporter_SelectsSectionsUsingTheSettingsPassedToGetAndSaveAllGraphData` |
| sections cached on the importer instead of rebuilt each cycle | `GraphImporter_BuildsItsSectionsOncePerCycle` |
| Teams section reads the user-metadata interval setting | `ProductionSections_CarryTheOriginalCadenceKeysAndIntervals` |
| Teams section keyed off the wrong `ImportJobSettings` flag | `ProductionSections_EachMapToExactlyOneImportSettingFlag` |
| Teams `"Skipping ..."` line reworded | `ProductionSections_KeepTheOriginalSkippedMessages` |
| a section renamed in the list | `ProductionSections_AreTheSixSectionsInTheOriginalOrder` |
| days window read from the field `AppConfig` | `UsageReportSection_PassesTheDaysWindowAndTheConfiguredUserGroupsFilter` |
| the `static` token cache reinstated | `TeamTokenManager_HoldsNoProcessWideState` |
| concurrency valve loses its `> 1` floor | `RuntimeOptions_MaxConcurrentSavesInvalid_DefaultsToOne` |
| dedup valve loses `Trim()` | `RuntimeOptions_PerBatchDedupCache_AcceptsOneAndTrueCaseInsensitively` |
| dedup valve returns `true` unconditionally | `RuntimeOptions_PerBatchDedupCache_IsOffForAnythingElse` |
| a gated section emits completion after returning false | `GraphImporter_SectionReturnsFalse_DoesNotRecordLastRunTime` |
| a gated section loses its name from the completion context | `GraphImporter_SuccessfulSections_ReportFinishedEventsWithTheirNames` |

Two further mutations turned out to be **equivalent mutants** rather than test gaps, and are recorded here so
nobody spends time re-deriving them: changing the concurrency valve's `parsed > 1` to `parsed > 0` is
unobservable (an input of `"1"` returns `1` down either branch), and dropping `Trim()` from
`int.TryParse(rawEnvValue.Trim(), ...)` is unobservable because `NumberStyles.Integer` already allows leading
and trailing whitespace. The `"  4  "` assertion is kept as a contract on the accepted input shape, with a
comment saying exactly that rather than claiming to guard the `Trim()`.

Two tests are honest about their limits:

- `ActivityReportsGate_TreatsALocalStoredTimestampAsAnInstant` cannot discriminate on a host at UTC, where a
  local and a UTC representation of the same instant have identical ticks — it calls `Assert.Inconclusive`
  there rather than passing vacuously. Everywhere else it does discriminate, for **any** non-zero offset:
  it sweeps the window on a 30-minute grid *and* samples at `minWait + skew/2`, where the correct answer and
  the answer a missing `ToUniversalTime()` would give are opposite for either sign of the offset. (An earlier
  version picked two fixed points 1h either side of the window and guarded on `|offset| < 1h`; a reviewer
  showed that passes vacuously at exactly UTC−1, where the 1h slack and the strict `>` cancel the missing
  conversion. Reworked and re-mutation-checked.)
- `GraphImporter_SectionThrows_UnwindsAndSkipsTheSectionsAfterIt` pins **current** behaviour, which is the
  opposite of the test #376 proposed (see below).

## Deliberately not done

- **No per-section exception isolation.** #376 proposed
  `GraphImporter_SectionThrows_StillRunsSubsequentSections`, but `GraphImporter` has never isolated a
  throwing section — `ProgramTasks.GetGraphTeamsAndUserData` catches only `ODataError` — and the task brief
  is explicit that if the equivalent does not already exist here, this PR must not add one. Adding it would
  quietly downgrade a hard failure to a logged warning. The test above pins today's contract instead, so the
  change cannot happen by accident.
- **`GetAndSaveActivityReportsMultiThreaded` stays on `GraphImporter`** and is wired in as a section via an
  `ActivityReportsImport` delegate. It is a public entry point with its own coverage
  (`GraphUsageReportImportTests.AllO365ActivityTests`), and moving ~150 lines plus its public surface would
  have doubled this diff for no test benefit. It is the obvious candidate for its own class in a follow-up.
- **`ProgramTasks` does not own the factory.** #376 suggested it should; #381's convention is that an
  existing constructor stays as a thin overload that builds the production adapter, which is what
  `GraphImporter`'s original constructor now does. `ProgramTasks` is otherwise untouched apart from the
  `ImportRuntimeOptions` extraction.
- No schema, migration or index changes.

## Reviewer hotspots

1. **`ProductionGraphImportSectionFactory.CreateSections`** vs the deleted `GetAndSaveAllGraphData` — this is
   the pure-move claim. Note the deliberate `settings` (per-cycle argument) / `_settings` (field) split: the
   original read `DaysBeforeNowToDownload` and the `ImportJobSettings` flags from the method argument and
   everything else from the field, and that distinction is preserved even though production passes the same
   object to both.
2. **No `ArgumentNullException` guards on the factory's `logger` / `settings`.** `GraphImporter`'s
   constructor never had them, so adding them would move the failure from an NRE inside the import to an
   `ArgumentNullException` at construction — an operator-visible change (#381 gotcha). The guard on
   `activityReportsImport` is kept: it is a new collaborator with no prior behaviour.
3. **The two-path split** in `GetAndSaveAllGraphData` (see above) — the reason it is not one path.
4. **The Teams section's narrowed DB context lifetime.**

## Verification

- Full solution builds clean in Debug (Release is what CI runs; no #if DEBUG branches were touched).
- Full local suite before the telemetry follow-up: **1,433 passed / 12 failed / 1 skipped** out of 1,446 discovered.
  The baseline on `dev` before this branch was 1,399 passed / 12 failed / 1 skipped out of 1,412 — so the
  discovered count rose by exactly the 34 tests added here, the pass count by the same 34, and the failure
  set is unchanged. Those 12 are the documented pre-existing environment failures: eight need real Graph or
  cognitive-services credentials (the local config carries placeholders, so they fail with
  `Tenant '00000000-0000-0000-0000-000000000002' not found`), and four need
  `Tests.UnitTests/bin/Debug/InstallTests/TestConfigs/InstallerTestConfig.json`, which the test project
  never copies to `bin`.
- Reviewed by four models (`claude-opus-4.8`, `gpt-5.6-sol`, `grok-4.6`, `gemini-3.7-flash`) over
  three rounds, fixing after each, until a round came back clean. Their findings are recorded in the
  `Review round ...` commit messages on this branch, and the wording corrections they produced are the
  reason several claims above are narrower than they started.
- Follow-up commit 958c382 adds the completion-event guard: 17/17 focused tests pass, the two new mutations fail for the intended reason, three models re-reviewed it clean, and every Release build/test/gitleaks check is green on the final head.

