### PR TITLE
Defer Teams channel delta token commits

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeTeamsPorts.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeTeamsPorts.cs
@@ -74,6 +74,7 @@ namespace UnitTests.FakeLoaderClasses
 
         /// <summary>Channel ids this loader was asked to read, in order.</summary>
         public List<string> ChannelsRead { get; } = new List<string>();
+        public List<string> MessageIdsReturned { get; } = new List<string>();
 
         /// <summary>Script a channel read that returns a new delta token.</summary>
         public FakeChannelMessagesSourceLoader ReturningToken(string channelId, string token)
@@ -102,8 +103,13 @@ namespace UnitTests.FakeLoaderClasses
 
             if (_failingChannelIds.Contains(channel.Id))
             {
-                throw new ChannelMessagesReadException(new InvalidOperationException("simulated expired user token"));
+                return Task.FromException<TeamsRedisManager.TeamChannelDeltaTokenInfo>(
+                    new ChannelMessagesReadException(new InvalidOperationException("simulated expired user token")));
             }
+
+            var messageId = $"{channel.Id}-message-{ChannelsRead.Count}";
+            channel.Messages.Add(new ChatMessage { Id = messageId });
+            MessageIdsReturned.Add(messageId);
 
             _tokensByChannelId.TryGetValue(channel.Id, out var token);
             return Task.FromResult(token);

--- a/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
@@ -204,6 +204,18 @@ namespace Tests.UnitTests
 
         private static ChannelWithReactions Channel(string id) => new ChannelWithReactions { Id = id, DisplayName = id };
 
+        private static async Task CrawlPersistAndCommitTokens(
+            TeamsChannelCrawler crawler,
+            List<ChannelWithReactions> channels,
+            string teamId,
+            ITeamChannelDeltaTokenStore store,
+            Func<Task> persist)
+        {
+            var pendingTokens = await crawler.PopulateNewMessagesAndReactions(channels, teamId);
+            await persist();
+            await TeamChannelDeltaTokenCommitter.CommitPendingTokens(store, teamId, pendingTokens);
+        }
+
         /// <summary>
         /// A channel read that hands back no delta token must leave the stored token alone. Overwriting
         /// it with null would silently turn every later read into a full channel crawl (or, worse,
@@ -219,8 +231,13 @@ namespace Tests.UnitTests
             var store = new InMemoryTeamChannelDeltaTokenStore();
             await store.SetDeltaToken("team-1", "channel-2", new TeamsRedisManager.TeamChannelDeltaTokenInfo { Token = "previous-delta-2" });
 
-            var crawler = new TeamsChannelCrawler(source, store);
-            await crawler.PopulateNewMessagesAndReactions(new List<ChannelWithReactions> { Channel("channel-1"), Channel("channel-2") }, "team-1");
+            var crawler = new TeamsChannelCrawler(source);
+            await CrawlPersistAndCommitTokens(
+                crawler,
+                new List<ChannelWithReactions> { Channel("channel-1"), Channel("channel-2") },
+                "team-1",
+                store,
+                () => Task.CompletedTask);
 
             CollectionAssert.AreEqual(new[] { "channel-1", "channel-2" }, source.ChannelsRead.ToArray(),
                 "Every channel in the team must be crawled, in order.");
@@ -230,12 +247,12 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// An expired user-delegated token aborts the whole team's crawl (the caller deletes the team's
-        /// auth token and retries next cycle), but the channels already crawled keep their new delta
-        /// tokens so the next run doesn't re-read them from scratch.
+        /// An expired user-delegated token aborts the whole team's crawl, but tokens returned by
+        /// earlier channels stay pending so they can be committed if those earlier channels are still
+        /// persisted successfully.
         /// </summary>
         [TestMethod]
-        public async Task TeamsChannelCrawler_AbortsTheTeamOnAReadFailureButKeepsEarlierTokens()
+        public async Task TeamsChannelCrawler_AbortsTheTeamOnAReadFailureLeavingEarlierTokensPending()
         {
             var source = new FakeChannelMessagesSourceLoader()
                 .ReturningToken("channel-1", "delta-1")
@@ -243,16 +260,138 @@ namespace Tests.UnitTests
                 .ReturningToken("channel-3", "delta-3");
 
             var store = new InMemoryTeamChannelDeltaTokenStore();
-            var crawler = new TeamsChannelCrawler(source, store);
+            var crawler = new TeamsChannelCrawler(source);
+            var pendingTokens = new List<TeamChannelDeltaTokenCommit>();
 
             await Assert.ThrowsExceptionAsync<ChannelMessagesReadException>(() =>
                 crawler.PopulateNewMessagesAndReactions(
-                    new List<ChannelWithReactions> { Channel("channel-1"), Channel("channel-2"), Channel("channel-3") }, "team-1"));
+                    new List<ChannelWithReactions> { Channel("channel-1"), Channel("channel-2"), Channel("channel-3") },
+                    "team-1",
+                    pendingTokens));
 
             CollectionAssert.AreEqual(new[] { "channel-1", "channel-2" }, source.ChannelsRead.ToArray(),
                 "The crawl stops at the failing channel rather than carrying on with a token we know is bad.");
-            Assert.AreEqual("delta-1", (await store.GetDeltaToken("team-1", "channel-1"))?.Token);
+            Assert.IsNull(await store.GetDeltaToken("team-1", "channel-1"),
+                "The first channel's token must stay pending until the team's SQL changes are durable.");
             Assert.IsNull(await store.GetDeltaToken("team-1", "channel-3"));
+            CollectionAssert.AreEqual(new[] { "channel-1" }, pendingTokens.Select(t => t.ChannelId).ToArray(),
+                "The caller must be able to commit earlier-channel checkpoints after persisting that partial channel data.");
+        }
+
+        /// <summary>
+        /// If an earlier channel was loaded and then a later channel fails, the earlier channel's data
+        /// is still present on the Team and may be saved. In that partial-success case the checkpoint
+        /// is committed at the same per-channel granularity after SQL succeeds.
+        /// </summary>
+        [TestMethod]
+        public async Task TeamsChannelCrawler_CommitsEarlierChannelTokenAfterPartialCrawlPersistenceSucceeds()
+        {
+            var source = new FakeChannelMessagesSourceLoader()
+                .ReturningToken("channel-1", "delta-1")
+                .Failing("channel-2");
+            var store = new InMemoryTeamChannelDeltaTokenStore();
+            var crawler = new TeamsChannelCrawler(source);
+            var pendingTokens = new List<TeamChannelDeltaTokenCommit>();
+
+            await Assert.ThrowsExceptionAsync<ChannelMessagesReadException>(() =>
+                crawler.PopulateNewMessagesAndReactions(
+                    new List<ChannelWithReactions> { Channel("channel-1"), Channel("channel-2") },
+                    "team-1",
+                    pendingTokens));
+
+            await TeamChannelDeltaTokenCommitter.CommitPendingTokens(store, "team-1", pendingTokens);
+
+            Assert.AreEqual("delta-1", (await store.GetDeltaToken("team-1", "channel-1"))?.Token,
+                "The successfully persisted channel can advance without waiting for the failed channel.");
+            Assert.IsNull(await store.GetDeltaToken("team-1", "channel-2"));
+        }
+
+        /// <summary>
+        /// Regression for #432: a channel delta token is only a pending checkpoint until SQL
+        /// persistence succeeds. If persistence fails, the token store is left at its previous value
+        /// and the next run reads the same channel again instead of resuming past unsaved messages.
+        /// </summary>
+        [TestMethod]
+        public async Task TeamsChannelCrawler_DoesNotAdvanceDeltaTokenWhenPersistenceFails()
+        {
+            var source = new FakeChannelMessagesSourceLoader()
+                .ReturningToken("channel-1", "delta-after-message");
+            var store = new InMemoryTeamChannelDeltaTokenStore();
+            var crawler = new TeamsChannelCrawler(source);
+            var channels = new List<ChannelWithReactions> { Channel("channel-1") };
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                CrawlPersistAndCommitTokens(
+                    crawler,
+                    channels,
+                    "team-1",
+                    store,
+                    () => Task.FromException(new InvalidOperationException("simulated SQL persistence failure"))));
+
+            Assert.IsNull(await store.GetDeltaToken("team-1", "channel-1"),
+                "A failed SQL commit must not advance the channel checkpoint.");
+
+            await CrawlPersistAndCommitTokens(
+                crawler,
+                new List<ChannelWithReactions> { Channel("channel-1") },
+                "team-1",
+                store,
+                () => Task.CompletedTask);
+
+            CollectionAssert.AreEqual(new[] { "channel-1", "channel-1" }, source.ChannelsRead.ToArray(),
+                "The retry must re-fetch the same channel because no durable checkpoint was written for the failed run.");
+            CollectionAssert.AreEqual(new[] { "channel-1-message-1", "channel-1-message-2" }, source.MessageIdsReturned.ToArray(),
+                "Both runs reached message retrieval; the failed run did not let the token skip the retry.");
+            Assert.AreEqual("delta-after-message", (await store.GetDeltaToken("team-1", "channel-1"))?.Token);
+        }
+
+        /// <summary>
+        /// The happy path still writes the returned token once, but only after the persistence delegate
+        /// has completed successfully.
+        /// </summary>
+        [TestMethod]
+        public async Task TeamsChannelCrawler_AdvancesDeltaTokenExactlyOnceAfterPersistenceSucceeds()
+        {
+            var source = new FakeChannelMessagesSourceLoader()
+                .ReturningToken("channel-1", "delta-after-success");
+            var store = new CountingTeamChannelDeltaTokenStore();
+            var crawler = new TeamsChannelCrawler(source);
+            var persisted = false;
+
+            await CrawlPersistAndCommitTokens(
+                crawler,
+                new List<ChannelWithReactions> { Channel("channel-1") },
+                "team-1",
+                store,
+                () =>
+                {
+                    persisted = true;
+                    return Task.CompletedTask;
+                });
+
+            Assert.IsTrue(persisted, "The test must execute the persistence boundary before committing the token.");
+            Assert.AreEqual(1, store.SetCalls.Count, "A successful crawl should advance each returned channel token exactly once.");
+            CollectionAssert.AreEqual(new[] { "team-1/channel-1" }, store.SetCalls.ToArray());
+            Assert.AreEqual("delta-after-success", (await store.GetDeltaToken("team-1", "channel-1"))?.Token);
+        }
+
+        private class CountingTeamChannelDeltaTokenStore : ITeamChannelDeltaTokenStore
+        {
+            private readonly InMemoryTeamChannelDeltaTokenStore _inner = new InMemoryTeamChannelDeltaTokenStore();
+
+            public List<string> SetCalls { get; } = new List<string>();
+
+            public Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> GetDeltaToken(string teamId, string channelId)
+                => _inner.GetDeltaToken(teamId, channelId);
+
+            public Task SetDeltaToken(string teamId, string channelId, TeamsRedisManager.TeamChannelDeltaTokenInfo deltaTokenInfo)
+            {
+                SetCalls.Add($"{teamId}/{channelId}");
+                return _inner.SetDeltaToken(teamId, channelId, deltaTokenInfo);
+            }
+
+            public Task RemoveDeltaToken(string teamId, string channelId)
+                => _inner.RemoveDeltaToken(teamId, channelId);
         }
 
         #endregion

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/Extensions/TeamChannelExtensions.cs
@@ -48,8 +48,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// The crawl itself lives in <see cref="TeamsChannelCrawler"/> so it can be tested without
         /// Graph or Redis; this overload wires up the production adapters.
         /// </summary>
-        public static async Task PopulateNewMessagesAndReactions(this List<ChannelWithReactions> channels, Team team, RefreshOAuthToken refreshToken,
-            CacheConnectionManager cacheConnectionManager, ILogger logger)
+        public static async Task<List<TeamChannelDeltaTokenCommit>> PopulateNewMessagesAndReactions(this List<ChannelWithReactions> channels, Team team, RefreshOAuthToken refreshToken,
+            CacheConnectionManager cacheConnectionManager, ILogger logger, List<TeamChannelDeltaTokenCommit> pendingDeltaTokenCommits = null)
         {
             // Nothing to crawl: return before building any adapter, so a team with no channels - or one
             // we hold no user token for - still touches neither Redis, the logger nor team.Id, exactly
@@ -57,13 +57,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             // saved a delta token only when one came back).
             if (channels.Count == 0 || refreshToken == null)
             {
-                return;
+                return pendingDeltaTokenCommits ?? new List<TeamChannelDeltaTokenCommit>();
             }
 
             var deltaTokenStore = new RedisTeamChannelDeltaTokenStore(cacheConnectionManager, logger);
             var messagesSource = new GraphChannelMessagesSourceLoader(refreshToken, deltaTokenStore, logger);
 
-            await new TeamsChannelCrawler(messagesSource, deltaTokenStore).PopulateNewMessagesAndReactions(channels, team.Id);
+            return await new TeamsChannelCrawler(messagesSource).PopulateNewMessagesAndReactions(channels, team.Id, pendingDeltaTokenCommits);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/O365Team.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/O365Team.cs
@@ -67,6 +67,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
         public bool HasRefreshToken { get; set; }
         public DateTime? LastRefreshed { get; set; }
+        public List<TeamChannelDeltaTokenCommit> PendingChannelDeltaTokenCommits { get; set; } = new List<TeamChannelDeltaTokenCommit>();
 
         #endregion
 
@@ -159,23 +160,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             catch (System.Data.Entity.Infrastructure.DbUpdateException ex)
             {
                 logger.LogError(ex, $"Got SQL exception saving Team: {ex.Message}. Will try again next cycle.");
-                await ClearChannelDeltaTokens(logger, appConfig);
                 return null;
             }
 
-            return dbTeam;
-        }
-
-        async Task ClearChannelDeltaTokens(ILogger logger, AppConfig appConfig)
-        {
-            var teamTokenManager = new TeamTokenManager(this, appConfig, logger);
-            foreach (var c in this.Channels)
+            if (this.PendingChannelDeltaTokenCommits.Count > 0 && teamTokenManager.CacheConnectionManager != null)
             {
-                if (teamTokenManager.CacheConnectionManager != null)
-                {
-                    await teamTokenManager.CacheConnectionManager.RemoveTeamChannelDeltaToken(this.Id, c.Id, logger);
-                }
+                var deltaTokenStore = new RedisTeamChannelDeltaTokenStore(teamTokenManager.CacheConnectionManager, logger);
+                await TeamChannelDeltaTokenCommitter.CommitPendingTokens(deltaTokenStore, this.Id, this.PendingChannelDeltaTokenCommits);
             }
+
+            return dbTeam;
         }
 
         /// <summary>
@@ -269,12 +263,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             else
             {
                 // We have a token. Load channel msgs/replies/reactions
+                var pendingDeltaTokenCommits = new List<TeamChannelDeltaTokenCommit>();
                 try
                 {
-                    await fullTeam.Channels.PopulateNewMessagesAndReactions(team, teamRefreshOAuthToken, teamTokenManager.CacheConnectionManager, logger);
+                    fullTeam.PendingChannelDeltaTokenCommits = await fullTeam.Channels.PopulateNewMessagesAndReactions(team, teamRefreshOAuthToken, teamTokenManager.CacheConnectionManager, logger, pendingDeltaTokenCommits);
                 }
                 catch (ChannelMessagesReadException ex)
                 {
+                    fullTeam.PendingChannelDeltaTokenCommits = pendingDeltaTokenCommits;
                     logger.LogError(ex, $"Couldn't get channel messages via cached token. '{ex.Message}'. Deleting token.");
                     await teamTokenManager.CacheConnectionManager.RemoveTeamAuthToken(team.Id);
                     teamRefreshOAuthToken = null;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamChannelDeltaTokenCommit.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamChannelDeltaTokenCommit.cs
@@ -1,0 +1,40 @@
+using Common.Entities.Redis.Teams;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
+{
+    /// <summary>
+    /// A channel delta token returned by Graph during a crawl. It is only a pending checkpoint until
+    /// the corresponding SQL work has succeeded.
+    /// </summary>
+    public class TeamChannelDeltaTokenCommit
+    {
+        public TeamChannelDeltaTokenCommit(string channelId, TeamsRedisManager.TeamChannelDeltaTokenInfo deltaTokenInfo)
+        {
+            ChannelId = channelId ?? throw new ArgumentNullException(nameof(channelId));
+            DeltaTokenInfo = deltaTokenInfo ?? throw new ArgumentNullException(nameof(deltaTokenInfo));
+        }
+
+        public string ChannelId { get; }
+        public TeamsRedisManager.TeamChannelDeltaTokenInfo DeltaTokenInfo { get; }
+    }
+
+    public static class TeamChannelDeltaTokenCommitter
+    {
+        public static async Task CommitPendingTokens(
+            ITeamChannelDeltaTokenStore deltaTokenStore,
+            string teamId,
+            IEnumerable<TeamChannelDeltaTokenCommit> pendingCommits)
+        {
+            if (deltaTokenStore == null) throw new ArgumentNullException(nameof(deltaTokenStore));
+            if (pendingCommits == null) return;
+
+            foreach (var pendingCommit in pendingCommits)
+            {
+                await deltaTokenStore.SetDeltaToken(teamId, pendingCommit.ChannelId, pendingCommit.DeltaTokenInfo);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsChannelCrawler.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsChannelCrawler.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -13,17 +12,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
     public class TeamsChannelCrawler
     {
         private readonly IChannelMessagesSourceLoader _messagesSource;
-        private readonly ITeamChannelDeltaTokenStore _deltaTokenStore;
 
-        public TeamsChannelCrawler(IChannelMessagesSourceLoader messagesSource, ITeamChannelDeltaTokenStore deltaTokenStore)
+        public TeamsChannelCrawler(IChannelMessagesSourceLoader messagesSource)
         {
-            _messagesSource = messagesSource ?? throw new ArgumentNullException(nameof(messagesSource));
-            _deltaTokenStore = deltaTokenStore ?? throw new ArgumentNullException(nameof(deltaTokenStore));
+            _messagesSource = messagesSource ?? throw new System.ArgumentNullException(nameof(messagesSource));
         }
 
         /// <summary>
-        /// Sets the "Messages" prop on each channel by reading each channel's messages, then saves the
-        /// delta token for the next read.
+        /// Sets the "Messages" prop on each channel by reading each channel's messages, then returns
+        /// the delta tokens that may be committed after SQL persistence succeeds.
         /// </summary>
         /// <remarks>
         /// A channel that returns no delta token leaves the stored token untouched, so a read that
@@ -31,19 +28,25 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// order and a read failure aborts the whole team's crawl, exactly as before - the caller
         /// deletes the team's auth token and retries next cycle.
         /// </remarks>
-        public async Task PopulateNewMessagesAndReactions(List<ChannelWithReactions> channels, string teamId)
+        public async Task<List<TeamChannelDeltaTokenCommit>> PopulateNewMessagesAndReactions(
+            List<ChannelWithReactions> channels,
+            string teamId,
+            List<TeamChannelDeltaTokenCommit> pendingDeltaTokenCommits = null)
         {
+            pendingDeltaTokenCommits = pendingDeltaTokenCommits ?? new List<TeamChannelDeltaTokenCommit>();
+
             foreach (var channel in channels)
             {
                 // Load stats. Will throw ChannelMessagesReadException if token is invalid
                 var channelDelta = await _messagesSource.LoadMessagesAndReactions(channel, teamId);
 
-                // Save delta token for next read
                 if (channelDelta != null)
                 {
-                    await _deltaTokenStore.SetDeltaToken(teamId, channel.Id, channelDelta);
+                    pendingDeltaTokenCommits.Add(new TeamChannelDeltaTokenCommit(channel.Id, channelDelta));
                 }
             }
+
+            return pendingDeltaTokenCommits;
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Graph\Teams\Rules\ChannelMessageScopeRules.cs" />
     <Compile Include="Graph\Teams\Rules\TeamsCrawlPagingPolicy.cs" />
     <Compile Include="Graph\Teams\Rules\TeamsCrawlRules.cs" />
+    <Compile Include="Graph\Teams\TeamChannelDeltaTokenCommit.cs" />
     <Compile Include="Graph\Teams\TeamChannelDeltaTokenStores.cs" />
     <Compile Include="Graph\Teams\TeamsChannelCrawler.cs" />
     <Compile Include="Graph\Teams\Extensions\ChatMessageListExtensions.cs" />


### PR DESCRIPTION
## Summary
- Defers Teams channel delta-token writes until after `O365Team.SaveToSQL` has completed its SQL `SaveChangesAsync` boundary.
- Carries returned channel delta tokens as pending checkpoints, preserving earlier-channel checkpoints when a later channel read fails so partial channel persistence can advance at per-channel granularity.
- Adds regression coverage for SQL-persistence failure retry, happy-path single token advancement, and partial-channel token commit behavior.

Addresses #432.

## Release classification note
This ordering defect is inherited byte-for-byte from `main`; PR #401 only extracted the existing behavior into `TeamsChannelCrawler`. This is not a regression introduced in the current release.

## Design notes
- Commit boundary: channel reads collect pending `TeamChannelDeltaTokenCommit` values; Redis `SetDeltaToken` is called only after SQL `SaveChangesAsync` succeeds.
- Partial success: if a later channel read fails, earlier successfully read channels keep pending tokens; if their data is persisted, those tokens commit per channel. The failed channel does not advance.
- Idempotency/trade-off: Teams message-stat persistence is additive, not fully idempotent. `MessageCognitiveStats.InsertOrAppendSqlStats` increments `TeamChannelStats.ChatsCount` for an existing channel/day, and reaction persistence appends `TeamsUserReactions` rows. Therefore, if SQL persistence succeeds but the later Redis delta-token commit fails or Redis is unavailable, the next run can re-fetch the old Graph window and double-count those already-saved messages/reactions. Operators would observe inflated per-channel/day message counts in `TeamChannelStats.ChatsCount` and duplicate reaction facts in `TeamsUserReactions`. This trade is intentional: a duplicate additive stat is visible and correctable from the affected date/channel, but advancing the Graph checkpoint before SQL succeeds loses unsaved messages permanently.
- Redis unavailable: a Redis write failure now occurs after SQL persistence instead of before it. That can force a retry from the old token and may duplicate additive stats as described above, but it no longer loses messages by advancing before SQL.

## Validation
- `MSBuild.exe "O365 Advanced Analytics Engine.sln" /p:Configuration=Debug /m:2` — passed.
- Targeted `Tests.UnitTests.TeamsCrawlTests` — passed, 13/13.
- Mutation check: temporarily changed the test persistence helper to commit tokens before the persistence delegate; `TeamsChannelCrawler_DoesNotAdvanceDeltaTokenWhenPersistenceFails` failed with `Assert.IsNull failed`, then the mutation was reverted and the targeted suite passed.
- Full `Tests.UnitTests.dll` run on this branch — 1461 passed, 12 failed, 1 skipped.
- Pre-existing failure check: checked out unmodified `origin/dev` (`0bc30867`), rebuilt `Tests.UnitTests.csproj`, re-ran only the eight non-VNet failures under the machine-wide vstest lock, and all eight failed there too (8 failed / 8 total). The four VNet failures are the known machine baseline caused by the missing copied installer test config.

## Review
- Round 1: claude-opus-4.8 and grok-4.6 found the partial-crawl checkpoint loss; gpt-5.6-sol found no issues.
- Fixed by appending pending tokens to a caller-owned list so earlier-channel checkpoints survive a later `ChannelMessagesReadException`.
- Round 2: claude-opus-4.8, gpt-5.6-sol, and grok-4.6 all reported no significant issues.
