### PR TITLE
Fix Power Platform Activity API feed gating

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -566,7 +566,7 @@ namespace App.ControlPanel.Engine
         async Task VerifyRuntimeAccountAllAPIs()
         {
             // Activity API test 
-            if (Config.SolutionConfig.ImportTaskSettings.ActivityLog)
+            if (Config.SolutionConfig.ImportTaskSettings.UsesActivityApi)
             {
                 await VerifyActivityAPIImport(Config.RuntimeAccountOffice365.ClientId, Config.RuntimeAccountOffice365.DirectoryId, Config.RuntimeAccountOffice365.Secret);
             }

--- a/src/AnalyticsEngine/Common/Entities/ImportTaskSettings.cs
+++ b/src/AnalyticsEngine/Common/Entities/ImportTaskSettings.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/AnalyticsEngine/Common/Entities/ImportTaskSettings.cs
+++ b/src/AnalyticsEngine/Common/Entities/ImportTaskSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -158,11 +158,17 @@ namespace Common.Entities
         public const string CONTENT_TYPE_AUDIT_SHAREPOINT = "Audit.SharePoint";
 
         /// <summary>
+        /// True when any enabled workload needs the Office 365 Management Activity API. SharePoint audit
+        /// events use Audit.SharePoint; Microsoft 365 Copilot and Power Platform both use Audit.General.
+        /// </summary>
+        public bool UsesActivityApi => ActivityLog || Copilot || ImportPowerPlatform;
+
+        /// <summary>
         /// Builds the "ContentTypesListAsString" value (the Office 365 Management Activity API feeds
-        /// to subscribe to) from the enabled audit-based imports: <see cref="Copilot"/> =&gt;
-        /// Audit.General, <see cref="ActivityLog"/> (SharePoint audit) =&gt; Audit.SharePoint.
-        /// Falls back to Audit.SharePoint when no audit source is selected so the runtime always has
-        /// a valid (if unused) workload list.
+        /// to subscribe to) from the enabled audit-based imports: <see cref="Copilot"/> and
+        /// <see cref="ImportPowerPlatform"/> =&gt; Audit.General, <see cref="ActivityLog"/> (SharePoint audit)
+        /// =&gt; Audit.SharePoint. Falls back to Audit.SharePoint when no audit source is selected so the
+        /// runtime always has a valid (if unused) workload list.
         /// </summary>
         public string ToActivityApiContentTypesString()
         {

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityImporterTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityImporterTests.cs
@@ -563,6 +563,20 @@ Event found in API, doesn't find it in cache, assumes it's a new ignored event, 
             Assert.IsTrue(spFilterConfig.InScope(new PowerAutomateAuditLogContent { Workload = ActivityImportConstants.WORKLOAD_POWER_AUTOMATE, ObjectId = string.Empty }));
         }
 
+        [TestMethod]
+        public void OrgURLsFilter_EmptyUrlList_DropsSharePointOnly()
+        {
+            var spFilterConfig = new SharePointOrgUrlsFilterConfig();
+
+            var spEvent = DataGenerators.GetRandomSharePointLog();
+            spEvent.ObjectId = "https://contoso.sharepoint.com/sites/example/Shared Documents/file.docx";
+
+            Assert.IsFalse(spFilterConfig.InScope(spEvent),
+                "With no org_urls rows, SharePoint/OneDrive audit events must not fall through to the generic empty-list allow-all URL rule.");
+            Assert.IsTrue(spFilterConfig.InScope(new PowerAppsAuditLogContent { Workload = ActivityImportConstants.WORKLOAD_POWER_APPS, ObjectId = "00000000-0000-0000-0000-000000000015" }),
+                "The empty SharePoint URL whitelist must not block non-SharePoint workloads delivered by the same Activity API cycle.");
+        }
+
         /// <summary>
         /// SharePoint events without a URL (e.g. ManagedSyncClientAllowed) have nothing to match
         /// against the org-URL whitelist, so the SharePoint filter treats them as out of scope.
@@ -752,6 +766,12 @@ Event found in API, doesn't find it in cache, assumes it's a new ignored event, 
             try
             {
                 var s = new AppConfig();
+                s.ImportJobSettings = new ImportTaskSettings
+                {
+                    ActivityLog = true,
+                    Copilot = true,
+                    ImportPowerPlatform = true,
+                };
                 return s;
             }
             catch (FormatException)

--- a/src/AnalyticsEngine/Tests.UnitTests/ImportStatTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ImportStatTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Reflection;
+using WebJob.Office365ActivityImporter.Engine.Entities;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class ImportStatTests
+    {
+        [TestMethod]
+        public void AddStats_AccumulatesEveryNumericCounter()
+        {
+            var first = CreatePopulatedStats(10);
+            var second = CreatePopulatedStats(100);
+            var total = new ImportStat();
+
+            total.AddStats(first);
+            total.AddStats(second);
+
+            foreach (var property in AccumulatedNumericProperties())
+            {
+                var expected = Convert.ToDouble(property.GetValue(first)) + Convert.ToDouble(property.GetValue(second));
+                var actual = Convert.ToDouble(property.GetValue(total));
+                Assert.AreEqual(expected, actual, 0.0001,
+                    $"ImportStat.AddStats must accumulate {property.Name}; update this test if a future numeric property is intentionally not additive.");
+            }
+        }
+
+        private static ImportStat CreatePopulatedStats(int seed)
+        {
+            var stat = new ImportStat();
+            int offset = 1;
+            foreach (var property in AccumulatedNumericProperties())
+            {
+                if (property.PropertyType == typeof(int))
+                {
+                    property.SetValue(stat, seed + offset);
+                }
+                else if (property.PropertyType == typeof(double))
+                {
+                    property.SetValue(stat, seed + offset + 0.25);
+                }
+                offset++;
+            }
+            return stat;
+        }
+
+        private static PropertyInfo[] AccumulatedNumericProperties()
+        {
+            return typeof(ImportStat)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(p => p.CanRead && p.CanWrite && (p.PropertyType == typeof(int) || p.PropertyType == typeof(double)))
+                .OrderBy(p => p.Name)
+                .ToArray();
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/SentEmailImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SentEmailImportTests.cs
@@ -48,6 +48,10 @@ namespace Tests.UnitTests
             Assert.IsFalse(settings.ActivityLog, "ActivityLog should default to false");
             Assert.IsFalse(settings.WebTraffic, "WebTraffic should default to false");
             Assert.IsFalse(settings.SentEmails, "SentEmails should default to false");
+            Assert.IsFalse(settings.Copilot, "Copilot should default to false");
+            Assert.IsFalse(settings.ImportPowerPlatform, "ImportPowerPlatform should default to false");
+            Assert.IsFalse(settings.GraphCopilotUsageReports, "GraphCopilotUsageReports should default to false");
+            Assert.IsFalse(settings.CopilotInteractionHistory, "CopilotInteractionHistory should default to false");
         }
 
         [TestMethod]
@@ -75,7 +79,8 @@ namespace Tests.UnitTests
             // Parse honours =True for every [ImportProp] (opt-in model).
             var settings = new ImportTaskSettings(
                 "Calls=True;GraphUsersMetadata=True;GraphUsageReports=True;" +
-                "GraphTeams=True;ActivityLog=True;WebTraffic=True;SentEmails=True");
+                "GraphTeams=True;ActivityLog=True;WebTraffic=True;SentEmails=True;" +
+                "Copilot=True;ImportPowerPlatform=True;GraphCopilotUsageReports=True;CopilotInteractionHistory=True");
 
             Assert.IsTrue(settings.Calls);
             Assert.IsTrue(settings.GraphUsersMetadata);
@@ -84,6 +89,10 @@ namespace Tests.UnitTests
             Assert.IsTrue(settings.ActivityLog);
             Assert.IsTrue(settings.WebTraffic);
             Assert.IsTrue(settings.SentEmails);
+            Assert.IsTrue(settings.Copilot);
+            Assert.IsTrue(settings.ImportPowerPlatform);
+            Assert.IsTrue(settings.GraphCopilotUsageReports);
+            Assert.IsTrue(settings.CopilotInteractionHistory);
         }
 
         [TestMethod]
@@ -155,6 +164,10 @@ namespace Tests.UnitTests
                 ActivityLog = true,
                 WebTraffic = false,
                 SentEmails = true,
+                Copilot = true,
+                ImportPowerPlatform = true,
+                GraphCopilotUsageReports = false,
+                CopilotInteractionHistory = true,
             };
 
             var reloaded = new ImportTaskSettings(original.ToSettingsString());
@@ -167,6 +180,10 @@ namespace Tests.UnitTests
             Assert.AreEqual(original.ActivityLog, reloaded.ActivityLog);
             Assert.AreEqual(original.WebTraffic, reloaded.WebTraffic);
             Assert.AreEqual(original.SentEmails, reloaded.SentEmails);
+            Assert.AreEqual(original.Copilot, reloaded.Copilot);
+            Assert.AreEqual(original.ImportPowerPlatform, reloaded.ImportPowerPlatform);
+            Assert.AreEqual(original.GraphCopilotUsageReports, reloaded.GraphCopilotUsageReports);
+            Assert.AreEqual(original.CopilotInteractionHistory, reloaded.CopilotInteractionHistory);
         }
 
         [TestMethod]
@@ -177,6 +194,7 @@ namespace Tests.UnitTests
             {
                 "Calls", "GraphUsersMetadata", "GraphUsageReports",
                 "GraphTeams", "ActivityLog", "WebTraffic", "SentEmails", "Copilot",
+                "ImportPowerPlatform", "GraphCopilotUsageReports", "CopilotInteractionHistory",
             })
             {
                 Assert.IsTrue(settingsString.Contains(propName + "="),
@@ -193,6 +211,7 @@ namespace Tests.UnitTests
             {
                 "Calls", "GraphUsersMetadata", "GraphUsageReports",
                 "GraphTeams", "ActivityLog", "WebTraffic", "SentEmails", "Copilot",
+                "ImportPowerPlatform", "GraphCopilotUsageReports", "CopilotInteractionHistory",
             })
             {
                 Assert.IsTrue(settingsString.Contains(propName + "=False"),
@@ -264,6 +283,9 @@ namespace Tests.UnitTests
             Assert.IsTrue(new ImportTaskSettings { WebTraffic = true }.HaveSomethingToDo());
             Assert.IsTrue(new ImportTaskSettings { SentEmails = true }.HaveSomethingToDo());
             Assert.IsTrue(new ImportTaskSettings { Copilot = true }.HaveSomethingToDo());
+            Assert.IsTrue(new ImportTaskSettings { ImportPowerPlatform = true }.HaveSomethingToDo());
+            Assert.IsTrue(new ImportTaskSettings { GraphCopilotUsageReports = true }.HaveSomethingToDo());
+            Assert.IsTrue(new ImportTaskSettings { CopilotInteractionHistory = true }.HaveSomethingToDo());
         }
 
         [TestMethod]
@@ -277,9 +299,13 @@ namespace Tests.UnitTests
             Assert.AreEqual("Audit.General",
                 new ImportTaskSettings { Copilot = true }.ToActivityApiContentTypesString());
 
-            // Copilot + SharePoint -> Audit.General;Audit.SharePoint
+            // Power Platform only -> Audit.General
+            Assert.AreEqual("Audit.General",
+                new ImportTaskSettings { ImportPowerPlatform = true }.ToActivityApiContentTypesString());
+
+            // Copilot + Power Platform + SharePoint -> Audit.General;Audit.SharePoint (no duplicate Audit.General)
             Assert.AreEqual("Audit.General;Audit.SharePoint",
-                new ImportTaskSettings { Copilot = true, ActivityLog = true }.ToActivityApiContentTypesString());
+                new ImportTaskSettings { Copilot = true, ImportPowerPlatform = true, ActivityLog = true }.ToActivityApiContentTypesString());
 
             // Neither audit source -> safe non-empty default so the runtime workload list is valid
             Assert.AreEqual("Audit.SharePoint",

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="GraphImportOrchestrationTests.cs" />
     <Compile Include="GraphImportSectionCompositionTests.cs" />
     <Compile Include="ImportRuntimeOptionsTests.cs" />
+    <Compile Include="ImportStatTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeTeamsPorts.cs" />
     <Compile Include="OrgUrlStoreTests.cs" />
     <Compile Include="FakeLoaderClasses\FixedClock.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/WorkloadToggleTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/WorkloadToggleTests.cs
@@ -1,13 +1,19 @@
 using Common.Entities;
+using DataUtils.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
 using ActivityImporter.Engine.ActivityAPI.Copilot;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
@@ -24,6 +30,66 @@ namespace Tests.UnitTests
     public class WorkloadToggleTests
     {
         private static ILogger Logger => new LoggerFactory().CreateLogger("WorkloadToggleTests");
+
+
+        [TestMethod]
+        public async Task ActivityReportWebLoader_PowerPlatformOnlySettings_ReadsGeneralFeedAndDropsCopilot()
+        {
+            var settings = new ImportTaskSettings { ImportPowerPlatform = true };
+            Assert.IsTrue(settings.UsesActivityApi, "Power Platform alone must run the Activity API import loop.");
+            Assert.AreEqual(ImportTaskSettings.CONTENT_TYPE_AUDIT_GENERAL, settings.ToActivityApiContentTypesString(),
+                "Power Platform alone must subscribe to the Audit.General feed it is delivered on.");
+
+            var json = @"[
+                { ""Workload"": ""PowerApps"", ""Operation"": ""CreateApp"", ""ObjectId"": ""00000000-0000-0000-0000-000000000010"" },
+                { ""Workload"": ""Copilot"", ""Operation"": ""CopilotInteraction"", ""ObjectId"": ""00000000-0000-0000-0000-000000000011"" }
+            ]";
+
+            using (var httpClient = new AutoThrottleHttpClient(new StaticJsonHandler(json), Logger))
+            {
+                var loader = new ActivityReportWebLoader(
+                    httpClient,
+                    Logger,
+                    Guid.Empty.ToString(),
+                    importPowerPlatform: settings.ImportPowerPlatform,
+                    importCopilot: settings.Copilot);
+
+                var logs = await loader.Load(new ActivityReportInfo
+                {
+                    ContentUri = new Uri("https://contoso.example/activity/content/00000000-0000-0000-0000-000000000012"),
+                    ContentId = "00000000-0000-0000-0000-000000000013",
+                    ContentType = ImportTaskSettings.CONTENT_TYPE_AUDIT_GENERAL,
+                });
+
+                Assert.IsTrue(logs.DownloadComplete);
+                Assert.AreEqual(1, logs.Count, "Only the Power Platform event should survive with Copilot disabled.");
+                Assert.IsInstanceOfType(logs[0], typeof(PowerAppsAuditLogContent));
+            }
+        }
+
+        [TestMethod]
+        public void Dispatch_CopilotDisabled_DropsCopilotWorkload()
+        {
+            var json = JToken.Parse(@"{
+                ""Workload"": ""Copilot"",
+                ""Operation"": ""CopilotInteraction"",
+                ""ObjectId"": ""00000000-0000-0000-0000-000000000014""
+            }");
+            var logBase = json.ToObject<WorkloadOnlyAuditLogContent>();
+
+            Assert.IsNull(
+                AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: true, importCopilot: false),
+                "Copilot audit events must be dropped when the Copilot import toggle is disabled, even if Audit.General is being read for Power Platform.");
+        }
+
+        [TestMethod]
+        public void UsesActivityApi_IncludesEveryAuditFeedConsumer()
+        {
+            Assert.IsTrue(new ImportTaskSettings { ActivityLog = true }.UsesActivityApi, "SharePoint audit uses Audit.SharePoint.");
+            Assert.IsTrue(new ImportTaskSettings { Copilot = true }.UsesActivityApi, "Copilot uses Audit.General.");
+            Assert.IsTrue(new ImportTaskSettings { ImportPowerPlatform = true }.UsesActivityApi, "Power Platform uses Audit.General.");
+            Assert.IsFalse(new ImportTaskSettings().UsesActivityApi, "No audit-feed toggle enabled means the Activity API loop should be skipped.");
+        }
 
         [TestMethod]
         public void Dispatch_PowerPlatformDisabled_DropsPowerPlatformWorkloads()
@@ -150,6 +216,24 @@ namespace Tests.UnitTests
             Assert.IsNotNull(
                 AuditLogContentDispatcher.Dispatch(json, logBase, Logger, importPowerPlatform: false),
                 "SharePoint events must never be affected by the Power Platform toggle.");
+        }
+
+        private sealed class StaticJsonHandler : HttpMessageHandler
+        {
+            private readonly string _json;
+
+            public StaticJsonHandler(string json)
+            {
+                _json = json;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_json, Encoding.UTF8, "application/json")
+                });
+            }
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/AuditFilterConfig.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/AuditFilterConfig.cs
@@ -39,6 +39,11 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI
                 return false;
             }
 
+            if (OrgUrlConfigs.Count == 0)
+            {
+                return false;
+            }
+
             // Analyse all org URLs to see which one matches this hit.
             return OrgUrlConfigs.UrlInScope(spContent.SiteUrl, spContent.ObjectId);
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
@@ -23,14 +23,16 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         private readonly ILogger _logger;
         private readonly string _tenantId;
         private readonly bool _importPowerPlatform;
+        private readonly bool _importCopilot;
         private int _reportDownloadErrors = 0;
 
-        public ActivityReportWebLoader(AutoThrottleHttpClient httpClient, ILogger logger, string tenantId, bool importPowerPlatform = true)
+        public ActivityReportWebLoader(AutoThrottleHttpClient httpClient, ILogger logger, string tenantId, bool importPowerPlatform = true, bool importCopilot = true)
         {
             _httpClient = httpClient;
             _logger = logger;
             _tenantId = tenantId;
             _importPowerPlatform = importPowerPlatform;
+            _importCopilot = importCopilot;
         }
 
         /// <summary>
@@ -193,7 +195,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
             // thin IO + batching layer.
             try
             {
-                thisAuditLogReport = AuditLogContentDispatcher.Dispatch(reportItem, logBase, _logger, _importPowerPlatform);
+                thisAuditLogReport = AuditLogContentDispatcher.Dispatch(reportItem, logBase, _logger, _importPowerPlatform, _importCopilot);
             }
             catch (JsonReaderException ex)
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityWebImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityWebImporter.cs
@@ -20,7 +20,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         {
             var auth = new ActivityAPIAppIndentityOAuthContext(logger, settings.ClientID, settings.TenantGUID.ToString(), settings.ClientSecret, settings.KeyVaultUrl, settings.UseClientCertificate);
             var httpClient = new ConfidentialClientApplicationThrottledHttpClient(auth, false, logger);
-            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, logger, settings.TenantGUID.ToString(), settings.ImportJobSettings?.ImportPowerPlatform ?? false);
+            _activityReportWebLoader = new ActivityReportWebLoader(
+                httpClient,
+                logger,
+                settings.TenantGUID.ToString(),
+                settings.ImportJobSettings?.ImportPowerPlatform ?? false,
+                settings.ImportJobSettings?.Copilot ?? false);
             _contentMetaDataLoader = new WebContentMetaDataLoader(logger, httpClient, settings);
             _activitySubscriptionManager = new ActivitySubscriptionManager(settings, logger, httpClient);
         }
@@ -31,7 +36,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         /// </summary>
         public ActivityWebImporter(ConfidentialClientApplicationThrottledHttpClient httpClient, AppConfig settings, AnalyticsLogger logger, int maxSavesPerBatch) : base(settings, logger, maxSavesPerBatch)
         {
-            _activityReportWebLoader = new ActivityReportWebLoader(httpClient, logger, settings.TenantGUID.ToString(), settings.ImportJobSettings?.ImportPowerPlatform ?? false);
+            _activityReportWebLoader = new ActivityReportWebLoader(
+                httpClient,
+                logger,
+                settings.TenantGUID.ToString(),
+                settings.ImportJobSettings?.ImportPowerPlatform ?? false,
+                settings.ImportJobSettings?.Copilot ?? false);
             _contentMetaDataLoader = new WebContentMetaDataLoader(logger, httpClient, settings);
             _activitySubscriptionManager = new ActivitySubscriptionManager(settings, logger, httpClient);
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/AuditLogContentDispatcher.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/AuditLogContentDispatcher.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform;
@@ -27,7 +27,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
         /// JSON deserialisation exceptions are intentionally not caught here - the caller already
         /// logs them with the originating workload name and continues to the next record.
         /// </summary>
-        public static AbstractAuditLogContent Dispatch(JToken reportItem, WorkloadOnlyAuditLogContent logBase, ILogger logger, bool importPowerPlatform = true)
+        public static AbstractAuditLogContent Dispatch(JToken reportItem, WorkloadOnlyAuditLogContent logBase, ILogger logger, bool importPowerPlatform = true, bool importCopilot = true)
         {
             if (reportItem == null || logBase == null)
             {
@@ -51,6 +51,14 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
                     || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_AUTOMATE
                     || logBase.Workload == ActivityImportConstants.WORKLOAD_POWER_BI
                     || logBase.Workload == ActivityImportConstants.WORKLOAD_COPILOT_STUDIO))
+            {
+                return null;
+            }
+
+            // Microsoft 365 Copilot interactions also arrive through Audit.General, but are controlled
+            // by their own opt-in toggle. A tenant reading Audit.General for Power Platform must not import
+            // Copilot records unless Copilot import is enabled too.
+            if (!importCopilot && logBase.Workload == ActivityImportConstants.WORKLOAD_COPILOT)
             {
                 return null;
             }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/AuditLogContentDispatcher.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/AuditLogContentDispatcher.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using WebJob.Office365ActivityImporter.Engine.Engine.Entities;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Entities/ImportStat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using WebJob.Office365ActivityImporter.Engine.Engine.Entities;
 
@@ -89,6 +89,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Entities
             this.ProcessedAlready += statsToAdd.ProcessedAlready;
             this.Imported += statsToAdd.Imported;
             this.URLsOutOfScope += statsToAdd.URLsOutOfScope;
+            this.UsersOutOfScope += statsToAdd.UsersOutOfScope;
             this.DownloadErrors += statsToAdd.DownloadErrors;
             this.MetadataDownloadErrors += statsToAdd.MetadataDownloadErrors;
             this.ReportDownloadErrors += statsToAdd.ReportDownloadErrors;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -308,9 +308,9 @@ namespace WebJob.Office365ActivityImporter
 #endif
                 }
 
-                // Activity import (Office 365 Management Activity API). Runs when SharePoint audit
-                // (ActivityLog) and/or Copilot interactions (delivered via Audit.General) are enabled.
-                if (configuredSettings.ImportJobSettings.ActivityLog || configuredSettings.ImportJobSettings.Copilot)
+                // Activity import (Office 365 Management Activity API). Runs when any workload needs
+                // Audit.SharePoint or Audit.General (SharePoint audit, Copilot, or Power Platform).
+                if (configuredSettings.ImportJobSettings.UsesActivityApi)
                 {
 #if !DEBUG
                     try

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -126,18 +126,23 @@ namespace WebJob.Office365ActivityImporter
 
                 if (spFilterList.OrgUrlConfigs.Count == 0)
                 {
-                    _logger.LogCritical("FATAL ERROR: No org URLs found in database! " +
-                        "This means everything would be ignored for SharePoint audit data. Add at least one URL to the org_urls table for this to work.");
-
-                    return;
-
+                    if (_settings.ImportJobSettings.ActivityLog)
+                    {
+                        _logger.LogWarning("No org URLs found in database. SharePoint/OneDrive audit events will be treated as out of scope; non-SharePoint Activity API workloads can still import.");
+                    }
+                    else
+                    {
+                        _logger.LogInformation("No org URLs found in database. Continuing because only non-SharePoint Activity API workloads are enabled.");
+                    }
                 }
+                else
+                {
+                    _logger.LogInformation("\nBeginning import. Filtering for SharePoint events below these URLs:");
 
-                _logger.LogInformation("\nBeginning import. Filtering for SharePoint events below these URLs:");
-
-                // Print URLs
-                spFilterList.Print(_logger);
-                Console.WriteLine();
+                    // Print URLs
+                    spFilterList.Print(_logger);
+                    Console.WriteLine();
+                }
 
                 _logger.LogInformation($"Starting activity import for {spFilterList.OrgUrlConfigs.Count} url filters");
 


### PR DESCRIPTION
## Summary
- Routes the Activity API import gate through `ImportTaskSettings.UsesActivityApi`, now true for `ActivityLog`, `Copilot`, or `ImportPowerPlatform`.
- Keeps Power Platform and Microsoft 365 Copilot Audit.General dispatch opt-ins independent: Power Platform events are dropped when `ImportPowerPlatform` is off, and Copilot events are dropped when `Copilot` is off.
- Allows non-SharePoint Activity API workloads to continue when `org_urls` is empty, while treating SharePoint/OneDrive audit events as out of scope.
- Accumulates `ImportStat.UsersOutOfScope` in cycle rollups.

Addresses #355
Addresses #418

## Implementation notes
- Subscription/feed selection remains in `ToActivityApiContentTypesString`: `Copilot || ImportPowerPlatform` => `Audit.General`; `ActivityLog` => `Audit.SharePoint`.
- Runtime gate: `Program.cs` uses `UsesActivityApi` so a Power Platform-only tenant actually runs `DownloadActivityData`.
- Per-event gate: `ActivityWebImporter` passes both `ImportPowerPlatform` and `Copilot` into `ActivityReportWebLoader`, which forwards them to `AuditLogContentDispatcher`.
- Empty `org_urls`: `ProgramTasks` now logs and continues; `SharePointOrgUrlsFilterConfig.InScope` explicitly rejects SharePoint events when the URL list is empty, so the generic empty-list allow-all URL helper is not reached for SharePoint audit.
- Installer test config verification now uses `UsesActivityApi`, so Power Platform-only installs check Management Activity API permissions.

## PR #354 collision
This branch removes the `ImportPowerPlatform`/`Audit.General` mismatch. Any PR #354 comment or test asserting that the mismatch is deliberate must not survive the combined result. I also searched the tree for `deliberately NOT included`, `UsesActivityApiExcludesPowerPlatformOnPurpose`, and related mismatch wording; no source comment remains in this branch.

## CONFIG_VERSION
No bump needed. This change adds only a computed `UsesActivityApi` helper and gate/dispatch logic; it does not add, remove, or rename any persisted property on `ImportTaskSettings`, `BaseSolutionInstallConfig`, `SolutionInstallConfig`, or `TargetSolutionConfig`.

## Mutation evidence
I temporarily reverted the new behavior and rebuilt affected assemblies. The new tests failed as intended:
- `ActivityReportWebLoader_PowerPlatformOnlySettings_ReadsGeneralFeedAndDropsCopilot`: failed when Power Platform was omitted from `UsesActivityApi`.
- `Dispatch_CopilotDisabled_DropsCopilotWorkload`: failed when the Copilot dispatch gate was removed.
- `UsesActivityApi_IncludesEveryAuditFeedConsumer`: failed when `UsesActivityApi` excluded `ImportPowerPlatform`.
- `AddStats_AccumulatesEveryNumericCounter`: failed when `UsersOutOfScope` accumulation was removed.

## Validation
- Build: `MSBuild.exe "O365 Advanced Analytics Engine.sln" /p:Configuration=Debug /m:2` succeeded.
- Targeted local tests: 47 passed (`WorkloadToggleTests`, `ImportStatTests`, `SentEmailImportTests`, and Activity URL-filter regressions).
- Post-review focused local tests after the empty-`org_urls` fix: 14 passed, including `FakeActivityTests`.
- CI full-suite evidence: required `test_dotnet (Release)` passed on this PR: https://github.com/pnp/Microsoft365-Analytics-Insights/actions/runs/33790125727/job/100764499195. All other PR checks are also green.
- Earlier local full-suite attempts hit the known machine/environment failures (4 VNet config-copy tests plus external-config tests). Per batch policy, CI is the authoritative full-suite result.

## Review
- Round 1: claude-opus-4.8 clean, gpt-5.6-sol clean, grok-4.6 found the empty-`org_urls` SharePoint allow-all bug; fixed.
- Round 2: all three models clean.
- Final round after the test adjustment: all three models clean.
