### PR TITLE
Keep the derived UsesActivityApi flag out of the saved installer config

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/ImportTaskSettings.cs
+++ b/src/AnalyticsEngine/Common/Entities/ImportTaskSettings.cs
@@ -191,6 +191,14 @@ namespace Common.Entities
         /// True when any enabled workload needs the Office 365 Management Activity API. SharePoint audit
         /// events use Audit.SharePoint; Microsoft 365 Copilot and Power Platform both use Audit.General.
         /// </summary>
+        /// <remarks>
+        /// Derived from the [ImportProp] toggles, so it is deliberately not persisted: this type is
+        /// serialised into the installer's saved *.json config via TargetSolutionConfig.ImportTaskSettings,
+        /// and writing a computed getter there would put a read-only field into every customer's config
+        /// file that looks settable but is silently ignored on load. Same reasoning as
+        /// BaseSolutionInstallConfig.ConfigSchemaVersion.
+        /// </remarks>
+        [Newtonsoft.Json.JsonIgnore]
         public bool UsesActivityApi => ActivityLog || Copilot || ImportPowerPlatform;
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/WorkloadToggleTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/WorkloadToggleTests.cs
@@ -1,4 +1,5 @@
 using Common.Entities;
+using Common.Entities.Installer;
 using DataUtils.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -89,6 +90,37 @@ namespace Tests.UnitTests
             Assert.IsTrue(new ImportTaskSettings { Copilot = true }.UsesActivityApi, "Copilot uses Audit.General.");
             Assert.IsTrue(new ImportTaskSettings { ImportPowerPlatform = true }.UsesActivityApi, "Power Platform uses Audit.General.");
             Assert.IsFalse(new ImportTaskSettings().UsesActivityApi, "No audit-feed toggle enabled means the Activity API loop should be skipped.");
+        }
+
+        [TestMethod]
+        public void ImportTaskSettings_SerialisedConfig_ContainsOnlyPersistedImportToggles()
+        {
+            // ImportTaskSettings is serialised into the installer's saved *.json config through
+            // TargetSolutionConfig.ImportTaskSettings. Only the [ImportProp] toggles are persisted state;
+            // a computed getter such as UsesActivityApi must not leak in, or every customer's config file
+            // gains a read-only field that looks settable but is silently discarded on load.
+            var settings = new ImportTaskSettings { ActivityLog = true, Copilot = true, ImportPowerPlatform = true };
+
+            var serialised = JObject.Parse(Newtonsoft.Json.JsonConvert.SerializeObject(settings));
+
+            var expected = ImportTaskSettings.GetImportPropertyNames().OrderBy(name => name).ToArray();
+            var actual = serialised.Properties().Select(p => p.Name).OrderBy(name => name).ToArray();
+
+            CollectionAssert.AreEqual(
+                expected,
+                actual,
+                "Saved installer config must serialise exactly the [ImportProp] toggles. Unexpected: "
+                    + string.Join(", ", actual.Except(expected)));
+
+            // Round-trip through the config type the installer actually writes, to prove the guard holds
+            // where it matters rather than only on the settings object in isolation.
+            var configJson = JObject.Parse(Newtonsoft.Json.JsonConvert.SerializeObject(
+                new TargetSolutionConfig { ImportTaskSettings = settings }));
+
+            CollectionAssert.DoesNotContain(
+                ((JObject)configJson[nameof(TargetSolutionConfig.ImportTaskSettings)]).Properties().Select(p => p.Name).ToArray(),
+                nameof(ImportTaskSettings.UsesActivityApi),
+                "UsesActivityApi is derived from the toggles and must stay out of the saved config.");
         }
 
         [TestMethod]


### PR DESCRIPTION
Release hygiene, found while preparing the `dev` -> `main` release PR.

## Problem

#446 added `ImportTaskSettings.UsesActivityApi`, a computed getter over the `[ImportProp]` toggles:

```csharp
public bool UsesActivityApi => ActivityLog || Copilot || ImportPowerPlatform;
```

`ImportTaskSettings` is not a runtime-only object - it is serialised into the installer's saved `*.json` config through `TargetSolutionConfig.ImportTaskSettings` (`SolutionInstallConfig` is round-tripped with `JsonConvert`, and `Web/Models/SystemStatus.cs` deserialises the same type). Newtonsoft serialises public read-only properties by default, so every config file written by this build gains:

```json
"UsesActivityApi": true
```

It is discarded on load (no setter), so nothing breaks - but it puts a read-only, derived field into a customer-editable file where it looks settable and is silently ignored, and it means the release does technically alter the shape of the saved config.

The codebase already has the convention for exactly this: `BaseSolutionInstallConfig.ConfigSchemaVersion` is a computed `Version` getter carrying `[Newtonsoft.Json.JsonIgnore]`.

## Change

- `[Newtonsoft.Json.JsonIgnore]` on `UsesActivityApi`, with a comment explaining why a derived toggle must not be persisted.
- `WorkloadToggleTests.ImportTaskSettings_SerialisedConfig_ContainsOnlyPersistedImportToggles` - serialises `ImportTaskSettings` and asserts the JSON property set equals `ImportTaskSettings.GetImportPropertyNames()` exactly, then round-trips `TargetSolutionConfig` to prove the guard holds on the type the installer actually writes. A future computed helper cannot leak in unnoticed.

## Schema / config impact

| | |
|---|---|
| **Database migrations** | **None.** No entity, `Migrations/` or `Create DB.sql` change. |
| **Config schema** | **None.** No persisted property added, removed or renamed - this change is what makes that statement exactly true, so **no `CONFIG_VERSION` bump**. |
| **Breaking changes** | None. Configs written by the previous build (which contain the stray field) still load unchanged - it was already being ignored. |

## Validation

- `MSBuild "O365 Advanced Analytics Engine.sln" /p:Configuration=Release /m` - exit 0.
- `vstest.console.exe Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~WorkloadToggleTests"` - 12/12 passed.
- **Mutation-checked.** Removing `[JsonIgnore]` and rebuilding fails the new test with `CollectionAssert.AreEqual failed. Saved installer config must serialise exactly the [ImportProp] toggles. Unexpected: UsesActivityApi.` - which is also the direct proof that the stray field was really being written. Attribute restored and re-verified green.
- 4 `HealthServiceTests` config tests fail in a **local** Release build with `System.FormatException: Guid should contain 32 digits` - these fail identically on unmodified `dev` (verified by stashing this change, rebuilding and re-running: same 4 failures). They are caused by the un-substituted local `App.Release.config` placeholders; CI substitutes real values in the *Config substitution - Unit tests* step, which is why `test_dotnet (Release)` is green.

Addresses no issue - preparatory cleanup for the current release.