### PR TITLE
Fix Graph user licence seams

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/UserLicenseRefreshTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserLicenseRefreshTests.cs
@@ -424,6 +424,73 @@ namespace Tests.UnitTests
 
         #region Processor-level: what actually gets written
 
+        [TestMethod]
+        public async Task UserLicenseProcessor_InjectedResolver_UsesSameKnownSkuMapping()
+        {
+            const string skuPartNumber = "ENTERPRISEPACK";
+            var expectedName = new OfficeLicenseNameResolver().GetDisplayNameFor(skuPartNumber);
+            var resolver = new RecordingLicenseNameResolver(new OfficeLicenseNameResolver());
+
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var processor = new UserLicenseProcessor(
+                    AnalyticsLogger.ConsoleOnlyTracer(),
+                    new FakeUserMetadataLoader(null, null, null),
+                    new UserMetadataCache(db),
+                    resolver);
+
+                var licence = await processor.GetLicenseType(skuPartNumber);
+
+                Assert.AreEqual(expectedName, licence.Name);
+                Assert.AreEqual(skuPartNumber, licence.SKUID);
+                CollectionAssert.AreEqual(new[] { skuPartNumber }, resolver.RequestedSkuPartNumbers.ToArray());
+            }
+        }
+
+        [TestMethod]
+        public async Task UserLicenseProcessor_InjectedResolver_UnknownSkuFallsBackToSkuPartNumber()
+        {
+            var skuPartNumber = $"UNKNOWN_TEST_SKU_{Guid.NewGuid():N}";
+
+            try
+            {
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    var processor = new UserLicenseProcessor(
+                        AnalyticsLogger.ConsoleOnlyTracer(),
+                        new FakeUserMetadataLoader(null, null, null),
+                        new UserMetadataCache(db),
+                        new FixedLicenseNameResolver(null));
+
+                    var licence = await processor.GetLicenseType(skuPartNumber);
+
+                    Assert.AreEqual(skuPartNumber, licence.Name);
+                    Assert.AreEqual(skuPartNumber, licence.SKUID);
+                }
+            }
+            finally
+            {
+                await RemoveTestLicences(skuPartNumber);
+            }
+        }
+
+        [TestMethod]
+        public async Task UserLicenseProcessor_ProductionConstructor_StillResolvesSkuNames()
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var processor = new UserLicenseProcessor(
+                    AnalyticsLogger.ConsoleOnlyTracer(),
+                    new FakeUserMetadataLoader(null, null, null),
+                    new UserMetadataCache(db));
+
+                var licence = await processor.GetLicenseType("ENTERPRISEPACK");
+
+                Assert.AreEqual("Office 365 E3", licence.Name);
+                Assert.AreEqual("ENTERPRISEPACK", licence.SKUID);
+            }
+        }
+
         /// <summary>
         /// A run where nothing changed must not write anything at all. The old implementation
         /// rewrote every row on every cycle, which is both the source of the outage window and,
@@ -686,6 +753,36 @@ namespace Tests.UnitTests
             }
         }
 
+        private class RecordingLicenseNameResolver : IOfficeLicenseNameResolver
+        {
+            private readonly IOfficeLicenseNameResolver _inner;
+
+            public RecordingLicenseNameResolver(IOfficeLicenseNameResolver inner)
+            {
+                _inner = inner;
+            }
+
+            public List<string> RequestedSkuPartNumbers { get; } = new List<string>();
+
+            public string GetDisplayNameFor(string id)
+            {
+                RequestedSkuPartNumbers.Add(id);
+                return _inner.GetDisplayNameFor(id);
+            }
+        }
+
+        private class FixedLicenseNameResolver : IOfficeLicenseNameResolver
+        {
+            private readonly string _displayName;
+
+            public FixedLicenseNameResolver(string displayName)
+            {
+                _displayName = displayName;
+            }
+
+            public string GetDisplayNameFor(string id) => _displayName;
+        }
+
         private static FakeUserMetadataLoader BuildLoader(
             (string Upn, string AadId)[] users,
             (Guid SkuId, string PartNumber, string[] LicensedUpns)[] skus)
@@ -748,6 +845,19 @@ namespace Tests.UnitTests
                 var lookups = await db.UserLicenseTypeLookups.Where(l => ids.Contains(l.UserId)).ToListAsync();
                 db.UserLicenseTypeLookups.RemoveRange(lookups);
                 db.users.RemoveRange(users);
+                await db.SaveChangesAsync();
+            }
+        }
+
+        private static async Task RemoveTestLicences(params string[] skuIds)
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var licences = await db.LicenseTypes
+                    .Where(l => skuIds.Contains(l.SKUID) &&
+                        !db.UserLicenseTypeLookups.Any(lookup => lookup.LicenseTypeId == l.ID))
+                    .ToListAsync();
+                db.LicenseTypes.RemoveRange(licences);
                 await db.SaveChangesAsync();
             }
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/UserManagerPrefetchLicenceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserManagerPrefetchLicenceTests.cs
@@ -120,6 +120,109 @@ namespace Tests.UnitTests
             }
         }
 
+        [TestMethod]
+        public async Task ManagerFallback_ManagerIsLaterReconciled_KeepsItsLicenceGraph()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var tag = Guid.NewGuid().ToString("N");
+            var managerUpn = $"fallbackmanager{tag}@test.com";
+            var reportUpn = $"fallbackreport{tag}@test.com";
+            var managerAadId = Guid.NewGuid().ToString();
+            var reportAadId = Guid.NewGuid().ToString();
+            var testSku = $"FALLBACK_TEST_SKU_{tag}";
+
+            await RemoveTestUsers(managerUpn, reportUpn);
+            try
+            {
+                using (var seed = new AnalyticsEntitiesContext())
+                {
+                    var licence = new LicenseType { Name = testSku, SKUID = testSku };
+                    var manager = new Common.Entities.User
+                    {
+                        UserPrincipalName = managerUpn,
+                        AzureAdId = managerAadId,
+                        AccountEnabled = true
+                    };
+                    var report = new Common.Entities.User
+                    {
+                        UserPrincipalName = reportUpn,
+                        AzureAdId = reportAadId,
+                        AccountEnabled = true
+                    };
+
+                    seed.LicenseTypes.Add(licence);
+                    seed.users.Add(manager);
+                    seed.users.Add(report);
+                    seed.UserLicenseTypeLookups.Add(new UserLicenseTypeLookup { User = manager, License = licence });
+                    await seed.SaveChangesAsync();
+                }
+
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    var snapshots = await db.users.AsNoTracking()
+                        .Include(u => u.LicenseLookups)
+                        .Where(u => u.UserPrincipalName == managerUpn || u.UserPrincipalName == reportUpn)
+                        .ToListAsync();
+                    var reportSnapshot = snapshots.Single(u => u.UserPrincipalName == reportUpn);
+
+                    var managerGraph = new GraphUser
+                    {
+                        Id = managerAadId,
+                        UserPrincipalName = managerUpn,
+                        AccountEnabled = true,
+                        Mail = managerUpn,
+                    };
+                    var reportGraph = new GraphUser
+                    {
+                        Id = reportAadId,
+                        UserPrincipalName = reportUpn,
+                        AccountEnabled = true,
+                        Mail = reportUpn,
+                        ManagerInfo = new List<ManagerInfo> { new ManagerInfo { Id = managerAadId } },
+                    };
+
+                    var mapper = new UserDataMapper(logger, new UserMetadataCache(db));
+                    mapper.SetGraphUserLookup(new List<GraphUser> { managerGraph, reportGraph });
+
+                    await mapper.UpdateUserMetadata(
+                        db,
+                        reportGraph,
+                        new List<GraphUser> { managerGraph, reportGraph },
+                        reportSnapshot,
+                        new Dictionary<string, Common.Entities.User>(StringComparer.OrdinalIgnoreCase),
+                        new List<Common.Entities.User>());
+
+                    var trackedManager = db.ChangeTracker.Entries<Common.Entities.User>()
+                        .Single(e => e.Entity.UserPrincipalName == managerUpn)
+                        .Entity;
+
+                    var loader = new FakeUserMetadataLoader(
+                        new List<GraphUser> { managerGraph, reportGraph },
+                        fakeSkus: null,
+                        fakeUsersBySku: null,
+                        fakeLicenseDetails: new Dictionary<string, List<LicenseDetails>>
+                        {
+                            { managerAadId, new List<LicenseDetails> { new LicenseDetails { SkuId = Guid.NewGuid(), SkuPartNumber = testSku } } },
+                        });
+
+                    await new UserLicenseProcessor(logger, loader, new UserMetadataCache(db))
+                        .ProcessUserLicenses(db, managerGraph, trackedManager);
+                    await db.SaveChangesAsync();
+                }
+
+                using (var verify = new AnalyticsEntitiesContext())
+                {
+                    Assert.AreEqual(1, await CountLicences(verify, managerUpn),
+                        "The fallback by-UPN manager query must load existing licence lookups before later per-user reconciliation reuses the tracked manager.");
+                }
+            }
+            finally
+            {
+                await RemoveTestUsers(managerUpn, reportUpn);
+                await RemoveTestLicences(testSku);
+            }
+        }
+
         private static async Task<int> CountLicences(AnalyticsEntitiesContext db, string upn)
         {
             return await db.UserLicenseTypeLookups.CountAsync(l => l.User.UserPrincipalName == upn);
@@ -157,6 +260,19 @@ namespace Tests.UnitTests
                     db.UserLicenseTypeLookups.RemoveRange(user.LicenseLookups);
                 }
                 db.users.RemoveRange(users);
+                await db.SaveChangesAsync();
+            }
+        }
+
+        private static async Task RemoveTestLicences(params string[] skuIds)
+        {
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                var licences = await db.LicenseTypes
+                    .Where(l => skuIds.Contains(l.SKUID) &&
+                        !db.UserLicenseTypeLookups.Any(lookup => lookup.LicenseTypeId == l.ID))
+                    .ToListAsync();
+                db.LicenseTypes.RemoveRange(licences);
                 await db.SaveChangesAsync();
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/OfficeLicenseNameResolver.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/OfficeLicenseNameResolver.cs
@@ -11,7 +11,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// <summary>
     /// CSV wrapper for license names
     /// </summary>
-    public class OfficeLicenseNameResolver
+    public class OfficeLicenseNameResolver : IOfficeLicenseNameResolver
     {
         private List<OfficeNamesCsvImportLine> _records = new List<OfficeNamesCsvImportLine>();
         public OfficeLicenseNameResolver()

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/IOfficeLicenseNameResolver.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/IOfficeLicenseNameResolver.cs
@@ -1,0 +1,10 @@
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Resolves Microsoft SKU part numbers to the display names stored in <c>dbo.license_types</c>.
+    /// </summary>
+    public interface IOfficeLicenseNameResolver
+    {
+        string GetDisplayNameFor(string id);
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserBatchProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserBatchProcessor.cs
@@ -173,10 +173,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     return tracked.Entity;
                 }
 
-                // If still can't find, try Find() as last resort
+                // If still can't find, load the row as a last resort. Find() cannot Include the
+                // licence graph; on the per-user licence path that could hand
+                // ProcessUserLicenses a tracked User with an empty LicenseLookups list.
                 if (user.ID > 0)
                 {
-                    var found = db.users.Find(user.ID);
+                    var found = db.users
+                        .Include(u => u.LicenseLookups)
+                        .FirstOrDefault(u => u.ID == user.ID);
                     if (found != null)
                     {
                         return found;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserDataMapper.cs
@@ -292,6 +292,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                             if (!_managerPrefetch.TryGet(managerUpn, out dbManager))
                             {
                                 dbManager = await db.users
+                                    .Include(u => u.LicenseLookups)
                                     .FirstOrDefaultAsync(u => u.UserPrincipalName == managerUpn);
                             }
 
@@ -357,7 +358,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 // branch above: this ran once per user with an unsaved template entity (#371).
                 if (!_managerPrefetch.TryGet(upn, out var existingUser))
                 {
-                    existingUser = await db.users.FirstOrDefaultAsync(u => u.UserPrincipalName == upn);
+                    existingUser = await db.users
+                        .Include(u => u.LicenseLookups)
+                        .FirstOrDefaultAsync(u => u.UserPrincipalName == upn);
                 }
                 if (existingUser != null)
                 {
@@ -400,10 +403,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 return trackedUser;
             }
 
-            // No tracked entity found - use Find() which will return tracked entity from DB
-            // This is more reliable than Attach() as it handles cases where the entity
-            // might have been modified in the database since it was loaded
-            var foundUser = db.users.Find(user.ID);
+            // No tracked entity found - query the tracked entity from DB with the same licence
+            // graph as the per-user licence path. Find() cannot Include navigation properties, and
+            // an empty User.LicenseLookups list would stop ProcessUserLicenses deleting stored rows
+            // before it re-adds the current Graph answer.
+            var foundUser = await db.users
+                .Include(u => u.LicenseLookups)
+                .FirstOrDefaultAsync(u => u.ID == user.ID);
 
             if (foundUser != null)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserLicenseProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserLicenseProcessor.cs
@@ -16,7 +16,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     internal class UserLicenseProcessor
     {
         private readonly AnalyticsLogger _logger;
-        private readonly OfficeLicenseNameResolver _officeLicenseNameResolver;
+        private readonly IOfficeLicenseNameResolver _officeLicenseNameResolver;
         private readonly IUserMetadataLoader _userLoader;
         private readonly UserMetadataCache _userMetaCache;
         private readonly Func<AnalyticsEntitiesContext, IUserLicenseStore> _licenseStoreFactory;
@@ -24,14 +24,32 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         public UserLicenseProcessor(
             AnalyticsLogger logger,
             IUserMetadataLoader userLoader,
+            UserMetadataCache userMetaCache)
+            : this(logger, userLoader, userMetaCache, new OfficeLicenseNameResolver(), null)
+        {
+        }
+
+        public UserLicenseProcessor(
+            AnalyticsLogger logger,
+            IUserMetadataLoader userLoader,
             UserMetadataCache userMetaCache,
+            Func<AnalyticsEntitiesContext, IUserLicenseStore> licenseStoreFactory)
+            : this(logger, userLoader, userMetaCache, new OfficeLicenseNameResolver(), licenseStoreFactory)
+        {
+        }
+
+        internal UserLicenseProcessor(
+            AnalyticsLogger logger,
+            IUserMetadataLoader userLoader,
+            UserMetadataCache userMetaCache,
+            IOfficeLicenseNameResolver officeLicenseNameResolver,
             Func<AnalyticsEntitiesContext, IUserLicenseStore> licenseStoreFactory = null)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _userLoader = userLoader ?? throw new ArgumentNullException(nameof(userLoader));
             _userMetaCache = userMetaCache ?? throw new ArgumentNullException(nameof(userMetaCache));
+            _officeLicenseNameResolver = officeLicenseNameResolver ?? throw new ArgumentNullException(nameof(officeLicenseNameResolver));
             _licenseStoreFactory = licenseStoreFactory ?? (db => new SqlUserLicenseStore(db, logger));
-            _officeLicenseNameResolver = new OfficeLicenseNameResolver();
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Graph\User\GraphUserGroupsCache.cs" />
     <Compile Include="Graph\User\GraphUserLoader.cs" />
     <Compile Include="Graph\User\IUserBulkUpdateWriter.cs" />
+    <Compile Include="Graph\User\IOfficeLicenseNameResolver.cs" />
     <Compile Include="Graph\User\IUserLicenseStore.cs" />
     <Compile Include="Graph\User\IUserLookupStore.cs" />
     <Compile Include="Graph\User\IUserMetadataLoader.cs" />


### PR DESCRIPTION
## Summary
- Load `User.LicenseLookups` on every Graph user-manager/attach fallback that can feed per-user licence reconciliation.
- Add `IOfficeLicenseNameResolver` and inject it into `UserLicenseProcessor`, while keeping the production constructors delegated to `OfficeLicenseNameResolver`.
- Add regression coverage for the fallback-attached manager case and resolver-seam SKU mapping/unknown-SKU behavior.

## Notes for reviewers
- Addresses #431. This behaviour predates the #381 refactor and was deliberately left unchanged in PR #423; this is a correctness follow-up, not a regression.
- Scope discovery: #431 named one un-Included fallback query, but the same latent duplicate-licence bug was reachable through multiple tracked-user fallback paths. This PR fixes the fallback manager UPN lookup, the `UserDataMapper.EnsureUserIsTrackedAsync` UPN and ID loads, and the `UserBatchProcessor.GetOrAttachUser` last-resort `Find()` path. Fixing only the one query named in the issue would have left the same empty-`LicenseLookups`/duplicate-licence failure reachable through the other paths.
- No schema or configuration changes.

## Validation
- `MSBuild.exe "O365 Advanced Analytics Engine.sln" /nologo /v:minimal /p:Configuration=Debug /m:2` passed locally.
- Targeted `vstest.console.exe Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~UserManagerPrefetchLicenceTests|FullyQualifiedName~UserLicenseRefreshTests"` passed locally: 17/17.
- Mutation check: removing the `Include(u => u.LicenseLookups)` from the fallback manager-by-UPN query makes `ManagerFallback_ManagerIsLaterReconciled_KeepsItsLicenceGraph` fail with duplicate key on `IX_license_type_id_user_id`; restored afterward.
- Authoritative full-suite evidence: required CI check `test_dotnet (Release)` passed on GitHub Actions, full suite on a clean runner, 9m24s: https://github.com/pnp/Microsoft365-Analytics-Insights/actions/runs/33758442091/job/100658549410
- Multi-model code-review loop: claude-opus-4.8, gpt-5.6-sol, and grok-4.6 all reported no significant issues; after the `UserBatchProcessor` last-resort path fix, the same three-model re-review was clean.

Addresses #431
Addresses #429