### PR TITLE
Copilot Adoption: stop the shared analysis being stranded on the request's SynchronizationContext

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSynchronizationContextTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSynchronizationContextTests.cs
@@ -106,9 +106,10 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// The consequence that made this permanent rather than merely slow: a run that survives
-        /// must also clear itself from the in-flight table, so a later poll is served from cache
-        /// instead of joining a stale generation.
+        /// The consequence that made this permanent rather than merely slow: a run that survives must
+        /// also clear itself from the in-flight table. The check deliberately happens with an EMPTY
+        /// cache, because a populated one answers the follow-up poll before the in-flight table is
+        /// ever consulted - so a cached result would make this pass even with the cleanup removed.
         /// </summary>
         [TestMethod]
         public async Task AnalysisRun_LeavesNoStaleGeneration_AfterTheStartingRequestHasEnded()
@@ -126,14 +127,22 @@ namespace Tests.UnitTests
                 await WithTimeout(run, "the analysis");
             }
 
+            // The published entry reaching its TTL is the ordinary case, not an exotic one - it is a
+            // 10-minute expiry against an analysis that can run for minutes. Once it has gone, the
+            // next poll has to be able to start a FRESH run, and it can only do that if the finished
+            // generation took itself out of the in-flight table.
+            cache.Evict();
+
             var second = await WithTimeout(
-                coordinator.GetAsync(28, new List<int>()), "the follow-up poll");
+                coordinator.GetAsync(28, new List<int>()), "the follow-up analysis");
 
             Assert.IsNotNull(second);
             Assert.AreEqual(
-                1,
+                2,
                 runner.CallCount,
-                "the second poll must be served from the published cache, not start a new analysis");
+                "once the cached result had expired the coordinator had to start a new analysis; "
+                + "still seeing a single call means the finished generation was left behind in the "
+                + "in-flight table, where it would serve its stale result for ever");
         }
 
         private static async Task<CopilotAdoptionAnalysis> WithTimeout(
@@ -309,6 +318,15 @@ namespace Tests.UnitTests
                 {
                     _items[key] = analysis;
                     _setCount++;
+                }
+            }
+
+            /// <summary>Drops everything, standing in for the cache entry reaching its TTL.</summary>
+            public void Evict()
+            {
+                lock (_gate)
+                {
+                    _items.Clear();
                 }
             }
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSynchronizationContextTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSynchronizationContextTests.cs
@@ -1,0 +1,316 @@
+extern alias AnalyticsWeb;
+
+using Common.Entities.CopilotAdoption;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AdoptionCache = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionAnalysisCache;
+using AdoptionCoordinator = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.CopilotAdoptionAnalysisCoordinator;
+using AdoptionRunner = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.ICopilotAdoptionAnalysisRunner;
+using NullAnalysisTelemetry = AnalyticsWeb::Web.AnalyticsWeb.Models.CopilotAdoption.NullCopilotAdoptionAnalysisTelemetry;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The Copilot adoption analysis deliberately OUTLIVES the HTTP request that starts it: the
+    /// request gives up after <c>FirstResponseBudget</c> and answers 202, while the shared run
+    /// carries on and a later poll collects the result.
+    ///
+    /// That only works if the run is not tied to the starting request. ASP.NET installs a
+    /// request-bound <see cref="SynchronizationContext"/>, and an <c>await</c> that does not say
+    /// <c>ConfigureAwait(false)</c> posts its continuation back to it. Once the request has ended
+    /// that context never pumps again, so the continuation is simply never run - the analysis stops
+    /// mid-flight with no exception, no timeout and no recycle, and because the coordinator only
+    /// clears its in-flight entry in a <c>finally</c> that never executes, every later poll joins
+    /// the same dead task and the page can never load again until the app restarts (issue #441).
+    ///
+    /// The failure is invisible in the obvious places - CPU and database are idle, the thread pool
+    /// is completely free, nothing throws - which is exactly why it took production telemetry to
+    /// find. These tests pin the invariant that makes it impossible.
+    /// </summary>
+    [TestClass]
+    public class CopilotAdoptionSynchronizationContextTests
+    {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// The run must not inherit the starting thread's context in the first place. This is the
+        /// direct statement of the invariant; the test below shows what it costs when it is broken.
+        /// </summary>
+        [TestMethod]
+        public async Task AnalysisRun_DoesNotCaptureTheStartingRequestsSynchronizationContext()
+        {
+            var runner = new ContextCapturingRunner();
+            var coordinator = NewCoordinator(runner);
+
+            using (var request = new RequestBoundSynchronizationContext())
+            {
+                var run = request.StartAndCapture(() => coordinator.GetAsync(28, new List<int>()));
+
+                Assert.IsTrue(
+                    runner.Entered.Wait(Timeout),
+                    "the analysis should have been started");
+                Assert.IsNotNull(
+                    request.ObservedContextOnStartingThread,
+                    "the fake request context must actually be installed, or this test proves nothing");
+
+                runner.Release();
+                await WithTimeout(run, "the analysis");
+
+                Assert.IsNull(
+                    runner.ObservedContext,
+                    "the analysis must run with no SynchronizationContext, so a continuation can "
+                    + "never be posted back to a request that has already finished");
+            }
+        }
+
+        /// <summary>
+        /// The regression test for the hang itself: end the starting request while the analysis is
+        /// still going, then let the analysis finish. It must still complete and publish.
+        /// </summary>
+        [TestMethod]
+        public async Task AnalysisRun_CompletesEvenAfterTheStartingRequestHasEnded()
+        {
+            var runner = new ContextCapturingRunner();
+            var cache = new InMemoryAnalysisCache();
+            var coordinator = NewCoordinator(runner, cache);
+
+            using (var request = new RequestBoundSynchronizationContext())
+            {
+                var run = request.StartAndCapture(() => coordinator.GetAsync(28, new List<int>()));
+                Assert.IsTrue(runner.Entered.Wait(Timeout), "the analysis should have been started");
+
+                // The 202 has gone back and ASP.NET has torn the request down. Anything posted to
+                // its context from here on is dropped on the floor.
+                request.CompleteRequest();
+
+                // Only now does the analysis finish its work, so its continuation is scheduled
+                // strictly after the request ended - the exact ordering seen in production.
+                runner.Release();
+
+                var analysis = await WithTimeout(run, "the analysis");
+
+                Assert.IsNotNull(analysis);
+                Assert.AreEqual(
+                    1,
+                    cache.SetCount,
+                    "the completed analysis must be published so the next poll can serve it");
+                Assert.AreEqual(
+                    0,
+                    request.PostsAfterCompletion,
+                    "nothing belonging to the analysis may be posted to the finished request");
+            }
+        }
+
+        /// <summary>
+        /// The consequence that made this permanent rather than merely slow: a run that survives
+        /// must also clear itself from the in-flight table, so a later poll is served from cache
+        /// instead of joining a stale generation.
+        /// </summary>
+        [TestMethod]
+        public async Task AnalysisRun_LeavesNoStaleGeneration_AfterTheStartingRequestHasEnded()
+        {
+            var runner = new ContextCapturingRunner();
+            var cache = new InMemoryAnalysisCache();
+            var coordinator = NewCoordinator(runner, cache);
+
+            using (var request = new RequestBoundSynchronizationContext())
+            {
+                var run = request.StartAndCapture(() => coordinator.GetAsync(28, new List<int>()));
+                Assert.IsTrue(runner.Entered.Wait(Timeout), "the analysis should have been started");
+                request.CompleteRequest();
+                runner.Release();
+                await WithTimeout(run, "the analysis");
+            }
+
+            var second = await WithTimeout(
+                coordinator.GetAsync(28, new List<int>()), "the follow-up poll");
+
+            Assert.IsNotNull(second);
+            Assert.AreEqual(
+                1,
+                runner.CallCount,
+                "the second poll must be served from the published cache, not start a new analysis");
+        }
+
+        private static async Task<CopilotAdoptionAnalysis> WithTimeout(
+            Task<CopilotAdoptionAnalysis> task, string what)
+        {
+            var finished = await Task.WhenAny(task, Task.Delay(Timeout));
+            Assert.AreSame(
+                task,
+                finished,
+                what + " never completed. It was stranded on the SynchronizationContext of the "
+                + "request that started it - see issue #441.");
+            return await task;
+        }
+
+        private static AdoptionCoordinator NewCoordinator(
+            AdoptionRunner runner, AdoptionCache cache = null)
+        {
+            return new AdoptionCoordinator(
+                runner,
+                cache ?? new InMemoryAnalysisCache(),
+                (windowDays, hasOverride) => NullAnalysisTelemetry.Instance,
+                TimeSpan.FromMinutes(10));
+        }
+
+        /// <summary>
+        /// Stands in for ASP.NET's request-bound context: continuations are queued to a single
+        /// pump, and once the request has ended anything posted is DROPPED rather than run. That
+        /// dropping is the whole point - it is what turns a captured context into a permanent hang.
+        /// </summary>
+        private sealed class RequestBoundSynchronizationContext : SynchronizationContext, IDisposable
+        {
+            private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> _queue =
+                new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>();
+            private readonly Thread _pump;
+            private int _postsAfterCompletion;
+
+            public RequestBoundSynchronizationContext()
+            {
+                _pump = new Thread(Pump)
+                {
+                    IsBackground = true,
+                    Name = "FakeAspNetRequestPump",
+                };
+                _pump.Start();
+            }
+
+            /// <summary>What <c>SynchronizationContext.Current</c> was on the starting thread.</summary>
+            public SynchronizationContext ObservedContextOnStartingThread { get; private set; }
+
+            public int PostsAfterCompletion => Volatile.Read(ref _postsAfterCompletion);
+
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                try
+                {
+                    _queue.Add(new KeyValuePair<SendOrPostCallback, object>(d, state));
+                }
+                catch (InvalidOperationException)
+                {
+                    // CompleteAdding has been called: the request is over and this continuation is
+                    // never going to run, which is precisely ASP.NET's behaviour.
+                    Interlocked.Increment(ref _postsAfterCompletion);
+                }
+            }
+
+            public override void Send(SendOrPostCallback d, object state) => d(state);
+
+            /// <summary>Runs <paramref name="start"/> ON the pump thread, so it starts under this context.</summary>
+            public Task<CopilotAdoptionAnalysis> StartAndCapture(
+                Func<Task<CopilotAdoptionAnalysis>> start)
+            {
+                var handoff = new TaskCompletionSource<Task<CopilotAdoptionAnalysis>>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+
+                Post(
+                    _ =>
+                    {
+                        ObservedContextOnStartingThread = Current;
+                        try
+                        {
+                            handoff.SetResult(start());
+                        }
+                        catch (Exception ex)
+                        {
+                            handoff.SetException(ex);
+                        }
+                    },
+                    null);
+
+                Assert.IsTrue(
+                    handoff.Task.Wait(Timeout),
+                    "the analysis was never started on the request thread");
+                return handoff.Task.Result;
+            }
+
+            /// <summary>Ends the "request". Later posts are dropped, exactly as ASP.NET drops them.</summary>
+            public void CompleteRequest() => _queue.CompleteAdding();
+
+            private void Pump()
+            {
+                SetSynchronizationContext(this);
+                foreach (var item in _queue.GetConsumingEnumerable())
+                {
+                    item.Key(item.Value);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (!_queue.IsAddingCompleted) _queue.CompleteAdding();
+                _pump.Join(Timeout);
+                _queue.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Mirrors <c>CopilotAdoptionService</c>: it awaits WITHOUT <c>ConfigureAwait(false)</c>,
+        /// which is what the real service does on every await that matters. If the coordinator lets
+        /// the caller's context reach here, the continuation goes back to that context.
+        /// </summary>
+        private sealed class ContextCapturingRunner : AdoptionRunner
+        {
+            private readonly TaskCompletionSource<bool> _gate =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _callCount;
+
+            public ManualResetEventSlim Entered { get; } = new ManualResetEventSlim(false);
+
+            public SynchronizationContext ObservedContext { get; private set; }
+
+            public int CallCount => Volatile.Read(ref _callCount);
+
+            public async Task<CopilotAdoptionAnalysis> RunAsync(
+                int windowDays,
+                List<int> seatLicenceTypeIds,
+                ICopilotAdoptionRunTelemetry telemetry)
+            {
+                Interlocked.Increment(ref _callCount);
+                ObservedContext = SynchronizationContext.Current;
+                Entered.Set();
+
+                await _gate.Task;
+
+                return new CopilotAdoptionAnalysis();
+            }
+
+            public void Release() => _gate.TrySetResult(true);
+        }
+
+        private sealed class InMemoryAnalysisCache : AdoptionCache
+        {
+            private readonly object _gate = new object();
+            private readonly Dictionary<string, CopilotAdoptionAnalysis> _items =
+                new Dictionary<string, CopilotAdoptionAnalysis>(StringComparer.Ordinal);
+            private int _setCount;
+
+            public int SetCount
+            {
+                get { lock (_gate) { return _setCount; } }
+            }
+
+            public bool TryGet(string key, out CopilotAdoptionAnalysis analysis)
+            {
+                lock (_gate)
+                {
+                    return _items.TryGetValue(key, out analysis);
+                }
+            }
+
+            public void Set(string key, CopilotAdoptionAnalysis analysis, TimeSpan ttl)
+            {
+                lock (_gate)
+                {
+                    _items[key] = analysis;
+                    _setCount++;
+                }
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -198,6 +198,7 @@
     <Compile Include="PowerPlatformAdminActivityRecordParseTests.cs" />
     <Compile Include="ProfilingStoredProcedureTests.cs" />
     <Compile Include="CopilotAdoptionSqlIntegrationTests.cs" />
+    <Compile Include="CopilotAdoptionSynchronizationContextTests.cs" />
     <Compile Include="CopilotAdoptionTelemetryTests.cs" />
     <Compile Include="CopilotAdoptionTests.cs" />
     <Compile Include="CopilotAdoptionWorkbookTests.cs" />

--- a/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionAnalysisCoordinator.cs
+++ b/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionAnalysisCoordinator.cs
@@ -132,7 +132,24 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
 
             Lazy<Task<CopilotAdoptionAnalysis>> candidate = null;
             candidate = new Lazy<Task<CopilotAdoptionAnalysis>>(
-                () => RunAndPublishAsync(cacheKey, candidate, windowDays, ids),
+                // Task.Run, deliberately, rather than calling RunAndPublishAsync directly.
+                //
+                // This run is SHARED and outlives the request that happened to start it: that request
+                // gives up after CopilotAdoptionAPIController.FirstResponseBudget and answers 202, and a
+                // later poll collects the result. But GetAsync is called ON a request thread, where
+                // ASP.NET has installed a request-bound SynchronizationContext. Any await in the analysis
+                // that does not say ConfigureAwait(false) would capture it and post its continuation back
+                // - and once that request has ended the context never pumps again, so the continuation
+                // simply never runs. The analysis then stops mid-flight with no exception, no timeout and
+                // no recycle, while the in-flight entry below is never cleared (its finally never runs),
+                // so every later poll joins the dead task and the page can never load again until the app
+                // restarts. That is issue #441, seen in production as a run still "alive" nearly an hour
+                // later with an idle database, an idle thread pool and nothing logged.
+                //
+                // Starting the run on the thread pool gives it no ambient SynchronizationContext at all,
+                // which fixes this for every await in the analysis - including ones not yet written -
+                // rather than relying on ~32 separate ConfigureAwait(false) calls staying correct.
+                () => Task.Run(() => RunAndPublishAsync(cacheKey, candidate, windowDays, ids)),
                 LazyThreadSafetyMode.ExecutionAndPublication);
 
             var effective = _inFlight.GetOrAdd(cacheKey, candidate);


### PR DESCRIPTION
Addresses #441.

## Problem

On a large tenant the Copilot Adoption page could hang permanently: the analysis started, ran, and then stopped making progress for ever — no exception, no query timeout, no failed step, no app recycle. The SPA polled until its ~10-minute deadline and reported that the analysis "is taking longer than expected".

The failure was strictly bimodal — the page either loaded quickly or never loaded at all — which turned out to be structural rather than coincidental.

## Root cause

The analysis is started **synchronously on an ASP.NET request thread**:

```
CopilotAdoptionAPIController
  -> CopilotAdoptionAnalysisCoordinator.TryGetAsync
  -> GetAsync
  -> Lazy<Task<CopilotAdoptionAnalysis>>.Value
  -> RunAndPublishAsync
  -> CopilotAdoptionService.AnalyseAsync(...)
```

`Web.Template.config` sets `httpRuntime targetFramework="4.7.2"`, so ASP.NET's task-friendly, **request-bound** `AspNetSynchronizationContext` is installed on that thread.

`CopilotAdoptionService.cs` is ~1,856 lines and contains exactly **one** `ConfigureAwait` — on `SemaphoreSlim.WaitAsync` (line 523), the single await where it makes no difference. Every await that mattered captured the request's context:

| Line | Await | `ConfigureAwait(false)` |
|---|---|---|
| 353 | `await RunStepsAsync(...)` | no |
| 491 | `await Task.WhenAll(running)` | no |
| 530 | `await step.Work(step.Output)` | no |
| 1543 | `await ...SqlQuery<T>(...).ToListAsync(...)` | no |
| 523 | `await gate.WaitAsync(...)` | yes (no effect) |

The request that started the run returns `202 Accepted` once `FirstResponseBudget` (20s) expires, and the HTTP request **ends**. Continuations still queued to that request's context are never pumped again, so the analysis stops mid-flight.

**Why it is bimodal.** The run survives only if it finishes inside the first request's 20-second budget. Under 20s the originating request is still open and its context still pumps, so the page loads normally; over 20s the request has ended and the run hangs for ever. There is no third outcome, which is why this never reproduced on small or warm tenants.

**Why it was permanent.** `RunAndPublishAsync` clears its in-flight entry only in a `finally` that never executed, so the wedged `Lazy<Task<...>>` stayed in `_inFlight`. Every later poll — and every later page load — joined the same dead task. The affected cache key could not recover without an app restart.

## Evidence

From the `CopilotAdoptionLifecycle` telemetry during a real occurrence on a production tenant:

- A single run, alive ~56 minutes, `CachePublished = 0`, `Failed = 0`, `HostStopping = 0`, one unchanged AppDomain — neither failing nor being recycled.
- Stages reached: `Started`, `StepStarted`, `QueryStarted`, `QueryCompleted`, `StepCompleted`, `Heartbeat`. It **never** reached `ScoringStarted`, so it was stuck inside `RunStepsAsync` -> `Task.WhenAll`.
- `ActiveOperations` empty on **all 112 heartbeats**. A step blocked at `gate.WaitAsync` has not yet called `StepStarted`, so it is invisible in `_active` — consistent with continuations that never resume.
- Thread pool entirely free (~32,765 workers, 1,000 completion ports), heartbeat drift a few ms, `Gen2` collection count flat: not starvation, not GC, not memory pressure.
- Database and web CPU both idle throughout — no SQL was being issued.
- The heartbeat kept reporting only because it runs on a **dedicated thread**, which is immune to the stall. That is what made a wedged run still look alive.

## The change

`CopilotAdoptionAnalysisCoordinator.GetAsync`'s `Lazy` value factory now starts the shared run with `Task.Run`, so it begins on a thread-pool thread with **no ambient `SynchronizationContext`**:

```csharp
() => Task.Run(() => RunAndPublishAsync(cacheKey, candidate, windowDays, ids)),
```

This is one line at the seam that owns the "this run outlives its request" contract, and it covers **every** await in the analysis — including ones not yet written.

### Why not add `ConfigureAwait(false)` to the service's 32 awaits

Once the entry point has no ambient context, `ConfigureAwait(false)` is provably a no-op: it only changes behaviour when `SynchronizationContext.Current` is non-null. Spreading it across 32 call sites is the fragile option — a single miss reintroduces the bug, and it does not cover future awaits. One line at the seam cannot be half-missed.

Reviewer note (raised by one reviewer, deliberately not actioned here): `CopilotAdoptionService` remains context-capturing in its own right, so a *future* caller that invokes `AnalyseAsync` directly from a request thread would reintroduce the hang. Every current caller — all nine controller entry points including the three exports, plus `Tests.FakeDataGen` — goes through the coordinator or has no request context. This is a pre-existing property that this change neither creates nor worsens.

## Tests

New `Tests.UnitTests\CopilotAdoptionSynchronizationContextTests.cs` reproduces the hang directly, using a fake request-bound `SynchronizationContext` that **drops** continuations once the request has ended — the behaviour that turns a captured context into a permanent hang. Runs are gated on a `TaskCompletionSource` rather than timing delays, so the ordering (request ends, *then* the analysis finishes) is deterministic.

| Test | Pre-fix | Post-fix |
|---|---|---|
| `AnalysisRun_DoesNotCaptureTheStartingRequestsSynchronizationContext` | fails (context captured) | passes |
| `AnalysisRun_CompletesEvenAfterTheStartingRequestHasEnded` | **hangs to the 10s timeout** | passes (3 ms) |
| `AnalysisRun_LeavesNoStaleGeneration_AfterTheStartingRequestHasEnded` | **hangs to the 10s timeout** | passes (2 ms) |

The third test evicts the cached result first (standing in for the 10-minute TTL expiring), because a populated cache answers the follow-up poll before `_inFlight` is ever consulted — so without eviction it would pass even with the cleanup deleted. **Verified by mutation in both directions:** with `RemoveInFlight(cacheKey, generation)` commented out it fails `Assert.AreEqual failed. Expected:<2>. Actual:<1>.`; restored, it passes.

All 138 `CopilotAdoption*` tests pass.

## Review

Reviewed through an iterative multi-model critique loop (Claude Opus 4.8, GPT-5.6 Sol, Grok 4.6, Gemini 3.7) until a round returned clean. Round 1 produced exactly one actionable finding — the non-discriminating stale-generation test above — raised independently by two reviewers; round 2 re-reviewed the fix for that finding and found no new defect.

Reviewers independently confirmed: `Task.Run` reliably yields a null `SynchronizationContext` on .NET Framework 4.8 (it uses `TaskScheduler.Default`, and the pool does not restore a captured context); nothing in the analysis path depends on `HttpContext.Current`, request culture, thread identity or impersonation; exception propagation, cancellation, the `RemoveInFlight` key+reference match and the just-published double-check are all unaffected.

## Risk and reviewer hotspots

- **`HttpContext.Current` is now null inside the run.** Confirmed safe: `CopilotAdoptionAnalysisRunner`, `CopilotAdoptionService`, `CopilotAdoptionTelemetryHost`, `DefaultAnalyticsDbContextFactory` and `CopilotAdoptionOptions` contain no reference to `HttpContext`, `CallContext`, `CurrentPrincipal` or impersonation. Connection strings come from AppDomain-wide configuration, already used from web-jobs with no request.
- **Latency is unchanged or slightly better.** A cache-miss `GetAsync` now returns to the request thread without running the analysis's synchronous prefix (including telemetry construction, which spawns a heartbeat thread) on it.
- **The `SynchronizationContext` telemetry dimension will now read `None`** for adoption runs. That dimension is what identified this bug; the value changing is the intended outcome, not a regression.

## Deferred

A stale-generation guard in `_inFlight`. With the root cause fixed, `RunAndPublishAsync` reliably reaches its `finally`, so the wedge is now only reachable if a run hangs for some *other* reason — a small surface, given SQL is bounded by `CommandTimeout = QueryTimeoutSecs` and failures are degraded to warnings by `SafeAsync`. Kept out of this PR so the root-cause fix stays reviewable; tracked in #441.
