### PR TITLE
Fix App Insights future watermark import window

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImportWindowTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImportWindowTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
+using DataUtils;
 using WebJob.AppInsightsImporter.Engine;
 
 namespace Tests.UnitTests
@@ -54,6 +55,38 @@ namespace Tests.UnitTests
             var start = AppInsightsImportWindow.ResolveStartDateUtc(null, newestHit, Now);
 
             Assert.AreEqual(newestHit.AddMinutes(-1), start);
+            Assert.AreEqual(DateTimeKind.Utc, start.Kind);
+        }
+
+        [TestMethod]
+        public void ImportWindow_UnspecifiedSqlWatermark_IsTreatedAsUtc()
+        {
+            var newestHitFromSql = new DateTime(2026, 5, 19, 8, 0, 0, DateTimeKind.Unspecified);
+
+            var normalized = AppInsightsImportWindow.NormalizeStoredHitTimestampUtc(newestHitFromSql);
+            var start = AppInsightsImportWindow.ResolveStartDateUtc(null, newestHitFromSql, Now);
+
+            Assert.AreEqual(new DateTime(2026, 5, 19, 8, 0, 0, DateTimeKind.Utc), normalized.Value);
+            Assert.AreEqual(DateTimeKind.Utc, normalized.Value.Kind,
+                "SQL datetime strips Kind; the importer must restore UTC rather than leave it unspecified.");
+            Assert.AreEqual(new DateTime(2026, 5, 19, 7, 59, 0, DateTimeKind.Utc), start);
+            Assert.AreEqual(DateTimeKind.Utc, start.Kind);
+        }
+
+        [TestMethod]
+        public void ImportWindow_LocalWatermark_IsConvertedToUtcBeforeItIsComparedWithTheUtcClock()
+        {
+            if (TimeZoneInfo.Local.GetUtcOffset(Now) == TimeSpan.Zero)
+            {
+                Assert.Inconclusive("This conversion test only proves a tick change on a non-UTC host.");
+            }
+
+            var localHit = new DateTime(2026, 5, 19, 8, 0, 0, DateTimeKind.Local);
+
+            var normalized = AppInsightsImportWindow.NormalizeStoredHitTimestampUtc(localHit);
+
+            Assert.AreEqual(localHit.ToUniversalTime(), normalized.Value);
+            Assert.AreEqual(DateTimeKind.Utc, normalized.Value.Kind);
         }
 
         [TestMethod]
@@ -128,16 +161,22 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void ImportWindow_StartAfterEnd_EnumeratesBackwards_WhichIsAKnownHazard()
+        public void DateTimeUtils_EachDay_StartAfterEnd_StillEnumeratesBackwards()
         {
-            // #374 proposed asserting this returns NO days. It does not - DateTimeUtils.EachDay walks
-            // backwards when from > thru, and this test pins the behaviour that actually ships rather
-            // than the behaviour the issue assumed.
-            //
-            // It is normally unreachable: the end is "now" and the start is derived from a stored
-            // timestamp. But a future-dated hit_timestamp - clock skew on the writing host, or bad data -
-            // makes the importer walk days in reverse, re-requesting a run of future dates. Preserved
-            // here deliberately (no behavioural change) and raised separately.
+            // DateTimeUtils.EachDay is shared code. Its descending mode is not changed here; the
+            // App Insights importer guards its own future-watermark call site instead.
+            var days = new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc).EachDay(
+                new DateTime(2026, 5, 20, 0, 0, 0, DateTimeKind.Utc));
+
+            CollectionAssert.AreEqual(
+                new[] { new DateTime(2026, 5, 22), new DateTime(2026, 5, 21), new DateTime(2026, 5, 20) },
+                days.ToArray(),
+                "Documents the shared helper's descending enumeration; it is not an endorsement of using it for import windows.");
+        }
+
+        [TestMethod]
+        public void ImportWindow_StartAfterEnd_StillDelegatesToTheSharedEachDayHelper()
+        {
             var days = AppInsightsImportWindow.EnumerateDays(
                 new DateTime(2026, 5, 22, 0, 0, 0, DateTimeKind.Utc),
                 new DateTime(2026, 5, 20, 0, 0, 0, DateTimeKind.Utc));

--- a/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImporterOrchestrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AppInsightsImporterOrchestrationTests.cs
@@ -32,7 +32,7 @@ namespace Tests.UnitTests
             public FixedClock Clock = new FixedClock(FixedNowUtc);
 
             public Task RunAsync(int? daysBeforeOverride = null) => new AppInsightsImporter(
-                new Common.Entities.Config.AppConfig(),
+                null,
                 AnalyticsLogger.ConsoleOnlyTracer(),
                 Clock,
                 Source,
@@ -103,6 +103,36 @@ namespace Tests.UnitTests
             CollectionAssert.AreEqual(
                 new[] { new DateTime(2019, 2, 12), new DateTime(2019, 2, 13), new DateTime(2019, 2, 14) },
                 h.Source.PageViewDaysRequested.ToArray());
+        }
+
+        [TestMethod]
+        public async Task AppInsightsImporter_FutureDatedWatermark_DoesNotWalkBackwardsAndLogsTheTimestamp()
+        {
+            var h = new Harness();
+            h.Watermark.NewestHitTimestampUtc = FixedNowUtc.AddDays(2).AddHours(3);
+
+            var console = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(console);
+            try
+            {
+                await h.RunAsync();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+
+            CollectionAssert.AreEqual(
+                new[] { FixedNowUtc.Date },
+                h.Source.PageViewDaysRequested.ToArray(),
+                "A future hit_timestamp must not make the importer walk backwards through future days.");
+            CollectionAssert.AreEqual(h.Source.PageViewDaysRequested.ToArray(), h.Source.CustomEventDaysRequested.ToArray());
+
+            var log = console.ToString();
+            StringAssert.Contains(log, "App Insights hit watermark is in the future");
+            StringAssert.Contains(log, h.Watermark.NewestHitTimestampUtc.Value.ToString("O"));
+            StringAssert.Contains(log, FixedNowUtc.ToString("O"));
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImportWindow.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImportWindow.cs
@@ -49,9 +49,34 @@ namespace WebJob.AppInsightsImporter.Engine
         /// </summary>
         public static DateTime ResolveStartDateUtc(DateTime? overrideStartUtc, DateTime? newestHitUtc, DateTime nowUtc)
         {
-            var startDate = overrideStartUtc ?? newestHitUtc ?? nowUtc.AddDays(-NoHitsFallbackDays);
+            var startDate = overrideStartUtc ?? NormalizeStoredHitTimestampUtc(newestHitUtc) ?? nowUtc.AddDays(-NoHitsFallbackDays);
 
             return startDate.AddMinutes(-EdgeHitRewindMinutes);
+        }
+
+        /// <summary>
+        /// SQL Server <c>datetime</c> values come back as <see cref="DateTimeKind.Unspecified"/> even
+        /// though <c>hits.hit_timestamp</c> is stored in UTC; local values supplied by tests/fakes are
+        /// converted so comparisons with the UTC clock remain meaningful.
+        /// </summary>
+        public static DateTime? NormalizeStoredHitTimestampUtc(DateTime? newestHitUtc)
+        {
+            if (!newestHitUtc.HasValue)
+            {
+                return null;
+            }
+
+            var timestamp = newestHitUtc.Value;
+            if (timestamp.Kind == DateTimeKind.Local)
+            {
+                return timestamp.ToUniversalTime();
+            }
+            if (timestamp.Kind == DateTimeKind.Unspecified)
+            {
+                return DateTime.SpecifyKind(timestamp, DateTimeKind.Utc);
+            }
+
+            return timestamp;
         }
 
         /// <summary>
@@ -59,10 +84,9 @@ namespace WebJob.AppInsightsImporter.Engine
         ///
         /// Delegates to <c>DateTimeUtils.EachDay</c> so the behaviour is exactly what the importer had.
         /// Note that includes its quirk: when <paramref name="startUtc"/> is AFTER
-        /// <paramref name="endUtc"/> the sequence runs BACKWARDS rather than being empty. That cannot
-        /// normally happen (the end is "now" and the start is derived from a stored timestamp), but a
-        /// future-dated hit_timestamp - clock skew on the writing host, or bad data - would produce it.
-        /// Preserved deliberately rather than changed here; see the PR for #374.
+        /// <paramref name="endUtc"/> the sequence runs BACKWARDS rather than being empty. The importer
+        /// guards its future-watermark call site before it gets here, leaving the shared helper's
+        /// pre-existing descending mode unchanged.
         /// </summary>
         public static IReadOnlyList<DateTime> EnumerateDays(DateTime startUtc, DateTime endUtc)
         {

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/AppInsightsImporter.cs
@@ -86,7 +86,8 @@ namespace WebJob.AppInsightsImporter.Engine
             // DateTime.Now on a non-UTC host shifts the day boundaries and the per-day KQL filter,
             // missing or duplicating edge hits near midnight. The rule itself lives in
             // AppInsightsImportWindow so it can be tested without a database or the wall clock (#374).
-            var scanFromDateOverride = AppInsightsImportWindow.ResolveOverrideStartUtc(daysBeforeOverride, _clock.UtcNow);
+            var nowUtc = _clock.UtcNow;
+            var scanFromDateOverride = AppInsightsImportWindow.ResolveOverrideStartUtc(daysBeforeOverride, nowUtc);
 
             var sw = Stopwatch.StartNew();
 
@@ -99,12 +100,18 @@ namespace WebJob.AppInsightsImporter.Engine
             _logger.LogInformation($"Startup: loaded {filterUrls.Count} URL filters in {sw.Elapsed.TotalSeconds:N1}s");
 
             var newestHitTimestamp = await hitWatermarkStore.GetNewestHitTimestampUtcAsync();
+            var effectiveNewestHitTimestamp = AppInsightsImportWindow.NormalizeStoredHitTimestampUtc(newestHitTimestamp);
+            if (!scanFromDateOverride.HasValue && effectiveNewestHitTimestamp.HasValue && effectiveNewestHitTimestamp.Value > nowUtc)
+            {
+                _logger.LogWarning($"App Insights hit watermark is in the future: newest stored hit_timestamp {effectiveNewestHitTimestamp.Value:O} is later than importer clock {nowUtc:O}. Using the importer clock as the watermark for this run so the import window does not walk backwards.");
+                effectiveNewestHitTimestamp = nowUtc;
+            }
 
             // Figure out when to start. Either the debug override, or last hit (if there is one), or 31 days ago,
             // rewound a little to catch edge hits. hit_timestamp is stored in UTC; the clock keeps the
             // fallback on the same clock. See AppInsightsImportWindow (#374).
             var startDate = AppInsightsImportWindow.ResolveStartDateUtc(
-                scanFromDateOverride, newestHitTimestamp, _clock.UtcNow);
+                scanFromDateOverride, effectiveNewestHitTimestamp, nowUtc);
 
             var jobTimer = new JobTimer(_logger, "Hits import");
             if (newestHitTimestamp.HasValue)


### PR DESCRIPTION
## Summary
- Guards the App Insights importer against a future-dated stored `hits.hit_timestamp` watermark before it reaches the day enumerator.
- Preserves the shared `DateTimeUtils.EachDay` descending behaviour deliberately; the issue is pre-existing behaviour preserved under #381's no-behavioural-change rule, not a regression.
- Normalizes stored hit timestamps for UTC comparisons: SQL `datetime`/`Unspecified` is treated as UTC, and `Local` values are converted to UTC.

Addresses #391

## EachDay caller audit
`git grep -n "EachDay"` found:
- `Common/DataUtils/DateTimeUtils.cs`: helper definition; left unchanged.
- `WebJob.AppInsightsImporter.Engine/AppInsightsImportWindow.cs`: only production caller; guarded at the App Insights call site before invoking it.
- `Tests.UnitTests/AppInsightsImportWindowTests.cs`: tests only; updated to pin the shared helper's existing reverse walk and the wrapper delegation.

## Tests
- PASS: Debug solution build: `MSBuild.exe "O365 Advanced Analytics Engine.sln" /p:Configuration=Debug /m:2`.
- PASS: targeted `AppInsightsImportWindowTests|AppInsightsImporterOrchestrationTests` (21/21).
- Mutation evidence: disabling the future-watermark guard makes `AppInsightsImporter_FutureDatedWatermark_DoesNotWalkBackwardsAndLogsTheTimestamp` fail with actual first day `2026-05-12` instead of `2026-05-10`; removing the helper normalization makes the new normalization tests fail to compile.
- Full `Tests.UnitTests` was attempted under the machine-wide lock, but the runner returned `-1` before completing. With copied local Debug config it reached the Copilot tests and then exited; earlier synthetic-config attempts showed unrelated environment/config failures (Redis/Cognitive/FakeActivity), not App Insights failures. Targeted App Insights coverage passes.

## Review
Three parallel `code-review` agents ran on `claude-opus-4.8`, `gpt-5.6-sol`, and `grok-4.6`; all reported clean/no significant issues.
