### PR TITLE
Audit import: make retries safe across partial saves

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ActivitySavePipelineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivitySavePipelineTests.cs
@@ -1,7 +1,13 @@
+using Common.Entities;
+using Common.Entities.Config;
+using Common.Entities.Entities;
+using Common.Entities.Entities.AuditLog;
+using DataUtils;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -10,8 +16,10 @@ using Tests.UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
+using FixedClock = UnitTests.FakeLoaderClasses.FixedClock;
 
 namespace Tests.UnitTests
 {
@@ -68,7 +76,26 @@ namespace Tests.UnitTests
             }, NullLoggerShim.Instance);
 
         private static ActivityStagingPass PassFor(AuditFilterConfig filterConfig, ILogger logger)
-            => new ActivityStagingPass(filterConfig, GroupsCache(), new Common.Entities.Config.UserGroupsFilterModel("Finance"), logger);
+            => new ActivityStagingPass(filterConfig, GroupsCache(), new UserGroupsFilterModel("Finance"), logger);
+
+        private sealed class SequenceActivityImportCacheProvider : IActivityImportCacheProvider
+        {
+            private readonly Queue<ActivityImportCache> _caches;
+
+            public SequenceActivityImportCacheProvider(params ActivityImportCache[] caches)
+            {
+                _caches = new Queue<ActivityImportCache>(caches);
+            }
+
+            public Task<ActivityImportCache> GetForWindowAsync(ActivityDedupCacheWindow window)
+                => Task.FromResult(_caches.Dequeue());
+        }
+
+        private sealed class FailingSaveSessionFactory : ISaveSessionFactory
+        {
+            public Task<SaveSession> CreateAsync(AnalyticsEntitiesContext db, ActivityImporter.Engine.ActivityAPI.Copilot.ICopilotMetadataLoader sharedCopilotLoader)
+                => Task.FromException<SaveSession>(new InvalidOperationException("metadata session failed"));
+        }
 
         [TestMethod]
         public async Task SavePipeline_EachOutcomeIsStagedAndCountedCorrectly()
@@ -174,6 +201,276 @@ namespace Tests.UnitTests
             StringAssert.Contains(merged.LastMergeSql, shard, "The merge must read the shard this save just loaded...");
             Assert.IsFalse(merged.LastMergeSql.Contains(ActivityImportConstants.STAGING_TABLE_ACTIVITY),
                 "...and must not touch the shared staging table another save may be loading.");
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_MergeFailure_ReleasesProcessedMarkerSoRetryRestagesTheEvent()
+        {
+            var log = SpEvent(InScopeUpn);
+            var cache = ActivityImportCache.GetEmptyCache();
+            var writer = new InMemoryActivityStagingWriter();
+            var mergeAttempts = 0;
+            writer.OnMerge = () => Interlocked.Increment(ref mergeAttempts) == 1
+                ? Task.FromException(new InvalidOperationException("merge failed"))
+                : Task.CompletedTask;
+            var pass = PassFor(new AllowAllFilterConfig(), new RecordingLogger());
+            var retryState = new ActivitySaveRetryState();
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => pass.RunAsync(
+                SetOf(log), cache, writer.CreateBatch(null), stagingTableName: null, mergeLock: null, retryState));
+
+            Assert.IsFalse(cache.HaveSeenInProcessedOrIgnoredEvents(log),
+                "A failed save attempt must release the in-memory marker, or the retry skips the event and falsely succeeds.");
+            Assert.IsTrue(retryState.ShouldRetry(log.Id),
+                "The retry must remember which staged id to force through a freshly loaded per-batch cache.");
+
+            var refreshedCache = ActivityImportCache.GetEmptyCache();
+            refreshedCache.RememberLoadedProcessedEvent(log);
+            var recovered = await pass.RunAsync(
+                SetOf(log), refreshedCache, writer.CreateBatch(null), stagingTableName: null, mergeLock: null, retryState);
+
+            Assert.AreEqual(2, mergeAttempts);
+            Assert.AreEqual(1, recovered.Stats.Imported);
+            Assert.AreEqual(1, writer.Batches[0].RowCountAtMerge);
+            Assert.AreEqual(1, writer.Batches[1].RowCountAtMerge,
+                "The retry must stage the event again even when a refreshed cache can see a row from the prior attempt.");
+            Assert.IsTrue(refreshedCache.HaveSeenInProcessedOrIgnoredEvents(log),
+                "The successful retry keeps the marker for later batches in the same cycle.");
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_MetadataFailure_ReleasesProcessedMarkerSoOuterRetryCanRestageTheEvent()
+        {
+            var log = SpEvent(InScopeUpn);
+            log.SourceContentId = "metadata-recovery-blob";
+            var firstCache = ActivityImportCache.GetEmptyCache();
+            var refreshedCache = ActivityImportCache.GetEmptyCache();
+            refreshedCache.RememberLoadedProcessedEvent(log);
+            var firstWriter = new InMemoryActivityStagingWriter();
+            var secondWriter = new InMemoryActivityStagingWriter();
+            var config = new AppConfig();
+            var firstManager = new ActivityReportSqlPersistenceManager(
+                new AllowAllFilterConfig(),
+                GroupsCache(),
+                new RecordingLogger(),
+                config,
+                maxConcurrentSaves: 1,
+                usePerBatchDedupCache: false,
+                clock: new FixedClock(Created.AddHours(1)),
+                cacheProvider: new SequenceActivityImportCacheProvider(firstCache),
+                stagingWriter: firstWriter,
+                copilotMetadataLoaderFactory: new FakeCopilotMetadataLoaderFactory(new RecordingCopilotMetadataLoader()),
+                saveSessionFactory: new FailingSaveSessionFactory());
+            var secondManager = new ActivityReportSqlPersistenceManager(
+                new AllowAllFilterConfig(),
+                GroupsCache(),
+                new RecordingLogger(),
+                config,
+                maxConcurrentSaves: 1,
+                usePerBatchDedupCache: false,
+                clock: new FixedClock(Created.AddHours(2)),
+                cacheProvider: new SequenceActivityImportCacheProvider(refreshedCache),
+                stagingWriter: secondWriter,
+                copilotMetadataLoaderFactory: new FakeCopilotMetadataLoaderFactory(new RecordingCopilotMetadataLoader()),
+                saveSessionFactory: new FailingSaveSessionFactory());
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => firstManager.CommitAll(SetOf(log)));
+
+            Assert.AreEqual(1, firstWriter.LastBatch.RowCountAtMerge,
+                "Precondition: the event reached the merge before the metadata phase failed.");
+            Assert.IsFalse(firstCache.HaveSeenInProcessedOrIgnoredEvents(log));
+
+            var recoverySet = SetOf(log);
+            recoverySet.MetadataRecoveryBlobIds.Add(log.SourceContentId);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => secondManager.CommitAll(recoverySet));
+
+            Assert.AreEqual(1, secondWriter.LastBatch.RowCountAtMerge,
+                "A new cycle must force the event through metadata when its blob carries a durable recovery marker.");
+            Assert.IsFalse(refreshedCache.HaveSeenInProcessedOrIgnoredEvents(log),
+                "A failed recovery attempt must leave the id available for another attempt.");
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_MetadataRecovery_DoesNotBypassAnotherCurrentBatchsReservation()
+        {
+            var log = SpEvent(InScopeUpn);
+            log.SourceContentId = "metadata-recovery-blob";
+            var cache = ActivityImportCache.GetEmptyCache();
+            cache.RememberProcessedEvent(log);
+            var writer = new InMemoryActivityStagingWriter();
+            var recoverySet = SetOf(log);
+            recoverySet.MetadataRecoveryBlobIds.Add(log.SourceContentId);
+
+            var result = await PassFor(new AllowAllFilterConfig(), new RecordingLogger()).RunAsync(
+                recoverySet, cache, writer.CreateBatch(null), stagingTableName: null, mergeLock: null,
+                new ActivitySaveRetryState());
+
+            Assert.AreEqual(0, result.Stats.Imported);
+            Assert.AreEqual(0, writer.LastBatch.RowCountAtMerge,
+                "Recovery bypasses only ids loaded from SQL, not a reservation made by another batch in this cycle.");
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_DbLoadedEventWithoutPriorRecoveryMarker_RemainsDeduplicated()
+        {
+            var log = SpEvent(InScopeUpn);
+            log.SourceContentId = "newly-premarked-blob";
+            var cache = ActivityImportCache.GetEmptyCache();
+            cache.RememberLoadedProcessedEvent(log);
+            var writer = new InMemoryActivityStagingWriter();
+
+            var result = await PassFor(new AllowAllFilterConfig(), new RecordingLogger()).RunAsync(
+                SetOf(log), cache, writer.CreateBatch(null), stagingTableName: null, mergeLock: null,
+                new ActivitySaveRetryState());
+
+            Assert.AreEqual(0, result.Stats.Imported);
+            Assert.AreEqual(0, writer.LastBatch.RowCountAtMerge,
+                "Pre-marking a new/cold blob is only crash protection; it must not replay DB data unless the marker existed before this cycle.");
+        }
+
+        [TestMethod]
+        public async Task MetadataRecovery_ReplayingStreamExchangeAndEntraMetadata_IsIdempotent()
+        {
+            var suffix = Guid.NewGuid().ToString("N");
+            var userUpn = "metadata.retry." + suffix + "@contoso.onmicrosoft.com";
+            var exchangePropertyName = "exchange-name-" + suffix;
+            var exchangePropertyValue = "exchange-value-" + suffix;
+            var entraPropertyName = "entra-name-" + suffix;
+            var entraPropertyValue = "entra-value-" + suffix;
+            var streamVideoId = Guid.NewGuid();
+
+            var exchange = new ExchangeAuditLogContent
+            {
+                Id = Guid.NewGuid(),
+                UserId = userUpn,
+                CreationTime = Created,
+                Workload = ActivityImportConstants.WORKLOAD_EXCHANGE,
+                Operation = "ExchangeMetadataRetry",
+                ObjectId = "mailbox-" + suffix,
+                ExtendedProperties = new List<Dictionary<string, string>>
+                {
+                    new Dictionary<string, string>
+                    {
+                        { "Name", exchangePropertyName },
+                        { "Value", exchangePropertyValue }
+                    }
+                }
+            };
+            var entra = new AzureADAuditLogContent
+            {
+                Id = Guid.NewGuid(),
+                UserId = userUpn,
+                CreationTime = Created,
+                Workload = ActivityImportConstants.WORKLOAD_AZURE_AD,
+                Operation = "EntraMetadataRetry",
+                ExtendedProperties = new List<Dictionary<string, string>>
+                {
+                    new Dictionary<string, string>
+                    {
+                        { "Name", entraPropertyName },
+                        { "Value", entraPropertyValue }
+                    }
+                }
+            };
+            var stream = new StreamAuditLogContent
+            {
+                Id = Guid.NewGuid(),
+                UserId = userUpn,
+                CreationTime = Created,
+                Workload = ActivityImportConstants.WORKLOAD_STREAM,
+                Operation = "StreamMetadataRetry",
+                ObjectId = "https://web.microsoftstream.com/video/" + streamVideoId,
+                ResourceTitle = "Synthetic retry video",
+                ClientApplicationId = O365ClientApplication.UNKNOWN_CLIENT_APP_ID.ToString()
+            };
+
+            try
+            {
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    var user = new User { UserPrincipalName = userUpn, AzureAdId = "metadata-retry-" + suffix };
+                    var exchangeEvent = new CommonAuditEvent
+                    {
+                        Id = exchange.Id,
+                        TimeStamp = exchange.CreationTime,
+                        User = user,
+                        Operation = new EventOperation { Name = exchange.Operation }
+                    };
+                    var entraEvent = new CommonAuditEvent
+                    {
+                        Id = entra.Id,
+                        TimeStamp = entra.CreationTime,
+                        User = user,
+                        Operation = new EventOperation { Name = entra.Operation }
+                    };
+                    var streamEvent = new CommonAuditEvent
+                    {
+                        Id = stream.Id,
+                        TimeStamp = stream.CreationTime,
+                        User = user,
+                        Operation = new EventOperation { Name = stream.Operation }
+                    };
+
+                    db.AuditEventsCommon.AddRange(new[] { exchangeEvent, entraEvent, streamEvent });
+                    db.exchange_events.Add(new ExchangeEventMetadata { AuditEvent = exchangeEvent, object_id = exchange.ObjectId });
+                    db.azure_ad_events.Add(new AzureADEventMetadata { AuditEvent = entraEvent });
+                    await db.SaveChangesAsync();
+
+                    var session = new SaveSession(
+                        new RecordingLogger(), db, new AppConfig(), new RecordingCopilotMetadataLoader());
+                    await exchange.ProcessExtendedProperties(session, exchangeEvent, new RecordingLogger());
+                    await entra.ProcessExtendedProperties(session, entraEvent, new RecordingLogger());
+                    await stream.ProcessExtendedProperties(session, streamEvent, new RecordingLogger());
+                    db.ChangeTracker.DetectChanges();
+                    await db.SaveChangesAsync();
+                }
+
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    var session = new SaveSession(
+                        new RecordingLogger(), db, new AppConfig(), new RecordingCopilotMetadataLoader());
+                    await exchange.ProcessExtendedProperties(
+                        session, await db.AuditEventsCommon.SingleAsync(e => e.Id == exchange.Id), new RecordingLogger());
+                    await entra.ProcessExtendedProperties(
+                        session, await db.AuditEventsCommon.SingleAsync(e => e.Id == entra.Id), new RecordingLogger());
+                    await stream.ProcessExtendedProperties(
+                        session, await db.AuditEventsCommon.SingleAsync(e => e.Id == stream.Id), new RecordingLogger());
+                    db.ChangeTracker.DetectChanges();
+                    await db.SaveChangesAsync();
+
+                    Assert.AreEqual(1, await db.Set<ExchangeExtendedProperties>()
+                        .CountAsync(p => p.ParentEventID == exchange.Id));
+                    Assert.AreEqual(1, await db.Set<AzureADExtendedProperties>()
+                        .CountAsync(p => p.ParentEventID == entra.Id));
+                    Assert.AreEqual(1, await db.StreamEvents.CountAsync(e => e.EventID == stream.Id));
+                }
+            }
+            finally
+            {
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    db.Set<ExchangeExtendedProperties>().RemoveRange(
+                        db.Set<ExchangeExtendedProperties>().Where(p => p.ParentEventID == exchange.Id));
+                    db.Set<AzureADExtendedProperties>().RemoveRange(
+                        db.Set<AzureADExtendedProperties>().Where(p => p.ParentEventID == entra.Id));
+                    db.StreamEvents.RemoveRange(db.StreamEvents.Where(e => e.EventID == stream.Id));
+                    db.exchange_events.RemoveRange(db.exchange_events.Where(e => e.EventID == exchange.Id));
+                    db.azure_ad_events.RemoveRange(db.azure_ad_events.Where(e => e.EventID == entra.Id));
+                    db.AuditEventsCommon.RemoveRange(
+                        db.AuditEventsCommon.Where(e => e.Id == exchange.Id || e.Id == entra.Id || e.Id == stream.Id));
+                    await db.SaveChangesAsync();
+
+                    db.audit_event_prop_names.RemoveRange(db.audit_event_prop_names.Where(n =>
+                        n.name == exchangePropertyName || n.name == entraPropertyName));
+                    db.audit_event_prop_vals.RemoveRange(db.audit_event_prop_vals.Where(v =>
+                        v.value == exchangePropertyValue || v.value == entraPropertyValue));
+                    db.Streams.RemoveRange(db.Streams.Where(v => v.StreamID == streamVideoId));
+                    db.users.RemoveRange(db.users.Where(u => u.UserPrincipalName == userUpn));
+                    db.event_operations.RemoveRange(db.event_operations.Where(o =>
+                        o.Name == exchange.Operation || o.Name == entra.Operation || o.Name == stream.Operation));
+                    await db.SaveChangesAsync();
+                }
+            }
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/AuditImportFailureHandlingTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AuditImportFailureHandlingTests.cs
@@ -1,10 +1,12 @@
 using DataUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Common.Entities.Config;
 using Tests.UnitTests.FailureHandling;
 using Tests.UnitTests.StressHarness;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint;
 using WebJob.Office365ActivityImporter.Engine.Entities;
 
 namespace Tests.UnitTests
@@ -39,6 +41,14 @@ namespace Tests.UnitTests
         }
 
         private static string Blob(int i) => FailureTestContentMetaDataLoader.BlobId(i);
+
+        [TestMethod]
+        public void InMemoryCheckpoint_DoesNotClaimDurableMetadataRecovery()
+        {
+            var store = new InMemoryProcessedBlobStore(TimeSpan.FromDays(8));
+            Assert.IsFalse(store is IActivityMetadataRecoveryStore,
+                "The in-memory fallback is process-lifetime only and must not claim restart-safe recovery.");
+        }
 
         [TestMethod]
         public async Task HealthyRun_AllBlobsImportedAndCheckpointed()
@@ -97,6 +107,10 @@ namespace Tests.UnitTests
             Assert.AreEqual(3, pm.AttemptsFor(failing), "the transient fault should be retried up to maxAttempts before giving up");
             Assert.IsFalse(store.IsProcessed(failing), "a failed batch's blob must NOT be checkpointed, so it retries next cycle");
             Assert.AreEqual(4, store.ProcessedCount, "only the four successful blobs are checkpointed");
+            Assert.IsTrue(store.IsMetadataRecoveryPending(failing),
+                "The pre-save recovery marker must remain until this blob eventually commits.");
+            Assert.IsFalse(store.IsMetadataRecoveryPending(Blob(1)),
+                "Successful blobs must clear the marker after their processed checkpoint is durable.");
         }
 
         /// <summary>
@@ -162,6 +176,88 @@ namespace Tests.UnitTests
             Assert.IsFalse(store.IsProcessed(Blob(1)));
             Assert.IsFalse(store.IsProcessed(Blob(4)));
             Assert.AreEqual(6, store.ProcessedCount);
+        }
+
+        [TestMethod]
+        public async Task ColdCheckpointStore_DoesNotReplayEveryBlobAsMetadataRecovery()
+        {
+            var store = new RecordingProcessedBlobStore();
+            var pm = new FailureInjectingPersistenceManager();
+
+            var stats = await BuildImporter(blobCount: 4, store).LoadReportsAndSave(pm);
+
+            Assert.AreEqual(4, stats.Imported);
+            Assert.IsFalse(pm.MetadataRecoveryRequestedFor(Blob(0)));
+            Assert.IsFalse(pm.MetadataRecoveryRequestedFor(Blob(1)));
+            Assert.IsFalse(pm.MetadataRecoveryRequestedFor(Blob(2)));
+            Assert.IsFalse(pm.MetadataRecoveryRequestedFor(Blob(3)));
+            Assert.AreEqual(4, store.ProcessedCount);
+            Assert.IsFalse(store.IsMetadataRecoveryPending(Blob(2)),
+                "Newly pre-marked blobs are cleared after a clean commit; they are not replay requests for this cycle.");
+        }
+
+        [TestMethod]
+        public async Task ExistingRecoveryMarker_ReplaysOnlyThatBlobAndClearsAfterSuccess()
+        {
+            var store = new RecordingProcessedBlobStore();
+            store.SeedMetadataRecovery(Blob(2));
+            var pm = new FailureInjectingPersistenceManager();
+
+            var stats = await BuildImporter(blobCount: 4, store).LoadReportsAndSave(pm);
+
+            Assert.AreEqual(4, stats.Imported);
+            Assert.IsTrue(pm.MetadataRecoveryRequestedFor(Blob(2)));
+            Assert.IsFalse(pm.MetadataRecoveryRequestedFor(Blob(1)));
+            Assert.IsFalse(store.IsMetadataRecoveryPending(Blob(2)));
+            Assert.IsTrue(store.IsProcessed(Blob(2)));
+        }
+
+        [TestMethod]
+        public async Task CheckpointReadFailure_AbortsBeforeAnyDatabaseSave()
+        {
+            var store = new RecordingProcessedBlobStore
+            {
+                ReadFailure = new InvalidOperationException("checkpoint unavailable")
+            };
+            var pm = new FailureInjectingPersistenceManager();
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => BuildImporter(blobCount: 3, store).LoadReportsAndSave(pm));
+
+            Assert.AreEqual(0, pm.TotalCommitAttempts,
+                "No SQL save may start when the two-phase checkpoint state is unknown.");
+            Assert.AreEqual(0, store.ProcessedCount);
+        }
+
+        [TestMethod]
+        public async Task RecoveryMarkerReadFailure_AbortsBeforeAnyDatabaseSave()
+        {
+            var store = new RecordingProcessedBlobStore
+            {
+                RecoveryReadFailure = new InvalidOperationException("recovery checkpoint unavailable")
+            };
+            var pm = new FailureInjectingPersistenceManager();
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => BuildImporter(blobCount: 3, store).LoadReportsAndSave(pm));
+
+            Assert.AreEqual(0, pm.TotalCommitAttempts);
+        }
+
+        [TestMethod]
+        public async Task RecoveryPreMarkFailure_AbortsBeforeAnyDatabaseSave()
+        {
+            var store = new RecordingProcessedBlobStore
+            {
+                RecoveryWriteFailure = new InvalidOperationException("recovery checkpoint unavailable")
+            };
+            var pm = new FailureInjectingPersistenceManager();
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => BuildImporter(blobCount: 3, store).LoadReportsAndSave(pm));
+
+            Assert.AreEqual(0, pm.TotalCommitAttempts,
+                "The recovery marker must be durable before the first SQL save can partially commit.");
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/AuditImportFailureHarness.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AuditImportFailureHarness.cs
@@ -120,13 +120,23 @@ namespace Tests.UnitTests.FailureHandling
     /// test can assert that FAILED batches' blobs are NOT marked processed (and therefore retried next cycle)
     /// while successful ones are.
     /// </summary>
-    public class RecordingProcessedBlobStore : IProcessedBlobStore
+    public class RecordingProcessedBlobStore : IProcessedBlobStore, IActivityMetadataRecoveryStore
     {
         private readonly HashSet<string> _processed = new HashSet<string>();
+        private readonly HashSet<string> _metadataRecoveryPending = new HashSet<string>();
         private readonly object _lock = new object();
+
+        public Exception ReadFailure { get; set; }
+        public Exception RecoveryReadFailure { get; set; }
+        public Exception RecoveryWriteFailure { get; set; }
 
         public Task<ISet<string>> GetProcessedBlobIdsAsync()
         {
+            if (ReadFailure != null)
+            {
+                return Task.FromException<ISet<string>>(ReadFailure);
+            }
+
             lock (_lock)
             {
                 return Task.FromResult<ISet<string>>(new HashSet<string>(_processed));
@@ -140,6 +150,52 @@ namespace Tests.UnitTests.FailureHandling
                 foreach (var b in blobIds) _processed.Add(b);
             }
             return Task.CompletedTask;
+        }
+
+        public Task<ISet<string>> GetMetadataRecoveryPendingBlobIdsAsync()
+        {
+            if (RecoveryReadFailure != null)
+            {
+                return Task.FromException<ISet<string>>(RecoveryReadFailure);
+            }
+
+            lock (_lock)
+            {
+                return Task.FromResult<ISet<string>>(new HashSet<string>(_metadataRecoveryPending));
+            }
+        }
+
+        public Task MarkMetadataRecoveryPendingAsync(IReadOnlyCollection<string> blobIds)
+        {
+            if (RecoveryWriteFailure != null)
+            {
+                return Task.FromException(RecoveryWriteFailure);
+            }
+
+            lock (_lock)
+            {
+                foreach (var b in blobIds) _metadataRecoveryPending.Add(b);
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task ClearMetadataRecoveryPendingAsync(IReadOnlyCollection<string> blobIds)
+        {
+            lock (_lock)
+            {
+                foreach (var b in blobIds) _metadataRecoveryPending.Remove(b);
+            }
+            return Task.CompletedTask;
+        }
+
+        public void SeedMetadataRecovery(string blobId)
+        {
+            lock (_lock) { _metadataRecoveryPending.Add(blobId); }
+        }
+
+        public bool IsMetadataRecoveryPending(string blobId)
+        {
+            lock (_lock) { return _metadataRecoveryPending.Contains(blobId); }
         }
 
         public bool IsProcessed(string blobId)
@@ -178,6 +234,8 @@ namespace Tests.UnitTests.FailureHandling
         private readonly HashSet<string> _constraintFailBlobs;
 
         private readonly ConcurrentDictionary<string, int> _attempts = new ConcurrentDictionary<string, int>();
+        private readonly ConcurrentDictionary<string, bool> _metadataRecoveryRequested =
+            new ConcurrentDictionary<string, bool>();
         private int _committedEvents;
         private int _committedBatches;
 
@@ -193,6 +251,8 @@ namespace Tests.UnitTests.FailureHandling
         public int TotalCommitAttempts => _attempts.Values.Sum();
         public int CommittedEvents => Interlocked.CompareExchange(ref _committedEvents, 0, 0);
         public int CommittedBatches => Interlocked.CompareExchange(ref _committedBatches, 0, 0);
+        public bool MetadataRecoveryRequestedFor(string blobId)
+            => _metadataRecoveryRequested.TryGetValue(blobId, out var requested) && requested;
 
         public async Task<ImportStat> CommitAll(ActivityReportSet activities)
         {
@@ -200,6 +260,7 @@ namespace Tests.UnitTests.FailureHandling
             // first event's SourceContentId identifies the batch's blob.
             var blobId = activities.FirstOrDefault()?.SourceContentId ?? "(no-source-content-id)";
             int attempt = _attempts.AddOrUpdate(blobId, 1, (k, v) => v + 1);
+            _metadataRecoveryRequested[blobId] = activities.Any(activities.RequiresMetadataRecovery);
 
             if (_constraintFailBlobs.Contains(blobId))
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAuditEventManagerStagingTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAuditEventManagerStagingTests.cs
@@ -217,21 +217,12 @@ namespace Tests.UnitTests
             //
             // The consequence of losing those Clear() calls differs per table, and is worse than mere
             // repeated work for two of the three:
-            //   * chat-only - the root copilot_chats row is de-duplicated by the merge, so the usual
-            //     cost is an unboundedly growing batch on the hot path. It is NOT purely cost, though:
-            //     common_upsert_copilot_agents.sql deliberately does not de-duplicate messages that
-            //     have no Id (ISNULL(pm.message_id, NEWID()) plus "WHERE pm.message_id IS NULL"), so a
-            //     retained chat-only row carrying such a message inserts a fresh copilot_event_messages
-            //     row on every commit. Cost-only holds only when the event has no messages, or every
-            //     message has a stable Id;
-            //   * SharePoint and Teams - insert_sp_copilot_events_from_staging_table.sql and
-            //     insert_teams_copilot_events_from_staging_table.sql insert into copilot_event_files /
-            //     copilot_event_meetings with NO NOT EXISTS guard, and both inherit [Key] on
-            //     copilot_chat_id from BaseCopilotSpecificEvent - so a retained row THAT SUCCESSFULLY
-            //     INSERTED its metadata can make the NEXT commit fail on a duplicate primary key.
-            //     (Both managers deliberately stage rows even when Graph resolution returns null; those
-            //     rows fail the workload scripts' inner joins against the lookup tables, so they never
-            //     inserted a metadata row and have no key to collide with.)
+            //   * chat-only - the root chat and its messages are de-duplicated by the merge (messages
+            //     without an Id get a deterministic fallback), so the remaining cost is an unboundedly
+            //     growing staging batch on the hot path;
+            //   * SharePoint and Teams - the workload merges de-duplicate on copilot_chat_id, so retained
+            //     rows do not create a second file/meeting record. They still make every later staging load
+            //     and lookup larger, so clearing remains a load-bearing performance contract.
             //
             // A guard needs a real database: under the current hard-wired InsertBatch design, staging is
             // only List.Add, but committing a non-empty batch opens a connection. It must cover all

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotEventManagerEdgeCaseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotEventManagerEdgeCaseTests.cs
@@ -4,9 +4,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Linq;
 using System.Threading.Tasks;
 using UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot.CostEstimate;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 
 namespace Tests.UnitTests
@@ -308,6 +310,109 @@ namespace Tests.UnitTests
                 // Still exactly one copilot_chats row
                 var chatCount = await db.CopilotChats.CountAsync(c => c.AuditEvent.Id == commonEvent.Id);
                 Assert.AreEqual(1, chatCount, "Duplicate event_id across batches should produce exactly one copilot_chats row.");
+            }
+        }
+
+        [TestMethod]
+        public async Task CopilotEventManager_FileAndMeetingMetadata_AreIdempotentAcrossRetries()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                await ClearEvents(db);
+
+                var suffix = Guid.NewGuid().ToString("N");
+                var user = new User
+                {
+                    AzureAdId = "retry-user-" + suffix,
+                    UserPrincipalName = "retry.user." + suffix + "@contoso.onmicrosoft.com"
+                };
+                var fileEvent = new CommonAuditEvent
+                {
+                    TimeStamp = DateTime.UtcNow,
+                    Operation = new EventOperation { Name = "Copilot file retry " + suffix },
+                    User = user,
+                    Id = Guid.NewGuid()
+                };
+                var meetingEvent = new CommonAuditEvent
+                {
+                    TimeStamp = DateTime.UtcNow,
+                    Operation = new EventOperation { Name = "Copilot meeting retry " + suffix },
+                    User = user,
+                    Id = Guid.NewGuid()
+                };
+
+                db.AuditEventsCommon.AddRange(new[] { fileEvent, meetingEvent });
+                await db.SaveChangesAsync();
+
+                var fileContent = new CopilotAuditLogContent
+                {
+                    CopilotEventData = new CopilotEventData
+                    {
+                        AppHost = "Word",
+                        Contexts = new List<Context>
+                        {
+                            new Context
+                            {
+                                Id = _config.TestCopilotDocContextIdSpSite,
+                                Type = _config.TeamSiteFileExtension
+                            }
+                        }
+                    },
+                    ParsedAuditEvent = new CopilotAuditEvent
+                    {
+                        Messages = new List<Message>
+                        {
+                            new Message { Id = null, IsPrompt = true, Size = 111 }
+                        }
+                    }
+                };
+                var meetingContent = new CopilotAuditLogContent
+                {
+                    CopilotEventData = new CopilotEventData
+                    {
+                        AppHost = "Teams",
+                        Contexts = new List<Context>
+                        {
+                            new Context
+                            {
+                                Id = "https://microsoft.teams.com/threads/19:meeting_retry_" + suffix + "@thread.v2",
+                                Type = ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING
+                            }
+                        }
+                    },
+                    ParsedAuditEvent = new CopilotAuditEvent
+                    {
+                        Messages = new List<Message>
+                        {
+                            new Message { Id = null, IsPrompt = false, Size = 222 }
+                        }
+                    }
+                };
+
+                for (int attempt = 0; attempt < 2; attempt++)
+                {
+                    var manager = new CopilotAuditEventManager(
+                        _config.ConnectionStrings.DatabaseConnectionString,
+                        new FakeCopilotMetadataLoader(),
+                        _logger);
+                    await manager.SaveSingleCopilotEventToSqlStaging(fileContent, fileEvent);
+                    await manager.SaveSingleCopilotEventToSqlStaging(meetingContent, meetingEvent);
+                    await manager.CommitAllChanges();
+                }
+
+                Assert.AreEqual(1,
+                    await db.CopilotEventMetadataFiles.CountAsync(f => f.ChatId == fileEvent.Id),
+                    "Retrying metadata must not duplicate the one resolved file row for an interaction.");
+                Assert.AreEqual(1,
+                    await db.CopilotEventMetadataMeetings.CountAsync(m => m.ChatId == meetingEvent.Id),
+                    "Retrying metadata must not duplicate the one resolved meeting row for an interaction.");
+                var messages = await db.CopilotMessages
+                    .Where(m => m.ChatId == fileEvent.Id || m.ChatId == meetingEvent.Id)
+                    .ToListAsync();
+                Assert.AreEqual(2, messages.Count,
+                    "Retrying metadata must not duplicate messages whose source payload omitted an Id.");
+                Assert.IsTrue(messages.All(m => m.MessageId.StartsWith("missing:", StringComparison.Ordinal)),
+                    "Missing message IDs need a deterministic retry key rather than a fresh GUID per attempt.");
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityImporter.cs
@@ -19,6 +19,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
     {
         private readonly int _maxSavesPerBatch;
         private readonly IProcessedBlobStore _processedBlobStore;
+        private readonly IActivityMetadataRecoveryStore _metadataRecoveryStore;
         private readonly int _maxConcurrentSaves;
         private int _reportSummariesTotal = 0;
         private int _reportSummariesProcessed = 0;
@@ -28,6 +29,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
         {
             _maxSavesPerBatch = maxSavesPerBatch;
             _processedBlobStore = processedBlobStore;
+            _metadataRecoveryStore = processedBlobStore as IActivityMetadataRecoveryStore;
             _maxConcurrentSaves = Math.Max(1, maxConcurrentSaves);
         }
 
@@ -80,6 +82,9 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
             // best-effort OPTIMISATION: a store failure must never fail the import - we just process every
             // blob this cycle (and marking is likewise best-effort in BlobCommitTracker).
             BlobCommitTracker blobTracker = null;
+            bool checkpointStateKnown = false;
+            ISet<string> metadataRecoveryBlobIds = new HashSet<string>();
+            List<string> selectedBlobIds = new List<string>();
             if (_processedBlobStore != null)
             {
                 int beforeFilter = allSummaries.Count;
@@ -87,10 +92,18 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 try
                 {
                     alreadyProcessed = await _processedBlobStore.GetProcessedBlobIdsAsync();
+                    checkpointStateKnown = alreadyProcessed != null;
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning($"Audit events import: blob checkpoint read failed ({ex.Message}); processing all content blobs this cycle.");
+                    if (_metadataRecoveryStore != null)
+                    {
+                        throw new InvalidOperationException(
+                            "Audit events import: blob checkpoint state could not be read; aborting before any database save so a partially committed blob cannot be mistaken for complete.",
+                            ex);
+                    }
+                    _logger.LogWarning($"Audit events import: blob checkpoint read failed ({ex.Message}); processing all content blobs, " +
+                        "but checkpoint writes are disabled this cycle because this custom store has no two-phase recovery capability.");
                 }
                 if (alreadyProcessed != null && alreadyProcessed.Count > 0)
                 {
@@ -100,7 +113,42 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 }
                 allStats.BlobsSkipped = beforeFilter - allSummaries.Count;
                 _logger.LogInformation($"Audit events import: blob checkpoint skipped {allStats.BlobsSkipped.ToString("n0")} of {beforeFilter.ToString("n0")} content blobs already committed in a previous cycle.");
-                blobTracker = new BlobCommitTracker(_processedBlobStore, _logger);
+
+                if (_metadataRecoveryStore != null)
+                {
+                    try
+                    {
+                        metadataRecoveryBlobIds =
+                            await _metadataRecoveryStore.GetMetadataRecoveryPendingBlobIdsAsync()
+                            ?? new HashSet<string>();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidOperationException(
+                            "Audit events import: metadata-recovery checkpoint state could not be read; aborting before any database save.",
+                            ex);
+                    }
+
+                    selectedBlobIds = allSummaries
+                        .Select(s => s.BlobId)
+                        .Where(id => !string.IsNullOrEmpty(id))
+                        .Distinct()
+                        .ToList();
+                    try
+                    {
+                        await _metadataRecoveryStore.MarkMetadataRecoveryPendingAsync(selectedBlobIds);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidOperationException(
+                            "Audit events import: content blobs could not be marked recovery-pending; aborting before any database save.",
+                            ex);
+                    }
+                }
+
+                blobTracker = new BlobCommitTracker(
+                    _processedBlobStore, _logger, _metadataRecoveryStore,
+                    selectedBlobIds, checkpointStateKnown);
             }
 
             // Remember total so we can report on progress when threads finish loading a chunk
@@ -114,12 +162,22 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
             {
                 try
                 {
+                    var saveSet = new WebActivityReportSet(reportChunk)
+                    {
+                        MetadataRecoveryBlobIds = checkpointStateKnown
+                            ? new HashSet<string>(
+                            reportChunk
+                                .Select(e => e.SourceContentId)
+                                .Where(id => !string.IsNullOrEmpty(id) && metadataRecoveryBlobIds.Contains(id)))
+                            : new HashSet<string>()
+                    };
+
                     // Retry transient SQL faults (a dropped/unrecoverable connection, timeout, deadlock, Azure
                     // SQL throttling/failover) so a momentary blip doesn't discard the batch and abort the
                     // cycle. CommitAll is safe to re-run: the merge SQL is idempotent (NOT EXISTS guards) and
                     // the metadata pass uses get-or-create lookups, and each attempt opens fresh connections.
                     var stats = await TransientSqlRetry.ExecuteWithRetryAsync(
-                        () => activityReportPersistenceManager.CommitAll(new WebActivityReportSet(reportChunk)),
+                        () => activityReportPersistenceManager.CommitAll(saveSet),
                         BatchSaveMaxAttempts, _logger, "Audit events import: batch save", BatchSaveRetryBaseDelay);
 
                     lock (allStats)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSet.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSet.cs
@@ -29,6 +29,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
         /// </summary>
         public bool DownloadComplete { get; set; } = true;
 
+        /// <summary>
+        /// Content blobs known not to have a completed checkpoint because the checkpoint store was read
+        /// successfully and did not contain them. Their existing audit rows may be staged again to drive
+        /// idempotent workload metadata after an earlier partial save.
+        /// </summary>
+        internal ISet<string> MetadataRecoveryBlobIds { get; set; } = new HashSet<string>();
+
+        internal bool RequiresMetadataRecovery(AbstractAuditLogContent auditEvent)
+        {
+            return auditEvent != null
+                && !string.IsNullOrEmpty(auditEvent.SourceContentId)
+                && MetadataRecoveryBlobIds.Contains(auditEvent.SourceContentId);
+        }
+
         #region Props
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -42,6 +42,7 @@ namespace WebJob.Office365ActivityImporter.Engine
         private readonly CopilotMetadataPrewarmer _copilotPrewarmer;
         private readonly ISaveSessionFactory _saveSessionFactory;
         private readonly ActivityStagingPass _stagingPass;
+        private readonly ActivitySaveRetryState _retryState = new ActivitySaveRetryState();
 
         /// <summary>
         /// Process-wide gate that serializes writes to the staging tables. Intentionally <c>static</c> so that
@@ -242,29 +243,45 @@ namespace WebJob.Office365ActivityImporter.Engine
             // ActivityStagingPass, which reaches SQL only through IActivityStagingBatch, so the batch's
             // counters, log lines and merge wiring can be asserted without a database (issue #373).
             var stagingBatch = _stagingWriter.CreateBatch(db);
-            var staged = await _stagingPass.RunAsync(activities, cache, stagingBatch, stagingTableName, mergeLock);
+            var staged = await _stagingPass.RunAsync(
+                activities, cache, stagingBatch, stagingTableName, mergeLock, _retryState);
             var stats = staged.Stats;
 
-            #region Add Extra Metadata
-
-            // The metadata pass writes SHARED tables (webs/sites via ProcessExtendedProperties, plus the
-            // Copilot / Power Platform commits), so in concurrent mode it is serialised by the same lock.
-            var swMeta = System.Diagnostics.Stopwatch.StartNew();
-            if (mergeLock != null) await mergeLock.WaitAsync();
             try
             {
-                await SaveMetadataAsync(db, staged.SavedToSql, sharedCopilotLoader, stats);
+                #region Add Extra Metadata
+
+                // The metadata pass writes SHARED tables (webs/sites via ProcessExtendedProperties, plus the
+                // Copilot / Power Platform commits), so in concurrent mode it is serialised by the same lock.
+                var swMeta = System.Diagnostics.Stopwatch.StartNew();
+                if (mergeLock != null) await mergeLock.WaitAsync();
+                try
+                {
+                    await SaveMetadataAsync(db, staged.SavedToSql, sharedCopilotLoader, stats);
+                }
+                finally
+                {
+                    if (mergeLock != null) mergeLock.Release();
+                }
+                swMeta.Stop();
+                stats.SaveMetadataMs = swMeta.Elapsed.TotalMilliseconds;
+                _retryState.MarkSucceeded(staged.SavedToSql);
+
+                #endregion
+
+                return stats;
             }
-            finally
+            catch
             {
-                if (mergeLock != null) mergeLock.Release();
+                _retryState.MarkForRetry(staged.SavedToSql);
+                var released = cache.ForgetProcessedEvents(staged.SavedToSql);
+                if (released > 0)
+                {
+                    _logger.LogWarning($"Audit events import: metadata save failed after staging/merge for {released.ToString("n0")} event(s); " +
+                        "released their in-memory dedup markers so a retry can run the metadata phase again.");
+                }
+                throw;
             }
-            swMeta.Stop();
-            stats.SaveMetadataMs = swMeta.Elapsed.TotalMilliseconds;
-
-            #endregion
-
-            return stats;
         }
 
         /// <summary>
@@ -430,4 +447,3 @@ namespace WebJob.Office365ActivityImporter.Engine
         public string WebUrl { get; set; }
     }
 }
-

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/AzureTableProcessedBlobStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/AzureTableProcessedBlobStore.cs
@@ -1,3 +1,4 @@
+using Azure;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
 using System;
@@ -16,9 +17,10 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
     /// RowKey and the original id kept in a property. Entries older than the retention window are purged on
     /// read to keep the table bounded (a blob that old can never be re-listed by the API).
     /// </summary>
-    public class AzureTableProcessedBlobStore : IProcessedBlobStore
+    public class AzureTableProcessedBlobStore : IProcessedBlobStore, IActivityMetadataRecoveryStore
     {
-        private const string PartitionKeyValue = "auditblob";
+        private const string ProcessedPartitionKey = "auditblob";
+        private const string MetadataRecoveryPartitionKey = "auditblob-metadata-recovery";
         private const string BlobIdProperty = "BlobId";
         private const string DefaultTableName = "AuditImporterProcessedBlobs";
         private const int MaxTransaction = 100; // Azure Table batch limit (single partition).
@@ -51,13 +53,42 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
         }
 
         public async Task<ISet<string>> GetProcessedBlobIdsAsync()
+            => await GetBlobIdsAsync(ProcessedPartitionKey);
+
+        public async Task MarkProcessedAsync(IReadOnlyCollection<string> blobIds)
+            => await MarkAsync(ProcessedPartitionKey, blobIds);
+
+        public async Task<ISet<string>> GetMetadataRecoveryPendingBlobIdsAsync()
+            => await GetBlobIdsAsync(MetadataRecoveryPartitionKey);
+
+        public async Task MarkMetadataRecoveryPendingAsync(IReadOnlyCollection<string> blobIds)
+            => await MarkAsync(MetadataRecoveryPartitionKey, blobIds);
+
+        public async Task ClearMetadataRecoveryPendingAsync(IReadOnlyCollection<string> blobIds)
+        {
+            if (blobIds == null || blobIds.Count == 0) return;
+
+            var entities = blobIds
+                .Where(id => !string.IsNullOrEmpty(id))
+                .Distinct()
+                .Select(id => new TableEntity(MetadataRecoveryPartitionKey, RowKeyFor(id)) { ETag = ETag.All })
+                .ToList();
+
+            foreach (var chunk in Chunk(entities, MaxTransaction))
+            {
+                var actions = chunk.Select(e => new TableTransactionAction(TableTransactionActionType.Delete, e));
+                await _table.SubmitTransactionAsync(actions);
+            }
+        }
+
+        private async Task<ISet<string>> GetBlobIdsAsync(string partitionKey)
         {
             var cutoff = DateTimeOffset.UtcNow - _retention;
             var result = new HashSet<string>();
             var expired = new List<TableEntity>();
 
             // Single-partition scan; Timestamp is a system property maintained by the service.
-            foreach (var e in _table.Query<TableEntity>(x => x.PartitionKey == PartitionKeyValue))
+            foreach (var e in _table.Query<TableEntity>(x => x.PartitionKey == partitionKey))
             {
                 var blobId = e.GetString(BlobIdProperty);
                 if (string.IsNullOrEmpty(blobId)) continue;
@@ -69,14 +100,14 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
             return result;
         }
 
-        public async Task MarkProcessedAsync(IReadOnlyCollection<string> blobIds)
+        private async Task MarkAsync(string partitionKey, IReadOnlyCollection<string> blobIds)
         {
             if (blobIds == null || blobIds.Count == 0) return;
 
             var entities = blobIds
                 .Where(id => !string.IsNullOrEmpty(id))
                 .Distinct()
-                .Select(id => new TableEntity(PartitionKeyValue, RowKeyFor(id)) { { BlobIdProperty, id } })
+                .Select(id => new TableEntity(partitionKey, RowKeyFor(id)) { { BlobIdProperty, id } })
                 .ToList();
 
             foreach (var chunk in Chunk(entities, MaxTransaction))

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/BlobCommitTracker.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/BlobCommitTracker.cs
@@ -20,14 +20,37 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
     public class BlobCommitTracker
     {
         private readonly IProcessedBlobStore _store;
+        private readonly IActivityMetadataRecoveryStore _metadataRecoveryStore;
         private readonly ILogger _logger;
         private readonly ConcurrentDictionary<string, int> _remaining = new ConcurrentDictionary<string, int>();
+        private readonly ConcurrentDictionary<string, byte> _metadataRecoveryPending;
+        private readonly bool _markProcessed;
         private long _markedDone;
 
         public BlobCommitTracker(IProcessedBlobStore store, ILogger logger)
+            : this(store, logger, markProcessed: true)
+        {
+        }
+
+        internal BlobCommitTracker(IProcessedBlobStore store, ILogger logger, bool markProcessed)
+            : this(store, logger, store as IActivityMetadataRecoveryStore, null, markProcessed)
+        {
+        }
+
+        internal BlobCommitTracker(IProcessedBlobStore store, ILogger logger,
+            IActivityMetadataRecoveryStore metadataRecoveryStore,
+            IEnumerable<string> metadataRecoveryPending,
+            bool markProcessed)
         {
             _store = store;
+            _metadataRecoveryStore = metadataRecoveryStore;
             _logger = logger;
+            _metadataRecoveryPending = new ConcurrentDictionary<string, byte>(
+                (metadataRecoveryPending ?? Enumerable.Empty<string>())
+                    .Where(id => !string.IsNullOrEmpty(id))
+                    .Distinct()
+                    .Select(id => new KeyValuePair<string, byte>(id, 0)));
+            _markProcessed = markProcessed;
         }
 
         public long MarkedDone => Interlocked.Read(ref _markedDone);
@@ -72,6 +95,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
 
         private async Task MarkAsync(IReadOnlyCollection<string> blobIds)
         {
+            if (!_markProcessed) return;
+
             // Best-effort: a checkpoint write failure must not fail the import. If we fail to record a blob,
             // it is simply re-processed next cycle (its events dedup against audit_events), which is safe.
             try
@@ -82,6 +107,22 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, $"Blob checkpoint: failed to record {blobIds.Count} processed blob(s); they will be re-processed next cycle.");
+                return;
+            }
+
+            var recovered = blobIds.Where(id => _metadataRecoveryPending.TryRemove(id, out _)).ToList();
+            if (recovered.Count == 0 || _metadataRecoveryStore == null) return;
+
+            try
+            {
+                await _metadataRecoveryStore.ClearMetadataRecoveryPendingAsync(recovered);
+            }
+            catch (Exception ex)
+            {
+                // The processed marker is already durable, so a stale pending marker is harmless: the
+                // processed id filters the blob before the recovery marker is consulted next cycle.
+                _logger?.LogWarning(ex,
+                    $"Blob checkpoint: failed to clear {recovered.Count} metadata-recovery marker(s) after recording the blobs as processed; stale markers are harmless.");
             }
         }
     }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/IProcessedBlobStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/IProcessedBlobStore.cs
@@ -28,4 +28,18 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
         /// </summary>
         Task MarkProcessedAsync(IReadOnlyCollection<string> blobIds);
     }
+
+    /// <summary>
+    /// Optional two-phase companion for <see cref="IProcessedBlobStore"/>. A blob is marked recovery-pending
+    /// before any of its events can be partially committed, then cleared only after its processed marker is
+    /// durable. Kept separate so existing custom checkpoint implementations remain source-compatible.
+    /// </summary>
+    public interface IActivityMetadataRecoveryStore
+    {
+        Task<ISet<string>> GetMetadataRecoveryPendingBlobIdsAsync();
+
+        Task MarkMetadataRecoveryPendingAsync(IReadOnlyCollection<string> blobIds);
+
+        Task ClearMetadataRecoveryPendingAsync(IReadOnlyCollection<string> blobIds);
+    }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/ProcessedBlobStoreFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/BlobCheckpoint/ProcessedBlobStoreFactory.cs
@@ -44,7 +44,8 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
                     for (var inner = ex.InnerException; inner != null; inner = inner.InnerException)
                         detail += " -> " + inner.Message;
                     logger?.LogError(ex, $"Blob checkpoint: could not initialise the Azure Table store ({ex.GetType().Name}: {detail}); " +
-                        "falling back to in-memory (dedupes across cycles but only for the life of this process - lost on restart/redeploy). " +
+                        "falling back to in-memory (dedupes across cycles but only for the life of this process - lost on restart/redeploy; " +
+                        "durable cross-cycle metadata recovery is unavailable in this degraded mode). " +
                         "Check the Storage connection string is valid and the account's Table service is reachable: storage firewall / " +
                         "private endpoint / selected-networks not blocking the importer. If the account has shared-key access disabled " +
                         "(allowSharedKeyAccess = false, giving '403 KeyBasedAuthenticationNotPermitted'), the importer authenticates with the " +
@@ -52,14 +53,16 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.BlobCheckpoint
                         "account ('Storage Blob Data Contributor' does NOT cover the Table service).");
                     // Surface the degraded (non-durable) checkpoint on the Health page instead of only in the log.
                     (logger as AnalyticsLogger)?.TrackHealthCheck(HealthComponent.BlobCheckpoint, HealthStatus.Degraded,
-                        $"Azure Table init failed ({ex.GetType().Name}); using non-durable in-memory checkpoint (lost on restart). See importer error log.");
+                        $"Azure Table init failed ({ex.GetType().Name}); using non-durable in-memory checkpoint " +
+                        "(lost on restart; durable cross-cycle metadata recovery unavailable). See importer error log.");
                 }
             }
             else
             {
                 logger?.LogInformation("Blob checkpoint: no storage connection string configured; using an in-memory store (persists across cycles only while this process runs).");
                 (logger as AnalyticsLogger)?.TrackHealthCheck(HealthComponent.BlobCheckpoint, HealthStatus.Degraded,
-                    "No Storage connection string configured; using non-durable in-memory checkpoint (lost on restart).");
+                    "No Storage connection string configured; using non-durable in-memory checkpoint " +
+                    "(lost on restart; durable cross-cycle metadata recovery unavailable).");
             }
 
             return new InMemoryProcessedBlobStore(retention);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SQL/common_upsert_copilot_agents.sql
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SQL/common_upsert_copilot_agents.sql
@@ -448,11 +448,13 @@ BEGIN
 -- isPrompt arrives as the JSON literal 'true'/'false', which CONVERT(bit, ...) cannot parse, hence the
 -- explicit CASE; Size is Edm.Int64 so TRY_CONVERT protects against a non-numeric value.
 --
--- De-duplicated on (chat, message id), which this insert previously was NOT. One interaction can be
+-- De-duplicated on (chat, persisted message id), which this insert previously was NOT. One interaction can be
 -- staged into TWO staging tables - a Teams chat context stages a chat-only row and a following file
 -- context stages a SharePoint row - and each staging table runs this merge, so its messages were
 -- inserted twice. The NOT EXISTS seeks the chat's handful of existing rows via IX_copilot_chat_id.
--- Messages with no Id keep the previous behaviour (a generated GUID, and therefore no de-dup).
+-- Messages with no Id use a deterministic fallback from the event id + prompt/response flag + size.
+-- parsed_messages is already DISTINCT on exactly that tuple, so this preserves the one-attempt row set
+-- while making a retry of the same audit event idempotent.
 ;WITH parsed_messages AS (
     SELECT DISTINCT
         imports.event_id,
@@ -462,21 +464,33 @@ BEGIN
     FROM [${STAGING_TABLE_ACTIVITY}] imports
     CROSS APPLY OPENJSON(imports.messages_json) msg
     WHERE imports.messages_json IS NOT NULL
+),
+resolved_messages AS (
+    SELECT
+        pm.event_id,
+        COALESCE(
+            pm.message_id,
+            N'missing:' + CONVERT(nvarchar(36), pm.event_id)
+                + N':' + COALESCE(CONVERT(nvarchar(1), pm.is_prompt), N'u')
+                + N':' + COALESCE(CONVERT(nvarchar(20), pm.[size]), N'u')
+        ) AS persisted_message_id,
+        pm.[size],
+        pm.is_prompt
+    FROM parsed_messages pm
 )
 INSERT INTO copilot_event_messages (copilot_chat_id, message_id, [size], is_prompt)
 SELECT
-    pm.event_id,
-    ISNULL(pm.message_id, NEWID()), -- Generate GUID if no ID provided
-    pm.[size],
-    pm.is_prompt
-FROM parsed_messages pm
-WHERE pm.message_id IS NULL
-   OR NOT EXISTS (
-        SELECT 1
-        FROM copilot_event_messages x
-        WHERE x.copilot_chat_id = pm.event_id
-          AND x.message_id = pm.message_id
-    );
+    rm.event_id,
+    rm.persisted_message_id,
+    rm.[size],
+    rm.is_prompt
+FROM resolved_messages rm
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM copilot_event_messages x
+    WHERE x.copilot_chat_id = rm.event_id
+      AND x.message_id = rm.persisted_message_id
+);
 
 END
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SQL/insert_sp_copilot_events_from_staging_table.sql
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SQL/insert_sp_copilot_events_from_staging_table.sql
@@ -42,3 +42,8 @@ insert into [copilot_event_files] (copilot_chat_id, file_name_id, file_extension
 	  inner join event_file_ext on event_file_ext.extension_name = imports.file_extension
 	  inner join urls on urls.full_url = imports.url
 	  inner join sites on sites.url_base = imports.url_base
+	  where not exists (
+		select 1
+		from copilot_event_files existing
+		where existing.copilot_chat_id = imports.event_id
+	  )

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SQL/insert_teams_copilot_events_from_staging_table.sql
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/SQL/insert_teams_copilot_events_from_staging_table.sql
@@ -20,3 +20,8 @@ insert into copilot_event_meetings (copilot_chat_id, meeting_id)
 		and online_meetings.name = imports.meeting_name
 		and online_meetings.created = CAST(imports.meeting_created_utc AS datetime)		
 	left join copilot_agents on copilot_agents.[agent_id] = imports.[agent_id]
+	where not exists (
+		select 1
+		from copilot_event_meetings existing
+		where existing.copilot_chat_id = imports.event_id
+	)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
@@ -13,6 +13,35 @@ using WebJob.Office365ActivityImporter.Engine.Properties;
 namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
 {
     /// <summary>
+    /// IDs staged by an earlier failed attempt. The next attempt must stage those IDs even if a fresh
+    /// per-batch cache can already see an audit row committed before the failure; otherwise the retry
+    /// skips the metadata phase and can falsely report success.
+    /// </summary>
+    internal sealed class ActivitySaveRetryState
+    {
+        private readonly ConcurrentDictionary<Guid, byte> _eventIds =
+            new ConcurrentDictionary<Guid, byte>();
+
+        public bool ShouldRetry(Guid eventId) => _eventIds.ContainsKey(eventId);
+
+        public void MarkForRetry(IEnumerable<AbstractAuditLogContent> events)
+        {
+            foreach (var auditEvent in events)
+            {
+                if (auditEvent != null) _eventIds[auditEvent.Id] = 0;
+            }
+        }
+
+        public void MarkSucceeded(IEnumerable<AbstractAuditLogContent> events)
+        {
+            foreach (var auditEvent in events)
+            {
+                if (auditEvent != null) _eventIds.TryRemove(auditEvent.Id, out _);
+            }
+        }
+    }
+
+    /// <summary>
     /// What one staging pass produced: the statistics for the batch and the events it handed to the
     /// staging batch, which the metadata pass then tries to match against the rows present in
     /// <c>audit_events</c> after the merge.
@@ -97,6 +126,13 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
         public async Task<ActivityStagingPassResult> RunAsync(ActivityReportSet activities, ActivityImportCache cache,
             IActivityStagingBatch batch, string stagingTableName, SemaphoreSlim mergeLock)
         {
+            return await RunAsync(activities, cache, batch, stagingTableName, mergeLock, retryState: null);
+        }
+
+        internal async Task<ActivityStagingPassResult> RunAsync(ActivityReportSet activities, ActivityImportCache cache,
+            IActivityStagingBatch batch, string stagingTableName, SemaphoreSlim mergeLock,
+            ActivitySaveRetryState retryState)
+        {
             var listOfActivitiesSavedToSQL = new ConcurrentBag<AbstractAuditLogContent>();
             // Sequential dedup within this set: a HashSet gives O(1) Contains. The previous
             // ConcurrentBag.Contains was O(n) per row (an O(n^2) scan over a large activity set).
@@ -116,52 +152,70 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
             Func<string, Task<bool>> userInGroupsFilter = upn => _userGroupsCache.IsInGroupsFilter(upn, _userGroupsFilter);
             Action<AbstractAuditLogContent> stageRow = log => batch.AddRow(new AuditLogTempEntity(log, log.UserId));
 
-            foreach (var abtractLog in activities)
+            try
             {
-                // Don't insert duplicates in same set. The decision itself (dedup -> URL scope -> user
-                // scope, plus what gets remembered where) lives in ActivityStagingRules so it can be
-                // asserted with no SQL and no Graph; see issue #373.
-                var decision = await ActivityStagingRules.DecideAndRememberAsync(
-                    abtractLog, processedIds, cache, urlInScope, userInGroupsFilter, stageRow);
-
-                if (!decision.IsDuplicate)
+                foreach (var abtractLog in activities)
                 {
-                    var result = decision.Result;
-                    if (result == SaveResultEnum.UserOutOfScope)
-                    {
-                        _logger.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
-                    }
+                    // Don't insert duplicates in same set. The decision itself (dedup -> URL scope -> user
+                    // scope, plus what gets remembered where) lives in ActivityStagingRules so it can be
+                    // asserted with no SQL and no Graph; see issue #373.
+                    var recoverMetadata = activities.RequiresMetadataRecovery(abtractLog)
+                        && cache.HaveSeenInProcessedOrIgnoredEvents(abtractLog)
+                        && !cache.WasRememberedThisCycle(abtractLog);
+                    var decision = await ActivityStagingRules.DecideAndRememberAsync(
+                        abtractLog, processedIds, cache, urlInScope, userInGroupsFilter, stageRow,
+                        retryState?.ShouldRetry(abtractLog.Id) == true || recoverMetadata);
 
-                    // Update stats
-                    if (result == SaveResultEnum.Imported)
+                    if (!decision.IsDuplicate)
                     {
-                        stats.Imported++;
-                        listOfActivitiesSavedToSQL.Add(abtractLog);
+                        var result = decision.Result;
+                        if (result == SaveResultEnum.UserOutOfScope)
+                        {
+                            _logger.LogInformation($"Skipping activity report for user '{abtractLog.UserId}' - not in user groups filter");
+                        }
+
+                        // Update stats
+                        if (result == SaveResultEnum.Imported)
+                        {
+                            stats.Imported++;
+                            listOfActivitiesSavedToSQL.Add(abtractLog);
+                        }
+                        else if (result == SaveResultEnum.ProcessedAlready) stats.ProcessedAlready++;
+                        else if (result == SaveResultEnum.UrlOutOfScope) stats.URLsOutOfScope++;
+                        else if (result == SaveResultEnum.UserOutOfScope) stats.UsersOutOfScope++;
+                        else _logger.LogError($"Unexpected log result for log {abtractLog.Id}");
                     }
-                    else if (result == SaveResultEnum.ProcessedAlready) stats.ProcessedAlready++;
-                    else if (result == SaveResultEnum.UrlOutOfScope) stats.URLsOutOfScope++;
-                    else if (result == SaveResultEnum.UserOutOfScope) stats.UsersOutOfScope++;
-                    else _logger.LogError($"Unexpected log result for log {abtractLog.Id}");
                 }
-            }
-            swDedup.Stop();
-            stats.SaveDedupMs = swDedup.Elapsed.TotalMilliseconds;
+                swDedup.Stop();
+                stats.SaveDedupMs = swDedup.Elapsed.TotalMilliseconds;
 
-            // Merge data
+                // Merge data
 #if DEBUG
-            Console.WriteLine("\nDEBUG: Merging activity staging table...");
+                Console.WriteLine("\nDEBUG: Merging activity staging table...");
 #endif
-            // Merge to normal tables. In concurrent mode each save has its own sharded staging table
-            // (stagingTableName) and mergeLock serialises ONLY the merge (which writes shared lookup/fact
-            // tables); the parallel staging LOAD inside the batch runs unlocked.
-            var effectiveStagingTable = ActivitySaveConcurrencyPolicy.EffectiveStagingTableName(stagingTableName);
-            var mergeSQL = Resources.Insert_Activity_from_Staging_Table.Replace("${STAGING_TABLE_ACTIVITY}", effectiveStagingTable);
-            var swMerge = System.Diagnostics.Stopwatch.StartNew();
-            await batch.LoadAndMergeAsync(StagingInsertsPerThread, mergeSQL, stagingTableName, mergeLock);
-            swMerge.Stop();
-            stats.SaveMergeMs = swMerge.Elapsed.TotalMilliseconds;
+                // Merge to normal tables. In concurrent mode each save has its own sharded staging table
+                // (stagingTableName) and mergeLock serialises ONLY the merge (which writes shared lookup/fact
+                // tables); the parallel staging LOAD inside the batch runs unlocked.
+                var effectiveStagingTable = ActivitySaveConcurrencyPolicy.EffectiveStagingTableName(stagingTableName);
+                var mergeSQL = Resources.Insert_Activity_from_Staging_Table.Replace("${STAGING_TABLE_ACTIVITY}", effectiveStagingTable);
+                var swMerge = System.Diagnostics.Stopwatch.StartNew();
+                await batch.LoadAndMergeAsync(StagingInsertsPerThread, mergeSQL, stagingTableName, mergeLock);
+                swMerge.Stop();
+                stats.SaveMergeMs = swMerge.Elapsed.TotalMilliseconds;
 
-            return new ActivityStagingPassResult(stats, listOfActivitiesSavedToSQL);
+                return new ActivityStagingPassResult(stats, listOfActivitiesSavedToSQL);
+            }
+            catch
+            {
+                retryState?.MarkForRetry(listOfActivitiesSavedToSQL);
+                var released = cache.ForgetProcessedEvents(listOfActivitiesSavedToSQL);
+                if (released > 0)
+                {
+                    _logger.LogWarning($"Audit events import: save attempt failed after staging {released.ToString("n0")} event(s); " +
+                        "released their in-memory dedup markers so a retry can stage them again.");
+                }
+                throw;
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivityStagingRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/ActivityStagingRules.cs
@@ -105,11 +105,34 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules
             Func<string, Task<bool>> userInGroupsFilter,
             Action<AbstractAuditLogContent> stageRow)
         {
+            return await DecideAndRememberAsync(
+                log, decidedInThisSet, cache, urlInScope, userInGroupsFilter, stageRow,
+                ignoreProcessedCache: false);
+        }
+
+        /// <summary>
+        /// Recovery-aware form used after an earlier attempt or cycle staged this event but failed before
+        /// the whole save completed. The in-set guard still applies; only the processed cache is bypassed
+        /// so an audit row committed by the earlier attempt can drive its metadata phase again.
+        /// </summary>
+        internal static async Task<ActivityStagingDecision> DecideAndRememberAsync(
+            AbstractAuditLogContent log,
+            HashSet<Guid> decidedInThisSet,
+            ActivityImportCache cache,
+            Func<AbstractAuditLogContent, bool> urlInScope,
+            Func<string, Task<bool>> userInGroupsFilter,
+            Action<AbstractAuditLogContent> stageRow,
+            bool ignoreProcessedCache)
+        {
             if (urlInScope == null) throw new ArgumentNullException(nameof(urlInScope));
             if (userInGroupsFilter == null) throw new ArgumentNullException(nameof(userInGroupsFilter));
             if (stageRow == null) throw new ArgumentNullException(nameof(stageRow));
+            if (log == null) throw new ArgumentNullException(nameof(log));
+            if (decidedInThisSet == null) throw new ArgumentNullException(nameof(decidedInThisSet));
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
 
-            if (IsAlreadyProcessed(log, decidedInThisSet, cache))
+            if (decidedInThisSet.Contains(log.Id)
+                || (!ignoreProcessedCache && cache.HaveSeenInProcessedOrIgnoredEvents(log)))
             {
                 return ActivityStagingDecision.Duplicate;
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
@@ -26,6 +26,7 @@ namespace WebJob.Office365ActivityImporter.Engine
         {
             ProcessedIDs = new Dictionary<int, Dictionary<Guid, DateTime>>();
             NewlyIgnoredIDs = new Dictionary<int, Dictionary<Guid, DateTime>>();
+            CurrentCycleProcessedIDs = new Dictionary<int, HashSet<Guid>>();
             AnonymisedUserNameCache = new Dictionary<string, string>();
         }
 
@@ -110,8 +111,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                 throw new ArgumentOutOfRangeException("cacheType");
             }
 
-            TimeSpan span = dt.Subtract(DateTime.MinValue);
-            int key = (int)Math.Round(span.TotalHours, 0);
+            int key = GetCacheChunkKey(dt);
             Dictionary<int, Dictionary<Guid, DateTime>> targetDictionary = null;
 
             // Pick type of dictionary
@@ -132,6 +132,12 @@ namespace WebJob.Office365ActivityImporter.Engine
             return targetDictionary[key];
         }
 
+        private static int GetCacheChunkKey(DateTime dt)
+        {
+            TimeSpan span = dt.Subtract(DateTime.MinValue);
+            return (int)Math.Round(span.TotalHours, 0);
+        }
+
         /// <summary>
         /// Return the cache dictionary for a specific DT
         /// </summary>
@@ -149,6 +155,24 @@ namespace WebJob.Office365ActivityImporter.Engine
                 // the cache is loaded, or the same event remembered by two concurrent save batches that now
                 // share this single run-scoped cache.
                 this.GetCacheChunkForAuditLog(processedDate, CacheType.Processed)[id] = processedDate;
+            }
+        }
+
+        internal void RememberLoadedProcessedEvent(AbstractAuditLogContent auditLogContent)
+        {
+            if (auditLogContent == null) throw new ArgumentNullException(nameof(auditLogContent));
+            AddProcessedID(auditLogContent.Id, auditLogContent.CreationTime);
+        }
+
+        internal bool WasRememberedThisCycle(AbstractAuditLogContent auditLogContent)
+        {
+            if (auditLogContent == null) throw new ArgumentNullException(nameof(auditLogContent));
+
+            lock (_lock)
+            {
+                int key = GetCacheChunkKey(auditLogContent.CreationTime);
+                return CurrentCycleProcessedIDs.TryGetValue(key, out var chunk)
+                    && chunk.Contains(auditLogContent.Id);
             }
         }
 
@@ -174,6 +198,13 @@ namespace WebJob.Office365ActivityImporter.Engine
         /// Cached list of all processed event IDs
         /// </summary>
         private Dictionary<int, Dictionary<Guid, DateTime>> ProcessedIDs { get; set; }
+
+        /// <summary>
+        /// IDs tentatively remembered by save attempts in this cycle, chunked by hour like
+        /// <see cref="ProcessedIDs"/>. This is normally only the small incremental tail, not a second copy
+        /// of the whole historical run cache.
+        /// </summary>
+        private Dictionary<int, HashSet<Guid>> CurrentCycleProcessedIDs { get; set; }
 
         /// <summary>
         /// List of all event IDs ignored (not imported). Events also added to ProcessedIDs.
@@ -257,7 +288,9 @@ namespace WebJob.Office365ActivityImporter.Engine
         }
 
         /// <summary>
-        /// Add item to "processed" queue
+        /// Add item to "processed" queue. A save attempt uses this as a tentative reservation so another
+        /// concurrent batch does not stage the same id; the save path removes the reservation if its merge
+        /// or metadata phase fails, allowing the retry to stage the event again.
         /// </summary>
         public void RememberProcessedEvent(AbstractAuditLogContent auditLogContent)
         {
@@ -267,6 +300,58 @@ namespace WebJob.Office365ActivityImporter.Engine
                 // Indexer (not .Add): idempotent, so the shared run-scoped cache is safe when the same event
                 // id is remembered by two concurrent save batches (a duplicate .Add would throw).
                 theCache[auditLogContent.Id] = auditLogContent.CreationTime;
+                int key = GetCacheChunkKey(auditLogContent.CreationTime);
+                if (!CurrentCycleProcessedIDs.TryGetValue(key, out var currentCycleChunk))
+                {
+                    currentCycleChunk = new HashSet<Guid>();
+                    CurrentCycleProcessedIDs.Add(key, currentCycleChunk);
+                }
+                currentCycleChunk.Add(auditLogContent.Id);
+            }
+        }
+
+        /// <summary>
+        /// Release processed-id reservations made by a save attempt that did not complete. Events that were
+        /// newly staged are supplied here; on a retry-aware pass that may include an id loaded from SQL after
+        /// an earlier attempt committed the audit row but failed during metadata.
+        /// </summary>
+        internal int ForgetProcessedEvents(IEnumerable<AbstractAuditLogContent> auditLogContents)
+        {
+            if (auditLogContents == null) throw new ArgumentNullException(nameof(auditLogContents));
+
+            lock (_lock)
+            {
+                var removedIds = new HashSet<Guid>();
+                foreach (var auditLogContent in auditLogContents)
+                {
+                    if (auditLogContent == null) continue;
+
+                    // Search every chunk rather than deriving the one from CreationTime. A row reloaded
+                    // from SQL can be rounded by the datetime type across this cache's half-hour chunk
+                    // boundary, while the in-memory source value is not.
+                    foreach (var chunk in ProcessedIDs.Values)
+                    {
+                        if (chunk.Remove(auditLogContent.Id))
+                        {
+                            removedIds.Add(auditLogContent.Id);
+                        }
+                    }
+                    foreach (var chunk in CurrentCycleProcessedIDs.Values)
+                    {
+                        chunk.Remove(auditLogContent.Id);
+                    }
+                }
+
+                foreach (var emptyKey in ProcessedIDs.Where(kv => kv.Value.Count == 0).Select(kv => kv.Key).ToList())
+                {
+                    ProcessedIDs.Remove(emptyKey);
+                }
+                foreach (var emptyKey in CurrentCycleProcessedIDs.Where(kv => kv.Value.Count == 0).Select(kv => kv.Key).ToList())
+                {
+                    CurrentCycleProcessedIDs.Remove(emptyKey);
+                }
+
+                return removedIds.Count;
             }
         }
 
@@ -280,6 +365,13 @@ namespace WebJob.Office365ActivityImporter.Engine
                 // Indexer (not .Add): idempotent for the shared run-scoped cache (see RememberProcessedEvent).
                 this.GetCacheChunkForAuditLog(auditLogContent, CacheType.NewlyIgnored)[auditLogContent.Id] = auditLogContent.CreationTime;
                 this.GetCacheChunkForAuditLog(auditLogContent, CacheType.Processed)[auditLogContent.Id] = auditLogContent.CreationTime;
+                int key = GetCacheChunkKey(auditLogContent.CreationTime);
+                if (!CurrentCycleProcessedIDs.TryGetValue(key, out var currentCycleChunk))
+                {
+                    currentCycleChunk = new HashSet<Guid>();
+                    CurrentCycleProcessedIDs.Add(key, currentCycleChunk);
+                }
+                currentCycleChunk.Add(auditLogContent.Id);
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/AzureADAuditLogContent.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/AzureADAuditLogContent.cs
@@ -13,14 +13,23 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
 
         public override async Task<bool> ProcessExtendedProperties(SaveSession saveBatch, CommonAuditEvent relatedAuditEvent, ILogger logger)
         {
-            var related2 = await saveBatch.Database.azure_ad_events.Where(m => m.EventID == this.Id).SingleOrDefaultAsync();
+            var related2 = await saveBatch.Database.azure_ad_events
+                .Include(m => m.Properties.Select(p => p.name))
+                .Include(m => m.Properties.Select(p => p.value))
+                .Where(m => m.EventID == this.Id)
+                .SingleOrDefaultAsync();
 
             // Read each extended property
             var props = GetPropertiesAndValues(saveBatch);
             foreach (var name in props.Keys)
             {
-                // Add new propery with lookups
-                related2.Properties.Add(new AzureADExtendedProperties() { name = name, value = props[name] });
+                var value = props[name];
+                if (!related2.Properties.Any(p =>
+                    string.Equals(p.name?.name, name.name, System.StringComparison.Ordinal)
+                    && string.Equals(p.value?.value, value.value, System.StringComparison.Ordinal)))
+                {
+                    related2.Properties.Add(new AzureADExtendedProperties() { name = name, value = value });
+                }
             }
 
             return props.Count > 0;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/ExchangeAuditLogContent.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/ExchangeAuditLogContent.cs
@@ -13,12 +13,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
 
         public override async Task<bool> ProcessExtendedProperties(SaveSession saveBatch, CommonAuditEvent relatedAuditEvent, ILogger logger)
         {
-            var related = await saveBatch.Database.exchange_events.Where(m => m.EventID == this.Id).SingleOrDefaultAsync();
+            var related = await saveBatch.Database.exchange_events
+                .Include(m => m.Properties.Select(p => p.name))
+                .Include(m => m.Properties.Select(p => p.value))
+                .Where(m => m.EventID == this.Id)
+                .SingleOrDefaultAsync();
             var props = GetPropertiesAndValues(saveBatch);
             foreach (var name in props.Keys)
             {
-                // Add new propery with lookups
-                (related as ExchangeEventMetadata).Properties.Add(new ExchangeExtendedProperties() { name = name, value = props[name] });
+                var value = props[name];
+                if (!related.Properties.Any(p =>
+                    string.Equals(p.name?.name, name.name, System.StringComparison.Ordinal)
+                    && string.Equals(p.value?.value, value.value, System.StringComparison.Ordinal)))
+                {
+                    related.Properties.Add(new ExchangeExtendedProperties() { name = name, value = value });
+                }
             }
 
             return props.Count > 0;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/StreamAuditLogContent.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/Serialisation/StreamAuditLogContent.cs
@@ -2,6 +2,8 @@
 using Common.Entities.Entities.AuditLog;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Data.Entity;
+using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 
@@ -30,9 +32,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities.Serialisation
             {
                 var vid = await session.StreamLookupManager.GetCreateOrUpdateStreamVideo(vidGuid, ResourceTitle);
                 var clientApp = await session.SharePointLookupManager.GetClientApp(ClientApplicationId);
-                var newEvent = new StreamEventMetada { Video = vid, AuditEvent = relatedAuditEvent, ClientApplication = clientApp };
+                var streamEvent = await session.Database.StreamEvents
+                    .Where(e => e.EventID == this.Id)
+                    .SingleOrDefaultAsync();
+                if (streamEvent == null)
+                {
+                    streamEvent = new StreamEventMetada { AuditEvent = relatedAuditEvent };
+                    session.Database.StreamEvents.Add(streamEvent);
+                }
 
-                session.Database.StreamEvents.Add(newEvent);
+                streamEvent.Video = vid;
+                streamEvent.ClientApplication = clientApp;
             }
             return vidGuid != Guid.Empty;
         }


### PR DESCRIPTION
## Why this is release-blocking

The release-wide critique found a failure path in the audit importer: an event ID was added to the run-scoped dedup cache immediately after being staged, before the staging merge and workload metadata both completed. If a transient SQL failure occurred after that point, `TransientSqlRetry` retried the same batch against the same cache, saw every event as already processed, staged zero rows, returned success, and allowed the source content blob to be checkpointed. That can turn a recoverable database blip into permanently skipped audit data.

A second pass found the same underlying issue after a partial metadata commit: retrying the metadata safely requires every replayed metadata writer to be idempotent, and cross-cycle recovery needs an exact durable signal rather than treating every uncheckpointed blob as failed.

## What changed

### Same-attempt retry safety

- Staged IDs are tentative reservations. A staging/merge or metadata failure releases them from the in-memory processed cache.
- `ActivitySaveRetryState` remembers only the IDs staged by the failed attempt, so a retry forces those IDs through a refreshed per-batch cache even if the base `audit_events` row committed before the failure.
- A current-cycle reservation from another batch still wins, so recovery does not disable normal cross-batch deduplication.

### Durable Azure Table recovery

- `IProcessedBlobStore` is unchanged. Azure Table adds the optional `IActivityMetadataRecoveryStore` capability in a separate partition.
- At cycle start the importer reads the processed and recovery-pending sets, snapshots the existing recovery set, filters already-complete blobs, then pre-marks every selected blob recovery-pending **before any download or SQL save**.
- Only markers that existed before this cycle trigger metadata replay. A cold/new store therefore does not replay the whole lookback window.
- A blob is recorded processed first and its recovery marker is cleared only afterwards. A failed processed write retains recovery; a failed clear leaves a harmless stale marker because the processed ID filters the blob first.
- If Azure Table checkpoint state cannot be read or the pre-mark cannot be written, the audit section aborts before any database save. It delays the cycle rather than risking a partial commit being recorded complete, and the existing top-level importer catch logs the abort and retries next cycle.
- The in-memory checkpoint fallback deliberately does **not** claim restart-safe recovery; its log and Health status now say so. Same-attempt retry safety still applies in that mode.

### Idempotent metadata replay

- Copilot file and meeting child rows anti-join on their actual primary key (`copilot_chat_id`).
- Copilot messages whose payload omits `Id` get a deterministic retry key from `(event id, isPrompt, size)`, matching the tuple the existing `DISTINCT` already treats as one message.
- Stream metadata upserts its single `event_id` row.
- Exchange and Entra extended properties load existing name/value pairs and add only missing pairs.
- SharePoint/General metadata and all Power Platform/remaining Copilot merges were already idempotent and are unchanged.

## Traceability

The retry path now emits explicit warning/error traces when a save attempt releases dedup reservations, when metadata fails after the base merge, and when Azure Table checkpoint/recovery state prevents a safe save. Operators can distinguish a delayed cycle from a completed or partially recovered one in Application Insights traces; no event IDs, blob IDs, payloads, tenant identifiers or customer text are added to telemetry.

## Verification

- Final head: `1072c91432e1205476fb68d34fe64fd8895ef228`.
- Diff against `dev`: 21 files, +1,056 / -108.
- Full Debug solution build: clean.
- Focused audit/recovery/idempotency slice: **61/61 passed**.
- Full local suite: **1,449 passed / 17 failed / 5 skipped (1,471 total)**. The 17 failures are exactly the baseline workstation failures (missing Graph/Redis credentials and the four installer tests whose JSON is not copied to `bin`); no baseline outcome changed. The fifth skip is the deliberate UTC-host inconclusive cadence test added by #424.
- Mutation checks proved the load-bearing guards: removing cache release, refreshed-cache force, recovery pre-mark, exact recovery scope, Copilot file anti-join, deterministic missing-message key, or the Stream/Exchange/Entra idempotency checks fails the intended test.
- Three independent models reviewed each repair round. Findings were fixed and re-reviewed until the final Azure-only scope returned clean from all three.

## Database / configuration effects

- **No EF migration.** No entity/schema shape changes, no `Create DB.sql` change, and no manual SQL upgrade script.
- **No `CONFIG_VERSION` change** and no new installer setting.
- Azure Table uses a new partition in the existing checkpoint table; Azure Table storage is schema-less and requires no operator migration.
- The three changed merge scripts are runtime importer SQL only.

## Risk / deliberate limitation

- Durable cross-cycle metadata recovery requires the Azure Table checkpoint. If the importer is using the documented in-memory fallback, recovery is process-lifetime only and does not survive a restart; that limitation is now explicit in logs and Health.
- Azure Table runtime failure now stops the audit section before SQL rather than continuing without a trustworthy two-phase checkpoint. This is intentional fail-closed behavior: delayed data is visible and retried; partial data silently marked complete is not recoverable.

No customer, tenant, environment or production-derived identifiers are included in this PR.
