### PR TITLE
Fix portal import, CORS, and telemetry accuracy

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/AnalyticsLogger.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/AnalyticsLogger.cs
@@ -35,6 +35,16 @@ namespace DataUtils
         private AnalyticsLogger() : this(string.Empty, string.Empty)
         {
         }
+
+        public AnalyticsLogger(TelemetryClient appInsights, string context)
+        {
+            AppInsights = appInsights;
+            if (AppInsights != null && !string.IsNullOrEmpty(context))
+            {
+                AppInsights.Context.Operation.Name = context;
+            }
+        }
+
         public AnalyticsLogger(string appInsightsConnectionString, string context)
         {
             if (!string.IsNullOrEmpty(appInsightsConnectionString))
@@ -62,9 +72,34 @@ namespace DataUtils
 
         public void TrackException(Exception ex)
         {
+            TrackException(ex, null, null);
+        }
+
+        public void TrackException(
+            Exception ex,
+            IDictionary<string, string> properties,
+            string operationId)
+        {
             if (AppInsights != null)
             {
-                AppInsights.TrackException(ex);
+                var telemetry = new ExceptionTelemetry(ex);
+                if (!string.IsNullOrEmpty(operationId))
+                {
+                    telemetry.Context.Operation.Id = operationId;
+                }
+                if (!string.IsNullOrEmpty(AppInsights.Context.Operation.Name))
+                {
+                    telemetry.Context.Operation.Name = AppInsights.Context.Operation.Name;
+                }
+                if (properties != null)
+                {
+                    foreach (var property in properties)
+                    {
+                        telemetry.Properties[property.Key] = property.Value;
+                    }
+                }
+
+                AppInsights.TrackException(telemetry);
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionTelemetryTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionTelemetryTests.cs
@@ -1,6 +1,11 @@
 extern alias AnalyticsWeb;
 
 using Common.Entities.CopilotAdoption;
+using DataUtils;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Concurrent;
@@ -18,8 +23,11 @@ using AdoptionRunner = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICo
 using AdoptionRunTelemetry = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionRunTelemetry;
 using AdoptionSink = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionEventSink;
 using AdoptionCompletion = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionCompletionEvent;
+using AdoptionCorrelation = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionExceptionCorrelation;
 using AdoptionQueuedSink = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.QueuedCopilotAdoptionEventSink;
 using AdoptionWriter = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionTelemetryWriter;
+using AppInsightsAdoptionWriter = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.AppInsightsCopilotAdoptionTelemetryWriter;
+using WebExceptionTelemetry = AnalyticsWeb::Web.AnalyticsWeb.WebExceptionTelemetry;
 
 namespace Tests.UnitTests
 {
@@ -258,6 +266,70 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public void FailureWriter_EmitsExceptionTelemetryWithRunId()
+        {
+            var channel = new RecordingTelemetryChannel();
+            var configuration = new TelemetryConfiguration
+            {
+                TelemetryChannel = channel,
+                ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000001",
+            };
+            var logger = new AnalyticsLogger(new TelemetryClient(configuration), "CopilotAdoptionTest");
+            var writer = new AppInsightsAdoptionWriter(logger);
+            var runId = "00000000000000000000000000000004";
+
+            writer.WriteFailure(new AdoptionFailure
+            {
+                RunId = runId,
+                WindowDays = 28,
+                Exception = new InvalidOperationException("synthetic failure"),
+            });
+
+            var exception = channel.Sent.OfType<ExceptionTelemetry>().Single();
+            Assert.AreEqual(runId, exception.Context.Operation.Id);
+            Assert.AreEqual(runId, exception.Properties["RunId"]);
+            Assert.AreEqual("CopilotAdoptionTest", exception.Context.Operation.Name);
+            Assert.IsTrue(
+                channel.Sent.OfType<TraceTelemetry>()
+                    .Any(trace => trace.Message.Contains("RunId " + runId)),
+                "The searchable fallback trace must carry the same RunId as exception telemetry.");
+        }
+
+        [TestMethod]
+        public void FailedRun_AttachesRunIdSoWebExceptionFallbackStillReportsWhenQueueRejects()
+        {
+            var channel = new RecordingTelemetryChannel();
+            var configuration = new TelemetryConfiguration
+            {
+                TelemetryChannel = channel,
+                ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000001",
+            };
+            var logger = new AnalyticsLogger(new TelemetryClient(configuration), "WebApiTest");
+            var sink = new RejectingSink();
+            var heartbeat = new ManualHeartbeatFactory();
+            var telemetry = NewTelemetry(sink, heartbeat);
+            var exception = new InvalidOperationException("synthetic rejected failure");
+
+            Assert.IsFalse(telemetry.QueueFailure(exception), "The fake must reject the queued failure.");
+            Assert.IsTrue(AdoptionCorrelation.TryGetRunId(exception, out var runId));
+
+            WebExceptionTelemetry.Report(exception, "WebApi /api/copilotadoption", _ => logger);
+            WebExceptionTelemetry.Report(exception, "WebApi /api/copilotadoption", _ => logger);
+
+            var exceptionTelemetry = channel.Sent.OfType<ExceptionTelemetry>().ToList();
+            Assert.AreEqual(
+                1,
+                exceptionTelemetry.Count,
+                "A rejected queue item must still be reported by the Web API fallback, but only once.");
+            Assert.AreEqual(runId, exceptionTelemetry[0].Context.Operation.Id);
+            Assert.AreEqual(runId, exceptionTelemetry[0].Properties["RunId"]);
+            Assert.IsTrue(
+                channel.Sent.OfType<TraceTelemetry>()
+                    .Any(trace => trace.Message.Contains("RunId " + runId)),
+                "The fallback trace must be joinable to the lifecycle failure by RunId.");
+        }
+
+        [TestMethod]
         public async Task TelemetryFactoryFailure_DoesNotStopOrPoisonTheAnalysis()
         {
             var runner = new SequencedRunner(
@@ -478,6 +550,56 @@ namespace Tests.UnitTests
             }
 
             public void Shutdown(TimeSpan timeout)
+            {
+            }
+        }
+
+        private sealed class RejectingSink : AdoptionSink
+        {
+            public int DroppedEvents => 1;
+
+            public void Track(AdoptionEvent telemetryEvent)
+            {
+            }
+
+            public void TrackCompletion(
+                AdoptionCompletion completion,
+                AdoptionEvent submittedEvent)
+            {
+            }
+
+            public bool TrackFailure(
+                AdoptionFailure failure,
+                AdoptionEvent failureEvent)
+            {
+                return false;
+            }
+
+            public void Shutdown(TimeSpan timeout)
+            {
+            }
+        }
+
+        private sealed class RecordingTelemetryChannel : ITelemetryChannel
+        {
+            private readonly List<ITelemetry> _sent = new List<ITelemetry>();
+
+            public IList<ITelemetry> Sent => _sent;
+
+            public bool? DeveloperMode { get; set; }
+
+            public string EndpointAddress { get; set; }
+
+            public void Send(ITelemetry item)
+            {
+                _sent.Add(item);
+            }
+
+            public void Flush()
+            {
+            }
+
+            public void Dispose()
             {
             }
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/HealthServiceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/HealthServiceTests.cs
@@ -2,6 +2,7 @@ extern alias AnalyticsWeb;
 
 using AnalyticsWeb::Web.AnalyticsWeb.Controllers;
 using AnalyticsWeb::Web.AnalyticsWeb.Models.Health;
+using Common.Entities;
 using Common.Entities.Entities.UsageReports;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -445,6 +446,50 @@ namespace Tests.UnitTests
             Assert.AreEqual(false, section.SchemaUpToDate);
             CollectionAssert.AreEqual(new[] { "202601010000001_SomethingNew" }, section.PendingMigrations);
             Assert.IsNull(section.SchemaError);
+        }
+
+        [TestMethod]
+        public async Task Config_EveryImportToggleHasAnEnabledImportBadge()
+        {
+            var importToggleNames = typeof(ImportTaskSettings)
+                .GetProperties()
+                .Where(property => property.PropertyType == typeof(bool)
+                                   && Attribute.IsDefined(
+                                       property,
+                                       typeof(ImportTaskSettings.ImportPropAttribute)))
+                .Select(property => property.Name)
+                .OrderBy(name => name)
+                .ToArray();
+
+            CollectionAssert.AreEqual(
+                importToggleNames,
+                HealthService.ImportLabelsBySettingProperty.Keys.OrderBy(name => name).ToArray(),
+                "Every public bool ImportTaskSettings import toggle must have a Health page label.");
+
+            var config = new TestsAppConfig
+            {
+                ImportJobSettings = new ImportTaskSettings(),
+            };
+            foreach (var propertyName in importToggleNames)
+            {
+                typeof(ImportTaskSettings).GetProperty(propertyName)
+                    .SetValue(config.ImportJobSettings, true);
+            }
+
+            var source = new FakeHealthDataSource
+            {
+                PendingMigrations = new List<string>(),
+            };
+            var service = Build(source, new InMemoryHealthCache());
+
+            var section = await service.LoadConfigAsync(config);
+
+            CollectionAssert.AreEquivalent(
+                HealthService.ImportLabelsBySettingProperty.Values.ToArray(),
+                section.EnabledImports.ToArray());
+            CollectionAssert.Contains(
+                section.EnabledImports,
+                "Copilot AI interaction history (tenant-wide unless scoped)");
         }
 
         #endregion

--- a/src/AnalyticsEngine/Tests.UnitTests/OrgUrlStoreTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/OrgUrlStoreTests.cs
@@ -1,3 +1,5 @@
+extern alias AnalyticsWeb;
+
 using App.ControlPanel.Engine;
 using App.ControlPanel.Engine.Models;
 using Common.Entities;
@@ -7,8 +9,11 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using UnitTests.FakeLoaderClasses;
+using WebCorsAttribute = AnalyticsWeb::Web.AnalyticsWeb.AllowCorsForOrgUrlsAttribute;
 
 namespace Tests.UnitTests
 {
@@ -150,6 +155,32 @@ namespace Tests.UnitTests
             Assert.AreEqual(1, store.Inserts.Count);
             Assert.AreEqual("https://contoso.sharepoint.com/sites/καλημέρα", store.Inserts[0].UrlBase,
                 "Values are normalised to lower case on write, for Greek as well as Latin.");
+        }
+
+        [TestMethod]
+        public async Task CorsPolicy_NormalisesCachedOrgUrlsToBrowserOrigins()
+        {
+            var loadCount = 0;
+            var provider = new WebCorsAttribute(() =>
+            {
+                loadCount++;
+                return Task.FromResult(new List<string>
+                {
+                    "HTTPS://CONTOSO.SHAREPOINT.COM/",
+                    "contoso.sharepoint.com/sites/ignored-by-origin",
+                    "ftp://contoso.sharepoint.com",
+                });
+            });
+
+            var first = await provider.GetCorsPolicyAsync(new HttpRequestMessage(), CancellationToken.None);
+            var second = await provider.GetCorsPolicyAsync(new HttpRequestMessage(), CancellationToken.None);
+
+            CollectionAssert.AreEquivalent(
+                new[] { "https://contoso.sharepoint.com" },
+                first.Origins.ToArray(),
+                "CORS origins are ordinal/case-sensitive, so cached org_urls rows must be normalised on read.");
+            CollectionAssert.AreEquivalent(first.Origins.ToArray(), second.Origins.ToArray());
+            Assert.AreEqual(1, loadCount, "Normalisation must happen while populating the existing cache, not per request.");
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Web/AllowCorsForOrgUrlsAttribute.cs
+++ b/src/AnalyticsEngine/Web/AllowCorsForOrgUrlsAttribute.cs
@@ -1,7 +1,10 @@
 ﻿using Common.Entities;
+using Common.Entities.Config;
+using DataUtils;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,20 +18,24 @@ namespace Web.AnalyticsWeb
     /// </summary>
     public class AllowCorsForOrgUrlsAttribute : Attribute, ICorsPolicyProvider
     {
+        private readonly Func<Task<List<string>>> _loadUrlBases;
         private List<string> _allowedCors = null;
+
+        public AllowCorsForOrgUrlsAttribute()
+            : this(LoadOrgUrlBasesAsync)
+        {
+        }
+
+        internal AllowCorsForOrgUrlsAttribute(Func<Task<List<string>>> loadUrlBases)
+        {
+            _loadUrlBases = loadUrlBases ?? throw new ArgumentNullException(nameof(loadUrlBases));
+        }
+
         public async Task<CorsPolicy> GetCorsPolicyAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (_allowedCors == null)
             {
-                using (var db = new AnalyticsEntitiesContext())
-                {
-                    _allowedCors = new List<string>();
-                    var origins = await db.org_urls.ToListAsync();
-                    foreach (var each in origins)
-                    {
-                        _allowedCors.Add(each.UrlBase);
-                    }
-                }
+                _allowedCors = NormaliseAllowedOrigins(await _loadUrlBases());
             }
 
             var retval = new CorsPolicy();
@@ -47,6 +54,95 @@ namespace Web.AnalyticsWeb
             }
 
             return retval;
+        }
+
+        private static async Task<List<string>> LoadOrgUrlBasesAsync()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                return await db.org_urls
+                    .Select(each => each.UrlBase)
+                    .ToListAsync();
+            }
+        }
+
+        internal static List<string> NormaliseAllowedOrigins(IEnumerable<string> urlBases)
+        {
+            var allowed = new HashSet<string>(StringComparer.Ordinal);
+            AnalyticsLogger logger = null;
+
+            foreach (var urlBase in urlBases ?? new string[0])
+            {
+                if (TryNormaliseAllowedOrigin(urlBase, out var origin, out var reason))
+                {
+                    allowed.Add(origin);
+                }
+                else if (!string.IsNullOrWhiteSpace(urlBase))
+                {
+                    LogInvalidOriginWarning(ref logger, reason);
+                }
+            }
+
+            return new List<string>(allowed);
+        }
+
+        private static void LogInvalidOriginWarning(ref AnalyticsLogger logger, string reason)
+        {
+            try
+            {
+                if (logger == null)
+                {
+                    var config = new AppConfig();
+                    logger = new AnalyticsLogger(config.AppInsightsConnectionString, nameof(AllowCorsForOrgUrlsAttribute));
+                }
+                logger.LogWarning($"Ignoring invalid org_urls.url_base row for CORS: {reason}.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(
+                    $"WARNING: Ignoring invalid org_urls.url_base row for CORS: {reason}. Logging failed ({ex.GetBaseException().GetType().Name}).");
+            }
+        }
+
+        internal static bool TryNormaliseAllowedOrigin(string urlBase, out string origin, out string reason)
+        {
+            origin = null;
+            reason = null;
+
+            if (string.IsNullOrWhiteSpace(urlBase))
+            {
+                return false;
+            }
+
+            var candidate = urlBase.Trim();
+            if (candidate == "*" || string.Equals(candidate, "https://", StringComparison.OrdinalIgnoreCase))
+            {
+                origin = candidate.ToLowerInvariant();
+                return true;
+            }
+
+            if (!candidate.Contains("://"))
+            {
+                candidate = "https://" + candidate;
+            }
+
+            if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri)
+                || string.IsNullOrEmpty(uri.Host)
+                || !string.IsNullOrEmpty(uri.UserInfo))
+            {
+                reason = "it is not a valid absolute origin";
+                return false;
+            }
+
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+            {
+                reason = "only HTTP and HTTPS origins are supported";
+                return false;
+            }
+
+            origin = uri.GetLeftPart(UriPartial.Authority).ToLowerInvariant();
+            return true;
         }
 
     }

--- a/src/AnalyticsEngine/Web/App_Start/WebExceptionTelemetry.cs
+++ b/src/AnalyticsEngine/Web/App_Start/WebExceptionTelemetry.cs
@@ -2,6 +2,7 @@
 using DataUtils;
 using System;
 using System.Web.Http.ExceptionHandling;
+using Web.AnalyticsWeb.Models.CopilotAdoption;
 
 namespace Web.AnalyticsWeb
 {
@@ -72,18 +73,37 @@ namespace Web.AnalyticsWeb
         /// </param>
         public static void Report(Exception ex, string context)
         {
+            Report(ex, context, ctx =>
+            {
+                var config = new AppConfig();
+                return new AnalyticsLogger(config.AppInsightsConnectionString, ctx);
+            });
+        }
+
+        internal static void Report(
+            Exception ex,
+            string context,
+            Func<string, AnalyticsLogger> loggerFactory)
+        {
             if (ex == null || AlreadyReported(ex)) return;
 
             try
             {
-                var config = new AppConfig();
-                var logger = new AnalyticsLogger(config.AppInsightsConnectionString, context);
+                var logger = loggerFactory(context);
+                CopilotAdoptionExceptionCorrelation.TryGetRunId(ex, out var runId);
+                var properties = string.IsNullOrEmpty(runId)
+                    ? null
+                    : new System.Collections.Generic.Dictionary<string, string>
+                    {
+                        { "RunId", runId },
+                    };
 
-                logger.TrackException(ex);
+                logger.TrackException(ex, properties, runId);
 
                 // The exception telemetry carries the type and stack, but a searchable line of text is
                 // what an operator actually greps for when a customer reports "it just returns a 500".
-                logger.LogError($"Unhandled web request error in {context}: {ex.GetBaseException().Message}");
+                var correlation = string.IsNullOrEmpty(runId) ? string.Empty : $" RunId {runId}.";
+                logger.LogError($"Unhandled web request error in {context}.{correlation} {ex.GetBaseException().Message}");
 
                 MarkReported(ex);
             }

--- a/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionTelemetry.cs
+++ b/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionTelemetry.cs
@@ -133,6 +133,44 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
         public Exception Exception { get; set; }
     }
 
+    internal static class CopilotAdoptionExceptionCorrelation
+    {
+        public const string RunIdDataKey = "CopilotAdoption.RunId";
+
+        public static void SetRunId(Exception exception, string runId)
+        {
+            if (exception == null || string.IsNullOrEmpty(runId)) return;
+
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                try
+                {
+                    current.Data[RunIdDataKey] = runId;
+                }
+                catch (Exception)
+                {
+                    // Some exception types expose a fixed IDictionary. The telemetry path must not fail.
+                }
+            }
+        }
+
+        public static bool TryGetRunId(Exception exception, out string runId)
+        {
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                var value = current.Data?[RunIdDataKey] as string;
+                if (!string.IsNullOrEmpty(value))
+                {
+                    runId = value;
+                    return true;
+                }
+            }
+
+            runId = null;
+            return false;
+        }
+    }
+
     internal interface ICopilotAdoptionEventSink
     {
         int DroppedEvents { get; }
@@ -171,6 +209,11 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
                 connectionString, nameof(Controllers.CopilotAdoptionAPIController));
         }
 
+        internal AppInsightsCopilotAdoptionTelemetryWriter(AnalyticsLogger logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
         public void Write(CopilotAdoptionLifecycleEvent telemetryEvent)
         {
             _logger.TrackEvent(
@@ -195,9 +238,13 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
 
         public void WriteFailure(CopilotAdoptionFailureEvent failure)
         {
-            _logger.TrackException(failure.Exception);
+            var properties = new Dictionary<string, string>
+            {
+                { "RunId", failure.RunId },
+            };
+            _logger.TrackException(failure.Exception, properties, failure.RunId);
             _logger.LogError(
-                $"Copilot adoption analysis failed ({failure.Exception.GetBaseException().GetType().Name}).");
+                $"Copilot adoption analysis failed ({failure.Exception.GetBaseException().GetType().Name}, RunId {failure.RunId}).");
         }
 
         public void Flush()
@@ -653,6 +700,7 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
 
         public bool QueueFailure(Exception exception)
         {
+            CopilotAdoptionExceptionCorrelation.SetRunId(exception, RunId);
             var failureEvent = CreateEvent(
                 CopilotAdoptionTelemetryStages.Failed,
                 outcome: "Failed",

--- a/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
+++ b/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
@@ -39,6 +39,22 @@ namespace Web.AnalyticsWeb.Models.Health
     {
         public const int CacheSeconds = 60;
 
+        internal static readonly IReadOnlyDictionary<string, string> ImportLabelsBySettingProperty =
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                { nameof(ImportTaskSettings.ActivityLog), "Activity/audit" },
+                { nameof(ImportTaskSettings.Copilot), "Copilot" },
+                { nameof(ImportTaskSettings.CopilotInteractionHistory), "Copilot AI interaction history (tenant-wide unless scoped)" },
+                { nameof(ImportTaskSettings.ImportPowerPlatform), "Power Platform" },
+                { nameof(ImportTaskSettings.GraphUsersMetadata), "User metadata" },
+                { nameof(ImportTaskSettings.GraphUsageReports), "Usage reports" },
+                { nameof(ImportTaskSettings.GraphCopilotUsageReports), "Copilot usage reports (Graph)" },
+                { nameof(ImportTaskSettings.GraphTeams), "Teams" },
+                { nameof(ImportTaskSettings.WebTraffic), "Web traffic" },
+                { nameof(ImportTaskSettings.SentEmails), "Sent emails" },
+                { nameof(ImportTaskSettings.Calls), "Teams calls" },
+            };
+
         // A full activity import cycle should complete at least this often (see HEALTH-MONITORING-DESIGN.md).
         private const int CycleSlaHours = 24;
 
@@ -237,16 +253,16 @@ namespace Web.AnalyticsWeb.Models.Health
 
                 if (config.ImportJobSettings != null)
                 {
-                    if (config.ImportJobSettings.ActivityLog) section.EnabledImports.Add("Activity/audit");
-                    if (config.ImportJobSettings.Copilot) section.EnabledImports.Add("Copilot");
-                    if (config.ImportJobSettings.ImportPowerPlatform) section.EnabledImports.Add("Power Platform");
-                    if (config.ImportJobSettings.GraphUsersMetadata) section.EnabledImports.Add("User metadata");
-                    if (config.ImportJobSettings.GraphUsageReports) section.EnabledImports.Add("Usage reports");
-                    if (config.ImportJobSettings.GraphCopilotUsageReports) section.EnabledImports.Add("Copilot usage reports (Graph)");
-                    if (config.ImportJobSettings.GraphTeams) section.EnabledImports.Add("Teams");
-                    if (config.ImportJobSettings.WebTraffic) section.EnabledImports.Add("Web traffic");
-                    if (config.ImportJobSettings.SentEmails) section.EnabledImports.Add("Sent emails");
-                    if (config.ImportJobSettings.Calls) section.EnabledImports.Add("Teams calls");
+                    foreach (var import in ImportLabelsBySettingProperty)
+                    {
+                        var property = typeof(ImportTaskSettings).GetProperty(import.Key);
+                        if (property != null
+                            && property.PropertyType == typeof(bool)
+                            && (bool)property.GetValue(config.ImportJobSettings))
+                        {
+                            section.EnabledImports.Add(import.Value);
+                        }
+                    }
                 }
 
                 var webhook = await _dataSource.GetCallWebhookStatusAsync();


### PR DESCRIPTION
## Summary
- Adds the missing Health page badge for `ImportTaskSettings.CopilotInteractionHistory`, using the installer wording: "Copilot AI interaction history (tenant-wide unless scoped)".
- Reworks Health enabled-import mapping around a single property-to-label map and adds reflection coverage so the next public bool `[ImportProp]` toggle fails tests if it has no badge.
- Normalises cached `org_urls.url_base` values into browser CORS origins on read: lowercase scheme/host, add missing `https://`, remove trailing slash/path, preserve legacy allow-all sentinels, and warn once during cache population for invalid rows without logging tenant URLs.
- Correlates Copilot Adoption queued and Web API fallback exception telemetry with the lifecycle `RunId` via `Exception.Data`, custom exception telemetry properties, and operation id.

## #385 design decisions
- **Read vs write:** normalise on read for CORS. Write-side normalisation already exists for installer-created rows, but read-side normalisation fixes existing/manual/legacy rows without a migration or data mutation. This is important because this release remains migration-free.
- **Scheme/trailing slash:** if a row has no scheme, treat it as `https://...`; if it has a trailing slash or path, cache only the origin (`scheme://host[:port]`) because browser `Origin` never includes a path. Non-HTTP(S) or otherwise invalid rows are ignored.
- **Invalid-row logging:** invalid rows are warned while the process-lifetime CORS cache is populated, not per request. The warning deliberately omits the raw URL to avoid tenant data in telemetry.
- #385 is pre-existing and not a regression from #384.

## #427 fallback guarantee
The Web API exception logger remains a fallback. The code stamps `RunId` on the exception before queueing/rethrowing, but it does **not** mark the exception as reported merely because it was enqueued. `WebExceptionTelemetry` still marks only after its own successful fallback report, and a new test pins that fallback telemetry fires when the queue rejects the failure event.

## Tests
- Build: `MSBuild.exe "O365 Advanced Analytics Engine.sln" /p:Configuration=Debug /m:2` ✅
- Targeted local: `vstest.console.exe Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~HealthServiceTests|FullyQualifiedName~OrgUrlStoreTests|FullyQualifiedName~CopilotAdoptionTelemetryTests"` ✅ 51 passed
- Mutation evidence: temporarily removed the import mapping, disabled CORS origin normalisation, and disabled failure RunId stamping; the three new tests failed, then passed after restoration.
- Full-suite evidence: GitHub Actions required check `test_dotnet (Release)` passed on PR #440 in 9m20s: https://github.com/pnp/Microsoft365-Analytics-Insights/actions/runs/33756541400/job/100652275561

## Review
- Multi-model code review round 1: `claude-opus-4.8`, `gpt-5.6-sol`, and `grok-4.6` all reported clean/no blockers. Reviewers were instructed not to run vstest.

Addresses #435
Addresses #385
Addresses #427
