### PR TITLE
Preserve Copilot interactions on metadata failure

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAuditEventManagerStagingTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAuditEventManagerStagingTests.cs
@@ -1,12 +1,16 @@
 using ActivityImporter.Engine.ActivityAPI.Copilot;
 using Common.Entities;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
 using System.Threading.Tasks;
 using UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 
 namespace Tests.UnitTests
@@ -20,7 +24,7 @@ namespace Tests.UnitTests
     /// The pre-existing CopilotTests suite still covers the SQL merge end to end.
     /// </summary>
     [TestClass]
-    public class CopilotAuditEventManagerStagingTests
+    public class CopilotAuditEventManagerStagingTests : CopilotTestBase
     {
         // Must contain the literal "19:meeting_" - StringUtils.GetMeetingIdFragmentFromMeetingThreadUrl
         // parses from there, and throws (so the row is not staged) for anything else.
@@ -215,18 +219,9 @@ namespace Tests.UnitTests
             // stages only a chat-only row and asserts final copilot_chats counts, which stay correct
             // even if the lists were never cleared, because the common merge de-duplicates chats.
             //
-            // The consequence of losing those Clear() calls differs per table, and is worse than mere
-            // repeated work for two of the three:
-            //   * chat-only - the root chat and its messages are de-duplicated by the merge (messages
-            //     without an Id get a deterministic fallback), so the remaining cost is an unboundedly
-            //     growing staging batch on the hot path;
-            //   * SharePoint and Teams - the workload merges de-duplicate on copilot_chat_id, so retained
-            //     rows do not create a second file/meeting record. They still make every later staging load
-            //     and lookup larger, so clearing remains a load-bearing performance contract.
-            //
-            // A guard needs a real database: under the current hard-wired InsertBatch design, staging is
-            // only List.Add, but committing a non-empty batch opens a connection. It must cover all
-            // three tables, not just the existing chat-only reset case.
+            // The SQL adapter's own Rows.Clear() calls need a DB-backed guard because staging is only
+            // List.Add, but committing a non-empty batch opens a connection. That separate guard covers
+            // all three concrete staging batches.
             var writer = new InMemoryCopilotStagingWriter();
             var manager = NewManager(writer);
 
@@ -244,6 +239,138 @@ namespace Tests.UnitTests
         public void CopilotEventManager_NullStagingWriter_Throws()
         {
             new CopilotAuditEventManager((ICopilotStagingWriter)null, new FakeCopilotMetadataLoader(), NullLogger.Instance);
+        }
+
+        [TestMethod]
+        public async Task SqlCopilotStagingWriter_CommitAllChanges_ClearsAllThreeStagedBatches()
+        {
+            var logger = new Tests.UnitTests.FakeLoaderClasses.RecordingLogger();
+            var meetingEventId = Guid.NewGuid();
+            var fileEventId = Guid.NewGuid();
+            var chatEventId = Guid.NewGuid();
+            var suffix = DateTime.UtcNow.Ticks.ToString();
+            var meetingUpn = "meeting-clear-" + suffix + "@contoso.onmicrosoft.com";
+            var fileUpn = "file-clear-" + suffix + "@contoso.onmicrosoft.com";
+            var chatUpn = "chat-clear-" + suffix + "@contoso.onmicrosoft.com";
+
+            using (var con = new SqlConnection(_config.ConnectionStrings.DatabaseConnectionString))
+            {
+                con.Open();
+                try
+                {
+                    InsertAuditEvent(con, meetingEventId, meetingUpn);
+                    InsertAuditEvent(con, fileEventId, fileUpn);
+                    InsertAuditEvent(con, chatEventId, chatUpn);
+
+                    var writer = new SqlCopilotStagingWriter(_config.ConnectionStrings.DatabaseConnectionString, logger);
+                    writer.StageTeams(new TeamsCopilotLogTempEntity
+                    {
+                        EventId = meetingEventId,
+                        AppHost = "Teams",
+                        MeetingId = "19:meeting-clear@thread.v2",
+                        MeetingCreatedUTC = new DateTime(2026, 4, 1, 9, 30, 0, DateTimeKind.Utc),
+                        MeetingName = "Contoso release sync"
+                    });
+                    writer.StageSharePoint(new SPCopilotLogTempEntity
+                    {
+                        EventId = fileEventId,
+                        AppHost = "Word",
+                        FileName = "Καλημέρα κόσμε",
+                        FileExtension = "docx",
+                        Url = "https://contoso.sharepoint.com/sites/example/Shared Documents/Καλημέρα κόσμε.docx",
+                        UrlBase = "https://contoso.sharepoint.com/sites/example"
+                    });
+                    writer.StageChatOnly(new ChatOnlyCopilotLogTempEntity
+                    {
+                        EventId = chatEventId,
+                        AppHost = "Teams"
+                    });
+
+                    await writer.CommitAllChanges();
+
+                    var logEntryCountAfterFirstCommit = logger.Entries.Count;
+                    var chatCountAfterFirstCommit = CountChats(con, meetingEventId, fileEventId, chatEventId);
+
+                    await writer.CommitAllChanges();
+
+                    var secondCommitInsertLogs = logger.Entries
+                        .Skip(logEntryCountAfterFirstCommit)
+                        .Where(IsInsertBatchLog)
+                        .Select(e => e.Message)
+                        .ToList();
+                    Assert.AreEqual(0, secondCommitInsertLogs.Count,
+                        "An empty second commit must not re-save any retained SharePoint, Teams or chat-only rows: "
+                        + string.Join(Environment.NewLine, secondCommitInsertLogs));
+
+                    Assert.AreEqual(chatCountAfterFirstCommit, CountChats(con, meetingEventId, fileEventId, chatEventId));
+                }
+                finally
+                {
+                    DeleteAuditEvents(con, meetingEventId, fileEventId, chatEventId, meetingUpn, fileUpn, chatUpn);
+                }
+            }
+        }
+
+        private static void InsertAuditEvent(SqlConnection con, Guid eventId, string upn)
+        {
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = @"
+IF NOT EXISTS (SELECT 1 FROM dbo.users WHERE user_name = @upn)
+    INSERT INTO dbo.users (user_name, azure_ad_id) VALUES (@upn, @azureAdId);
+
+INSERT INTO dbo.audit_events (id, time_stamp, user_id)
+SELECT @eventId, @timestamp, u.id
+FROM dbo.users u
+WHERE u.user_name = @upn;";
+                cmd.Parameters.AddWithValue("@upn", upn);
+                cmd.Parameters.AddWithValue("@azureAdId", "00000000-0000-0000-0000-000000000000");
+                cmd.Parameters.AddWithValue("@eventId", eventId);
+                cmd.Parameters.AddWithValue("@timestamp", new DateTime(2026, 4, 1, 9, 0, 0, DateTimeKind.Utc));
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private static int CountChats(SqlConnection con, Guid meetingEventId, Guid fileEventId, Guid chatEventId)
+        {
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = @"
+SELECT COUNT(*)
+FROM dbo.copilot_chats
+WHERE event_id IN (@meetingEventId, @fileEventId, @chatEventId);";
+                cmd.Parameters.AddWithValue("@meetingEventId", meetingEventId);
+                cmd.Parameters.AddWithValue("@fileEventId", fileEventId);
+                cmd.Parameters.AddWithValue("@chatEventId", chatEventId);
+                return Convert.ToInt32(cmd.ExecuteScalar());
+            }
+        }
+
+        private static void DeleteAuditEvents(SqlConnection con, Guid meetingEventId, Guid fileEventId, Guid chatEventId, string meetingUpn, string fileUpn, string chatUpn)
+        {
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = @"
+DELETE FROM dbo.copilot_event_files WHERE copilot_chat_id IN (@meetingEventId, @fileEventId, @chatEventId);
+DELETE FROM dbo.copilot_event_meetings WHERE copilot_chat_id IN (@meetingEventId, @fileEventId, @chatEventId);
+DELETE FROM dbo.copilot_chats WHERE event_id IN (@meetingEventId, @fileEventId, @chatEventId);
+DELETE FROM dbo.audit_events WHERE id IN (@meetingEventId, @fileEventId, @chatEventId);
+DELETE FROM dbo.users WHERE user_name IN (@meetingUpn, @fileUpn, @chatUpn);";
+                cmd.Parameters.AddWithValue("@meetingEventId", meetingEventId);
+                cmd.Parameters.AddWithValue("@fileEventId", fileEventId);
+                cmd.Parameters.AddWithValue("@chatEventId", chatEventId);
+                cmd.Parameters.AddWithValue("@meetingUpn", meetingUpn);
+                cmd.Parameters.AddWithValue("@fileUpn", fileUpn);
+                cmd.Parameters.AddWithValue("@chatUpn", chatUpn);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private static bool IsInsertBatchLog(Tests.UnitTests.FakeLoaderClasses.RecordingLogger.Entry entry)
+        {
+            return entry.Level == LogLevel.Information
+                && entry.Message.StartsWith("Inserting ", StringComparison.Ordinal)
+                && entry.Message.Contains(" records into ");
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotEventManagerEdgeCaseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotEventManagerEdgeCaseTests.cs
@@ -615,82 +615,74 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// When the metadata loader throws for meeting/file contexts the manager should
-        /// catch the exception and not stage any meeting/file rows, while still allowing
-        /// CommitAllChanges to succeed.
+        /// When the metadata loader throws for meeting/file contexts the manager should catch the
+        /// exception, omit only the failed enrichment, and still stage the Copilot interaction.
         /// </summary>
         [TestMethod]
         public async Task CopilotEventManagerMetadataLoaderExceptionHandledGracefully()
         {
-            using (var db = new AnalyticsEntitiesContext())
+            var writer = new InMemoryCopilotStagingWriter();
+            var logger = new Tests.UnitTests.FakeLoaderClasses.RecordingLogger();
+            var copilotEventManager = new CopilotAuditEventManager(
+                writer,
+                new ThrowingCopilotMetadataLoader(),
+                logger);
+
+            var meetingEvent = new CommonAuditEvent
             {
-                await ClearEvents(db);
+                TimeStamp = DateTime.Now,
+                Operation = new EventOperation { Name = "ThrowMeeting Test" + DateTime.Now.Ticks },
+                User = new User { AzureAdId = "test", UserPrincipalName = "test@throwmeeting.com" + DateTime.Now.Ticks },
+                Id = Guid.NewGuid()
+            };
+            var fileEvent = new CommonAuditEvent
+            {
+                TimeStamp = DateTime.Now,
+                Operation = new EventOperation { Name = "ThrowFile Test" + DateTime.Now.Ticks },
+                User = new User { AzureAdId = "test", UserPrincipalName = "test@throwfile.com" + DateTime.Now.Ticks },
+                Id = Guid.NewGuid()
+            };
 
-                var copilotEventManager = new CopilotAuditEventManager(
-                    _config.ConnectionStrings.DatabaseConnectionString,
-                    new ThrowingCopilotMetadataLoader(),
-                    _logger);
-
-                var meetingEvent = new CommonAuditEvent
+            // Meeting context — loader will throw on GetUserIdFromUpn
+            await copilotEventManager.SaveSingleCopilotEventToSqlStaging(new CopilotAuditLogContent
+            {
+                CopilotEventData = new CopilotEventData
                 {
-                    TimeStamp = DateTime.Now,
-                    Operation = new EventOperation { Name = "ThrowMeeting Test" + DateTime.Now.Ticks },
-                    User = new User { AzureAdId = "test", UserPrincipalName = "test@throwmeeting.com" + DateTime.Now.Ticks },
-                    Id = Guid.NewGuid()
-                };
-                var fileEvent = new CommonAuditEvent
+                AppHost = "Teams",
+                Contexts = new List<Context>
                 {
-                    TimeStamp = DateTime.Now,
-                    Operation = new EventOperation { Name = "ThrowFile Test" + DateTime.Now.Ticks },
-                    User = new User { AzureAdId = "test", UserPrincipalName = "test@throwfile.com" + DateTime.Now.Ticks },
-                    Id = Guid.NewGuid()
-                };
-
-                db.AuditEventsCommon.AddRange(new[] { meetingEvent, fileEvent });
-                await db.SaveChangesAsync();
-
-                // Meeting context — loader will throw on GetUserIdFromUpn
-                await copilotEventManager.SaveSingleCopilotEventToSqlStaging(new CopilotAuditLogContent
-                {
-                    CopilotEventData = new CopilotEventData
+                    new Context
                     {
-                        AppHost = "Teams",
-                        Contexts = new List<Context>
-                        {
-                            new Context
-                            {
-                                Id = "https://microsoft.teams.com/threads/19:meeting_throw@thread.v2",
-                                Type = ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING
-                            }
-                        }
+                        Id = "https://microsoft.teams.com/threads/19:meeting_throw@thread.v2",
+                        Type = ActivityImportConstants.COPILOT_CONTEXT_TYPE_TEAMS_MEETING
                     }
-                }, meetingEvent);
+                }
+                }
+            }, meetingEvent);
 
-                // File context — loader will throw on GetSpoFileInfo
-                await copilotEventManager.SaveSingleCopilotEventToSqlStaging(new CopilotAuditLogContent
+            // File context — loader will throw on GetSpoFileInfo
+            await copilotEventManager.SaveSingleCopilotEventToSqlStaging(new CopilotAuditLogContent
+            {
+                CopilotEventData = new CopilotEventData
                 {
-                    CopilotEventData = new CopilotEventData
+                AppHost = "Word",
+                Contexts = new List<Context>
+                {
+                    new Context
                     {
-                        AppHost = "Word",
-                        Contexts = new List<Context>
-                        {
-                            new Context
-                            {
-                                Id = "https://contoso.sharepoint.com/sites/test/doc.docx",
-                                Type = "docx"
-                            }
-                        }
+                        Id = "https://contoso.sharepoint.com/sites/test/doc.docx",
+                        Type = "docx"
                     }
-                }, fileEvent);
+                }
+                }
+            }, fileEvent);
 
-                // CommitAllChanges should succeed even though no rows were staged
-                await copilotEventManager.CommitAllChanges();
-
-                var meetingCount = await db.CopilotEventMetadataMeetings.CountAsync();
-                var fileCount = await db.CopilotEventMetadataFiles.CountAsync();
-                Assert.AreEqual(0, meetingCount, "No meeting rows should be staged when the loader throws.");
-                Assert.AreEqual(0, fileCount, "No file rows should be staged when the loader throws.");
-            }
+            Assert.AreEqual(0, writer.TeamsRows.Count, "No meeting enrichment row should be staged when the loader throws.");
+            Assert.AreEqual(0, writer.SharePointRows.Count, "No file enrichment row should be staged when the loader throws.");
+            Assert.AreEqual(2, writer.ChatOnlyRows.Count,
+                "Optional metadata resolution failures must not discard the underlying Copilot interactions.");
+            Assert.AreEqual(2, logger.Entries.Count(e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning),
+                "Each failed optional metadata resolution should be visible to operators.");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -122,6 +122,11 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                             {
                                 eventMeetings++; _totalMeetingsCount++;
                             }
+                            else if (eventMeetings == 0 && eventFiles == 0 && eventChats == 0)
+                            {
+                                AddChatOnly(auditRecord, baseOfficeEvent);
+                                eventChats++; _totalChatOnlyCount++;
+                            }
                         }
                         break; // meeting ends further processing for meeting/file
                     }
@@ -140,6 +145,11 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                             if (await TryAddFileAsync(context.Id, auditRecord, baseOfficeEvent))
                             {
                                 eventFiles++; _totalFilesCount++;
+                            }
+                            else if (eventMeetings == 0 && eventFiles == 0 && eventChats == 0)
+                            {
+                                AddChatOnly(auditRecord, baseOfficeEvent);
+                                eventChats++; _totalChatOnlyCount++;
                             }
                         }
                         break; // after first file we break out (matching prior behaviour)
@@ -183,7 +193,8 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, $"Failed to stage meeting metadata for event {baseOfficeEvent.Id} context {contextId}");
+                _logger.LogWarning(ex,
+                    $"Failed to resolve optional meeting metadata for event {baseOfficeEvent.Id} context {contextId}; staging the Copilot interaction without meeting enrichment.");
                 return false;
             }
         }
@@ -231,7 +242,8 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, $"Failed to stage file metadata for event {baseOfficeEvent.Id} context {contextId}");
+                _logger.LogWarning(ex,
+                    $"Failed to resolve optional file metadata for event {baseOfficeEvent.Id} context {contextId}; staging the Copilot interaction without file enrichment.");
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Preserve Copilot interactions when optional meeting or file metadata resolution throws by staging the event through the chat-only path and logging a warning with event/context details.
- Extend the metadata-loader exception regression test so optional enrichment failures still leave the interaction staged.
- Add a DB-backed `SqlCopilotStagingWriter` regression test that stages SharePoint, Teams, and chat-only rows, commits twice, and verifies the second empty commit does not re-save retained rows.

## Design decisions
- A partially enriched Copilot row is better than no row: Copilot reports are driven by `dbo.copilot_chats`, so dropping the row permanently under-reports usage; missing file/meeting enrichment only affects optional drill-down metadata.
- No repair marker/schema change: this release is migration-free, and the source audit event is already processed after the parent `audit_events` commit. The safe end state is to import the interaction without the optional enrichment and make the failure visible in logs.
- Accessed-resource de-dup remains correct: the fallback preserves common fields, including accessed resources/messages/contexts JSON, through the chat-only staging path; no empty resource metadata tuple is added to the SharePoint/Teams-specific tables.

## Validation
- Debug solution build: `MSBuild "O365 Advanced Analytics Engine.sln" /p:Configuration=Debug /m:2` passed.
- Targeted tests passed:
  - `CopilotEventManagerMetadataLoaderExceptionHandledGracefully`
  - `SqlCopilotStagingWriter_CommitAllChanges_ClearsAllThreeStagedBatches`
- Mutation checks:
  - Disabling the metadata-failure fallback made `CopilotEventManagerMetadataLoaderExceptionHandledGracefully` fail (`Expected:<2>. Actual:<0>` chat-only rows).
  - Removing each concrete `Rows.Clear()` call in turn made the staging-writer test fail with a retained second-commit insert log for `debug_import_staging_copilot_sp`, `debug_import_staging_copilot_teams`, and `debug_import_staging_copilot_chatonly` respectively.
- Full `Tests.UnitTests` run completed: 1472 total, 1458 passed, 13 failed, 1 skipped. The 4 expected VNet fixture-copy failures were present. The other 9 failures were environment/configuration-dependent existing tests that attempted unavailable fake external services or legacy schema state (Cognitive Services DNS, zeroed Entra tenant auth/Redis/Graph/Service Bus, and the legacy FK migration fixture), not this Copilot change.

## Review
- Multi-model review loop completed to a clean round on claude-opus-4.8, gpt-5.6-sol, and grok-4.6.
- One reviewer reported a suspected `Inserting 0 records` issue; it was verified as a false positive because `InsertBatch.SaveToStagingTable` returns before logging when `Rows.Count == 0`. A follow-up clean round confirmed no blockers.

Addresses #362
Addresses #389