### PR TITLE
Licence activity reporting: aggregate explorer and admin drill-down

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,6 +175,10 @@ jobs:
           -p:ProcessorArchitecture=${{ env.Build_ProcessorArchitecture }}
         env:
           Configuration: ${{ matrix.configuration }}
+      - name: Execute portal tests
+        if: needs.setup_tests.outputs.run_dotnet == 'true'
+        working-directory: src\AnalyticsEngine\Web\Scripts\portal
+        run: npm run test
       - name: Execute unit tests
         if: needs.setup_tests.outputs.run_dotnet == 'true'
         uses: jesusfer/vstest-action@f5ec12ddb71f6e151b738fa4740f8fea61e9214b

--- a/src/AnalyticsEngine/Common/DataUtils/AnalyticsLogger.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/AnalyticsLogger.cs
@@ -377,7 +377,8 @@ namespace DataUtils
             HealthCheck,
             ImporterHeartbeat,
             CopilotAdoptionAnalysis,
-            CopilotAdoptionLifecycle
+            CopilotAdoptionLifecycle,
+            LicenceActivityLifecycle
         }
     }
 }

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -81,6 +81,12 @@
   <ItemGroup>
     <Compile Include="BaseEntity.cs" />
     <Compile Include="BuildConstants.cs" />
+    <Compile Include="LicenceActivity\ILicenceActivityStore.cs" />
+    <Compile Include="LicenceActivity\LicenceActivityModels.cs" />
+    <Compile Include="LicenceActivity\LicenceActivityQuery.cs" />
+    <Compile Include="LicenceActivity\LicenceActivityWorkbook.cs" />
+    <Compile Include="LicenceActivity\LicenceActivitySql.cs" />
+    <Compile Include="LicenceActivity\SqlLicenceActivityStore.cs" />
     <Compile Include="Config\AppConfig.cs" />
     <Compile Include="Config\AppConnectionStrings.cs" />
     <Compile Include="CopilotAdoption\AdoptionBand.cs" />

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/ILicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/ILicenceActivityStore.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Common.Entities.LicenceActivity
+{
+    public interface ILicenceActivityStore
+    {
+        Task<LicenceActivityOverview> LoadOverviewAsync(
+            LicenceActivityQuery query, LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken);
+
+        Task<LicenceActivityUsers> LoadUsersAsync(
+            LicenceActivityOverview overview, LicenceActivityQuery query, LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken);
+    }
+
+    public interface ILicenceActivityDiagnostics
+    {
+        void Stage(string stage, long elapsedMs = 0);
+    }
+
+    public sealed class NullLicenceActivityDiagnostics : ILicenceActivityDiagnostics
+    {
+        public static readonly NullLicenceActivityDiagnostics Instance = new NullLicenceActivityDiagnostics();
+        private NullLicenceActivityDiagnostics() { }
+        public void Stage(string stage, long elapsedMs = 0) { }
+    }
+
+    public sealed class LicenceActivitySources
+    {
+        public bool UserMetadata { get; set; }
+        public bool UsageReports { get; set; }
+        public bool CopilotUsageReports { get; set; }
+        public bool CopilotAudit { get; set; }
+        public bool CopilotInteractions { get; set; }
+        public DateTime NowUtc { get; set; }
+
+        public string CacheKey => string.Join(":", UserMetadata, UsageReports, CopilotUsageReports,
+            CopilotAudit, CopilotInteractions, NowUtc.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    public static class LicenceActivityRules
+    {
+        public const string Method =
+            "Activity bands describe the share of observed reporting samples with activity: zero = none, "
+            + "low = below 25%, moderate = 25% to below 75%, high = at least 75%. "
+            + "Incomplete evidence is unknown, not zero. Counts are workload-specific snapshot averages, not daily events.";
+
+        public const string AssignmentCaveat =
+            "Historical activity is shown against currently imported licence assignments, not historical ownership. "
+            + "A user can hold several SKUs; summed assignments are not a unique-user total. Assigned seats are not purchased capacity.";
+
+        public const string InterpretationCaveat =
+            "Activity by a licence holder does not prove that this SKU enabled it. These estimates do not measure productivity, "
+            + "ROI or compliance and are not sufficient evidence to remove a licence.";
+
+        public static string Band(int activeSamples, int observedSamples, int expectedSamples)
+        {
+            if (expectedSamples <= 0 || observedSamples != expectedSamples || activeSamples < 0 || activeSamples > observedSamples)
+                return "unknown";
+            if (activeSamples == 0) return "zero";
+            if ((long)activeSamples * 4 < expectedSamples) return "low";
+            return (long)activeSamples * 4 < (long)expectedSamples * 3 ? "moderate" : "high";
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityModels.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityModels.cs
@@ -1,0 +1,127 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+
+namespace Common.Entities.LicenceActivity
+{
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityAvailability
+    {
+        public bool Available { get; set; }
+        public bool CanViewUsers { get; set; }
+        public int MinimumDays { get; set; } = LicenceActivityQuery.MinimumDays;
+        public int MaximumDays { get; set; } = LicenceActivityQuery.MaximumDays;
+        public List<string> Messages { get; set; } = new List<string>();
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public abstract class LicenceActivitySnapshot
+    {
+        public string SnapshotId { get; set; }
+        public DateTime GeneratedUtc { get; set; }
+        public DateTime ExpiresUtc { get; set; }
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityOverview : LicenceActivitySnapshot
+    {
+        public LicenceActivityQuery Query { get; set; }
+        public int DistinctAssignedUsers { get; set; }
+        public List<LicenceActivitySku> Licences { get; set; } = new List<LicenceActivitySku>();
+        public List<LicenceActivityCoverage> Coverage { get; set; } = new List<LicenceActivityCoverage>();
+        public List<LicenceActivityDemographic> Departments { get; set; } = new List<LicenceActivityDemographic>();
+        public List<LicenceActivityDemographic> Countries { get; set; } = new List<LicenceActivityDemographic>();
+        public bool DemographicsTruncated { get; set; }
+        public List<string> Messages { get; set; } = new List<string>();
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivitySku
+    {
+        public int LicenceTypeId { get; set; }
+        public string Name { get; set; }
+        public string SkuId { get; set; }
+        public int AssignedUsers { get; set; }
+        public List<LicenceActivityDistribution> Workloads { get; set; } = new List<LicenceActivityDistribution>();
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityDistribution
+    {
+        public string Workload { get; set; }
+        public int High { get; set; }
+        public int Moderate { get; set; }
+        public int Low { get; set; }
+        public int Zero { get; set; }
+        public int Unknown { get; set; }
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityDemographic
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int AssignedUsers { get; set; }
+        public List<LicenceActivityDistribution> Workloads { get; set; } = new List<LicenceActivityDistribution>();
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityCoverage
+    {
+        public string Workload { get; set; }
+        public string Status { get; set; }
+        public string Source { get; set; }
+        public string Measure { get; set; }
+        public string Granularity { get; set; }
+        public string Message { get; set; }
+        public DateTime? EffectiveFromUtc { get; set; }
+        public DateTime? EffectiveToUtc { get; set; }
+        public DateTime? LatestImportUtc { get; set; }
+        public int LagDays { get; set; }
+        public int? ReportPeriodDays { get; set; }
+        public int ExpectedSamples { get; set; }
+        public int ObservedSamples { get; set; }
+        public int UnmatchedUsers { get; set; }
+        public List<DateTime> SnapshotDates { get; set; } = new List<DateTime>();
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityUsers : LicenceActivitySnapshot
+    {
+        public string OverviewId { get; set; }
+        public LicenceActivityQuery Query { get; set; }
+        public int TotalUsers { get; set; }
+        public int RankedUsers { get; set; }
+        public List<LicenceActivityUser> MostActive { get; set; } = new List<LicenceActivityUser>();
+        public List<LicenceActivityUser> LeastActive { get; set; } = new List<LicenceActivityUser>();
+        public List<LicenceActivityUser> Users { get; set; } = new List<LicenceActivityUser>();
+        public List<string> Messages { get; set; } = new List<string>();
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityUser
+    {
+        public int UserId { get; set; }
+        public string UserPrincipalName { get; set; }
+        public string Department { get; set; }
+        public string Country { get; set; }
+        public bool? AccountEnabled { get; set; }
+        public List<LicenceActivityEvidence> Workloads { get; set; } = new List<LicenceActivityEvidence>();
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityEvidence
+    {
+        public string Workload { get; set; }
+        public string Status { get; set; }
+        public string Band { get; set; }
+        public string Source { get; set; }
+        public string Measure { get; set; }
+        public int ActiveSamples { get; set; }
+        public int ObservedSamples { get; set; }
+        public int ExpectedSamples { get; set; }
+        public double? AverageActions { get; set; }
+        public DateTime? LastActivityUtc { get; set; }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityQuery.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityQuery.cs
@@ -1,0 +1,95 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace Common.Entities.LicenceActivity
+{
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public sealed class LicenceActivityQuery
+    {
+        public const int MinimumDays = 7;
+        public const int MaximumDays = 180;
+        public const int MaximumRows = 100;
+        public const int MaximumPage = 10000;
+        public static readonly string[] Workloads = { "teams", "outlook", "onedrive", "sharepoint", "copilot" };
+        private static readonly string[] Sorts = { "upn", "activity", "lastActivity" };
+
+        public string From { get; private set; }
+        public string To { get; private set; }
+        public int? DepartmentId { get; private set; }
+        public int? CountryId { get; private set; }
+        public int? LicenceTypeId { get; private set; }
+        public string Workload { get; private set; }
+        public string Search { get; private set; }
+        public string Sort { get; private set; }
+        public string Direction { get; private set; }
+        public int Top { get; private set; }
+        public int Page { get; private set; }
+        public int PageSize { get; private set; }
+
+        [JsonIgnore]
+        public DateTime FromUtc => ParseDate(From);
+        [JsonIgnore]
+        public DateTime ToUtc => ParseDate(To);
+        [JsonIgnore]
+        public DateTime EndExclusiveUtc => ToUtc.AddDays(1);
+        [JsonIgnore]
+        public int Days => (ToUtc - FromUtc).Days + 1;
+
+        private LicenceActivityQuery() { }
+
+        public static LicenceActivityQuery Create(
+            string from, string to, DateTime nowUtc, int? departmentId = null, int? countryId = null,
+            int? licenceTypeId = null, string workload = "teams", string search = null,
+            string sort = "upn", string direction = "asc", int top = 10, int page = 1, int pageSize = 50)
+        {
+            if ((from == null) != (to == null))
+                throw new ArgumentException("Supply both from and to dates in YYYY-MM-DD format.");
+            var settled = nowUtc.Date.AddDays(-3);
+            var end = to == null ? settled.AddDays(-(int)settled.DayOfWeek) : ParseDate(to);
+            var start = from == null ? end.AddDays(-27) : ParseDate(from);
+            var days = (end - start).Days + 1;
+            if (days < MinimumDays || days > MaximumDays || end >= nowUtc.Date)
+                throw new ArgumentException("Choose 7 to 180 inclusive UTC dates, ending before today. Custom ranges are never rounded.");
+            if (start.Year < 1753)
+                throw new ArgumentException("The earliest supported date is 1753-01-01.");
+            if (departmentId < 0 || countryId < 0 || licenceTypeId <= 0)
+                throw new ArgumentException("Licence IDs must be positive; demographic IDs must be zero (unknown) or positive.");
+            if (!Workloads.Contains(workload, StringComparer.Ordinal))
+                throw new ArgumentException("Choose teams, outlook, onedrive, sharepoint or copilot.");
+            if (!Sorts.Contains(sort, StringComparer.Ordinal) || (direction != "asc" && direction != "desc"))
+                throw new ArgumentException("Choose a supported sort and asc or desc direction.");
+            if (top < 1 || top > MaximumRows || pageSize < 1 || pageSize > MaximumRows || page < 1 || page > MaximumPage)
+                throw new ArgumentException("Top and pageSize must be 1 to 100; page must be 1 to 10000.");
+            search = (search ?? string.Empty).Trim();
+            if (search.Length > 100 || search.Any(char.IsControl))
+                throw new ArgumentException("Search must contain at most 100 characters and no control characters.");
+
+            return new LicenceActivityQuery
+            {
+                From = start.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                To = end.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                DepartmentId = departmentId, CountryId = countryId, LicenceTypeId = licenceTypeId,
+                Workload = workload, Search = search, Sort = sort, Direction = direction,
+                Top = top, Page = page, PageSize = pageSize
+            };
+        }
+
+        public LicenceActivityQuery ForUsers(
+            int licenceTypeId, string workload, string search, string sort, string direction,
+            int top, int page, int pageSize, DateTime nowUtc) =>
+            Create(From, To, nowUtc, DepartmentId, CountryId, licenceTypeId, workload, search, sort, direction, top, page, pageSize);
+
+        public string CacheKey() => JsonConvert.SerializeObject(this);
+
+        private static DateTime ParseDate(string value)
+        {
+            if (!DateTime.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var date))
+                throw new ArgumentException("Dates must use YYYY-MM-DD format.");
+            return DateTime.SpecifyKind(date, DateTimeKind.Utc);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -1,0 +1,3015 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Common.Entities.LicenceActivity
+{
+    /// <summary>
+    /// Builds the bounded SQL batches used by <see cref="SqlLicenceActivityStore"/>.
+    /// Only fixed table, column and ordering fragments are interpolated; every request value is a SQL parameter.
+    /// </summary>
+    internal static class LicenceActivitySql
+    {
+        internal const int CommandTimeoutSeconds = 20;
+
+        internal const int Teams = 1;
+        internal const int Outlook = 2;
+        internal const int OneDrive = 3;
+        internal const int SharePoint = 4;
+        internal const int Copilot = 5;
+
+        internal const string Available = "available";
+        internal const string Disabled = "disabled";
+        internal const string NotImported = "notImported";
+        internal const string MissingCoverage = "missingCoverage";
+        internal const string UnmatchableIdentity = "unmatchableIdentity";
+        internal const string Partial = "partial";
+
+        internal const string M365ReportSource = "microsoftGraphUsageReport";
+        internal const string CopilotReportSource = "microsoftGraphCopilotUsageReport";
+        internal const string CopilotAuditSource = "copilotAudit";
+        internal const string CopilotInteractionSource = "copilotInteractions";
+
+        internal static string BuildOverview(LicenceActivitySources sources)
+        {
+            if (sources == null) throw new ArgumentNullException(nameof(sources));
+
+            var sql = new StringBuilder(30000);
+            sql.Append(OverviewPreamble);
+
+            AppendM365Overview(
+                sql, Teams, "teams", "dbo.teams_user_activity_log",
+                "average published message and meeting counters across supporting snapshots",
+                sources.UsageReports);
+
+            AppendM365Overview(
+                sql, Outlook, "outlook", "dbo.outlook_user_activity_log",
+                "average published sent and read counters across supporting snapshots",
+                sources.UsageReports);
+
+            AppendM365Overview(
+                sql, OneDrive, "onedrive", "dbo.onedrive_user_activity_log",
+                "average published viewed-or-edited counter across supporting snapshots",
+                sources.UsageReports);
+
+            AppendM365Overview(
+                sql, SharePoint, "sharepoint", "dbo.sharepoint_user_activity_log",
+                "average published viewed-or-edited counter across supporting snapshots",
+                sources.UsageReports);
+
+            if (sources.UsageReports) sql.Append(M365OverviewScores);
+            AppendCopilotOverview(sql, sources);
+            sql.Append(OverviewProjection);
+            return sql.ToString();
+        }
+
+        internal static string SampleParameterName(int workload, int index)
+        {
+            return "@sample" + workload.ToString(CultureInfo.InvariantCulture)
+                + "_" + index.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static void AppendSampleInserts(StringBuilder sql, LicenceActivityOverview overview)
+        {
+            foreach (var coverage in overview.Coverage)
+            {
+                var workload = WorkloadId(coverage.Workload);
+                if (workload == 0 || coverage.SnapshotDates == null) continue;
+
+                for (var index = 0; index < coverage.SnapshotDates.Count; index++)
+                {
+                    sql.AppendFormat(
+                        CultureInfo.InvariantCulture,
+                        "INSERT #Samples (workload, sample_date) VALUES ({0}, {1});\r\n",
+                        workload,
+                        SampleParameterName(workload, index));
+                }
+            }
+        }
+
+        internal static string BuildUsers(
+            LicenceActivityOverview overview,
+            LicenceActivityQuery query)
+        {
+            if (overview == null) throw new ArgumentNullException(nameof(overview));
+            if (query == null) throw new ArgumentNullException(nameof(query));
+
+            var sql = new StringBuilder(26000);
+            sql.Append(UsersPreamble);
+            AppendSampleInserts(sql, overview);
+
+            var selectedCoverage = overview.Coverage
+                .FirstOrDefault(c => c.Workload == query.Workload);
+            if (selectedCoverage != null)
+                AppendWorkloadUsers(sql, selectedCoverage, "#EligibleUsers");
+
+            sql.Append(@"
+CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserScores
+    ON #Scores (workload, user_id);
+");
+            sql.Append(BuildUsersSelection(query));
+
+            foreach (var coverage in overview.Coverage
+                .Where(c => c.Workload != query.Workload))
+            {
+                AppendWorkloadUsers(sql, coverage, "#ReturnedUsers");
+            }
+
+            sql.Append(UsersFinalProjection);
+            return sql.ToString();
+        }
+
+        internal static string BuildOverviewBase(string eligibleTable = "#EligibleUsers")
+        {
+            if (eligibleTable == "#EligibleUsers") return OverviewBaseSql;
+            ValidateSharedEligibleTableName(eligibleTable);
+            var start = OverviewBaseSql.IndexOf(
+                "CREATE TABLE #Demographics",
+                StringComparison.Ordinal);
+            if (start < 0) throw new InvalidOperationException("The overview base SQL is malformed.");
+            return ("SET NOCOUNT ON;\r\nSET XACT_ABORT ON;\r\n\r\n"
+                + OverviewBaseSql.Substring(start)).Replace("#EligibleUsers", eligibleTable);
+        }
+
+        internal static string BuildM365Overview(string eligibleTable = "#EligibleUsers")
+        {
+            return BuildM365OverviewGroup(
+                eligibleTable,
+                Teams, Outlook, OneDrive, SharePoint);
+        }
+
+        internal static string BuildM365OverviewGroup(
+            string eligibleTable,
+            params int[] workloads)
+        {
+            var sql = new StringBuilder(26000);
+            AppendOverviewPartPreamble(sql, eligibleTable);
+            foreach (var workload in workloads.Distinct())
+            {
+                switch (workload)
+                {
+                    case Teams:
+                        AppendM365Overview(
+                            sql, Teams, "teams", "dbo.teams_user_activity_log",
+                            "average published message and meeting counters across supporting snapshots",
+                            true);
+                        AppendM365OverviewScore(
+                            sql, Teams, "dbo.teams_user_activity_log");
+                        break;
+                    case Outlook:
+                        AppendM365Overview(
+                            sql, Outlook, "outlook", "dbo.outlook_user_activity_log",
+                            "average published sent and read counters across supporting snapshots",
+                            true);
+                        AppendM365OverviewScore(
+                            sql, Outlook, "dbo.outlook_user_activity_log");
+                        break;
+                    case OneDrive:
+                        AppendM365Overview(
+                            sql, OneDrive, "onedrive", "dbo.onedrive_user_activity_log",
+                            "average published viewed-or-edited counter across supporting snapshots",
+                            true);
+                        AppendM365OverviewScore(
+                            sql, OneDrive, "dbo.onedrive_user_activity_log");
+                        break;
+                    case SharePoint:
+                        AppendM365Overview(
+                            sql, SharePoint, "sharepoint", "dbo.sharepoint_user_activity_log",
+                            "average published viewed-or-edited counter across supporting snapshots",
+                            true);
+                        AppendM365OverviewScore(
+                            sql, SharePoint, "dbo.sharepoint_user_activity_log");
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(workloads));
+                }
+            }
+            sql.Append(OverviewProjection);
+            return sql.ToString()
+                .Replace("#EligibleUsers", eligibleTable)
+                .Replace("OPTION (RECOMPILE)", "OPTION (RECOMPILE, MAXDOP 2)");
+        }
+
+        internal static string BuildM365OverviewPart(
+            int workload,
+            string eligibleTable = "#EligibleUsers",
+            string bandTable = null)
+        {
+            var sql = new StringBuilder(14000);
+            AppendOverviewPartPreamble(sql, eligibleTable);
+
+            switch (workload)
+            {
+                case Teams:
+                    AppendM365Overview(
+                        sql, Teams, "teams", "dbo.teams_user_activity_log",
+                        "average published message and meeting counters across supporting snapshots",
+                        true);
+                    AppendM365OverviewScore(
+                        sql, Teams, "dbo.teams_user_activity_log");
+                    break;
+                case Outlook:
+                    AppendM365Overview(
+                        sql, Outlook, "outlook", "dbo.outlook_user_activity_log",
+                        "average published sent and read counters across supporting snapshots",
+                        true);
+                    AppendM365OverviewScore(
+                        sql, Outlook, "dbo.outlook_user_activity_log");
+                    break;
+                case OneDrive:
+                    AppendM365Overview(
+                        sql, OneDrive, "onedrive", "dbo.onedrive_user_activity_log",
+                        "average published viewed-or-edited counter across supporting snapshots",
+                        true);
+                    AppendM365OverviewScore(
+                        sql, OneDrive, "dbo.onedrive_user_activity_log");
+                    break;
+                case SharePoint:
+                    AppendM365Overview(
+                        sql, SharePoint, "sharepoint", "dbo.sharepoint_user_activity_log",
+                        "average published viewed-or-edited counter across supporting snapshots",
+                        true);
+                    AppendM365OverviewScore(
+                        sql, SharePoint, "dbo.sharepoint_user_activity_log");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(workload));
+            }
+
+            sql.Append(bandTable == null
+                ? BuildSingleWorkloadProjection(workload, workload == Teams)
+                : BuildBandWriterProjection(workload, bandTable));
+            return sql.ToString()
+                .Replace("#EligibleUsers", eligibleTable)
+                .Replace("OPTION (RECOMPILE)", "OPTION (RECOMPILE, MAXDOP 1)");
+        }
+
+        internal static string BuildCopilotOverviewPart(
+            LicenceActivitySources sources,
+            string eligibleTable = "#EligibleUsers",
+            string bandTable = null)
+        {
+            var sql = new StringBuilder(18000);
+            AppendOverviewPartPreamble(sql, eligibleTable);
+            AppendCopilotOverview(sql, sources);
+            sql.Append(bandTable == null
+                ? BuildSingleWorkloadProjection(Copilot, true)
+                : BuildBandWriterProjection(Copilot, bandTable));
+            return sql.ToString()
+                .Replace("#EligibleUsers", eligibleTable)
+                .Replace("OPTION (RECOMPILE)", "OPTION (RECOMPILE, MAXDOP 1)");
+        }
+
+        internal static string BuildSharedEligibleUsers(
+            string tableName,
+            IEnumerable<string> bandTables = null)
+        {
+            ValidateSharedEligibleTableName(tableName);
+            var sql = new StringBuilder(@"
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+
+IF (SELECT COUNT_BIG(*) FROM dbo.license_types) > 500
+BEGIN
+    RAISERROR('Licence activity supports at most 500 imported licence types.', 16, 1);
+    RETURN;
+END;
+
+CREATE TABLE " + tableName + @"
+(
+    user_id int NOT NULL PRIMARY KEY,
+    department_id int NOT NULL,
+    country_id int NOT NULL
+);
+
+INSERT " + tableName + @" (user_id, department_id, country_id)
+SELECT u.id, ISNULL(u.department_id, 0), ISNULL(u.country_or_region_id, 0)
+FROM dbo.users AS u
+WHERE (@departmentId IS NULL
+       OR u.department_id = @departmentId
+       OR (@departmentId = 0 AND u.department_id IS NULL))
+  AND (@countryId IS NULL
+       OR u.country_or_region_id = @countryId
+       OR (@countryId = 0 AND u.country_or_region_id IS NULL))
+  AND EXISTS
+      (SELECT 1 FROM dbo.user_license_type_lookups AS owned WHERE owned.user_id = u.id)
+OPTION (RECOMPILE);
+");
+            if (bandTables != null)
+            {
+                foreach (var bandTable in bandTables)
+                {
+                    ValidateSharedBandTableName(bandTable);
+                    sql.Append(@"
+CREATE TABLE " + bandTable + @"
+(
+    user_id int NOT NULL PRIMARY KEY,
+    band tinyint NOT NULL
+);
+");
+                }
+            }
+            return sql.ToString();
+        }
+
+        internal static string BuildOverviewDistributions(
+            string eligibleTable,
+            IReadOnlyList<string> bandTables)
+        {
+            ValidateSharedEligibleTableName(eligibleTable);
+            if (bandTables == null || bandTables.Count != 5)
+                throw new ArgumentException("Exactly five workload-band tables are required.", nameof(bandTables));
+            foreach (var table in bandTables) ValidateSharedBandTableName(table);
+
+            return @"
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+
+;WITH AllBands AS
+(
+    SELECT 1 AS workload, user_id, band FROM " + bandTables[0] + @"
+    UNION ALL SELECT 2, user_id, band FROM " + bandTables[1] + @"
+    UNION ALL SELECT 3, user_id, band FROM " + bandTables[2] + @"
+    UNION ALL SELECT 4, user_id, band FROM " + bandTables[3] + @"
+    UNION ALL SELECT 5, user_id, band FROM " + bandTables[4] + @"
+)
+SELECT eligible.user_id,
+       eligible.department_id,
+       eligible.country_id,
+       MAX(CASE WHEN bands.workload = 1 THEN bands.band END) AS teams_band,
+       MAX(CASE WHEN bands.workload = 2 THEN bands.band END) AS outlook_band,
+       MAX(CASE WHEN bands.workload = 3 THEN bands.band END) AS onedrive_band,
+       MAX(CASE WHEN bands.workload = 4 THEN bands.band END) AS sharepoint_band,
+       MAX(CASE WHEN bands.workload = 5 THEN bands.band END) AS copilot_band
+INTO #UserBands
+FROM " + eligibleTable + @" AS eligible
+LEFT JOIN AllBands AS bands ON bands.user_id = eligible.user_id
+GROUP BY eligible.user_id, eligible.department_id, eligible.country_id
+OPTION (RECOMPILE, MAXDOP 2);
+
+CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserBands ON #UserBands (user_id);
+
+;WITH Memberships AS
+(
+    SELECT DISTINCT owned.license_type_id, owned.user_id
+    FROM dbo.user_license_type_lookups AS owned
+    JOIN " + eligibleTable + @" AS eligible ON eligible.user_id = owned.user_id
+),
+Grouped AS
+(
+    SELECT members.license_type_id,
+           bands.teams_band,
+           bands.outlook_band,
+           bands.onedrive_band,
+           bands.sharepoint_band,
+           bands.copilot_band,
+           COUNT(*) AS users
+    FROM Memberships AS members
+    JOIN #UserBands AS bands ON bands.user_id = members.user_id
+    GROUP BY members.license_type_id,
+             bands.teams_band, bands.outlook_band, bands.onedrive_band,
+             bands.sharepoint_band, bands.copilot_band
+),
+Counts AS
+(
+    SELECT license_type_id,
+           SUM(users) AS assigned_users,
+           SUM(CASE WHEN teams_band = 3 THEN users ELSE 0 END) AS teams_high,
+           SUM(CASE WHEN teams_band = 2 THEN users ELSE 0 END) AS teams_moderate,
+           SUM(CASE WHEN teams_band = 1 THEN users ELSE 0 END) AS teams_low,
+           SUM(CASE WHEN teams_band = 0 THEN users ELSE 0 END) AS teams_zero,
+           SUM(CASE WHEN teams_band IS NOT NULL THEN users ELSE 0 END) AS teams_known,
+           SUM(CASE WHEN outlook_band = 3 THEN users ELSE 0 END) AS outlook_high,
+           SUM(CASE WHEN outlook_band = 2 THEN users ELSE 0 END) AS outlook_moderate,
+           SUM(CASE WHEN outlook_band = 1 THEN users ELSE 0 END) AS outlook_low,
+           SUM(CASE WHEN outlook_band = 0 THEN users ELSE 0 END) AS outlook_zero,
+           SUM(CASE WHEN outlook_band IS NOT NULL THEN users ELSE 0 END) AS outlook_known,
+           SUM(CASE WHEN onedrive_band = 3 THEN users ELSE 0 END) AS onedrive_high,
+           SUM(CASE WHEN onedrive_band = 2 THEN users ELSE 0 END) AS onedrive_moderate,
+           SUM(CASE WHEN onedrive_band = 1 THEN users ELSE 0 END) AS onedrive_low,
+           SUM(CASE WHEN onedrive_band = 0 THEN users ELSE 0 END) AS onedrive_zero,
+           SUM(CASE WHEN onedrive_band IS NOT NULL THEN users ELSE 0 END) AS onedrive_known,
+           SUM(CASE WHEN sharepoint_band = 3 THEN users ELSE 0 END) AS sharepoint_high,
+           SUM(CASE WHEN sharepoint_band = 2 THEN users ELSE 0 END) AS sharepoint_moderate,
+           SUM(CASE WHEN sharepoint_band = 1 THEN users ELSE 0 END) AS sharepoint_low,
+           SUM(CASE WHEN sharepoint_band = 0 THEN users ELSE 0 END) AS sharepoint_zero,
+           SUM(CASE WHEN sharepoint_band IS NOT NULL THEN users ELSE 0 END) AS sharepoint_known,
+           SUM(CASE WHEN copilot_band = 3 THEN users ELSE 0 END) AS copilot_high,
+           SUM(CASE WHEN copilot_band = 2 THEN users ELSE 0 END) AS copilot_moderate,
+           SUM(CASE WHEN copilot_band = 1 THEN users ELSE 0 END) AS copilot_low,
+           SUM(CASE WHEN copilot_band = 0 THEN users ELSE 0 END) AS copilot_zero,
+           SUM(CASE WHEN copilot_band IS NOT NULL THEN users ELSE 0 END) AS copilot_known
+    FROM Grouped
+    GROUP BY license_type_id
+)
+SELECT licence.id AS LicenceTypeId,
+       values_by_workload.workload_name AS Workload,
+       values_by_workload.high_count AS High,
+       values_by_workload.moderate_count AS Moderate,
+       values_by_workload.low_count AS Low,
+       values_by_workload.zero_count AS Zero,
+       ISNULL(counts.assigned_users, 0) - values_by_workload.known_count AS Unknown
+FROM dbo.license_types AS licence
+LEFT JOIN Counts AS counts ON counts.license_type_id = licence.id
+CROSS APPLY
+(
+    VALUES
+      ('teams', ISNULL(counts.teams_high, 0), ISNULL(counts.teams_moderate, 0),
+       ISNULL(counts.teams_low, 0), ISNULL(counts.teams_zero, 0), ISNULL(counts.teams_known, 0)),
+      ('outlook', ISNULL(counts.outlook_high, 0), ISNULL(counts.outlook_moderate, 0),
+       ISNULL(counts.outlook_low, 0), ISNULL(counts.outlook_zero, 0), ISNULL(counts.outlook_known, 0)),
+      ('onedrive', ISNULL(counts.onedrive_high, 0), ISNULL(counts.onedrive_moderate, 0),
+       ISNULL(counts.onedrive_low, 0), ISNULL(counts.onedrive_zero, 0), ISNULL(counts.onedrive_known, 0)),
+      ('sharepoint', ISNULL(counts.sharepoint_high, 0), ISNULL(counts.sharepoint_moderate, 0),
+       ISNULL(counts.sharepoint_low, 0), ISNULL(counts.sharepoint_zero, 0), ISNULL(counts.sharepoint_known, 0)),
+      ('copilot', ISNULL(counts.copilot_high, 0), ISNULL(counts.copilot_moderate, 0),
+       ISNULL(counts.copilot_low, 0), ISNULL(counts.copilot_zero, 0), ISNULL(counts.copilot_known, 0))
+) AS values_by_workload
+    (workload_name, high_count, moderate_count, low_count, zero_count, known_count)
+ORDER BY licence.id, values_by_workload.workload_name
+OPTION (RECOMPILE);
+
+CREATE TABLE #Demographics
+(
+    dimension tinyint NOT NULL,
+    demographic_id int NOT NULL,
+    assigned_users int NOT NULL,
+    PRIMARY KEY (dimension, demographic_id)
+);
+
+;WITH Counts AS
+(
+    SELECT department_id AS demographic_id, COUNT(*) AS assigned_users
+    FROM " + eligibleTable + @"
+    GROUP BY department_id
+),
+Ranked AS
+(
+    SELECT *, ROW_NUMBER() OVER
+        (ORDER BY assigned_users DESC, demographic_id) AS row_number
+    FROM Counts
+)
+INSERT #Demographics
+SELECT 1, demographic_id, assigned_users
+FROM Ranked
+WHERE row_number <= 50
+   OR (@departmentId IS NOT NULL AND demographic_id = @departmentId);
+
+;WITH Counts AS
+(
+    SELECT country_id AS demographic_id, COUNT(*) AS assigned_users
+    FROM " + eligibleTable + @"
+    GROUP BY country_id
+),
+Ranked AS
+(
+    SELECT *, ROW_NUMBER() OVER
+        (ORDER BY assigned_users DESC, demographic_id) AS row_number
+    FROM Counts
+)
+INSERT #Demographics
+SELECT 2, demographic_id, assigned_users
+FROM Ranked
+WHERE row_number <= 50
+   OR (@countryId IS NOT NULL AND demographic_id = @countryId);
+
+;WITH DepartmentGroups AS
+(
+    SELECT bands.department_id AS demographic_id,
+           bands.teams_band,
+           bands.outlook_band,
+           bands.onedrive_band,
+           bands.sharepoint_band,
+           bands.copilot_band,
+           COUNT(*) AS users
+    FROM #UserBands AS bands
+    GROUP BY bands.department_id,
+             bands.teams_band, bands.outlook_band, bands.onedrive_band,
+             bands.sharepoint_band, bands.copilot_band
+),
+CountryGroups AS
+(
+    SELECT bands.country_id AS demographic_id,
+           bands.teams_band,
+           bands.outlook_band,
+           bands.onedrive_band,
+           bands.sharepoint_band,
+           bands.copilot_band,
+           COUNT(*) AS users
+    FROM #UserBands AS bands
+    GROUP BY bands.country_id,
+             bands.teams_band, bands.outlook_band, bands.onedrive_band,
+             bands.sharepoint_band, bands.copilot_band
+),
+AllGroups AS
+(
+    SELECT 1 AS dimension, * FROM DepartmentGroups
+    UNION ALL
+    SELECT 2, * FROM CountryGroups
+),
+Expanded AS
+(
+    SELECT groups.dimension,
+           groups.demographic_id,
+           values_by_workload.workload_name,
+           values_by_workload.band,
+           groups.users
+    FROM AllGroups AS groups
+    CROSS APPLY
+    (
+        VALUES ('teams', groups.teams_band),
+               ('outlook', groups.outlook_band),
+               ('onedrive', groups.onedrive_band),
+               ('sharepoint', groups.sharepoint_band),
+               ('copilot', groups.copilot_band)
+    ) AS values_by_workload (workload_name, band)
+),
+Counts AS
+(
+    SELECT dimension,
+           demographic_id,
+           workload_name,
+           SUM(CASE WHEN band = 3 THEN users ELSE 0 END) AS high_count,
+           SUM(CASE WHEN band = 2 THEN users ELSE 0 END) AS moderate_count,
+           SUM(CASE WHEN band = 1 THEN users ELSE 0 END) AS low_count,
+           SUM(CASE WHEN band = 0 THEN users ELSE 0 END) AS zero_count,
+           SUM(CASE WHEN band IS NOT NULL THEN users ELSE 0 END) AS known_count
+    FROM Expanded
+    GROUP BY dimension, demographic_id, workload_name
+)
+SELECT CASE WHEN demographics.dimension = 1 THEN 'department' ELSE 'country' END AS Dimension,
+       demographics.demographic_id AS Id,
+       workloads.workload_name AS Workload,
+       ISNULL(counts.high_count, 0) AS High,
+       ISNULL(counts.moderate_count, 0) AS Moderate,
+       ISNULL(counts.low_count, 0) AS Low,
+       ISNULL(counts.zero_count, 0) AS Zero,
+       demographics.assigned_users - ISNULL(counts.known_count, 0) AS Unknown
+FROM #Demographics AS demographics
+CROSS JOIN
+    (VALUES ('teams'), ('outlook'), ('onedrive'), ('sharepoint'), ('copilot'))
+    AS workloads (workload_name)
+LEFT JOIN Counts AS counts
+  ON counts.dimension = demographics.dimension
+ AND counts.demographic_id = demographics.demographic_id
+ AND counts.workload_name = workloads.workload_name
+ORDER BY demographics.dimension, demographics.demographic_id, workloads.workload_name
+OPTION (RECOMPILE);
+
+SELECT (SELECT COUNT(*) FROM " + eligibleTable + @") AS DistinctAssignedUsers,
+       CAST(CASE
+           WHEN (SELECT COUNT(DISTINCT department_id) FROM " + eligibleTable + @")
+                    > (SELECT COUNT(*) FROM #Demographics WHERE dimension = 1)
+             OR (SELECT COUNT(DISTINCT country_id) FROM " + eligibleTable + @")
+                    > (SELECT COUNT(*) FROM #Demographics WHERE dimension = 2)
+           THEN 1 ELSE 0 END AS bit) AS DemographicsTruncated;
+
+SELECT licence.id AS LicenceTypeId,
+       licence.name AS Name,
+       licence.sku_id AS SkuId,
+       0 AS AssignedUsers
+FROM dbo.license_types AS licence
+ORDER BY licence.name, licence.id;
+
+SELECT CASE WHEN demographics.dimension = 1 THEN 'department' ELSE 'country' END AS Dimension,
+       demographics.demographic_id AS Id,
+       CASE WHEN demographics.dimension = 1
+            THEN COALESCE(department.name, N'Unknown')
+            ELSE COALESCE(country.name, N'Unknown')
+       END AS Name,
+       demographics.assigned_users AS AssignedUsers
+FROM #Demographics AS demographics
+LEFT JOIN dbo.user_departments AS department
+  ON demographics.dimension = 1 AND department.id = demographics.demographic_id
+LEFT JOIN dbo.user_country_or_region AS country
+  ON demographics.dimension = 2 AND country.id = demographics.demographic_id
+ORDER BY demographics.dimension, demographics.assigned_users DESC, Name, demographics.demographic_id;
+";
+        }
+
+        internal static string BuildSingleBandDistribution(
+            int workload,
+            string eligibleTable,
+            string bandTable,
+            bool includeBase)
+        {
+            ValidateSharedEligibleTableName(eligibleTable);
+            ValidateSharedBandTableName(bandTable);
+
+            var projection = BuildSingleWorkloadProjection(workload, includeBase);
+            var knownStart = projection.IndexOf(
+                "CREATE TABLE #Known", StringComparison.Ordinal);
+            var resultsStart = projection.IndexOf(
+                "SELECT coverage.workload_name AS Workload", StringComparison.Ordinal);
+            if (knownStart < 0 || resultsStart <= knownStart)
+                throw new InvalidOperationException("The workload projection SQL is malformed.");
+            projection = projection.Remove(knownStart, resultsStart - knownStart)
+                .Replace("#Known", bandTable);
+
+            var sql = new StringBuilder(12000);
+            AppendOverviewPartPreamble(sql, eligibleTable);
+            sql.AppendFormat(
+                CultureInfo.InvariantCulture,
+                @"
+INSERT #Coverage
+(
+    workload, workload_name, status, source, measure, granularity, message,
+    effective_from_utc, effective_to_utc, latest_import_utc, lag_days,
+    report_period_days, expected_samples, observed_samples, unmatched_users
+)
+VALUES
+({0}, '{1}', 'available', '', N'', '', NULL,
+ NULL, NULL, NULL, 0, NULL, 0, 0, 0);
+",
+                workload,
+                WorkloadName(workload));
+            sql.Append(projection);
+            return sql.ToString()
+                .Replace("#EligibleUsers", eligibleTable)
+                .Replace("OPTION (RECOMPILE)", "OPTION (RECOMPILE, MAXDOP 1)");
+        }
+
+        private static void AppendWorkloadUsers(
+            StringBuilder sql,
+            LicenceActivityCoverage coverage,
+            string scopeTable)
+        {
+            var workload = WorkloadId(coverage.Workload);
+            if (workload == Teams)
+            {
+                AppendM365Users(sql, coverage, Teams, "dbo.teams_user_activity_log",
+                    "CAST(ISNULL(activity.private_chat_count, 0) AS float)"
+                    + " + CAST(ISNULL(activity.team_chat_count, 0) AS float)"
+                    + " + CAST(ISNULL(activity.post_messages, 0) AS float)"
+                    + " + CAST(ISNULL(activity.reply_messages, 0) AS float)"
+                    + " + CAST(ISNULL(activity.meetings_attended_count, 0) AS float)"
+                    + " + CAST(ISNULL(activity.meetings_organized_count, 0) AS float)",
+                    scopeTable);
+            }
+            else if (workload == Outlook)
+            {
+                AppendM365Users(sql, coverage, Outlook, "dbo.outlook_user_activity_log",
+                    "CAST(ISNULL(activity.email_send_count, 0) AS float)"
+                    + " + CAST(ISNULL(activity.email_read_count, 0) AS float)",
+                    scopeTable);
+            }
+            else if (workload == OneDrive)
+            {
+                AppendM365Users(sql, coverage, OneDrive, "dbo.onedrive_user_activity_log",
+                    "CAST(ISNULL(activity.viewed_or_edited, 0) AS float)",
+                    scopeTable);
+            }
+            else if (workload == SharePoint)
+            {
+                AppendM365Users(sql, coverage, SharePoint, "dbo.sharepoint_user_activity_log",
+                    "CAST(ISNULL(activity.viewed_or_edited, 0) AS float)",
+                    scopeTable);
+            }
+            else if (workload == Copilot)
+            {
+                AppendCopilotUsers(sql, coverage, scopeTable);
+            }
+        }
+
+        internal static int WorkloadId(string workload)
+        {
+            switch (workload)
+            {
+                case "teams": return Teams;
+                case "outlook": return Outlook;
+                case "onedrive": return OneDrive;
+                case "sharepoint": return SharePoint;
+                case "copilot": return Copilot;
+                default: return 0;
+            }
+        }
+
+        internal static string WorkloadName(int workload)
+        {
+            switch (workload)
+            {
+                case Teams: return "teams";
+                case Outlook: return "outlook";
+                case OneDrive: return "onedrive";
+                case SharePoint: return "sharepoint";
+                case Copilot: return "copilot";
+                default: throw new ArgumentOutOfRangeException(nameof(workload));
+            }
+        }
+
+        private static void AppendOverviewPartPreamble(StringBuilder sql, string eligibleTable)
+        {
+            if (eligibleTable == "#EligibleUsers")
+            {
+                sql.Append(OverviewPreamble);
+                return;
+            }
+
+            ValidateSharedEligibleTableName(eligibleTable);
+            var start = OverviewPreamble.IndexOf("CREATE TABLE #Weeks", StringComparison.Ordinal);
+            if (start < 0) throw new InvalidOperationException("The overview SQL preamble is malformed.");
+            sql.Append("SET NOCOUNT ON;\r\nSET XACT_ABORT ON;\r\nSET DATEFIRST 1;\r\n\r\n");
+            sql.Append(OverviewPreamble.Substring(start).Replace("#EligibleUsers", eligibleTable));
+        }
+
+        private static void ValidateSharedEligibleTableName(string tableName)
+        {
+            const string prefix = "##LicenceActivityEligible_";
+            if (tableName == null
+                || !tableName.StartsWith(prefix, StringComparison.Ordinal)
+                || tableName.Length != prefix.Length + 32
+                || tableName.Substring(prefix.Length).Any(c => !Uri.IsHexDigit(c)))
+            {
+                throw new ArgumentException("Invalid shared eligible-user temp table name.", nameof(tableName));
+            }
+        }
+
+        private static void ValidateSharedBandTableName(string tableName)
+        {
+            const string prefix = "##LicenceActivityBand";
+            if (tableName == null
+                || !tableName.StartsWith(prefix, StringComparison.Ordinal)
+                || tableName.Length != prefix.Length + 2 + 32
+                || tableName[prefix.Length] < '1'
+                || tableName[prefix.Length] > '5'
+                || tableName[prefix.Length + 1] != '_'
+                || tableName.Substring(prefix.Length + 2).Any(c => !Uri.IsHexDigit(c)))
+            {
+                throw new ArgumentException("Invalid shared workload-band temp table name.", nameof(tableName));
+            }
+        }
+
+        private static readonly string OverviewBaseSql = @"
+/* LicenceActivity:OverviewBase */
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+SET DATEFIRST 1;
+
+IF (SELECT COUNT_BIG(*) FROM dbo.license_types) > 500
+BEGIN
+    RAISERROR('Licence activity supports at most 500 imported licence types.', 16, 1);
+    RETURN;
+END;
+
+CREATE TABLE #EligibleUsers
+(
+    user_id int NOT NULL PRIMARY KEY,
+    department_id int NOT NULL,
+    country_id int NOT NULL
+);
+
+INSERT #EligibleUsers
+SELECT DISTINCT u.id, ISNULL(u.department_id, 0), ISNULL(u.country_or_region_id, 0)
+FROM dbo.users AS u
+WHERE (@departmentId IS NULL
+       OR u.department_id = @departmentId
+       OR (@departmentId = 0 AND u.department_id IS NULL))
+  AND (@countryId IS NULL
+       OR u.country_or_region_id = @countryId
+       OR (@countryId = 0 AND u.country_or_region_id IS NULL))
+  AND EXISTS
+      (SELECT 1 FROM dbo.user_license_type_lookups AS owned WHERE owned.user_id = u.id)
+OPTION (RECOMPILE);
+
+CREATE TABLE #Demographics
+(
+    dimension tinyint NOT NULL,
+    demographic_id int NOT NULL,
+    demographic_name nvarchar(100) NOT NULL,
+    assigned_users int NOT NULL,
+    PRIMARY KEY (dimension, demographic_id)
+);
+
+;WITH Counts AS
+(
+    SELECT eligible.department_id AS demographic_id,
+           COALESCE(department.name, N'Unknown') AS demographic_name,
+           COUNT(*) AS assigned_users
+    FROM #EligibleUsers AS eligible
+    LEFT JOIN dbo.user_departments AS department ON department.id = eligible.department_id
+    GROUP BY eligible.department_id, department.name
+),
+Ranked AS
+(
+    SELECT *, ROW_NUMBER() OVER
+        (ORDER BY assigned_users DESC, demographic_name, demographic_id) AS row_number
+    FROM Counts
+)
+INSERT #Demographics
+SELECT 1, demographic_id, demographic_name, assigned_users
+FROM Ranked
+WHERE row_number <= 50
+   OR (@departmentId IS NOT NULL AND demographic_id = @departmentId);
+
+;WITH Counts AS
+(
+    SELECT eligible.country_id AS demographic_id,
+           COALESCE(country.name, N'Unknown') AS demographic_name,
+           COUNT(*) AS assigned_users
+    FROM #EligibleUsers AS eligible
+    LEFT JOIN dbo.user_country_or_region AS country ON country.id = eligible.country_id
+    GROUP BY eligible.country_id, country.name
+),
+Ranked AS
+(
+    SELECT *, ROW_NUMBER() OVER
+        (ORDER BY assigned_users DESC, demographic_name, demographic_id) AS row_number
+    FROM Counts
+)
+INSERT #Demographics
+SELECT 2, demographic_id, demographic_name, assigned_users
+FROM Ranked
+WHERE row_number <= 50
+   OR (@countryId IS NOT NULL AND demographic_id = @countryId);
+
+SELECT (SELECT COUNT(*) FROM #EligibleUsers) AS DistinctAssignedUsers,
+       CAST(CASE
+           WHEN (SELECT COUNT(DISTINCT department_id) FROM #EligibleUsers)
+                    > (SELECT COUNT(*) FROM #Demographics WHERE dimension = 1)
+             OR (SELECT COUNT(DISTINCT country_id) FROM #EligibleUsers)
+                    > (SELECT COUNT(*) FROM #Demographics WHERE dimension = 2)
+           THEN 1 ELSE 0 END AS bit) AS DemographicsTruncated;
+
+SELECT licence.id AS LicenceTypeId,
+       licence.name AS Name,
+       licence.sku_id AS SkuId,
+       0 AS AssignedUsers
+FROM dbo.license_types AS licence
+ORDER BY licence.name, licence.id;
+
+SELECT CASE WHEN dimension = 1 THEN 'department' ELSE 'country' END AS Dimension,
+       demographic_id AS Id,
+       demographic_name AS Name,
+       assigned_users AS AssignedUsers
+FROM #Demographics
+ORDER BY dimension, assigned_users DESC, demographic_name, demographic_id;
+";
+
+        private static readonly string OverviewPreamble = @"
+/* LicenceActivity:Overview */
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+SET DATEFIRST 1;
+
+IF (SELECT COUNT_BIG(*) FROM dbo.license_types) > 500
+BEGIN
+    RAISERROR('Licence activity supports at most 500 imported licence types.', 16, 1);
+    RETURN;
+END;
+
+CREATE TABLE #EligibleUsers
+(
+    user_id int NOT NULL PRIMARY KEY,
+    department_id int NOT NULL,
+    country_id int NOT NULL
+);
+
+INSERT #EligibleUsers (user_id, department_id, country_id)
+SELECT DISTINCT u.id,
+       ISNULL(u.department_id, 0),
+       ISNULL(u.country_or_region_id, 0)
+FROM dbo.users AS u
+WHERE (@departmentId IS NULL
+       OR u.department_id = @departmentId
+       OR (@departmentId = 0 AND u.department_id IS NULL))
+  AND (@countryId IS NULL
+       OR u.country_or_region_id = @countryId
+       OR (@countryId = 0 AND u.country_or_region_id IS NULL))
+  AND EXISTS
+  (
+      SELECT 1
+      FROM dbo.user_license_type_lookups AS owned
+      WHERE owned.user_id = u.id
+  )
+OPTION (RECOMPILE);
+
+CREATE TABLE #Weeks
+(
+    week_start date NOT NULL PRIMARY KEY,
+    m365_from date NOT NULL,
+    m365_to date NOT NULL,
+    copilot_d7_from date NOT NULL,
+    copilot_d7_to date NOT NULL
+);
+
+DECLARE @firstWeek date =
+    DATEADD(DAY,
+        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), @from) % 7) + 7) % 7),
+        @from);
+
+;WITH WeekStarts AS
+(
+    SELECT @firstWeek AS week_start
+    UNION ALL
+    SELECT DATEADD(DAY, 7, week_start)
+    FROM WeekStarts
+    WHERE DATEADD(DAY, 7, week_start) <= @to
+)
+INSERT #Weeks (week_start, m365_from, m365_to, copilot_d7_from, copilot_d7_to)
+SELECT week_start,
+       CASE WHEN week_start < @from THEN @from ELSE week_start END,
+       CASE WHEN DATEADD(DAY, 6, week_start) > @to THEN @to ELSE DATEADD(DAY, 6, week_start) END,
+       CASE WHEN week_start < DATEADD(DAY, 6, @from) THEN DATEADD(DAY, 6, @from) ELSE week_start END,
+       CASE WHEN DATEADD(DAY, 6, week_start) > @to THEN @to ELSE DATEADD(DAY, 6, week_start) END
+FROM WeekStarts
+OPTION (MAXRECURSION 0);
+
+CREATE TABLE #Samples
+(
+    workload tinyint NOT NULL,
+    sample_date date NOT NULL,
+    PRIMARY KEY (workload, sample_date)
+);
+
+CREATE TABLE #Coverage
+(
+    workload tinyint NOT NULL PRIMARY KEY,
+    workload_name varchar(20) NOT NULL,
+    status varchar(32) NOT NULL,
+    source varchar(64) NOT NULL,
+    measure nvarchar(240) NOT NULL,
+    granularity varchar(48) NOT NULL,
+    message nvarchar(800) NULL,
+    effective_from_utc datetime NULL,
+    effective_to_utc datetime NULL,
+    latest_import_utc datetime NULL,
+    lag_days int NOT NULL,
+    report_period_days int NULL,
+    expected_samples int NOT NULL,
+    observed_samples int NOT NULL,
+    unmatched_users int NOT NULL
+);
+
+-- Report-backed workloads materialise every user who has at least one actual (user, sample-date)
+-- row, including explicit zero rows. Per-user observed_samples decides whether zero is complete;
+-- an absent or incomplete row set remains unknown and can never enter least-active.
+CREATE TABLE #Scores
+(
+    workload tinyint NOT NULL,
+    user_id int NOT NULL,
+    active_samples int NOT NULL,
+    observed_samples int NOT NULL,
+    frequency_known bit NOT NULL
+);
+";
+
+        private static void AppendM365Overview(
+            StringBuilder sql,
+            int workload,
+            string workloadName,
+            string table,
+            string measure,
+            bool enabled)
+        {
+            var suffix = workload.ToString(CultureInfo.InvariantCulture);
+            sql.AppendFormat(
+                CultureInfo.InvariantCulture,
+                @"
+DECLARE @expected{0} int =
+(
+    SELECT COUNT(*)
+    FROM #Weeks
+    WHERE m365_from <= m365_to
+);
+",
+                suffix);
+
+            if (!enabled)
+            {
+                sql.AppendFormat(
+                    CultureInfo.InvariantCulture,
+                    @"
+INSERT #Coverage
+(
+    workload, workload_name, status, source, measure, granularity, message,
+    effective_from_utc, effective_to_utc, latest_import_utc, lag_days,
+    report_period_days, expected_samples, observed_samples, unmatched_users
+)
+VALUES
+(
+    {0}, '{1}', 'disabled', 'microsoftGraphUsageReport',
+    N'{2}', 'weeklySupportingSnapshot',
+    N'The Microsoft 365 usage-report import is disabled. Absence cannot be interpreted as zero.',
+    NULL, NULL, NULL, 0, NULL, @expected{0}, 0, 0
+);
+",
+                    suffix, workloadName, measure);
+                return;
+            }
+
+            sql.AppendFormat(
+                CultureInfo.InvariantCulture,
+                @"
+DECLARE @latest{0} datetime = (SELECT MAX([date]) FROM {1});
+
+INSERT #Samples (workload, sample_date)
+SELECT {0}, selected.sample_date
+FROM #Weeks AS weeks
+CROSS APPLY
+(
+    SELECT TOP (1) CAST(available.[date] AS date) AS sample_date
+    FROM {1} AS available WITH (INDEX(IX_date))
+    WHERE available.[date] >= weeks.m365_from
+      AND available.[date] < DATEADD(DAY, 1, weeks.m365_to)
+      AND available.[date] < DATEADD(DAY, 1, @settled)
+    ORDER BY available.[date] DESC
+) AS selected
+WHERE weeks.m365_from <= weeks.m365_to
+  AND weeks.m365_from <= @settled
+OPTION (RECOMPILE);
+
+DECLARE @observed{0} int =
+    (SELECT COUNT(*) FROM #Samples WHERE workload = {0});
+DECLARE @complete{0} int =
+(
+    SELECT COUNT(*)
+    FROM #Weeks AS weeks
+    JOIN #Samples AS samples
+      ON samples.workload = {0}
+     AND samples.sample_date = weeks.m365_to
+    WHERE weeks.m365_from <= weeks.m365_to
+      AND weeks.m365_to <= @settled
+);
+DECLARE @status{0} varchar(32) =
+    CASE
+        WHEN @latest{0} IS NULL THEN 'notImported'
+        WHEN @expected{0} = 0 OR @observed{0} = 0 THEN 'missingCoverage'
+        WHEN @observed{0} < @expected{0} OR @complete{0} < @expected{0} THEN 'partial'
+        ELSE 'available'
+    END;
+
+INSERT #Coverage
+(
+    workload, workload_name, status, source, measure, granularity, message,
+    effective_from_utc, effective_to_utc, latest_import_utc, lag_days,
+    report_period_days, expected_samples, observed_samples, unmatched_users
+)
+SELECT {0}, '{2}', @status{0}, 'microsoftGraphUsageReport',
+       N'{3}', 'weeklySupportingSnapshot',
+       CASE @status{0}
+           WHEN 'available' THEN N'One settled report-date snapshot was sampled per calendar week. Frequency uses same-week last_activity_date only. Published counters are averaged as snapshot evidence and are never summed or relabelled as daily events. These tables store report dates, not an import-completion timestamp.'
+           WHEN 'partial' THEN N'At least one requested Monday-week portion lacks a settled snapshot on its exact end date. Earlier snapshots are as-of evidence only; all bands remain unknown and no user is ranked least-active.'
+           WHEN 'notImported' THEN N'The import is enabled but this workload has not stored a report yet.'
+           ELSE N'No settled report snapshot covers this requested range.'
+       END,
+       MIN(CAST(CASE WHEN sampled_week.week_start < @from
+                     THEN @from ELSE sampled_week.week_start END AS datetime)),
+       MAX(CAST(samples.sample_date AS datetime)),
+       NULL,
+       CASE WHEN MAX(samples.sample_date) IS NULL THEN 0
+            ELSE DATEDIFF(DAY, MAX(samples.sample_date), @now) END,
+       NULL, @expected{0}, @observed{0}, 0
+FROM (SELECT sample_date FROM #Samples WHERE workload = {0}) AS samples
+CROSS APPLY
+(
+    SELECT DATEADD(DAY,
+        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), samples.sample_date) % 7) + 7) % 7),
+        samples.sample_date) AS week_start
+) AS sampled_week;
+",
+                suffix, table, workloadName, measure);
+        }
+
+        private static void AppendM365OverviewScore(
+            StringBuilder sql,
+            int workload,
+            string table)
+        {
+            sql.AppendFormat(
+                CultureInfo.InvariantCulture,
+                @"
+IF @status{0} = 'available'
+BEGIN
+    IF @expected{0} = 1
+    BEGIN
+        INSERT #Scores
+            (workload, user_id, active_samples, observed_samples, frequency_known)
+        SELECT {0},
+               activity.user_id,
+               MAX(CASE
+                       WHEN activity.last_activity_date >= weeks.m365_from
+                        AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
+                        AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
+                       THEN 1 ELSE 0
+                   END),
+               1,
+               CAST(CASE WHEN COUNT(*) = 1 THEN 1 ELSE 0 END AS bit)
+        FROM #Samples AS chosen
+        JOIN #Weeks AS weeks
+          ON chosen.sample_date >= weeks.m365_from
+         AND chosen.sample_date <= weeks.m365_to
+        JOIN {1} AS activity WITH (INDEX(IX_date))
+          ON activity.[date] >= chosen.sample_date
+         AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
+        JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
+        WHERE chosen.workload = {0}
+        GROUP BY activity.user_id
+        OPTION (RECOMPILE, MAXDOP 1);
+    END
+    ELSE
+    BEGIN
+        ;WITH PerSample AS
+        (
+            SELECT activity.user_id,
+                       activity.[date] AS sample_date,
+                       MAX(CASE
+                               WHEN activity.last_activity_date >=
+                                    CASE WHEN report_week.week_start < @from
+                                         THEN @from ELSE report_week.week_start END
+                                AND activity.last_activity_date < DATEADD(DAY, 1, activity.[date])
+                               THEN 1 ELSE 0
+                           END) AS was_active
+            FROM {1} AS activity
+            JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
+            CROSS APPLY
+            (
+                    SELECT DATEADD(
+                        DAY, 1 - DATEPART(WEEKDAY, activity.[date]), activity.[date]) AS week_start
+            ) AS report_week
+            WHERE activity.[date] >= @from
+              AND activity.[date] < @endExclusive
+              AND activity.[date] < DATEADD(DAY, 1, @settled)
+              AND
+              (
+                      activity.[date] = @to
+                      OR DATEPART(WEEKDAY, activity.[date]) = 7
+              )
+            GROUP BY activity.user_id, activity.[date]
+        ),
+        PerUser AS
+        (
+            SELECT user_id,
+                       SUM(was_active) AS active_samples,
+                       COUNT(*) AS observed_samples
+            FROM PerSample
+            GROUP BY user_id
+        )
+        INSERT #Scores
+            (workload, user_id, active_samples, observed_samples, frequency_known)
+        SELECT {0},
+                   user_id,
+                   active_samples,
+                   observed_samples,
+                   CAST(CASE WHEN observed_samples = @expected{0}
+                             THEN 1 ELSE 0 END AS bit)
+        FROM PerUser
+        OPTION (RECOMPILE, MAXDOP 1);
+    END;
+END;
+",
+                workload, table);
+        }
+
+        private static void AppendCopilotOverview(StringBuilder sql, LicenceActivitySources sources)
+        {
+            if (sources.CopilotUsageReports)
+            {
+                sql.Append(CopilotOfficialOverview);
+            }
+            else
+            {
+                var fallbackSource = sources.CopilotAudit
+                    ? CopilotAuditSource
+                    : sources.CopilotInteractions ? CopilotInteractionSource : CopilotReportSource;
+                var initialStatus = sources.CopilotAudit || sources.CopilotInteractions
+                    ? NotImported
+                    : Disabled;
+                var initialMessage = sources.CopilotAudit || sources.CopilotInteractions
+                    ? "The enabled Copilot event source has not stored evidence in this range."
+                    : "Every per-user Copilot source is disabled.";
+
+                sql.AppendFormat(
+                    CultureInfo.InvariantCulture,
+                    @"
+DECLARE @copilotPreferredStatus varchar(32) = '{0}';
+DECLARE @copilotPreferredSource varchar(64) = '{1}';
+DECLARE @copilotPreferredMessage nvarchar(800) = N'{2}';
+DECLARE @copilotLatestImport datetime = NULL;
+DECLARE @copilotUnmatched int = 0;
+DECLARE @copilotNeedsFallback bit = 1;
+",
+                    initialStatus, fallbackSource, initialMessage);
+            }
+
+            if (sources.CopilotAudit)
+            {
+                sql.Append(CopilotAuditFallbackOverview);
+            }
+
+            if (sources.CopilotInteractions)
+            {
+                sql.Append(CopilotInteractionFallbackOverview);
+            }
+
+            if (!sources.CopilotUsageReports && sources.CopilotAudit)
+            {
+                sql.Append(@"
+IF @copilotNeedsFallback = 1
+   AND EXISTS (SELECT 1 FROM dbo.copilot_chats WHERE time_stamp IS NOT NULL)
+BEGIN
+    SET @copilotPreferredStatus = 'missingCoverage';
+    SET @copilotPreferredMessage =
+        N'Copilot audit data exists, but no event falls in the requested range; absence cannot be interpreted as zero.';
+END;
+");
+                if (sources.CopilotInteractions)
+                {
+                    sql.Append(@"
+IF @copilotNeedsFallback = 1
+   AND NOT EXISTS (SELECT 1 FROM dbo.copilot_chats WHERE time_stamp IS NOT NULL)
+   AND EXISTS (SELECT 1 FROM dbo.copilot_interactions)
+BEGIN
+    SET @copilotPreferredStatus = 'missingCoverage';
+    SET @copilotPreferredSource = 'copilotInteractions';
+    SET @copilotPreferredMessage =
+        N'Copilot interaction history exists, but no event falls in the requested range; absence cannot be interpreted as zero.';
+END;
+");
+                }
+            }
+            else if (!sources.CopilotUsageReports && sources.CopilotInteractions)
+            {
+                sql.Append(@"
+IF @copilotNeedsFallback = 1
+   AND EXISTS (SELECT 1 FROM dbo.copilot_interactions)
+BEGIN
+    SET @copilotPreferredStatus = 'missingCoverage';
+    SET @copilotPreferredMessage =
+        N'Copilot interaction history exists, but no event falls in the requested range; absence cannot be interpreted as zero.';
+END;
+");
+            }
+
+            sql.Append(@"
+IF @copilotNeedsFallback = 1
+BEGIN
+    INSERT #Coverage
+    (
+        workload, workload_name, status, source, measure, granularity, message,
+        effective_from_utc, effective_to_utc, latest_import_utc, lag_days,
+        report_period_days, expected_samples, observed_samples, unmatched_users
+    )
+    VALUES
+    (
+        5, 'copilot', @copilotPreferredStatus, @copilotPreferredSource,
+        N'positive Copilot evidence only', 'unknown',
+        @copilotPreferredMessage, NULL, NULL, @copilotLatestImport, 0, NULL,
+        (SELECT COUNT(*) FROM #Weeks), 0,
+        @copilotUnmatched
+    );
+END;
+");
+        }
+
+        private static readonly string M365OverviewScores = @"
+;WITH PerSample AS
+(
+    SELECT 1 AS workload,
+           activity.user_id,
+           chosen.sample_date,
+           MAX(CASE
+                   WHEN activity.last_activity_date >= weeks.m365_from
+                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
+                    AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
+                   THEN 1 ELSE 0
+               END) AS was_active
+    FROM #Samples AS chosen
+    JOIN #Weeks AS weeks
+      ON chosen.sample_date >= weeks.m365_from
+     AND chosen.sample_date <= weeks.m365_to
+    JOIN dbo.teams_user_activity_log AS activity
+      ON activity.[date] >= chosen.sample_date
+     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
+    JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
+    WHERE chosen.workload = 1
+    GROUP BY activity.user_id, chosen.sample_date
+
+    UNION ALL
+
+    SELECT 2,
+           activity.user_id,
+           chosen.sample_date,
+           MAX(CASE
+                   WHEN activity.last_activity_date >= weeks.m365_from
+                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
+                    AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
+                   THEN 1 ELSE 0
+               END)
+    FROM #Samples AS chosen
+    JOIN #Weeks AS weeks
+      ON chosen.sample_date >= weeks.m365_from
+     AND chosen.sample_date <= weeks.m365_to
+    JOIN dbo.outlook_user_activity_log AS activity
+      ON activity.[date] >= chosen.sample_date
+     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
+    JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
+    WHERE chosen.workload = 2
+    GROUP BY activity.user_id, chosen.sample_date
+
+    UNION ALL
+
+    SELECT 3,
+           activity.user_id,
+           chosen.sample_date,
+           MAX(CASE
+                   WHEN activity.last_activity_date >= weeks.m365_from
+                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
+                    AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
+                   THEN 1 ELSE 0
+               END)
+    FROM #Samples AS chosen
+    JOIN #Weeks AS weeks
+      ON chosen.sample_date >= weeks.m365_from
+     AND chosen.sample_date <= weeks.m365_to
+    JOIN dbo.onedrive_user_activity_log AS activity
+      ON activity.[date] >= chosen.sample_date
+     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
+    JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
+    WHERE chosen.workload = 3
+    GROUP BY activity.user_id, chosen.sample_date
+
+    UNION ALL
+
+    SELECT 4,
+           activity.user_id,
+           chosen.sample_date,
+           MAX(CASE
+                   WHEN activity.last_activity_date >= weeks.m365_from
+                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
+                    AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
+                   THEN 1 ELSE 0
+               END)
+    FROM #Samples AS chosen
+    JOIN #Weeks AS weeks
+      ON chosen.sample_date >= weeks.m365_from
+     AND chosen.sample_date <= weeks.m365_to
+    JOIN dbo.sharepoint_user_activity_log AS activity
+      ON activity.[date] >= chosen.sample_date
+     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
+    JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
+    WHERE chosen.workload = 4
+    GROUP BY activity.user_id, chosen.sample_date
+),
+PerUser AS
+(
+    SELECT workload,
+           user_id,
+           SUM(was_active) AS active_samples,
+           COUNT(*) AS observed_samples
+    FROM PerSample
+    GROUP BY workload, user_id
+)
+INSERT #Scores
+    (workload, user_id, active_samples, observed_samples, frequency_known)
+SELECT workload,
+       user_id,
+       active_samples,
+       observed_samples,
+       CAST(CASE
+                WHEN observed_samples =
+                     CASE workload
+                         WHEN 1 THEN @expected1
+                         WHEN 2 THEN @expected2
+                         WHEN 3 THEN @expected3
+                         ELSE @expected4
+                     END
+                THEN 1 ELSE 0
+            END AS bit)
+FROM PerUser
+OPTION (RECOMPILE);
+";
+
+        private static readonly string CopilotOfficialOverview = @"
+DECLARE @copilotLogImported datetime = NULL;
+DECLARE @copilotLogObfuscated bit = 0;
+DECLARE @copilotLogRowsRead int = 0;
+DECLARE @copilotLogError nvarchar(1000) = NULL;
+
+SELECT TOP (1)
+       @copilotLogImported = imported_utc,
+       @copilotLogObfuscated = is_upn_obfuscated,
+       @copilotLogRowsRead = rows_read,
+       @copilotLogError = error
+FROM dbo.copilot_usage_report_import_log
+WHERE report_name = N'getMicrosoft365CopilotUsageUserDetail'
+ORDER BY imported_utc DESC, id DESC;
+
+DECLARE @copilotPreferredStatus varchar(32) =
+    CASE
+        WHEN @copilotLogObfuscated = 1 THEN 'unmatchableIdentity'
+        WHEN @copilotLogImported IS NULL THEN 'notImported'
+        WHEN @copilotLogError IS NOT NULL THEN 'partial'
+        ELSE 'missingCoverage'
+    END;
+DECLARE @copilotPreferredSource varchar(64) = 'microsoftGraphCopilotUsageReport';
+DECLARE @copilotPreferredMessage nvarchar(800) =
+    CASE
+        WHEN @copilotLogObfuscated = 1
+            THEN N'The official Copilot report concealed every user identity, so it cannot be joined to licence holders.'
+        WHEN @copilotLogImported IS NULL
+            THEN N'The official per-user Copilot usage report has not been imported.'
+        WHEN @copilotLogError IS NOT NULL
+            THEN N'The latest official per-user Copilot report import failed; absence cannot be interpreted as zero.'
+        ELSE N'No fully-contained official Copilot report window covers the requested range.'
+    END;
+DECLARE @copilotLatestImport datetime = @copilotLogImported;
+DECLARE @copilotUnmatched int =
+    CASE WHEN @copilotLogObfuscated = 1 THEN @copilotLogRowsRead ELSE 0 END;
+DECLARE @copilotNeedsFallback bit = 1;
+
+IF @copilotLogObfuscated = 0 AND @copilotLogError IS NULL
+BEGIN
+    DECLARE @copilotD7Expected int =
+    (
+        SELECT COUNT(*)
+        FROM #Weeks
+        WHERE copilot_d7_from <= copilot_d7_to
+    );
+
+    IF EXISTS
+    (
+        SELECT 1
+        FROM dbo.copilot_usage_user_activity_log
+        WHERE report_period_days = 7
+          AND [date] >= DATEADD(DAY, 6, @from)
+          AND [date] < DATEADD(DAY, 1, @to)
+          AND [date] < DATEADD(DAY, 1, @settled)
+    )
+    BEGIN
+        INSERT #Samples (workload, sample_date)
+        SELECT 5, selected.sample_date
+        FROM #Weeks AS weeks
+        CROSS APPLY
+        (
+            SELECT TOP (1) CAST(available.[date] AS date) AS sample_date
+            FROM dbo.copilot_usage_user_activity_log AS available
+                 WITH (INDEX(IX_date_user_id_report_period_days))
+            WHERE available.report_period_days = 7
+              AND available.[date] >= weeks.copilot_d7_from
+              AND available.[date] < DATEADD(DAY, 1, weeks.copilot_d7_to)
+              AND available.[date] < DATEADD(DAY, 1, @settled)
+            ORDER BY available.[date] DESC
+        ) AS selected
+        WHERE weeks.copilot_d7_from <= weeks.copilot_d7_to
+          AND weeks.copilot_d7_from <= @settled
+        OPTION (RECOMPILE);
+    END;
+
+    DECLARE @copilotD7Observed int =
+        (SELECT COUNT(*) FROM #Samples WHERE workload = 5);
+    DECLARE @copilotD7EffectiveFrom date =
+        (SELECT DATEADD(DAY, -6, MIN(sample_date)) FROM #Samples WHERE workload = 5);
+    DECLARE @copilotD7EffectiveTo date =
+        (SELECT MAX(sample_date) FROM #Samples WHERE workload = 5);
+    DECLARE @copilotD7Complete int =
+    (
+        SELECT COUNT(*)
+        FROM #Weeks AS weeks
+        JOIN #Samples AS samples
+          ON samples.workload = 5
+         AND samples.sample_date = weeks.copilot_d7_to
+        WHERE weeks.copilot_d7_from <= weeks.copilot_d7_to
+          AND weeks.copilot_d7_to <= @settled
+    );
+
+    IF @copilotD7Observed > 0
+    BEGIN
+        SET @copilotNeedsFallback = 0;
+        SET @copilotPreferredStatus =
+            CASE WHEN @copilotD7Expected = @copilotD7Observed
+                       AND @copilotD7Expected = @copilotD7Complete
+                       AND @copilotD7EffectiveFrom = @from
+                       AND @copilotD7EffectiveTo = @to
+                 THEN 'available' ELSE 'partial' END;
+
+        INSERT #Coverage
+        (
+            workload, workload_name, status, source, measure, granularity, message,
+            effective_from_utc, effective_to_utc, latest_import_utc, lag_days,
+            report_period_days, expected_samples, observed_samples, unmatched_users
+        )
+        SELECT 5, 'copilot', @copilotPreferredStatus, 'microsoftGraphCopilotUsageReport',
+               N'average prompts in sampled rolling 7-day reports',
+               'weeklySampleOfRolling7DayReport',
+               CASE WHEN @copilotPreferredStatus = 'available'
+                    THEN N'The latest settled, fully-contained D7 report was sampled once per calendar week; overlapping counts are averaged, never summed. Missing user rows and rows without v2 counters remain unknown. The official report covers Copilot-licensed users only.'
+                    ELSE N'At least one requested D7 window lacks a settled snapshot on its exact end date. Earlier snapshots are as-of evidence only; all bands remain unknown and no user is ranked least-active.'
+               END,
+               CAST(@copilotD7EffectiveFrom AS datetime),
+               CAST(@copilotD7EffectiveTo AS datetime),
+               @copilotLogImported,
+               DATEDIFF(DAY, MAX(samples.sample_date), @now),
+               7, @copilotD7Expected, @copilotD7Observed, 0
+        FROM (SELECT sample_date FROM #Samples WHERE workload = 5) AS samples;
+
+        IF @copilotPreferredStatus = 'available'
+        BEGIN
+            IF @copilotD7Expected = 1
+            BEGIN
+                INSERT #Scores
+                    (workload, user_id, active_samples, observed_samples, frequency_known)
+                SELECT 5,
+                       report.user_id,
+                       CASE
+                           WHEN report.active_usage_days BETWEEN 1 AND 7
+                             OR report.prompts_all_apps > 0
+                             OR (report.last_activity_date >= DATEADD(DAY, -6, report.[date])
+                                 AND report.last_activity_date < DATEADD(DAY, 1, report.[date]))
+                           THEN 1 ELSE 0
+                       END,
+                       1,
+                       CAST(CASE
+                           WHEN report.active_usage_days BETWEEN 0 AND 7
+                            AND (report.prompts_all_apps IS NULL OR report.prompts_all_apps >= 0)
+                           THEN 1 ELSE 0
+                       END AS bit)
+                FROM dbo.copilot_usage_user_activity_log AS report
+                JOIN #Samples AS chosen
+                  ON chosen.workload = 5
+                 AND report.[date] >= chosen.sample_date
+                 AND report.[date] < DATEADD(DAY, 1, chosen.sample_date)
+                JOIN #EligibleUsers AS eligible ON eligible.user_id = report.user_id
+                WHERE report.report_period_days = 7
+                OPTION (RECOMPILE, MAXDOP 1);
+            END
+            ELSE
+            BEGIN
+                INSERT #Scores
+                    (workload, user_id, active_samples, observed_samples, frequency_known)
+                SELECT 5, report.user_id,
+                       SUM(CASE
+                               WHEN report.active_usage_days BETWEEN 1 AND 7
+                                 OR report.prompts_all_apps > 0
+                               THEN 1
+                               WHEN report.active_usage_days IS NULL
+                                AND report.prompts_all_apps IS NULL
+                                AND report.last_activity_date >= DATEADD(DAY, -6, report.[date])
+                                AND report.last_activity_date < DATEADD(DAY, 1, report.[date])
+                               THEN 1
+                               ELSE 0
+                           END),
+                       COUNT(*),
+                       CAST(CASE
+                                WHEN COUNT(*) = @copilotD7Expected
+                                 AND COUNT(report.active_usage_days) = COUNT(*)
+                                 AND MIN(report.active_usage_days) >= 0
+                                 AND MAX(report.active_usage_days) <= 7
+                                 AND (COUNT(report.prompts_all_apps) = 0
+                                      OR MIN(report.prompts_all_apps) >= 0)
+                                THEN 1 ELSE 0
+                            END AS bit)
+                FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(0))
+                JOIN #EligibleUsers AS eligible ON eligible.user_id = report.user_id
+                WHERE report.report_period_days = 7
+                  AND report.[date] >= DATEADD(DAY, 6, @from)
+                  AND report.[date] < @endExclusive
+                  AND report.[date] < DATEADD(DAY, 1, @settled)
+                  AND
+                  (
+                      report.[date] = @to
+                      OR DATEPART(WEEKDAY, report.[date]) = 7
+                  )
+                GROUP BY report.user_id
+                OPTION (RECOMPILE, MAXDOP 4);
+            END
+        END
+    END
+    ELSE
+    BEGIN
+        -- Stored periods are read from the (date, user, report_period_days) key. A longer rolling
+        -- window is never repeated or summed: at most one fully-contained snapshot is exposed,
+        -- with its exact effective range.
+        DECLARE @copilotLongPeriod int = NULL;
+        DECLARE @copilotLongDate date = NULL;
+
+        SELECT TOP (1)
+               @copilotLongPeriod = report.report_period_days,
+               @copilotLongDate = CAST(report.[date] AS date)
+        FROM dbo.copilot_usage_user_activity_log AS report
+        WHERE report.report_period_days IN (28, 90, 180)
+          AND report.[date] < DATEADD(DAY, 1, @settled)
+          AND report.[date] < DATEADD(DAY, 1, @to)
+          AND DATEADD(DAY, 1 - report.report_period_days, CAST(report.[date] AS date)) >= @from
+        GROUP BY report.report_period_days, CAST(report.[date] AS date)
+        ORDER BY CASE
+                     WHEN CAST(report.[date] AS date) = @to
+                      AND DATEADD(DAY, 1 - report.report_period_days, CAST(report.[date] AS date)) = @from
+                     THEN 0 ELSE 1
+                 END,
+                 report.report_period_days DESC,
+                 CAST(report.[date] AS date) DESC
+        OPTION (RECOMPILE);
+
+        IF @copilotLongPeriod IS NOT NULL
+        BEGIN
+            SET @copilotNeedsFallback = 0;
+            SET @copilotPreferredStatus =
+                CASE WHEN @copilotLongDate = @to
+                       AND DATEADD(DAY, 1 - @copilotLongPeriod, @copilotLongDate) = @from
+                     THEN 'available' ELSE 'missingCoverage' END;
+
+            INSERT #Samples (workload, sample_date) VALUES (5, @copilotLongDate);
+
+            INSERT #Coverage
+            (
+                workload, workload_name, status, source, measure, granularity, message,
+                effective_from_utc, effective_to_utc, latest_import_utc, lag_days,
+                report_period_days, expected_samples, observed_samples, unmatched_users
+            )
+            VALUES
+            (
+                5, 'copilot', @copilotPreferredStatus, 'microsoftGraphCopilotUsageReport',
+                N'prompts and active usage days in one rolling report',
+                'singleRollingWindow',
+                CASE WHEN @copilotPreferredStatus = 'available'
+                     THEN N'The requested dates exactly match one official rolling Copilot report window. Missing user rows and rows without active_usage_days remain unknown. The official report covers Copilot-licensed users only.'
+                     ELSE N'The source only has a longer rolling window inside the request. Its evidence is shown with the exact effective dates, but bands remain unknown for the custom range.'
+                END,
+                DATEADD(DAY, 1 - @copilotLongPeriod, CAST(@copilotLongDate AS datetime)),
+                CAST(@copilotLongDate AS datetime),
+                @copilotLogImported,
+                DATEDIFF(DAY, @copilotLongDate, @now),
+                @copilotLongPeriod, @copilotLongPeriod, @copilotLongPeriod, 0
+            );
+
+            INSERT #Scores
+                (workload, user_id, active_samples, observed_samples, frequency_known)
+            SELECT 5,
+                   report.user_id,
+                   CASE
+                       WHEN report.active_usage_days BETWEEN 0 AND @copilotLongPeriod
+                           THEN report.active_usage_days
+                       WHEN report.prompts_all_apps > 0
+                         OR (report.last_activity_date >= DATEADD(DAY, 1 - @copilotLongPeriod, @copilotLongDate)
+                             AND report.last_activity_date < DATEADD(DAY, 1, @copilotLongDate))
+                           THEN 1 ELSE 0
+                   END,
+                   CASE
+                       WHEN report.active_usage_days BETWEEN 0 AND @copilotLongPeriod
+                        AND (report.prompts_all_apps IS NULL OR report.prompts_all_apps >= 0)
+                           THEN @copilotLongPeriod ELSE 0
+                   END,
+                   CAST(CASE
+                       WHEN report.active_usage_days BETWEEN 0 AND @copilotLongPeriod
+                        AND (report.prompts_all_apps IS NULL OR report.prompts_all_apps >= 0)
+                           THEN 1 ELSE 0
+                   END AS bit)
+            FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(0))
+            JOIN #EligibleUsers AS eligible ON eligible.user_id = report.user_id
+            WHERE report.report_period_days = @copilotLongPeriod
+              AND report.[date] >= @copilotLongDate
+              AND report.[date] < DATEADD(DAY, 1, @copilotLongDate)
+            OPTION (RECOMPILE);
+        END
+    END
+END;
+";
+
+        private static readonly string CopilotAuditFallbackOverview = @"
+IF @copilotNeedsFallback = 1
+   AND EXISTS
+   (
+       SELECT 1
+       FROM dbo.copilot_chats
+       WHERE time_stamp >= @from
+         AND time_stamp < @endExclusive
+         AND user_id IS NOT NULL
+   )
+BEGIN
+    SET @copilotNeedsFallback = 0;
+    SET @copilotPreferredStatus =
+        CASE WHEN @copilotPreferredStatus = 'unmatchableIdentity'
+             THEN 'unmatchableIdentity' ELSE 'partial' END;
+    SET @copilotPreferredMessage =
+        CASE WHEN @copilotPreferredStatus = 'unmatchableIdentity'
+             THEN N'The official report identities are concealed. Audit events provide positive evidence, but their absence is not a measured zero.'
+             ELSE N'Copilot audit events provide positive evidence only; no database signal proves complete event coverage, so absent users remain unknown.'
+        END;
+
+    ;WITH EventWeeks AS
+    (
+        SELECT chats.user_id,
+               DATEADD(DAY,
+                   -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(chats.time_stamp AS date)) % 7) + 7) % 7),
+                   CAST(chats.time_stamp AS date)) AS week_start,
+               COUNT_BIG(*) AS actions,
+               MAX(chats.time_stamp) AS last_activity_utc
+        FROM dbo.copilot_chats AS chats
+        JOIN #EligibleUsers AS eligible ON eligible.user_id = chats.user_id
+        WHERE chats.time_stamp >= @from
+          AND chats.time_stamp < @endExclusive
+        GROUP BY chats.user_id,
+                 DATEADD(DAY,
+                    -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(chats.time_stamp AS date)) % 7) + 7) % 7),
+                    CAST(chats.time_stamp AS date))
+    )
+    INSERT #Scores
+        (workload, user_id, active_samples, observed_samples, frequency_known)
+    SELECT 5, user_id, COUNT(*), 0, 0
+    FROM EventWeeks
+    GROUP BY user_id
+    OPTION (RECOMPILE);
+
+    INSERT #Coverage
+    (
+        workload, workload_name, status, source, measure, granularity, message,
+        effective_from_utc, effective_to_utc, latest_import_utc, lag_days,
+        report_period_days, expected_samples, observed_samples, unmatched_users
+    )
+    SELECT 5, 'copilot', @copilotPreferredStatus, 'copilotAudit',
+           N'interactions per active calendar week', 'eventPositiveOnly',
+           @copilotPreferredMessage, MIN(time_stamp), MAX(time_stamp),
+           NULL,
+           DATEDIFF(DAY, MAX(CAST(time_stamp AS date)), @now),
+           NULL, (SELECT COUNT(*) FROM #Weeks), 0, @copilotUnmatched
+    FROM dbo.copilot_chats
+    WHERE time_stamp >= @from AND time_stamp < @endExclusive;
+END;
+";
+
+        private static readonly string CopilotInteractionFallbackOverview = @"
+IF @copilotNeedsFallback = 1
+   AND EXISTS
+   (
+       SELECT 1
+       FROM dbo.copilot_interactions
+       WHERE created_utc >= @from
+         AND created_utc < @endExclusive
+   )
+BEGIN
+    SET @copilotNeedsFallback = 0;
+    SET @copilotPreferredStatus =
+        CASE WHEN @copilotPreferredStatus = 'unmatchableIdentity'
+             THEN 'unmatchableIdentity' ELSE 'partial' END;
+    SET @copilotPreferredMessage =
+        CASE WHEN @copilotPreferredStatus = 'unmatchableIdentity'
+             THEN N'The official report identities are concealed. Interaction history provides positive evidence, but its absence is not a measured zero.'
+             ELSE N'Copilot interaction history provides positive evidence only; no database signal proves complete history for every user, so absent users remain unknown.'
+        END;
+
+    ;WITH EventWeeks AS
+    (
+        SELECT interactions.user_id,
+               DATEADD(DAY,
+                   -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(interactions.created_utc AS date)) % 7) + 7) % 7),
+                   CAST(interactions.created_utc AS date)) AS week_start,
+               COUNT_BIG(*) AS actions,
+               MAX(interactions.created_utc) AS last_activity_utc
+        FROM dbo.copilot_interactions AS interactions
+        JOIN #EligibleUsers AS eligible ON eligible.user_id = interactions.user_id
+        WHERE interactions.created_utc >= @from
+          AND interactions.created_utc < @endExclusive
+        GROUP BY interactions.user_id,
+                 DATEADD(DAY,
+                    -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(interactions.created_utc AS date)) % 7) + 7) % 7),
+                    CAST(interactions.created_utc AS date))
+    )
+    INSERT #Scores
+        (workload, user_id, active_samples, observed_samples, frequency_known)
+    SELECT 5, user_id, COUNT(*), 0, 0
+    FROM EventWeeks
+    GROUP BY user_id
+    OPTION (RECOMPILE);
+
+    INSERT #Coverage
+    (
+        workload, workload_name, status, source, measure, granularity, message,
+        effective_from_utc, effective_to_utc, latest_import_utc, lag_days,
+        report_period_days, expected_samples, observed_samples, unmatched_users
+    )
+    SELECT 5, 'copilot', @copilotPreferredStatus, 'copilotInteractions',
+           N'interaction rows per active calendar week', 'eventPositiveOnly',
+           @copilotPreferredMessage, MIN(created_utc), MAX(created_utc),
+           (SELECT MAX(run_finished_utc) FROM dbo.copilot_interaction_import_log),
+           CASE WHEN MAX(CAST(created_utc AS date)) IS NULL THEN 0
+                ELSE DATEDIFF(DAY, MAX(CAST(created_utc AS date)), @now) END,
+           NULL, (SELECT COUNT(*) FROM #Weeks), 0, @copilotUnmatched
+    FROM dbo.copilot_interactions
+    WHERE created_utc >= @from AND created_utc < @endExclusive;
+END;
+";
+
+        private static string BuildSingleWorkloadProjection(int workload, bool includeBase)
+        {
+            var result = string.Format(
+                CultureInfo.InvariantCulture,
+                @"
+CREATE TABLE #Demographics
+(
+    dimension tinyint NOT NULL,
+    demographic_id int NOT NULL,
+    assigned_users int NOT NULL,
+    PRIMARY KEY (dimension, demographic_id)
+);
+
+;WITH DepartmentCounts AS
+(
+    SELECT department_id AS demographic_id, COUNT(*) AS assigned_users
+    FROM #EligibleUsers
+    GROUP BY department_id
+),
+Ranked AS
+(
+    SELECT *, ROW_NUMBER() OVER
+        (ORDER BY assigned_users DESC, demographic_id) AS row_number
+    FROM DepartmentCounts
+)
+INSERT #Demographics
+SELECT 1, demographic_id, assigned_users
+FROM Ranked
+WHERE row_number <= 50
+   OR (@departmentId IS NOT NULL AND demographic_id = @departmentId);
+
+;WITH CountryCounts AS
+(
+    SELECT country_id AS demographic_id, COUNT(*) AS assigned_users
+    FROM #EligibleUsers
+    GROUP BY country_id
+),
+Ranked AS
+(
+    SELECT *, ROW_NUMBER() OVER
+        (ORDER BY assigned_users DESC, demographic_id) AS row_number
+    FROM CountryCounts
+)
+INSERT #Demographics
+SELECT 2, demographic_id, assigned_users
+FROM Ranked
+WHERE row_number <= 50
+   OR (@countryId IS NOT NULL AND demographic_id = @countryId);
+
+CREATE TABLE #Known
+(
+    user_id int NOT NULL,
+    band tinyint NOT NULL
+);
+
+INSERT #Known (user_id, band)
+SELECT scores.user_id,
+       CASE
+           WHEN scores.active_samples = 0 THEN 0
+           WHEN CAST(scores.active_samples AS bigint) * 4 < coverage.expected_samples THEN 1
+           WHEN CAST(scores.active_samples AS bigint) * 4
+                < CAST(coverage.expected_samples AS bigint) * 3 THEN 2
+           ELSE 3
+       END
+FROM #Scores AS scores
+JOIN #Coverage AS coverage ON coverage.workload = {0}
+WHERE scores.workload = {0}
+  AND coverage.status = 'available'
+  AND
+  (
+      (coverage.source IN ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+       AND scores.frequency_known = 1
+       AND scores.observed_samples = coverage.expected_samples)
+      OR coverage.source NOT IN ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+  )
+OPTION (RECOMPILE);
+
+SELECT coverage.workload_name AS Workload,
+       coverage.status AS Status,
+       coverage.source AS Source,
+       coverage.measure AS Measure,
+       coverage.granularity AS Granularity,
+       coverage.message AS Message,
+       coverage.effective_from_utc AS EffectiveFromUtc,
+       coverage.effective_to_utc AS EffectiveToUtc,
+       coverage.latest_import_utc AS LatestImportUtc,
+       coverage.lag_days AS LagDays,
+       coverage.report_period_days AS ReportPeriodDays,
+       coverage.expected_samples AS ExpectedSamples,
+       coverage.observed_samples AS ObservedSamples,
+       coverage.unmatched_users AS UnmatchedUsers
+FROM #Coverage AS coverage
+WHERE coverage.workload = {0};
+
+SELECT coverage.workload_name AS WorkloadName,
+       samples.sample_date AS SnapshotDate
+FROM #Samples AS samples
+JOIN #Coverage AS coverage ON coverage.workload = samples.workload
+WHERE samples.workload = {0}
+ORDER BY samples.sample_date;
+
+;WITH Memberships AS
+(
+    SELECT DISTINCT owned.license_type_id, owned.user_id
+    FROM dbo.user_license_type_lookups AS owned
+    JOIN #EligibleUsers AS eligible ON eligible.user_id = owned.user_id
+),
+LicenceBands AS
+(
+    SELECT members.license_type_id,
+           known.band,
+           COUNT(*) AS users
+    FROM Memberships AS members
+    LEFT JOIN #Known AS known ON known.user_id = members.user_id
+    GROUP BY members.license_type_id, known.band
+),
+LicenceCounts AS
+(
+    SELECT license_type_id,
+           SUM(users) AS assigned_users,
+           SUM(CASE WHEN band = 3 THEN users ELSE 0 END) AS high_count,
+           SUM(CASE WHEN band = 2 THEN users ELSE 0 END) AS moderate_count,
+           SUM(CASE WHEN band = 1 THEN users ELSE 0 END) AS low_count,
+           SUM(CASE WHEN band = 0 THEN users ELSE 0 END) AS zero_count,
+           SUM(CASE WHEN band IS NOT NULL THEN users ELSE 0 END) AS known_count
+    FROM LicenceBands
+    GROUP BY license_type_id
+)
+SELECT licence.id AS LicenceTypeId,
+       coverage.workload_name AS Workload,
+       ISNULL(counts.high_count, 0) AS High,
+       ISNULL(counts.moderate_count, 0) AS Moderate,
+       ISNULL(counts.low_count, 0) AS Low,
+       ISNULL(counts.zero_count, 0) AS Zero,
+       ISNULL(counts.assigned_users, 0) - ISNULL(counts.known_count, 0) AS Unknown
+FROM dbo.license_types AS licence
+CROSS JOIN #Coverage AS coverage
+LEFT JOIN LicenceCounts AS counts ON counts.license_type_id = licence.id
+WHERE coverage.workload = {0}
+ORDER BY licence.id
+OPTION (RECOMPILE);
+
+;WITH DepartmentBands AS
+(
+    SELECT eligible.department_id AS demographic_id,
+           known.band,
+           COUNT(*) AS users
+    FROM #EligibleUsers AS eligible
+    LEFT JOIN #Known AS known ON known.user_id = eligible.user_id
+    GROUP BY eligible.department_id, known.band
+),
+CountryBands AS
+(
+    SELECT eligible.country_id AS demographic_id,
+           known.band,
+           COUNT(*) AS users
+    FROM #EligibleUsers AS eligible
+    LEFT JOIN #Known AS known ON known.user_id = eligible.user_id
+    GROUP BY eligible.country_id, known.band
+),
+AllBands AS
+(
+    SELECT 1 AS dimension, demographic_id, band, users FROM DepartmentBands
+    UNION ALL
+    SELECT 2, demographic_id, band, users FROM CountryBands
+),
+Counts AS
+(
+    SELECT dimension,
+           demographic_id,
+           SUM(CASE WHEN band = 3 THEN users ELSE 0 END) AS high_count,
+           SUM(CASE WHEN band = 2 THEN users ELSE 0 END) AS moderate_count,
+           SUM(CASE WHEN band = 1 THEN users ELSE 0 END) AS low_count,
+           SUM(CASE WHEN band = 0 THEN users ELSE 0 END) AS zero_count,
+           SUM(CASE WHEN band IS NOT NULL THEN users ELSE 0 END) AS known_count
+    FROM AllBands
+    GROUP BY dimension, demographic_id
+)
+SELECT CASE WHEN demographics.dimension = 1 THEN 'department' ELSE 'country' END AS Dimension,
+       demographics.demographic_id AS Id,
+       coverage.workload_name AS Workload,
+       ISNULL(counts.high_count, 0) AS High,
+       ISNULL(counts.moderate_count, 0) AS Moderate,
+       ISNULL(counts.low_count, 0) AS Low,
+       ISNULL(counts.zero_count, 0) AS Zero,
+       demographics.assigned_users - ISNULL(counts.known_count, 0) AS Unknown
+FROM #Demographics AS demographics
+CROSS JOIN #Coverage AS coverage
+LEFT JOIN Counts AS counts
+  ON counts.dimension = demographics.dimension
+ AND counts.demographic_id = demographics.demographic_id
+WHERE coverage.workload = {0}
+ORDER BY demographics.dimension, demographics.demographic_id
+OPTION (RECOMPILE);
+",
+                workload);
+            return includeBase ? result + SingleWorkloadBaseResults : result;
+        }
+
+        private static readonly string SingleWorkloadBaseResults = @"
+SELECT (SELECT COUNT(*) FROM #EligibleUsers) AS DistinctAssignedUsers,
+       CAST(CASE
+           WHEN (SELECT COUNT(DISTINCT department_id) FROM #EligibleUsers)
+                    > (SELECT COUNT(*) FROM #Demographics WHERE dimension = 1)
+             OR (SELECT COUNT(DISTINCT country_id) FROM #EligibleUsers)
+                    > (SELECT COUNT(*) FROM #Demographics WHERE dimension = 2)
+           THEN 1 ELSE 0 END AS bit) AS DemographicsTruncated;
+
+SELECT licence.id AS LicenceTypeId,
+       licence.name AS Name,
+       licence.sku_id AS SkuId,
+       0 AS AssignedUsers
+FROM dbo.license_types AS licence
+ORDER BY licence.name, licence.id;
+
+SELECT CASE WHEN demographics.dimension = 1 THEN 'department' ELSE 'country' END AS Dimension,
+       demographics.demographic_id AS Id,
+       CASE WHEN demographics.dimension = 1
+            THEN COALESCE(department.name, N'Unknown')
+            ELSE COALESCE(country.name, N'Unknown')
+       END AS Name,
+       demographics.assigned_users AS AssignedUsers
+FROM #Demographics AS demographics
+LEFT JOIN dbo.user_departments AS department
+  ON demographics.dimension = 1 AND department.id = demographics.demographic_id
+LEFT JOIN dbo.user_country_or_region AS country
+  ON demographics.dimension = 2 AND country.id = demographics.demographic_id
+ORDER BY demographics.dimension, demographics.assigned_users DESC, Name, demographics.demographic_id;
+";
+
+        private static string BuildBandWriterProjection(int workload, string bandTable)
+        {
+            ValidateSharedBandTableName(bandTable);
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                @"
+INSERT {1} (user_id, band)
+SELECT scores.user_id,
+       CASE
+           WHEN scores.active_samples = 0 THEN 0
+           WHEN CAST(scores.active_samples AS bigint) * 4 < coverage.expected_samples THEN 1
+           WHEN CAST(scores.active_samples AS bigint) * 4
+                < CAST(coverage.expected_samples AS bigint) * 3 THEN 2
+           ELSE 3
+       END
+FROM #Scores AS scores
+JOIN #Coverage AS coverage ON coverage.workload = {0}
+WHERE scores.workload = {0}
+  AND coverage.status = 'available'
+  AND
+  (
+      (coverage.source IN ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+       AND scores.frequency_known = 1
+       AND scores.observed_samples = coverage.expected_samples)
+      OR coverage.source NOT IN ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+  )
+OPTION (RECOMPILE);
+
+SELECT coverage.workload_name AS Workload,
+       coverage.status AS Status,
+       coverage.source AS Source,
+       coverage.measure AS Measure,
+       coverage.granularity AS Granularity,
+       coverage.message AS Message,
+       coverage.effective_from_utc AS EffectiveFromUtc,
+       coverage.effective_to_utc AS EffectiveToUtc,
+       coverage.latest_import_utc AS LatestImportUtc,
+       coverage.lag_days AS LagDays,
+       coverage.report_period_days AS ReportPeriodDays,
+       coverage.expected_samples AS ExpectedSamples,
+       coverage.observed_samples AS ObservedSamples,
+       coverage.unmatched_users AS UnmatchedUsers
+FROM #Coverage AS coverage
+WHERE coverage.workload = {0};
+
+SELECT coverage.workload_name AS WorkloadName,
+       samples.sample_date AS SnapshotDate
+FROM #Samples AS samples
+JOIN #Coverage AS coverage ON coverage.workload = samples.workload
+WHERE samples.workload = {0}
+ORDER BY samples.sample_date;
+",
+                workload,
+                bandTable);
+        }
+
+        private static readonly string OverviewProjection = @"
+CREATE TABLE #LicenceCounts
+(
+    licence_type_id int NOT NULL PRIMARY KEY,
+    assigned_users int NOT NULL
+);
+
+CREATE TABLE #LicenceDistributions
+(
+    licence_type_id int NOT NULL,
+    workload tinyint NOT NULL,
+    high_count int NOT NULL,
+    moderate_count int NOT NULL,
+    low_count int NOT NULL,
+    zero_count int NOT NULL,
+    unknown_count int NOT NULL,
+    PRIMARY KEY (licence_type_id, workload)
+);
+
+;WITH KnownScores AS
+(
+    SELECT scores.workload,
+           scores.user_id,
+           CASE
+               WHEN scores.active_samples = 0 THEN 0
+               WHEN CAST(scores.active_samples AS bigint) * 4 < coverage.expected_samples THEN 1
+               WHEN CAST(scores.active_samples AS bigint) * 4
+                    < CAST(coverage.expected_samples AS bigint) * 3 THEN 2
+               ELSE 3
+           END AS band
+    FROM #Scores AS scores
+    JOIN #Coverage AS coverage ON coverage.workload = scores.workload
+    WHERE coverage.status = 'available'
+      AND
+      (
+          (coverage.source IN ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+           AND scores.frequency_known = 1
+           AND scores.observed_samples = coverage.expected_samples)
+          OR coverage.source NOT IN ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+      )
+)
+SELECT eligible.user_id,
+       eligible.department_id,
+       eligible.country_id,
+       MAX(CASE WHEN known.workload = 1 THEN known.band END) AS teams_band,
+       MAX(CASE WHEN known.workload = 2 THEN known.band END) AS outlook_band,
+       MAX(CASE WHEN known.workload = 3 THEN known.band END) AS onedrive_band,
+       MAX(CASE WHEN known.workload = 4 THEN known.band END) AS sharepoint_band,
+       MAX(CASE WHEN known.workload = 5 THEN known.band END) AS copilot_band
+INTO #UserBands
+FROM #EligibleUsers AS eligible
+LEFT JOIN KnownScores AS known ON known.user_id = eligible.user_id
+GROUP BY eligible.user_id, eligible.department_id, eligible.country_id
+OPTION (RECOMPILE);
+
+CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserBands ON #UserBands (user_id);
+
+;WITH Memberships AS
+(
+    SELECT DISTINCT license_type_id, user_id
+    FROM dbo.user_license_type_lookups
+),
+MembershipBandGroups AS
+(
+    SELECT members.license_type_id,
+           bands.teams_band,
+           bands.outlook_band,
+           bands.onedrive_band,
+           bands.sharepoint_band,
+           bands.copilot_band,
+           COUNT(*) AS users
+    FROM Memberships AS members
+    JOIN #UserBands AS bands ON bands.user_id = members.user_id
+    GROUP BY members.license_type_id,
+             bands.teams_band,
+             bands.outlook_band,
+             bands.onedrive_band,
+             bands.sharepoint_band,
+             bands.copilot_band
+),
+BandCounts AS
+(
+    SELECT license_type_id AS licence_type_id,
+           SUM(users) AS assigned_users,
+           SUM(CASE WHEN teams_band = 3 THEN users ELSE 0 END) AS teams_high,
+           SUM(CASE WHEN teams_band = 2 THEN users ELSE 0 END) AS teams_moderate,
+           SUM(CASE WHEN teams_band = 1 THEN users ELSE 0 END) AS teams_low,
+           SUM(CASE WHEN teams_band = 0 THEN users ELSE 0 END) AS teams_zero,
+           SUM(CASE WHEN teams_band IS NOT NULL THEN users ELSE 0 END) AS teams_known,
+           SUM(CASE WHEN outlook_band = 3 THEN users ELSE 0 END) AS outlook_high,
+           SUM(CASE WHEN outlook_band = 2 THEN users ELSE 0 END) AS outlook_moderate,
+           SUM(CASE WHEN outlook_band = 1 THEN users ELSE 0 END) AS outlook_low,
+           SUM(CASE WHEN outlook_band = 0 THEN users ELSE 0 END) AS outlook_zero,
+           SUM(CASE WHEN outlook_band IS NOT NULL THEN users ELSE 0 END) AS outlook_known,
+           SUM(CASE WHEN onedrive_band = 3 THEN users ELSE 0 END) AS onedrive_high,
+           SUM(CASE WHEN onedrive_band = 2 THEN users ELSE 0 END) AS onedrive_moderate,
+           SUM(CASE WHEN onedrive_band = 1 THEN users ELSE 0 END) AS onedrive_low,
+           SUM(CASE WHEN onedrive_band = 0 THEN users ELSE 0 END) AS onedrive_zero,
+           SUM(CASE WHEN onedrive_band IS NOT NULL THEN users ELSE 0 END) AS onedrive_known,
+           SUM(CASE WHEN sharepoint_band = 3 THEN users ELSE 0 END) AS sharepoint_high,
+           SUM(CASE WHEN sharepoint_band = 2 THEN users ELSE 0 END) AS sharepoint_moderate,
+           SUM(CASE WHEN sharepoint_band = 1 THEN users ELSE 0 END) AS sharepoint_low,
+           SUM(CASE WHEN sharepoint_band = 0 THEN users ELSE 0 END) AS sharepoint_zero,
+           SUM(CASE WHEN sharepoint_band IS NOT NULL THEN users ELSE 0 END) AS sharepoint_known,
+           SUM(CASE WHEN copilot_band = 3 THEN users ELSE 0 END) AS copilot_high,
+           SUM(CASE WHEN copilot_band = 2 THEN users ELSE 0 END) AS copilot_moderate,
+           SUM(CASE WHEN copilot_band = 1 THEN users ELSE 0 END) AS copilot_low,
+           SUM(CASE WHEN copilot_band = 0 THEN users ELSE 0 END) AS copilot_zero,
+           SUM(CASE WHEN copilot_band IS NOT NULL THEN users ELSE 0 END) AS copilot_known
+    FROM MembershipBandGroups
+    GROUP BY license_type_id
+)
+SELECT *
+INTO #LicenceBandCounts
+FROM BandCounts
+OPTION (RECOMPILE);
+
+INSERT #LicenceCounts (licence_type_id, assigned_users)
+SELECT licence.id, ISNULL(bands.assigned_users, 0)
+FROM dbo.license_types AS licence
+LEFT JOIN #LicenceBandCounts AS bands ON bands.licence_type_id = licence.id;
+
+INSERT #LicenceDistributions
+SELECT counts.licence_type_id,
+       values_by_workload.workload,
+       values_by_workload.high_count,
+       values_by_workload.moderate_count,
+       values_by_workload.low_count,
+       values_by_workload.zero_count,
+       counts.assigned_users - values_by_workload.known_count
+FROM #LicenceCounts AS counts
+LEFT JOIN #LicenceBandCounts AS bands ON bands.licence_type_id = counts.licence_type_id
+CROSS APPLY
+(
+    VALUES
+      (1, ISNULL(bands.teams_high, 0), ISNULL(bands.teams_moderate, 0),
+          ISNULL(bands.teams_low, 0), ISNULL(bands.teams_zero, 0), ISNULL(bands.teams_known, 0)),
+      (2, ISNULL(bands.outlook_high, 0), ISNULL(bands.outlook_moderate, 0),
+          ISNULL(bands.outlook_low, 0), ISNULL(bands.outlook_zero, 0), ISNULL(bands.outlook_known, 0)),
+      (3, ISNULL(bands.onedrive_high, 0), ISNULL(bands.onedrive_moderate, 0),
+          ISNULL(bands.onedrive_low, 0), ISNULL(bands.onedrive_zero, 0), ISNULL(bands.onedrive_known, 0)),
+      (4, ISNULL(bands.sharepoint_high, 0), ISNULL(bands.sharepoint_moderate, 0),
+          ISNULL(bands.sharepoint_low, 0), ISNULL(bands.sharepoint_zero, 0), ISNULL(bands.sharepoint_known, 0)),
+      (5, ISNULL(bands.copilot_high, 0), ISNULL(bands.copilot_moderate, 0),
+          ISNULL(bands.copilot_low, 0), ISNULL(bands.copilot_zero, 0), ISNULL(bands.copilot_known, 0))
+) AS values_by_workload
+    (workload, high_count, moderate_count, low_count, zero_count, known_count)
+OPTION (RECOMPILE);
+
+DROP TABLE #LicenceBandCounts;
+
+CREATE TABLE #Demographics
+(
+    dimension tinyint NOT NULL,
+    demographic_id int NOT NULL,
+    demographic_name nvarchar(100) NOT NULL,
+    assigned_users int NOT NULL,
+    PRIMARY KEY (dimension, demographic_id)
+);
+
+;WITH DepartmentCounts AS
+(
+    SELECT eligible.department_id AS demographic_id,
+           COALESCE(department.name, N'Unknown') AS demographic_name,
+           COUNT(*) AS assigned_users
+    FROM #EligibleUsers AS eligible
+    LEFT JOIN dbo.user_departments AS department ON department.id = eligible.department_id
+    GROUP BY eligible.department_id, department.name
+),
+RankedDepartments AS
+(
+    SELECT *, ROW_NUMBER() OVER
+        (ORDER BY assigned_users DESC, demographic_name, demographic_id) AS row_number
+    FROM DepartmentCounts
+)
+INSERT #Demographics (dimension, demographic_id, demographic_name, assigned_users)
+SELECT 1, demographic_id, demographic_name, assigned_users
+FROM RankedDepartments
+WHERE row_number <= 50
+   OR (@departmentId IS NOT NULL AND demographic_id = @departmentId);
+
+IF @departmentId IS NOT NULL
+   AND NOT EXISTS
+       (SELECT 1 FROM #Demographics WHERE dimension = 1 AND demographic_id = @departmentId)
+BEGIN
+    INSERT #Demographics (dimension, demographic_id, demographic_name, assigned_users)
+    SELECT 1, @departmentId, COALESCE(department.name, N'Unknown'), 0
+    FROM (SELECT @departmentId AS id) AS selected
+    LEFT JOIN dbo.user_departments AS department ON department.id = selected.id;
+END;
+
+;WITH CountryCounts AS
+(
+    SELECT eligible.country_id AS demographic_id,
+           COALESCE(country.name, N'Unknown') AS demographic_name,
+           COUNT(*) AS assigned_users
+    FROM #EligibleUsers AS eligible
+    LEFT JOIN dbo.user_country_or_region AS country ON country.id = eligible.country_id
+    GROUP BY eligible.country_id, country.name
+),
+RankedCountries AS
+(
+    SELECT *, ROW_NUMBER() OVER
+        (ORDER BY assigned_users DESC, demographic_name, demographic_id) AS row_number
+    FROM CountryCounts
+)
+INSERT #Demographics (dimension, demographic_id, demographic_name, assigned_users)
+SELECT 2, demographic_id, demographic_name, assigned_users
+FROM RankedCountries
+WHERE row_number <= 50
+   OR (@countryId IS NOT NULL AND demographic_id = @countryId);
+
+IF @countryId IS NOT NULL
+   AND NOT EXISTS
+       (SELECT 1 FROM #Demographics WHERE dimension = 2 AND demographic_id = @countryId)
+BEGIN
+    INSERT #Demographics (dimension, demographic_id, demographic_name, assigned_users)
+    SELECT 2, @countryId, COALESCE(country.name, N'Unknown'), 0
+    FROM (SELECT @countryId AS id) AS selected
+    LEFT JOIN dbo.user_country_or_region AS country ON country.id = selected.id;
+END;
+
+CREATE TABLE #DemographicDistributions
+(
+    dimension tinyint NOT NULL,
+    demographic_id int NOT NULL,
+    workload tinyint NOT NULL,
+    high_count int NOT NULL,
+    moderate_count int NOT NULL,
+    low_count int NOT NULL,
+    zero_count int NOT NULL,
+    unknown_count int NOT NULL,
+    PRIMARY KEY (dimension, demographic_id, workload)
+);
+
+;WITH DepartmentCounts AS
+(
+    SELECT band_values.workload,
+           bands.department_id AS demographic_id,
+           SUM(CASE WHEN band_values.band = 3 THEN 1 ELSE 0 END) AS high_count,
+           SUM(CASE WHEN band_values.band = 2 THEN 1 ELSE 0 END) AS moderate_count,
+           SUM(CASE WHEN band_values.band = 1 THEN 1 ELSE 0 END) AS low_count,
+           SUM(CASE WHEN band_values.band = 0 THEN 1 ELSE 0 END) AS zero_count,
+           COUNT(band_values.band) AS known_count
+    FROM #UserBands AS bands
+    CROSS APPLY
+    (
+        VALUES (1, bands.teams_band),
+               (2, bands.outlook_band),
+               (3, bands.onedrive_band),
+               (4, bands.sharepoint_band),
+               (5, bands.copilot_band)
+    ) AS band_values (workload, band)
+    GROUP BY band_values.workload, bands.department_id
+)
+INSERT #DemographicDistributions
+SELECT 1,
+       demographics.demographic_id,
+       coverage.workload,
+       ISNULL(counts.high_count, 0),
+       ISNULL(counts.moderate_count, 0),
+       ISNULL(counts.low_count, 0),
+       ISNULL(counts.zero_count, 0),
+       demographics.assigned_users - ISNULL(counts.known_count, 0)
+FROM #Demographics AS demographics
+CROSS JOIN #Coverage AS coverage
+LEFT JOIN DepartmentCounts AS counts
+  ON counts.demographic_id = demographics.demographic_id
+ AND counts.workload = coverage.workload
+WHERE demographics.dimension = 1
+OPTION (RECOMPILE);
+
+;WITH CountryCounts AS
+(
+    SELECT band_values.workload,
+           bands.country_id AS demographic_id,
+           SUM(CASE WHEN band_values.band = 3 THEN 1 ELSE 0 END) AS high_count,
+           SUM(CASE WHEN band_values.band = 2 THEN 1 ELSE 0 END) AS moderate_count,
+           SUM(CASE WHEN band_values.band = 1 THEN 1 ELSE 0 END) AS low_count,
+           SUM(CASE WHEN band_values.band = 0 THEN 1 ELSE 0 END) AS zero_count,
+           COUNT(band_values.band) AS known_count
+    FROM #UserBands AS bands
+    CROSS APPLY
+    (
+        VALUES (1, bands.teams_band),
+               (2, bands.outlook_band),
+               (3, bands.onedrive_band),
+               (4, bands.sharepoint_band),
+               (5, bands.copilot_band)
+    ) AS band_values (workload, band)
+    GROUP BY band_values.workload, bands.country_id
+)
+INSERT #DemographicDistributions
+SELECT 2,
+       demographics.demographic_id,
+       coverage.workload,
+       ISNULL(counts.high_count, 0),
+       ISNULL(counts.moderate_count, 0),
+       ISNULL(counts.low_count, 0),
+       ISNULL(counts.zero_count, 0),
+       demographics.assigned_users - ISNULL(counts.known_count, 0)
+FROM #Demographics AS demographics
+CROSS JOIN #Coverage AS coverage
+LEFT JOIN CountryCounts AS counts
+  ON counts.demographic_id = demographics.demographic_id
+ AND counts.workload = coverage.workload
+WHERE demographics.dimension = 2
+OPTION (RECOMPILE);
+
+SELECT (SELECT COUNT(*) FROM #EligibleUsers) AS DistinctAssignedUsers,
+       CAST(CASE
+           WHEN (SELECT COUNT(DISTINCT department_id) FROM #EligibleUsers)
+                    > (SELECT COUNT(*) FROM #Demographics WHERE dimension = 1)
+             OR (SELECT COUNT(DISTINCT country_id) FROM #EligibleUsers)
+                    > (SELECT COUNT(*) FROM #Demographics WHERE dimension = 2)
+           THEN 1 ELSE 0 END AS bit) AS DemographicsTruncated;
+
+SELECT workload_name AS Workload,
+       status AS Status,
+       source AS Source,
+       measure AS Measure,
+       granularity AS Granularity,
+       message AS Message,
+       effective_from_utc AS EffectiveFromUtc,
+       effective_to_utc AS EffectiveToUtc,
+       latest_import_utc AS LatestImportUtc,
+       lag_days AS LagDays,
+       report_period_days AS ReportPeriodDays,
+       expected_samples AS ExpectedSamples,
+       observed_samples AS ObservedSamples,
+       unmatched_users AS UnmatchedUsers
+FROM #Coverage
+ORDER BY workload;
+
+SELECT WorkloadName = coverage.workload_name,
+       SnapshotDate = samples.sample_date
+FROM #Samples AS samples
+JOIN #Coverage AS coverage ON coverage.workload = samples.workload
+ORDER BY samples.workload, samples.sample_date;
+
+SELECT licence.id AS LicenceTypeId,
+       licence.name AS Name,
+       licence.sku_id AS SkuId,
+       counts.assigned_users AS AssignedUsers
+FROM dbo.license_types AS licence
+JOIN #LicenceCounts AS counts ON counts.licence_type_id = licence.id
+ORDER BY licence.name, licence.id;
+
+SELECT distributions.licence_type_id AS LicenceTypeId,
+       coverage.workload_name AS Workload,
+       distributions.high_count AS High,
+       distributions.moderate_count AS Moderate,
+       distributions.low_count AS Low,
+       distributions.zero_count AS Zero,
+       distributions.unknown_count AS Unknown
+FROM #LicenceDistributions AS distributions
+JOIN #Coverage AS coverage ON coverage.workload = distributions.workload
+ORDER BY distributions.licence_type_id, distributions.workload;
+
+SELECT CASE WHEN dimension = 1 THEN 'department' ELSE 'country' END AS Dimension,
+       demographic_id AS Id,
+       demographic_name AS Name,
+       assigned_users AS AssignedUsers
+FROM #Demographics
+ORDER BY dimension, assigned_users DESC, demographic_name, demographic_id;
+
+SELECT CASE WHEN distributions.dimension = 1 THEN 'department' ELSE 'country' END AS Dimension,
+       distributions.demographic_id AS Id,
+       coverage.workload_name AS Workload,
+       distributions.high_count AS High,
+       distributions.moderate_count AS Moderate,
+       distributions.low_count AS Low,
+       distributions.zero_count AS Zero,
+       distributions.unknown_count AS Unknown
+FROM #DemographicDistributions AS distributions
+JOIN #Coverage AS coverage ON coverage.workload = distributions.workload
+ORDER BY distributions.dimension, distributions.demographic_id, distributions.workload;
+";
+
+        private static readonly string UsersPreamble = @"
+/* LicenceActivity:Users */
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+
+CREATE TABLE #EligibleUsers
+(
+    user_id int NOT NULL PRIMARY KEY,
+    user_name varchar(250) NOT NULL,
+    department_name nvarchar(100) NULL,
+    country_name nvarchar(100) NULL,
+    account_enabled bit NULL
+);
+
+INSERT #EligibleUsers (user_id, user_name, department_name, country_name, account_enabled)
+SELECT DISTINCT u.id, u.user_name, department.name, country.name, u.account_enabled
+FROM dbo.user_license_type_lookups AS owned
+JOIN dbo.users AS u ON u.id = owned.user_id
+LEFT JOIN dbo.user_departments AS department ON department.id = u.department_id
+LEFT JOIN dbo.user_country_or_region AS country ON country.id = u.country_or_region_id
+WHERE owned.license_type_id = @licenceTypeId
+  AND (@departmentId IS NULL
+       OR u.department_id = @departmentId
+       OR (@departmentId = 0 AND u.department_id IS NULL))
+  AND (@countryId IS NULL
+       OR u.country_or_region_id = @countryId
+       OR (@countryId = 0 AND u.country_or_region_id IS NULL))
+  AND (@searchPattern = N''
+       OR u.user_name LIKE @searchPattern ESCAPE N'\'
+       OR u.mail LIKE @searchPattern ESCAPE N'\')
+OPTION (RECOMPILE);
+
+CREATE TABLE #Coverage
+(
+    workload tinyint NOT NULL PRIMARY KEY,
+    status varchar(32) NOT NULL,
+    source varchar(64) NOT NULL,
+    measure nvarchar(240) NOT NULL,
+    expected_samples int NOT NULL,
+    observed_samples int NOT NULL,
+    report_period_days int NULL
+);
+
+INSERT #Coverage
+(
+    workload, status, source, measure, expected_samples, observed_samples, report_period_days
+)
+VALUES
+    (1, @status1, @source1, @measure1, @expected1, @observed1, @period1),
+    (2, @status2, @source2, @measure2, @expected2, @observed2, @period2),
+    (3, @status3, @source3, @measure3, @expected3, @observed3, @period3),
+    (4, @status4, @source4, @measure4, @expected4, @observed4, @period4),
+    (5, @status5, @source5, @measure5, @expected5, @observed5, @period5);
+
+CREATE TABLE #Samples
+(
+    workload tinyint NOT NULL,
+    sample_date date NOT NULL,
+    PRIMARY KEY (workload, sample_date)
+);
+
+CREATE TABLE #Scores
+(
+    workload tinyint NOT NULL,
+    user_id int NOT NULL,
+    active_samples int NOT NULL,
+    observed_samples int NOT NULL,
+    frequency_known bit NOT NULL,
+    average_actions float NULL,
+    last_activity_utc datetime NULL
+);
+";
+
+        private static void AppendM365Users(
+            StringBuilder sql,
+            LicenceActivityCoverage coverage,
+            int workload,
+            string table,
+            string actionExpression,
+            string scopeTable)
+        {
+            if (coverage.SnapshotDates == null || coverage.SnapshotDates.Count == 0)
+                return;
+
+            sql.AppendFormat(
+                CultureInfo.InvariantCulture,
+                @"
+;WITH PerSample AS
+(
+    SELECT activity.user_id,
+           CAST(activity.[date] AS date) AS sample_date,
+           MAX({2}) AS actions,
+           MAX(CASE
+                   WHEN activity.last_activity_date >= @from
+                    AND activity.last_activity_date < @endExclusive
+                    AND activity.last_activity_date < DATEADD(DAY, 1, CAST(activity.[date] AS date))
+                    AND activity.last_activity_date >= DATEADD(DAY,
+                        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
+                        CAST(activity.[date] AS date))
+                    AND activity.last_activity_date < DATEADD(DAY, 7,
+                        DATEADD(DAY,
+                            -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
+                            CAST(activity.[date] AS date)))
+                   THEN activity.last_activity_date
+               END) AS last_activity_utc,
+           MAX(CASE
+                   WHEN activity.last_activity_date >= @from
+                    AND activity.last_activity_date < @endExclusive
+                    AND activity.last_activity_date < DATEADD(DAY, 1, CAST(activity.[date] AS date))
+                    AND activity.last_activity_date >= DATEADD(DAY,
+                        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
+                        CAST(activity.[date] AS date))
+                    AND activity.last_activity_date < DATEADD(DAY, 7,
+                        DATEADD(DAY,
+                            -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
+                            CAST(activity.[date] AS date)))
+                   THEN 1 ELSE 0
+               END) AS was_active
+    FROM {1} AS activity
+    JOIN #Samples AS chosen
+      ON chosen.workload = {0}
+     AND activity.[date] >= chosen.sample_date
+     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
+    JOIN {3} AS eligible ON eligible.user_id = activity.user_id
+    GROUP BY activity.user_id, CAST(activity.[date] AS date)
+)
+INSERT #Scores
+    (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
+SELECT {0}, user_id,
+       SUM(was_active),
+       COUNT(*),
+       CAST(CASE WHEN COUNT(*) = @expected{0} THEN 1 ELSE 0 END AS bit),
+       AVG(actions),
+       MAX(last_activity_utc)
+FROM PerSample
+GROUP BY user_id
+OPTION (RECOMPILE);
+",
+                workload, table, actionExpression, scopeTable);
+        }
+
+        private static void AppendCopilotUsers(
+            StringBuilder sql,
+            LicenceActivityCoverage coverage,
+            string scopeTable)
+        {
+            if (coverage.Source == CopilotReportSource
+                && coverage.SnapshotDates != null
+                && coverage.SnapshotDates.Count > 0
+                && coverage.ReportPeriodDays.HasValue)
+            {
+                if (coverage.ReportPeriodDays.Value == 7)
+                    sql.Append(CopilotD7Users.Replace("#ActivityScope", scopeTable));
+                else
+                    sql.Append(CopilotLongUsers.Replace("#ActivityScope", scopeTable));
+                return;
+            }
+
+            if (coverage.Source == CopilotAuditSource)
+            {
+                sql.Append(CopilotAuditUsers.Replace("#ActivityScope", scopeTable));
+            }
+            else if (coverage.Source == CopilotInteractionSource)
+            {
+                sql.Append(CopilotInteractionUsers.Replace("#ActivityScope", scopeTable));
+            }
+        }
+
+        private static readonly string CopilotD7Users = @"
+INSERT #Scores
+    (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
+SELECT 5, report.user_id,
+       SUM(CASE
+               WHEN report.active_usage_days BETWEEN 1 AND 7
+                 OR report.prompts_all_apps > 0
+                 OR (report.last_activity_date >= DATEADD(DAY, -6, CAST(report.[date] AS date))
+                     AND report.last_activity_date < DATEADD(DAY, 1, CAST(report.[date] AS date)))
+               THEN 1 ELSE 0
+           END),
+       COUNT(*),
+       CAST(CASE
+                WHEN COUNT(*) = @expected5
+                 AND MIN(CASE
+                             WHEN report.active_usage_days BETWEEN 0 AND 7
+                              AND (report.prompts_all_apps IS NULL
+                                   OR report.prompts_all_apps >= 0)
+                             THEN 1 ELSE 0
+                         END) = 1
+                THEN 1 ELSE 0
+            END AS bit),
+       CASE
+           WHEN MIN(CASE WHEN report.prompts_all_apps >= 0 THEN 1 ELSE 0 END) = 1
+               THEN AVG(CAST(report.prompts_all_apps AS float))
+       END,
+       MAX(CASE
+               WHEN report.last_activity_date >= DATEADD(DAY, -6, CAST(report.[date] AS date))
+                AND report.last_activity_date < DATEADD(DAY, 1, CAST(report.[date] AS date))
+               THEN report.last_activity_date
+           END)
+FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(0))
+JOIN #Samples AS chosen
+  ON chosen.workload = 5
+ AND report.[date] >= chosen.sample_date
+ AND report.[date] < DATEADD(DAY, 1, chosen.sample_date)
+JOIN #ActivityScope AS eligible ON eligible.user_id = report.user_id
+WHERE report.report_period_days = 7
+GROUP BY report.user_id
+OPTION (RECOMPILE);
+";
+
+        private static readonly string CopilotLongUsers = @"
+DECLARE @copilotSnapshot date =
+    (SELECT MAX(sample_date) FROM #Samples WHERE workload = 5);
+
+INSERT #Scores
+    (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
+SELECT 5,
+       report.user_id,
+       CASE
+           WHEN report.active_usage_days BETWEEN 0 AND @period5
+               THEN report.active_usage_days
+           WHEN report.prompts_all_apps > 0
+             OR (report.last_activity_date >= DATEADD(DAY, 1 - @period5, @copilotSnapshot)
+                 AND report.last_activity_date < DATEADD(DAY, 1, @copilotSnapshot))
+               THEN 1 ELSE 0
+       END,
+       CASE
+           WHEN report.active_usage_days BETWEEN 0 AND @period5
+            AND (report.prompts_all_apps IS NULL OR report.prompts_all_apps >= 0)
+               THEN @period5 ELSE 0
+       END,
+       CAST(CASE
+           WHEN report.active_usage_days BETWEEN 0 AND @period5
+            AND (report.prompts_all_apps IS NULL OR report.prompts_all_apps >= 0)
+               THEN 1 ELSE 0
+       END AS bit),
+       CASE WHEN report.prompts_all_apps >= 0
+            THEN CAST(report.prompts_all_apps AS float) END,
+       CASE
+           WHEN report.last_activity_date >= DATEADD(DAY, 1 - @period5, @copilotSnapshot)
+            AND report.last_activity_date < DATEADD(DAY, 1, @copilotSnapshot)
+               THEN report.last_activity_date
+       END
+FROM dbo.copilot_usage_user_activity_log AS report
+JOIN #ActivityScope AS eligible ON eligible.user_id = report.user_id
+WHERE report.report_period_days = @period5
+  AND report.[date] >= @copilotSnapshot
+  AND report.[date] < DATEADD(DAY, 1, @copilotSnapshot)
+OPTION (RECOMPILE);
+";
+
+        private static readonly string CopilotAuditUsers = @"
+;WITH EventWeeks AS
+(
+    SELECT chats.user_id,
+           DATEADD(DAY,
+               -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(chats.time_stamp AS date)) % 7) + 7) % 7),
+               CAST(chats.time_stamp AS date)) AS week_start,
+           COUNT_BIG(*) AS actions,
+           MAX(chats.time_stamp) AS last_activity_utc
+    FROM dbo.copilot_chats AS chats
+    JOIN #ActivityScope AS eligible ON eligible.user_id = chats.user_id
+    WHERE chats.time_stamp >= @from
+      AND chats.time_stamp < @endExclusive
+    GROUP BY chats.user_id,
+             DATEADD(DAY,
+                -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(chats.time_stamp AS date)) % 7) + 7) % 7),
+                CAST(chats.time_stamp AS date))
+)
+INSERT #Scores
+    (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
+SELECT 5, user_id, COUNT(*), 0, 0, AVG(CAST(actions AS float)), MAX(last_activity_utc)
+FROM EventWeeks
+GROUP BY user_id
+OPTION (RECOMPILE);
+";
+
+        private static readonly string CopilotInteractionUsers = @"
+;WITH EventWeeks AS
+(
+    SELECT interactions.user_id,
+           DATEADD(DAY,
+               -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(interactions.created_utc AS date)) % 7) + 7) % 7),
+               CAST(interactions.created_utc AS date)) AS week_start,
+           COUNT_BIG(*) AS actions,
+           MAX(interactions.created_utc) AS last_activity_utc
+    FROM dbo.copilot_interactions AS interactions
+    JOIN #ActivityScope AS eligible ON eligible.user_id = interactions.user_id
+    WHERE interactions.created_utc >= @from
+      AND interactions.created_utc < @endExclusive
+    GROUP BY interactions.user_id,
+             DATEADD(DAY,
+                -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(interactions.created_utc AS date)) % 7) + 7) % 7),
+                CAST(interactions.created_utc AS date))
+)
+INSERT #Scores
+    (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
+SELECT 5, user_id, COUNT(*), 0, 0, AVG(CAST(actions AS float)), MAX(last_activity_utc)
+FROM EventWeeks
+GROUP BY user_id
+OPTION (RECOMPILE);
+";
+
+        private static string BuildUsersSelection(LicenceActivityQuery query)
+        {
+            var selected = WorkloadId(query.Workload);
+            var pageOrder = UserPageOrder(query);
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                @"
+CREATE TABLE #RankBase
+(
+    user_id int NOT NULL PRIMARY KEY,
+    user_name varchar(250) NOT NULL,
+    department_name nvarchar(100) NULL,
+    country_name nvarchar(100) NULL,
+    account_enabled bit NULL,
+    selected_status varchar(32) NOT NULL,
+    selected_active_samples int NOT NULL,
+    selected_average_actions float NULL,
+    selected_last_activity_utc datetime NULL,
+    can_rank_most bit NOT NULL,
+    can_rank_least bit NOT NULL
+);
+
+INSERT #RankBase
+SELECT eligible.user_id,
+       eligible.user_name,
+       eligible.department_name,
+       eligible.country_name,
+       eligible.account_enabled,
+       CASE
+           WHEN coverage.status <> 'available' THEN coverage.status
+           WHEN coverage.source IN
+                    ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+            AND score.user_id IS NULL THEN 'missingCoverage'
+           WHEN coverage.source IN
+                    ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+            AND (score.frequency_known = 0 OR score.observed_samples <> coverage.expected_samples)
+               THEN 'partial'
+           ELSE 'available'
+       END,
+       ISNULL(score.active_samples, 0),
+       CASE WHEN score.user_id IS NULL
+                  AND coverage.status = 'available'
+                  AND coverage.source NOT IN
+                      ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+            THEN CAST(0 AS float) ELSE score.average_actions END,
+       score.last_activity_utc,
+       CAST(CASE
+                WHEN (coverage.status = 'available'
+                      AND NOT (coverage.source IN
+                                   ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+                               AND (score.user_id IS NULL
+                                    OR score.frequency_known = 0
+                                    OR score.observed_samples <> coverage.expected_samples)))
+                  OR ISNULL(score.active_samples, 0) > 0
+                 THEN 1 ELSE 0 END AS bit),
+       CAST(CASE
+                WHEN coverage.status = 'available'
+                 AND NOT (coverage.source IN
+                              ('microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport')
+                          AND (score.user_id IS NULL
+                               OR score.frequency_known = 0
+                               OR score.observed_samples <> coverage.expected_samples))
+                THEN 1 ELSE 0 END AS bit)
+FROM #EligibleUsers AS eligible
+CROSS JOIN
+(
+    SELECT status, source, expected_samples
+    FROM #Coverage
+    WHERE workload = {0}
+) AS coverage
+LEFT JOIN #Scores AS score
+  ON score.workload = {0}
+ AND score.user_id = eligible.user_id
+OPTION (RECOMPILE);
+
+SELECT COUNT(*) AS TotalUsers,
+       ISNULL(SUM(CASE WHEN can_rank_most = 1 THEN 1 ELSE 0 END), 0) AS RankedUsers
+FROM #RankBase;
+
+CREATE TABLE #Picked
+(
+    list_kind tinyint NOT NULL,
+    ordinal int NOT NULL,
+    user_id int NOT NULL,
+    PRIMARY KEY (list_kind, ordinal),
+    UNIQUE (list_kind, user_id)
+);
+
+INSERT #Picked (list_kind, ordinal, user_id)
+SELECT 1,
+       ROW_NUMBER() OVER
+       (
+           ORDER BY CASE
+                        WHEN selected_status = 'available' AND selected_active_samples > 0 THEN 0
+                        WHEN selected_status <> 'available' AND selected_active_samples > 0 THEN 1
+                        WHEN selected_status = 'available' THEN 2
+                        ELSE 3
+                    END,
+                    selected_active_samples DESC,
+                    selected_average_actions DESC,
+                    selected_last_activity_utc DESC,
+                    user_name,
+                    user_id
+       ),
+       user_id
+FROM
+(
+    SELECT TOP (@top) *
+    FROM #RankBase
+    WHERE can_rank_most = 1
+    ORDER BY CASE
+                 WHEN selected_status = 'available' AND selected_active_samples > 0 THEN 0
+                 WHEN selected_status <> 'available' AND selected_active_samples > 0 THEN 1
+                 WHEN selected_status = 'available' THEN 2
+                 ELSE 3
+             END,
+             selected_active_samples DESC,
+             selected_average_actions DESC,
+             selected_last_activity_utc DESC,
+             user_name,
+             user_id
+) AS most_active
+OPTION (RECOMPILE);
+
+INSERT #Picked (list_kind, ordinal, user_id)
+SELECT 2,
+       ROW_NUMBER() OVER
+       (
+           ORDER BY selected_active_samples,
+                    selected_average_actions,
+                    selected_last_activity_utc,
+                    user_name,
+                    user_id
+       ),
+       user_id
+FROM
+(
+    SELECT TOP (@top) *
+    FROM #RankBase
+    WHERE can_rank_least = 1
+    ORDER BY selected_active_samples,
+             selected_average_actions,
+             selected_last_activity_utc,
+             user_name,
+             user_id
+) AS least_active
+OPTION (RECOMPILE);
+
+;WITH Paged AS
+(
+    SELECT user_id,
+           ROW_NUMBER() OVER (ORDER BY {1}) AS row_number
+    FROM #RankBase
+)
+INSERT #Picked (list_kind, ordinal, user_id)
+SELECT 3, row_number - @offset, user_id
+FROM Paged
+WHERE row_number > @offset
+  AND row_number <= @offset + @pageSize
+OPTION (RECOMPILE);
+
+CREATE TABLE #ReturnedUsers
+(
+    user_id int NOT NULL PRIMARY KEY
+);
+
+INSERT #ReturnedUsers (user_id)
+SELECT DISTINCT user_id
+FROM #Picked;
+",
+                selected, pageOrder);
+        }
+
+        private static readonly string UsersFinalProjection = @"
+SELECT picked.list_kind AS ListKind,
+       picked.ordinal AS Ordinal,
+       users.user_id AS UserId,
+       users.user_name AS UserPrincipalName,
+       users.department_name AS Department,
+       users.country_name AS Country,
+       users.account_enabled AS AccountEnabled,
+       ISNULL(teams.active_samples, 0) AS TeamsActiveSamples,
+       CAST(CASE WHEN teams.user_id IS NULL THEN 0 ELSE 1 END AS bit) AS TeamsRowPresent,
+       ISNULL(teams.observed_samples, 0) AS TeamsObservedSamples,
+       ISNULL(teams.frequency_known, 0) AS TeamsFrequencyKnown,
+       teams.average_actions AS TeamsAverageActions,
+       teams.last_activity_utc AS TeamsLastActivityUtc,
+       ISNULL(outlook.active_samples, 0) AS OutlookActiveSamples,
+       CAST(CASE WHEN outlook.user_id IS NULL THEN 0 ELSE 1 END AS bit) AS OutlookRowPresent,
+       ISNULL(outlook.observed_samples, 0) AS OutlookObservedSamples,
+       ISNULL(outlook.frequency_known, 0) AS OutlookFrequencyKnown,
+       outlook.average_actions AS OutlookAverageActions,
+       outlook.last_activity_utc AS OutlookLastActivityUtc,
+       ISNULL(onedrive.active_samples, 0) AS OneDriveActiveSamples,
+       CAST(CASE WHEN onedrive.user_id IS NULL THEN 0 ELSE 1 END AS bit) AS OneDriveRowPresent,
+       ISNULL(onedrive.observed_samples, 0) AS OneDriveObservedSamples,
+       ISNULL(onedrive.frequency_known, 0) AS OneDriveFrequencyKnown,
+       onedrive.average_actions AS OneDriveAverageActions,
+       onedrive.last_activity_utc AS OneDriveLastActivityUtc,
+       ISNULL(sharepoint.active_samples, 0) AS SharePointActiveSamples,
+       CAST(CASE WHEN sharepoint.user_id IS NULL THEN 0 ELSE 1 END AS bit) AS SharePointRowPresent,
+       ISNULL(sharepoint.observed_samples, 0) AS SharePointObservedSamples,
+       ISNULL(sharepoint.frequency_known, 0) AS SharePointFrequencyKnown,
+       sharepoint.average_actions AS SharePointAverageActions,
+       sharepoint.last_activity_utc AS SharePointLastActivityUtc,
+       ISNULL(copilot.active_samples, 0) AS CopilotActiveSamples,
+       CAST(CASE WHEN copilot.user_id IS NULL THEN 0 ELSE 1 END AS bit) AS CopilotRowPresent,
+       ISNULL(copilot.observed_samples, 0) AS CopilotObservedSamples,
+       ISNULL(copilot.frequency_known, 0) AS CopilotFrequencyKnown,
+       copilot.average_actions AS CopilotAverageActions,
+       copilot.last_activity_utc AS CopilotLastActivityUtc
+FROM #Picked AS picked
+JOIN #EligibleUsers AS users ON users.user_id = picked.user_id
+LEFT JOIN #Scores AS teams ON teams.workload = 1 AND teams.user_id = users.user_id
+LEFT JOIN #Scores AS outlook ON outlook.workload = 2 AND outlook.user_id = users.user_id
+LEFT JOIN #Scores AS onedrive ON onedrive.workload = 3 AND onedrive.user_id = users.user_id
+LEFT JOIN #Scores AS sharepoint ON sharepoint.workload = 4 AND sharepoint.user_id = users.user_id
+LEFT JOIN #Scores AS copilot ON copilot.workload = 5 AND copilot.user_id = users.user_id
+ORDER BY picked.list_kind, picked.ordinal
+OPTION (RECOMPILE);
+";
+
+        private static string UserPageOrder(LicenceActivityQuery query)
+        {
+            var direction = query.Direction == "desc" ? "DESC" : "ASC";
+            if (query.Sort == "activity")
+            {
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "CASE WHEN selected_status = 'available' AND selected_active_samples > 0 THEN 0 "
+                    + "WHEN selected_status <> 'available' AND selected_active_samples > 0 THEN 1 "
+                    + "WHEN selected_status = 'available' THEN 2 ELSE 3 END, "
+                    + "selected_active_samples {0}, selected_average_actions {0}, "
+                    + "selected_last_activity_utc {0}, user_name, user_id",
+                    direction);
+            }
+
+            if (query.Sort == "lastActivity")
+            {
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "CASE WHEN selected_status = 'available' AND selected_active_samples > 0 THEN 0 "
+                    + "WHEN selected_status <> 'available' AND selected_active_samples > 0 THEN 1 "
+                    + "WHEN selected_status = 'available' THEN 2 ELSE 3 END, "
+                    + "selected_last_activity_utc {0}, selected_active_samples {0}, "
+                    + "selected_average_actions {0}, user_name, user_id",
+                    direction);
+            }
+
+            return "user_name " + direction + ", user_id";
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityWorkbook.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityWorkbook.cs
@@ -1,0 +1,114 @@
+using Common.Entities.Xlsx;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Common.Entities.LicenceActivity
+{
+    public static class LicenceActivityWorkbook
+    {
+        public static byte[] Build(LicenceActivityOverview overview, LicenceActivityUsers users = null)
+        {
+            if (overview == null) throw new ArgumentNullException(nameof(overview));
+            if (users != null && users.OverviewId != overview.SnapshotId)
+                throw new ArgumentException("The user snapshot does not belong to this overview.", nameof(users));
+
+            using (var book = new XlsxWriter())
+            {
+                var report = book.AddSheet("Snapshot").SetColumnWidths(32, 40, 100);
+                report.AddTitle("Microsoft 365 licence activity");
+                report.AddHeaderRow("Property", "Value", "Meaning");
+                report.AddRow("Overview generated (UTC)", overview.GeneratedUtc.ToString("O"), "The values displayed on screen; export does not re-query the database.");
+                report.AddRow("Requested from (UTC)", overview.Query.From, "Inclusive UTC date.");
+                report.AddRow("Requested to (UTC)", overview.Query.To, "Inclusive UTC date; actual source coverage is on the Workload coverage sheet.");
+                report.AddRow("Department filter ID", overview.Query.DepartmentId, "Blank = all; 0 = unknown metadata.");
+                report.AddRow("Country filter ID", overview.Query.CountryId, "Blank = all; 0 = unknown metadata.");
+                report.AddRow("Distinct assigned users", overview.DistinctAssignedUsers, "Unique people across the selected demographic population.");
+                report.AddRow("Demographics truncated", overview.DemographicsTruncated, "Only the largest demographic groups are displayed when the bound is reached.");
+                report.AddRow("Current assignments", null, XlsxCell.Wrapped(LicenceActivityRules.AssignmentCaveat));
+                report.AddRow("Interpretation", null, XlsxCell.Wrapped(LicenceActivityRules.InterpretationCaveat));
+                report.AddRow("Activity bands", null, XlsxCell.Wrapped(LicenceActivityRules.Method));
+                foreach (var message in overview.Messages) report.AddRow("Note", null, XlsxCell.Wrapped(message));
+
+                var licences = book.AddSheet("Licences");
+                licences.AddHeaderRow("Licence", "SKU ID", "Assigned users", "Workload", "High", "Moderate", "Low", "No activity", "Unknown");
+                foreach (var sku in overview.Licences)
+                    foreach (var distribution in sku.Workloads)
+                        licences.AddRow(sku.Name, sku.SkuId, sku.AssignedUsers, distribution.Workload,
+                            distribution.High, distribution.Moderate, distribution.Low, distribution.Zero, distribution.Unknown);
+                FormatTable(licences, 9);
+                report.AddRow("Licence sheet", null, "One row per SKU and workload. Assigned users repeat across workloads; do not sum this column.");
+
+                var coverage = book.AddSheet("Workload coverage");
+                coverage.AddHeaderRow("Workload", "Status", "Source", "Measure", "Granularity", "Effective from (UTC)",
+                    "Effective through (UTC)", "Latest import (UTC)", "Lag days", "Report period days", "Observed samples",
+                    "Expected samples", "Unmatched users", "Snapshot dates (UTC)", "Notes");
+                foreach (var source in overview.Coverage)
+                    coverage.AddRow(source.Workload, source.Status, source.Source, source.Measure, source.Granularity,
+                        source.EffectiveFromUtc, source.EffectiveToUtc, source.LatestImportUtc, source.LagDays,
+                        source.ReportPeriodDays, source.ObservedSamples, source.ExpectedSamples, source.UnmatchedUsers,
+                        string.Join(", ", source.SnapshotDates.Select(d => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))),
+                        XlsxCell.Wrapped(source.Message));
+                FormatTable(coverage, 15);
+
+                WriteDemographics(book, "Departments", overview.Departments);
+                WriteDemographics(book, "Countries", overview.Countries);
+                if (users != null)
+                {
+                    if (users.MostActive.Count > LicenceActivityQuery.MaximumRows
+                        || users.LeastActive.Count > LicenceActivityQuery.MaximumRows
+                        || users.Users.Count > LicenceActivityQuery.MaximumRows)
+                        throw new ArgumentException("User snapshot exceeds the export row limit.", nameof(users));
+                    report.AddRow("Users generated (UTC)", users.GeneratedUtc.ToString("O"), "Current bounded lists and browse page, not the entire assigned population.");
+                    report.AddRow("Selected licence ID", users.Query.LicenceTypeId);
+                    report.AddRow("Ranking workload", users.Query.Workload, "Workloads are not combined into a score.");
+                    report.AddRow("Most/least count", users.Query.Top);
+                    report.AddRow("Search", users.Query.Search);
+                    report.AddRow("Browse sort", users.Query.Sort + " " + users.Query.Direction);
+                    report.AddRow("Browse page", users.Query.Page);
+                    report.AddRow("Page size", users.Query.PageSize);
+                    report.AddRow("Matching users", users.TotalUsers);
+                    report.AddRow("Users with rankable evidence", users.RankedUsers, "Missing evidence is excluded from least-active ranking.");
+                    foreach (var message in users.Messages) report.AddRow("User note", null, XlsxCell.Wrapped(message));
+                    WriteUsers(book, "Most active", users.MostActive);
+                    WriteUsers(book, "Least active", users.LeastActive);
+                    WriteUsers(book, "User page", users.Users);
+                }
+                else report.AddRow("Individual users", "Not included", "Aggregate-only snapshot.");
+                return book.ToArray();
+            }
+        }
+
+        private static void WriteDemographics(XlsxWriter book, string name, IEnumerable<LicenceActivityDemographic> groups)
+        {
+            var sheet = book.AddSheet(name);
+            sheet.AddHeaderRow("Group ID", "Group", "Distinct assigned users", "Workload", "High", "Moderate", "Low", "No activity", "Unknown");
+            foreach (var group in groups)
+                foreach (var distribution in group.Workloads)
+                    sheet.AddRow(group.Id, group.Name, group.AssignedUsers, distribution.Workload,
+                        distribution.High, distribution.Moderate, distribution.Low, distribution.Zero, distribution.Unknown);
+            FormatTable(sheet, 9);
+        }
+
+        private static void WriteUsers(XlsxWriter book, string name, IEnumerable<LicenceActivityUser> users)
+        {
+            var sheet = book.AddSheet(name);
+            sheet.AddHeaderRow("User ID", "UPN", "Department", "Country", "Account enabled",
+                "Workload", "Coverage", "Band", "Source", "Measure", "Active samples", "Observed samples", "Expected samples",
+                "Average actions per observed sample", "Last activity (UTC)");
+            foreach (var user in users)
+                foreach (var evidence in user.Workloads)
+                    sheet.AddRow(user.UserId, user.UserPrincipalName, user.Department, user.Country, user.AccountEnabled,
+                        evidence.Workload, evidence.Status, evidence.Band, evidence.Source, evidence.Measure, evidence.ActiveSamples,
+                        evidence.ObservedSamples, evidence.ExpectedSamples, evidence.AverageActions, evidence.LastActivityUtc);
+            FormatTable(sheet, 15);
+        }
+
+        private static void FormatTable(XlsxSheet sheet, int columns)
+        {
+            sheet.FreezeTopRows(1);
+            sheet.AddAutoFilter(1, sheet.CurrentRow, 1, columns);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
@@ -1,0 +1,1331 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Data.SqlTypes;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Common.Entities.LicenceActivity
+{
+    /// <summary>
+    /// Bounded ADO.NET adapter for licence activity. Each call owns one short-lived SQL connection and
+    /// executes one batch; no EF context or request synchronization context is shared.
+    /// </summary>
+    public sealed class SqlLicenceActivityStore : ILicenceActivityStore
+    {
+        private static readonly SemaphoreSlim OverviewSqlSlots = new SemaphoreSlim(6, 6);
+        private readonly string _connectionString;
+        private readonly SqlLicenceActivityStoreInstrumentation _instrumentation;
+
+        public SqlLicenceActivityStore(string connectionString)
+            : this(connectionString, null)
+        {
+        }
+
+        internal SqlLicenceActivityStore(
+            string connectionString,
+            SqlLicenceActivityStoreInstrumentation instrumentation)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+                throw new ArgumentException("A SQL connection string is required.", nameof(connectionString));
+
+            _connectionString = connectionString;
+            _instrumentation = instrumentation;
+        }
+
+        public async Task<LicenceActivityOverview> LoadOverviewAsync(
+            LicenceActivityQuery query,
+            LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics,
+            CancellationToken cancellationToken)
+        {
+            if (query == null) throw new ArgumentNullException(nameof(query));
+            if (sources == null) throw new ArgumentNullException(nameof(sources));
+            if (!sources.UserMetadata)
+                throw new InvalidOperationException("Licence activity requires the user metadata import.");
+
+            diagnostics = diagnostics ?? NullLicenceActivityDiagnostics.Instance;
+            var sqlWatch = Stopwatch.StartNew();
+            diagnostics.Stage("OverviewSqlStarted");
+            diagnostics.Stage("CoverageStarted");
+
+            var suffix = Guid.NewGuid().ToString("N");
+            var eligibleTable = "##LicenceActivityEligible_" + suffix;
+            using (var eligibleConnection = await CreateSharedEligibleUsersAsync(
+                eligibleTable, query, sources, diagnostics, cancellationToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    var partTasks = new List<Task<OverviewPart>>();
+                    if (sources.UsageReports)
+                    {
+                        for (var workload = LicenceActivitySql.Teams;
+                            workload <= LicenceActivitySql.SharePoint;
+                            workload++)
+                        {
+                            partTasks.Add(ExecuteOverviewPartAsync(
+                                LicenceActivitySql.BuildM365OverviewPart(workload, eligibleTable),
+                                LicenceActivitySql.WorkloadName(workload),
+                                query, sources, diagnostics, cancellationToken));
+                        }
+                    }
+
+                    partTasks.Add(ExecuteOverviewPartAsync(
+                        LicenceActivitySql.BuildCopilotOverviewPart(sources, eligibleTable),
+                        "copilot",
+                        query, sources, diagnostics, cancellationToken));
+
+                    var materialisationWatch = Stopwatch.StartNew();
+                    diagnostics.Stage("MaterialisationStarted");
+                    var parts = await Task.WhenAll(partTasks).ConfigureAwait(false);
+
+                    var baseResult = parts.Select(part => part.Base)
+                        .First(value => value != null);
+                    var overview = MergeOverview(baseResult, parts, query, sources);
+                    materialisationWatch.Stop();
+                    sqlWatch.Stop();
+                    diagnostics.Stage("MaterialisationCompleted", materialisationWatch.ElapsedMilliseconds);
+                    diagnostics.Stage("CoverageCompleted", sqlWatch.ElapsedMilliseconds);
+                    diagnostics.Stage("OverviewSqlCompleted", sqlWatch.ElapsedMilliseconds);
+                    diagnostics.Stage("ProjectionCompleted");
+                    return overview;
+                }
+                finally
+                {
+                    await DropSharedEligibleUsersAsync(
+                        eligibleConnection, eligibleTable).ConfigureAwait(false);
+                }
+            }
+        }
+
+        public async Task<LicenceActivityUsers> LoadUsersAsync(
+            LicenceActivityOverview overview,
+            LicenceActivityQuery query,
+            LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics,
+            CancellationToken cancellationToken)
+        {
+            if (overview == null) throw new ArgumentNullException(nameof(overview));
+            if (query == null) throw new ArgumentNullException(nameof(query));
+            if (sources == null) throw new ArgumentNullException(nameof(sources));
+            if (!sources.UserMetadata)
+                throw new InvalidOperationException("Licence activity requires the user metadata import.");
+            if (!query.LicenceTypeId.HasValue)
+                throw new ArgumentException("A licenceTypeId is required for individual users.", nameof(query));
+            if (overview.Query == null
+                || overview.Query.From != query.From
+                || overview.Query.To != query.To
+                || overview.Query.DepartmentId != query.DepartmentId
+                || overview.Query.CountryId != query.CountryId)
+            {
+                throw new ArgumentException(
+                    "Individual users must inherit the overview date range and demographic scope.",
+                    nameof(query));
+            }
+            if (!overview.Licences.Any(l => l.LicenceTypeId == query.LicenceTypeId.Value))
+                throw new ArgumentException("The selected licence is not present in this overview.", nameof(query));
+
+            diagnostics = diagnostics ?? NullLicenceActivityDiagnostics.Instance;
+
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                var connectionWatch = Stopwatch.StartNew();
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                connectionWatch.Stop();
+                _instrumentation?.ConnectionOpened?.Invoke(connection);
+                diagnostics.Stage("ConnectionOpened", connectionWatch.ElapsedMilliseconds);
+
+                using (var command = new SqlCommand(LicenceActivitySql.BuildUsers(overview, query), connection)
+                {
+                    CommandTimeout = _instrumentation?.CommandTimeoutSeconds
+                        ?? LicenceActivitySql.CommandTimeoutSeconds
+                })
+                {
+                    AddUserParameters(command, overview, query, sources);
+                    var sqlWatch = Stopwatch.StartNew();
+                    diagnostics.Stage("UsersSqlStarted");
+
+                    using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        var materialisationWatch = Stopwatch.StartNew();
+                        diagnostics.Stage("MaterialisationStarted");
+                        var users = await ReadUsersAsync(
+                            reader, overview, query, diagnostics, cancellationToken).ConfigureAwait(false);
+                        materialisationWatch.Stop();
+                        sqlWatch.Stop();
+                        diagnostics.Stage("MaterialisationCompleted", materialisationWatch.ElapsedMilliseconds);
+                        diagnostics.Stage("UsersSqlCompleted", sqlWatch.ElapsedMilliseconds);
+                        return users;
+                    }
+                }
+            }
+        }
+
+        private async Task<SqlConnection> CreateSharedEligibleUsersAsync(
+            string tableName,
+            LicenceActivityQuery query,
+            LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics,
+            CancellationToken cancellationToken)
+        {
+            var connection = new SqlConnection(_connectionString);
+            try
+            {
+                var watch = Stopwatch.StartNew();
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                watch.Stop();
+                if (_instrumentation?.ConnectionOpenedForOperation != null)
+                    _instrumentation.ConnectionOpenedForOperation(connection, "eligible");
+                else
+                    _instrumentation?.ConnectionOpened?.Invoke(connection);
+                diagnostics.Stage("ConnectionOpened", watch.ElapsedMilliseconds);
+
+                using (var command = new SqlCommand(
+                    LicenceActivitySql.BuildSharedEligibleUsers(tableName),
+                    connection)
+                {
+                    CommandTimeout = _instrumentation?.CommandTimeoutSeconds
+                        ?? LicenceActivitySql.CommandTimeoutSeconds
+                })
+                {
+                    AddScopeParameters(command, query, sources);
+                    await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+                return connection;
+            }
+            catch
+            {
+                connection.Dispose();
+                throw;
+            }
+        }
+
+        private static Task DropSharedEligibleUsersAsync(
+            SqlConnection connection,
+            string tableName)
+        {
+            if (connection.State != ConnectionState.Open) return Task.CompletedTask;
+            using (var command = new SqlCommand("DROP TABLE " + tableName + ";", connection)
+            {
+                CommandTimeout = LicenceActivitySql.CommandTimeoutSeconds
+            })
+            {
+                command.ExecuteNonQuery();
+            }
+            return Task.CompletedTask;
+        }
+
+        private async Task<OverviewPart> ExecuteCoveragePartAsync(
+            string sql,
+            string operation,
+            LicenceActivityQuery query,
+            LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics,
+            CancellationToken cancellationToken)
+        {
+            return await ExecuteOverviewSqlAsync(
+                sql,
+                operation,
+                query,
+                sources,
+                diagnostics,
+                async reader =>
+                {
+                    var part = new OverviewPart();
+                    await RequireResultAsync(
+                        reader, true, cancellationToken,
+                        "Workload", "Status", "Source", "ExpectedSamples").ConfigureAwait(false);
+                    if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                        throw new InvalidOperationException(
+                            "A licence activity workload coverage row was not returned.");
+                    part.Coverage = new LicenceActivityCoverage
+                    {
+                        Workload = ReadString(reader, "Workload"),
+                        Status = ReadString(reader, "Status"),
+                        Source = ReadString(reader, "Source"),
+                        Measure = ReadString(reader, "Measure"),
+                        Granularity = ReadString(reader, "Granularity"),
+                        Message = ReadNullableString(reader, "Message"),
+                        EffectiveFromUtc = ReadNullableUtc(reader, "EffectiveFromUtc"),
+                        EffectiveToUtc = ReadNullableUtc(reader, "EffectiveToUtc"),
+                        LatestImportUtc = ReadNullableUtc(reader, "LatestImportUtc"),
+                        LagDays = ReadInt32(reader, "LagDays"),
+                        ReportPeriodDays = ReadNullableInt32(reader, "ReportPeriodDays"),
+                        ExpectedSamples = ReadInt32(reader, "ExpectedSamples"),
+                        ObservedSamples = ReadInt32(reader, "ObservedSamples"),
+                        UnmatchedUsers = ReadInt32(reader, "UnmatchedUsers")
+                    };
+
+                    await RequireResultAsync(
+                        reader, false, cancellationToken,
+                        "WorkloadName", "SnapshotDate").ConfigureAwait(false);
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                        part.Coverage.SnapshotDates.Add(ReadUtc(reader, "SnapshotDate"));
+                    await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
+                    return part;
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<OverviewProjectionResult> ExecuteOverviewDistributionAsync(
+            string eligibleTable,
+            IReadOnlyList<string> bandTables,
+            LicenceActivityQuery query,
+            LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics,
+            CancellationToken cancellationToken)
+        {
+            return await ExecuteOverviewSqlAsync(
+                LicenceActivitySql.BuildOverviewDistributions(eligibleTable, bandTables),
+                "distributions",
+                query,
+                sources,
+                diagnostics,
+                async reader =>
+                {
+                    var result = new OverviewProjectionResult();
+                    await RequireResultAsync(
+                        reader, true, cancellationToken,
+                        "LicenceTypeId", "Workload", "High", "Unknown").ConfigureAwait(false);
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        result.LicenceDistributions.Add(new LicenceDistributionRow
+                        {
+                            LicenceTypeId = ReadInt32(reader, "LicenceTypeId"),
+                            Distribution = ReadDistribution(reader)
+                        });
+                    }
+
+                    await RequireResultAsync(
+                        reader, false, cancellationToken,
+                        "Dimension", "Id", "Workload", "High", "Unknown").ConfigureAwait(false);
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        result.DemographicDistributions.Add(new DemographicDistributionRow
+                        {
+                            Dimension = ReadString(reader, "Dimension"),
+                            Id = ReadInt32(reader, "Id"),
+                            Distribution = ReadDistribution(reader)
+                        });
+                    }
+
+                    await RequireResultAsync(
+                        reader, false, cancellationToken,
+                        "DistinctAssignedUsers", "DemographicsTruncated").ConfigureAwait(false);
+                    if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                        throw new InvalidOperationException("The licence activity base summary was not returned.");
+                    result.Base.DistinctAssignedUsers = ReadInt32(reader, "DistinctAssignedUsers");
+                    result.Base.DemographicsTruncated = ReadBoolean(reader, "DemographicsTruncated");
+
+                    await RequireResultAsync(
+                        reader, false, cancellationToken,
+                        "LicenceTypeId", "Name", "SkuId", "AssignedUsers").ConfigureAwait(false);
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        result.Base.Licences.Add(new LicenceActivitySku
+                        {
+                            LicenceTypeId = ReadInt32(reader, "LicenceTypeId"),
+                            Name = ReadNullableString(reader, "Name"),
+                            SkuId = ReadNullableString(reader, "SkuId"),
+                            AssignedUsers = ReadInt32(reader, "AssignedUsers")
+                        });
+                    }
+
+                    await RequireResultAsync(
+                        reader, false, cancellationToken,
+                        "Dimension", "Id", "Name", "AssignedUsers").ConfigureAwait(false);
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        result.Base.Demographics.Add(new DemographicRow
+                        {
+                            Dimension = ReadString(reader, "Dimension"),
+                            Value = new LicenceActivityDemographic
+                            {
+                                Id = ReadInt32(reader, "Id"),
+                                Name = ReadString(reader, "Name"),
+                                AssignedUsers = ReadInt32(reader, "AssignedUsers")
+                            }
+                        });
+                    }
+                    await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
+                    return result;
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+
+                private async Task<OverviewPart> ExecuteOverviewPartAsync(
+                    string sql,
+                    string operation,
+                    LicenceActivityQuery query,
+                    LicenceActivitySources sources,
+                    ILicenceActivityDiagnostics diagnostics,
+                    CancellationToken cancellationToken)
+                {
+                    return await ExecuteOverviewSqlAsync(
+                        sql,
+                        operation,
+                        query,
+                        sources,
+                        diagnostics,
+                        async reader =>
+                        {
+                            var part = new OverviewPart();
+                            await RequireResultAsync(
+                                reader, true, cancellationToken,
+                                "Workload", "Status", "Source", "ExpectedSamples").ConfigureAwait(false);
+                            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                                throw new InvalidOperationException("A licence activity workload coverage row was not returned.");
+                            part.Coverage = new LicenceActivityCoverage
+                            {
+                                Workload = ReadString(reader, "Workload"),
+                                Status = ReadString(reader, "Status"),
+                                Source = ReadString(reader, "Source"),
+                                Measure = ReadString(reader, "Measure"),
+                                Granularity = ReadString(reader, "Granularity"),
+                                Message = ReadNullableString(reader, "Message"),
+                                EffectiveFromUtc = ReadNullableUtc(reader, "EffectiveFromUtc"),
+                                EffectiveToUtc = ReadNullableUtc(reader, "EffectiveToUtc"),
+                                LatestImportUtc = ReadNullableUtc(reader, "LatestImportUtc"),
+                                LagDays = ReadInt32(reader, "LagDays"),
+                                ReportPeriodDays = ReadNullableInt32(reader, "ReportPeriodDays"),
+                                ExpectedSamples = ReadInt32(reader, "ExpectedSamples"),
+                                ObservedSamples = ReadInt32(reader, "ObservedSamples"),
+                                UnmatchedUsers = ReadInt32(reader, "UnmatchedUsers")
+                            };
+
+                            await RequireResultAsync(
+                                reader, false, cancellationToken,
+                                "WorkloadName", "SnapshotDate").ConfigureAwait(false);
+                            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                                part.Coverage.SnapshotDates.Add(ReadUtc(reader, "SnapshotDate"));
+
+                            await RequireResultAsync(
+                                reader, false, cancellationToken,
+                                "LicenceTypeId", "Workload", "High", "Unknown").ConfigureAwait(false);
+                            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                            {
+                                part.LicenceDistributions.Add(new LicenceDistributionRow
+                                {
+                                    LicenceTypeId = ReadInt32(reader, "LicenceTypeId"),
+                                    Distribution = ReadDistribution(reader)
+                                });
+                            }
+
+                            await RequireResultAsync(
+                                reader, false, cancellationToken,
+                                "Dimension", "Id", "Workload", "High", "Unknown").ConfigureAwait(false);
+                            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                            {
+                                part.DemographicDistributions.Add(new DemographicDistributionRow
+                                {
+                                    Dimension = ReadString(reader, "Dimension"),
+                                    Id = ReadInt32(reader, "Id"),
+                                    Distribution = ReadDistribution(reader)
+                                });
+                            }
+
+                            if (operation == "teams"
+                                || operation == "copilot"
+                                || operation == "distribution-teams")
+                            {
+                                part.Base = new OverviewBase();
+                                await RequireResultAsync(
+                                    reader, false, cancellationToken,
+                                    "DistinctAssignedUsers", "DemographicsTruncated").ConfigureAwait(false);
+                                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                                    throw new InvalidOperationException("The licence activity base summary was not returned.");
+                                part.Base.DistinctAssignedUsers = ReadInt32(reader, "DistinctAssignedUsers");
+                                part.Base.DemographicsTruncated = ReadBoolean(reader, "DemographicsTruncated");
+
+                                await RequireResultAsync(
+                                    reader, false, cancellationToken,
+                                    "LicenceTypeId", "Name", "SkuId", "AssignedUsers").ConfigureAwait(false);
+                                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                                {
+                                    part.Base.Licences.Add(new LicenceActivitySku
+                                    {
+                                        LicenceTypeId = ReadInt32(reader, "LicenceTypeId"),
+                                        Name = ReadNullableString(reader, "Name"),
+                                        SkuId = ReadNullableString(reader, "SkuId"),
+                                        AssignedUsers = ReadInt32(reader, "AssignedUsers")
+                                    });
+                                }
+
+                                await RequireResultAsync(
+                                    reader, false, cancellationToken,
+                                    "Dimension", "Id", "Name", "AssignedUsers").ConfigureAwait(false);
+                                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                                {
+                                    part.Base.Demographics.Add(new DemographicRow
+                                    {
+                                        Dimension = ReadString(reader, "Dimension"),
+                                        Value = new LicenceActivityDemographic
+                                        {
+                                            Id = ReadInt32(reader, "Id"),
+                                            Name = ReadString(reader, "Name"),
+                                            AssignedUsers = ReadInt32(reader, "AssignedUsers")
+                                        }
+                                    });
+                                }
+                            }
+                            await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
+                            return part;
+                        },
+                        cancellationToken).ConfigureAwait(false);
+                }
+
+                private async Task<T> ExecuteOverviewSqlAsync<T>(
+                    string sql,
+                    string operation,
+                    LicenceActivityQuery query,
+                    LicenceActivitySources sources,
+                    ILicenceActivityDiagnostics diagnostics,
+                    Func<SqlDataReader, Task<T>> materialize,
+                    CancellationToken cancellationToken)
+                {
+                    await OverviewSqlSlots.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    var operationWatch = Stopwatch.StartNew();
+                    try
+                    {
+                        using (var connection = new SqlConnection(_connectionString))
+                        {
+                            var connectionWatch = Stopwatch.StartNew();
+                            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                            connectionWatch.Stop();
+                            if (_instrumentation?.ConnectionOpenedForOperation != null)
+                                _instrumentation.ConnectionOpenedForOperation(connection, operation);
+                            else
+                                _instrumentation?.ConnectionOpened?.Invoke(connection);
+                            diagnostics.Stage("ConnectionOpened", connectionWatch.ElapsedMilliseconds);
+
+                            using (var command = new SqlCommand(sql, connection)
+                            {
+                                CommandTimeout = _instrumentation?.CommandTimeoutSeconds
+                                    ?? LicenceActivitySql.CommandTimeoutSeconds
+                            })
+                            {
+                                AddScopeParameters(command, query, sources);
+                                using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+                                    return await materialize(reader).ConfigureAwait(false);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        operationWatch.Stop();
+                        _instrumentation?.OperationCompleted?.Invoke(
+                            operation, operationWatch.ElapsedMilliseconds);
+                        OverviewSqlSlots.Release();
+                    }
+                }
+
+                private static LicenceActivityOverview MergeOverview(
+                    OverviewBase baseResult,
+                    IEnumerable<OverviewPart> loadedParts,
+                    LicenceActivityQuery query,
+                    LicenceActivitySources sources)
+                {
+                    var overview = new LicenceActivityOverview
+                    {
+                        Query = query,
+                        DistinctAssignedUsers = baseResult.DistinctAssignedUsers,
+                        DemographicsTruncated = baseResult.DemographicsTruncated,
+                        Licences = baseResult.Licences
+                    };
+
+                    foreach (var row in baseResult.Demographics)
+                    {
+                        if (row.Dimension == "department") overview.Departments.Add(row.Value);
+                        else overview.Countries.Add(row.Value);
+                    }
+
+                    var parts = loadedParts.ToList();
+                    if (!sources.UsageReports)
+                    {
+                        for (var workload = LicenceActivitySql.Teams;
+                            workload <= LicenceActivitySql.SharePoint;
+                            workload++)
+                        {
+                            parts.Add(DisabledM365Part(workload, query));
+                        }
+                    }
+
+                    var licences = overview.Licences.ToDictionary(l => l.LicenceTypeId);
+                    var demographics = baseResult.Demographics.ToDictionary(
+                        d => DemographicKey(d.Dimension, d.Value.Id),
+                        d => d.Value,
+                        StringComparer.Ordinal);
+
+                    foreach (var part in parts.OrderBy(p => LicenceActivitySql.WorkloadId(p.Coverage.Workload)))
+                    {
+                        overview.Coverage.Add(part.Coverage);
+                        foreach (var distribution in part.LicenceDistributions)
+                        {
+                            LicenceActivitySku licence;
+                            if (licences.TryGetValue(distribution.LicenceTypeId, out licence))
+                                licence.Workloads.Add(distribution.Distribution);
+                        }
+                        foreach (var distribution in part.DemographicDistributions)
+                        {
+                            LicenceActivityDemographic demographic;
+                            if (demographics.TryGetValue(
+                                DemographicKey(distribution.Dimension, distribution.Id),
+                                out demographic))
+                            {
+                                demographic.Workloads.Add(distribution.Distribution);
+                            }
+                        }
+                    }
+
+                    foreach (var licence in overview.Licences)
+                    {
+                        if (licence.Workloads.Count > 0)
+                        {
+                            licence.AssignedUsers = licence.Workloads.Max(w =>
+                                w.High + w.Moderate + w.Low + w.Zero + w.Unknown);
+                        }
+                        foreach (var workload in LicenceActivityQuery.Workloads)
+                        {
+                            if (!licence.Workloads.Any(w => w.Workload == workload))
+                            {
+                                licence.Workloads.Add(new LicenceActivityDistribution
+                                {
+                                    Workload = workload,
+                                    Unknown = licence.AssignedUsers
+                                });
+                            }
+                        }
+                        licence.Workloads = licence.Workloads
+                            .OrderBy(w => LicenceActivitySql.WorkloadId(w.Workload)).ToList();
+                    }
+                    foreach (var demographic in overview.Departments.Concat(overview.Countries))
+                    {
+                        foreach (var workload in LicenceActivityQuery.Workloads)
+                        {
+                            if (!demographic.Workloads.Any(w => w.Workload == workload))
+                            {
+                                demographic.Workloads.Add(new LicenceActivityDistribution
+                                {
+                                    Workload = workload,
+                                    Unknown = demographic.AssignedUsers
+                                });
+                            }
+                        }
+                        demographic.Workloads = demographic.Workloads
+                            .OrderBy(w => LicenceActivitySql.WorkloadId(w.Workload)).ToList();
+                    }
+
+                    if (overview.Licences.Count == 0)
+                        overview.Messages.Add("No imported licence types are available.");
+                    else if (overview.DistinctAssignedUsers == 0)
+                        overview.Messages.Add("Licence types are imported, but no users in the selected scope currently hold one.");
+                    overview.Messages.Add(
+                        "User display names are not imported by this solution. Individual results use the user principal name; search also checks the stored mail address.");
+                    foreach (var coverage in overview.Coverage.Where(c => c.Status != LicenceActivitySql.Available))
+                    {
+                        if (!string.IsNullOrWhiteSpace(coverage.Message))
+                            overview.Messages.Add(coverage.Workload + ": " + coverage.Message);
+                    }
+                    if (overview.DemographicsTruncated)
+                        overview.Messages.Add("Department or country breakdowns are limited to the 50 largest values.");
+                    return overview;
+                }
+
+        private static void MergeOverviewIntoOverview(
+            LicenceActivityOverview overview,
+            LicenceActivityOverview additional)
+        {
+            overview.Coverage.AddRange(additional.Coverage);
+
+            var licences = overview.Licences.ToDictionary(licence => licence.LicenceTypeId);
+            foreach (var additionalLicence in additional.Licences)
+            {
+                LicenceActivitySku licence;
+                if (licences.TryGetValue(additionalLicence.LicenceTypeId, out licence))
+                    licence.Workloads.AddRange(additionalLicence.Workloads);
+            }
+
+            var demographics = overview.Departments
+                .Select(value => new { Dimension = "department", Value = value })
+                .Concat(overview.Countries.Select(
+                    value => new { Dimension = "country", Value = value }))
+                .ToDictionary(
+                    item => DemographicKey(item.Dimension, item.Value.Id),
+                    item => item.Value,
+                    StringComparer.Ordinal);
+            foreach (var item in additional.Departments.Select(
+                         value => new { Dimension = "department", Value = value })
+                     .Concat(additional.Countries.Select(
+                         value => new { Dimension = "country", Value = value })))
+            {
+                LicenceActivityDemographic demographic;
+                if (demographics.TryGetValue(
+                    DemographicKey(item.Dimension, item.Value.Id),
+                    out demographic))
+                {
+                    demographic.Workloads.AddRange(item.Value.Workloads);
+                }
+            }
+        }
+
+        private static void MergePartIntoOverview(
+            LicenceActivityOverview overview,
+            OverviewPart part)
+        {
+            overview.Coverage.Add(part.Coverage);
+            overview.Coverage = overview.Coverage
+                .OrderBy(coverage => LicenceActivitySql.WorkloadId(coverage.Workload))
+                .ToList();
+
+            var licences = overview.Licences.ToDictionary(licence => licence.LicenceTypeId);
+            foreach (var distribution in part.LicenceDistributions)
+            {
+                LicenceActivitySku licence;
+                if (licences.TryGetValue(distribution.LicenceTypeId, out licence))
+                    licence.Workloads.Add(distribution.Distribution);
+            }
+
+            var demographics = overview.Departments
+                .Select(value => new { Dimension = "department", Value = value })
+                .Concat(overview.Countries.Select(
+                    value => new { Dimension = "country", Value = value }))
+                .ToDictionary(
+                    item => DemographicKey(item.Dimension, item.Value.Id),
+                    item => item.Value,
+                    StringComparer.Ordinal);
+            foreach (var distribution in part.DemographicDistributions)
+            {
+                LicenceActivityDemographic demographic;
+                if (demographics.TryGetValue(
+                    DemographicKey(distribution.Dimension, distribution.Id),
+                    out demographic))
+                {
+                    demographic.Workloads.Add(distribution.Distribution);
+                }
+            }
+
+            foreach (var licence in overview.Licences)
+            {
+                if (!licence.Workloads.Any(
+                    distribution => distribution.Workload == part.Coverage.Workload))
+                {
+                    licence.Workloads.Add(new LicenceActivityDistribution
+                    {
+                        Workload = part.Coverage.Workload,
+                        Unknown = licence.AssignedUsers
+                    });
+                }
+                licence.Workloads = licence.Workloads
+                    .OrderBy(distribution => LicenceActivitySql.WorkloadId(distribution.Workload))
+                    .ToList();
+            }
+            foreach (var demographic in overview.Departments.Concat(overview.Countries))
+            {
+                if (!demographic.Workloads.Any(
+                    distribution => distribution.Workload == part.Coverage.Workload))
+                {
+                    demographic.Workloads.Add(new LicenceActivityDistribution
+                    {
+                        Workload = part.Coverage.Workload,
+                        Unknown = demographic.AssignedUsers
+                    });
+                }
+                demographic.Workloads = demographic.Workloads
+                    .OrderBy(distribution => LicenceActivitySql.WorkloadId(distribution.Workload))
+                    .ToList();
+            }
+
+            overview.Messages.Clear();
+            if (overview.Licences.Count == 0)
+                overview.Messages.Add("No imported licence types are available.");
+            else if (overview.DistinctAssignedUsers == 0)
+                overview.Messages.Add("Licence types are imported, but no users in the selected scope currently hold one.");
+            overview.Messages.Add(
+                "User display names are not imported by this solution. Individual results use the user principal name; search also checks the stored mail address.");
+            foreach (var coverage in overview.Coverage.Where(
+                coverage => coverage.Status != LicenceActivitySql.Available))
+            {
+                if (!string.IsNullOrWhiteSpace(coverage.Message))
+                    overview.Messages.Add(coverage.Workload + ": " + coverage.Message);
+            }
+            if (overview.DemographicsTruncated)
+                overview.Messages.Add("Department or country breakdowns are limited to the 50 largest values.");
+        }
+
+        private static OverviewPart DisabledM365Part(int workload, LicenceActivityQuery query)
+                {
+                    return new OverviewPart
+                    {
+                        Coverage = new LicenceActivityCoverage
+                        {
+                            Workload = LicenceActivitySql.WorkloadName(workload),
+                            Status = LicenceActivitySql.Disabled,
+                            Source = LicenceActivitySql.M365ReportSource,
+                            Measure = "published usage-report snapshot evidence",
+                            Granularity = "weeklySupportingSnapshot",
+                            Message = "The Microsoft 365 usage-report import is disabled. Absence cannot be interpreted as zero.",
+                            ExpectedSamples = WeekPortionCount(query)
+                        }
+                    };
+                }
+
+        private static int WeekPortionCount(LicenceActivityQuery query)
+                {
+                    var first = query.FromUtc.Date.AddDays(-(((int)query.FromUtc.DayOfWeek + 6) % 7));
+                    var count = 0;
+                    for (var date = first; date <= query.ToUtc.Date; date = date.AddDays(7)) count++;
+                    return count;
+        }
+
+        private static void AddScopeParameters(
+            SqlCommand command,
+            LicenceActivityQuery query,
+            LicenceActivitySources sources)
+        {
+            AddDate(command, "@from", query.FromUtc);
+            AddDate(command, "@to", query.ToUtc);
+            AddDate(command, "@endExclusive", query.EndExclusiveUtc);
+            AddDate(command, "@settled", sources.NowUtc.Date.AddDays(-3));
+            AddDate(command, "@now", sources.NowUtc.Date);
+            AddNullableInt(command, "@departmentId", query.DepartmentId);
+            AddNullableInt(command, "@countryId", query.CountryId);
+        }
+
+        private static void AddUserParameters(
+            SqlCommand command,
+            LicenceActivityOverview overview,
+            LicenceActivityQuery query,
+            LicenceActivitySources sources)
+        {
+            AddScopeParameters(command, query, sources);
+            command.Parameters.Add("@licenceTypeId", SqlDbType.Int).Value = query.LicenceTypeId.Value;
+            command.Parameters.Add("@top", SqlDbType.Int).Value = query.Top;
+            command.Parameters.Add("@offset", SqlDbType.Int).Value = (query.Page - 1) * query.PageSize;
+            command.Parameters.Add("@pageSize", SqlDbType.Int).Value = query.PageSize;
+
+            var escapedSearch = EscapeLikeValue(query.Search);
+            command.Parameters.Add("@searchPattern", SqlDbType.NVarChar, 202).Value =
+                escapedSearch.Length == 0 ? string.Empty : "%" + escapedSearch + "%";
+
+            var byWorkload = overview.Coverage.ToDictionary(c => c.Workload, StringComparer.Ordinal);
+            for (var workload = LicenceActivitySql.Teams; workload <= LicenceActivitySql.Copilot; workload++)
+            {
+                var name = LicenceActivitySql.WorkloadName(workload);
+                LicenceActivityCoverage coverage;
+                if (!byWorkload.TryGetValue(name, out coverage))
+                {
+                    coverage = new LicenceActivityCoverage
+                    {
+                        Workload = name,
+                        Status = LicenceActivitySql.MissingCoverage,
+                        Source = string.Empty,
+                        Measure = string.Empty
+                    };
+                }
+
+                command.Parameters.Add("@status" + workload, SqlDbType.VarChar, 32).Value =
+                    coverage.Status ?? LicenceActivitySql.MissingCoverage;
+                command.Parameters.Add("@source" + workload, SqlDbType.VarChar, 64).Value =
+                    coverage.Source ?? string.Empty;
+                command.Parameters.Add("@measure" + workload, SqlDbType.NVarChar, 240).Value =
+                    coverage.Measure ?? string.Empty;
+                command.Parameters.Add("@expected" + workload, SqlDbType.Int).Value =
+                    coverage.ExpectedSamples;
+                command.Parameters.Add("@observed" + workload, SqlDbType.Int).Value =
+                    coverage.ObservedSamples;
+                command.Parameters.Add("@period" + workload, SqlDbType.Int).Value =
+                    coverage.ReportPeriodDays.HasValue
+                        ? (object)coverage.ReportPeriodDays.Value
+                        : DBNull.Value;
+
+                if (coverage.SnapshotDates == null) continue;
+                for (var index = 0; index < coverage.SnapshotDates.Count; index++)
+                {
+                    AddDate(
+                        command,
+                        LicenceActivitySql.SampleParameterName(workload, index),
+                        coverage.SnapshotDates[index]);
+                }
+            }
+        }
+
+        private async Task<LicenceActivityOverview> ReadOverviewAsync(
+            SqlDataReader reader,
+            LicenceActivityQuery query,
+            ILicenceActivityDiagnostics diagnostics,
+            CancellationToken cancellationToken)
+        {
+            var overview = new LicenceActivityOverview { Query = query };
+
+            await RequireResultAsync(
+                reader, true, cancellationToken, "DistinctAssignedUsers", "DemographicsTruncated")
+                .ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                throw new InvalidOperationException("The licence activity overview summary was not returned.");
+            overview.DistinctAssignedUsers = ReadInt32(reader, "DistinctAssignedUsers");
+            overview.DemographicsTruncated = ReadBoolean(reader, "DemographicsTruncated");
+
+            await RequireResultAsync(
+                reader, false, cancellationToken, "Workload", "Status", "Source", "ExpectedSamples")
+                .ConfigureAwait(false);
+            var coverageByWorkload = new Dictionary<string, LicenceActivityCoverage>(StringComparer.Ordinal);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var coverage = new LicenceActivityCoverage
+                {
+                    Workload = ReadString(reader, "Workload"),
+                    Status = ReadString(reader, "Status"),
+                    Source = ReadString(reader, "Source"),
+                    Measure = ReadString(reader, "Measure"),
+                    Granularity = ReadString(reader, "Granularity"),
+                    Message = ReadNullableString(reader, "Message"),
+                    EffectiveFromUtc = ReadNullableUtc(reader, "EffectiveFromUtc"),
+                    EffectiveToUtc = ReadNullableUtc(reader, "EffectiveToUtc"),
+                    LatestImportUtc = ReadNullableUtc(reader, "LatestImportUtc"),
+                    LagDays = ReadInt32(reader, "LagDays"),
+                    ReportPeriodDays = ReadNullableInt32(reader, "ReportPeriodDays"),
+                    ExpectedSamples = ReadInt32(reader, "ExpectedSamples"),
+                    ObservedSamples = ReadInt32(reader, "ObservedSamples"),
+                    UnmatchedUsers = ReadInt32(reader, "UnmatchedUsers")
+                };
+                overview.Coverage.Add(coverage);
+                coverageByWorkload[coverage.Workload] = coverage;
+            }
+
+            await RequireResultAsync(
+                reader, false, cancellationToken, "WorkloadName", "SnapshotDate")
+                .ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                LicenceActivityCoverage coverage;
+                if (coverageByWorkload.TryGetValue(ReadString(reader, "WorkloadName"), out coverage))
+                    coverage.SnapshotDates.Add(ReadUtc(reader, "SnapshotDate"));
+            }
+
+            await RequireResultAsync(
+                reader, false, cancellationToken, "LicenceTypeId", "Name", "SkuId", "AssignedUsers")
+                .ConfigureAwait(false);
+            var licencesById = new Dictionary<int, LicenceActivitySku>();
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var licence = new LicenceActivitySku
+                {
+                    LicenceTypeId = ReadInt32(reader, "LicenceTypeId"),
+                    Name = ReadNullableString(reader, "Name"),
+                    SkuId = ReadNullableString(reader, "SkuId"),
+                    AssignedUsers = ReadInt32(reader, "AssignedUsers")
+                };
+                overview.Licences.Add(licence);
+                licencesById[licence.LicenceTypeId] = licence;
+            }
+
+            await RequireResultAsync(
+                reader, false, cancellationToken, "LicenceTypeId", "Workload", "High", "Unknown")
+                .ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                LicenceActivitySku licence;
+                if (licencesById.TryGetValue(ReadInt32(reader, "LicenceTypeId"), out licence))
+                    licence.Workloads.Add(ReadDistribution(reader));
+            }
+
+            await RequireResultAsync(
+                reader, false, cancellationToken, "Dimension", "Id", "Name", "AssignedUsers")
+                .ConfigureAwait(false);
+            var demographics = new Dictionary<string, LicenceActivityDemographic>(StringComparer.Ordinal);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var dimension = ReadString(reader, "Dimension");
+                var demographic = new LicenceActivityDemographic
+                {
+                    Id = ReadInt32(reader, "Id"),
+                    Name = ReadString(reader, "Name"),
+                    AssignedUsers = ReadInt32(reader, "AssignedUsers")
+                };
+                if (dimension == "department")
+                    overview.Departments.Add(demographic);
+                else
+                    overview.Countries.Add(demographic);
+                demographics[DemographicKey(dimension, demographic.Id)] = demographic;
+            }
+
+            await RequireResultAsync(
+                reader, false, cancellationToken, "Dimension", "Id", "Workload", "High", "Unknown")
+                .ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                LicenceActivityDemographic demographic;
+                var key = DemographicKey(ReadString(reader, "Dimension"), ReadInt32(reader, "Id"));
+                if (demographics.TryGetValue(key, out demographic))
+                    demographic.Workloads.Add(ReadDistribution(reader));
+            }
+            await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
+
+            if (overview.Licences.Count == 0)
+                overview.Messages.Add("No imported licence types are available.");
+            else if (overview.DistinctAssignedUsers == 0)
+                overview.Messages.Add("Licence types are imported, but no users in the selected scope currently hold one.");
+
+            overview.Messages.Add(
+                "User display names are not imported by this solution. Individual results use the user principal name; search also checks the stored mail address.");
+
+            foreach (var coverage in overview.Coverage.Where(c => c.Status != LicenceActivitySql.Available))
+            {
+                if (!string.IsNullOrWhiteSpace(coverage.Message))
+                    overview.Messages.Add(coverage.Workload + ": " + coverage.Message);
+            }
+
+            if (overview.DemographicsTruncated)
+                overview.Messages.Add("Department or country breakdowns are limited to the 50 largest values.");
+
+            diagnostics.Stage("ProjectionCompleted");
+            return overview;
+        }
+
+        private async Task<LicenceActivityUsers> ReadUsersAsync(
+            SqlDataReader reader,
+            LicenceActivityOverview overview,
+            LicenceActivityQuery query,
+            ILicenceActivityDiagnostics diagnostics,
+            CancellationToken cancellationToken)
+        {
+            var result = new LicenceActivityUsers
+            {
+                OverviewId = overview.SnapshotId,
+                Query = query
+            };
+
+            await RequireResultAsync(reader, true, cancellationToken, "TotalUsers", "RankedUsers")
+                .ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                throw new InvalidOperationException("The licence activity user summary was not returned.");
+            result.TotalUsers = ReadInt32(reader, "TotalUsers");
+            result.RankedUsers = ReadInt32(reader, "RankedUsers");
+
+            await RequireResultAsync(
+                reader, false, cancellationToken, "ListKind", "Ordinal", "UserId", "TeamsActiveSamples")
+                .ConfigureAwait(false);
+            var coverage = overview.Coverage.ToDictionary(c => c.Workload, StringComparer.Ordinal);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var user = ReadUser(reader, coverage);
+                switch (ReadInt32(reader, "ListKind"))
+                {
+                    case 1:
+                        result.MostActive.Add(user);
+                        break;
+                    case 2:
+                        result.LeastActive.Add(user);
+                        break;
+                    case 3:
+                        result.Users.Add(user);
+                        break;
+                }
+            }
+            await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
+
+            result.Messages.Add(
+                "Most/least lists rank the selected workload by active supporting samples, then average actions and last activity. Complete positive measurements rank before partial positive evidence, which still ranks above measured zero; unknown or incomplete evidence is excluded from least-active.");
+
+            LicenceActivityCoverage selectedCoverage;
+            if (coverage.TryGetValue(query.Workload, out selectedCoverage)
+                && selectedCoverage.Status != LicenceActivitySql.Available
+                && !string.IsNullOrWhiteSpace(selectedCoverage.Message))
+            {
+                result.Messages.Add(selectedCoverage.Message);
+            }
+            if (result.TotalUsers > 0 && result.RankedUsers == 0)
+                result.Messages.Add("No user has complete or positive evidence for the selected workload and range.");
+
+            diagnostics.Stage("ProjectionCompleted");
+            return result;
+        }
+
+        private static LicenceActivityUser ReadUser(
+            SqlDataReader reader,
+            IReadOnlyDictionary<string, LicenceActivityCoverage> coverage)
+        {
+            var user = new LicenceActivityUser
+            {
+                UserId = ReadInt32(reader, "UserId"),
+                UserPrincipalName = ReadString(reader, "UserPrincipalName"),
+                Department = ReadNullableString(reader, "Department"),
+                Country = ReadNullableString(reader, "Country"),
+                AccountEnabled = ReadNullableBoolean(reader, "AccountEnabled")
+            };
+
+            AddEvidence(user, reader, coverage, "teams", "Teams");
+            AddEvidence(user, reader, coverage, "outlook", "Outlook");
+            AddEvidence(user, reader, coverage, "onedrive", "OneDrive");
+            AddEvidence(user, reader, coverage, "sharepoint", "SharePoint");
+            AddEvidence(user, reader, coverage, "copilot", "Copilot");
+            return user;
+        }
+
+        private static void AddEvidence(
+            LicenceActivityUser user,
+            SqlDataReader reader,
+            IReadOnlyDictionary<string, LicenceActivityCoverage> coverageByWorkload,
+            string workload,
+            string columnPrefix)
+        {
+            LicenceActivityCoverage coverage;
+            if (!coverageByWorkload.TryGetValue(workload, out coverage))
+            {
+                coverage = new LicenceActivityCoverage
+                {
+                    Workload = workload,
+                    Status = LicenceActivitySql.MissingCoverage,
+                    Source = string.Empty,
+                    Measure = string.Empty
+                };
+            }
+
+            var active = ReadInt32(reader, columnPrefix + "ActiveSamples");
+            var status = coverage.Status ?? LicenceActivitySql.MissingCoverage;
+            var observedSamples = coverage.ObservedSamples;
+            if (coverage.Source == LicenceActivitySql.M365ReportSource
+                || coverage.Source == LicenceActivitySql.CopilotReportSource)
+            {
+                var rowPresent = ReadBoolean(reader, columnPrefix + "RowPresent");
+                observedSamples = ReadInt32(reader, columnPrefix + "ObservedSamples");
+                if (status == LicenceActivitySql.Available)
+                {
+                    if (!rowPresent)
+                        status = LicenceActivitySql.MissingCoverage;
+                    else if (!ReadBoolean(reader, columnPrefix + "FrequencyKnown")
+                        || observedSamples != coverage.ExpectedSamples)
+                        status = LicenceActivitySql.Partial;
+                }
+            }
+
+            user.Workloads.Add(new LicenceActivityEvidence
+            {
+                Workload = workload,
+                Status = status,
+                Band = status == LicenceActivitySql.Available
+                    ? LicenceActivityRules.Band(active, observedSamples, coverage.ExpectedSamples)
+                    : "unknown",
+                Source = coverage.Source,
+                Measure = coverage.Measure,
+                ActiveSamples = active,
+                ObservedSamples = observedSamples,
+                ExpectedSamples = coverage.ExpectedSamples,
+                AverageActions = ReadNullableDouble(reader, columnPrefix + "AverageActions"),
+                LastActivityUtc = ReadNullableUtc(reader, columnPrefix + "LastActivityUtc")
+            });
+        }
+
+        private async Task RequireResultAsync(
+            SqlDataReader reader,
+            bool includeCurrent,
+            CancellationToken cancellationToken,
+            params string[] requiredColumns)
+        {
+            var hasResult = includeCurrent || await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+            while (hasResult)
+            {
+                if (HasColumns(reader, requiredColumns)) return;
+                await CaptureShowplanAsync(reader, cancellationToken).ConfigureAwait(false);
+                hasResult = await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            throw new InvalidOperationException(
+                "The licence activity SQL batch did not return the expected bounded result set.");
+        }
+
+        private async Task CaptureShowplanAsync(
+            SqlDataReader reader,
+            CancellationToken cancellationToken)
+        {
+            if (_instrumentation?.ShowplanReceived == null
+                || reader.FieldCount != 1
+                || (reader.GetName(0).IndexOf("Showplan", StringComparison.OrdinalIgnoreCase) < 0
+                    && reader.GetFieldType(0) != typeof(SqlXml)))
+                return;
+
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (!reader.IsDBNull(0))
+                {
+                    var value = reader.GetValue(0);
+                    var xml = value is SqlXml
+                        ? ((SqlXml)value).Value
+                        : Convert.ToString(value);
+                    _instrumentation.ShowplanReceived(xml);
+                }
+            }
+        }
+
+        private async Task DrainRemainingResultsAsync(
+            SqlDataReader reader,
+            CancellationToken cancellationToken)
+        {
+            while (await reader.NextResultAsync(cancellationToken).ConfigureAwait(false))
+                await CaptureShowplanAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static bool HasColumns(SqlDataReader reader, IEnumerable<string> columns)
+        {
+            if (reader.FieldCount == 0) return false;
+            var present = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 0; index < reader.FieldCount; index++)
+                present.Add(reader.GetName(index));
+            return columns.All(present.Contains);
+        }
+
+        private static LicenceActivityDistribution ReadDistribution(SqlDataReader reader)
+        {
+            return new LicenceActivityDistribution
+            {
+                Workload = ReadString(reader, "Workload"),
+                High = ReadInt32(reader, "High"),
+                Moderate = ReadInt32(reader, "Moderate"),
+                Low = ReadInt32(reader, "Low"),
+                Zero = ReadInt32(reader, "Zero"),
+                Unknown = ReadInt32(reader, "Unknown")
+            };
+        }
+
+        private static string DemographicKey(string dimension, int id)
+        {
+            return dimension + ":" + id;
+        }
+
+        private static string EscapeLikeValue(string value)
+        {
+            return (value ?? string.Empty)
+                .Replace(@"\", @"\\")
+                .Replace("%", @"\%")
+                .Replace("_", @"\_")
+                .Replace("[", @"\[");
+        }
+
+        private static void AddDate(SqlCommand command, string name, DateTime value)
+        {
+            command.Parameters.Add(name, SqlDbType.Date).Value = value.Date;
+        }
+
+        private static void AddNullableInt(SqlCommand command, string name, int? value)
+        {
+            command.Parameters.Add(name, SqlDbType.Int).Value =
+                value.HasValue ? (object)value.Value : DBNull.Value;
+        }
+
+        private static int ReadInt32(SqlDataReader reader, string column)
+        {
+            return Convert.ToInt32(reader.GetValue(reader.GetOrdinal(column)));
+        }
+
+        private static int? ReadNullableInt32(SqlDataReader reader, string column)
+        {
+            var ordinal = reader.GetOrdinal(column);
+            return reader.IsDBNull(ordinal) ? (int?)null : Convert.ToInt32(reader.GetValue(ordinal));
+        }
+
+        private static double? ReadNullableDouble(SqlDataReader reader, string column)
+        {
+            var ordinal = reader.GetOrdinal(column);
+            return reader.IsDBNull(ordinal) ? (double?)null : Convert.ToDouble(reader.GetValue(ordinal));
+        }
+
+        private static bool ReadBoolean(SqlDataReader reader, string column)
+        {
+            return Convert.ToBoolean(reader.GetValue(reader.GetOrdinal(column)));
+        }
+
+        private static bool? ReadNullableBoolean(SqlDataReader reader, string column)
+        {
+            var ordinal = reader.GetOrdinal(column);
+            return reader.IsDBNull(ordinal) ? (bool?)null : Convert.ToBoolean(reader.GetValue(ordinal));
+        }
+
+        private static string ReadString(SqlDataReader reader, string column)
+        {
+            return Convert.ToString(reader.GetValue(reader.GetOrdinal(column)));
+        }
+
+        private static string ReadNullableString(SqlDataReader reader, string column)
+        {
+            var ordinal = reader.GetOrdinal(column);
+            return reader.IsDBNull(ordinal) ? null : Convert.ToString(reader.GetValue(ordinal));
+        }
+
+        private static DateTime ReadUtc(SqlDataReader reader, string column)
+        {
+            return DateTime.SpecifyKind(
+                Convert.ToDateTime(reader.GetValue(reader.GetOrdinal(column))),
+                DateTimeKind.Utc);
+        }
+
+        private static DateTime? ReadNullableUtc(SqlDataReader reader, string column)
+        {
+            var ordinal = reader.GetOrdinal(column);
+            return reader.IsDBNull(ordinal)
+                ? (DateTime?)null
+                : DateTime.SpecifyKind(Convert.ToDateTime(reader.GetValue(ordinal)), DateTimeKind.Utc);
+        }
+
+        private sealed class OverviewBase
+        {
+            internal int DistinctAssignedUsers;
+            internal bool DemographicsTruncated;
+            internal List<LicenceActivitySku> Licences { get; } = new List<LicenceActivitySku>();
+            internal List<DemographicRow> Demographics { get; } = new List<DemographicRow>();
+        }
+
+        private sealed class OverviewPart
+        {
+            internal OverviewBase Base;
+            internal LicenceActivityCoverage Coverage;
+            internal List<LicenceDistributionRow> LicenceDistributions { get; } =
+                new List<LicenceDistributionRow>();
+            internal List<DemographicDistributionRow> DemographicDistributions { get; } =
+                new List<DemographicDistributionRow>();
+        }
+
+        private sealed class OverviewProjectionResult
+        {
+            internal OverviewBase Base { get; } = new OverviewBase();
+            internal List<LicenceDistributionRow> LicenceDistributions { get; } =
+                new List<LicenceDistributionRow>();
+            internal List<DemographicDistributionRow> DemographicDistributions { get; } =
+                new List<DemographicDistributionRow>();
+        }
+
+        private sealed class DemographicRow
+        {
+            internal string Dimension;
+            internal LicenceActivityDemographic Value;
+        }
+
+        private sealed class LicenceDistributionRow
+        {
+            internal int LicenceTypeId;
+            internal LicenceActivityDistribution Distribution;
+        }
+
+        private sealed class DemographicDistributionRow
+        {
+            internal string Dimension;
+            internal int Id;
+            internal LicenceActivityDistribution Distribution;
+        }
+    }
+
+    /// <summary>
+    /// Test-only hook for collecting SQL Server STATISTICS IO/TIME and XML showplans from a scratch database.
+    /// Production construction does not install one.
+    /// </summary>
+    internal sealed class SqlLicenceActivityStoreInstrumentation
+    {
+        internal Action<SqlConnection> ConnectionOpened { get; set; }
+        internal Action<SqlConnection, string> ConnectionOpenedForOperation { get; set; }
+        internal Action<string, long> OperationCompleted { get; set; }
+        internal Action<string> ShowplanReceived { get; set; }
+        internal int? CommandTimeoutSeconds { get; set; }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityApiTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityApiTests.cs
@@ -1,0 +1,253 @@
+extern alias AnalyticsWeb;
+
+using AnalyticsWeb::Web.AnalyticsWeb.Controllers;
+using AnalyticsWeb::Web.AnalyticsWeb.Models.LicenceActivity;
+using Common.Entities.LicenceActivity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class LicenceActivityApiTests
+    {
+        [TestMethod]
+        public async Task AnonymousRequestsAreDenied_AggregatesDoNotRequireTheDetailRole()
+        {
+            using (var app = new Harness())
+            {
+                app.Principal = new GenericPrincipal(new GenericIdentity(string.Empty), new string[0]);
+                Assert.AreEqual(HttpStatusCode.Unauthorized, (await app.Client.GetAsync("api/LicenceActivity/availability")).StatusCode);
+                app.Principal = SignedIn();
+                var availability = await app.Json("api/LicenceActivity/availability");
+                Assert.AreEqual(false, (bool)availability["canViewUsers"]);
+                Assert.AreEqual(true, (bool)availability["available"]);
+                var overview = await app.Json("api/LicenceActivity/overview");
+                Assert.IsNotNull(overview["snapshotId"]);
+                Assert.AreEqual(HttpStatusCode.Forbidden,
+                    (await app.Client.GetAsync("api/LicenceActivity/users?overviewId=" + overview["snapshotId"] + "&licenceTypeId=1")).StatusCode);
+                Assert.AreEqual(0, app.Store.UserCalls);
+            }
+        }
+
+        [TestMethod]
+        public async Task DisabledPrerequisite_IsExplicitAndDoesNotQueryStorage()
+        {
+            using (var app = new Harness())
+            {
+                app.Sources.UserMetadata = false;
+                var availability = await app.Json("api/LicenceActivity/availability");
+                Assert.AreEqual(false, (bool)availability["available"]);
+                StringAssert.Contains(availability["messages"].ToString(), "GraphUsersMetadata");
+                Assert.AreEqual(HttpStatusCode.PreconditionFailed, (await app.Client.GetAsync("api/LicenceActivity/overview")).StatusCode);
+                Assert.AreEqual(0, app.Store.OverviewCalls);
+            }
+        }
+
+        [TestMethod]
+        public async Task ConcurrentSameCookieRequests_ShareOneColdQueryAndReturnWithoutPolling()
+        {
+            using (var app = new Harness())
+            {
+                var entered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                app.Store.OverviewLoader = async () =>
+                {
+                    entered.TrySetResult(true);
+                    await release.Task;
+                    return LicenceActivityTests.SampleOverview();
+                };
+                var first = app.Client.GetAsync("api/LicenceActivity/overview");
+                await entered.Task;
+                var second = app.Client.GetAsync("api/LicenceActivity/overview");
+                var third = app.Client.GetAsync("api/LicenceActivity/overview");
+                release.TrySetResult(true);
+                foreach (var response in await Task.WhenAll(first, second, third))
+                {
+                    Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                    Assert.IsTrue(response.Headers.CacheControl.NoStore);
+                }
+                Assert.AreEqual(1, app.Store.OverviewCalls);
+            }
+        }
+
+        [TestMethod]
+        public async Task InvalidQueriesFailBeforeSql_CustomScopeIsInheritedByUsers()
+        {
+            using (var app = new Harness())
+            {
+                Assert.AreEqual(HttpStatusCode.BadRequest,
+                    (await app.Client.GetAsync("api/LicenceActivity/overview?from=2000-06-29&to=2000-06-30")).StatusCode);
+                Assert.AreEqual(HttpStatusCode.BadRequest,
+                    (await app.Client.GetAsync("api/LicenceActivity/overview?departmentId=not-an-integer")).StatusCode);
+                Assert.AreEqual(0, app.Store.OverviewCalls);
+                app.Principal = SignedIn(LicenceActivityAPIController.UserDetailRole);
+                var overview = await app.Json("api/LicenceActivity/overview?from=2000-05-02&to=2000-06-22&departmentId=7&countryId=0");
+                var id = (string)overview["snapshotId"];
+                var users = await app.Json("api/LicenceActivity/users?overviewId=" + id + "&licenceTypeId=1&workload=outlook&top=25&search=Contoso&page=2&pageSize=10&sort=activity&direction=desc");
+                Assert.AreEqual("2000-05-02", (string)users["query"]["from"]);
+                Assert.AreEqual("2000-06-22", (string)users["query"]["to"]);
+                Assert.AreEqual(7, (int)users["query"]["departmentId"]);
+                Assert.AreEqual(0, (int)users["query"]["countryId"]);
+                Assert.AreEqual(25, (int)users["query"]["top"]);
+                Assert.AreEqual("Contoso", (string)users["query"]["search"]);
+                Assert.AreEqual(HttpStatusCode.BadRequest,
+                    (await app.Client.GetAsync("api/LicenceActivity/users?overviewId=" + id + "&licenceTypeId=1&pageSize=101")).StatusCode);
+                Assert.AreEqual(HttpStatusCode.NotFound,
+                    (await app.Client.GetAsync("api/LicenceActivity/users?overviewId=" + id + "&licenceTypeId=999")).StatusCode);
+                Assert.AreEqual(1, app.Store.UserCalls);
+            }
+        }
+
+        [TestMethod]
+        public async Task Excel_IsTheCachedCurrentSnapshot_RechecksDetailAccess_AndRefusesExpiry()
+        {
+            using (var app = new Harness())
+            {
+                app.Principal = SignedIn(LicenceActivityAPIController.UserDetailRole);
+                var overview = await app.Json("api/LicenceActivity/overview");
+                var id = (string)overview["snapshotId"];
+                var users = await app.Json("api/LicenceActivity/users?overviewId=" + id + "&licenceTypeId=1");
+                var exportUrl = "api/LicenceActivity/export?overviewId=" + id + "&usersId=" + users["snapshotId"];
+                var export = await app.Client.GetAsync(exportUrl);
+                Assert.AreEqual(HttpStatusCode.OK, export.StatusCode);
+                Assert.AreEqual("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", export.Content.Headers.ContentType.MediaType);
+                Assert.IsTrue(export.Content.Headers.ContentDisposition.FileName.EndsWith(".xlsx"));
+                using (var zip = new ZipArchive(new MemoryStream(await export.Content.ReadAsByteArrayAsync())))
+                    Assert.IsNotNull(zip.GetEntry("xl/workbook.xml"));
+                Assert.AreEqual(1, app.Store.OverviewCalls, "Export must not run a fresh overview query.");
+                Assert.AreEqual(1, app.Store.UserCalls, "Export must not run a fresh user query.");
+                app.Principal = SignedIn();
+                Assert.AreEqual(HttpStatusCode.Forbidden, (await app.Client.GetAsync(exportUrl)).StatusCode);
+                Assert.AreEqual(HttpStatusCode.OK, (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + id)).StatusCode);
+                app.Now = app.Now.AddMinutes(6);
+                Assert.AreEqual(HttpStatusCode.Gone, (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + id)).StatusCode);
+                Assert.AreEqual(1, app.Store.OverviewCalls);
+            }
+        }
+
+        [TestMethod]
+        public async Task ExpiredUserSnapshot_CanReloadUnderTheSameOverview_AndMismatchedExportIsRejected()
+        {
+            using (var app = new Harness())
+            {
+                app.Principal = SignedIn(LicenceActivityAPIController.UserDetailRole);
+                var overview = await app.Json("api/LicenceActivity/overview");
+                var overviewId = (string)overview["snapshotId"];
+                var usersUrl = "api/LicenceActivity/users?overviewId=" + overviewId + "&licenceTypeId=1";
+                var firstUsers = await app.Json(usersUrl);
+                var firstUsersId = (string)firstUsers["snapshotId"];
+
+                // Users expire sooner than their overview. Refreshing the overview alone returns
+                // the same snapshot, so the browser must explicitly reload the current user query.
+                app.Now = app.Now.AddMinutes(2).AddSeconds(1);
+                var sameOverview = await app.Json("api/LicenceActivity/overview");
+                Assert.AreEqual(overviewId, (string)sameOverview["snapshotId"]);
+                Assert.AreEqual(HttpStatusCode.OK,
+                    (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + overviewId)).StatusCode);
+                Assert.AreEqual(HttpStatusCode.Gone,
+                    (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + overviewId + "&usersId=" + firstUsersId)).StatusCode);
+
+                var freshUsers = await app.Json(usersUrl);
+                var freshUsersId = (string)freshUsers["snapshotId"];
+                Assert.AreNotEqual(firstUsersId, freshUsersId);
+                Assert.AreEqual(HttpStatusCode.OK,
+                    (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + overviewId + "&usersId=" + freshUsersId)).StatusCode);
+                Assert.AreEqual(1, app.Store.OverviewCalls, "Reloading an expired user page must not require a different overview.");
+                Assert.AreEqual(2, app.Store.UserCalls);
+
+                var otherOverview = await app.Json("api/LicenceActivity/overview?departmentId=7");
+                Assert.AreEqual(HttpStatusCode.Conflict,
+                    (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + otherOverview["snapshotId"] + "&usersId=" + freshUsersId)).StatusCode);
+                Assert.AreEqual(HttpStatusCode.OK,
+                    (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + overviewId + "&usersId=" + freshUsersId)).StatusCode);
+                Assert.AreEqual(2, app.Store.OverviewCalls);
+                Assert.AreEqual(2, app.Store.UserCalls, "Neither a refused export nor a valid export may query storage.");
+            }
+        }
+
+        [TestMethod]
+        public async Task FailedRun_IsTerminalAndRetryable_NotAnEmptySuccessfulReport()
+        {
+            using (var app = new Harness())
+            {
+                app.Store.OverviewLoader = () => Task.FromException<LicenceActivityOverview>(new InvalidOperationException("private filter"));
+                var failed = await app.Client.GetAsync("api/LicenceActivity/overview");
+                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, failed.StatusCode);
+                Assert.AreEqual(TimeSpan.FromSeconds(5), failed.Headers.RetryAfter.Delta);
+                Assert.IsFalse((await failed.Content.ReadAsStringAsync()).Contains("private filter"));
+                app.Store.OverviewLoader = () => Task.FromResult(LicenceActivityTests.SampleOverview());
+                Assert.AreEqual(HttpStatusCode.OK, (await app.Client.GetAsync("api/LicenceActivity/overview")).StatusCode);
+                Assert.AreEqual(2, app.Store.OverviewCalls);
+            }
+        }
+
+        private static IPrincipal SignedIn(params string[] roles)
+        {
+            var identity = new ClaimsIdentity("synthetic-test");
+            identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "synthetic-reader"));
+            foreach (var role in roles) identity.AddClaim(new Claim(ClaimTypes.Role, role));
+            return new ClaimsPrincipal(identity);
+        }
+
+        private sealed class Harness : IDisposable
+        {
+            private readonly LicenceActivityHttpHost _host;
+            internal DateTime Now = LicenceActivityTests.Now;
+            internal IPrincipal Principal = SignedIn();
+            internal readonly FakeStore Store = new FakeStore();
+            internal readonly LicenceActivitySources Sources = new LicenceActivitySources
+            {
+                UserMetadata = true, UsageReports = true, NowUtc = LicenceActivityTests.Now
+            };
+            internal HttpClient Client => _host.Client;
+
+            internal Harness()
+            {
+                _host = new LicenceActivityHttpHost(Store, Sources, () => Now, () => Principal);
+            }
+
+            internal async Task<JObject> Json(string url)
+            {
+                var response = await Client.GetAsync(url);
+                var body = await response.Content.ReadAsStringAsync();
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, body);
+                return JObject.Parse(body);
+            }
+            public void Dispose() => _host.Dispose();
+        }
+
+        private sealed class FakeStore : ILicenceActivityStore
+        {
+            internal int OverviewCalls;
+            internal int UserCalls;
+            internal Func<Task<LicenceActivityOverview>> OverviewLoader = () => Task.FromResult(LicenceActivityTests.SampleOverview());
+            public Task<LicenceActivityOverview> LoadOverviewAsync(LicenceActivityQuery query, LicenceActivitySources sources,
+                ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref OverviewCalls);
+                return OverviewLoader();
+            }
+            public Task<LicenceActivityUsers> LoadUsersAsync(LicenceActivityOverview overview, LicenceActivityQuery query,
+                LicenceActivitySources sources, ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref UserCalls);
+                return Task.FromResult(new LicenceActivityUsers { TotalUsers = 3, RankedUsers = 2 });
+            }
+        }
+
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityHttpHost.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityHttpHost.cs
@@ -1,0 +1,86 @@
+extern alias AnalyticsWeb;
+
+using AnalyticsWeb::Web.AnalyticsWeb.Controllers;
+using AnalyticsWeb::Web.AnalyticsWeb.Models.LicenceActivity;
+using Common.Entities.LicenceActivity;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
+
+namespace Tests.UnitTests
+{
+    internal sealed class LicenceActivityHttpHost : IDisposable
+    {
+        private readonly HttpConfiguration _configuration;
+        private readonly HttpServer _server;
+        private readonly SemaphoreSlim _slots = new SemaphoreSlim(4, 4);
+        internal HttpClient Client { get; }
+
+        internal LicenceActivityHttpHost(
+            ILicenceActivityStore store, LicenceActivitySources sources, Func<DateTime> utcNow,
+            Func<IPrincipal> principal = null, Action<LicenceActivityDiagnosticEvent> diagnostic = null)
+        {
+            var overview = new LicenceActivitySnapshotCache<LicenceActivityOverview>(16, TimeSpan.FromMinutes(5), _slots,
+                utcNow, id => new LicenceActivityRunDiagnostics(id, item => { diagnostic?.Invoke(item); return true; }),
+                reportFailure: (id, ex) => { });
+            var users = new LicenceActivitySnapshotCache<LicenceActivityUsers>(32, TimeSpan.FromMinutes(2), _slots,
+                utcNow, id => new LicenceActivityRunDiagnostics(id, item => { diagnostic?.Invoke(item); return true; }),
+                reportFailure: (id, ex) => { });
+            _configuration = new HttpConfiguration();
+            _configuration.Services.Replace(typeof(IHttpControllerTypeResolver), new ControllerTypes());
+            _configuration.Services.Replace(typeof(IHttpControllerActivator), new ControllerActivator(() =>
+                new LicenceActivityAPIController(() => new LicenceActivityRequestContext("synthetic-scope", sources, store), overview, users)));
+            _configuration.MessageHandlers.Add(new PrincipalHandler(principal ?? Administrator));
+            _configuration.MapHttpAttributeRoutes();
+            _server = new HttpServer(_configuration);
+            Client = new HttpClient(_server) { BaseAddress = new Uri("http://localhost/") };
+            Client.DefaultRequestHeaders.Add("Cookie", "ASP.NET_SessionId=synthetic-same-browser");
+        }
+
+        private static IPrincipal Administrator()
+        {
+            var identity = new ClaimsIdentity("synthetic-load-test");
+            identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "synthetic-administrator"));
+            identity.AddClaim(new Claim(ClaimTypes.Role, LicenceActivityAPIController.UserDetailRole));
+            return new ClaimsPrincipal(identity);
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _server.Dispose();
+            _configuration.Dispose();
+            // Shared loads can outlive a cancelled HTTP caller. Do not dispose their semaphore
+            // before those loads have released it; no wait handle is created by this host.
+        }
+
+        private sealed class ControllerTypes : IHttpControllerTypeResolver
+        {
+            public ICollection<Type> GetControllerTypes(IAssembliesResolver assembliesResolver) =>
+                new[] { typeof(LicenceActivityAPIController) };
+        }
+        private sealed class ControllerActivator : IHttpControllerActivator
+        {
+            private readonly Func<IHttpController> _create;
+            internal ControllerActivator(Func<IHttpController> create) { _create = create; }
+            public IHttpController Create(HttpRequestMessage request, HttpControllerDescriptor controllerDescriptor, Type controllerType) => _create();
+        }
+        private sealed class PrincipalHandler : DelegatingHandler
+        {
+            private readonly Func<IPrincipal> _principal;
+            internal PrincipalHandler(Func<IPrincipal> principal) { _principal = principal; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                request.GetRequestContext().Principal = _principal();
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityLoadTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityLoadTests.cs
@@ -1,0 +1,488 @@
+extern alias AnalyticsWeb;
+
+using Common.Entities.LicenceActivity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests
+{
+    // Invoked by the opt-in synthetic SQL performance fixture, using the same seeded database.
+    internal static class LicenceActivityLoadTests
+    {
+        internal const int ColdBudgetMs = 15000;
+        internal const int WarmBudgetMs = 500;
+        internal const int ConcurrentBudgetMs = 25000;
+        internal const long MemoryDeltaBudgetBytes = 128L * 1024 * 1024;
+
+        internal static async Task<LoadResult> RunAsync(
+            ILicenceActivityStore sqlStore, LicenceActivitySources sources, DateTime endUtc,
+            Func<long> logicalReads, Action<string> progress = null)
+        {
+            if (logicalReads == null) throw new ArgumentNullException(nameof(logicalReads));
+            var result = new LoadResult();
+            var store = new MeteredStore(sqlStore);
+            var elapsed = Stopwatch.StartNew();
+            using (var memory = new MemorySampler())
+            {
+                foreach (var run in new[] { 7, 180 }.SelectMany(days => Enumerable.Range(1, 3),
+                    (days, repeat) => new { Days = days, Repeat = repeat }))
+                {
+                    var days = run.Days;
+                    progress?.Invoke("HTTP load: " + days + "-day window, 50 SKUs, repeat " + run.Repeat + "/3.");
+                    var hostStart = elapsed.Elapsed;
+                    Func<DateTime> hostNow = () => sources.NowUtc.Add(elapsed.Elapsed - hostStart);
+                    using (var host = new LicenceActivityHttpHost(store, sources, hostNow))
+                    {
+                        var query = "from=" + endUtc.AddDays(1 - days).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+                            + "&to=" + endUtc.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                        var overviewPath = "api/LicenceActivity/overview?" + query;
+                        var overview = await Measure(host.Client, overviewPath, "overview-cold", days, 300000,
+                            store, logicalReads, result, ColdBudgetMs);
+                        Assert.AreEqual(300000, (int)overview["distinctAssignedUsers"], "Load fixture must contain 300,000 distinct licence holders.");
+                        var skus = ((JArray)overview["licences"]).OrderBy(s => (int)s["assignedUsers"]).ToArray();
+                        Assert.AreEqual(50, skus.Length, "The current acceptance target is 50, not 20, licence types.");
+                        Assert.IsTrue(skus.Any(s => (int)s["assignedUsers"] > 0 && (int)s["assignedUsers"] <= 100),
+                            "Include a genuinely small non-empty SKU.");
+                        Assert.AreEqual(300000, (int)skus.Last()["assignedUsers"], "Include a tenant-wide SKU.");
+                        result.Assignments = skus.Sum(s => (long)s["assignedUsers"]);
+                        Assert.IsTrue(result.Assignments >= 2000000, "Exercise millions of overlapping memberships.");
+                        foreach (var workload in LicenceActivityQuery.Workloads)
+                        {
+                            var distributions = skus.SelectMany(s => (JArray)s["workloads"])
+                                .Where(w => (string)w["workload"] == workload).ToArray();
+                            Assert.IsTrue(distributions.Any(w => (int)w["zero"] > 0),
+                                workload + ": do not benchmark an all-unknown shortcut; seed explicit measured-zero evidence.");
+                            Assert.IsTrue(distributions.Any(w => (int)w["high"] > 0),
+                                workload + ": seed positive activity too.");
+                        }
+                        var overviewId = (string)overview["snapshotId"];
+                        await Measure(host.Client, overviewPath, "overview-warm", days, 300000,
+                            store, logicalReads, result, WarmBudgetMs, requireCacheHit: true);
+
+                        // A complete 50 x 5 sweep can outlive the real five-minute overview TTL.
+                        // Honour that TTL rather than freezing the cache clock or counting a legitimate
+                        // expiry as a latency failure. Explicit idle time is not part of request latency.
+                        async Task EnsureOverview(int nextRequestBudgetMs)
+                        {
+                            var delay = DelayBeforeOverviewRefresh(
+                                ((DateTime)overview["expiresUtc"]).ToUniversalTime(), hostNow(), nextRequestBudgetMs);
+                            if (!delay.HasValue) return;
+                            result.CacheExpiryWaitMs += (long)delay.Value.TotalMilliseconds;
+                            if (delay.Value > TimeSpan.Zero) await Task.Delay(delay.Value);
+                            var previousId = overviewId;
+                            overview = await Measure(host.Client, overviewPath, "overview-expiry-renewal", days, 300000,
+                                store, logicalReads, result, ColdBudgetMs);
+                            overviewId = (string)overview["snapshotId"];
+                            Assert.AreNotEqual(previousId, overviewId, "An expired overview must be replaced, not reused.");
+                            Assert.AreEqual(300000, (int)overview["distinctAssignedUsers"]);
+                            Assert.AreEqual(50, ((JArray)overview["licences"]).Count);
+                        }
+
+                        foreach (var cell in WorkloadMatrix(skus))
+                        {
+                            await EnsureOverview(ColdBudgetMs + WarmBudgetMs);
+                            // Most/least are always ranked by the selected workload. The default UPN
+                            // sort affects only the browse page; activity-sort paging is checked below.
+                            var path = UserPath(overviewId, cell.LicenceTypeId, cell.Workload, 100, 1, 100);
+                            var users = await Measure(host.Client, path, "users-cold", days, cell.AssignedPopulation,
+                                store, logicalReads, result, ColdBudgetMs,
+                                licenceTypeId: cell.LicenceTypeId, workload: cell.Workload, repeat: run.Repeat);
+                            CheckUsers(users, 100, 100);
+                            Assert.AreEqual(cell.AssignedPopulation, (int)users["totalUsers"]);
+                            Assert.AreEqual(cell.LicenceTypeId, (int)users["query"]["licenceTypeId"]);
+                            Assert.AreEqual(cell.Workload, (string)users["query"]["workload"]);
+                            Assert.AreEqual(Math.Min(100, cell.KnownUsers), ((JArray)users["leastActive"]).Count,
+                                "Every known user, including genuine zeros, must be eligible for least-active ranking.");
+                            Assert.IsTrue(((JArray)users["mostActive"]).Count >= Math.Min(100, cell.PositiveKnownUsers),
+                                "Known positive activity must not be replaced by an empty or all-unknown shortcut.");
+                            await Measure(host.Client, path, "users-warm", days, cell.AssignedPopulation,
+                                store, logicalReads, result, WarmBudgetMs, requireCacheHit: true,
+                                licenceTypeId: cell.LicenceTypeId, workload: cell.Workload, repeat: run.Repeat);
+                            result.CompletedMatrixCells++;
+                            memory.Sample();
+                        }
+
+                        var tenantSku = (int)skus.Last()["licenceTypeId"];
+                        foreach (var workload in LicenceActivityQuery.Workloads)
+                        {
+                            await EnsureOverview(ColdBudgetMs);
+                            var path = UserPath(overviewId, tenantSku, workload, 25, 2, 50)
+                                + "&sort=activity&direction=desc";
+                            var users = await Measure(host.Client, path, "workload-ranking", days, 300000,
+                                store, logicalReads, result, ColdBudgetMs,
+                                licenceTypeId: tenantSku, workload: workload, repeat: run.Repeat);
+                            CheckUsers(users, 25, 50);
+                        }
+
+                        await EnsureOverview(ColdBudgetMs);
+                        await Measure(host.Client, UserPath(overviewId, tenantSku, "teams", 10, 3000, 100),
+                            "deep-page", days, 300000, store, logicalReads, result, ColdBudgetMs);
+                        await EnsureOverview(ColdBudgetMs);
+                        var missing = await Measure(host.Client,
+                            UserPath(overviewId, tenantSku, "teams", 10, 1, 50) + "&search=nonexistent-synthetic-identity",
+                            "search-miss", days, 300000, store, logicalReads, result, ColdBudgetMs);
+                        Assert.AreEqual(0, (int)missing["totalUsers"]);
+                        await EnsureOverview(ColdBudgetMs);
+                        await Measure(host.Client,
+                            UserPath(overviewId, tenantSku, "teams", 10, 1, 50) + "&search=contoso",
+                            "search-common", days, 300000, store, logicalReads, result, ColdBudgetMs);
+
+                        var department = ((JArray)overview["departments"]).FirstOrDefault(d => (int)d["id"] > 0);
+                        var country = ((JArray)overview["countries"]).FirstOrDefault(c => (int)c["id"] > 0);
+                        Assert.IsNotNull(department, "Seed realistic department metadata.");
+                        Assert.IsNotNull(country, "Seed realistic country metadata.");
+                        await Measure(host.Client, overviewPath + "&departmentId=" + department["id"],
+                            "department", days, 300000, store, logicalReads, result, ColdBudgetMs);
+                        await Measure(host.Client, overviewPath + "&countryId=" + country["id"],
+                            "country", days, 300000, store, logicalReads, result, ColdBudgetMs);
+
+                        // A new query shape prevents an earlier warm result from concealing a duplicate cold run.
+                        await EnsureOverview(ConcurrentBudgetMs);
+                        var duplicatePath = UserPath(overviewId, tenantSku, "teams", 97, 3, 91);
+                        var before = store.Calls;
+                        var readsBefore = logicalReads();
+                        var duplicateResponses = await Task.WhenAll(Enumerable.Range(0, 8)
+                            .Select(_ => Request(host.Client, duplicatePath)));
+                        CheckResponses(duplicateResponses, ConcurrentBudgetMs);
+                        Assert.AreEqual(1, store.Calls - before, "Eight identical cold HTTP requests must perform one SQL load.");
+                        Assert.AreEqual(1, duplicateResponses.Select(r => (string)r.Json["snapshotId"]).Distinct().Count());
+                        result.Observations.Add(Group("duplicate-cold-8", days, duplicateResponses,
+                            store.Calls - before, logicalReads() - readsBefore));
+
+                        await EnsureOverview(ConcurrentBudgetMs);
+                        before = store.Calls;
+                        readsBefore = logicalReads();
+                        var distinctResponses = await Task.WhenAll(new[] { skus[0], skus[16], skus[32], skus[49] }
+                            .Select(s => Request(host.Client, UserPath(overviewId, (int)s["licenceTypeId"], "outlook", 93, 4, 87))));
+                        CheckResponses(distinctResponses, ConcurrentBudgetMs);
+                        Assert.AreEqual(4, store.Calls - before);
+                        Assert.IsTrue(store.PeakActive <= 4, "Concurrent SQL work must remain bounded across request keys.");
+                        result.Observations.Add(Group("distinct-cold-4", days, distinctResponses,
+                            store.Calls - before, logicalReads() - readsBefore));
+
+                        await EnsureOverview(ColdBudgetMs * 2);
+                        var exportUsers = await Measure(host.Client, UserPath(overviewId, tenantSku, "teams", 100, 1, 100),
+                            "export-view", days, 300000, store, logicalReads, result, ColdBudgetMs);
+                        before = store.Calls;
+                        var export = await Request(host.Client, "api/LicenceActivity/export?overviewId=" + overviewId
+                            + "&usersId=" + exportUsers["snapshotId"], workbook: true);
+                        Assert.AreEqual(HttpStatusCode.OK, export.Status);
+                        Assert.IsTrue(export.ElapsedMs <= ColdBudgetMs, "Excel HTTP latency exceeded the cold-request budget.");
+                        Assert.AreEqual(0, store.Calls - before, "Excel must use the actual displayed snapshot, not re-query.");
+                        Assert.IsTrue(export.Bytes > 0);
+                        result.Observations.Add(Group("excel-snapshot", days, new[] { export }, 0, 0));
+                    }
+                }
+                memory.Sample();
+                result.ManagedHeapDeltaBytes = Math.Max(0, memory.PeakManagedBytes - memory.InitialManagedBytes);
+                result.PrivateMemoryDeltaBytes = Math.Max(0, memory.PeakPrivateBytes - memory.InitialPrivateBytes);
+                Assert.IsTrue(result.ManagedHeapDeltaBytes <= MemoryDeltaBudgetBytes,
+                    "The web process plus in-process HTTP client exceeded the managed-memory growth budget.");
+                Assert.IsTrue(result.PrivateMemoryDeltaBytes <= MemoryDeltaBudgetBytes,
+                    "The web process plus in-process HTTP client exceeded the private-memory growth budget.");
+            }
+            Assert.AreEqual(result.RequiredMatrixCells, result.CompletedMatrixCells,
+                "Acceptance requires all 50 SKUs x 5 workloads x 2 windows x 3 fresh-host repeats, with immediate warm partners.");
+            result.ElapsedMs = elapsed.ElapsedMilliseconds;
+            result.PeakConcurrentSqlLoads = store.PeakActive;
+            var output = Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_LOAD_RESULTS");
+            if (!string.IsNullOrWhiteSpace(output))
+                File.WriteAllText(Path.GetFullPath(output), JsonConvert.SerializeObject(result, Formatting.Indented),
+                    new UTF8Encoding(false));
+            else
+                progress?.Invoke("HTTP load results: " + JsonConvert.SerializeObject(result));
+            return result;
+        }
+
+        private static string UserPath(string overviewId, int licence, string workload, int top, int page, int size) =>
+            "api/LicenceActivity/users?overviewId=" + overviewId + "&licenceTypeId=" + licence
+            + "&workload=" + workload + "&top=" + top + "&page=" + page + "&pageSize=" + size;
+
+        internal static IEnumerable<WorkloadCase> WorkloadMatrix(IEnumerable<JToken> skus)
+        {
+            foreach (var sku in skus)
+                foreach (var workload in LicenceActivityQuery.Workloads)
+                {
+                    var distribution = ((JArray)sku["workloads"]).Single(w => (string)w["workload"] == workload);
+                    var positive = (int)distribution["high"] + (int)distribution["moderate"] + (int)distribution["low"];
+                    yield return new WorkloadCase
+                    {
+                        LicenceTypeId = (int)sku["licenceTypeId"], AssignedPopulation = (int)sku["assignedUsers"],
+                        Workload = workload, PositiveKnownUsers = positive, KnownUsers = positive + (int)distribution["zero"]
+                    };
+                }
+        }
+
+        internal static TimeSpan? DelayBeforeOverviewRefresh(DateTime expiresUtc, DateTime nowUtc, int nextRequestBudgetMs)
+        {
+            var remaining = expiresUtc - nowUtc;
+            if (remaining.TotalMilliseconds > nextRequestBudgetMs + 1000) return null;
+            return remaining <= TimeSpan.Zero ? TimeSpan.Zero : remaining.Add(TimeSpan.FromMilliseconds(50));
+        }
+
+        internal sealed class WorkloadCase
+        {
+            internal int LicenceTypeId;
+            internal int AssignedPopulation;
+            internal string Workload;
+            internal int KnownUsers;
+            internal int PositiveKnownUsers;
+        }
+
+        private static async Task<JObject> Measure(
+            HttpClient client, string path, string scenario, int days, int population, MeteredStore store,
+            Func<long> reads, LoadResult result, int budgetMs, bool requireCacheHit = false,
+            int? licenceTypeId = null, string workload = null, int? repeat = null)
+        {
+            var before = store.Calls;
+            var readsBefore = reads();
+            var response = await Request(client, path);
+            CheckResponses(new[] { response }, budgetMs);
+            var observation = Group(scenario, days, new[] { response }, store.Calls - before, reads() - readsBefore);
+            observation.AssignedPopulation = population;
+            observation.LicenceTypeId = licenceTypeId;
+            observation.Workload = workload;
+            observation.Repeat = repeat;
+            if (requireCacheHit)
+            {
+                Assert.AreEqual(0, observation.SqlLoads);
+                Assert.AreEqual(0L, observation.LogicalReads);
+            }
+            result.Observations.Add(observation);
+            return response.Json;
+        }
+
+        private static async Task<Response> Request(HttpClient client, string path, bool workbook = false)
+        {
+            var watch = Stopwatch.StartNew();
+            using (var response = await client.GetAsync(path))
+            {
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                watch.Stop();
+                return new Response
+                {
+                    Status = response.StatusCode, ElapsedMs = watch.ElapsedMilliseconds, Bytes = bytes.Length,
+                    Json = workbook ? null : JObject.Parse(Encoding.UTF8.GetString(bytes))
+                };
+            }
+        }
+
+        private static void CheckResponses(IEnumerable<Response> responses, int budgetMs)
+        {
+            foreach (var response in responses)
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.Status, response.Json?.ToString());
+                Assert.IsTrue(response.ElapsedMs <= budgetMs, "HTTP latency budget exceeded: " + response.ElapsedMs + "ms > " + budgetMs + "ms.");
+                Assert.IsTrue(response.Bytes <= 1024 * 1024, "Response exceeded 1 MiB.");
+            }
+        }
+
+        private static void CheckUsers(JObject result, int top, int pageSize)
+        {
+            Assert.IsTrue(((JArray)result["mostActive"]).Count <= top);
+            Assert.IsTrue(((JArray)result["leastActive"]).Count <= top);
+            Assert.IsTrue(((JArray)result["users"]).Count <= pageSize);
+            Assert.IsTrue((int)result["rankedUsers"] <= (int)result["totalUsers"]);
+            var workload = (string)result["query"]["workload"];
+            foreach (var user in (JArray)result["leastActive"])
+            {
+                var evidence = ((JArray)user["workloads"]).Single(w => (string)w["workload"] == workload);
+                Assert.AreNotEqual("unknown", (string)evidence["band"], "Missing evidence must never rank as least-active.");
+            }
+        }
+
+        private static Observation Group(string scenario, int days, Response[] responses, int loads, long reads)
+        {
+            var ordered = responses.Select(r => r.ElapsedMs).OrderBy(t => t).ToArray();
+            return new Observation
+            {
+                Scenario = scenario, WindowDays = days, Requests = responses.Length, SqlLoads = loads,
+                LogicalReads = reads, MedianMs = ordered[ordered.Length / 2],
+                P95Ms = ordered[(int)Math.Ceiling(ordered.Length * 0.95) - 1],
+                MaximumMs = ordered.Last(), MaximumResponseBytes = responses.Max(r => r.Bytes)
+            };
+        }
+
+        internal sealed class LoadResult
+        {
+            public int Users { get; set; } = 300000;
+            public int LicenceTypes { get; set; } = 50;
+            public long Assignments { get; set; }
+            public string Scope { get; set; } = "In-process attributed HTTP API, real SQL adapter, production cache and Excel writer; synthetic database only. Client and server share the measured process. Cold means fresh application caches/HttpServer, not a fresh OS process or cold SQL. Not an IIS/network/Entra deployment test or an Azure capacity guarantee.";
+            public string SqlBufferPool { get; set; } = "Retained/uncontrolled SQL buffer and plan caches; no DBCC cache clearing. Not SQL-cold evidence.";
+            public string ConcurrencyUnit { get; set; } = "SqlLoads counts shared store/report loads, not individual SQL commands or connections; each load can issue multiple commands.";
+            public int MemorySampleIntervalMs { get; set; } = 50;
+            public int RequiredMatrixCells { get; set; } = 50 * 5 * 2 * 3;
+            public int CompletedMatrixCells { get; set; }
+            public long CacheExpiryWaitMs { get; set; }
+            public long ElapsedMs { get; set; }
+            public long ManagedHeapDeltaBytes { get; set; }
+            public long PrivateMemoryDeltaBytes { get; set; }
+            public int PeakConcurrentSqlLoads { get; set; }
+            public List<Observation> Observations { get; set; } = new List<Observation>();
+        }
+
+        internal sealed class Observation
+        {
+            public string Scenario { get; set; }
+            public int WindowDays { get; set; }
+            public int AssignedPopulation { get; set; }
+            public int? LicenceTypeId { get; set; }
+            public string Workload { get; set; }
+            public int? Repeat { get; set; }
+            public int Requests { get; set; }
+            public int SqlLoads { get; set; }
+            public long LogicalReads { get; set; }
+            public long MedianMs { get; set; }
+            public long P95Ms { get; set; }
+            public long MaximumMs { get; set; }
+            public int MaximumResponseBytes { get; set; }
+        }
+
+        private sealed class Response
+        {
+            internal HttpStatusCode Status;
+            internal long ElapsedMs;
+            internal int Bytes;
+            internal JObject Json;
+        }
+
+        private sealed class MeteredStore : ILicenceActivityStore
+        {
+            private readonly ILicenceActivityStore _inner;
+            private int _calls;
+            private int _active;
+            private int _peakActive;
+            internal MeteredStore(ILicenceActivityStore inner) { _inner = inner; }
+            internal int Calls => Volatile.Read(ref _calls);
+            internal int PeakActive => Volatile.Read(ref _peakActive);
+            private async Task<T> Run<T>(Func<Task<T>> action)
+            {
+                Interlocked.Increment(ref _calls);
+                var active = Interlocked.Increment(ref _active);
+                int previous;
+                do { previous = Volatile.Read(ref _peakActive); }
+                while (active > previous && Interlocked.CompareExchange(ref _peakActive, active, previous) != previous);
+                try { return await action().ConfigureAwait(false); }
+                finally { Interlocked.Decrement(ref _active); }
+            }
+            public Task<LicenceActivityOverview> LoadOverviewAsync(LicenceActivityQuery query, LicenceActivitySources sources,
+                ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken) =>
+                Run(() => _inner.LoadOverviewAsync(query, sources, diagnostics, cancellationToken));
+            public Task<LicenceActivityUsers> LoadUsersAsync(LicenceActivityOverview overview, LicenceActivityQuery query,
+                LicenceActivitySources sources, ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken) =>
+                Run(() => _inner.LoadUsersAsync(overview, query, sources, diagnostics, cancellationToken));
+        }
+
+        private sealed class MemorySampler : IDisposable
+        {
+            private readonly object _gate = new object();
+            private readonly Timer _timer;
+            private readonly Process _process = Process.GetCurrentProcess();
+            internal long InitialManagedBytes { get; }
+            internal long InitialPrivateBytes { get; }
+            internal long PeakManagedBytes { get; private set; }
+            internal long PeakPrivateBytes { get; private set; }
+            internal MemorySampler()
+            {
+                InitialManagedBytes = GC.GetTotalMemory(false);
+                InitialPrivateBytes = _process.PrivateMemorySize64;
+                PeakManagedBytes = InitialManagedBytes;
+                PeakPrivateBytes = InitialPrivateBytes;
+                _timer = new Timer(_ => Sample(), null, 50, 50);
+            }
+            internal void Sample()
+            {
+                lock (_gate)
+                {
+                    _process.Refresh();
+                    PeakManagedBytes = Math.Max(PeakManagedBytes, GC.GetTotalMemory(false));
+                    PeakPrivateBytes = Math.Max(PeakPrivateBytes, _process.PrivateMemorySize64);
+                }
+            }
+            public void Dispose()
+            {
+                using (var drained = new ManualResetEvent(false))
+                {
+                    _timer.Dispose(drained);
+                    drained.WaitOne();
+                }
+                _process.Dispose();
+            }
+        }
+
+    }
+
+    [TestClass]
+    public class LicenceActivityLoadHarnessTests
+    {
+        [TestMethod]
+        public void WorkloadMatrix_ExercisesEverySkuAndWorkload_AndRetainsKnownZeroPopulation()
+        {
+            var skus = Enumerable.Range(1, 50).Select(id => new JObject
+            {
+                ["licenceTypeId"] = id,
+                ["assignedUsers"] = id * 1000,
+                ["workloads"] = new JArray(LicenceActivityQuery.Workloads.Select(workload => new JObject
+                {
+                    ["workload"] = workload, ["high"] = 1, ["moderate"] = 1,
+                    ["low"] = 0, ["zero"] = 7, ["unknown"] = id * 1000 - 9
+                }))
+            }).ToArray();
+
+            var matrix = LicenceActivityLoadTests.WorkloadMatrix(skus).ToArray();
+            Assert.AreEqual(250, matrix.Length);
+            Assert.AreEqual(250, matrix.Select(c => c.LicenceTypeId + ":" + c.Workload).Distinct().Count());
+            foreach (var sku in skus)
+                Assert.AreEqual(5, matrix.Count(c => c.LicenceTypeId == (int)sku["licenceTypeId"]));
+            foreach (var workload in LicenceActivityQuery.Workloads)
+                Assert.AreEqual(50, matrix.Count(c => c.Workload == workload));
+            Assert.IsTrue(matrix.All(c => c.KnownUsers == 9 && c.PositiveKnownUsers == 2),
+                "Measured zeros are known evidence; unknown rows must not inflate least-active eligibility.");
+            Assert.AreEqual(42000, matrix.Single(c => c.LicenceTypeId == 42 && c.Workload == "outlook").AssignedPopulation);
+        }
+
+        [TestMethod]
+        public void OverviewRenewal_HonoursRealExpiryWithoutRenewingHealthySnapshots()
+        {
+            var now = new DateTime(2000, 7, 4, 0, 0, 0, DateTimeKind.Utc);
+            var pairBudget = LicenceActivityLoadTests.ColdBudgetMs + LicenceActivityLoadTests.WarmBudgetMs;
+            Assert.IsNull(LicenceActivityLoadTests.DelayBeforeOverviewRefresh(now.AddMinutes(1), now, pairBudget));
+            Assert.AreEqual(TimeSpan.FromMilliseconds(10050),
+                LicenceActivityLoadTests.DelayBeforeOverviewRefresh(now.AddSeconds(10), now, pairBudget).Value);
+            Assert.AreEqual(TimeSpan.Zero,
+                LicenceActivityLoadTests.DelayBeforeOverviewRefresh(now, now, pairBudget).Value);
+            Assert.AreEqual(TimeSpan.Zero,
+                LicenceActivityLoadTests.DelayBeforeOverviewRefresh(now.AddSeconds(-1), now, pairBudget).Value);
+            Assert.IsNull(LicenceActivityLoadTests.DelayBeforeOverviewRefresh(now.AddSeconds(17), now, pairBudget));
+            Assert.IsNotNull(LicenceActivityLoadTests.DelayBeforeOverviewRefresh(now.AddSeconds(16), now, pairBudget));
+        }
+
+        [TestMethod]
+        public void EvidenceScope_DeclaresMatrixAndColdnessWithoutWeakeningBudgets()
+        {
+            var result = new LicenceActivityLoadTests.LoadResult();
+            Assert.AreEqual(1500, result.RequiredMatrixCells);
+            StringAssert.Contains(result.Scope, "fresh application caches");
+            StringAssert.Contains(result.SqlBufferPool, "Not SQL-cold evidence");
+            StringAssert.Contains(result.ConcurrencyUnit, "not individual SQL commands");
+            Assert.AreEqual(50, result.MemorySampleIntervalMs);
+            Assert.AreEqual(15000, LicenceActivityLoadTests.ColdBudgetMs);
+            Assert.AreEqual(500, LicenceActivityLoadTests.WarmBudgetMs);
+            Assert.AreEqual(25000, LicenceActivityLoadTests.ConcurrentBudgetMs);
+            Assert.AreEqual(128L * 1024 * 1024, LicenceActivityLoadTests.MemoryDeltaBudgetBytes);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityPerformanceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityPerformanceTests.cs
@@ -1,0 +1,394 @@
+using Common.Entities.LicenceActivity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Explicitly opt-in release-scale harness. It creates one uniquely named scratch database containing
+    /// 300,000 synthetic users, 50 SKUs, just over two million
+    /// overlapping assignments and millions of sampled workload rows, then executes the real store batches.
+    /// The first invocation is the cold application
+    /// call and three repeats produce the warm median. It deliberately does not run DBCC DROPCLEANBUFFERS:
+    /// that is server-global and unsafe on the shared developer SQL instance.
+    /// Elapsed times from this LocalDB harness are diagnostic and must not be treated as Azure SQL
+    /// 200-400 DTU acceptance evidence or converted linearly to DTUs.
+    /// </summary>
+    [TestClass]
+    [DoNotParallelize]
+    public class LicenceActivityPerformanceTests
+    {
+        [TestMethod]
+        [TestCategory("Performance")]
+        public async Task SqlStore_AtReleaseScale_RecordsElapsedReadsAndPlansAcrossWindowsAndSkuSizes()
+        {
+            if (!string.Equals(
+                Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF"),
+                "1",
+                StringComparison.Ordinal))
+            {
+                // Inconclusive, NOT a silent Passed. This test asserts nothing when it is opted out,
+                // so reporting Passed would let an untouched release-scale harness masquerade as
+                // acceptance evidence in a TRX. vstest reports Inconclusive as Skipped, so CI (which
+                // never sets LICENCE_ACTIVITY_PERF) stays green without claiming the scale run happened.
+                Assert.Inconclusive(
+                    "LICENCE_ACTIVITY_PERF skipped; set LICENCE_ACTIVITY_PERF=1 to seed the LocalDB scale fixture. "
+                    + "No scale assertion was executed. This harness is not Azure SQL 200-400 DTU acceptance evidence.");
+            }
+
+            var indexMode = ReadIndexMode();
+            var seed = Stopwatch.StartNew();
+            try
+            {
+                using (var fixture = LicenceActivitySqlFixture.CreateScale(
+                    "LicenceActivityScale", indexMode))
+                {
+                    seed.Stop();
+                    var metricsIndexes = Convert.ToInt32(fixture.Scalar(
+                        indexMode == LicenceActivityUsageIndexMode.Columnstore
+                            ? "SELECT COUNT(*) FROM sys.indexes WHERE name LIKE N'NCCI[_]%[_]metrics';"
+                            : indexMode == LicenceActivityUsageIndexMode.BTreeFallback
+                                ? "SELECT COUNT(*) FROM sys.indexes WHERE name LIKE N'IX[_]%[_]metrics';"
+                                : "SELECT COUNT(*) FROM sys.indexes WHERE name LIKE N'NCCI[_]%[_]metrics' OR name LIKE N'IX[_]%[_]metrics';"));
+                    Assert.AreEqual(
+                        indexMode == LicenceActivityUsageIndexMode.DateOnly ? 0 : 4,
+                        metricsIndexes);
+                    Console.WriteLine(
+                        "LICENCE_ACTIVITY_PERF seedMs={0} users=300000 skus=50 indexMode={1}",
+                        seed.ElapsedMilliseconds,
+                        indexMode);
+                    Console.WriteLine(
+                        "LICENCE_ACTIVITY_PERF environment=LocalDB azureBaseline=200-400DTU azureLatency=unmeasured");
+
+                    var sources = new LicenceActivitySources
+                    {
+                        UserMetadata = true,
+                        UsageReports = !string.Equals(
+                            Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DISABLE_M365"),
+                            "1",
+                            StringComparison.Ordinal),
+                        CopilotUsageReports = !string.Equals(
+                            Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DISABLE_COPILOT"),
+                            "1",
+                            StringComparison.Ordinal),
+                        NowUtc = LicenceActivitySqlFixture.NowUtc
+                    };
+                    var narrowQuery = LicenceActivityQuery.Create(
+                        LicenceActivitySqlFixture.NarrowFromUtc.ToString("yyyy-MM-dd"),
+                        LicenceActivitySqlFixture.NarrowToUtc.ToString("yyyy-MM-dd"),
+                        LicenceActivitySqlFixture.NowUtc);
+                    var wideQuery = LicenceActivityQuery.Create(
+                        LicenceActivitySqlFixture.WideFromUtc.ToString("yyyy-MM-dd"),
+                        LicenceActivitySqlFixture.WideToUtc.ToString("yyyy-MM-dd"),
+                        LicenceActivitySqlFixture.NowUtc);
+
+                    if (int.TryParse(
+                        Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_TIMEOUT"),
+                        out var diagnosticTimeout)
+                        && diagnosticTimeout > LicenceActivitySql.CommandTimeoutSeconds)
+                    {
+                        var diagnosticWide = string.Equals(
+                            Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_WINDOW"),
+                            "wide",
+                            StringComparison.OrdinalIgnoreCase);
+                        var diagnosticQuery = diagnosticWide ? wideQuery : narrowQuery;
+                        var diagnosticScenario = diagnosticWide
+                            ? "overview-wide-180d"
+                            : "overview-narrow-7d";
+                        var diagnostic = new LicenceActivitySqlMeasurement();
+                        var includeShowplan = string.Equals(
+                            Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_SHOWPLAN"),
+                            "1",
+                            StringComparison.Ordinal);
+                        var diagnosticWatch = Stopwatch.StartNew();
+                        await fixture.Store(diagnostic.Instrumentation(
+                                includeShowplan: includeShowplan,
+                                commandTimeoutSeconds: diagnosticTimeout))
+                            .LoadOverviewAsync(
+                                diagnosticQuery, sources,
+                                NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                        diagnosticWatch.Stop();
+                        Console.WriteLine(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC scenario={0} elapsedMs={1} logicalReads={2} readsByOperation={3} operations={4}",
+                            diagnosticScenario,
+                            diagnosticWatch.ElapsedMilliseconds,
+                            diagnostic.TotalLogicalReads,
+                            string.Join(",", diagnostic.LogicalReadsByOperation),
+                            string.Join(",", diagnostic.Operations));
+                        Console.WriteLine(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC statementTimings={0}",
+                            string.Join(
+                                " | ",
+                                diagnostic.Messages
+                                    .Where(message => message.IndexOf(
+                                        "Execution Times", StringComparison.Ordinal) >= 0)
+                                    .Select(message => string.Join(
+                                        " ",
+                                        message.Split(
+                                            (char[])null,
+                                            StringSplitOptions.RemoveEmptyEntries)))));
+                        if (includeShowplan)
+                        {
+                            Console.WriteLine(
+                                "LICENCE_ACTIVITY_PERF_DIAGNOSTIC operators={0}",
+                                string.Join(",", PlanOperators(diagnostic.Showplans)));
+                        }
+                        // A long diagnostic timeout deliberately exceeds the production command
+                        // timeout so a slow plan can be root-caused instead of being cut off. That is
+                        // legitimate, but it means the acceptance assertions below were NEVER reached
+                        // and the production budgets were NOT honoured. Reporting Passed here would
+                        // turn a root-cause probe into fake acceptance evidence, so end the run as
+                        // Inconclusive with the diagnostics already written to the console above.
+                        Assert.Inconclusive(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC run only (scenario={0}, commandTimeoutSeconds={1} > production {2}). "
+                            + "Diagnostics were captured but NO acceptance assertion or HTTP load was executed, "
+                            + "so this run is NOT Azure SQL 200-400 DTU acceptance evidence.",
+                            diagnosticScenario,
+                            diagnosticTimeout,
+                            LicenceActivitySql.CommandTimeoutSeconds);
+                    }
+
+                LicenceActivityOverview narrow = null;
+                var narrowMetrics = await Measure(
+                    fixture,
+                    "overview-narrow-7d",
+                    async store =>
+                    {
+                        narrow = await store.LoadOverviewAsync(
+                            narrowQuery, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                    });
+
+                LicenceActivityOverview wide = null;
+                var wideMetrics = await Measure(
+                    fixture,
+                    "overview-wide-180d",
+                    async store =>
+                    {
+                        wide = await store.LoadOverviewAsync(
+                            wideQuery, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                    });
+
+                Assert.AreEqual(50, narrow.Licences.Count);
+                Assert.AreEqual(50, wide.Licences.Count);
+                Assert.AreEqual(300000, wide.DistinctAssignedUsers);
+                Assert.AreEqual(300000, wide.Licences.Single(l => l.LicenceTypeId == 1).AssignedUsers);
+                Assert.AreEqual(240000, wide.Licences.Single(l => l.LicenceTypeId == 2).AssignedUsers);
+                Assert.AreEqual(50, wide.Licences.Single(l => l.LicenceTypeId == 3).AssignedUsers);
+                Assert.AreEqual(1, wide.Licences.Single(l => l.LicenceTypeId == 4).AssignedUsers);
+                Assert.AreEqual(100, wide.Licences.Single(l => l.LicenceTypeId == 7).AssignedUsers);
+                Assert.AreEqual(15000, wide.Licences.Single(l => l.LicenceTypeId == 10).AssignedUsers);
+                Assert.IsTrue(Convert.ToInt64(fixture.Scalar(
+                    "SELECT COUNT_BIG(*) FROM dbo.user_license_type_lookups;")) >= 2000000);
+                foreach (var table in new[]
+                {
+                    "teams_user_activity_log", "outlook_user_activity_log",
+                    "onedrive_user_activity_log", "sharepoint_user_activity_log",
+                    "copilot_usage_user_activity_log"
+                })
+                {
+                    Assert.AreEqual(7800000L, Convert.ToInt64(fixture.Scalar(
+                        "SELECT SUM(rows) FROM sys.partitions WHERE object_id = OBJECT_ID(N'dbo."
+                        + table + "') AND index_id IN (0, 1);")), table);
+                }
+
+                foreach (var window in new[]
+                {
+                    new { Name = "narrow-7d", Query = narrowQuery, Overview = narrow },
+                    new { Name = "wide-180d", Query = wideQuery, Overview = wide }
+                })
+                {
+                    foreach (var sku in new[]
+                    {
+                        new { Id = 4, Name = "sparse-1", Expected = 1 },
+                        new { Id = 3, Name = "small-50", Expected = 50 },
+                        new { Id = 2, Name = "common-240k", Expected = 240000 },
+                        new { Id = 1, Name = "all-300k", Expected = 300000 }
+                    })
+                    {
+                        var usersQuery = window.Query.ForUsers(
+                            sku.Id, "teams", null, "activity", "desc",
+                            top: 100, page: 1, pageSize: 100,
+                            nowUtc: LicenceActivitySqlFixture.NowUtc);
+                        LicenceActivityUsers users = null;
+                        var metrics = await Measure(
+                            fixture,
+                            "users-" + window.Name + "-" + sku.Name,
+                            async store =>
+                            {
+                                users = await store.LoadUsersAsync(
+                                    window.Overview, usersQuery, sources,
+                                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                            });
+
+                        Assert.AreEqual(sku.Expected, users.TotalUsers);
+                        Assert.IsTrue(users.MostActive.Count <= 100);
+                        Assert.IsTrue(users.LeastActive.Count <= 100);
+                        Assert.IsTrue(users.Users.Count <= 100);
+                        Assert.IsTrue(users.TotalUsers >= users.Users.Count);
+                        AssertMeasured(metrics);
+                    }
+                }
+
+                AssertMeasured(narrowMetrics);
+                AssertMeasured(wideMetrics);
+
+                var loadMeasurement = new LicenceActivitySqlMeasurement();
+                var load = await LicenceActivityLoadTests.RunAsync(
+                    fixture.Store(loadMeasurement.Instrumentation(includeShowplan: false)),
+                    sources,
+                    LicenceActivitySqlFixture.WideToUtc,
+                    () => loadMeasurement.TotalLogicalReads,
+                    message => Console.WriteLine("LICENCE_ACTIVITY_PERF " + message));
+                    Console.WriteLine(
+                        "LICENCE_ACTIVITY_PERF httpLoadMs={0} assignments={1} peakConcurrentSql={2} "
+                        + "managedHeapDelta={3} privateMemoryDelta={4}",
+                        load.ElapsedMs,
+                        load.Assignments,
+                        load.PeakConcurrentSqlLoads,
+                        load.ManagedHeapDeltaBytes,
+                        load.PrivateMemoryDeltaBytes);
+                }
+            }
+            finally
+            {
+                if (string.Equals(
+                    Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_CLEANUP"),
+                    "1",
+                    StringComparison.Ordinal))
+                {
+                    LicenceActivitySqlFixture.CleanupRetainedScale();
+                }
+            }
+        }
+
+        private static async Task<Measurement> Measure(
+            LicenceActivitySqlFixture fixture,
+            string scenario,
+            Func<SqlLicenceActivityStore, Task> execute)
+        {
+            var coldDiagnostics = new LicenceActivitySqlMeasurement();
+            var first = Stopwatch.StartNew();
+            try
+            {
+                await execute(fixture.Store(coldDiagnostics.Instrumentation(includeShowplan: false)));
+            }
+            catch
+            {
+                first.Stop();
+                Console.WriteLine(
+                    "LICENCE_ACTIVITY_PERF_TIMEOUT scenario={0} elapsedMs={1} logicalReadsBeforeFailure={2} messages={3}",
+                    scenario,
+                    first.ElapsedMilliseconds,
+                    coldDiagnostics.TotalLogicalReads,
+                    string.Join(" | ", coldDiagnostics.Messages));
+                throw;
+            }
+            first.Stop();
+
+            var repeats = new List<long>();
+            for (var run = 0; run < 3; run++)
+            {
+                var watch = Stopwatch.StartNew();
+                await execute(fixture.Store());
+                watch.Stop();
+                repeats.Add(watch.ElapsedMilliseconds);
+            }
+            repeats.Sort();
+
+            var diagnostics = new LicenceActivitySqlMeasurement();
+            var planWatch = Stopwatch.StartNew();
+            await execute(fixture.Store(diagnostics.Instrumentation(includeShowplan: true)));
+            planWatch.Stop();
+
+            var operators = PlanOperators(diagnostics.Showplans);
+            var measurement = new Measurement
+            {
+                Scenario = scenario,
+                ColdApplicationCallMs = first.ElapsedMilliseconds,
+                WarmMedianMs = repeats[repeats.Count / 2],
+                InstrumentedMs = planWatch.ElapsedMilliseconds,
+                LogicalReads = diagnostics.TotalLogicalReads,
+                PlanCount = diagnostics.Showplans.Count,
+                Operators = operators
+            };
+
+            Console.WriteLine(
+                "LICENCE_ACTIVITY_PERF scenario={0} coldAppMs={1} warmMedianMs={2} "
+                + "instrumentedMs={3} logicalReads={4} plans={5} operators={6}",
+                measurement.Scenario,
+                measurement.ColdApplicationCallMs,
+                measurement.WarmMedianMs,
+                measurement.InstrumentedMs,
+                measurement.LogicalReads,
+                measurement.PlanCount,
+                measurement.Operators);
+            return measurement;
+        }
+
+        private static void AssertMeasured(Measurement measurement)
+        {
+            Assert.IsTrue(measurement.ColdApplicationCallMs >= 0);
+            Assert.IsTrue(measurement.WarmMedianMs >= 0);
+            Assert.IsTrue(measurement.LogicalReads > 0,
+                measurement.Scenario + " did not emit STATISTICS IO logical reads.");
+            Assert.IsTrue(measurement.PlanCount > 0,
+                measurement.Scenario + " did not emit a STATISTICS XML plan.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(measurement.Operators));
+        }
+
+        private static string PlanOperators(IEnumerable<string> plans)
+        {
+            var operators = new SortedSet<string>(StringComparer.Ordinal);
+            foreach (var plan in plans)
+            {
+                if (string.IsNullOrWhiteSpace(plan)) continue;
+                var document = XDocument.Parse(plan);
+                foreach (var element in document.Descendants()
+                    .Where(e => e.Name.LocalName == "RelOp"))
+                {
+                    var physical = element.Attribute("PhysicalOp");
+                    if (physical == null) continue;
+                    var accessed = element.Descendants()
+                        .FirstOrDefault(e => e.Name.LocalName == "Object");
+                    var index = accessed?.Attribute("Index");
+                    var table = accessed?.Attribute("Table");
+                    operators.Add(
+                        physical.Value
+                        + (table == null ? string.Empty : "[" + table.Value + "]")
+                        + (index == null ? string.Empty : "[" + index.Value + "]"));
+                }
+            }
+            return string.Join("|", operators);
+        }
+
+        private static LicenceActivityUsageIndexMode ReadIndexMode()
+        {
+            var configured = Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_INDEX_MODE");
+            if (string.Equals(configured, "fallback", StringComparison.OrdinalIgnoreCase))
+                return LicenceActivityUsageIndexMode.BTreeFallback;
+            if (string.Equals(configured, "date", StringComparison.OrdinalIgnoreCase))
+                return LicenceActivityUsageIndexMode.DateOnly;
+            if (string.Equals(configured, "columnstore", StringComparison.OrdinalIgnoreCase))
+                return LicenceActivityUsageIndexMode.Columnstore;
+            return LicenceActivityUsageIndexMode.BTreeFallback;
+        }
+
+        private sealed class Measurement
+        {
+            internal string Scenario;
+            internal long ColdApplicationCallMs;
+            internal long WarmMedianMs;
+            internal long InstrumentedMs;
+            internal long LogicalReads;
+            internal int PlanCount;
+            internal string Operators;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
@@ -1,0 +1,961 @@
+using Common.Entities.LicenceActivity;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data.SqlClient;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace Tests.UnitTests
+{
+    internal enum LicenceActivityUsageIndexMode
+    {
+        DateOnly,
+        Columnstore,
+        BTreeFallback
+    }
+
+    /// <summary>
+    /// Throwaway, synthetic SQL schema shared by the focused licence-activity integration and scale tests.
+    /// Column types and index keys match the shipped schema; no production database is ever opened.
+    /// </summary>
+    internal sealed class LicenceActivitySqlFixture : IDisposable
+    {
+        private const string RetainedDatabasePrefix = "UT_LicenceActivityScale_";
+        private const string RetainedMarker = "300000-users|50-skus|v2";
+        private static readonly Regex RetainedDatabaseName = new Regex(
+            "^" + RetainedDatabasePrefix + "[0-9a-f]{32}$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        internal static readonly DateTime NowUtc =
+            new DateTime(2000, 7, 4, 0, 0, 0, DateTimeKind.Utc);
+        internal static readonly DateTime WideFromUtc =
+            new DateTime(2000, 1, 3, 0, 0, 0, DateTimeKind.Utc);
+        internal static readonly DateTime WideToUtc =
+            new DateTime(2000, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+        internal static readonly DateTime NarrowFromUtc =
+            new DateTime(2000, 6, 19, 0, 0, 0, DateTimeKind.Utc);
+        internal static readonly DateTime NarrowToUtc =
+            new DateTime(2000, 6, 25, 0, 0, 0, DateTimeKind.Utc);
+
+        private readonly ScratchDatabase _database;
+        private readonly bool _retained;
+
+        internal string ConnectionString { get; }
+
+        private LicenceActivitySqlFixture(ScratchDatabase database)
+        {
+            _database = database;
+            ConnectionString = database.ConnectionString;
+        }
+
+        private LicenceActivitySqlFixture(string connectionString, bool retained)
+        {
+            ConnectionString = connectionString;
+            _retained = retained;
+        }
+
+        internal static LicenceActivitySqlFixture Create(
+            string purpose,
+            LicenceActivityUsageIndexMode usageIndexMode = LicenceActivityUsageIndexMode.BTreeFallback,
+            bool createUsageIndexes = true)
+        {
+            var fixture = new LicenceActivitySqlFixture(ScratchDatabase.Create(purpose));
+            fixture.CreateSchema();
+            if (createUsageIndexes) fixture.ApplyUsageIndexes(usageIndexMode);
+            return fixture;
+        }
+
+        internal static LicenceActivitySqlFixture CreateScale(
+            string purpose,
+            LicenceActivityUsageIndexMode usageIndexMode = LicenceActivityUsageIndexMode.BTreeFallback)
+        {
+            if (string.Equals(
+                Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_RETAIN_DB"),
+                "1",
+                StringComparison.Ordinal))
+            {
+                return CreateOrReuseRetainedScale(usageIndexMode);
+            }
+
+            var fixture = Create(purpose, usageIndexMode, createUsageIndexes: false);
+            try
+            {
+                fixture.SeedScale();
+                fixture.ApplyUsageIndexes(usageIndexMode);
+                return fixture;
+            }
+            catch
+            {
+                fixture.Dispose();
+                throw;
+            }
+        }
+
+        internal static void CleanupRetainedScale()
+        {
+            var statePath = RetainedStatePath();
+            if (!File.Exists(statePath)) return;
+
+            var databaseName = File.ReadAllText(statePath).Trim();
+            ValidateRetainedDatabaseName(databaseName);
+
+            var configured = LocalDbConnectionBuilder("master");
+            var retained = new SqlConnectionStringBuilder(configured.ConnectionString)
+            {
+                InitialCatalog = databaseName
+            };
+            ValidateRetainedMarker(retained.ConnectionString);
+
+            ExecuteOn(
+                configured.ConnectionString,
+                $@"IF DB_ID(N'{databaseName}') IS NOT NULL
+                   BEGIN
+                       ALTER DATABASE [{databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                       DROP DATABASE [{databaseName}];
+                   END");
+            File.Delete(statePath);
+        }
+
+        internal SqlLicenceActivityStore Store()
+        {
+            return new SqlLicenceActivityStore(ConnectionString);
+        }
+
+        internal SqlLicenceActivityStore Store(SqlLicenceActivityStoreInstrumentation instrumentation)
+        {
+            return new SqlLicenceActivityStore(ConnectionString, instrumentation);
+        }
+
+        internal void Execute(string sql)
+        {
+            ExecuteOn(ConnectionString, sql);
+        }
+
+        internal object Scalar(string sql)
+        {
+            using (var connection = new SqlConnection(ConnectionString))
+            {
+                connection.Open();
+                using (var command = new SqlCommand(sql, connection) { CommandTimeout = 0 })
+                {
+                    var value = command.ExecuteScalar();
+                    return value == DBNull.Value ? null : value;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_retained) _database?.Dispose();
+        }
+
+        private static LicenceActivitySqlFixture CreateOrReuseRetainedScale(
+            LicenceActivityUsageIndexMode usageIndexMode)
+        {
+            var statePath = RetainedStatePath();
+            if (File.Exists(statePath))
+            {
+                var databaseName = File.ReadAllText(statePath).Trim();
+                ValidateRetainedDatabaseName(databaseName);
+                var retained = LocalDbConnectionBuilder(databaseName);
+                ValidateRetainedMarker(retained.ConnectionString);
+                var retainedFixture =
+                    new LicenceActivitySqlFixture(retained.ConnectionString, retained: true);
+                if (!retainedFixture.UsageIndexesMatch(usageIndexMode))
+                    retainedFixture.ApplyUsageIndexes(usageIndexMode);
+                return retainedFixture;
+            }
+
+            var database = RetainedDatabasePrefix + Guid.NewGuid().ToString("N");
+            ValidateRetainedDatabaseName(database);
+            var master = LocalDbConnectionBuilder("master");
+            var retainedConnection = LocalDbConnectionBuilder(database);
+
+            ExecuteOn(master.ConnectionString, $"CREATE DATABASE [{database}];");
+            var fixture = new LicenceActivitySqlFixture(retainedConnection.ConnectionString, retained: true);
+            try
+            {
+                fixture.CreateSchema();
+                fixture.SeedScale();
+                fixture.ApplyUsageIndexes(usageIndexMode);
+                fixture.Execute(@"
+CREATE TABLE dbo.LicenceActivitySyntheticMarker
+(
+    marker nvarchar(100) NOT NULL PRIMARY KEY
+);
+INSERT dbo.LicenceActivitySyntheticMarker (marker)
+VALUES (N'300000-users|50-skus|v2');");
+
+                var directory = Path.GetDirectoryName(statePath);
+                if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+                File.WriteAllText(statePath, database);
+                return fixture;
+            }
+            catch
+            {
+                ExecuteOn(
+                    master.ConnectionString,
+                    $@"IF DB_ID(N'{database}') IS NOT NULL
+                       BEGIN
+                           ALTER DATABASE [{database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                           DROP DATABASE [{database}];
+                       END");
+                throw;
+            }
+        }
+
+        private static SqlConnectionStringBuilder LocalDbConnectionBuilder(string database)
+        {
+            var configured = ConfigurationManager.ConnectionStrings["SPOInsightsEntities"];
+            if (configured == null)
+                throw new InvalidOperationException("The SPOInsightsEntities connection string is required.");
+
+            var builder = new SqlConnectionStringBuilder(configured.ConnectionString);
+            if (builder.DataSource.IndexOf("(localdb)", StringComparison.OrdinalIgnoreCase) < 0)
+                throw new InvalidOperationException(
+                    "Retained licence-activity performance databases are allowed only on LocalDB.");
+            builder.InitialCatalog = database;
+            return builder;
+        }
+
+        private static string RetainedStatePath()
+        {
+            var path = Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_STATE_FILE");
+            if (string.IsNullOrWhiteSpace(path) || !Path.IsPathRooted(path))
+                throw new InvalidOperationException(
+                    "LICENCE_ACTIVITY_PERF_STATE_FILE must be an absolute out-of-band session-state path.");
+            return Path.GetFullPath(path);
+        }
+
+        private static void ValidateRetainedDatabaseName(string databaseName)
+        {
+            if (!RetainedDatabaseName.IsMatch(databaseName ?? string.Empty))
+                throw new InvalidOperationException("The retained synthetic database name is invalid.");
+        }
+
+        private static void ValidateRetainedMarker(string connectionString)
+        {
+            using (var connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (var command = new SqlCommand(@"
+SELECT marker
+FROM dbo.LicenceActivitySyntheticMarker;", connection))
+                {
+                    var marker = command.ExecuteScalar() as string;
+                    if (!string.Equals(marker, RetainedMarker, StringComparison.Ordinal))
+                        throw new InvalidOperationException(
+                            "The retained database is not the licence-activity synthetic fixture.");
+                }
+            }
+        }
+
+        private static void ExecuteOn(string connectionString, string sql)
+        {
+            using (var connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (var command = new SqlCommand(sql, connection) { CommandTimeout = 0 })
+                    command.ExecuteNonQuery();
+            }
+        }
+
+        internal void ApplyUsageIndexes(LicenceActivityUsageIndexMode mode)
+        {
+            Execute(@"
+DECLARE @tables TABLE (name sysname);
+INSERT @tables VALUES
+    (N'teams_user_activity_log'),
+    (N'outlook_user_activity_log'),
+    (N'onedrive_user_activity_log'),
+    (N'sharepoint_user_activity_log');
+
+DECLARE @table sysname;
+DECLARE tables CURSOR LOCAL FAST_FORWARD FOR SELECT name FROM @tables;
+OPEN tables;
+FETCH NEXT FROM tables INTO @table;
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    DECLARE @sql nvarchar(max);
+    IF EXISTS (SELECT 1 FROM sys.indexes
+               WHERE object_id = OBJECT_ID(N'dbo.' + @table) AND name = N'IX_date')
+    BEGIN
+        SET @sql = N'DROP INDEX [IX_date] ON [dbo].[' + @table + N'];';
+        EXEC sp_executesql @sql;
+    END;
+    IF EXISTS (SELECT 1 FROM sys.indexes
+               WHERE object_id = OBJECT_ID(N'dbo.' + @table) AND name LIKE N'NCCI[_]%[_]metrics')
+    BEGIN
+        SELECT TOP (1) @sql = N'DROP INDEX [' + name + N'] ON [dbo].[' + @table + N'];'
+        FROM sys.indexes
+        WHERE object_id = OBJECT_ID(N'dbo.' + @table) AND name LIKE N'NCCI[_]%[_]metrics';
+        EXEC sp_executesql @sql;
+    END;
+    IF EXISTS (SELECT 1 FROM sys.indexes
+               WHERE object_id = OBJECT_ID(N'dbo.' + @table) AND name LIKE N'IX[_]%[_]metrics')
+    BEGIN
+        SELECT TOP (1) @sql = N'DROP INDEX [' + name + N'] ON [dbo].[' + @table + N'];'
+        FROM sys.indexes
+        WHERE object_id = OBJECT_ID(N'dbo.' + @table) AND name LIKE N'IX[_]%[_]metrics';
+        EXEC sp_executesql @sql;
+    END;
+
+    SET @sql = N'CREATE NONCLUSTERED INDEX [IX_date] ON [dbo].[' + @table
+             + N'] ([date], [last_activity_date]) INCLUDE ([user_id]);';
+    EXEC sp_executesql @sql;
+
+    FETCH NEXT FROM tables INTO @table;
+END;
+CLOSE tables;
+DEALLOCATE tables;");
+
+            if (mode == LicenceActivityUsageIndexMode.DateOnly) return;
+
+            if (mode == LicenceActivityUsageIndexMode.Columnstore)
+            {
+                Execute(@"
+CREATE NONCLUSTERED COLUMNSTORE INDEX [NCCI_teams_user_activity_log_metrics]
+ON dbo.teams_user_activity_log
+([user_id], [date], [last_activity_date], [private_chat_count], [team_chat_count],
+ [post_messages], [reply_messages], [meetings_attended_count], [meetings_organized_count]);
+
+CREATE NONCLUSTERED COLUMNSTORE INDEX [NCCI_outlook_user_activity_log_metrics]
+ON dbo.outlook_user_activity_log
+([user_id], [date], [last_activity_date], [email_send_count], [email_read_count]);
+
+CREATE NONCLUSTERED COLUMNSTORE INDEX [NCCI_sharepoint_user_activity_log_metrics]
+ON dbo.sharepoint_user_activity_log
+([user_id], [date], [last_activity_date], [viewed_or_edited]);
+
+CREATE NONCLUSTERED COLUMNSTORE INDEX [NCCI_onedrive_user_activity_log_metrics]
+ON dbo.onedrive_user_activity_log
+([user_id], [date], [last_activity_date], [viewed_or_edited]);");
+                return;
+            }
+
+            Execute(@"
+CREATE NONCLUSTERED INDEX [IX_teams_user_activity_log_metrics]
+ON dbo.teams_user_activity_log ([date])
+INCLUDE ([user_id], [last_activity_date], [private_chat_count], [team_chat_count],
+         [post_messages], [reply_messages], [meetings_attended_count], [meetings_organized_count]);
+
+CREATE NONCLUSTERED INDEX [IX_outlook_user_activity_log_metrics]
+ON dbo.outlook_user_activity_log ([date])
+INCLUDE ([user_id], [last_activity_date], [email_send_count], [email_read_count]);
+
+CREATE NONCLUSTERED INDEX [IX_sharepoint_user_activity_log_metrics]
+ON dbo.sharepoint_user_activity_log ([date])
+INCLUDE ([user_id], [last_activity_date], [viewed_or_edited]);
+
+CREATE NONCLUSTERED INDEX [IX_onedrive_user_activity_log_metrics]
+ON dbo.onedrive_user_activity_log ([date])
+INCLUDE ([user_id], [last_activity_date], [viewed_or_edited]);");
+        }
+
+        private bool UsageIndexesMatch(LicenceActivityUsageIndexMode mode)
+        {
+            var values = Convert.ToString(Scalar(@"
+SELECT CONCAT(
+    SUM(CASE WHEN name LIKE N'NCCI[_]%[_]metrics' THEN 1 ELSE 0 END),
+    N':',
+    SUM(CASE WHEN name LIKE N'IX[_]%[_]metrics' THEN 1 ELSE 0 END))
+FROM sys.indexes
+WHERE object_id IN
+(
+    OBJECT_ID(N'dbo.teams_user_activity_log'),
+    OBJECT_ID(N'dbo.outlook_user_activity_log'),
+    OBJECT_ID(N'dbo.onedrive_user_activity_log'),
+    OBJECT_ID(N'dbo.sharepoint_user_activity_log')
+);"), CultureInfo.InvariantCulture);
+            switch (mode)
+            {
+                case LicenceActivityUsageIndexMode.Columnstore:
+                    return values == "4:0";
+                case LicenceActivityUsageIndexMode.BTreeFallback:
+                    return values == "0:4";
+                default:
+                    return values == "0:0";
+            }
+        }
+
+        internal void SeedScale(int userCount = 300000, int licenceCount = 50)
+        {
+            if (userCount != 300000 || licenceCount != 50)
+                throw new ArgumentException("The release-scale harness is intentionally fixed at 300,000 users and 50 SKUs.");
+
+            Execute(@"
+;WITH E1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+E2(n) AS (SELECT 0 FROM E1 AS a CROSS JOIN E1 AS b),
+Numbers(n) AS
+(
+    SELECT TOP (60) ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+    FROM E2 AS a CROSS JOIN E1 AS b
+)
+INSERT dbo.user_departments (name)
+SELECT CASE WHEN n = 60 THEN N'Καλημέρα κόσμε' ELSE N'Synthetic department ' + CAST(n AS nvarchar(10)) END
+FROM Numbers;
+
+;WITH E1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+E2(n) AS (SELECT 0 FROM E1 AS a CROSS JOIN E1 AS b),
+Numbers(n) AS
+(
+    SELECT TOP (20) ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+    FROM E2
+)
+INSERT dbo.user_country_or_region (name)
+SELECT N'Synthetic country ' + CAST(n AS nvarchar(10))
+FROM Numbers;
+
+;WITH E1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+E2(n) AS (SELECT 0 FROM E1 AS a CROSS JOIN E1 AS b),
+E4(n) AS (SELECT 0 FROM E2 AS a CROSS JOIN E2 AS b),
+E6(n) AS (SELECT 0 FROM E4 AS a CROSS JOIN E2 AS b),
+Numbers(n) AS
+(
+    SELECT TOP (300000) ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+    FROM E6
+)
+INSERT dbo.users WITH (TABLOCK)
+    (user_name, mail, account_enabled, department_id, country_or_region_id)
+SELECT 'synthetic' + RIGHT('000000' + CAST(n AS varchar(6)), 6) + '@contoso.example',
+       N'synthetic' + RIGHT(N'000000' + CAST(n AS nvarchar(6)), 6) + N'@contoso.example',
+       CASE WHEN n % 50 = 0 THEN 0 ELSE 1 END,
+       ((n - 1) % 60) + 1,
+       ((n - 1) % 20) + 1
+FROM Numbers;
+
+;WITH E1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+E2(n) AS (SELECT 0 FROM E1 AS a CROSS JOIN E1 AS b),
+Numbers(n) AS
+(
+    SELECT TOP (50) ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+    FROM E2
+)
+INSERT dbo.license_types (name, sku_id)
+SELECT N'Synthetic SKU ' + RIGHT(N'00' + CAST(n AS nvarchar(2)), 2),
+       N'SYNTHETIC_' + RIGHT(N'00' + CAST(n AS nvarchar(2)), 2)
+FROM Numbers;
+
+-- Three named selectivities: all-user SKU 1, common SKU 2, and small SKU 3.
+INSERT dbo.user_license_type_lookups WITH (TABLOCK) (user_id, license_type_id)
+SELECT id, 1 FROM dbo.users;
+
+INSERT dbo.user_license_type_lookups WITH (TABLOCK) (user_id, license_type_id)
+SELECT id, 2 FROM dbo.users WHERE id % 5 <> 0;
+
+INSERT dbo.user_license_type_lookups WITH (TABLOCK) (user_id, license_type_id)
+SELECT TOP (50) id, 3 FROM dbo.users ORDER BY id;
+
+DECLARE @sparseLicences TABLE
+(
+    license_type_id int NOT NULL PRIMARY KEY,
+    assigned_users int NOT NULL
+);
+INSERT @sparseLicences (license_type_id, assigned_users)
+VALUES (4, 1), (5, 5), (6, 25), (7, 100), (8, 500), (9, 5000), (10, 15000);
+
+INSERT dbo.user_license_type_lookups WITH (TABLOCK) (user_id, license_type_id)
+SELECT users.id, sparse.license_type_id
+FROM @sparseLicences AS sparse
+JOIN dbo.users AS users ON users.id <= sparse.assigned_users;
+
+-- The remaining 40 overlapping memberships each cover one eighth of the population:
+-- 1.5m rows, and just over 2m current assignments in total.
+INSERT dbo.user_license_type_lookups WITH (TABLOCK) (user_id, license_type_id)
+SELECT users.id, licences.id
+FROM dbo.users AS users
+CROSS JOIN dbo.license_types AS licences
+WHERE licences.id BETWEEN 11 AND 50
+  AND (users.id + licences.id * 13) % 8 = 0;");
+
+            Execute(ScaleUsageSeedSql);
+
+            Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-30', N'v2', N'D7',
+     '2000-07-01T01:00:00', 300000, 300000, 0, NULL);");
+        }
+
+        private void CreateSchema()
+        {
+            Execute(@"
+CREATE TABLE dbo.user_departments
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_user_departments PRIMARY KEY,
+    name nvarchar(100) NULL
+);
+CREATE UNIQUE INDEX IX_name ON dbo.user_departments(name);
+
+CREATE TABLE dbo.user_country_or_region
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_user_country_or_region PRIMARY KEY,
+    name nvarchar(100) NULL
+);
+CREATE UNIQUE INDEX IX_name ON dbo.user_country_or_region(name);
+
+CREATE TABLE dbo.users
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_users PRIMARY KEY,
+    user_name varchar(250) NOT NULL,
+    mail nvarchar(max) NULL,
+    last_updated datetime NULL,
+    azure_ad_id nvarchar(max) NULL,
+    account_enabled bit NULL,
+    postalcode nvarchar(50) NULL,
+    company_name_id int NULL,
+    state_or_province_id int NULL,
+    manager_id int NULL,
+    country_or_region_id int NULL,
+    office_location_id int NULL,
+    usage_location_id int NULL,
+    department_id int NULL,
+    job_title_id int NULL
+);
+CREATE INDEX IX_department_id ON dbo.users(department_id);
+CREATE INDEX IX_country_or_region_id ON dbo.users(country_or_region_id);
+
+CREATE TABLE dbo.license_types
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_license_types PRIMARY KEY,
+    sku_id nvarchar(max) NULL,
+    name nvarchar(100) NULL
+);
+CREATE UNIQUE INDEX IX_name ON dbo.license_types(name);
+
+CREATE TABLE dbo.user_license_type_lookups
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_user_license_type_lookups PRIMARY KEY,
+    user_id int NOT NULL,
+    license_type_id int NOT NULL
+);
+CREATE UNIQUE INDEX IX_license_type_id_user_id
+    ON dbo.user_license_type_lookups(license_type_id, user_id);
+CREATE INDEX IX_user_id ON dbo.user_license_type_lookups(user_id);
+
+CREATE TABLE dbo.teams_user_activity_log
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_teams_user_activity_log PRIMARY KEY,
+    private_chat_count bigint NOT NULL,
+    team_chat_count bigint NOT NULL,
+    calls_count bigint NOT NULL,
+    meetings_count bigint NOT NULL,
+    adhoc_meetings_attended_count bigint NOT NULL,
+    adhoc_meetings_organized_count bigint NOT NULL,
+    meetings_attended_count bigint NOT NULL,
+    meetings_organized_count bigint NOT NULL,
+    scheduled_onetime_meetings_attended_count bigint NOT NULL,
+    scheduled_onetime_meetings_organized_count bigint NOT NULL,
+    scheduled_recurring_meetings_attended_count bigint NOT NULL,
+    scheduled_recurring_meetings_organized_count bigint NOT NULL,
+    audio_duration_seconds int NOT NULL,
+    video_duration_seconds int NOT NULL,
+    screenshare_duration_seconds int NOT NULL,
+    post_messages bigint NOT NULL,
+    reply_messages bigint NOT NULL,
+    urgent_messages bigint NOT NULL,
+    user_id int NOT NULL,
+    [date] datetime NOT NULL,
+    last_activity_date datetime NULL
+);
+CREATE INDEX IX_user_id ON dbo.teams_user_activity_log(user_id);
+
+CREATE TABLE dbo.outlook_user_activity_log
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_outlook_user_activity_log PRIMARY KEY,
+    email_send_count bigint NOT NULL,
+    email_receive_count bigint NOT NULL,
+    email_read_count bigint NOT NULL,
+    meeting_created_count bigint NOT NULL,
+    meeting_interacted_count bigint NOT NULL,
+    user_id int NOT NULL,
+    [date] datetime NOT NULL,
+    last_activity_date datetime NULL
+);
+CREATE INDEX IX_user_id ON dbo.outlook_user_activity_log(user_id);
+
+CREATE TABLE dbo.onedrive_user_activity_log
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_onedrive_user_activity_log PRIMARY KEY,
+    viewed_or_edited bigint NOT NULL,
+    synced bigint NOT NULL,
+    shared_internally bigint NOT NULL,
+    shared_externally bigint NOT NULL,
+    user_id int NOT NULL,
+    [date] datetime NOT NULL,
+    last_activity_date datetime NULL
+);
+CREATE INDEX IX_user_id ON dbo.onedrive_user_activity_log(user_id);
+
+CREATE TABLE dbo.sharepoint_user_activity_log
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_sharepoint_user_activity_log PRIMARY KEY,
+    viewed_or_edited bigint NOT NULL,
+    synced bigint NOT NULL,
+    shared_internally bigint NOT NULL,
+    shared_externally bigint NOT NULL,
+    user_id int NOT NULL,
+    [date] datetime NOT NULL,
+    last_activity_date datetime NULL
+);
+CREATE INDEX IX_user_id ON dbo.sharepoint_user_activity_log(user_id);
+
+CREATE TABLE dbo.copilot_usage_report_import_log
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_copilot_usage_report_import_log PRIMARY KEY,
+    report_name nvarchar(100) NULL,
+    report_refresh_date datetime NULL,
+    report_version nvarchar(10) NULL,
+    report_period nvarchar(10) NULL,
+    imported_utc datetime NOT NULL,
+    rows_read int NOT NULL,
+    rows_saved int NOT NULL,
+    is_upn_obfuscated bit NOT NULL,
+    error nvarchar(1000) NULL
+);
+
+CREATE TABLE dbo.copilot_usage_user_activity_log
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_copilot_usage_user_activity_log PRIMARY KEY,
+    report_period_days int NOT NULL,
+    prompts_all_apps int NULL,
+    prompts_chat_work int NULL,
+    prompts_chat_web int NULL,
+    active_usage_days int NULL,
+    chat_last_activity_date datetime NULL,
+    teams_last_activity_date datetime NULL,
+    word_last_activity_date datetime NULL,
+    excel_last_activity_date datetime NULL,
+    powerpoint_last_activity_date datetime NULL,
+    outlook_last_activity_date datetime NULL,
+    onenote_last_activity_date datetime NULL,
+    loop_last_activity_date datetime NULL,
+    chat_work_last_activity_date datetime NULL,
+    chat_web_last_activity_date datetime NULL,
+    m365_copilot_last_activity_date datetime NULL,
+    edge_last_activity_date datetime NULL,
+    agent_last_activity_date datetime NULL,
+    is_upn_obfuscated bit NOT NULL,
+    user_id int NOT NULL,
+    [date] datetime NOT NULL,
+    last_activity_date datetime NULL
+);
+CREATE UNIQUE INDEX IX_date_user_id_report_period_days
+    ON dbo.copilot_usage_user_activity_log([date], user_id, report_period_days);
+
+CREATE TABLE dbo.copilot_chats
+(
+    event_id uniqueidentifier NOT NULL CONSTRAINT PK_copilot_chats PRIMARY KEY,
+    app_host nvarchar(max) NULL,
+    agent_id int NULL,
+    user_id int NULL,
+    time_stamp datetime NULL
+);
+CREATE INDEX IX_copilot_chats_time_stamp_user_id
+    ON dbo.copilot_chats(time_stamp, user_id) INCLUDE(app_host, agent_id);
+
+CREATE TABLE dbo.copilot_interactions
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_copilot_interactions PRIMARY KEY,
+    graph_interaction_id nvarchar(200) NOT NULL,
+    session_id int NOT NULL,
+    user_id int NOT NULL,
+    request_id nvarchar(200) NULL,
+    interaction_type_id int NULL,
+    app_class_id int NULL,
+    conversation_type_id int NULL,
+    locale_id int NULL,
+    device_id int NULL,
+    created_utc datetime NOT NULL,
+    body_char_count int NOT NULL,
+    body_word_count int NOT NULL,
+    attachment_count int NOT NULL,
+    link_count int NOT NULL,
+    mention_count int NOT NULL,
+    context_count int NOT NULL,
+    response_latency_ms int NULL,
+    sentiment_score float NULL,
+    language_id int NULL
+);
+CREATE INDEX IX_user_id_created_utc
+    ON dbo.copilot_interactions(user_id, created_utc);
+CREATE INDEX IX_created_utc
+    ON dbo.copilot_interactions(created_utc);
+
+CREATE TABLE dbo.copilot_interaction_import_log
+(
+    id int IDENTITY NOT NULL CONSTRAINT PK_copilot_interaction_import_log PRIMARY KEY,
+    run_started_utc datetime NOT NULL,
+    run_finished_utc datetime NULL,
+    users_in_scope int NOT NULL,
+    users_scanned int NOT NULL,
+    users_skipped int NOT NULL,
+    users_failed int NOT NULL,
+    interactions_read int NOT NULL,
+    interactions_saved int NOT NULL,
+    cognitive_docs_scored int NOT NULL,
+    error nvarchar(1000) NULL
+);");
+        }
+
+        private const string ScaleUsageSeedSql = @"
+CREATE TABLE #SyntheticSamples
+(
+    sample_number int NOT NULL PRIMARY KEY,
+    sample_date date NOT NULL
+);
+
+;WITH E1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+Numbers(n) AS
+(
+    SELECT TOP (26) ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) - 1
+    FROM E1 AS a CROSS JOIN E1 AS b
+)
+INSERT #SyntheticSamples (sample_number, sample_date)
+SELECT n,
+       CASE
+           WHEN n = 0 THEN CONVERT(date, '20000109', 112)
+           WHEN n = 25 THEN CONVERT(date, '20000630', 112)
+           ELSE DATEADD(DAY, n * 7 + 6, CONVERT(date, '20000103', 112))
+       END
+FROM Numbers;
+
+INSERT dbo.teams_user_activity_log WITH (TABLOCK)
+(
+    private_chat_count, team_chat_count, calls_count, meetings_count,
+    adhoc_meetings_attended_count, adhoc_meetings_organized_count,
+    meetings_attended_count, meetings_organized_count,
+    scheduled_onetime_meetings_attended_count, scheduled_onetime_meetings_organized_count,
+    scheduled_recurring_meetings_attended_count, scheduled_recurring_meetings_organized_count,
+    audio_duration_seconds, video_duration_seconds, screenshare_duration_seconds,
+    post_messages, reply_messages, urgent_messages, user_id, [date], last_activity_date
+)
+SELECT CASE WHEN activity.is_active = 1 THEN 1 + (users.id + samples.sample_number) % 8 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 3 + samples.sample_number) % 7 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 3 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 4 ELSE 0 END,
+       0, 0,
+       CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 4 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 5 + samples.sample_number) % 3 ELSE 0 END,
+       0, 0, 0, 0, 0, 0, 0,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 7 + samples.sample_number) % 6 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 11 + samples.sample_number) % 5 ELSE 0 END,
+       0,
+       users.id, samples.sample_date,
+       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+FROM dbo.users AS users
+CROSS JOIN #SyntheticSamples AS samples
+CROSS APPLY
+(
+    SELECT CAST(CASE
+        WHEN (users.id + 1) % 10 <= 2 THEN 1
+        WHEN (users.id + 1) % 10 BETWEEN 3 AND 5
+         AND samples.sample_number % 2 = users.id % 2 THEN 1
+        WHEN (users.id + 1) % 10 BETWEEN 6 AND 7
+         AND samples.sample_number % 10 = users.id % 10 THEN 1
+        ELSE 0
+    END AS int) AS is_active
+) AS activity;
+
+INSERT dbo.outlook_user_activity_log WITH (TABLOCK)
+(
+    email_send_count, email_receive_count, email_read_count,
+    meeting_created_count, meeting_interacted_count, user_id, [date], last_activity_date
+)
+SELECT CASE WHEN activity.is_active = 1 THEN 1 + (users.id + samples.sample_number) % 12 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 3 + samples.sample_number) % 20 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN 1 + (users.id * 5 + samples.sample_number) % 25 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 3 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 7 + samples.sample_number) % 4 ELSE 0 END,
+       users.id, samples.sample_date,
+       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+FROM dbo.users AS users
+CROSS JOIN #SyntheticSamples AS samples
+CROSS APPLY
+(
+    SELECT CAST(CASE
+        WHEN (users.id + 3) % 10 <= 2 THEN 1
+        WHEN (users.id + 3) % 10 BETWEEN 3 AND 5
+         AND samples.sample_number % 2 = users.id % 2 THEN 1
+        WHEN (users.id + 3) % 10 BETWEEN 6 AND 7
+         AND samples.sample_number % 10 = users.id % 10 THEN 1
+        ELSE 0
+    END AS int) AS is_active
+) AS activity;
+
+INSERT dbo.onedrive_user_activity_log WITH (TABLOCK)
+(
+    viewed_or_edited, synced, shared_internally, shared_externally,
+    user_id, [date], last_activity_date
+)
+SELECT CASE WHEN activity.is_active = 1 THEN 1 + (users.id * 3 + samples.sample_number) % 18 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 5 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 7 + samples.sample_number) % 3 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 11 + samples.sample_number) % 2 ELSE 0 END,
+       users.id, samples.sample_date,
+       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+FROM dbo.users AS users
+CROSS JOIN #SyntheticSamples AS samples
+CROSS APPLY
+(
+    SELECT CAST(CASE
+        WHEN (users.id + 5) % 10 <= 2 THEN 1
+        WHEN (users.id + 5) % 10 BETWEEN 3 AND 5
+         AND samples.sample_number % 2 = users.id % 2 THEN 1
+        WHEN (users.id + 5) % 10 BETWEEN 6 AND 7
+         AND samples.sample_number % 10 = users.id % 10 THEN 1
+        ELSE 0
+    END AS int) AS is_active
+) AS activity;
+
+INSERT dbo.sharepoint_user_activity_log WITH (TABLOCK)
+(
+    viewed_or_edited, synced, shared_internally, shared_externally,
+    user_id, [date], last_activity_date
+)
+SELECT CASE WHEN activity.is_active = 1 THEN 1 + (users.id * 5 + samples.sample_number) % 22 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 4 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 7 + samples.sample_number) % 4 ELSE 0 END,
+       CASE WHEN activity.is_active = 1 THEN (users.id * 13 + samples.sample_number) % 2 ELSE 0 END,
+       users.id, samples.sample_date,
+       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+FROM dbo.users AS users
+CROSS JOIN #SyntheticSamples AS samples
+CROSS APPLY
+(
+    SELECT CAST(CASE
+        WHEN (users.id + 7) % 10 <= 2 THEN 1
+        WHEN (users.id + 7) % 10 BETWEEN 3 AND 5
+         AND samples.sample_number % 2 = users.id % 2 THEN 1
+        WHEN (users.id + 7) % 10 BETWEEN 6 AND 7
+         AND samples.sample_number % 10 = users.id % 10 THEN 1
+        ELSE 0
+    END AS int) AS is_active
+) AS activity;
+
+INSERT dbo.copilot_usage_user_activity_log WITH (TABLOCK)
+(
+    report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+    user_id, [date], last_activity_date
+)
+SELECT 7,
+       CASE WHEN activity.is_active = 1
+            THEN 1 + (users.id * 7 + samples.sample_number) % 30 ELSE 0 END,
+       activity.is_active,
+       0,
+       users.id, samples.sample_date,
+       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+FROM dbo.users AS users
+CROSS JOIN #SyntheticSamples AS samples
+CROSS APPLY
+(
+    SELECT CAST(CASE
+        WHEN (users.id + 9) % 10 <= 2 THEN 1
+        WHEN (users.id + 9) % 10 BETWEEN 3 AND 5
+         AND samples.sample_number % 2 = users.id % 2 THEN 1
+        WHEN (users.id + 9) % 10 BETWEEN 6 AND 7
+         AND samples.sample_number % 10 = users.id % 10 THEN 1
+        ELSE 0
+    END AS int) AS is_active
+) AS activity;
+
+DROP TABLE #SyntheticSamples;";
+    }
+
+    internal sealed class LicenceActivitySqlMeasurement
+    {
+        private static readonly Regex LogicalReads =
+            new Regex(@"logical reads\s+(?<reads>[0-9]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private const int MaximumRetainedMessages = 128;
+        private long _totalLogicalReads;
+        private int _retainedMessages;
+        private readonly ConcurrentDictionary<string, long> _logicalReadsByOperation =
+            new ConcurrentDictionary<string, long>(StringComparer.Ordinal);
+
+        internal readonly ConcurrentQueue<string> Messages = new ConcurrentQueue<string>();
+        internal readonly ConcurrentQueue<string> Showplans = new ConcurrentQueue<string>();
+        internal readonly ConcurrentQueue<string> Operations = new ConcurrentQueue<string>();
+
+        internal long TotalLogicalReads => Interlocked.Read(ref _totalLogicalReads);
+        internal IEnumerable<string> LogicalReadsByOperation =>
+            _logicalReadsByOperation
+                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                .Select(pair => pair.Key + "=" + pair.Value.ToString(CultureInfo.InvariantCulture));
+
+        private void RecordMessage(string message, string operation = null)
+        {
+            if (string.IsNullOrEmpty(message)) return;
+
+            long reads = 0;
+            foreach (Match match in LogicalReads.Matches(message))
+            {
+                reads += long.Parse(match.Groups["reads"].Value, CultureInfo.InvariantCulture);
+            }
+            if (reads != 0)
+            {
+                Interlocked.Add(ref _totalLogicalReads, reads);
+                _logicalReadsByOperation.AddOrUpdate(
+                    operation ?? "unlabelled", reads, (key, value) => value + reads);
+            }
+
+            Messages.Enqueue(string.IsNullOrEmpty(operation)
+                ? message
+                : "[" + operation + "] " + message);
+            if (Interlocked.Increment(ref _retainedMessages) > MaximumRetainedMessages
+                && Messages.TryDequeue(out _))
+            {
+                Interlocked.Decrement(ref _retainedMessages);
+            }
+        }
+
+        internal SqlLicenceActivityStoreInstrumentation Instrumentation(
+            bool includeShowplan,
+            int? commandTimeoutSeconds = null)
+        {
+            Action<SqlConnection, string> configure = (connection, operation) =>
+            {
+                connection.InfoMessage += (sender, args) => RecordMessage(args.Message, operation);
+                using (var command = new SqlCommand(
+                    includeShowplan
+                        ? "SET STATISTICS IO ON; SET STATISTICS TIME ON; SET STATISTICS XML ON;"
+                        : "SET STATISTICS IO ON; SET STATISTICS TIME ON;",
+                    connection))
+                {
+                    command.ExecuteNonQuery();
+                }
+            };
+
+            return new SqlLicenceActivityStoreInstrumentation
+            {
+                CommandTimeoutSeconds = commandTimeoutSeconds,
+                ConnectionOpened = connection => configure(connection, null),
+                ConnectionOpenedForOperation = configure,
+                OperationCompleted = (operation, elapsedMs) =>
+                    Operations.Enqueue(operation + "=" + elapsedMs.ToString(CultureInfo.InvariantCulture) + "ms"),
+                ShowplanReceived = plan => Showplans.Enqueue(plan)
+            };
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -1,0 +1,1118 @@
+using Common.Entities.LicenceActivity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class LicenceActivitySqlTests
+    {
+        private static readonly string[] SampleDates =
+        {
+            "2000-05-07", "2000-05-14", "2000-05-21", "2000-05-28",
+            "2000-06-04", "2000-06-11", "2000-06-18", "2000-06-25"
+        };
+
+        private static readonly string[] CopilotD7Dates =
+        {
+            "2000-05-07", "2000-05-14", "2000-05-21", "2000-05-28",
+            "2000-06-04", "2000-06-11", "2000-06-18", "2000-06-25"
+        };
+
+        [TestMethod]
+        public void SyntheticFixture_MatchesProductionTextAndIndexBoundaries()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceSchema"))
+            {
+                Assert.AreEqual("varchar:250", Convert.ToString(fixture.Scalar(@"
+SELECT TYPE_NAME(c.user_type_id) + ':' + CAST(c.max_length AS varchar(10))
+FROM sys.columns AS c
+WHERE c.object_id = OBJECT_ID(N'dbo.users') AND c.name = N'user_name';")));
+                Assert.AreEqual("nvarchar:200", Convert.ToString(fixture.Scalar(@"
+SELECT TYPE_NAME(c.user_type_id) + ':' + CAST(c.max_length AS varchar(10))
+FROM sys.columns AS c
+WHERE c.object_id = OBJECT_ID(N'dbo.user_departments') AND c.name = N'name';")));
+                Assert.AreEqual(1, Convert.ToInt32(fixture.Scalar(@"
+SELECT COUNT(*)
+FROM sys.indexes AS i
+JOIN sys.index_columns AS ic
+  ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+JOIN sys.columns AS c
+  ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+WHERE i.object_id = OBJECT_ID(N'dbo.teams_user_activity_log')
+  AND i.name = N'IX_date'
+  AND c.name = N'last_activity_date'
+  AND ic.key_ordinal = 2;")));
+                Assert.AreEqual(1, Convert.ToInt32(fixture.Scalar(@"
+SELECT COUNT(*)
+FROM sys.indexes AS i
+JOIN sys.index_columns AS ic
+  ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+JOIN sys.columns AS c
+  ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+WHERE i.object_id = OBJECT_ID(N'dbo.teams_user_activity_log')
+  AND i.name = N'IX_teams_user_activity_log_metrics'
+  AND c.name = N'meetings_organized_count'
+  AND ic.is_included_column = 1;")));
+                Assert.AreEqual(1, Convert.ToInt32(fixture.Scalar(@"
+SELECT COUNT(*)
+FROM sys.indexes AS i
+JOIN sys.index_columns AS first_key
+  ON first_key.object_id = i.object_id AND first_key.index_id = i.index_id
+JOIN sys.columns AS first_column
+  ON first_column.object_id = first_key.object_id AND first_column.column_id = first_key.column_id
+JOIN sys.index_columns AS second_key
+  ON second_key.object_id = i.object_id AND second_key.index_id = i.index_id
+JOIN sys.columns AS second_column
+  ON second_column.object_id = second_key.object_id AND second_column.column_id = second_key.column_id
+WHERE i.object_id = OBJECT_ID(N'dbo.user_license_type_lookups')
+  AND i.is_unique = 1
+  AND first_key.key_ordinal = 1 AND first_column.name = N'license_type_id'
+  AND second_key.key_ordinal = 2 AND second_column.name = N'user_id';")));
+            }
+        }
+
+        [TestMethod]
+        public void DisabledSources_AreNotReferencedAndSearchNeverLowersTheUpnColumn()
+        {
+            var disabledSql = LicenceActivitySql.BuildOverview(Sources(usageReports: false));
+            foreach (var table in new[]
+            {
+                "teams_user_activity_log", "outlook_user_activity_log",
+                "onedrive_user_activity_log", "sharepoint_user_activity_log",
+                "copilot_usage_user_activity_log", "copilot_chats", "copilot_interactions"
+            })
+            {
+                Assert.IsFalse(disabledSql.Contains(table),
+                    "A disabled source must not be queried: " + table);
+            }
+
+            var overview = new LicenceActivityOverview { Query = OverviewQuery() };
+            foreach (var workload in LicenceActivityQuery.Workloads)
+            {
+                overview.Coverage.Add(new LicenceActivityCoverage
+                {
+                    Workload = workload,
+                    Status = "disabled",
+                    Source = string.Empty,
+                    Measure = string.Empty
+                });
+            }
+            var usersSql = LicenceActivitySql.BuildUsers(
+                overview,
+                OverviewQuery().ForUsers(
+                    1, "teams", "ALPHA", "upn", "asc", 10, 1, 20,
+                    LicenceActivitySqlFixture.NowUtc));
+            Assert.IsFalse(usersSql.Contains("LOWER("));
+            StringAssert.Contains(usersSql, "u.user_name LIKE @searchPattern");
+            StringAssert.Contains(usersSql, "u.mail LIKE @searchPattern");
+        }
+
+        [TestMethod]
+        public async Task Overview_DeduplicatesOverlappingMembershipsAndBandsMeasuredZeros()
+        {
+            using (var fixture = CreateMeasuredFixture())
+            {
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+
+                Assert.AreEqual(5, overview.DistinctAssignedUsers,
+                    "Disabled accounts and guests still hold their current assignments.");
+                Assert.AreEqual(3, overview.Licences.Count);
+                Assert.AreEqual(5, overview.Licences.Single(l => l.LicenceTypeId == 1).AssignedUsers);
+                Assert.AreEqual(2, overview.Licences.Single(l => l.LicenceTypeId == 2).AssignedUsers);
+                Assert.AreEqual(0, overview.Licences.Single(l => l.LicenceTypeId == 3).AssignedUsers,
+                    "An imported empty SKU must not disappear.");
+
+                var teams = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "teams");
+                Assert.AreEqual(1, teams.High, "Teams high distribution");
+                Assert.AreEqual(1, teams.Moderate, "Teams moderate distribution");
+                Assert.AreEqual(1, teams.Low, "Teams low distribution");
+                Assert.AreEqual(2, teams.Zero, "Teams zero distribution");
+                Assert.AreEqual(0, teams.Unknown, "Teams unknown distribution");
+
+                var empty = overview.Licences.Single(l => l.LicenceTypeId == 3);
+                Assert.IsTrue(empty.Workloads.All(w =>
+                    w.High == 0 && w.Moderate == 0 && w.Low == 0 && w.Zero == 0 && w.Unknown == 0));
+
+                var coverage = overview.Coverage.Single(c => c.Workload == "teams");
+                Assert.AreEqual("available", coverage.Status);
+                Assert.AreEqual(8, coverage.ExpectedSamples);
+                Assert.AreEqual(8, coverage.ObservedSamples);
+                Assert.IsNull(coverage.ReportPeriodDays,
+                    "The M365 tables do not persist a report-period key.");
+                Assert.IsNull(coverage.LatestImportUtc,
+                    "The daily report tables store report dates, not an import-completion timestamp.");
+                Assert.AreEqual(new DateTime(2000, 5, 1), coverage.EffectiveFromUtc.Value);
+                Assert.AreEqual(new DateTime(2000, 6, 25), coverage.EffectiveToUtc.Value);
+                CollectionAssert.AreEqual(
+                    SampleDates,
+                    coverage.SnapshotDates.Select(d => d.ToString("yyyy-MM-dd")).ToArray());
+
+                Assert.AreEqual("Καλημέρα κόσμε",
+                    overview.Departments.Single(d => d.Id == 2).Name,
+                    "The production nvarchar metadata boundary must preserve non-Latin values.");
+                Assert.AreEqual(1, overview.Departments.Single(d => d.Id == 0).AssignedUsers);
+            }
+        }
+
+        [TestMethod]
+        public async Task LegacyDuplicateMemberships_DoNotInflateCountsOrBreakUserStaging()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceDuplicates"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+DROP INDEX IX_license_type_id_user_id ON dbo.user_license_type_lookups;
+INSERT dbo.user_license_type_lookups (user_id, license_type_id) VALUES (1, 1);");
+
+                var sources = Sources(usageReports: false);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual(5, overview.DistinctAssignedUsers);
+                Assert.AreEqual(5,
+                    overview.Licences.Single(l => l.LicenceTypeId == 1).AssignedUsers);
+
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview,
+                    OverviewQuery().ForUsers(
+                        1, "teams", null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources,
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                Assert.AreEqual(5, users.TotalUsers);
+                Assert.AreEqual(5, users.Users.Select(u => u.UserId).Distinct().Count());
+            }
+        }
+
+        [TestMethod]
+        public async Task ConcurrentConnections_DoNotCollideOnTempTableConstraintNames()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceTempNames"))
+            {
+                SeedDirectory(fixture);
+                using (var blocker = new SqlConnection(fixture.ConnectionString))
+                {
+                    blocker.Open();
+                    using (var command = new SqlCommand(@"
+CREATE TABLE #probe
+(
+    workload tinyint NOT NULL,
+    sample_date date NOT NULL,
+    CONSTRAINT PK_LicenceActivity_Samples PRIMARY KEY (workload, sample_date)
+);", blocker))
+                    {
+                        command.ExecuteNonQuery();
+                    }
+
+                    var overview = await fixture.Store().LoadOverviewAsync(
+                        OverviewQuery(), Sources(usageReports: false),
+                        NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                    Assert.AreEqual(3, overview.Licences.Count);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task Coverage_DistinguishesDisabledNotImportedPartialAndUnsettledRows()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCoverage"))
+            {
+                SeedDirectory(fixture);
+                SeedOneUsageTable(fixture, "teams_user_activity_log", SampleDates.Take(7).ToArray());
+                SeedOneUsageTable(fixture, "teams_user_activity_log", new[] { "2000-06-22", "2000-07-02" });
+                var coverageQuery = LicenceActivityQuery.Create(
+                    "2000-05-01", "2000-07-02", LicenceActivitySqlFixture.NowUtc);
+
+                var partial = await fixture.Store().LoadOverviewAsync(
+                    coverageQuery, Sources(usageReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+
+                var teams = partial.Coverage.Single(c => c.Workload == "teams");
+                Assert.AreEqual("partial", teams.Status);
+                Assert.AreEqual(9, teams.ExpectedSamples);
+                Assert.AreEqual(8, teams.ObservedSamples,
+                    "The Thursday snapshot is valid as-of evidence, while the unsettled July 2 row is excluded.");
+                Assert.AreEqual("2000-06-22", teams.SnapshotDates.Last().ToString("yyyy-MM-dd"));
+                Assert.AreEqual(5, partial.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "teams").Unknown);
+                Assert.AreEqual("notImported",
+                    partial.Coverage.Single(c => c.Workload == "outlook").Status);
+
+                var partialUsers = await fixture.Store().LoadUsersAsync(
+                    partial,
+                    coverageQuery.ForUsers(
+                        1, "teams", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    Sources(usageReports: true),
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                Assert.IsTrue(partialUsers.MostActive.Count > 0,
+                    "Positive as-of evidence remains useful for most-active.");
+                Assert.AreEqual(0, partialUsers.LeastActive.Count,
+                    "An incomplete week can hide activity, so nobody is ranked least-active.");
+
+                var disabled = await fixture.Store().LoadOverviewAsync(
+                    coverageQuery, Sources(usageReports: false),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.IsTrue(disabled.Coverage
+                    .Where(c => c.Workload != "copilot")
+                    .All(c => c.Status == "disabled" && c.ObservedSamples == 0));
+                Assert.AreEqual(5, disabled.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "teams").Unknown);
+
+                var disabledUsers = await fixture.Store().LoadUsersAsync(
+                    disabled,
+                    coverageQuery.ForUsers(
+                        1, "teams", null, "activity", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    Sources(usageReports: false),
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                Assert.AreEqual(0, disabledUsers.MostActive.Count);
+                Assert.AreEqual(0, disabledUsers.LeastActive.Count);
+                Assert.AreEqual(5, disabledUsers.Users.Count);
+                Assert.IsTrue(disabledUsers.Users.All(u =>
+                    u.Workloads.Single(w => w.Workload == "teams").Band == "unknown"));
+            }
+        }
+
+        [TestMethod]
+        public async Task PerUserMissingRows_AreUnknownAndNeverLeastActive()
+        {
+            using (var fixture = CreateMeasuredFixture())
+            {
+                fixture.Execute(@"
+DELETE FROM dbo.teams_user_activity_log WHERE user_id = 5;
+DELETE FROM dbo.outlook_user_activity_log WHERE user_id = 5;
+DELETE FROM dbo.onedrive_user_activity_log WHERE user_id = 5;
+DELETE FROM dbo.sharepoint_user_activity_log WHERE user_id = 5;
+DELETE FROM dbo.teams_user_activity_log
+WHERE user_id = 3 AND [date] = '2000-05-14';
+DELETE FROM dbo.outlook_user_activity_log
+WHERE user_id = 3 AND [date] = '2000-05-14';
+DELETE FROM dbo.onedrive_user_activity_log
+WHERE user_id = 3 AND [date] = '2000-05-14';
+DELETE FROM dbo.sharepoint_user_activity_log
+WHERE user_id = 3 AND [date] = '2000-05-14';");
+
+                var sources = Sources(usageReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+
+                Assert.AreEqual("available",
+                    overview.Coverage.Single(c => c.Workload == "teams").Status,
+                    "Other users still prove that every global snapshot date exists.");
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "teams");
+                Assert.AreEqual(1, distribution.High);
+                Assert.AreEqual(1, distribution.Moderate);
+                Assert.AreEqual(0, distribution.Low);
+                Assert.AreEqual(1, distribution.Zero);
+                Assert.AreEqual(2, distribution.Unknown);
+                foreach (var workload in new[] { "outlook", "onedrive", "sharepoint" })
+                {
+                    var other = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                        .Workloads.Single(w => w.Workload == workload);
+                    Assert.AreEqual(1, other.Zero, workload);
+                    Assert.AreEqual(2, other.Unknown, workload);
+                }
+
+                var greekDepartment = overview.Departments.Single(d => d.Id == 2)
+                    .Workloads.Single(w => w.Workload == "teams");
+                Assert.AreEqual(1, greekDepartment.Unknown,
+                    "A user missing one weekly row is unknown in demographic aggregates.");
+                var unknownDepartment = overview.Departments.Single(d => d.Id == 0)
+                    .Workloads.Single(w => w.Workload == "teams");
+                Assert.AreEqual(1, unknownDepartment.Unknown,
+                    "A user missing every weekly row is unknown in demographic aggregates.");
+
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview,
+                    OverviewQuery().ForUsers(
+                        1, "teams", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources,
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+
+                CollectionAssert.DoesNotContain(users.LeastActive.Select(u => u.UserId).ToList(), 3);
+                CollectionAssert.DoesNotContain(users.LeastActive.Select(u => u.UserId).ToList(), 5);
+                Assert.AreEqual("partial", users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == "teams").Status);
+                Assert.AreEqual(7, users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == "teams").ObservedSamples);
+                Assert.AreEqual("missingCoverage", users.Users.Single(u => u.UserId == 5)
+                    .Workloads.Single(w => w.Workload == "teams").Status);
+                Assert.AreEqual(0, users.Users.Single(u => u.UserId == 5)
+                    .Workloads.Single(w => w.Workload == "teams").ObservedSamples);
+                Assert.IsNull(users.Users.Single(u => u.UserId == 5)
+                    .Workloads.Single(w => w.Workload == "teams").AverageActions);
+                Assert.IsTrue(users.Users.Single(u => u.UserId == 5).Workloads
+                    .Where(w => w.Workload != "copilot")
+                    .All(w => w.Status == "missingCoverage" && w.Band == "unknown"));
+                Assert.AreEqual("zero", users.Users.Single(u => u.UserId == 4)
+                    .Workloads.Single(w => w.Workload == "teams").Band,
+                    "A complete set of explicit zero rows remains a measured zero.");
+            }
+        }
+
+        [TestMethod]
+        public async Task Copilot_PrefersFullyContainedD7AndNeverCombinesPeriodCollisions()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotD7"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v2', N'D7',
+     '2000-07-01T01:00:00', 5, 5, 0, NULL);");
+
+                for (var index = 0; index < CopilotD7Dates.Length; index++)
+                {
+                    var active = index < 2 ? 1 : 0;
+                    var prompts = index < 2 ? 12 + index : 0;
+                    var lastActivitySql = active == 1
+                        ? "'" + CopilotD7Dates[index] + "'"
+                        : "NULL";
+                    fixture.Execute($@"
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+VALUES
+    (7, {prompts}, {active}, 0, 1, '{CopilotD7Dates[index]}',
+     {lastActivitySql}),
+    (7, 0, 0, 0, 4, '{CopilotD7Dates[index]}', NULL),
+    (28, 1000, 28, 0, 1, '{CopilotD7Dates[index]}', '{CopilotD7Dates[index]}');");
+                }
+
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: false, copilotReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+
+                var coverage = overview.Coverage.Single(c => c.Workload == "copilot");
+                Assert.AreEqual("available", coverage.Status);
+                Assert.AreEqual(7, coverage.ReportPeriodDays.Value);
+                Assert.AreEqual(8, coverage.ExpectedSamples);
+                Assert.AreEqual(8, coverage.SnapshotDates.Count);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual(1, distribution.Moderate);
+                Assert.AreEqual(1, distribution.Zero);
+                Assert.AreEqual(3, distribution.Unknown);
+
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview,
+                    OverviewQuery().ForUsers(
+                        1, "copilot", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    Sources(usageReports: false, copilotReports: true),
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+
+                var activeUser = users.Users.Single(u => u.UserId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual(2, activeUser.ActiveSamples);
+                Assert.AreEqual("moderate", activeUser.Band);
+                Assert.AreEqual(25d / 8d, activeUser.AverageActions.Value, 0.001,
+                    "D28 prompt totals on the same date must not fan out or enter the D7 average.");
+                Assert.AreEqual("zero", users.Users.Single(u => u.UserId == 4)
+                    .Workloads.Single(w => w.Workload == "copilot").Band);
+                Assert.AreEqual("unknown", users.Users.Single(u => u.UserId == 2)
+                    .Workloads.Single(w => w.Workload == "copilot").Band,
+                    "A missing official per-user row is unknown, not measured zero.");
+            }
+        }
+
+        [TestMethod]
+        public async Task Copilot_D7LeadingGapMakesCustomRangePartialAndDisablesLeastActive()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotD7Gap"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v2', N'D7',
+     '2000-07-01T01:00:00', 5, 5, 0, NULL);");
+                foreach (var date in CopilotD7Dates)
+                {
+                    fixture.Execute($@"
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+VALUES (7, 0, 0, 0, 1, '{date}', NULL);");
+                }
+
+                var query = LicenceActivityQuery.Create(
+                    "2000-05-02", "2000-06-25", LicenceActivitySqlFixture.NowUtc);
+                var sources = Sources(usageReports: false, copilotReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var coverage = overview.Coverage.Single(c => c.Workload == "copilot");
+                Assert.AreEqual("partial", coverage.Status);
+                Assert.AreEqual(new DateTime(2000, 5, 8), coverage.EffectiveFromUtc.Value);
+                Assert.AreEqual(new DateTime(2000, 6, 25), coverage.EffectiveToUtc.Value);
+
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview,
+                    query.ForUsers(
+                        1, "copilot", null, "activity", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources,
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                Assert.AreEqual(0, users.LeastActive.Count);
+                Assert.AreEqual("unknown", users.Users.Single(u => u.UserId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot").Band);
+            }
+        }
+
+        [TestMethod]
+        public async Task Copilot_LongerRollingWindowReportsItsEffectiveRangeAndMissingCoverage()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotD28"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v2', N'D28',
+     '2000-07-01T01:00:00', 5, 5, 0, NULL);
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+VALUES (28, 40, 10, 0, 1, '2000-06-25', '2000-06-24');");
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+SELECT 28, 0, 0, 0, id, '2000-06-25', NULL
+FROM dbo.users
+WHERE id IN (2, 3, 4, 5);
+UPDATE dbo.copilot_usage_user_activity_log
+SET prompts_all_apps = -2, active_usage_days = -1
+WHERE user_id = 5 AND report_period_days = 28;");
+
+                var wide = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: false, copilotReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var wideCoverage = wide.Coverage.Single(c => c.Workload == "copilot");
+                Assert.AreEqual("missingCoverage", wideCoverage.Status);
+                Assert.AreEqual(28, wideCoverage.ReportPeriodDays.Value);
+                Assert.AreEqual(new DateTime(2000, 5, 29), wideCoverage.EffectiveFromUtc.Value);
+                Assert.AreEqual(new DateTime(2000, 6, 25), wideCoverage.EffectiveToUtc.Value);
+
+                var wideUsers = await fixture.Store().LoadUsersAsync(
+                    wide,
+                    OverviewQuery().ForUsers(
+                        1, "copilot", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    Sources(usageReports: false, copilotReports: true),
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                Assert.AreEqual("unknown", wideUsers.Users.Single(u => u.UserId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot").Band,
+                    "A D28 snapshot inside a 56-day request must not be presented as full-range evidence.");
+
+                var exactQuery = LicenceActivityQuery.Create(
+                    "2000-05-29", "2000-06-25", LicenceActivitySqlFixture.NowUtc);
+                var exact = await fixture.Store().LoadOverviewAsync(
+                    exactQuery, Sources(usageReports: false, copilotReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual("available", exact.Coverage.Single(c => c.Workload == "copilot").Status);
+                var exactDistribution = exact.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual(1, exactDistribution.Moderate);
+                Assert.AreEqual(3, exactDistribution.Zero);
+                Assert.AreEqual(1, exactDistribution.Unknown);
+
+                var exactUsers = await fixture.Store().LoadUsersAsync(
+                    exact,
+                    exactQuery.ForUsers(
+                        1, "copilot", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    Sources(usageReports: false, copilotReports: true),
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                var invalid = exactUsers.Users.Single(u => u.UserId == 5)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual("partial", invalid.Status);
+                Assert.IsNull(invalid.AverageActions);
+                CollectionAssert.DoesNotContain(exactUsers.LeastActive.Select(u => u.UserId).ToList(), 5);
+                Assert.AreEqual("zero", exactUsers.Users.Single(u => u.UserId == 2)
+                    .Workloads.Single(w => w.Workload == "copilot").Band);
+            }
+        }
+
+        [TestMethod]
+        public async Task Copilot_LongPeriodChoicePrefersLargestContainedCoverageAfterExactMatch()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotPeriodChoice"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v2', N'D90',
+     '2000-07-01T01:00:00', 2, 2, 0, NULL);
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+VALUES
+    (28, 10, 4, 0, 1, '2000-06-25', '2000-06-24'),
+    (90, 30, 12, 0, 1, '2000-06-25', '2000-06-24');");
+
+                var query = LicenceActivityQuery.Create(
+                    "1999-12-29", "2000-06-25", LicenceActivitySqlFixture.NowUtc);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, Sources(usageReports: false, copilotReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var coverage = overview.Coverage.Single(c => c.Workload == "copilot");
+                Assert.AreEqual(90, coverage.ReportPeriodDays.Value);
+                Assert.AreEqual(new DateTime(2000, 3, 28), coverage.EffectiveFromUtc.Value);
+            }
+        }
+
+        [TestMethod]
+        public async Task Copilot_V1LastActivityIsPositiveEvidenceButNotFrequencyOrLeastActiveProof()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotV1"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v1', N'D7',
+     '2000-07-01T01:00:00', 1, 1, 0, NULL);");
+                foreach (var date in CopilotD7Dates)
+                {
+                    fixture.Execute($@"
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+VALUES (7, NULL, NULL, 0, 1, '{date}', '{date}');");
+                }
+
+                var sources = Sources(usageReports: false, copilotReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual(5, distribution.Unknown);
+                Assert.AreEqual(0, distribution.High);
+
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview,
+                    OverviewQuery().ForUsers(
+                        1, "copilot", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources,
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                var evidence = users.MostActive.Single().Workloads
+                    .Single(w => w.Workload == "copilot");
+                Assert.AreEqual("partial", evidence.Status);
+                Assert.AreEqual("unknown", evidence.Band);
+                Assert.AreEqual(0, users.LeastActive.Count);
+            }
+        }
+
+        [TestMethod]
+        public async Task Copilot_NegativeD7MetricsAreUnknownWhileExplicitZeroRemainsMeasured()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotNegative"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v2', N'D7',
+     '2000-07-01T01:00:00', 2, 2, 0, NULL);");
+
+                for (var index = 0; index < CopilotD7Dates.Length; index++)
+                {
+                    var date = CopilotD7Dates[index];
+                    var activeDays = index == 0 ? -1 : 1;
+                    var prompts = index == 0 ? -2 : 5;
+                    var lastActivitySql = index == 0 ? "NULL" : "'" + date + "'";
+                    fixture.Execute($@"
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+VALUES
+    (7, {prompts}, {activeDays}, 0, 1, '{date}',
+     {lastActivitySql}),
+    (7, 0, 0, 0, 4, '{date}', NULL);");
+                }
+
+                var sources = Sources(usageReports: false, copilotReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual(1, distribution.Zero);
+                Assert.AreEqual(4, distribution.Unknown);
+
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview,
+                    OverviewQuery().ForUsers(
+                        1, "copilot", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources,
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                var invalid = users.Users.Single(u => u.UserId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual("partial", invalid.Status);
+                Assert.AreEqual("unknown", invalid.Band);
+                Assert.IsNull(invalid.AverageActions,
+                    "A negative prompt counter must not enter an average.");
+                CollectionAssert.DoesNotContain(users.LeastActive.Select(u => u.UserId).ToList(), 1);
+                Assert.AreEqual("zero", users.Users.Single(u => u.UserId == 4)
+                    .Workloads.Single(w => w.Workload == "copilot").Band);
+            }
+        }
+
+        [TestMethod]
+        public async Task Copilot_ConcealedIdentitiesUsePositiveOnlyFallbackAndNeverCreateFalseZeros()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotFallback"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-30', N'v2', N'D28',
+     '2000-07-01T01:00:00', 5, 0, 1, NULL);
+INSERT dbo.copilot_chats (event_id, app_host, user_id, time_stamp)
+VALUES
+    ('00000000-0000-0000-0000-000000000001', N'Teams', 1, '2000-06-20'),
+    ('00000000-0000-0000-0000-000000000002', N'Teams', 1, '2000-06-21');");
+
+                var sources = Sources(
+                    usageReports: false, copilotReports: true, copilotAudit: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+
+                var coverage = overview.Coverage.Single(c => c.Workload == "copilot");
+                Assert.AreEqual("unmatchableIdentity", coverage.Status);
+                Assert.AreEqual("copilotAudit", coverage.Source);
+                Assert.AreEqual(5, coverage.UnmatchedUsers);
+                Assert.AreEqual(5, overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot").Unknown);
+
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview,
+                    OverviewQuery().ForUsers(
+                        1, "copilot", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources,
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+
+                Assert.AreEqual(1, users.MostActive[0].UserId);
+                Assert.AreEqual(0, users.LeastActive.Count,
+                    "Positive-only event evidence must never turn absence into a least-active zero.");
+                Assert.AreEqual("unknown", users.MostActive[0].Workloads
+                    .Single(w => w.Workload == "copilot").Band);
+            }
+        }
+
+        [TestMethod]
+        public async Task Copilot_InteractionHistoryIsUsedWhenItIsTheOnlyEnabledPositiveSource()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotInteractions"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_interactions
+    (graph_interaction_id, session_id, user_id, created_utc,
+     body_char_count, body_word_count, attachment_count, link_count,
+     mention_count, context_count)
+VALUES
+    (N'synthetic-interaction-1', 1, 2, '2000-06-20', 20, 4, 0, 0, 0, 0);
+INSERT dbo.copilot_interaction_import_log
+    (run_started_utc, run_finished_utc, users_in_scope, users_scanned, users_skipped,
+     users_failed, interactions_read, interactions_saved, cognitive_docs_scored, error)
+VALUES
+    ('2000-07-01T00:00:00', '2000-07-01T00:05:00', 5, 5, 0, 0, 1, 1, 0, NULL);");
+
+                var sources = Sources(
+                    usageReports: false, copilotInteractions: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var coverage = overview.Coverage.Single(c => c.Workload == "copilot");
+                Assert.AreEqual("partial", coverage.Status);
+                Assert.AreEqual("copilotInteractions", coverage.Source);
+                Assert.AreEqual(new DateTime(2000, 7, 1, 0, 5, 0, DateTimeKind.Utc),
+                    coverage.LatestImportUtc.Value);
+
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview,
+                    OverviewQuery().ForUsers(
+                        1, "copilot", null, "activity", "desc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources,
+                    NullLicenceActivityDiagnostics.Instance,
+                    CancellationToken.None);
+                Assert.AreEqual(2, users.MostActive.Single().UserId);
+                Assert.AreEqual(0, users.LeastActive.Count);
+            }
+        }
+
+        [TestMethod]
+        public async Task Users_RankPageFilterAndEscapeSearchInSqlWithDeterministicTies()
+        {
+            using (var fixture = CreateMeasuredFixture())
+            {
+                var sources = Sources(usageReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+
+                var query = OverviewQuery().ForUsers(
+                    1, "teams", null, "activity", "desc", 2, 1, 2,
+                    LicenceActivitySqlFixture.NowUtc);
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview, query, sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+
+                CollectionAssert.AreEqual(
+                    new[] { 1, 2 },
+                    users.MostActive.Select(u => u.UserId).ToArray());
+                CollectionAssert.AreEqual(
+                    new[] { 4, 5 },
+                    users.LeastActive.Select(u => u.UserId).ToArray(),
+                    "Measured-zero ties use UPN then numeric id and include disabled accounts.");
+                Assert.AreEqual(0, users.LeastActive.Single(u => u.UserId == 5)
+                    .Workloads.Single(w => w.Workload == "teams").ActiveSamples,
+                    "Positive snapshot counters do not prove weekly activity when last_activity_date is outside that week.");
+                Assert.AreEqual(5, users.TotalUsers);
+                Assert.AreEqual(5, users.RankedUsers);
+                Assert.AreEqual(2, users.Users.Count);
+
+                var secondPage = query.ForUsers(
+                    1, "teams", null, "activity", "desc", 2, 2, 2,
+                    LicenceActivitySqlFixture.NowUtc);
+                var secondPageUsers = await fixture.Store().LoadUsersAsync(
+                    overview, secondPage, sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                CollectionAssert.AreEqual(
+                    new[] { 3, 5 },
+                    secondPageUsers.Users.Select(u => u.UserId).ToArray(),
+                    "The browse order is activity descending, then the published-counter average; user 5 has an out-of-week counter but still a zero activity band.");
+
+                var underscore = query.ForUsers(
+                    1, "teams", "_", "upn", "asc", 10, 1, 20,
+                    LicenceActivitySqlFixture.NowUtc);
+                var underscoreUsers = await fixture.Store().LoadUsersAsync(
+                    overview, underscore, sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual(1, underscoreUsers.TotalUsers);
+                Assert.AreEqual("zero_user@contoso.example", underscoreUsers.Users[0].UserPrincipalName);
+
+                var caseInsensitive = query.ForUsers(
+                    1, "teams", "ALPHA", "upn", "asc", 10, 1, 20,
+                    LicenceActivitySqlFixture.NowUtc);
+                var caseInsensitiveUsers = await fixture.Store().LoadUsersAsync(
+                    overview, caseInsensitive, sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual("alpha@contoso.example", caseInsensitiveUsers.Users.Single().UserPrincipalName);
+
+                var mailAlias = query.ForUsers(
+                    1, "teams", "alias.search", "upn", "asc", 10, 1, 20,
+                    LicenceActivitySqlFixture.NowUtc);
+                var mailAliasUsers = await fixture.Store().LoadUsersAsync(
+                    overview, mailAlias, sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual("zero_user@contoso.example", mailAliasUsers.Users.Single().UserPrincipalName);
+
+                foreach (var literal in new[] { "%", "[", "Καλημέρα" })
+                {
+                    var escaped = query.ForUsers(
+                        1, "teams", literal, "upn", "asc", 10, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc);
+                    var escapedUsers = await fixture.Store().LoadUsersAsync(
+                        overview, escaped, sources,
+                        NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                    Assert.AreEqual(0, escapedUsers.TotalUsers,
+                        "LIKE metacharacters and Unicode input must remain data, never SQL syntax.");
+                }
+
+                var greekDepartment = LicenceActivityQuery.Create(
+                    OverviewQuery().From, OverviewQuery().To, LicenceActivitySqlFixture.NowUtc,
+                    departmentId: 2, licenceTypeId: 1, workload: "teams");
+                var filteredOverview = await fixture.Store().LoadOverviewAsync(
+                    greekDepartment, sources,
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual(1, filteredOverview.DistinctAssignedUsers);
+                Assert.AreEqual("Καλημέρα κόσμε", filteredOverview.Departments.Single().Name);
+            }
+        }
+
+        [TestMethod]
+        public async Task Overview_RejectsMoreThanFiveHundredImportedSkusExplicitly()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceLimit"))
+            {
+                fixture.Execute(@"
+;WITH E1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+E2(n) AS (SELECT 0 FROM E1 AS a CROSS JOIN E1 AS b),
+E4(n) AS (SELECT 0 FROM E2 AS a CROSS JOIN E2 AS b),
+Numbers(n) AS
+(
+    SELECT TOP (501) ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+    FROM E4
+)
+INSERT dbo.license_types (name, sku_id)
+SELECT N'Synthetic limit ' + CAST(n AS nvarchar(10)),
+       N'LIMIT_' + CAST(n AS nvarchar(10))
+FROM Numbers;");
+
+                var exception = await Assert.ThrowsExceptionAsync<System.Data.SqlClient.SqlException>(() =>
+                    fixture.Store().LoadOverviewAsync(
+                        OverviewQuery(), Sources(usageReports: false),
+                        NullLicenceActivityDiagnostics.Instance, CancellationToken.None));
+                StringAssert.Contains(exception.Message, "at most 500");
+            }
+        }
+
+        [TestMethod]
+        public async Task Demographics_AreBoundedToFiftyButRetainTheSelectedValue()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceDemographics"))
+            {
+                fixture.Execute(@"
+;WITH E1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+E2(n) AS (SELECT 0 FROM E1 AS a CROSS JOIN E1 AS b),
+Numbers(n) AS
+(
+    SELECT TOP (51) ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+    FROM E2
+)
+INSERT dbo.user_departments (name)
+SELECT N'Synthetic department ' + RIGHT(N'00' + CAST(n AS nvarchar(2)), 2)
+FROM Numbers;
+
+INSERT dbo.license_types (name, sku_id)
+VALUES (N'Synthetic demographic SKU', N'SYNTHETIC_DEMOGRAPHIC');
+
+;WITH E1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+E2(n) AS (SELECT 0 FROM E1 AS a CROSS JOIN E1 AS b),
+Numbers(n) AS
+(
+    SELECT TOP (51) ROW_NUMBER() OVER (ORDER BY (SELECT NULL))
+    FROM E2
+)
+INSERT dbo.users (user_name, account_enabled, department_id)
+SELECT 'demographic' + CAST(n AS varchar(2)) + '@contoso.example', 1, n
+FROM Numbers;
+
+INSERT dbo.user_license_type_lookups (user_id, license_type_id)
+SELECT id, 1 FROM dbo.users;");
+
+                var unfiltered = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: false),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual(50, unfiltered.Departments.Count);
+                Assert.IsTrue(unfiltered.DemographicsTruncated);
+
+                var selectedQuery = LicenceActivityQuery.Create(
+                    OverviewQuery().From, OverviewQuery().To,
+                    LicenceActivitySqlFixture.NowUtc, departmentId: 51);
+                var selected = await fixture.Store().LoadOverviewAsync(
+                    selectedQuery, Sources(usageReports: false),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual(1, selected.Departments.Count);
+                Assert.AreEqual(51, selected.Departments[0].Id);
+                Assert.AreEqual(1, selected.Departments[0].AssignedUsers);
+            }
+        }
+
+        private static LicenceActivitySqlFixture CreateMeasuredFixture()
+        {
+            var fixture = LicenceActivitySqlFixture.Create("LicenceMeasured");
+            SeedDirectory(fixture);
+            SeedAllUsageTables(fixture, SampleDates);
+            fixture.Execute(@"
+INSERT dbo.teams_user_activity_log
+(
+    private_chat_count, team_chat_count, calls_count, meetings_count,
+    adhoc_meetings_attended_count, adhoc_meetings_organized_count,
+    meetings_attended_count, meetings_organized_count,
+    scheduled_onetime_meetings_attended_count, scheduled_onetime_meetings_organized_count,
+    scheduled_recurring_meetings_attended_count, scheduled_recurring_meetings_organized_count,
+    audio_duration_seconds, video_duration_seconds, screenshare_duration_seconds,
+    post_messages, reply_messages, urgent_messages, user_id, [date], last_activity_date
+)
+VALUES
+    (99, 99, 0, 0, 0, 0, 99, 99, 0, 0, 0, 0, 0, 0, 0, 99, 99, 0,
+     5, '2000-05-07', '2000-04-24');");
+            return fixture;
+        }
+
+        private static void SeedDirectory(LicenceActivitySqlFixture fixture)
+        {
+            fixture.Execute(@"
+INSERT dbo.user_departments (name)
+VALUES (N'Engineering'), (N'Καλημέρα κόσμε');
+INSERT dbo.user_country_or_region (name)
+VALUES (N'Contoso North'), (N'Contoso South');
+
+INSERT dbo.users
+    (user_name, mail, account_enabled, department_id, country_or_region_id)
+VALUES
+    ('alpha@contoso.example', N'alpha@contoso.example', 1, 1, 1),
+    ('beta@contoso.example', N'beta@contoso.example', 1, 1, 1),
+    ('guest#EXT#@contoso.example', N'guest#EXT#@contoso.example', 1, 2, 2),
+    ('disabled@contoso.example', N'disabled@contoso.example', 0, 1, 1),
+    ('zero_user@contoso.example', N'alias.search@contoso.example', NULL, NULL, NULL);
+
+INSERT dbo.license_types (name, sku_id)
+VALUES
+    (N'Contoso Suite', N'CONTOSO_SUITE'),
+    (N'Contoso Add-on', N'CONTOSO_ADDON'),
+    (N'Contoso Empty', N'CONTOSO_EMPTY');
+
+INSERT dbo.user_license_type_lookups (user_id, license_type_id)
+VALUES
+    (1, 1), (2, 1), (3, 1), (4, 1), (5, 1),
+    (1, 2), (4, 2);");
+        }
+
+        private static void SeedAllUsageTables(
+            LicenceActivitySqlFixture fixture,
+            string[] sampleDates)
+        {
+            SeedOneUsageTable(fixture, "teams_user_activity_log", sampleDates);
+            SeedOneUsageTable(fixture, "outlook_user_activity_log", sampleDates);
+            SeedOneUsageTable(fixture, "onedrive_user_activity_log", sampleDates);
+            SeedOneUsageTable(fixture, "sharepoint_user_activity_log", sampleDates);
+        }
+
+        private static void SeedOneUsageTable(
+            LicenceActivitySqlFixture fixture,
+            string table,
+            string[] sampleDates)
+        {
+            for (var index = 0; index < sampleDates.Length; index++)
+            {
+                var date = sampleDates[index];
+                var activeUsers = index == 0
+                    ? "1,2,3"
+                    : index == 1 ? "1,2" : "1";
+
+                if (table == "teams_user_activity_log")
+                {
+                    fixture.Execute($@"
+INSERT dbo.teams_user_activity_log
+(
+    private_chat_count, team_chat_count, calls_count, meetings_count,
+    adhoc_meetings_attended_count, adhoc_meetings_organized_count,
+    meetings_attended_count, meetings_organized_count,
+    scheduled_onetime_meetings_attended_count, scheduled_onetime_meetings_organized_count,
+    scheduled_recurring_meetings_attended_count, scheduled_recurring_meetings_organized_count,
+    audio_duration_seconds, video_duration_seconds, screenshare_duration_seconds,
+    post_messages, reply_messages, urgent_messages, user_id, [date], last_activity_date
+)
+SELECT CASE WHEN id IN ({activeUsers}) THEN 2 ELSE 0 END,
+       CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
+       0, 0, 0, 0,
+       CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
+       0, 0, 0, 0, 0, 0, 0, 0,
+       CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
+       0, 0, id, '{date}',
+       CASE WHEN id IN ({activeUsers}) THEN '{date}' ELSE NULL END
+FROM dbo.users;");
+                }
+                else if (table == "outlook_user_activity_log")
+                {
+                    fixture.Execute($@"
+INSERT dbo.outlook_user_activity_log
+    (email_send_count, email_receive_count, email_read_count,
+     meeting_created_count, meeting_interacted_count, user_id, [date], last_activity_date)
+SELECT CASE WHEN id IN ({activeUsers}) THEN 2 ELSE 0 END,
+       CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
+       CASE WHEN id IN ({activeUsers}) THEN 3 ELSE 0 END,
+       0, 0, id, '{date}',
+       CASE WHEN id IN ({activeUsers}) THEN '{date}' ELSE NULL END
+FROM dbo.users;");
+                }
+                else
+                {
+                    fixture.Execute($@"
+INSERT dbo.{table}
+    (viewed_or_edited, synced, shared_internally, shared_externally,
+     user_id, [date], last_activity_date)
+SELECT CASE WHEN id IN ({activeUsers}) THEN 4 ELSE 0 END,
+       CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
+       0, 0, id, '{date}',
+       CASE WHEN id IN ({activeUsers}) THEN '{date}' ELSE NULL END
+FROM dbo.users;");
+                }
+            }
+        }
+
+        private static LicenceActivityQuery OverviewQuery()
+        {
+            return LicenceActivityQuery.Create(
+                "2000-05-01", "2000-06-25", LicenceActivitySqlFixture.NowUtc);
+        }
+
+        private static LicenceActivitySources Sources(
+            bool usageReports,
+            bool copilotReports = false,
+            bool copilotAudit = false,
+            bool copilotInteractions = false)
+        {
+            return new LicenceActivitySources
+            {
+                UserMetadata = true,
+                UsageReports = usageReports,
+                CopilotUsageReports = copilotReports,
+                CopilotAudit = copilotAudit,
+                CopilotInteractions = copilotInteractions,
+                NowUtc = LicenceActivitySqlFixture.NowUtc
+            };
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityTests.cs
@@ -1,0 +1,473 @@
+extern alias AnalyticsWeb;
+
+using AnalyticsWeb::Web.AnalyticsWeb.Models.LicenceActivity;
+using Common.Entities.LicenceActivity;
+using DataUtils;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class LicenceActivityTests
+    {
+        internal static readonly DateTime Now = new DateTime(2000, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        [TestMethod]
+        public void CustomDates_AreExactUtcAndNeverRounded()
+        {
+            var query = LicenceActivityQuery.Create("2000-05-03", "2000-06-21", Now);
+            Assert.AreEqual("2000-05-03", query.From);
+            Assert.AreEqual("2000-06-21", query.To);
+            Assert.AreEqual(50, query.Days);
+            Assert.AreEqual(DateTimeKind.Utc, query.FromUtc.Kind);
+            Assert.AreEqual(new DateTime(2000, 6, 22, 0, 0, 0, DateTimeKind.Utc), query.EndExclusiveUtc);
+            var changed = query.ForUsers(2, "copilot", "Contoso", "activity", "desc", 100, 3, 100, Now);
+            Assert.AreEqual(query.From, changed.From);
+            Assert.AreEqual(query.To, changed.To);
+        }
+
+        [TestMethod]
+        public void DefaultRange_UsesFourFullySettledWeeks()
+        {
+            var query = LicenceActivityQuery.Create(null, null, Now);
+            Assert.AreEqual("2000-05-29", query.From);
+            Assert.AreEqual("2000-06-25", query.To);
+            Assert.AreEqual(DayOfWeek.Monday, query.FromUtc.DayOfWeek);
+            Assert.AreEqual(DayOfWeek.Sunday, query.ToUtc.DayOfWeek);
+            Assert.IsTrue(query.ToUtc <= Now.Date.AddDays(-3));
+        }
+
+        [TestMethod]
+        public void InvalidRangesAndBounds_AreRejected()
+        {
+            foreach (var range in new[]
+            {
+                new[] { "2000-06-01", (string)null }, new[] { "", "2000-06-21" },
+                new[] { "2000-06-20", "2000-06-21" }, new[] { "1999-01-01", "2000-06-21" },
+                new[] { "2000-07-01", "2000-07-28" }, new[] { "2000-06-30", "2000-06-01" },
+                new[] { "2000-05-03T12:00:00Z", "2000-06-21" }
+            })
+                Assert.ThrowsException<ArgumentException>(() => LicenceActivityQuery.Create(range[0], range[1], Now));
+            Assert.ThrowsException<ArgumentException>(() => LicenceActivityQuery.Create(null, null, Now, top: 0));
+            Assert.ThrowsException<ArgumentException>(() => LicenceActivityQuery.Create(null, null, Now, pageSize: 101));
+            Assert.ThrowsException<ArgumentException>(() => LicenceActivityQuery.Create(null, null, Now, page: 10001));
+            Assert.ThrowsException<ArgumentException>(() => LicenceActivityQuery.Create(null, null, Now, workload: "total"));
+            Assert.ThrowsException<ArgumentException>(() => LicenceActivityQuery.Create(null, null, Now, sort: "user_name;DROP"));
+            Assert.ThrowsException<ArgumentException>(() => LicenceActivityQuery.Create(null, null, Now, search: new string('x', 101)));
+        }
+
+        [TestMethod]
+        public void Bands_NeedCompleteEvidenceAndUseExplainableThresholds()
+        {
+            Assert.AreEqual("unknown", LicenceActivityRules.Band(0, 0, 4));
+            Assert.AreEqual("unknown", LicenceActivityRules.Band(0, 3, 4));
+            Assert.AreEqual("unknown", LicenceActivityRules.Band(0, 0, 0));
+            Assert.AreEqual("zero", LicenceActivityRules.Band(0, 4, 4));
+            Assert.AreEqual("low", LicenceActivityRules.Band(1, 8, 8));
+            Assert.AreEqual("moderate", LicenceActivityRules.Band(1, 4, 4));
+            Assert.AreEqual("high", LicenceActivityRules.Band(3, 4, 4));
+        }
+
+        [TestMethod]
+        public void CacheKeys_IncludeEveryResultAffectingInput()
+        {
+            var first = LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1);
+            var keys = new[]
+            {
+                first.CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 2).CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, departmentId: 3).CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, countryId: 0).CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, workload: "outlook").CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, search: "Contoso").CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, page: 2).CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, pageSize: 100).CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, top: 25).CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, direction: "desc").CacheKey(),
+                LicenceActivityQuery.Create(null, null, Now, licenceTypeId: 1, sort: "activity").CacheKey()
+            };
+            Assert.AreEqual(keys.Length, keys.Distinct().Count());
+        }
+
+        [TestMethod]
+        public void Excel_ExportsTheDisplayedSnapshotWithUnicodeAndNoFormulaInjection()
+        {
+            var overview = SampleOverview();
+            var users = new LicenceActivityUsers
+            {
+                OverviewId = overview.SnapshotId, Query = overview.Query.ForUsers(1, "teams", "Contoso", "upn", "asc", 10, 1, 50, Now),
+                GeneratedUtc = Now
+            };
+            users.LeastActive.Add(new LicenceActivityUser
+            {
+                UserId = 1, Department = "Καλημέρα κόσμε", UserPrincipalName = "synthetic@contoso.example",
+                Country = "=SUM(1,2)",
+                Workloads = { new LicenceActivityEvidence { Workload = "teams", Band = "zero", Status = "available", AverageActions = 0 } }
+            });
+            using (var archive = new ZipArchive(new MemoryStream(LicenceActivityWorkbook.Build(overview, users))))
+            {
+                var xml = string.Join("\n", archive.Entries.Where(e => e.FullName.StartsWith("xl/worksheets/", StringComparison.Ordinal))
+                    .Select(Read));
+                StringAssert.Contains(xml, "Καλημέρα κόσμε");
+                StringAssert.Contains(xml, "=SUM(1,2)");
+                StringAssert.Contains(xml, "synthetic@contoso.example");
+                StringAssert.Contains(xml, "zero");
+                Assert.IsFalse(xml.Contains("<f>"), "Tenant text must be inline strings, never spreadsheet formulae.");
+                var workbook = Read(archive.GetEntry("xl/workbook.xml"));
+                StringAssert.Contains(workbook, "Least active");
+                StringAssert.Contains(workbook, "Workload coverage");
+            }
+            using (var archive = new ZipArchive(new MemoryStream(LicenceActivityWorkbook.Build(overview))))
+                Assert.IsFalse(Read(archive.GetEntry("xl/workbook.xml")).Contains("Least active"));
+            users.OverviewId = "different";
+            Assert.ThrowsException<ArgumentException>(() => LicenceActivityWorkbook.Build(overview, users));
+        }
+
+        private static string Read(ZipArchiveEntry entry)
+        {
+            using (var reader = new StreamReader(entry.Open(), Encoding.UTF8)) return reader.ReadToEnd();
+        }
+
+        internal static LicenceActivityOverview SampleOverview() => new LicenceActivityOverview
+        {
+            SnapshotId = "synthetic-overview", Query = LicenceActivityQuery.Create(null, null, Now),
+            GeneratedUtc = Now, ExpiresUtc = Now.AddMinutes(5), DistinctAssignedUsers = 3,
+            Licences =
+            {
+                new LicenceActivitySku
+                {
+                    LicenceTypeId = 1, Name = "Contoso licence", SkuId = "00000000-0000-0000-0000-000000000000",
+                    AssignedUsers = 3,
+                    Workloads = { new LicenceActivityDistribution { Workload = "teams", High = 1, Zero = 1, Unknown = 1 } }
+                }
+            }
+        };
+    }
+
+    [TestClass]
+    public class LicenceActivityCacheTests
+    {
+        private static TaskCompletionSource<bool> Gate() =>
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private static LicenceActivitySnapshotCache<LicenceActivityOverview> Cache(
+            int capacity = 4, Func<DateTime> clock = null,
+            Func<string, LicenceActivityRunDiagnostics> diagnostics = null,
+            Action<string, Exception> failure = null, TimeSpan? timeout = null) =>
+            new LicenceActivitySnapshotCache<LicenceActivityOverview>(
+                capacity, TimeSpan.FromMinutes(5), new SemaphoreSlim(4), clock ?? (() => LicenceActivityTests.Now),
+                diagnostics ?? (id => new LicenceActivityRunDiagnostics(id, _ => true)), timeout,
+                failure ?? ((id, ex) => { }));
+
+        [TestMethod]
+        public async Task DuplicateColdRequests_DeduplicateAndCallerCancellationDoesNotCancelTheRun()
+        {
+            var cache = Cache();
+            var entered = Gate();
+            var release = Gate();
+            var calls = 0;
+            CancellationToken sharedToken = default(CancellationToken);
+            Func<ILicenceActivityDiagnostics, CancellationToken, Task<LicenceActivityOverview>> load = async (d, token) =>
+            {
+                Interlocked.Increment(ref calls);
+                sharedToken = token;
+                entered.TrySetResult(true);
+                await release.Task;
+                return LicenceActivityTests.SampleOverview();
+            };
+            var first = cache.GetAsync("tenant", "same", load);
+            var second = cache.GetAsync("tenant", "same", load);
+            await entered.Task;
+            using (var cancelled = new CancellationTokenSource())
+            {
+                var caller = LicenceActivitySnapshotCache<LicenceActivityOverview>.WaitForCallerAsync(first, cancelled.Token);
+                cancelled.Cancel();
+                await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => caller);
+                Assert.IsFalse(sharedToken.IsCancellationRequested);
+            }
+            release.TrySetResult(true);
+            Assert.AreSame(await first, await second);
+            Assert.AreEqual(1, calls);
+            var warm = await cache.GetAsync("tenant", "same", load);
+            Assert.AreSame(await second, warm);
+            Assert.ThrowsException<LicenceActivityExpiredException>(() => cache.Find("other-tenant", warm.SnapshotId));
+        }
+
+        [TestMethod]
+        public async Task SharedRun_InnerAwaitsDoNotCaptureEndedRequestContext()
+        {
+            var cache = Cache();
+            var release = Gate();
+            SynchronizationContext observed = null;
+            var request = new EndedRequestContext();
+            Task<LicenceActivityOverview> run;
+            var previous = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(request);
+                run = cache.GetAsync("tenant", "context", async (d, token) =>
+                {
+                    observed = SynchronizationContext.Current;
+                    await release.Task;
+                    return LicenceActivityTests.SampleOverview();
+                });
+            }
+            finally { SynchronizationContext.SetSynchronizationContext(previous); }
+            release.TrySetResult(true);
+            Assert.AreSame(run, await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(5))));
+            await run;
+            Assert.IsNull(observed);
+            Assert.AreEqual(0, request.Posts);
+        }
+
+        [TestMethod]
+        public async Task Failure_IsEvictedAndRetried_AndRefusedFailureUsesFallback()
+        {
+            var reported = Gate();
+            var cache = Cache(diagnostics: id => new LicenceActivityRunDiagnostics(id, _ => false),
+                failure: (id, ex) => reported.TrySetResult(true));
+            var task = cache.GetAsync("tenant", "failure", (d, token) =>
+                Task.FromException<LicenceActivityOverview>(new InvalidOperationException("private search text")));
+            var exception = await Assert.ThrowsExceptionAsync<LicenceActivityFailedException>(() => task);
+            Assert.IsFalse(exception.Message.Contains("private search text"));
+            Assert.AreSame(reported.Task, await Task.WhenAny(reported.Task, Task.Delay(TimeSpan.FromSeconds(5))));
+            var fresh = await cache.GetAsync("tenant", "failure", (d, token) => Task.FromResult(LicenceActivityTests.SampleOverview()));
+            Assert.IsNotNull(fresh.SnapshotId);
+        }
+
+        [TestMethod]
+        public async Task PublicationAndCapacityRelease_PrecedeOptionalTelemetry()
+        {
+            var blocked = Gate();
+            using (var release = new ManualResetEventSlim())
+            {
+                var cache = Cache(diagnostics: id => new LicenceActivityRunDiagnostics(id, e =>
+                {
+                    if (e.Stage == "CachePublished")
+                    {
+                        blocked.TrySetResult(true);
+                        release.Wait(TimeSpan.FromSeconds(5));
+                    }
+                    return true;
+                }));
+                try
+                {
+                    var result = await cache.GetAsync("tenant", "publication", (d, token) => Task.FromResult(LicenceActivityTests.SampleOverview()));
+                    Assert.AreSame(blocked.Task, await Task.WhenAny(blocked.Task, Task.Delay(TimeSpan.FromSeconds(5))));
+                    Assert.AreSame(result, cache.Find("tenant", result.SnapshotId));
+                }
+                finally { release.Set(); }
+            }
+        }
+
+        [TestMethod]
+        public async Task BoundedCache_EvictsCompletedEntriesAndDoesNotEvictInFlightWork()
+        {
+            var now = LicenceActivityTests.Now;
+            var cache = Cache(1, () => now);
+            var first = await cache.GetAsync("tenant", "one", (d, ct) => Task.FromResult(LicenceActivityTests.SampleOverview()));
+            var release = Gate();
+            var secondTask = cache.GetAsync("tenant", "two", async (d, ct) => { await release.Task; return LicenceActivityTests.SampleOverview(); });
+            Assert.ThrowsException<LicenceActivityExpiredException>(() => cache.Find("tenant", first.SnapshotId));
+            Assert.ThrowsException<LicenceActivityBusyException>(() =>
+                cache.GetAsync("tenant", "three", (d, ct) => Task.FromResult(LicenceActivityTests.SampleOverview())));
+            release.TrySetResult(true);
+            var second = await secondTask;
+            now = now.AddMinutes(6);
+            Assert.ThrowsException<LicenceActivityExpiredException>(() => cache.Find("tenant", second.SnapshotId));
+            var third = await cache.GetAsync("tenant", "two", (d, ct) => Task.FromResult(LicenceActivityTests.SampleOverview()));
+            Assert.AreNotEqual(second.SnapshotId, third.SnapshotId, "An expired generation must not persist through its finished task.");
+        }
+
+        [TestMethod]
+        public async Task ExpiryAndResponseSizeBounds_AreEnforced()
+        {
+            var cache = Cache();
+            Assert.ThrowsException<LicenceActivityExpiredException>(() =>
+                cache.GetAsync("tenant", "expired", (d, ct) => Task.FromResult(LicenceActivityTests.SampleOverview()), LicenceActivityTests.Now));
+            var tooLarge = cache.GetAsync("tenant", "huge", (d, ct) =>
+            {
+                var value = LicenceActivityTests.SampleOverview();
+                value.Messages.Add(new string('x', LicenceActivitySnapshotCache<LicenceActivityOverview>.MaximumJsonBytes));
+                return Task.FromResult(value);
+            });
+            await Assert.ThrowsExceptionAsync<LicenceActivityFailedException>(() => tooLarge);
+        }
+
+        [TestMethod]
+        public async Task TelemetryConstructionOrDeliveryFailure_DoesNotFailTheReport()
+        {
+            foreach (var factory in new Func<string, LicenceActivityRunDiagnostics>[]
+            {
+                id => throw new InvalidOperationException("telemetry construction"),
+                id => new LicenceActivityRunDiagnostics(id, e => throw new InvalidOperationException("telemetry delivery"))
+            })
+            {
+                var cache = Cache(diagnostics: factory);
+                var result = await cache.GetAsync("tenant", "telemetry", (d, ct) =>
+                {
+                    d.Stage("OverviewSqlStarted");
+                    d.Stage("OverviewSqlCompleted", 1);
+                    return Task.FromResult(LicenceActivityTests.SampleOverview());
+                });
+                Assert.AreEqual(3, result.DistinctAssignedUsers);
+            }
+        }
+
+        [TestMethod]
+        public async Task RunTimeout_IsIndependentOfCallerAndAllowsRetry()
+        {
+            var cache = Cache(timeout: TimeSpan.FromMilliseconds(30));
+            var timedOut = cache.GetAsync("tenant", "slow", async (d, ct) =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(10), ct);
+                return LicenceActivityTests.SampleOverview();
+            });
+            await Assert.ThrowsExceptionAsync<LicenceActivityFailedException>(() => timedOut);
+            var retry = await cache.GetAsync("tenant", "slow", (d, ct) => Task.FromResult(LicenceActivityTests.SampleOverview()));
+            Assert.IsNotNull(retry);
+        }
+
+        [TestMethod]
+        public async Task DeadlineBoundsResponseEvenWhenLoaderIgnoresCancellation_WithoutReleasingLiveCapacity()
+        {
+            var slots = new SemaphoreSlim(1, 1);
+            var release = Gate();
+            var entered = Gate();
+            var cache = new LicenceActivitySnapshotCache<LicenceActivityOverview>(
+                2, TimeSpan.FromMinutes(5), slots, () => LicenceActivityTests.Now,
+                id => new LicenceActivityRunDiagnostics(id, _ => true), TimeSpan.FromMilliseconds(100),
+                (id, ex) => { });
+            var first = cache.GetAsync("tenant", "slow", async (d, token) =>
+            {
+                entered.TrySetResult(true);
+                await release.Task;
+                return LicenceActivityTests.SampleOverview();
+            });
+            try
+            {
+                await entered.Task;
+                Assert.AreSame(first, await Task.WhenAny(first, Task.Delay(TimeSpan.FromSeconds(3))),
+                    "The response deadline must not depend on loader cooperation.");
+                await Assert.ThrowsExceptionAsync<LicenceActivityFailedException>(() => first);
+                Assert.AreEqual(0, slots.CurrentCount,
+                    "An operation still owning SQL resources must keep its concurrency slot.");
+                Assert.ThrowsException<LicenceActivityBusyException>(() =>
+                    cache.GetAsync("tenant", "other", (d, token) => Task.FromResult(LicenceActivityTests.SampleOverview())));
+            }
+            finally { release.TrySetResult(true); }
+
+            await WaitForSlots(slots, 1);
+            var retry = await cache.GetAsync("tenant", "slow", (d, token) => Task.FromResult(LicenceActivityTests.SampleOverview()));
+            Assert.IsNotNull(retry);
+        }
+
+        [TestMethod]
+        public async Task TimedOutLateGeneration_CannotPublishOverOrEvictItsReplacement()
+        {
+            var slots = new SemaphoreSlim(2, 2);
+            var release = Gate();
+            var cache = new LicenceActivitySnapshotCache<LicenceActivityOverview>(
+                4, TimeSpan.FromMinutes(5), slots, () => LicenceActivityTests.Now,
+                id => new LicenceActivityRunDiagnostics(id, _ => true), TimeSpan.FromMilliseconds(100),
+                (id, ex) => { });
+            var first = cache.GetAsync("tenant", "same", async (d, token) =>
+            {
+                await release.Task;
+                return LicenceActivityTests.SampleOverview();
+            });
+            LicenceActivityOverview replacement = null;
+            try
+            {
+                Assert.AreSame(first, await Task.WhenAny(first, Task.Delay(TimeSpan.FromSeconds(3))));
+                await Assert.ThrowsExceptionAsync<LicenceActivityFailedException>(() => first);
+                replacement = await cache.GetAsync("tenant", "same", (d, token) =>
+                    Task.FromResult(LicenceActivityTests.SampleOverview()));
+            }
+            finally { release.TrySetResult(true); }
+            await WaitForSlots(slots, 2);
+            Assert.AreSame(replacement, cache.Find("tenant", replacement.SnapshotId));
+            Assert.AreSame(replacement, await cache.GetAsync("tenant", "same",
+                (d, token) => throw new AssertFailedException("A valid replacement was evicted by an older generation.")));
+        }
+
+        private static async Task WaitForSlots(SemaphoreSlim slots, int count)
+        {
+            for (var attempt = 0; attempt < 300 && slots.CurrentCount != count; attempt++)
+                await Task.Delay(10);
+            Assert.AreEqual(count, slots.CurrentCount, "The completed loader must release its concurrency slot.");
+        }
+
+        [TestMethod]
+        public void Diagnostics_AreAllowListedAndContainNoFilterValues()
+        {
+            var events = new ConcurrentQueue<LicenceActivityDiagnosticEvent>();
+            var diagnostics = new LicenceActivityRunDiagnostics("synthetic-run", item => { events.Enqueue(item); return true; });
+            diagnostics.Stage("OverviewSqlCompleted", 12);
+            diagnostics.Failed(new InvalidOperationException("private payload"));
+            Assert.ThrowsException<ArgumentException>(() => diagnostics.Stage("private payload"));
+            Assert.IsTrue(events.All(e => e.ExceptionType != "private payload"));
+            Assert.AreEqual(nameof(InvalidOperationException), events.Last().ExceptionType);
+            Assert.AreEqual(1L, events.First().Sequence);
+            Assert.AreEqual(2L, events.Last().Sequence);
+        }
+
+        [TestMethod]
+        public void DrainedTelemetry_FlushesItsChannelBeforeTheBoundedShutdownWait()
+        {
+            var channel = new FlushRecordingChannel();
+            using (var configuration = new TelemetryConfiguration
+            {
+                TelemetryChannel = channel,
+                ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000001"
+            })
+            {
+                var logger = new AnalyticsLogger(new TelemetryClient(configuration), "LicenceActivityTest");
+                var waited = false;
+                LicenceActivityTelemetry.DrainEvents(new[]
+                {
+                    new LicenceActivityDiagnosticEvent
+                    {
+                        RunId = "synthetic-shutdown", Stage = "HostStopping", OccurredUtc = DateTimeOffset.UtcNow
+                    }
+                }, () => logger, () =>
+                {
+                    Assert.IsTrue(channel.Sent > 0);
+                    Assert.IsTrue(channel.Flushed > 0, "Flush must precede the bounded channel-drain interval.");
+                    waited = true;
+                });
+                Assert.IsTrue(waited);
+                Assert.AreEqual(1, channel.Flushed);
+            }
+        }
+
+        private sealed class FlushRecordingChannel : ITelemetryChannel
+        {
+            internal int Sent;
+            internal int Flushed;
+            public bool? DeveloperMode { get; set; }
+            public string EndpointAddress { get; set; }
+            public void Send(ITelemetry item) => Sent++;
+            public void Flush() => Flushed++;
+            public void Dispose() { }
+        }
+
+        private sealed class EndedRequestContext : SynchronizationContext
+        {
+            internal int Posts;
+            public override void Post(SendOrPostCallback d, object state) => Interlocked.Increment(ref Posts);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -31,6 +31,13 @@
   <ItemGroup>
     <Compile Remove="Generated\**" />
     <Compile Include="AppConfigDefaultsTests.cs" />
+    <Compile Include="LicenceActivityTests.cs" />
+    <Compile Include="LicenceActivityApiTests.cs" />
+    <Compile Include="LicenceActivityHttpHost.cs" />
+    <Compile Include="LicenceActivityLoadTests.cs" />
+    <Compile Include="LicenceActivitySqlFixture.cs" />
+    <Compile Include="LicenceActivitySqlTests.cs" />
+    <Compile Include="LicenceActivityPerformanceTests.cs" />
     <Compile Include="PreInstallAdvisorTests.cs" />
     <Compile Include="ImportCadenceTests.cs" />
     <Compile Include="AppInsightsApiClientTests.cs" />

--- a/src/AnalyticsEngine/Web/Controllers/LicenceActivityAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/LicenceActivityAPIController.cs
@@ -1,0 +1,198 @@
+using Common.Entities.Config;
+using Common.Entities.LicenceActivity;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Web.AnalyticsWeb.Models.LicenceActivity;
+
+namespace Web.AnalyticsWeb.Controllers
+{
+    [Authorize]
+    [RoutePrefix("api/LicenceActivity")]
+    public sealed class LicenceActivityAPIController : ApiController
+    {
+        public const string UserDetailRole = "LicenceActivity.ReadUsers";
+        private static readonly LicenceActivitySnapshotCache<LicenceActivityOverview> OverviewCache =
+            new LicenceActivitySnapshotCache<LicenceActivityOverview>(16, TimeSpan.FromMinutes(5));
+        private static readonly LicenceActivitySnapshotCache<LicenceActivityUsers> UsersCache =
+            new LicenceActivitySnapshotCache<LicenceActivityUsers>(32, TimeSpan.FromMinutes(2));
+
+        private readonly Func<LicenceActivityRequestContext> _context;
+        private readonly LicenceActivitySnapshotCache<LicenceActivityOverview> _overviews;
+        private readonly LicenceActivitySnapshotCache<LicenceActivityUsers> _users;
+
+        public LicenceActivityAPIController() : this(CreateContext, OverviewCache, UsersCache) { }
+
+        internal LicenceActivityAPIController(
+            Func<LicenceActivityRequestContext> context,
+            LicenceActivitySnapshotCache<LicenceActivityOverview> overviews,
+            LicenceActivitySnapshotCache<LicenceActivityUsers> users)
+        {
+            _context = context;
+            _overviews = overviews;
+            _users = users;
+        }
+
+        [HttpGet, Route("availability")]
+        public IHttpActionResult Availability()
+        {
+            var sources = _context().Sources;
+            var result = new LicenceActivityAvailability { Available = sources.UserMetadata, CanViewUsers = CanViewUsers(User) };
+            if (!sources.UserMetadata)
+                result.Messages.Add("Enable GraphUsersMetadata (user metadata) in the installer to import licence-to-user assignments. This tab remains visible while the prerequisite is disabled.");
+            if (!result.CanViewUsers)
+                result.Messages.Add("Individual users require the LicenceActivity.ReadUsers application role. Aggregate reports and aggregate Excel snapshots remain available.");
+            result.Messages.Add("User display names are not imported. Search uses UPN or email; department and country filters use imported metadata.");
+            return Reply(HttpStatusCode.OK, result);
+        }
+
+        [HttpGet, Route("overview")]
+        public Task<IHttpActionResult> Overview(
+            string from = null, string to = null, int? departmentId = null, int? countryId = null,
+            CancellationToken cancellationToken = default(CancellationToken)) =>
+            ExecuteAsync(async () =>
+            {
+                var context = _context();
+                var query = LicenceActivityQuery.Create(from, to, context.Sources.NowUtc, departmentId, countryId);
+                if (!context.Sources.UserMetadata) return MissingMetadata();
+                var task = _overviews.GetAsync(context.Scope, query.CacheKey(), async (diagnostics, lifetime) =>
+                {
+                    var result = await context.Store.LoadOverviewAsync(query, context.Sources, diagnostics, lifetime).ConfigureAwait(false);
+                    result.Query = query;
+                    result.Messages.Add(LicenceActivityRules.AssignmentCaveat);
+                    result.Messages.Add(LicenceActivityRules.InterpretationCaveat);
+                    result.Messages.Add(LicenceActivityRules.Method);
+                    return result;
+                });
+                return Reply(HttpStatusCode.OK,
+                    await LicenceActivitySnapshotCache<LicenceActivityOverview>.WaitForCallerAsync(task, cancellationToken));
+            });
+
+        [HttpGet, Route("users")]
+        public Task<IHttpActionResult> Users(
+            string overviewId, int licenceTypeId, string workload = "teams", int top = 10, string search = null,
+            string sort = "upn", string direction = "asc", int page = 1, int pageSize = 50,
+            CancellationToken cancellationToken = default(CancellationToken)) =>
+            ExecuteAsync(async () =>
+            {
+                if (!CanViewUsers(User)) return ForbiddenUsers();
+                var context = _context();
+                if (!context.Sources.UserMetadata) return MissingMetadata();
+                var overview = _overviews.Find(context.Scope, overviewId);
+                if (!overview.Licences.Any(sku => sku.LicenceTypeId == licenceTypeId))
+                    return Reply(HttpStatusCode.NotFound, new { message = "That licence is not part of this snapshot." });
+                var query = overview.Query.ForUsers(licenceTypeId, workload, search, sort, direction, top, page, pageSize, context.Sources.NowUtc);
+                var task = _users.GetAsync(context.Scope, overviewId + "\n" + query.CacheKey(), async (diagnostics, lifetime) =>
+                {
+                    var result = await context.Store.LoadUsersAsync(overview, query, context.Sources, diagnostics, lifetime).ConfigureAwait(false);
+                    result.OverviewId = overviewId;
+                    result.Query = query;
+                    return result;
+                }, overview.ExpiresUtc);
+                return Reply(HttpStatusCode.OK,
+                    await LicenceActivitySnapshotCache<LicenceActivityUsers>.WaitForCallerAsync(task, cancellationToken));
+            });
+
+        [HttpGet, Route("export")]
+        public Task<IHttpActionResult> Export(string overviewId, string usersId = null) =>
+            ExecuteAsync(() =>
+            {
+                if (usersId != null && !CanViewUsers(User)) return Task.FromResult(ForbiddenUsers());
+                var context = _context();
+                if (!context.Sources.UserMetadata) return Task.FromResult(MissingMetadata());
+                var overview = _overviews.Find(context.Scope, overviewId);
+                var users = usersId == null ? null : _users.Find(context.Scope, usersId);
+                if (users != null && users.OverviewId != overviewId)
+                    return Task.FromResult(Reply(HttpStatusCode.Conflict, new { message = "The snapshots do not match. Refresh the current view before exporting." }));
+                var response = Request.CreateResponse(HttpStatusCode.OK);
+                response.Content = new ByteArrayContent(LicenceActivityWorkbook.Build(overview, users));
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+                response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+                {
+                    FileName = "licence-activity-" + overview.GeneratedUtc.ToString("yyyy-MM-dd") + ".xlsx"
+                };
+                response.Headers.CacheControl = new CacheControlHeaderValue { NoStore = true, Private = true };
+                return Task.FromResult<IHttpActionResult>(ResponseMessage(response));
+            });
+
+        internal static bool CanViewUsers(IPrincipal principal)
+        {
+            if (principal?.Identity?.IsAuthenticated != true) return false;
+            if (principal.IsInRole(UserDetailRole)) return true;
+            var claims = principal as ClaimsPrincipal;
+            return claims?.Claims.Any(c => (c.Type == "roles" || c.Type == ClaimTypes.Role)
+                && c.Value == UserDetailRole) == true;
+        }
+
+        private async Task<IHttpActionResult> ExecuteAsync(Func<Task<IHttpActionResult>> action)
+        {
+            if (!ModelState.IsValid) return Reply(HttpStatusCode.BadRequest, new { message = "The request contains an invalid parameter." });
+            try { return await action(); }
+            catch (ArgumentException ex) { return Reply(HttpStatusCode.BadRequest, new { message = ex.Message }); }
+            catch (LicenceActivityExpiredException)
+            {
+                return Reply(HttpStatusCode.Gone, new { message = "This snapshot has expired or was evicted. Refresh the current view before continuing or exporting." });
+            }
+            catch (LicenceActivityBusyException)
+            {
+                return Reply(HttpStatusCode.ServiceUnavailable, new { message = "Licence reporting is busy. Retry in a few seconds." }, true);
+            }
+            catch (LicenceActivityFailedException ex)
+            {
+                return Reply(HttpStatusCode.ServiceUnavailable, new { message = ex.Message }, true);
+            }
+        }
+
+        private IHttpActionResult MissingMetadata() =>
+            Reply(HttpStatusCode.PreconditionFailed, new { message = "Enable GraphUsersMetadata to import licence assignments." });
+
+        private IHttpActionResult ForbiddenUsers() =>
+            Reply(HttpStatusCode.Forbidden, new { message = "Individual licence activity requires the LicenceActivity.ReadUsers application role." });
+
+        private IHttpActionResult Reply(HttpStatusCode status, object body, bool retry = false)
+        {
+            var response = Request.CreateResponse(status, body);
+            response.Headers.CacheControl = new CacheControlHeaderValue { NoStore = true, Private = true };
+            if (retry) response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(5));
+            return ResponseMessage(response);
+        }
+
+        private static LicenceActivityRequestContext CreateContext()
+        {
+            var config = new AppConfig();
+            var settings = config.ImportJobSettings ?? new Common.Entities.ImportTaskSettings();
+            var sources = new LicenceActivitySources
+            {
+                UserMetadata = settings.GraphUsersMetadata, UsageReports = settings.GraphUsageReports,
+                CopilotUsageReports = settings.GraphCopilotUsageReports, CopilotAudit = settings.Copilot,
+                CopilotInteractions = settings.CopilotInteractionHistory, NowUtc = DateTime.UtcNow
+            };
+            string scope;
+            using (var sha = SHA256.Create())
+                scope = Convert.ToBase64String(sha.ComputeHash(Encoding.UTF8.GetBytes(
+                    config.TenantGUID + "\n" + config.ConnectionStrings.DatabaseConnectionString + "\n" + sources.CacheKey)));
+            return new LicenceActivityRequestContext(scope, sources,
+                new SqlLicenceActivityStore(config.ConnectionStrings.DatabaseConnectionString));
+        }
+    }
+
+    internal sealed class LicenceActivityRequestContext
+    {
+        internal LicenceActivityRequestContext(string scope, LicenceActivitySources sources, ILicenceActivityStore store)
+        {
+            Scope = scope; Sources = sources; Store = store;
+        }
+        internal string Scope { get; }
+        internal LicenceActivitySources Sources { get; }
+        internal ILicenceActivityStore Store { get; }
+    }
+}

--- a/src/AnalyticsEngine/Web/Global.asax.cs
+++ b/src/AnalyticsEngine/Web/Global.asax.cs
@@ -80,6 +80,7 @@ namespace Web.AnalyticsWeb
         /// </remarks>
         protected void Application_End(object sender, EventArgs e)
         {
+            Models.LicenceActivity.LicenceActivityTelemetry.Shutdown();
             CopilotAdoptionTelemetryHost.Shutdown(HostingEnvironment.ShutdownReason.ToString());
         }
     }

--- a/src/AnalyticsEngine/Web/Models/LicenceActivity/LicenceActivitySnapshotCache.cs
+++ b/src/AnalyticsEngine/Web/Models/LicenceActivity/LicenceActivitySnapshotCache.cs
@@ -1,0 +1,240 @@
+using Common.Entities.LicenceActivity;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Web.AnalyticsWeb.Models.LicenceActivity
+{
+    internal sealed class LicenceActivityBusyException : Exception { }
+    internal sealed class LicenceActivityExpiredException : Exception { }
+
+    internal sealed class LicenceActivityFailedException : Exception
+    {
+        public LicenceActivityFailedException(string runId)
+            : base("Licence activity could not be loaded. Retry the request. Reference: " + runId) { }
+    }
+
+    internal static class LicenceActivityConcurrency
+    {
+        internal static readonly SemaphoreSlim Slots = new SemaphoreSlim(4, 4);
+    }
+
+    // Only bounded result pages live here, never the user-by-licence population.
+    internal sealed class LicenceActivitySnapshotCache<T> where T : LicenceActivitySnapshot
+    {
+        internal const int MaximumJsonBytes = 1024 * 1024;
+        private readonly object _gate = new object();
+        private readonly Dictionary<string, Entry> _entries = new Dictionary<string, Entry>(StringComparer.Ordinal);
+        private readonly int _capacity;
+        private readonly TimeSpan _ttl;
+        private readonly TimeSpan _runTimeout;
+        private readonly Func<DateTime> _utcNow;
+        private readonly SemaphoreSlim _slots;
+        private readonly Func<string, LicenceActivityRunDiagnostics> _diagnostics;
+        private readonly Action<string, Exception> _reportFailure;
+
+        internal LicenceActivitySnapshotCache(
+            int capacity, TimeSpan ttl, SemaphoreSlim slots = null, Func<DateTime> utcNow = null,
+            Func<string, LicenceActivityRunDiagnostics> diagnostics = null, TimeSpan? runTimeout = null,
+            Action<string, Exception> reportFailure = null)
+        {
+            if (capacity < 1 || ttl <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(capacity));
+            _capacity = capacity;
+            _ttl = ttl;
+            _slots = slots ?? LicenceActivityConcurrency.Slots;
+            _utcNow = utcNow ?? (() => DateTime.UtcNow);
+            _diagnostics = diagnostics ?? LicenceActivityTelemetry.Start;
+            _runTimeout = runTimeout ?? TimeSpan.FromSeconds(30);
+            if (_runTimeout <= TimeSpan.Zero || _runTimeout.TotalMilliseconds > uint.MaxValue - 1)
+                throw new ArgumentOutOfRangeException(nameof(runTimeout));
+            _reportFailure = reportFailure ?? LicenceActivityTelemetry.ReportFailure;
+        }
+
+        internal Task<T> GetAsync(
+            string scope, string key, Func<ILicenceActivityDiagnostics, CancellationToken, Task<T>> load,
+            DateTime? notAfterUtc = null)
+        {
+            if (load == null) throw new ArgumentNullException(nameof(load));
+            Entry entry;
+            var compoundKey = scope + "\n" + key;
+            lock (_gate)
+            {
+                Prune();
+                if (notAfterUtc.HasValue && notAfterUtc <= _utcNow())
+                    throw new LicenceActivityExpiredException();
+                if (_entries.TryGetValue(compoundKey, out var existing)) return existing.Completion.Task;
+                Entry oldest = null;
+                if (_entries.Count >= _capacity)
+                {
+                    oldest = _entries.Values.Where(e => e.Value != null).OrderBy(e => e.Value.ExpiresUtc).FirstOrDefault();
+                    if (oldest == null) throw new LicenceActivityBusyException();
+                }
+                if (!_slots.Wait(0)) throw new LicenceActivityBusyException();
+                if (oldest != null) _entries.Remove(oldest.Key);
+                entry = new Entry(compoundKey, scope);
+                _entries.Add(compoundKey, entry);
+            }
+
+            // The response deadline starts at admission, not whenever a thread-pool worker starts.
+            entry.Deadline = new Timer(_ => ExpireRun(entry), null, _runTimeout, Timeout.InfiniteTimeSpan);
+            // Inner awaits must never capture the initiating ASP.NET request's SynchronizationContext.
+            _ = Task.Run(() => LoadAndPublishAsync(entry, load, notAfterUtc));
+            return entry.Completion.Task;
+        }
+
+        internal T Find(string scope, string snapshotId)
+        {
+            if (string.IsNullOrEmpty(snapshotId)) throw new LicenceActivityExpiredException();
+            lock (_gate)
+            {
+                Prune();
+                var result = _entries.Values.FirstOrDefault(e => e.Scope == scope && e.Value?.SnapshotId == snapshotId);
+                return result?.Value ?? throw new LicenceActivityExpiredException();
+            }
+        }
+
+        internal static async Task<T> WaitForCallerAsync(Task<T> task, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var cancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (cancellationToken.Register(() => cancelled.TrySetResult(true)))
+            {
+                if (await Task.WhenAny(task, cancelled.Task).ConfigureAwait(false) != task)
+                    throw new OperationCanceledException(cancellationToken);
+                return await task.ConfigureAwait(false);
+            }
+        }
+
+        private async Task LoadAndPublishAsync(
+            Entry entry, Func<ILicenceActivityDiagnostics, CancellationToken, Task<T>> load, DateTime? notAfterUtc)
+        {
+            LicenceActivityRunDiagnostics diagnostics = null;
+            Exception failure = null;
+            T value = null;
+            try
+            {
+                try { diagnostics = _diagnostics(entry.RunId); }
+                catch (Exception)
+                {
+                    // Telemetry construction is optional; a failed query still uses the fallback below.
+                }
+                Volatile.Write(ref entry.Diagnostics, diagnostics);
+                entry.Lifetime.Token.ThrowIfCancellationRequested();
+                value = await load(diagnostics ?? (ILicenceActivityDiagnostics)NullLicenceActivityDiagnostics.Instance,
+                    entry.Lifetime.Token).ConfigureAwait(false);
+                entry.Lifetime.Token.ThrowIfCancellationRequested();
+                if (value == null) throw new InvalidOperationException("The report loader returned no result.");
+                value.SnapshotId = Guid.NewGuid().ToString("N");
+                value.GeneratedUtc = _utcNow();
+                value.ExpiresUtc = value.GeneratedUtc.Add(_ttl);
+                if (notAfterUtc.HasValue && value.ExpiresUtc > notAfterUtc.Value) value.ExpiresUtc = notAfterUtc.Value;
+                if (value.ExpiresUtc <= value.GeneratedUtc) throw new LicenceActivityExpiredException();
+                if (Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(value)) > MaximumJsonBytes)
+                    throw new InvalidOperationException("The bounded report response exceeds its size budget.");
+                entry.Lifetime.Token.ThrowIfCancellationRequested();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                // A timed-out response does not free a still-running SQL operation's capacity. The
+                // store owns its connection and must finish cancellation/disposal before this release.
+                _slots.Release();
+            }
+
+            try
+            {
+                if (failure == null)
+                {
+                    var published = false;
+                    lock (_gate)
+                    {
+                        if (!entry.Completion.Task.IsCompleted
+                            && _entries.TryGetValue(entry.Key, out var current) && ReferenceEquals(current, entry))
+                        {
+                            entry.Value = value;
+                            published = entry.Completion.TrySetResult(value);
+                        }
+                    }
+                    if (published) diagnostics?.Stage("CachePublished");
+                }
+                else
+                {
+                    FailRun(entry, failure);
+                }
+            }
+            finally
+            {
+                entry.Deadline.Dispose();
+                entry.Lifetime.Dispose();
+                diagnostics?.Dispose();
+            }
+        }
+
+        private void ExpireRun(Entry entry)
+        {
+            Exception failure = new TimeoutException("The shared report response deadline elapsed.");
+            if (!FailRun(entry, failure, report: false))
+                return;
+            try { entry.Lifetime.Cancel(); }
+            catch (ObjectDisposedException)
+            {
+                // The completed loader can dispose its lifetime after the deadline wins publication.
+            }
+            catch (AggregateException cancellationFailure)
+            {
+                failure = cancellationFailure;
+            }
+            ReportFailure(entry, failure);
+        }
+
+        private bool FailRun(Entry entry, Exception failure, bool report = true)
+        {
+            lock (_gate)
+            {
+                if (entry.Completion.Task.IsCompleted) return false;
+                if (_entries.TryGetValue(entry.Key, out var current) && ReferenceEquals(current, entry))
+                    _entries.Remove(entry.Key);
+                entry.Completion.TrySetException(failure is LicenceActivityExpiredException
+                    ? failure : new LicenceActivityFailedException(entry.RunId));
+                _ = entry.Completion.Task.Exception;
+            }
+            if (report) ReportFailure(entry, failure);
+            return true;
+        }
+
+        private void ReportFailure(Entry entry, Exception failure)
+        {
+            var diagnostics = Volatile.Read(ref entry.Diagnostics);
+            if (diagnostics == null || !diagnostics.Failed(failure)) _reportFailure(entry.RunId, failure);
+        }
+
+        private void Prune()
+        {
+            var now = _utcNow();
+            foreach (var key in _entries.Where(e => e.Value.Value != null && e.Value.Value.ExpiresUtc <= now)
+                .Select(e => e.Key).ToArray())
+                _entries.Remove(key);
+        }
+
+        private sealed class Entry
+        {
+            internal Entry(string key, string scope) { Key = key; Scope = scope; }
+            internal string Key { get; }
+            internal string Scope { get; }
+            internal string RunId { get; } = Guid.NewGuid().ToString("N");
+            internal CancellationTokenSource Lifetime { get; } = new CancellationTokenSource();
+            internal Timer Deadline { get; set; }
+            internal LicenceActivityRunDiagnostics Diagnostics;
+            internal T Value { get; set; }
+            internal TaskCompletionSource<T> Completion { get; } =
+                new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Models/LicenceActivity/LicenceActivityTelemetry.cs
+++ b/src/AnalyticsEngine/Web/Models/LicenceActivity/LicenceActivityTelemetry.cs
@@ -1,0 +1,189 @@
+using Common.Entities.Config;
+using Common.Entities.LicenceActivity;
+using DataUtils;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Web.AnalyticsWeb.Models.LicenceActivity
+{
+    internal sealed class LicenceActivityDiagnosticEvent
+    {
+        internal string RunId;
+        internal string Stage;
+        internal string ExceptionType;
+        internal long ElapsedMs;
+        internal long DurationMs;
+        internal long Sequence;
+        internal DateTimeOffset OccurredUtc;
+    }
+
+    internal sealed class LicenceActivityRunDiagnostics : ILicenceActivityDiagnostics, IDisposable
+    {
+        private static readonly HashSet<string> Stages = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Started", "ConnectionOpened", "CoverageStarted", "CoverageCompleted",
+            "OverviewSqlStarted", "OverviewSqlCompleted", "UsersSqlStarted", "UsersSqlCompleted",
+            "MaterialisationStarted", "MaterialisationCompleted", "ProjectionCompleted",
+            "CachePublished", "Failed", "HostStopping"
+        };
+        private readonly string _runId;
+        private readonly Func<LicenceActivityDiagnosticEvent, bool> _enqueue;
+        private readonly Action _dispose;
+        private readonly Stopwatch _watch = Stopwatch.StartNew();
+        private long _sequence;
+
+        internal LicenceActivityRunDiagnostics(
+            string runId, Func<LicenceActivityDiagnosticEvent, bool> enqueue, Action dispose = null)
+        {
+            _runId = runId;
+            _enqueue = enqueue;
+            _dispose = dispose;
+        }
+
+        public void Stage(string stage, long elapsedMs = 0)
+        {
+            if (!Stages.Contains(stage)) throw new ArgumentException("Unknown licence activity diagnostic stage.", nameof(stage));
+            Send(stage, elapsedMs, null);
+        }
+
+        internal bool Failed(Exception exception) => Send("Failed", 0, exception.GetBaseException().GetType().Name);
+
+        private bool Send(string stage, long durationMs, string exceptionType)
+        {
+            try
+            {
+                return _enqueue(new LicenceActivityDiagnosticEvent
+                {
+                    RunId = _runId, Stage = stage, ExceptionType = exceptionType,
+                    Sequence = Interlocked.Increment(ref _sequence), ElapsedMs = _watch.ElapsedMilliseconds,
+                    DurationMs = durationMs, OccurredUtc = DateTimeOffset.UtcNow
+                });
+            }
+            catch (Exception)
+            {
+                // An optional diagnostic adapter must not fail a report or its publication.
+                return false;
+            }
+        }
+
+        public void Dispose() => _dispose?.Invoke();
+    }
+
+    internal static class LicenceActivityTelemetry
+    {
+        private static readonly string InstanceId = Guid.NewGuid().ToString("N");
+        private static readonly ConcurrentDictionary<string, LicenceActivityRunDiagnostics> Active =
+            new ConcurrentDictionary<string, LicenceActivityRunDiagnostics>();
+        private static readonly BlockingCollection<LicenceActivityDiagnosticEvent> Queue =
+            new BlockingCollection<LicenceActivityDiagnosticEvent>(256);
+        private static readonly Lazy<Thread> Worker = new Lazy<Thread>(() =>
+        {
+            var thread = new Thread(Drain) { IsBackground = true, Name = "LicenceActivityTelemetry" };
+            thread.Start();
+            return thread;
+        });
+        private static int _dropped;
+        private static int _stopping;
+
+        internal static LicenceActivityRunDiagnostics Start(string runId)
+        {
+            var run = new LicenceActivityRunDiagnostics(runId, Enqueue, () => Active.TryRemove(runId, out _));
+            Active[runId] = run;
+            run.Stage("Started");
+            return run;
+        }
+
+        private static bool Enqueue(LicenceActivityDiagnosticEvent item)
+        {
+            try
+            {
+                if (Volatile.Read(ref _stopping) == 0)
+                {
+                    _ = Worker.Value;
+                    if (Queue.TryAdd(item)) return true;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Shutdown can complete the collection between the stopping check and TryAdd.
+            }
+            Interlocked.Increment(ref _dropped);
+            return false;
+        }
+
+        private static void Drain()
+        {
+            DrainEvents(Queue.GetConsumingEnumerable(),
+                () => new AnalyticsLogger(new AppConfig().AppInsightsConnectionString, "LicenceActivity"),
+                () => Thread.Sleep(1000));
+        }
+
+        internal static void DrainEvents(
+            IEnumerable<LicenceActivityDiagnosticEvent> events,
+            Func<AnalyticsLogger> loggerFactory,
+            Action afterFlush)
+        {
+            AnalyticsLogger logger = null;
+            try
+            {
+                foreach (var item in events)
+                {
+                    try
+                    {
+                        if (logger == null) logger = loggerFactory();
+                        var dimensions = new Dictionary<string, string>
+                        {
+                            { "RunId", item.RunId }, { "InstanceId", InstanceId }, { "Stage", item.Stage }
+                        };
+                        if (item.ExceptionType != null) dimensions.Add("ExceptionType", item.ExceptionType);
+                        logger.TrackEvent(AnalyticsLogger.AnalyticsEvent.LicenceActivityLifecycle, dimensions,
+                            new Dictionary<string, double>
+                            {
+                                { "ElapsedMs", item.ElapsedMs }, { "DurationMs", item.DurationMs },
+                                { "Sequence", item.Sequence }, { "DroppedEvents", Volatile.Read(ref _dropped) },
+                                { "ManagedHeapBytes", GC.GetTotalMemory(false) }
+                            }, item.RunId, item.OccurredUtc);
+                    }
+                    catch (Exception)
+                    {
+                        Interlocked.Increment(ref _dropped);
+                        if (item.Stage == "Failed")
+                            ReportFailure(item.RunId, new InvalidOperationException("Diagnostic delivery failed."));
+                    }
+                }
+            }
+            finally
+            {
+                try
+                {
+                    logger?.Flush();
+                    if (logger != null) afterFlush();
+                }
+                catch (Exception)
+                {
+                    Interlocked.Increment(ref _dropped);
+                    Console.WriteLine("Licence activity telemetry could not flush during shutdown.");
+                }
+            }
+        }
+
+        internal static void ReportFailure(string runId, Exception exception)
+        {
+            // Never give the general exception reporter SQL messages or request/filter values.
+            WebExceptionTelemetry.Report(new InvalidOperationException(
+                "Licence activity failed (" + exception.GetBaseException().GetType().Name + "). RunId " + runId),
+                "LicenceActivity");
+        }
+
+        internal static void Shutdown()
+        {
+            foreach (var run in Active.Values) run.Stage("HostStopping");
+            if (Interlocked.Exchange(ref _stopping, 1) != 0) return;
+            Queue.CompleteAdding();
+            if (Worker.IsValueCreated && Thread.CurrentThread != Worker.Value) Worker.Value.Join(TimeSpan.FromSeconds(2));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/index.html
+++ b/src/AnalyticsEngine/Web/Scripts/portal/index.html
@@ -25,6 +25,7 @@
     window.o365AnalyticsProfilingStatusAPI = baseUrl + "api/ProfilingStatus";
     window.o365AnalyticsReportsAPI = baseUrl + "api/Reports";
     window.o365AnalyticsCopilotAdoptionAPI = baseUrl + "api/CopilotAdoption";
+    window.o365AnalyticsLicenceActivityAPI = baseUrl + "api/LicenceActivity";
     window.o365AnalyticsHealthAPI = baseUrl + "api/Health";
     window.o365AnalyticsUpdateCheckAPI = baseUrl + "api/UpdateCheck";
   </script>

--- a/src/AnalyticsEngine/Web/Scripts/portal/package-lock.json
+++ b/src/AnalyticsEngine/Web/Scripts/portal/package-lock.json
@@ -16,12 +16,83 @@
       },
       "devDependencies": {
         "@microsoft/microsoft-graph-types": "^2.43.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.3",
+        "@testing-library/user-event": "^14.6.7",
         "@types/node": "^26.0.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
+        "jsdom": "^30.0.1",
         "typescript": "^6.0.3",
-        "vite": "^8.1.0"
+        "vite": "^8.1.0",
+        "vitest": "^5.0.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -31,6 +102,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -81,6 +305,24 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
       "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
       "license": "MIT"
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -1699,6 +1941,34 @@
         "csstype": "^3.2.3"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@microsoft/microsoft-graph-types": {
       "version": "2.43.1",
       "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.43.1.tgz",
@@ -2008,6 +2278,104 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2018,6 +2386,38 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.0.0",
@@ -2073,6 +2473,107 @@
         }
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -2086,11 +2587,78 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2101,6 +2669,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
@@ -2124,6 +2699,46 @@
       "license": "MIT",
       "peerDependencies": {
         "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2157,6 +2772,84 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/keyborg": {
@@ -2426,6 +3119,53 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -2445,6 +3185,33 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2453,9 +3220,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2494,6 +3261,31 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -2514,6 +3306,13 @@
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "7.18.0",
@@ -2551,6 +3350,30 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -2596,6 +3419,19 @@
         "@babel/runtime": "^7.1.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2608,6 +3444,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2618,10 +3461,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tabster": {
@@ -2632,6 +3509,26 @@
       "dependencies": {
         "keyborg": "^2.14.0",
         "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2649,6 +3546,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -2669,6 +3612,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -2764,6 +3717,171 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/src/AnalyticsEngine/Web/Scripts/portal/package.json
+++ b/src/AnalyticsEngine/Web/Scripts/portal/package.json
@@ -8,7 +8,9 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@fluentui/react-components": "^9.74.1",
@@ -19,11 +21,17 @@
   },
   "devDependencies": {
     "@microsoft/microsoft-graph-types": "^2.43.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.7",
     "@types/node": "^26.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^30.0.1",
     "typescript": "^6.0.3",
-    "vite": "^8.1.0"
+    "vite": "^8.1.0",
+    "vitest": "^5.0.0"
   }
 }

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.test.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { apiFetch } from './http';
+import { LicenceActivityApiError, downloadExport, fetchOverview, fetchUsers } from './licenceActivityApi';
+
+vi.mock('./http', () => ({ apiFetch: vi.fn() }));
+
+const mockedFetch = vi.mocked(apiFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function lastUrl(): string {
+  const calls = mockedFetch.mock.calls;
+  return String(calls[calls.length - 1][0]);
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+});
+
+describe('licenceActivityApi query building', () => {
+  it('builds the overview query with only the filters that are set (0 is a real demographic id)', async () => {
+    mockedFetch.mockImplementation(async () => jsonResponse({ snapshotId: 'ov1' }));
+
+    await fetchOverview({ from: '2026-05-01', to: '2026-05-19' });
+    expect(lastUrl()).toContain('/api/LicenceActivity/overview?from=2026-05-01&to=2026-05-19');
+    expect(lastUrl()).not.toContain('departmentId');
+
+    await fetchOverview({ from: '2026-05-01', to: '2026-05-19', departmentId: 0, countryId: 7 });
+    expect(lastUrl()).toContain('departmentId=0');
+    expect(lastUrl()).toContain('countryId=7');
+  });
+
+  it('sends top, page, pageSize, sort and direction together and trims the search', async () => {
+    mockedFetch.mockImplementation(async () => jsonResponse({ snapshotId: 'u1' }));
+
+    await fetchUsers({
+      overviewId: 'ov1',
+      licenceTypeId: 3,
+      workload: 'copilot',
+      top: 25,
+      sort: 'activity',
+      direction: 'desc',
+      search: '  ada  ',
+      page: 2,
+      pageSize: 50,
+    });
+    const url = lastUrl();
+    expect(url).toContain('workload=copilot');
+    expect(url).toContain('top=25');
+    expect(url).toContain('page=2');
+    expect(url).toContain('pageSize=50');
+    expect(url).toContain('sort=activity');
+    expect(url).toContain('direction=desc');
+    expect(url).toContain('search=ada');
+  });
+});
+
+describe('licenceActivityApi error mapping', () => {
+  it('maps statuses to kinds and prefers the server message', async () => {
+    const cases: { status: number; kind: string }[] = [
+      { status: 503, kind: 'busy' },
+      { status: 410, kind: 'expired' },
+      { status: 409, kind: 'expired' },
+      { status: 404, kind: 'expired' },
+      { status: 403, kind: 'forbidden' },
+      { status: 412, kind: 'precondition' },
+      { status: 400, kind: 'badRequest' },
+    ];
+
+    for (const { status, kind } of cases) {
+      mockedFetch.mockImplementation(async () => jsonResponse({ message: `msg ${status}` }, status));
+      await expect(fetchOverview({ from: '2026-05-01', to: '2026-05-19' })).rejects.toMatchObject({
+        kind,
+        status,
+        message: `msg ${status}`,
+      });
+    }
+  });
+
+  it('falls back to a generated message when the server sends none', async () => {
+    mockedFetch.mockImplementation(async () => new Response(null, { status: 503 }));
+    await expect(fetchOverview({ from: '2026-05-01', to: '2026-05-19' })).rejects.toMatchObject({
+      kind: 'busy',
+      message: expect.stringMatching(/busy/i),
+    });
+  });
+});
+
+describe('downloadExport', () => {
+  beforeEach(() => {
+    Object.defineProperty(URL, 'createObjectURL', { value: vi.fn(() => 'blob:stub'), configurable: true });
+    Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
+  });
+
+  it('omits usersId for an aggregate-only export and includes it otherwise', async () => {
+    mockedFetch.mockImplementation(async () => new Response('xlsx-bytes', { status: 200 }));
+
+    await downloadExport({ overviewId: 'ov1' });
+    expect(lastUrl()).toContain('/api/LicenceActivity/export?overviewId=ov1');
+    expect(lastUrl()).not.toContain('usersId');
+
+    await downloadExport({ overviewId: 'ov1', usersId: 'us9' });
+    expect(lastUrl()).toContain('usersId=us9');
+    expect(URL.createObjectURL).toHaveBeenCalled();
+  });
+
+  it('surfaces an expired/mismatched snapshot instead of downloading fresh data', async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({ message: 'The snapshots do not match.' }, 409));
+    await expect(downloadExport({ overviewId: 'ov1', usersId: 'us9' })).rejects.toMatchObject({
+      kind: 'expired',
+    });
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+
+    mockedFetch.mockResolvedValue(new Response(null, { status: 410 }));
+    await expect(downloadExport({ overviewId: 'ov1' })).rejects.toBeInstanceOf(LicenceActivityApiError);
+  });
+
+  it('never saves a JSON error body that leaked as HTTP 200 as an .xlsx', async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({ message: 'not a workbook' }, 200));
+    await expect(downloadExport({ overviewId: 'ov1' })).rejects.toBeInstanceOf(LicenceActivityApiError);
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.ts
@@ -1,0 +1,226 @@
+import { apiFetch } from './http';
+import type {
+  LicenceActivityAvailability,
+  LicenceActivityOverview,
+  LicenceActivityUsers,
+  OverviewParams,
+  UsersParams,
+} from '../types/licenceActivity';
+
+const baseUrl = (): string =>
+  window.o365AnalyticsLicenceActivityAPI ?? `${window.location.origin}/api/LicenceActivity`;
+
+/**
+ * How a Licence-activity request failed, so callers can react to the case rather than a raw status.
+ *   - `busy`       503: the query hit its finite timeout on a large tenant. This tool does NOT poll
+ *                       (a bounded, killable query is simpler than a long-poll); the UI offers a
+ *                       manual "Try again".
+ *   - `expired`    410/409/404: the cached snapshot the request referenced is gone, superseded, or no
+ *                       longer contains that licence. The caller must NOT silently re-query - it must
+ *                       tell the user to refresh so the exported file always matches the screen.
+ *   - `forbidden`  403: the user lacks the LicenceActivity.ReadUsers role.
+ *   - `precondition` 412: the licence import (GraphUsersMetadata) is disabled.
+ *   - `badRequest` 400: an invalid parameter (e.g. a range outside 7..180 days).
+ *   - `http`       anything else.
+ */
+export type LicenceActivityErrorKind =
+  | 'busy'
+  | 'expired'
+  | 'forbidden'
+  | 'precondition'
+  | 'badRequest'
+  | 'http';
+
+/** A typed failure from the Licence-activity API, carrying the server's own message when it sent one. */
+export class LicenceActivityApiError extends Error {
+  readonly kind: LicenceActivityErrorKind;
+  readonly status: number;
+
+  constructor(kind: LicenceActivityErrorKind, status: number, message: string) {
+    super(message);
+    this.name = 'LicenceActivityApiError';
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+function kindForStatus(status: number): LicenceActivityErrorKind {
+  switch (status) {
+    case 503:
+      return 'busy';
+    case 410:
+    case 409:
+    case 404:
+      return 'expired';
+    case 403:
+      return 'forbidden';
+    case 412:
+      return 'precondition';
+    case 400:
+      return 'badRequest';
+    default:
+      return 'http';
+  }
+}
+
+function fallbackMessage(kind: LicenceActivityErrorKind, status: number, what: string): string {
+  switch (kind) {
+    case 'busy':
+      return `The server is busy and ${what} timed out. Try again in a moment, or narrow the date range.`;
+    case 'expired':
+      return `This snapshot has expired or was refreshed. Reload to get a current one.`;
+    case 'forbidden':
+      return `You do not have permission to view ${what}. Individual user detail needs the "LicenceActivity.ReadUsers" role.`;
+    case 'precondition':
+      return `Licence activity is not available: the licence import is disabled on this deployment.`;
+    case 'badRequest':
+      return `That request was rejected. Check the selected dates and filters.`;
+    default:
+      return `Couldn't load ${what} (${status}).`;
+  }
+}
+
+/** Reads the server's `{ message }` error body without consuming the original response. */
+async function readServerMessage(response: Response): Promise<string | null> {
+  try {
+    const body = (await response.clone().json()) as { message?: unknown } | null;
+    return body && typeof body.message === 'string' ? body.message : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Turns a non-OK response into a typed error, preferring the server's message. */
+async function errorFor(response: Response, what: string): Promise<LicenceActivityApiError> {
+  const kind = kindForStatus(response.status);
+  const message = (await readServerMessage(response)) ?? fallbackMessage(kind, response.status, what);
+  return new LicenceActivityApiError(kind, response.status, message);
+}
+
+async function getJson<T>(path: string, what: string, signal?: AbortSignal): Promise<T> {
+  const response = await apiFetch(`${baseUrl()}${path}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw await errorFor(response, what);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/** Which parts of the tool this deployment / signed-in user can see, and the allowed window bounds. */
+export function fetchAvailability(signal?: AbortSignal): Promise<LicenceActivityAvailability> {
+  return getJson<LicenceActivityAvailability>('/availability', 'the licence activity availability', signal);
+}
+
+function overviewQuery(params: OverviewParams): URLSearchParams {
+  const qs = new URLSearchParams({ from: params.from, to: params.to });
+  // == null covers null and undefined; 0 is a valid demographic id ("unknown" bucket) and must survive.
+  if (params.departmentId != null) qs.set('departmentId', String(params.departmentId));
+  if (params.countryId != null) qs.set('countryId', String(params.countryId));
+  return qs;
+}
+
+/** The executive overview: SKU assignments, five workload distributions and per-workload coverage. */
+export function fetchOverview(params: OverviewParams, signal?: AbortSignal): Promise<LicenceActivityOverview> {
+  return getJson<LicenceActivityOverview>(
+    `/overview?${overviewQuery(params)}`,
+    'the licence activity overview',
+    signal,
+  );
+}
+
+function usersQuery(params: UsersParams): URLSearchParams {
+  const qs = new URLSearchParams({
+    overviewId: params.overviewId,
+    licenceTypeId: String(params.licenceTypeId),
+    workload: params.workload,
+    top: String(params.top),
+    sort: params.sort,
+    direction: params.direction,
+    page: String(params.page),
+    pageSize: String(params.pageSize),
+  });
+  if (params.search && params.search.trim()) qs.set('search', params.search.trim());
+  return qs;
+}
+
+/**
+ * The users snapshot for the selected licence: one request returns the bounded most/least active
+ * lists and the current browse page together. Individual user data needs the
+ * `LicenceActivity.ReadUsers` role; a caller without it gets a `forbidden` error.
+ */
+export function fetchUsers(params: UsersParams, signal?: AbortSignal): Promise<LicenceActivityUsers> {
+  return getJson<LicenceActivityUsers>(`/users?${usersQuery(params)}`, 'the licensed users', signal);
+}
+
+/** Pulls a filename out of a Content-Disposition header, if the server set one. */
+function filenameFromResponse(response: Response): string | null {
+  const header = response.headers.get('Content-Disposition');
+  if (!header) return null;
+  const utf8 = /filename\*=UTF-8''([^;]+)/i.exec(header);
+  if (utf8?.[1]) return decodeURIComponent(utf8[1]);
+  const plain = /filename="?([^";]+)"?/i.exec(header);
+  return plain?.[1] ?? null;
+}
+
+/** Saves a blob to disk via a transient object URL (download without navigating). */
+function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export interface ExportParams {
+  /** The overview snapshot to export. Required - the export is always at least the aggregate. */
+  overviewId: string;
+  /** The current users snapshot. Omitted for an aggregate-only workbook. */
+  usersId?: string;
+}
+
+/**
+ * Downloads the Excel snapshot of the current report.
+ *
+ * Fetched and saved as a blob rather than pointed at with a plain `<a href>` DELIBERATELY: the server
+ * answers 410 when a referenced snapshot has expired and 409 when the users and overview snapshots no
+ * longer match, and we must surface that as "refresh the page" instead of letting the browser show a
+ * raw error. The backend builds the workbook from the EXACT cached overview (and, when `usersId` is
+ * given, the exact cached user rows) - it does not re-run the analysis. Omit `usersId` for an
+ * aggregate-only export.
+ */
+export async function downloadExport(params: ExportParams, signal?: AbortSignal): Promise<void> {
+  const qs = new URLSearchParams({ overviewId: params.overviewId });
+  if (params.usersId) qs.set('usersId', params.usersId);
+
+  const response = await apiFetch(`${baseUrl()}/export?${qs}`, {
+    method: 'GET',
+    headers: { Accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw await errorFor(response, 'the Excel export');
+  }
+
+  // Belt and braces: never save a JSON error body as an .xlsx. The server returns the spreadsheet
+  // content type on success; anything JSON here is an error that leaked as 200, so surface it
+  // visibly rather than handing the user a "workbook" that is really an error document.
+  const contentType = response.headers.get('Content-Type') ?? '';
+  if (contentType.includes('application/json')) {
+    throw await errorFor(response, 'the Excel export');
+  }
+
+  const blob = await response.blob();
+  saveBlob(blob, filenameFromResponse(response) ?? 'licence-activity.xlsx');
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/ApiErrorBar.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/ApiErrorBar.tsx
@@ -1,0 +1,48 @@
+import { MessageBar, MessageBarBody, MessageBarActions, Button } from '@fluentui/react-components';
+import { ArrowClockwise16Regular } from '@fluentui/react-icons';
+import { LicenceActivityApiError, type LicenceActivityErrorKind } from '../../api/licenceActivityApi';
+
+/** A displayable message plus the failure kind, from any thrown value. */
+export function describeError(err: unknown, fallback: string): { message: string; kind?: LicenceActivityErrorKind } {
+  if (err instanceof LicenceActivityApiError) return { message: err.message, kind: err.kind };
+  if (err instanceof Error && err.message) return { message: err.message };
+  return { message: fallback };
+}
+
+/** MessageBar intent for a failure kind: the transient / refreshable ones are warnings, the rest errors. */
+function intentForKind(kind: LicenceActivityErrorKind | undefined): 'warning' | 'error' {
+  return kind === 'busy' || kind === 'expired' ? 'warning' : 'error';
+}
+
+interface ApiErrorBarProps {
+  error: unknown;
+  fallback: string;
+  /** When given, renders a retry/refresh button. The caller decides what retrying does. */
+  onRetry?: () => void;
+  retryLabel?: string;
+}
+
+/**
+ * Renders an API failure with the right severity and, optionally, a retry affordance.
+ *
+ * This tool does not poll: a busy (503) result is a dead end until the user asks again, so the retry
+ * button is how they do that. An expired (410/409) snapshot is offered a "Refresh" instead, because
+ * the fix is to remint the snapshot, not to repeat the same doomed request.
+ */
+export default function ApiErrorBar({ error, fallback, onRetry, retryLabel }: ApiErrorBarProps) {
+  const { message, kind } = describeError(error, fallback);
+  const label = retryLabel ?? (kind === 'expired' ? 'Refresh' : 'Try again');
+
+  return (
+    <MessageBar intent={intentForKind(kind)}>
+      <MessageBarBody>{message}</MessageBarBody>
+      {onRetry && (
+        <MessageBarActions>
+          <Button size="small" icon={<ArrowClockwise16Regular />} onClick={onRetry}>
+            {label}
+          </Button>
+        </MessageBarActions>
+      )}
+    </MessageBar>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/CoveragePanel.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/CoveragePanel.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import CoveragePanel from './CoveragePanel';
+import type { LicenceActivityCoverage } from '../../types/licenceActivity';
+
+function cov(over: Partial<LicenceActivityCoverage> = {}): LicenceActivityCoverage {
+  return {
+    workload: 'teams',
+    status: 'available',
+    source: 'Usage reports',
+    measure: 'reporting samples',
+    granularity: 'weekly',
+    message: null,
+    effectiveFromUtc: '2026-04-22T00:00:00Z',
+    effectiveToUtc: '2026-05-19T00:00:00Z',
+    latestImportUtc: '2026-05-20T00:00:00Z',
+    lagDays: 1,
+    reportPeriodDays: 28,
+    expectedSamples: 100,
+    observedSamples: 95,
+    unmatchedUsers: 2,
+    snapshotDates: [],
+    ...over,
+  };
+}
+
+const NOW = new Date('2026-05-20T12:00:00Z');
+
+describe('CoveragePanel', () => {
+  it('renders each backend status with a friendly label and shows the snapshot lifetime', () => {
+    renderWithProvider(
+      <CoveragePanel
+        generatedUtc="2026-05-20T10:00:00Z"
+        expiresUtc="2026-05-20T10:05:00Z"
+        now={NOW}
+        coverage={[
+          cov({ workload: 'teams', status: 'available' }),
+          cov({ workload: 'outlook', status: 'partial' }),
+          cov({ workload: 'onedrive', status: 'missingCoverage' }),
+          cov({ workload: 'sharepoint', status: 'unmatchableIdentity' }),
+          cov({ workload: 'copilot', status: 'notImported' }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Available')).toBeInTheDocument();
+    expect(screen.getByText('Partial')).toBeInTheDocument();
+    expect(screen.getByText('Missing coverage')).toBeInTheDocument();
+    expect(screen.getByText('Unmatchable identity')).toBeInTheDocument();
+    expect(screen.getByText('Not imported')).toBeInTheDocument();
+
+    // Sources/coverage are explicit: workloads, source and snapshot lifetime are all shown.
+    expect(screen.getByText('Teams')).toBeInTheDocument();
+    expect(screen.getAllByText(/Usage reports/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/generated/i)).toBeInTheDocument();
+  });
+
+  it('labels a disabled import distinctly', () => {
+    renderWithProvider(
+      <CoveragePanel
+        generatedUtc="2026-05-20T10:00:00Z"
+        expiresUtc="2026-05-20T10:05:00Z"
+        now={NOW}
+        coverage={[cov({ workload: 'teams', status: 'disabled' })]}
+      />,
+    );
+    expect(screen.getByText('Import disabled')).toBeInTheDocument();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/CoveragePanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/CoveragePanel.tsx
@@ -1,0 +1,152 @@
+import { makeStyles, tokens, Card, Text, Badge } from '@fluentui/react-components';
+import type { LicenceActivityCoverage, WorkloadKey } from '../../types/licenceActivity';
+import { WORKLOADS } from '../../types/licenceActivity';
+import { DASH, formatAge, formatDate, formatDateTime, formatMaybeCount } from './format';
+import { statusMeta } from './statuses';
+
+const useStyles = makeStyles({
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    padding: '14px 16px',
+  },
+  head: {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  title: {
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: tokens.colorNeutralForeground3,
+  },
+  generated: {
+    color: tokens.colorNeutralForeground3,
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))',
+    gap: '10px',
+  },
+  item: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '3px',
+    padding: '10px 12px',
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground2,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  itemHead: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '8px',
+  },
+  line: {
+    color: tokens.colorNeutralForeground2,
+  },
+  sub: {
+    color: tokens.colorNeutralForeground3,
+  },
+  message: {
+    color: tokens.colorNeutralForeground2,
+    marginTop: '2px',
+  },
+});
+
+function workloadLabel(workload: string): string {
+  return WORKLOADS.find((w) => w.key === (workload as WorkloadKey))?.label ?? workload;
+}
+
+/**
+ * The status vocabulary is fixed (LicenceActivityCoverage.Status): available | partial |
+ * missingCoverage | unmatchableIdentity | notImported | disabled. Tone/label come from the shared
+ * status helper so the coverage panel and the per-user evidence detail describe a status identically.
+ */
+interface CoveragePanelProps {
+  generatedUtc: string;
+  expiresUtc: string;
+  coverage: LicenceActivityCoverage[];
+  /** Injectable "now" for deterministic "generated N days ago" captions in tests. */
+  now?: Date;
+}
+
+/**
+ * States, per workload, exactly which import fed the figures and how fresh and complete it is.
+ *
+ * This is load-bearing, not decoration: a workload's distribution can legitimately be all "Unknown"
+ * because its source was not imported or did not cover some users, and the reader needs to see that
+ * cause here rather than mistake it for an absence of activity. Every field the backend provides -
+ * source, measure, freshness, sample counts, unmatched users, and the raw status - is shown.
+ */
+export default function CoveragePanel({ generatedUtc, expiresUtc, coverage, now }: CoveragePanelProps) {
+  const styles = useStyles();
+
+  return (
+    <Card className={styles.card}>
+      <div className={styles.head}>
+        <Text size={200} weight="semibold" className={styles.title}>
+          Data sources &amp; coverage
+        </Text>
+        <Text size={200} className={styles.generated}>
+          Snapshot generated {formatDateTime(generatedUtc)} ({formatAge(generatedUtc, now)}); expires{' '}
+          {formatDateTime(expiresUtc)}
+        </Text>
+      </div>
+
+      {coverage.length === 0 ? (
+        <Text size={200} className={styles.sub}>
+          No per-workload coverage was reported for this snapshot.
+        </Text>
+      ) : (
+        <div className={styles.grid}>
+          {coverage.map((entry) => (
+            <div key={entry.workload} className={styles.item}>
+              <div className={styles.itemHead}>
+                <Text size={300} weight="semibold">
+                  {workloadLabel(entry.workload)}
+                </Text>
+                <Badge appearance="tint" color={statusMeta(entry.status).tone} size="small">
+                  {statusMeta(entry.status).label}
+                </Badge>
+              </div>
+
+              <Text size={200} className={styles.line}>
+                Source: {entry.source || DASH}
+                {entry.measure ? ` \u00b7 ${entry.measure}` : ''}
+                {entry.granularity ? ` (${entry.granularity})` : ''}
+              </Text>
+
+              <Text size={100} className={styles.sub}>
+                Imported {formatDate(entry.latestImportUtc)}
+                {entry.lagDays > 0 ? ` \u00b7 ${entry.lagDays}d lag` : ''}
+                {entry.reportPeriodDays ? ` \u00b7 ${entry.reportPeriodDays}d period` : ''}
+              </Text>
+
+              <Text size={100} className={styles.sub}>
+                Covers {formatDate(entry.effectiveFromUtc)}
+                {' \u2013 '}
+                {formatDate(entry.effectiveToUtc)}
+              </Text>
+
+              <Text size={100} className={styles.sub}>
+                {formatMaybeCount(entry.observedSamples)} / {formatMaybeCount(entry.expectedSamples)} samples
+                {entry.unmatchedUsers > 0 ? ` \u00b7 ${entry.unmatchedUsers.toLocaleString()} unmatched` : ''}
+              </Text>
+
+              {entry.message && (
+                <Text size={100} className={styles.message}>
+                  {entry.message}
+                </Text>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DateRangeControl.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DateRangeControl.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import DateRangeControl from './DateRangeControl';
+import { presetRange } from './dateRange';
+
+const NOW = new Date(Date.UTC(2026, 4, 20, 12)); // 2026-05-20; latest allowed end = 2026-05-19
+
+describe('DateRangeControl', () => {
+  it('emits the matching range when a preset is clicked', () => {
+    const onChange = vi.fn();
+    renderWithProvider(
+      <DateRangeControl value={{ from: '2026-01-01', to: '2026-03-01' }} onChange={onChange} now={NOW} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Last settled week' }));
+    expect(onChange).toHaveBeenCalledWith(presetRange(7, NOW));
+  });
+
+  it('marks the active preset as pressed', () => {
+    renderWithProvider(<DateRangeControl value={presetRange(28, NOW)} onChange={vi.fn()} now={NOW} />);
+    expect(screen.getByRole('button', { name: 'Last 4 fully settled weeks' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Last settled week' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('validates a custom range: rejects inverted / today / too-short, accepts a valid one', () => {
+    const onChange = vi.fn();
+    renderWithProvider(
+      <DateRangeControl value={presetRange(28, NOW)} onChange={onChange} now={NOW} minDays={7} maxDays={180} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom range' }));
+    const from = screen.getByLabelText('Start date');
+    const to = screen.getByLabelText('End date');
+
+    // Inverted.
+    fireEvent.change(from, { target: { value: '2026-05-10' } });
+    fireEvent.change(to, { target: { value: '2026-05-01' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/on or before/i);
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Ends today (not allowed - reporting covers whole past days).
+    fireEvent.change(to, { target: { value: '2026-05-20' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/before today/i);
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Too short (3 days < 7).
+    fireEvent.change(to, { target: { value: '2026-05-12' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/at least 7 days/i);
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Valid (7 days, ends before today).
+    fireEvent.change(to, { target: { value: '2026-05-16' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(onChange).toHaveBeenCalledWith({ from: '2026-05-10', to: '2026-05-16' });
+  });
+
+  it('opens the custom editor reflecting the current range when it is not a preset', () => {
+    renderWithProvider(
+      <DateRangeControl value={{ from: '2026-02-01', to: '2026-02-10' }} onChange={vi.fn()} now={NOW} />,
+    );
+    expect(screen.getByLabelText('Start date')).toHaveValue('2026-02-01');
+    expect(screen.getByLabelText('End date')).toHaveValue('2026-02-10');
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DateRangeControl.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DateRangeControl.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react';
+import { makeStyles, tokens, Button, Input, Text } from '@fluentui/react-components';
+import type { DateRange } from '../../types/licenceActivity';
+import {
+  PRESETS,
+  PRESET_LABELS,
+  diffDaysInclusive,
+  latestEndString,
+  matchPreset,
+  presetRange,
+  validateRange,
+  type PresetDays,
+} from './dateRange';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  presets: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    flexWrap: 'wrap',
+  },
+  custom: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    gap: '8px',
+    flexWrap: 'wrap',
+  },
+  field: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  fieldLabel: {
+    color: tokens.colorNeutralForeground3,
+  },
+  hint: {
+    color: tokens.colorNeutralForeground3,
+  },
+  error: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+});
+
+interface DateRangeControlProps {
+  value: DateRange;
+  onChange: (range: DateRange) => void;
+  /** Injectable "now" so the preset maths and the future-date rule are deterministic in tests. */
+  now?: Date;
+  /** Allowed window bounds, from the availability payload (backend 7..180). */
+  minDays?: number;
+  maxDays?: number;
+  disabled?: boolean;
+}
+
+/**
+ * The reporting-window control: four one-click presets (7 / 28 / 90 / 180 days) plus an explicit,
+ * validated custom range. Ranges end yesterday (the server reports whole past days only) and must be
+ * within the allowed span.
+ *
+ * The selected range lives in the page above this component, so it is preserved when the user changes
+ * a demographic filter or the drilled-into licence - only this control (or a preset click) ever
+ * changes it. Custom input is validated on Apply and the offending draft is kept on screen with the
+ * reason, rather than being silently discarded.
+ */
+export default function DateRangeControl({
+  value,
+  onChange,
+  now,
+  minDays,
+  maxDays,
+  disabled,
+}: DateRangeControlProps) {
+  const styles = useStyles();
+  const latestEnd = latestEndString(now);
+
+  const activePreset = matchPreset(value, now);
+  const [customOpen, setCustomOpen] = useState<boolean>(() => activePreset == null);
+  const [draft, setDraft] = useState<DateRange>(value);
+  const [error, setError] = useState<string | null>(null);
+
+  // Follow the range when it changes from outside this control (a preset click, or the page resetting
+  // it), so the custom editor always opens on the range currently in effect.
+  useEffect(() => {
+    setDraft(value);
+    setError(null);
+  }, [value.from, value.to]);
+
+  const applyPreset = (p: PresetDays): void => {
+    setError(null);
+    setCustomOpen(false);
+    onChange(presetRange(p, now));
+  };
+
+  const openCustom = (): void => {
+    setDraft(value);
+    setError(null);
+    setCustomOpen(true);
+  };
+
+  const applyCustom = (): void => {
+    const result = validateRange(draft, { now, minDays, maxDays });
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    setError(null);
+    onChange(draft);
+  };
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.presets}>
+        {PRESETS.map((p) => (
+          <Button
+            key={p}
+            size="small"
+            appearance={activePreset === p && !customOpen ? 'primary' : 'secondary'}
+            disabled={disabled}
+            aria-pressed={activePreset === p && !customOpen}
+            onClick={() => applyPreset(p)}
+          >
+            {PRESET_LABELS[p]}
+          </Button>
+        ))}
+        <Button
+          size="small"
+          appearance={customOpen ? 'primary' : 'secondary'}
+          disabled={disabled}
+          aria-pressed={customOpen}
+          onClick={openCustom}
+        >
+          Custom range
+        </Button>
+        {!customOpen && (
+          <Text size={200} className={styles.hint}>
+            {diffDaysInclusive(value.from, value.to).toLocaleString()} days ending {value.to}
+          </Text>
+        )}
+      </div>
+
+      {customOpen && (
+        <div>
+          <div className={styles.custom}>
+            <label className={styles.field}>
+              <Text size={200} className={styles.fieldLabel}>
+                From
+              </Text>
+              <Input
+                type="date"
+                value={draft.from}
+                max={draft.to || latestEnd}
+                disabled={disabled}
+                aria-label="Start date"
+                onChange={(_e, d) => setDraft((prev) => ({ ...prev, from: d.value }))}
+              />
+            </label>
+            <label className={styles.field}>
+              <Text size={200} className={styles.fieldLabel}>
+                To
+              </Text>
+              <Input
+                type="date"
+                value={draft.to}
+                min={draft.from || undefined}
+                max={latestEnd}
+                disabled={disabled}
+                aria-label="End date"
+                onChange={(_e, d) => setDraft((prev) => ({ ...prev, to: d.value }))}
+              />
+            </label>
+            <Button appearance="primary" size="small" disabled={disabled} onClick={applyCustom}>
+              Apply
+            </Button>
+          </div>
+          {error && (
+            <Text size={200} role="alert" className={styles.error} style={{ marginTop: '4px' }} block>
+              {error}
+            </Text>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DemographicBreakdown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DemographicBreakdown.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import DemographicBreakdown from './DemographicBreakdown';
+import { WORKLOADS } from '../../types/licenceActivity';
+import type { LicenceActivityDemographic } from '../../types/licenceActivity';
+
+function demo(over: Partial<LicenceActivityDemographic> = {}): LicenceActivityDemographic {
+  return {
+    id: Math.floor(Math.random() * 1e9),
+    name: 'Engineering',
+    assignedUsers: 100,
+    workloads: WORKLOADS.map((w) => ({ workload: w.key, high: 5, moderate: 3, low: 2, zero: 4, unknown: 1 })),
+    ...over,
+  };
+}
+
+describe('DemographicBreakdown', () => {
+  it('renders segment names, assigned counts and a column per workload, largest first', () => {
+    renderWithProvider(
+      <DemographicBreakdown
+        title="By department"
+        segmentLabel="Department"
+        rows={[
+          demo({ id: 1, name: 'Engineering', assignedUsers: 100 }),
+          demo({ id: 2, name: 'Καλημέρα', assignedUsers: 50 }), // Unicode-safe segment name
+        ]}
+        truncated={false}
+      />,
+    );
+
+    expect(screen.getByText('Engineering')).toBeInTheDocument();
+    expect(screen.getByText('Καλημέρα')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+    // A column header per workload (aggregate breakdown, not just a filter list).
+    for (const w of WORKLOADS) {
+      expect(screen.getByText(w.label)).toBeInTheDocument();
+    }
+    // Sorted largest-first.
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]).toHaveTextContent('Engineering');
+  });
+
+  it('makes truncation explicit', () => {
+    renderWithProvider(
+      <DemographicBreakdown title="By country" segmentLabel="Country" rows={[demo()]} truncated />,
+    );
+    expect(screen.getByText(/truncated/i)).toBeInTheDocument();
+  });
+
+  it('caps at 50 rows and says so', () => {
+    const many = Array.from({ length: 60 }, (_, i) => demo({ id: i + 1, name: `Dept ${i + 1}`, assignedUsers: 100 - i }));
+    renderWithProvider(
+      <DemographicBreakdown title="By department" segmentLabel="Department" rows={many} truncated={false} />,
+    );
+    expect(screen.getByText(/top 50/i)).toBeInTheDocument();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DemographicBreakdown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DemographicBreakdown.tsx
@@ -1,0 +1,125 @@
+import { memo, useMemo } from 'react';
+import { makeStyles, tokens, Card, Text, MessageBar, MessageBarBody } from '@fluentui/react-components';
+import type { LicenceActivityDemographic, LicenceActivityDistribution } from '../../types/licenceActivity';
+import { WORKLOADS } from '../../types/licenceActivity';
+import { formatCount } from './format';
+import { useLaTableStyles } from './tableStyles';
+import { MiniDistribution, BandLegend } from './MiniDistribution';
+
+/** Hard client-side cap so a tenant with hundreds of departments can't render an unbounded table.
+ *  The backend also truncates (demographicsTruncated); either way the note below makes it explicit. */
+const MAX_ROWS = 50;
+
+const EMPTY: LicenceActivityDistribution = { workload: '', high: 0, moderate: 0, low: 0, zero: 0, unknown: 0 };
+
+const useStyles = makeStyles({
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+  },
+  head: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  scroll: {
+    maxHeight: '360px',
+    overflowY: 'auto',
+  },
+  stickyHead: {
+    position: 'sticky',
+    insetBlockStart: 0,
+    backgroundColor: tokens.colorNeutralBackground1,
+    zIndex: 1,
+  },
+});
+
+interface DemographicBreakdownProps {
+  title: string;
+  segmentLabel: string;
+  rows: LicenceActivityDemographic[];
+  /** The backend's demographicsTruncated flag - true when its own list was capped. */
+  truncated: boolean;
+}
+
+/**
+ * An aggregate breakdown of a demographic dimension (department or country): assigned users and the
+ * five workload distributions per segment, straight from the overview DTO - not merely the filter
+ * option list. Sorted largest-first, capped and scroll-bounded so it stays responsive at ~50 segments
+ * on a 300k-user tenant, with truncation made explicit.
+ */
+function DemographicBreakdown({ title, segmentLabel, rows, truncated }: DemographicBreakdownProps) {
+  const styles = useStyles();
+  const table = useLaTableStyles();
+
+  const sorted = useMemo(
+    () => [...rows].sort((a, b) => b.assignedUsers - a.assignedUsers || a.name.localeCompare(b.name)),
+    [rows],
+  );
+  const shown = sorted.slice(0, MAX_ROWS);
+  const capped = truncated || sorted.length > MAX_ROWS;
+
+  if (rows.length === 0) return null;
+
+  return (
+    <Card className={styles.card}>
+      <div className={styles.head}>
+        <Text weight="semibold" size={400}>
+          {title}
+        </Text>
+        <Text size={200} className={styles.muted}>
+          Assigned users and per-workload activity by {segmentLabel.toLowerCase()}, largest first.
+        </Text>
+        <BandLegend />
+      </div>
+
+      {capped && (
+        <MessageBar intent="info">
+          <MessageBarBody>
+            Showing the top {formatCount(shown.length)} {segmentLabel.toLowerCase()} by assigned users; the full list
+            is truncated.
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      <div className={`${table.wrap} ${styles.scroll}`}>
+        <table className={table.table}>
+          <thead className={styles.stickyHead}>
+            <tr>
+              <th className={table.th}>{segmentLabel}</th>
+              <th className={`${table.th} ${table.thNumeric}`}>Assigned</th>
+              {WORKLOADS.map((w) => (
+                <th key={w.key} className={table.th}>
+                  {w.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {shown.map((seg) => (
+              <tr key={seg.id}>
+                <td className={table.td}>{seg.name}</td>
+                <td className={`${table.td} ${table.tdNumeric}`}>{formatCount(seg.assignedUsers)}</td>
+                {WORKLOADS.map((w) => {
+                  const dist = seg.workloads.find((d) => d.workload === w.key) ?? { ...EMPTY, workload: w.key };
+                  return (
+                    <td key={w.key} className={table.td}>
+                      <MiniDistribution distribution={dist} />
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
+// Memoised: renders up to 50 rows x 5 mini-bars and should not re-render on unrelated page state.
+export default memo(DemographicBreakdown);

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/MiniDistribution.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/MiniDistribution.tsx
@@ -1,0 +1,85 @@
+import { makeStyles, tokens, Text } from '@fluentui/react-components';
+import type { LicenceActivityDistribution } from '../../types/licenceActivity';
+import { ACTIVITY_BANDS, distributionTotal } from './bands';
+import { formatCount } from './format';
+
+const useStyles = makeStyles({
+  bar: {
+    display: 'flex',
+    width: '96px',
+    height: '12px',
+    borderRadius: tokens.borderRadiusSmall,
+    overflow: 'hidden',
+    backgroundColor: tokens.colorNeutralBackground3,
+  },
+  seg: {
+    height: '100%',
+  },
+  legend: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '4px 14px',
+  },
+  legendItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+  },
+  swatch: {
+    width: '10px',
+    height: '10px',
+    borderRadius: '2px',
+    flexShrink: 0,
+  },
+  legendLabel: {
+    color: tokens.colorNeutralForeground2,
+  },
+});
+
+/**
+ * A compact stacked bar for one distribution, grey full-width when nothing was measured (total 0).
+ *
+ * The aria-label and title carry the exact per-band counts, so the bar is never colour-only - a
+ * screen reader (and a hover) get the numbers, satisfying "accessible legend + text evidence".
+ */
+export function MiniDistribution({ distribution }: { distribution: LicenceActivityDistribution }) {
+  const styles = useStyles();
+  const total = distributionTotal(distribution);
+  const label = ACTIVITY_BANDS.map((b) => `${b.label} ${formatCount(distribution[b.key])}`).join(', ');
+
+  return (
+    <div className={styles.bar} role="img" aria-label={label} title={label}>
+      {total <= 0 ? (
+        <div className={styles.seg} style={{ width: '100%', backgroundColor: '#8a8886' }} />
+      ) : (
+        ACTIVITY_BANDS.map((b) => {
+          const count = distribution[b.key];
+          return count > 0 ? (
+            <div
+              key={b.key}
+              className={styles.seg}
+              style={{ width: `${(count / total) * 100}%`, backgroundColor: b.colour }}
+            />
+          ) : null;
+        })
+      )}
+    </div>
+  );
+}
+
+/** An accessible legend of the band colours, shown once per table so the mini-bars are readable. */
+export function BandLegend() {
+  const styles = useStyles();
+  return (
+    <div className={styles.legend}>
+      {ACTIVITY_BANDS.map((b) => (
+        <span key={b.key} className={styles.legendItem}>
+          <span className={styles.swatch} style={{ backgroundColor: b.colour }} aria-hidden />
+          <Text size={100} className={styles.legendLabel}>
+            {b.label}
+          </Text>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import SkuAssignments from './SkuAssignments';
+import type { LicenceActivitySku } from '../../types/licenceActivity';
+
+const licences: LicenceActivitySku[] = [
+  { licenceTypeId: 10, name: 'E5', skuId: 'ENTERPRISEPREMIUM', assignedUsers: 100, workloads: [] },
+  { licenceTypeId: 20, name: 'F3', skuId: 'DESKLESSPACK', assignedUsers: 50, workloads: [] },
+];
+
+describe('SkuAssignments', () => {
+  it('lists licences with assigned counts and selects one on click', () => {
+    const onSelect = vi.fn();
+    renderWithProvider(<SkuAssignments licences={licences} selectedLicenceTypeId={10} onSelect={onSelect} />);
+
+    expect(screen.getByText('E5')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('F3'));
+    expect(onSelect).toHaveBeenCalledWith(20);
+  });
+
+  it('selects from anywhere in the row, and the button still fires exactly once', () => {
+    // The row carries a pointer cursor and a hover highlight across its whole width, but activation
+    // used to live only in the first cell's button - so the assigned-users cell and the distribution
+    // cells advertised a click target that did nothing. Both directions are pinned here: a click on a
+    // NON-button cell now selects (the affordance is honest), and a click on the button itself still
+    // results in exactly ONE onSelect call rather than two via bubbling.
+    const onSelect = vi.fn();
+    renderWithProvider(<SkuAssignments licences={licences} selectedLicenceTypeId={null} onSelect={onSelect} />);
+
+    // Direction 1: the previously-dead area of the row now activates.
+    fireEvent.click(screen.getByText('50'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(20);
+
+    // Direction 2: the real button is not double-counted by the new row handler.
+    onSelect.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /E5/ }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(10);
+  });
+
+  it('activates selection via a real button, keeping native table-row semantics', () => {
+    renderWithProvider(<SkuAssignments licences={licences} selectedLicenceTypeId={10} onSelect={vi.fn()} />);
+
+    // The rows keep native semantics - no role="button" hijacking the row/cell roles (which would
+    // also fold every cell, including the five distribution bars, into one huge button label).
+    const rows = screen.getAllByRole('row');
+    expect(rows.length).toBe(3); // header + two SKU rows
+    rows.forEach((r) => expect(r).not.toHaveAttribute('role'));
+
+    // Selection is a real, focusable button per row; the selected one is pressed.
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBe(2);
+    const e5 = screen.getByRole('button', { name: /E5/ });
+    expect(e5).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /F3/ })).toHaveAttribute('aria-pressed', 'false');
+
+    // The accessible name is concise (the SKU), not a 60-word row concatenation: the distribution
+    // labels live in other cells and are not part of the control.
+    expect(e5).not.toHaveTextContent('High');
+  });
+
+  it('selects with the keyboard via the real button', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    renderWithProvider(<SkuAssignments licences={licences} selectedLicenceTypeId={null} onSelect={onSelect} />);
+
+    const f3 = screen.getByRole('button', { name: /F3/ });
+    f3.focus();
+    await user.keyboard('{Enter}');
+    expect(onSelect).toHaveBeenCalledWith(20);
+  });
+
+  it('renders a non-Latin (Greek) SKU name without corruption', () => {
+    // A SKU name is a Unicode-safe field.
+    renderWithProvider(
+      <SkuAssignments
+        licences={[{ licenceTypeId: 30, name: 'Άδεια Καλημέρα', skuId: 'GREEK_SKU', assignedUsers: 5, workloads: [] }]}
+        selectedLicenceTypeId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Άδεια Καλημέρα')).toBeInTheDocument();
+  });
+
+  it('scales to many SKUs: sorts biggest-first, filters, and stays selectable', () => {
+    const many: LicenceActivitySku[] = Array.from({ length: 12 }, (_, i) => ({
+      licenceTypeId: i + 1,
+      name: `SKU ${i + 1}`,
+      skuId: `PART${i + 1}`,
+      assignedUsers: (i + 1) * 10,
+      workloads: [],
+    }));
+    // A sparse licence with a non-Latin name (the kind that's easy to lose among 50 SKUs).
+    many.push({ licenceTypeId: 99, name: 'Άδεια σπάνια', skuId: 'RARE', assignedUsers: 1, workloads: [] });
+
+    const onSelect = vi.fn();
+    renderWithProvider(<SkuAssignments licences={many} selectedLicenceTypeId={null} onSelect={onSelect} />);
+
+    // Biggest first (assigned desc): SKU 12 (120) leads.
+    expect(screen.getAllByRole('button')[0]).toHaveTextContent('SKU 12');
+
+    // The filter narrows the (bounded, scrollable) list to the sparse one.
+    fireEvent.change(screen.getByLabelText('Filter licences'), { target: { value: 'σπάνια' } });
+    expect(screen.getByText('Άδεια σπάνια')).toBeInTheDocument();
+    expect(screen.queryByText('SKU 12')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Άδεια σπάνια'));
+    expect(onSelect).toHaveBeenCalledWith(99);
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.tsx
@@ -1,0 +1,223 @@
+import { memo, useMemo, useState, type CSSProperties } from 'react';
+import { makeStyles, tokens, Card, Text, Input } from '@fluentui/react-components';
+import type { LicenceActivityDistribution, LicenceActivitySku } from '../../types/licenceActivity';
+import { WORKLOADS } from '../../types/licenceActivity';
+import { formatCount } from './format';
+import { useLaTableStyles } from './tableStyles';
+import { MiniDistribution, BandLegend } from './MiniDistribution';
+
+/** Above this many SKUs, show the filter box and cap the table height so the selector stays scannable. */
+const FILTER_THRESHOLD = 8;
+
+const EMPTY: LicenceActivityDistribution = { workload: '', high: 0, moderate: 0, low: 0, zero: 0, unknown: 0 };
+
+const useStyles = makeStyles({
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+  },
+  head: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  headText: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  filter: {
+    minWidth: '220px',
+  },
+  sku: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  // Cap the height so 50 SKUs scroll within the card instead of pushing the workload distributions
+  // and drill-down far down the page. The sticky header keeps the columns visible while scrolling.
+  scroll: {
+    maxHeight: '360px',
+    overflowY: 'auto',
+  },
+  stickyHead: {
+    position: 'sticky',
+    insetBlockStart: 0,
+    backgroundColor: tokens.colorNeutralBackground1,
+    zIndex: 1,
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '16px 0',
+  },
+});
+
+interface SkuAssignmentsProps {
+  licences: LicenceActivitySku[];
+  selectedLicenceTypeId: number | null;
+  onSelect: (licenceTypeId: number) => void;
+}
+
+// A visually-seamless reset so the real <button> fills the cell without its default chrome. Kept as a
+// plain inline style to sidestep Griffel's shorthand restrictions (border/background/font). The native
+// focus outline is intentionally NOT removed, so keyboard focus stays visible.
+const selectButtonStyle: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  background: 'transparent',
+  border: 'none',
+  padding: '2px 0',
+  margin: 0,
+  font: 'inherit',
+  color: 'inherit',
+  cursor: 'pointer',
+};
+
+/**
+ * The executive licence view: one row per SKU with how many users hold it. Selecting a row drives the
+ * workload distributions and (for users with the role) the per-user drill-down.
+ *
+ * Built to stay responsive at ~50 SKUs of very uneven size (some tenant-wide, some with a handful of
+ * seats): the list is sorted by assigned users so the biggest are first, a filter narrows it by name
+ * or SKU id, and the body scrolls within a bounded height. Rendering is O(SKUs) - the heavy per-user
+ * work stays server-side and paged.
+ */
+function SkuAssignments({ licences, selectedLicenceTypeId, onSelect }: SkuAssignmentsProps) {
+  const styles = useStyles();
+  const table = useLaTableStyles();
+  const [filter, setFilter] = useState('');
+
+  const sorted = useMemo(
+    () => [...licences].sort((a, b) => b.assignedUsers - a.assignedUsers || a.name.localeCompare(b.name)),
+    [licences],
+  );
+
+  const visible = useMemo(() => {
+    const q = filter.trim().toLocaleLowerCase();
+    if (!q) return sorted;
+    return sorted.filter(
+      (s) => s.name.toLocaleLowerCase().includes(q) || (s.skuId ?? '').toLocaleLowerCase().includes(q),
+    );
+  }, [sorted, filter]);
+
+  const showFilter = licences.length > FILTER_THRESHOLD;
+
+  if (licences.length === 0) {
+    return (
+      <Card className={styles.card}>
+        <Text className={styles.muted}>No licence assignments were found for this scope.</Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={styles.card}>
+      <div className={styles.head}>
+        <div className={styles.headText}>
+          <Text weight="semibold" size={400}>
+            Licence assignments
+          </Text>
+          <Text size={200} className={styles.muted}>
+            Select a licence to see its workload activity and, with the required role, who holds it.
+            {showFilter ? ` Showing ${formatCount(visible.length)} of ${formatCount(licences.length)}.` : ''}
+          </Text>
+        </div>
+        {showFilter && (
+          <Input
+            className={styles.filter}
+            value={filter}
+            placeholder="Filter by name or SKU"
+            aria-label="Filter licences"
+            onChange={(_e, d) => setFilter(d.value)}
+          />
+        )}
+      </div>
+
+      <BandLegend />
+
+      <div className={`${table.wrap} ${showFilter ? styles.scroll : ''}`.trim()}>
+        <table className={table.table}>
+          <thead className={showFilter ? styles.stickyHead : undefined}>
+            <tr>
+              <th className={table.th}>Licence</th>
+              <th className={`${table.th} ${table.thNumeric}`}>Assigned users</th>
+              {WORKLOADS.map((w) => (
+                <th key={w.key} className={table.th}>
+                  {w.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((sku) => {
+              const selected = sku.licenceTypeId === selectedLicenceTypeId;
+              return (
+                <tr
+                  key={sku.licenceTypeId}
+                  className={`${table.selectableRow} ${selected ? table.selectedRow : ''}`.trim()}
+                  // `selectableRow` puts a pointer cursor and a hover highlight on the WHOLE row, but
+                  // activation lives in the button in the first cell - so the assigned-users cell and
+                  // the five distribution cells (most of the row's width) advertised a click target
+                  // that did nothing. Make the advertisement true for the mouse rather than removing
+                  // the useful hover cue. This adds no ARIA role, so the native row/cell semantics
+                  // the a11y tests pin are untouched, and the button remains the only control exposed
+                  // to assistive technology and the keyboard.
+                  onClick={() => onSelect(sku.licenceTypeId)}
+                >
+                  <td className={table.td}>
+                    {/* Activation lives in a real button (keyboard-operable, correctly announced),
+                        so the <tr> keeps native table-row semantics instead of role="button", which
+                        would swallow the row/cell roles and read every cell as one giant label. */}
+                    <button
+                      type="button"
+                      style={selectButtonStyle}
+                      aria-pressed={selected}
+                      onClick={(e) => {
+                        // The row handler would otherwise fire too; harmless (same id) but avoid the
+                        // duplicate call so onSelect stays once-per-activation for callers and tests.
+                        e.stopPropagation();
+                        onSelect(sku.licenceTypeId);
+                      }}
+                    >
+                      <span className={styles.sku}>
+                        <Text size={300} weight="semibold">
+                          {sku.name}
+                        </Text>
+                        {sku.skuId && (
+                          <Text size={100} className={styles.muted}>
+                            {sku.skuId}
+                          </Text>
+                        )}
+                      </span>
+                    </button>
+                  </td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>{formatCount(sku.assignedUsers)}</td>
+                  {WORKLOADS.map((w) => {
+                    const dist = sku.workloads.find((d) => d.workload === w.key) ?? { ...EMPTY, workload: w.key };
+                    return (
+                      <td key={w.key} className={table.td}>
+                        <MiniDistribution distribution={dist} />
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {visible.length === 0 && <Text className={styles.empty}>No licences match &ldquo;{filter}&rdquo;.</Text>}
+    </Card>
+  );
+}
+
+// Memoised: the page re-renders when unrelated state changes (users snapshot id, export state), and
+// this list of up to 50 rows should not re-render unless the licences or the selection actually change.
+export default memo(SkuAssignments);

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import UsersDrillDown from './UsersDrillDown';
+import { fetchUsers } from '../../api/licenceActivityApi';
+import type {
+  LicenceActivityCoverage,
+  LicenceActivitySku,
+  LicenceActivityUser,
+  LicenceActivityUsers,
+  UsersParams,
+} from '../../types/licenceActivity';
+
+vi.mock('../../api/licenceActivityApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/licenceActivityApi')>();
+  return { ...actual, fetchUsers: vi.fn() };
+});
+
+const mockUsers = vi.mocked(fetchUsers);
+
+const licence: LicenceActivitySku = {
+  licenceTypeId: 10,
+  name: 'E5',
+  skuId: 'ENTERPRISEPREMIUM',
+  assignedUsers: 100,
+  workloads: [],
+};
+
+function user(upn: string, workload: string): LicenceActivityUser {
+  return {
+    userId: upn.length,
+    userPrincipalName: upn,
+    department: 'Engineering',
+    country: 'Greece',
+    accountEnabled: true,
+    workloads: [
+      {
+        workload,
+        status: 'known',
+        band: 'high',
+        source: 'Usage reports',
+        measure: 'active days',
+        activeSamples: 10,
+        observedSamples: 20,
+        expectedSamples: 20,
+        averageActions: 3.5,
+        lastActivityUtc: '2026-05-19T00:00:00Z',
+      },
+    ],
+  };
+}
+
+function usersResponse(params: UsersParams): LicenceActivityUsers {
+  return {
+    snapshotId: `snap-${params.page}-${params.top}-${params.workload}`,
+    generatedUtc: '2026-05-20T00:00:00Z',
+    expiresUtc: '2026-05-20T00:02:00Z',
+    overviewId: params.overviewId,
+    query: {
+      from: '2026-05-01',
+      to: '2026-05-19',
+      departmentId: null,
+      countryId: null,
+      licenceTypeId: params.licenceTypeId,
+      workload: params.workload,
+      search: params.search ?? '',
+      sort: params.sort,
+      direction: params.direction,
+      top: params.top,
+      page: params.page,
+      pageSize: params.pageSize,
+    },
+    totalUsers: 120,
+    rankedUsers: 120,
+    mostActive: [user('ada@contoso.com', params.workload)],
+    leastActive: [user('zoe@contoso.com', params.workload)],
+    users: [user('ada@contoso.com', params.workload)],
+    messages: [],
+  };
+}
+
+function lastParams(): UsersParams {
+  const calls = mockUsers.mock.calls;
+  return calls[calls.length - 1][0];
+}
+
+beforeEach(() => {
+  mockUsers.mockReset();
+  mockUsers.mockImplementation(async (params) => usersResponse(params));
+});
+
+function coverageEntry(over: Partial<LicenceActivityCoverage> = {}): LicenceActivityCoverage {
+  return {
+    workload: 'teams',
+    status: 'notImported',
+    source: null,
+    measure: null,
+    granularity: null,
+    message: null,
+    effectiveFromUtc: null,
+    effectiveToUtc: null,
+    latestImportUtc: null,
+    lagDays: 0,
+    reportPeriodDays: null,
+    expectedSamples: 0,
+    observedSamples: 0,
+    unmatchedUsers: 0,
+    snapshotDates: [],
+    ...over,
+  };
+}
+
+function renderDrill(coverage: LicenceActivityCoverage[] = []) {
+  return renderWithProvider(
+    <UsersDrillDown
+      overviewId="ov1"
+      licence={licence}
+      coverage={coverage}
+      onUsersSnapshot={vi.fn()}
+      onRefreshOverview={vi.fn()}
+    />,
+  );
+}
+
+describe('UsersDrillDown', () => {
+  it('issues one activity-ranked request by default, and re-requests when top changes (clamped 1..100)', async () => {
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+    expect(lastParams()).toMatchObject({
+      workload: 'teams',
+      top: 10,
+      sort: 'activity',
+      direction: 'desc',
+      page: 1,
+      pageSize: 50,
+    });
+
+    const topInput = screen.getByLabelText('Number of users in each list');
+    fireEvent.change(topInput, { target: { value: '25' } });
+    fireEvent.blur(topInput);
+    await waitFor(() => expect(lastParams()).toMatchObject({ top: 25 }));
+
+    fireEvent.change(topInput, { target: { value: '999' } });
+    fireEvent.blur(topInput);
+    await waitFor(() => expect(lastParams()).toMatchObject({ top: 100 }));
+  });
+
+  it('changes the workload', async () => {
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    await waitFor(() => expect(lastParams()).toMatchObject({ workload: 'outlook' }));
+  });
+
+  it('browses with server-side search, sort and paging', async () => {
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    const search = screen.getByLabelText('Search users');
+    fireEvent.change(search, { target: { value: 'ada' } });
+    fireEvent.keyDown(search, { key: 'Enter' });
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada' }));
+
+    fireEvent.change(screen.getByLabelText('Sort users'), { target: { value: 'upn:asc' } });
+    await waitFor(() => expect(lastParams()).toMatchObject({ sort: 'upn', direction: 'asc' }));
+
+    // total 120, pageSize 50 -> 3 pages.
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ page: 2 }));
+  });
+
+  // The server (LicenceActivityQuery.Create) throws -> HTTP 400 for a search over 100 characters or
+  // containing ANY control character. A single-line <input> strips CR/LF itself (the HTML value
+  // sanitization algorithm, in jsdom and real browsers alike), so a newline is NOT the reachable
+  // case - the other C0/C1 controls are, and .trim() does not remove one from the middle of a paste.
+  // Because the browse controls only render while `data` is non-null, a 400 caused by the search used
+  // to unmount the very box holding the offending term, while every surviving control preserved that
+  // term - an unrecoverable dead end. Each case gets its own render: this component submits a search
+  // once per mount, so chaining several submissions into one test does not exercise what it claims.
+
+  it('strips control characters from a search instead of submitting a guaranteed 400', async () => {
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    const search = screen.getByLabelText('Search users');
+    fireEvent.change(search, { target: { value: 'ada\u0007lovelace' } });
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada lovelace' }));
+    expect(lastParams().search).not.toMatch(/[\u0000-\u001f\u007f]/);
+  });
+
+  it('caps an over-long search at the server limit', async () => {
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'a'.repeat(250) } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(lastParams().search).toHaveLength(100));
+  });
+
+  it('leaves an ordinary search term completely untouched', async () => {
+    // The positive direction of the two guards above: sanitising must not mangle a real UPN search.
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'ada@contoso.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada@contoso.com' }));
+  });
+
+  it('keeps a way to clear the search when a failed load hides the browse controls', async () => {
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    mockUsers.mockRejectedValueOnce(new Error('boom'));
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'zzz' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    const clear = await screen.findByRole('button', { name: /Clear search and try again/ });
+    fireEvent.click(clear);
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: '' }));
+  });
+
+  it('explains why a workload cannot be ranked when its coverage is incomplete', async () => {
+    renderDrill([coverageEntry({ workload: 'teams', status: 'notImported' })]);
+    // The selected workload defaults to Teams, whose coverage is notImported here.
+    expect(await screen.findByText(/Not imported/)).toBeInTheDocument();
+  });
+
+  it('renders API messages (coverage / ranking limitations)', async () => {
+    mockUsers.mockImplementation(async (params) => ({
+      ...usersResponse(params),
+      messages: ['Teams ranking is limited by partial coverage.'],
+    }));
+    renderDrill();
+    expect(await screen.findByText(/limited by partial coverage/)).toBeInTheDocument();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
@@ -224,6 +224,35 @@ describe('UsersDrillDown', () => {
     await waitFor(() => expect(lastParams()).toMatchObject({ search: '' }));
   });
 
+  it('lets a space be typed mid-term (sanitising must not fight the space bar)', async () => {
+    // Regression guard for a defect introduced by the sanitisation fix itself: trimming on every
+    // change, with searchDraft fed back into the controlled input, erased a trailing space as soon as
+    // it was typed, so "ada smith" could never be entered. Typing is simulated one keystroke at a
+    // time on purpose - supplying the whole value in a single change event does NOT exercise this.
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    const search = screen.getByLabelText('Search users') as HTMLInputElement;
+    for (const ch of 'ada smith') {
+      fireEvent.change(search, { target: { value: search.value + ch } });
+    }
+    expect(search.value).toBe('ada smith');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada smith' }));
+  });
+
+  it('still trims a term when it is committed', async () => {
+    // The other direction: trimming did not disappear, it just moved to commit time.
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: '  ada@contoso.com  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada@contoso.com' }));
+  });
+
   it('explains why a workload cannot be ranked when its coverage is incomplete', async () => {
     renderDrill([coverageEntry({ workload: 'teams', status: 'notImported' })]);
     // The selected workload defaults to Teams, whose coverage is notImported here.

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
@@ -253,6 +253,29 @@ describe('UsersDrillDown', () => {
     await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada@contoso.com' }));
   });
 
+  it('strips C1 controls too, but leaves accented letters alone', async () => {
+    // .NET char.IsControl - which is what the server tests - covers C0, DEL AND C1 (U+0080-U+009F).
+    // The first version of this sanitiser stopped at DEL, so a pasted U+0085 NEL still reached the
+    // server and still produced the 400 the sanitiser exists to prevent. The positive direction
+    // matters just as much: U+00A0 and the accented Latin-1 letters just above the C1 block are NOT
+    // controls, and eating them would corrupt perfectly valid non-English UPN searches.
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'ada\u0085smith' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada smith' }));
+  });
+
+  it('leaves non-ASCII letters in a search untouched', async () => {
+    renderDrill();
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'ándré.Καλημέρα@contoso.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ándré.Καλημέρα@contoso.com' }));
+  });
+
   it('explains why a workload cannot be ranked when its coverage is incomplete', async () => {
     renderDrill([coverageEntry({ workload: 'teams', status: 'notImported' })]);
     // The selected workload defaults to Teams, whose coverage is notImported here.

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -197,12 +197,17 @@ export default function UsersDrillDown({
 
   // Never let the box hold a term the server is guaranteed to reject. LicenceActivityQuery.Create
   // throws (=> HTTP 400) for a search over MAX_SEARCH characters or containing ANY control character,
-  // and .trim() alone does not remove a control character embedded in the middle of a pasted value -
-  // a two-line paste used to produce an unrecoverable 400. Sanitising on the way in keeps the client
-  // inside the server's contract instead of discovering it by failing.
-  const sanitiseSearch = (value: string) =>
+  // and a single-line <input> only strips CR/LF for us - the other C0/C1 controls survive a paste.
+  //
+  // Two functions, deliberately: trimming WHILE EDITING would make the space bar unusable, because
+  // `searchDraft` is fed straight back into the controlled input, so " " typed after "ada" would be
+  // erased before the next keystroke and "ada smith" could never be typed. So editing only removes
+  // what is genuinely un-submittable (control characters, over-length), and trimming happens once, at
+  // commit.
+  const sanitiseDraft = (value: string) =>
     // eslint-disable-next-line no-control-regex
-    value.replace(/[\u0000-\u001f\u007f]+/g, ' ').slice(0, MAX_SEARCH).trim();
+    value.replace(/[\u0000-\u001f\u007f]+/g, ' ').slice(0, MAX_SEARCH);
+  const commitSearch = (value: string) => setSearch(sanitiseDraft(value).trim());
   const [sort, setSort] = useState<UsersSortKey>('activity');
   const [direction, setDirection] = useState<SortDirection>('desc');
   const [page, setPage] = useState(1);
@@ -419,12 +424,12 @@ export default function UsersDrillDown({
                 maxLength={MAX_SEARCH}
                 placeholder="Search UPN or email"
                 aria-label="Search users"
-                onChange={(_e, d) => setSearchDraft(sanitiseSearch(d.value))}
+                onChange={(_e, d) => setSearchDraft(sanitiseDraft(d.value))}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') setSearch(sanitiseSearch(searchDraft));
+                  if (e.key === 'Enter') commitSearch(searchDraft);
                 }}
               />
-              <Button size="small" onClick={() => setSearch(sanitiseSearch(searchDraft))}>
+              <Button size="small" onClick={() => commitSearch(searchDraft)}>
                 Search
               </Button>
               <Select

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -196,8 +196,12 @@ export default function UsersDrillDown({
   const [search, setSearch] = useState('');
 
   // Never let the box hold a term the server is guaranteed to reject. LicenceActivityQuery.Create
-  // throws (=> HTTP 400) for a search over MAX_SEARCH characters or containing ANY control character,
-  // and a single-line <input> only strips CR/LF for us - the other C0/C1 controls survive a paste.
+  // throws (=> HTTP 400) for a search over MAX_SEARCH characters or containing ANY control character.
+  // "Control" must mean exactly what .NET's char.IsControl means, which is C0 (U+0000-U+001F), DEL
+  // (U+007F) AND C1 (U+0080-U+009F) - an earlier version of this regex stopped at DEL, so a pasted
+  // C1 character such as U+0085 NEL (common from Windows-1252 and PDF copy) still produced a 400.
+  // The range deliberately ends at U+009F: U+00A0 NBSP and the accented Latin-1 letters above it are
+  // NOT controls and must survive untouched.
   //
   // Two functions, deliberately: trimming WHILE EDITING would make the space bar unusable, because
   // `searchDraft` is fed straight back into the controlled input, so " " typed after "ada" would be
@@ -206,7 +210,7 @@ export default function UsersDrillDown({
   // commit.
   const sanitiseDraft = (value: string) =>
     // eslint-disable-next-line no-control-regex
-    value.replace(/[\u0000-\u001f\u007f]+/g, ' ').slice(0, MAX_SEARCH);
+    value.replace(/[\u0000-\u001f\u007f-\u009f]+/g, ' ').slice(0, MAX_SEARCH);
   const commitSearch = (value: string) => setSearch(sanitiseDraft(value).trim());
   const [sort, setSort] = useState<UsersSortKey>('activity');
   const [direction, setDirection] = useState<SortDirection>('desc');

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -1,0 +1,481 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  makeStyles,
+  tokens,
+  Card,
+  Text,
+  Input,
+  Select,
+  Button,
+  Spinner,
+  MessageBar,
+  MessageBarBody,
+} from '@fluentui/react-components';
+import { ArrowClockwise16Regular } from '@fluentui/react-icons';
+import {
+  WORKLOADS,
+  type LicenceActivityCoverage,
+  type LicenceActivitySku,
+  type SortDirection,
+  type UsersParams,
+  type UsersSortKey,
+  type WorkloadKey,
+} from '../../types/licenceActivity';
+import UsersTable from './UsersTable';
+import ApiErrorBar, { describeError } from './ApiErrorBar';
+import { useUsersQuery } from './useUsersQuery';
+import { statusMeta } from './statuses';
+import { formatCount } from './format';
+
+const PAGE_SIZE = 50;
+const MIN_TOP = 1;
+const MAX_TOP = 100;
+// Must match LicenceActivityQuery.Create's server-side limit, which throws (=> HTTP 400) above it.
+const MAX_SEARCH = 100;
+
+const BROWSE_SORTS: { value: string; label: string }[] = [
+  { value: 'activity:desc', label: 'Most active first' },
+  { value: 'activity:asc', label: 'Least active first' },
+  { value: 'lastActivity:desc', label: 'Most recently active' },
+  { value: 'lastActivity:asc', label: 'Longest since active' },
+  { value: 'upn:asc', label: 'UPN (A\u2013Z)' },
+  { value: 'upn:desc', label: 'UPN (Z\u2013A)' },
+];
+
+const useStyles = makeStyles({
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+  head: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  headText: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  controls: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    flexWrap: 'wrap',
+  },
+  field: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+  },
+  topInput: {
+    width: '84px',
+  },
+  twoUp: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+    gap: '16px',
+  },
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  panelHead: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: '8px',
+  },
+  browse: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+  },
+  browseControls: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    flexWrap: 'wrap',
+  },
+  grow: {
+    flexGrow: 1,
+    minWidth: '200px',
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  center: {
+    textAlign: 'center',
+    padding: '24px',
+  },
+});
+
+function clampTop(n: number): number {
+  if (!Number.isFinite(n)) return MIN_TOP;
+  return Math.max(MIN_TOP, Math.min(MAX_TOP, Math.round(n)));
+}
+
+/** A 1..100 count field with commit-on-blur/Enter, so the bounded lists refetch once per change. */
+function TopCountInput({ value, onCommit, disabled }: { value: number; onCommit: (n: number) => void; disabled?: boolean }) {
+  const styles = useStyles();
+  const [text, setText] = useState(String(value));
+  useEffect(() => setText(String(value)), [value]);
+
+  const commit = (): void => {
+    const n = clampTop(Number(text));
+    onCommit(n);
+    setText(String(n));
+  };
+
+  return (
+    <Input
+      className={styles.topInput}
+      type="number"
+      min={MIN_TOP}
+      max={MAX_TOP}
+      value={text}
+      disabled={disabled}
+      aria-label="Number of users in each list"
+      onChange={(_e, d) => setText(d.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          commit();
+        }
+      }}
+    />
+  );
+}
+
+interface UsersDrillDownProps {
+  overviewId: string;
+  licence: LicenceActivitySku;
+  /** The overview's per-workload coverage, used to explain why a workload can't be ranked. */
+  coverage: LicenceActivityCoverage[];
+  /** Reports the snapshot id of the loaded users list, for the exact-snapshot export. Null while
+   *  loading / on error. Should be a stable reference. */
+  onUsersSnapshot: (usersId: string | null) => void;
+  /** Reloads the overview - the correct fix when a users request fails because the snapshot expired. */
+  onRefreshOverview: () => void;
+  /** Bumped by the parent to force a fresh users fetch (re-mint) even when the params are otherwise
+   *  unchanged - e.g. after an export 410, when the overview is still cached under the same id so the
+   *  params never change on their own. A same-key reload keeps the current rows on screen while the
+   *  new snapshot loads. Undefined/0 means "no forced refresh yet". */
+  refreshToken?: number;
+}
+
+/**
+ * The per-licence drill-down. One workload at a time; a single request returns the top-N most and
+ * least active users AND the current browse page together, so their shared snapshot id is an
+ * unambiguous "current bounded rows" for the export. All fetching is cancellable and stale-safe.
+ */
+export default function UsersDrillDown({
+  overviewId,
+  licence,
+  coverage,
+  onUsersSnapshot,
+  onRefreshOverview,
+  refreshToken,
+}: UsersDrillDownProps) {
+  const styles = useStyles();
+
+  const [workload, setWorkload] = useState<WorkloadKey>('teams');
+  const [top, setTop] = useState(10);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [search, setSearch] = useState('');
+
+  // Never let the box hold a term the server is guaranteed to reject. LicenceActivityQuery.Create
+  // throws (=> HTTP 400) for a search over MAX_SEARCH characters or containing ANY control character,
+  // and .trim() alone does not remove a control character embedded in the middle of a pasted value -
+  // a two-line paste used to produce an unrecoverable 400. Sanitising on the way in keeps the client
+  // inside the server's contract instead of discovering it by failing.
+  const sanitiseSearch = (value: string) =>
+    // eslint-disable-next-line no-control-regex
+    value.replace(/[\u0000-\u001f\u007f]+/g, ' ').slice(0, MAX_SEARCH).trim();
+  const [sort, setSort] = useState<UsersSortKey>('activity');
+  const [direction, setDirection] = useState<SortDirection>('desc');
+  const [page, setPage] = useState(1);
+
+  const workloadLabel = WORKLOADS.find((w) => w.key === workload)?.label ?? workload;
+  const workloadCoverage = coverage.find((c) => c.workload === workload) ?? null;
+  const coverageIncomplete = workloadCoverage != null && workloadCoverage.status !== 'available';
+  const rankEmptyText = coverageIncomplete
+    ? `${workloadLabel} activity is not fully measured, so users can't be ranked here - see the note above.`
+    : 'No users to rank for this workload.';
+
+  // Reset the page atomically when the scope (licence / workload / browse filter) changes, DURING
+  // render - so `params` never briefly pairs a new scope with the old page, which would fire a wasted
+  // SQL load before the page-1 reset. This is the React "adjust state during render" pattern.
+  const scopeKey = `${overviewId}\n${licence.licenceTypeId}\n${workload}\n${search}\n${sort}\n${direction}`;
+  const [scope, setScope] = useState(scopeKey);
+  if (scope !== scopeKey) {
+    setScope(scopeKey);
+    setPage(1);
+  }
+
+  const params = useMemo<UsersParams>(
+    () => ({
+      overviewId,
+      licenceTypeId: licence.licenceTypeId,
+      workload,
+      top,
+      search,
+      sort,
+      direction,
+      page,
+      pageSize: PAGE_SIZE,
+    }),
+    [overviewId, licence.licenceTypeId, workload, top, search, sort, direction, page],
+  );
+
+  const { data, loading, error, reload } = useUsersQuery(params);
+
+  // A parent-driven forced refresh (e.g. after an export 410). Re-mint the current view's snapshot
+  // without changing any params, so the licence/workload/page/filters the admin is looking at are all
+  // preserved. Skip the initial mount (token 0/undefined) so this never double-fetches on first load.
+  const firstRefreshToken = useRef(refreshToken);
+  useEffect(() => {
+    if (refreshToken === firstRefreshToken.current) return;
+    firstRefreshToken.current = refreshToken;
+    reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshToken]);
+
+  // Keep the page's export in step with the list currently on screen.
+  useEffect(() => {
+    onUsersSnapshot(data?.snapshotId ?? null);
+  }, [data?.snapshotId, onUsersSnapshot]);
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.totalUsers / PAGE_SIZE)) : 1;
+  const retry = describeError(error, '').kind === 'expired' ? onRefreshOverview : reload;
+
+  return (
+    <Card className={styles.card}>
+      <div className={styles.head}>
+        <div className={styles.headText}>
+          <Text weight="semibold" size={400}>
+            {licence.name}
+          </Text>
+          <Text size={200} className={styles.muted}>
+            {formatCount(licence.assignedUsers)} users hold this licence. Choose a workload to rank them by its
+            activity.
+          </Text>
+        </div>
+        <div className={styles.controls}>
+          <div className={styles.field}>
+            <Text size={200} className={styles.muted}>
+              Workload
+            </Text>
+            <Select value={workload} aria-label="Workload" onChange={(_e, d) => setWorkload(d.value as WorkloadKey)}>
+              {WORKLOADS.map((w) => (
+                <option key={w.key} value={w.key}>
+                  {w.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className={styles.field}>
+            <Text size={200} className={styles.muted}>
+              Show top
+            </Text>
+            <TopCountInput value={top} onCommit={setTop} />
+            <Text size={200} className={styles.muted}>
+              of each
+            </Text>
+          </div>
+          <Button
+            size="small"
+            appearance="subtle"
+            icon={<ArrowClockwise16Regular />}
+            onClick={reload}
+            aria-label="Refresh users"
+          >
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {error != null && <ApiErrorBar error={error} fallback="Couldn't load the users." onRetry={retry} />}
+
+      {/* A failed load unmounts the browse controls below (they live inside `data && ...`), which
+          would otherwise strand an admin whose SEARCH TERM caused the failure: every surviving
+          control preserves `search`, so retrying just reproduces it. Sanitising the input makes a
+          search-induced 400 unreachable, and this keeps a guaranteed escape route for any other
+          cause. */}
+      {error != null && !data && search !== '' && (
+        <div className={styles.center}>
+          <Button
+            size="small"
+            onClick={() => {
+              setSearchDraft('');
+              setSearch('');
+            }}
+          >
+            Clear search and try again
+          </Button>
+        </div>
+      )}
+
+      {coverageIncomplete && workloadCoverage && (
+        <MessageBar intent="warning">
+          <MessageBarBody>
+            <strong>
+              {workloadLabel}: {statusMeta(workloadCoverage.status).label}.
+            </strong>{' '}
+            {statusMeta(workloadCoverage.status).explanation}
+            {workloadCoverage.message ? ` ${workloadCoverage.message}` : ''} Users with positive evidence still appear
+            as most active; nobody is ranked least active for this workload.
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      {data && data.messages.length > 0 && (
+        <MessageBar intent="info">
+          <MessageBarBody>
+            <ul style={{ margin: 0, paddingInlineStart: '20px' }}>
+              {data.messages.map((m) => (
+                <li key={m}>{m}</li>
+              ))}
+            </ul>
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      {loading && !data && (
+        <div className={styles.center}>
+          <Spinner size="small" label="Loading users..." />
+        </div>
+      )}
+
+      {data && (
+        <>
+          <div className={styles.twoUp}>
+            <div className={styles.panel}>
+              <div className={styles.panelHead}>
+                <Text weight="semibold" size={300}>
+                  Most active
+                </Text>
+                <Text size={200} className={styles.muted}>
+                  top {top}
+                </Text>
+              </div>
+              <UsersTable
+                rows={data.mostActive}
+                workload={workload}
+                workloadLabel={workloadLabel}
+                showRank
+                emptyText={rankEmptyText}
+              />
+            </div>
+            <div className={styles.panel}>
+              <div className={styles.panelHead}>
+                <Text weight="semibold" size={300}>
+                  Least active
+                </Text>
+                <Text size={200} className={styles.muted}>
+                  bottom {top}
+                </Text>
+              </div>
+              <UsersTable
+                rows={data.leastActive}
+                workload={workload}
+                workloadLabel={workloadLabel}
+                showRank
+                emptyText={rankEmptyText}
+              />
+            </div>
+          </div>
+
+          <div className={styles.browse}>
+            <div className={styles.panelHead}>
+              <Text weight="semibold" size={300}>
+                Browse all
+              </Text>
+              <Text size={200} className={styles.muted}>
+                {formatCount(data.totalUsers)} users
+              </Text>
+            </div>
+
+            <Text size={100} className={styles.muted}>
+              User display names are not imported; search uses UPN or email. This is a deliberate limitation, not a
+              missing name.
+            </Text>
+
+            <div className={styles.browseControls}>
+              <Input
+                className={styles.grow}
+                value={searchDraft}
+                maxLength={MAX_SEARCH}
+                placeholder="Search UPN or email"
+                aria-label="Search users"
+                onChange={(_e, d) => setSearchDraft(sanitiseSearch(d.value))}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') setSearch(sanitiseSearch(searchDraft));
+                }}
+              />
+              <Button size="small" onClick={() => setSearch(sanitiseSearch(searchDraft))}>
+                Search
+              </Button>
+              <Select
+                value={`${sort}:${direction}`}
+                aria-label="Sort users"
+                onChange={(_e, d) => {
+                  const [nextSort, nextDir] = d.value.split(':');
+                  setSort(nextSort as UsersSortKey);
+                  setDirection(nextDir as SortDirection);
+                }}
+              >
+                {BROWSE_SORTS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+
+            <UsersTable
+              rows={data.users}
+              workload={workload}
+              workloadLabel={workloadLabel}
+              startRank={(data.query.page - 1) * data.query.pageSize + 1}
+              showRank
+              emptyText={search ? 'No users match your search.' : 'No users to show for this selection.'}
+            />
+
+            {data.totalUsers > 0 && (
+              <div className={styles.footer}>
+                <Text size={200} className={styles.muted}>
+                  Showing {formatCount((data.query.page - 1) * data.query.pageSize + 1)}&ndash;
+                  {formatCount(Math.min(data.query.page * data.query.pageSize, data.totalUsers))} of{' '}
+                  {formatCount(data.totalUsers)} users
+                </Text>
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                  <Button size="small" disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>
+                    Previous
+                  </Button>
+                  <Text size={200} className={styles.muted}>
+                    Page {data.query.page} of {totalPages}
+                  </Text>
+                  <Button size="small" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import UsersTable from './UsersTable';
+import { WORKLOADS } from '../../types/licenceActivity';
+import type { LicenceActivityEvidence, LicenceActivityUser } from '../../types/licenceActivity';
+
+function evidence(over: Partial<LicenceActivityEvidence> = {}): LicenceActivityEvidence {
+  return {
+    workload: 'teams',
+    status: 'known',
+    band: 'high',
+    source: 'Usage reports',
+    measure: 'reporting samples',
+    activeSamples: 15,
+    observedSamples: 20,
+    expectedSamples: 20,
+    averageActions: 3.5,
+    lastActivityUtc: '2026-05-19T00:00:00Z',
+    ...over,
+  };
+}
+
+function usr(over: Partial<LicenceActivityUser> = {}): LicenceActivityUser {
+  return {
+    userId: Math.floor(Math.random() * 1e9),
+    userPrincipalName: 'ada@contoso.com',
+    department: 'Engineering',
+    country: 'Greece',
+    accountEnabled: true,
+    workloads: [evidence()],
+    ...over,
+  };
+}
+
+describe('UsersTable', () => {
+  it('identifies the user by UPN only (no display names exist to show or invent)', () => {
+    renderWithProvider(<UsersTable rows={[usr()]} workload="teams" workloadLabel="Teams" />);
+    expect(screen.getByText('ada@contoso.com')).toBeInTheDocument();
+  });
+
+  it('renders non-Latin (Greek) department text without corruption', () => {
+    // Department is a Unicode-safe field (unlike the ASCII-by-policy UPN).
+    renderWithProvider(
+      <UsersTable rows={[usr({ department: 'Καλημέρα κόσμε' })]} workload="teams" workloadLabel="Teams" />,
+    );
+    expect(screen.getByText('Καλημέρα κόσμε')).toBeInTheDocument();
+  });
+
+  it('shows the active-sample frequency and a coloured band', () => {
+    renderWithProvider(<UsersTable rows={[usr()]} workload="teams" workloadLabel="Teams" />);
+    // 15 / 20 observed samples = 75% (the parenthesised cell value, not the band-method tooltip).
+    expect(screen.getByText('(75%)')).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+  });
+
+  it('renders an unknown band (incomplete coverage) as Unknown, not zero', () => {
+    renderWithProvider(
+      <UsersTable
+        rows={[usr({ workloads: [evidence({ status: 'unknown', band: 'unknown' })] })]}
+        workload="teams"
+        workloadLabel="Teams"
+      />,
+    );
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    // A user with no evidence for the workload at all is also Unknown, never a zero.
+    renderWithProvider(<UsersTable rows={[usr({ workloads: [] })]} workload="copilot" workloadLabel="Copilot" />);
+    expect(screen.getAllByText('Unknown').length).toBeGreaterThan(0);
+  });
+
+  it('expands a row to show all five workloads (so the same person can be inspected without re-ranking)', () => {
+    const user = usr({
+      workloads: WORKLOADS.map((w) =>
+        evidence({
+          workload: w.key,
+          status: w.key === 'copilot' ? 'notImported' : 'available',
+          band: w.key === 'copilot' ? 'unknown' : 'high',
+        }),
+      ),
+    });
+    renderWithProvider(<UsersTable rows={[user]} workload="teams" workloadLabel="Teams" />);
+
+    // Collapsed: only the selected workload is summarised, so the not-imported one isn't shown yet.
+    expect(screen.queryByText('Not imported')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Show all workloads/ }));
+
+    // Expanded: every workload is listed with its coverage status.
+    for (const w of WORKLOADS) {
+      expect(screen.getAllByText(w.label).length).toBeGreaterThan(0);
+    }
+    expect(screen.getByText('Not imported')).toBeInTheDocument();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.tsx
@@ -1,0 +1,329 @@
+import { Fragment, useState } from 'react';
+import { makeStyles, tokens, Text, Badge, Button, Tooltip } from '@fluentui/react-components';
+import { ChevronDown16Regular, ChevronRight16Regular } from '@fluentui/react-icons';
+import type { LicenceActivityEvidence, LicenceActivityUser, WorkloadKey } from '../../types/licenceActivity';
+import { WORKLOADS } from '../../types/licenceActivity';
+import { BAND_METHOD, bandColour, bandForeground, bandLabel, frequencyPct } from './bands';
+import { DASH, UNKNOWN_TEXT, formatAge, formatDate } from './format';
+import { statusMeta } from './statuses';
+import { useLaTableStyles } from './tableStyles';
+
+const useStyles = makeStyles({
+  user: {
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: '180px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  disabled: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  reason: {
+    color: tokens.colorNeutralForeground3,
+  },
+  rank: {
+    color: tokens.colorNeutralForeground3,
+    fontVariantNumeric: 'tabular-nums',
+    width: '36px',
+  },
+  bandBadge: {
+    whiteSpace: 'nowrap',
+  },
+  toggle: {
+    minWidth: '24px',
+    width: '24px',
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '18px 0',
+    textAlign: 'center',
+  },
+  detail: {
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+  detailInner: {
+    padding: '8px 12px',
+  },
+  detailTitle: {
+    color: tokens.colorNeutralForeground2,
+    marginBottom: '6px',
+  },
+  detailTable: {
+    width: '100%',
+    borderCollapse: 'collapse',
+  },
+  detailCell: {
+    padding: '4px 8px',
+    verticalAlign: 'top',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: tokens.colorNeutralStroke3,
+  },
+  detailHead: {
+    textAlign: 'left',
+    padding: '4px 8px',
+    color: tokens.colorNeutralForeground3,
+    fontWeight: tokens.fontWeightSemibold,
+    whiteSpace: 'nowrap',
+  },
+});
+
+function evidenceFor(user: LicenceActivityUser, workload: WorkloadKey | string): LicenceActivityEvidence | null {
+  return user.workloads.find((w) => w.workload === workload) ?? null;
+}
+
+function isUnknown(ev: LicenceActivityEvidence | null): boolean {
+  // The band is authoritative (LicenceActivityRules.Band returns "unknown" for incomplete coverage).
+  return !ev || ev.band === 'unknown';
+}
+
+/** An activity average to one decimal, or the unknown marker when not measured (never 0). */
+function formatAverage(value: number | null | undefined): string {
+  if (value == null) return UNKNOWN_TEXT;
+  return (Math.round(value * 10) / 10).toLocaleString();
+}
+
+/** Active/observed samples with expected context, distinguishing "nothing observed" from a real 0. */
+function formatSamples(ev: LicenceActivityEvidence | null): string {
+  if (!ev) return UNKNOWN_TEXT;
+  if (ev.observedSamples <= 0) return DASH; // nothing observed - not a measured zero
+  const base = `${ev.activeSamples} / ${ev.observedSamples}`;
+  return ev.observedSamples !== ev.expectedSamples ? `${base} of ${ev.expectedSamples}` : base;
+}
+
+/** A band badge - grey "Unknown" when incomplete, coloured otherwise. `showReason` adds the coverage
+ *  reason under an unknown badge (used in the main row; off in the detail, which has a status column). */
+function BandCell({ ev, showReason = true }: { ev: LicenceActivityEvidence | null; showReason?: boolean }) {
+  const styles = useStyles();
+  const unknown = isUnknown(ev);
+  const shown = unknown ? 'unknown' : ev?.band ?? 'unknown';
+  // Only surface a reason that ADDS information: a literal "unknown" status would just repeat the badge.
+  const reason = showReason && unknown && ev && ev.status && ev.status !== 'unknown' ? statusMeta(ev.status).label : null;
+  return (
+    <span style={{ display: 'inline-flex', flexDirection: 'column', gap: '2px' }}>
+      <Badge
+        className={styles.bandBadge}
+        size="small"
+        style={{ backgroundColor: bandColour(shown), color: bandForeground(shown) }}
+      >
+        {unknown ? UNKNOWN_TEXT : bandLabel(shown)}
+      </Badge>
+      {reason && (
+        <Text size={100} className={styles.reason}>
+          {reason}
+        </Text>
+      )}
+    </span>
+  );
+}
+
+/** The expandable per-user panel: every workload's evidence, so an admin can inspect the same person
+ *  without re-ranking the list by a different workload. */
+function AllWorkloadsDetail({ user }: { user: LicenceActivityUser }) {
+  const styles = useStyles();
+  return (
+    <div className={styles.detailInner}>
+      <Text size={200} weight="semibold" block className={styles.detailTitle}>
+        All workloads for {user.userPrincipalName}
+      </Text>
+      <table className={styles.detailTable}>
+        <thead>
+          <tr>
+            <th className={styles.detailHead}>Workload</th>
+            <th className={styles.detailHead}>Coverage</th>
+            <th className={styles.detailHead}>Band</th>
+            <th className={styles.detailHead}>Source &middot; Measure</th>
+            <th className={styles.detailHead}>Active / observed</th>
+            <th className={styles.detailHead}>Avg</th>
+            <th className={styles.detailHead}>Last activity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {WORKLOADS.map((w) => {
+            const ev = evidenceFor(user, w.key);
+            const meta = statusMeta(ev?.status);
+            return (
+              <tr key={w.key}>
+                <td className={styles.detailCell}>
+                  <Text size={200} weight="semibold">
+                    {w.label}
+                  </Text>
+                </td>
+                <td className={styles.detailCell}>
+                  <Text size={200}>{meta.label}</Text>
+                  {meta.explanation && (
+                    <Text size={100} block className={styles.reason}>
+                      {meta.explanation}
+                    </Text>
+                  )}
+                </td>
+                <td className={styles.detailCell}>
+                  <BandCell ev={ev} showReason={false} />
+                </td>
+                <td className={styles.detailCell}>
+                  <Text size={200}>
+                    {ev?.source || DASH}
+                    {ev?.measure ? ` \u00b7 ${ev.measure}` : ''}
+                  </Text>
+                </td>
+                <td className={styles.detailCell}>
+                  <Text size={200}>{formatSamples(ev)}</Text>
+                </td>
+                <td className={styles.detailCell}>
+                  <Text size={200}>{formatAverage(ev?.averageActions)}</Text>
+                </td>
+                <td className={styles.detailCell}>
+                  <Text size={200}>{formatDate(ev?.lastActivityUtc)}</Text>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface UsersTableProps {
+  rows: LicenceActivityUser[];
+  /** Which workload's evidence to render in the main row for each user. */
+  workload: WorkloadKey;
+  workloadLabel: string;
+  /** Show a leading rank column (used by the most/least highlight lists). */
+  showRank?: boolean;
+  /** Rank of the first row (1-based). Lets a paged browse continue the numbering across pages. */
+  startRank?: number;
+  emptyText?: string;
+}
+
+/**
+ * The drill-down user list. Identifier-first (UPN only - no display names are imported). The main row
+ * summarises the SELECTED workload; each row expands to show ALL FIVE workloads' evidence (status,
+ * source, measure, active/observed/expected samples, average and last activity), so the same person
+ * can be inspected across workloads without re-ranking the list.
+ *
+ * Every figure is unknown-aware: an incomplete-coverage band shows "Unknown" with the reason, and
+ * "nothing observed" is a dash rather than a zero that would read as measured inactivity.
+ */
+export default function UsersTable({
+  rows,
+  workload,
+  workloadLabel,
+  showRank,
+  startRank = 1,
+  emptyText = 'No users match this selection.',
+}: UsersTableProps) {
+  const styles = useStyles();
+  const table = useLaTableStyles();
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+  const toggle = (userId: number): void =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+
+  if (rows.length === 0) {
+    return <div className={styles.empty}>{emptyText}</div>;
+  }
+
+  const colSpan = 7 + (showRank ? 1 : 0);
+
+  return (
+    <div className={table.wrap}>
+      <table className={table.table}>
+        <thead>
+          <tr>
+            <th className={table.th} aria-label="Expand" />
+            {showRank && <th className={`${table.th} ${table.thNumeric}`}>#</th>}
+            <th className={table.th}>User</th>
+            <th className={table.th}>Department</th>
+            <th className={table.th}>
+              <Tooltip relationship="description" content={BAND_METHOD}>
+                <span style={{ borderBottom: `1px dotted ${tokens.colorNeutralForeground4}`, cursor: 'help' }}>
+                  {workloadLabel} band
+                </span>
+              </Tooltip>
+            </th>
+            <th className={`${table.th} ${table.thNumeric}`}>Avg actions</th>
+            <th className={`${table.th} ${table.thNumeric}`}>Active samples</th>
+            <th className={table.th}>Last activity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => {
+            const ev = evidenceFor(row, workload);
+            const open = expanded.has(row.userId);
+            return (
+              <Fragment key={row.userId}>
+                <tr>
+                  <td className={table.td}>
+                    <Button
+                      className={styles.toggle}
+                      appearance="subtle"
+                      size="small"
+                      icon={open ? <ChevronDown16Regular /> : <ChevronRight16Regular />}
+                      aria-expanded={open}
+                      aria-label={`Show all workloads for ${row.userPrincipalName}`}
+                      onClick={() => toggle(row.userId)}
+                    />
+                  </td>
+                  {showRank && (
+                    <td className={`${table.td} ${table.tdNumeric} ${styles.rank}`}>{startRank + index}</td>
+                  )}
+                  <td className={table.td}>
+                    <span className={styles.user}>
+                      <Text size={200} weight="semibold">
+                        {row.userPrincipalName}
+                      </Text>
+                      {row.accountEnabled === false && (
+                        <Text size={100} className={styles.disabled}>
+                          Account disabled
+                        </Text>
+                      )}
+                    </span>
+                  </td>
+                  <td className={table.td}>{row.department || DASH}</td>
+                  <td className={table.td}>
+                    <BandCell ev={ev} />
+                  </td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>{formatAverage(ev?.averageActions)}</td>
+                  <td className={`${table.td} ${table.tdNumeric}`}>
+                    {(() => {
+                      const freq = ev && ev.observedSamples > 0 ? frequencyPct(ev.activeSamples, ev.observedSamples) : null;
+                      return (
+                        <>
+                          {formatSamples(ev)}
+                          {freq != null && <span className={styles.muted}> ({Math.round(freq)}%)</span>}
+                        </>
+                      );
+                    })()}
+                  </td>
+                  <td className={table.td}>
+                    {formatDate(ev?.lastActivityUtc)}
+                    {ev?.lastActivityUtc && (
+                      <Text size={100} block className={styles.muted}>
+                        {formatAge(ev.lastActivityUtc)}
+                      </Text>
+                    )}
+                  </td>
+                </tr>
+                {open && (
+                  <tr className={styles.detail}>
+                    <td className={table.td} colSpan={colSpan}>
+                      <AllWorkloadsDetail user={row} />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/WorkloadDistributions.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/WorkloadDistributions.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import WorkloadDistributions from './WorkloadDistributions';
+import type { LicenceActivityDistribution, WorkloadKey } from '../../types/licenceActivity';
+
+function dist(workload: WorkloadKey, over: Partial<LicenceActivityDistribution> = {}): LicenceActivityDistribution {
+  return { workload, high: 0, moderate: 0, low: 0, zero: 0, unknown: 0, ...over };
+}
+
+describe('WorkloadDistributions', () => {
+  it('summarises active over the MEASURED population and shows a measured zero band', () => {
+    renderWithProvider(<WorkloadDistributions workloads={[dist('teams', { high: 5, zero: 3 })]} />);
+    // measured = 5 + 3 = 8, active = 5 -> 62.5%
+    expect(screen.getByText(/5 of 8 active/)).toBeInTheDocument();
+    expect(screen.getByText(/62\.5%/)).toBeInTheDocument();
+    // "No activity" (measured zero) is a real, rendered band - not merged with Unknown.
+    expect(screen.getByText('No activity 3')).toBeInTheDocument();
+  });
+
+  it('renders a fully-unmeasured workload as "Not measured", never "0 active"', () => {
+    renderWithProvider(<WorkloadDistributions workloads={[dist('copilot', { unknown: 10 })]} />);
+    expect(screen.getByText('Not measured')).toBeInTheDocument();
+    expect(screen.getByText('Unknown 10')).toBeInTheDocument();
+    expect(screen.queryByText(/of .* active/)).not.toBeInTheDocument();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/WorkloadDistributions.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/WorkloadDistributions.tsx
@@ -1,0 +1,161 @@
+import { memo } from 'react';
+import { makeStyles, tokens, Card, Text } from '@fluentui/react-components';
+import type { LicenceActivityDistribution, WorkloadKey } from '../../types/licenceActivity';
+import { WORKLOADS } from '../../types/licenceActivity';
+import {
+  ACTIVITY_BANDS,
+  activeCount,
+  activeRatePct,
+  BAND_METHOD,
+  bandCount,
+  distributionTotal,
+  measuredCount,
+} from './bands';
+import { formatCount, formatPct } from './format';
+
+const useStyles = makeStyles({
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+    gap: '16px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  head: {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    gap: '8px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  bar: {
+    display: 'flex',
+    height: '18px',
+    width: '100%',
+    borderRadius: tokens.borderRadiusSmall,
+    overflow: 'hidden',
+    backgroundColor: tokens.colorNeutralBackground3,
+  },
+  segment: {
+    height: '100%',
+  },
+  legend: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '4px 14px',
+    marginTop: '2px',
+  },
+  legendItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+  },
+  swatch: {
+    width: '10px',
+    height: '10px',
+    borderRadius: '2px',
+    flexShrink: 0,
+  },
+  legendLabel: {
+    color: tokens.colorNeutralForeground2,
+  },
+});
+
+/** One workload's five-band stacked bar plus a legend of counts. */
+function DistributionCard({ distribution }: { distribution: LicenceActivityDistribution }) {
+  const styles = useStyles();
+  const total = distributionTotal(distribution);
+  const measured = measuredCount(distribution);
+  const rate = activeRatePct(distribution);
+  const label = WORKLOADS.find((w) => w.key === (distribution.workload as WorkloadKey))?.label ?? distribution.workload;
+
+  return (
+    <Card className={styles.card}>
+      <div className={styles.head}>
+        <Text weight="semibold" size={400}>
+          {label}
+        </Text>
+        <Text size={200} className={styles.muted}>
+          {rate == null
+            ? 'Not measured'
+            : `${formatCount(activeCount(distribution))} of ${formatCount(measured)} active (${formatPct(rate)})`}
+        </Text>
+      </div>
+
+      <div className={styles.bar} role="img" aria-label={`${label} activity distribution`}>
+        {ACTIVITY_BANDS.map((band) => {
+          const count = bandCount(distribution, band.key);
+          if (count <= 0 || total <= 0) return null;
+          return (
+            <div
+              key={band.key}
+              className={styles.segment}
+              style={{ width: `${(count / total) * 100}%`, backgroundColor: band.colour }}
+              title={`${band.label}: ${formatCount(count)}`}
+            />
+          );
+        })}
+      </div>
+
+      <div className={styles.legend}>
+        {ACTIVITY_BANDS.map((band) => (
+          <span key={band.key} className={styles.legendItem}>
+            <span className={styles.swatch} style={{ backgroundColor: band.colour }} aria-hidden />
+            <Text size={100} className={styles.legendLabel}>
+              {band.label} {formatCount(bandCount(distribution, band.key))}
+            </Text>
+          </span>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+interface WorkloadDistributionsProps {
+  workloads: LicenceActivityDistribution[];
+}
+
+/**
+ * The five workloads' activity distributions for a licence, side by side and DELIBERATELY separate -
+ * no blended "productivity" or "ROI" score across them, because Teams messages and SharePoint edits
+ * are not commensurable and one number would invite exactly the false comparison the separate charts
+ * avoid.
+ *
+ * Each bar keeps "No activity" (measured zero, red) and "Unknown" (not measured, grey) as distinct
+ * segments, so a workload with no import reads as a grey bar - visibly unmeasured - rather than as an
+ * all-zero one that would imply nobody used it.
+ */
+function WorkloadDistributions({ workloads }: WorkloadDistributionsProps) {
+  const styles = useStyles();
+
+  // Present in a stable workload order regardless of how the backend ordered them. Only ever the five
+  // workloads of the ONE selected licence - never all 50 SKUs' distributions at once.
+  const ordered = WORKLOADS.map((w) => workloads.find((d) => d.workload === w.key)).filter(
+    (d): d is LicenceActivityDistribution => d != null,
+  );
+
+  if (ordered.length === 0) {
+    return <Text className={styles.muted}>No workload activity is available for this licence.</Text>;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      <Text size={100} className={styles.muted}>
+        {BAND_METHOD} Active counts are users with any measured activity, out of those with complete coverage.
+      </Text>
+      <div className={styles.grid}>
+        {ordered.map((distribution) => (
+          <DistributionCard key={distribution.workload} distribution={distribution} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Memoised: renders only when the selected licence's workloads change, not on every page re-render.
+export default memo(WorkloadDistributions);

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/bands.test.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/bands.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { ACTIVITY_BANDS, bandColour, bandForeground } from './bands';
+
+// WCAG 2.x relative luminance + contrast ratio, so the badge fill/foreground pairs are checked with
+// the same maths the reviewer used (white on low #c19c00 = 2.62, on unknown #8a8886 = 3.53 - both fail).
+function channelLuminance(value8bit: number): number {
+  const c = value8bit / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance(hex: string): number {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return 0.2126 * channelLuminance(r) + 0.7152 * channelLuminance(g) + 0.0722 * channelLuminance(b);
+}
+
+function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+const AA_NORMAL = 4.5;
+
+describe('band badge contrast (WCAG AA)', () => {
+  it('every band badge foreground clears 4.5:1 against its fill', () => {
+    for (const band of ACTIVITY_BANDS) {
+      const ratio = contrastRatio(band.colour, band.foreground);
+      expect(
+        ratio,
+        `${band.key}: ${band.foreground} on ${band.colour} = ${ratio.toFixed(2)}`,
+      ).toBeGreaterThanOrEqual(AA_NORMAL);
+    }
+  });
+
+  it('the two light fills (low, unknown) use dark text - white would fail, which was the bug', () => {
+    for (const key of ['low', 'unknown'] as const) {
+      // The original white-on-fill choice fails AA...
+      expect(contrastRatio(bandColour(key), '#ffffff')).toBeLessThan(AA_NORMAL);
+      // ...and the chosen foreground is dark (not white) and passes.
+      expect(bandForeground(key)).not.toBe('#ffffff');
+      expect(contrastRatio(bandColour(key), bandForeground(key))).toBeGreaterThanOrEqual(AA_NORMAL);
+    }
+  });
+
+  it('leaves the moderate fill untouched (it already passed with white)', () => {
+    expect(bandColour('moderate')).toBe('#498205');
+    expect(bandForeground('moderate')).toBe('#ffffff');
+    expect(contrastRatio('#498205', '#ffffff')).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/bands.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/bands.ts
@@ -1,0 +1,103 @@
+import type { LicenceActivityDistribution } from '../../types/licenceActivity';
+
+/** The engagement bands, worst-to-best after the two "active" tiers, with the two non-active tiers
+ * kept visually distinct: `zero` (measured, no activity) is red; `unknown` (not measured) is grey. */
+export type BandKey = 'high' | 'moderate' | 'low' | 'zero' | 'unknown';
+
+export interface BandDef {
+  key: BandKey;
+  label: string;
+  colour: string;
+  /** The badge text colour to use ON `colour`, chosen so the pair clears WCAG AA (>= 4.5:1). The two
+   *  light fills (low gold, unknown grey) need dark text; the darker fills read fine against white. */
+  foreground: string;
+}
+
+// Foregrounds are deliberately per-band rather than a single "on brand" white: white on the low
+// (#c19c00, ratio 2.62) and unknown (#8a8886, ratio 3.53) fills fails AA, so those two use near-black
+// (ratios ~8.0 and ~5.9). High/Moderate/Zero keep white (ratios ~6.8 / 4.69 / 4.93). See bands.test.ts.
+const DARK_FG = '#000000';
+const LIGHT_FG = '#ffffff';
+
+export const ACTIVITY_BANDS: BandDef[] = [
+  { key: 'high', label: 'High', colour: '#0b6a0b', foreground: LIGHT_FG },
+  { key: 'moderate', label: 'Moderate', colour: '#498205', foreground: LIGHT_FG },
+  { key: 'low', label: 'Low', colour: '#c19c00', foreground: DARK_FG },
+  { key: 'zero', label: 'No activity', colour: '#d13438', foreground: LIGHT_FG },
+  { key: 'unknown', label: 'Unknown', colour: '#8a8886', foreground: DARK_FG },
+];
+
+const BY_KEY: Record<string, BandDef> = Object.fromEntries(ACTIVITY_BANDS.map((b) => [b.key, b]));
+
+/**
+ * The official band definitions, mirroring LicenceActivityRules.Method on the backend. These describe
+ * a share of observed reporting SAMPLES with activity - deliberately not "active days", which the
+ * measure only becomes if a workload's source/measure says so.
+ */
+export const BAND_DESCRIPTIONS: Record<BandKey, string> = {
+  high: 'Active in at least 75% of observed samples.',
+  moderate: 'Active in 25% to under 75% of observed samples.',
+  low: 'Active in under 25% of observed samples (but more than none).',
+  zero: 'No activity in any sample, with complete coverage of the period.',
+  unknown: 'Coverage was incomplete, so activity could not be determined - this is not zero.',
+};
+
+/** A one-line summary of the banding, for a column tooltip. */
+export const BAND_METHOD =
+  'Bands are the share of observed reporting samples with activity: high \u2265 75%, moderate 25\u201374%, ' +
+  'low under 25%, zero none (with complete coverage). Incomplete coverage is Unknown, not zero. ' +
+  'These are sample frequencies, not daily events.';
+
+export function bandLabel(band: string): string {
+  return BY_KEY[band]?.label ?? band;
+}
+
+export function bandDescription(band: string): string | null {
+  return (BY_KEY[band] ? BAND_DESCRIPTIONS[band as BandKey] : null) ?? null;
+}
+
+export function bandColour(band: string): string {
+  return BY_KEY[band]?.colour ?? '#8a8886';
+}
+
+/** The accessible badge text colour for a band's fill (see BandDef.foreground). Defaults to the
+ *  unknown band's dark foreground for any unrecognised band, matching bandColour's grey fallback. */
+export function bandForeground(band: string): string {
+  return BY_KEY[band]?.foreground ?? BY_KEY.unknown.foreground;
+}
+
+/** The active-sample frequency as a percentage, or null when nothing was observed. */
+export function frequencyPct(activeSamples: number, observedSamples: number): number | null {
+  return observedSamples > 0 ? (activeSamples / observedSamples) * 100 : null;
+}
+
+export function bandCount(distribution: LicenceActivityDistribution, key: BandKey): number {
+  return distribution[key];
+}
+
+/** Everyone the distribution accounts for, measured or not. */
+export function distributionTotal(distribution: LicenceActivityDistribution): number {
+  return distribution.high + distribution.moderate + distribution.low + distribution.zero + distribution.unknown;
+}
+
+/** Users with any measured activity (high + moderate + low). */
+export function activeCount(distribution: LicenceActivityDistribution): number {
+  return distribution.high + distribution.moderate + distribution.low;
+}
+
+/** Users measured at all (everyone except the unknown tier). */
+export function measuredCount(distribution: LicenceActivityDistribution): number {
+  return distributionTotal(distribution) - distribution.unknown;
+}
+
+/**
+ * Active users as a percentage of those actually MEASURED, or null when nobody was measured.
+ *
+ * Deliberately divides by the measured population, not the assigned population: including the
+ * unknown tier in the denominator would understate the rate and, worse, let "we didn't measure it"
+ * masquerade as "they weren't active".
+ */
+export function activeRatePct(distribution: LicenceActivityDistribution): number | null {
+  const measured = measuredCount(distribution);
+  return measured <= 0 ? null : (activeCount(distribution) / measured) * 100;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/dateRange.test.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/dateRange.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  addDays,
+  diffDaysInclusive,
+  isValidDateString,
+  latestEndString,
+  matchPreset,
+  parseDateString,
+  presetRange,
+  settledEndString,
+  todayString,
+  validateRange,
+} from './dateRange';
+
+// A fixed "now" at midday UTC so the UTC-based date maths is deterministic regardless of the
+// machine's timezone. Assertions about the settled-Sunday end are property-based (it's a Sunday,
+// at least 3 days old) rather than hard-coded, so they hold whatever weekday `now` falls on.
+const NOW = new Date(Date.UTC(2026, 4, 20, 12)); // 2026-05-20T12:00Z
+
+function utcDay(dateString: string): number {
+  return parseDateString(dateString)!.getUTCDay(); // 0 = Sunday, 1 = Monday
+}
+
+describe('dateRange helpers', () => {
+  it('reports today, yesterday (custom ceiling) and rejects impossible dates', () => {
+    expect(todayString(NOW)).toBe('2026-05-20');
+    expect(latestEndString(NOW)).toBe('2026-05-19'); // custom `to` ceiling stays yesterday
+    expect(isValidDateString('2026-02-31')).toBe(false);
+    expect(isValidDateString('2026-05-20')).toBe(true);
+  });
+
+  it('addDays returns invalid input unchanged instead of falling back to today', () => {
+    expect(addDays('2026-05-19', -6)).toBe('2026-05-13');
+    expect(addDays('not-a-date', 5)).toBe('not-a-date');
+    expect(addDays('', -1)).toBe('');
+  });
+
+  it('settles to the latest Sunday that is at least 3 days old', () => {
+    const end = settledEndString(NOW);
+    expect(utcDay(end)).toBe(0); // a Sunday
+    expect(end <= addDays(todayString(NOW), -3)).toBe(true); // on/before today-3
+  });
+
+  it('builds presets that all end on the settled Sunday with exact spans (90/180 not rounded)', () => {
+    const end = settledEndString(NOW);
+
+    for (const days of [7, 28, 90, 180] as const) {
+      const range = presetRange(days, NOW);
+      expect(range.to).toBe(end); // every preset ends on the same settled Sunday
+      expect(diffDaysInclusive(range.from, range.to)).toBe(days); // exact span, never rounded to weeks
+    }
+
+    // The 7- and 28-day presets are whole settled weeks (start on a Monday); 90/180 need not be.
+    expect(utcDay(presetRange(7, NOW).from)).toBe(1);
+    expect(utcDay(presetRange(28, NOW).from)).toBe(1);
+  });
+
+  it('recognises a preset and returns null for a genuine custom range', () => {
+    expect(matchPreset(presetRange(90, NOW), NOW)).toBe(90);
+    expect(matchPreset({ from: '2026-01-01', to: '2026-03-15' }, NOW)).toBeNull();
+  });
+});
+
+describe('validateRange (custom stays exact: 7..180, ending before today)', () => {
+  it('accepts a valid window', () => {
+    expect(validateRange({ from: '2026-05-01', to: '2026-05-19' }, { now: NOW })).toEqual({ ok: true });
+  });
+
+  it('rejects an inverted range', () => {
+    expect(validateRange({ from: '2026-05-19', to: '2026-05-01' }, { now: NOW })).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/on or before/i),
+    });
+  });
+
+  it('rejects an end date that is today or later', () => {
+    expect(validateRange({ from: '2026-05-13', to: '2026-05-20' }, { now: NOW })).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/before today/i),
+    });
+  });
+
+  it('rejects a range shorter than the minimum', () => {
+    expect(validateRange({ from: '2026-05-17', to: '2026-05-19' }, { now: NOW, minDays: 7 })).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/at least 7 days/i),
+    });
+  });
+
+  it('rejects a start date before the backend minimum (1753-01-01)', () => {
+    expect(validateRange({ from: '1752-12-31', to: '1753-02-01' }, { now: NOW })).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/1753-01-01/),
+    });
+  });
+
+  it('rejects a range longer than the maximum', () => {
+    expect(validateRange({ from: '2025-05-19', to: '2026-05-19' }, { now: NOW, maxDays: 180 })).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/longer than 180 days/i),
+    });
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/dateRange.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/dateRange.ts
@@ -1,0 +1,160 @@
+// Pure date-range helpers for the Licence activity report, kept free of React so the preset maths
+// and the custom-range validation can be unit-tested directly.
+//
+// These mirror the backend rules in LicenceActivityQuery.Create:
+//   - Dates are UTC calendar dates in `YYYY-MM-DD` form (the `from`/`to` params).
+//   - The window must be MinimumDays..MaximumDays (7..180) inclusive.
+//   - It must END BEFORE TODAY (UTC): the server rejects `to == today`, so the custom `to` ceiling is
+//     yesterday. PRESETS go further and end on the latest fully-settled Sunday (at least 3 days old),
+//     so a default window is whole Monday-Sunday weeks; CUSTOM ranges stay exact and are never rounded.
+// Working in UTC (not local) matches the server's `nowUtc.Date`, so a viewer east of UTC can't pick a
+// date the server then rejects as "in the future".
+
+import type { DateRange } from '../../types/licenceActivity';
+
+/** The preset windows offered as one-click buttons, in ascending length. Every preset ENDS on the
+ * latest settled Sunday. The 7- and 28-day presets are whole settled weeks (Monday start); 90 and 180
+ * are EXACT day counts ending on the same settled Sunday - never rounded to whole weeks. */
+export const PRESETS = [7, 28, 90, 180] as const;
+export type PresetDays = (typeof PRESETS)[number];
+
+export const PRESET_LABELS: Record<PresetDays, string> = {
+  7: 'Last settled week',
+  28: 'Last 4 fully settled weeks',
+  // NOT "Last 90/180 days": like every preset these END on the latest settled Sunday, which is 3-9
+  // days before today, so the window is 90/180 days ending THEN - not the 90/180 days up to today.
+  // The 7/28 labels were already honest about this; these two were not.
+  90: 'Last 90 settled days',
+  180: 'Last 180 settled days',
+};
+
+/** Backend LicenceActivityQuery.MinimumDays / MaximumDays; overridable from the availability payload. */
+export const DEFAULT_MIN_DAYS = 7;
+export const DEFAULT_MAX_DAYS = 180;
+
+/** Earliest date the backend accepts (LicenceActivityQuery rejects start.Year < 1753). */
+export const MIN_SUPPORTED_DATE = '1753-01-01';
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** A Date as a UTC `YYYY-MM-DD` string. */
+export function toDateString(d: Date): string {
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+}
+
+/** Today (UTC) as `YYYY-MM-DD`. */
+export function todayString(now: Date = new Date()): string {
+  return toDateString(now);
+}
+
+/** Yesterday (UTC) as `YYYY-MM-DD` - the latest date the server will accept as `to`. */
+export function latestEndString(now: Date = new Date()): string {
+  return addDays(todayString(now), -1);
+}
+
+/**
+ * The settlement lag: a Monday-Sunday week is only treated as fully settled once its Sunday snapshot
+ * has landed, which the backend allows up to 3 days after the week ends. Presets end on the latest
+ * settled week so a default window is whole, settled weeks rather than a partial trailing one.
+ */
+export const SETTLE_LAG_DAYS = 3;
+
+/** The latest fully-settled Sunday: the most recent Sunday on or before (today UTC - SETTLE_LAG_DAYS). */
+export function settledEndString(now: Date = new Date()): string {
+  const cutoff = addDays(todayString(now), -SETTLE_LAG_DAYS);
+  const cutoffDate = parseDateString(cutoff);
+  const daysSinceSunday = cutoffDate ? cutoffDate.getUTCDay() : 0; // getUTCDay: 0 = Sunday
+  return addDays(cutoff, -daysSinceSunday);
+}
+
+/** Strict check that a string is a real `YYYY-MM-DD` calendar date (rejects 2026-02-31 etc.). */
+export function isValidDateString(s: string | null | undefined): boolean {
+  if (!s || !/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const [y, m, d] = s.split('-').map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  return date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d;
+}
+
+/** Parse a `YYYY-MM-DD` string to a UTC-midnight Date, or null if it isn't a real date. */
+export function parseDateString(s: string): Date | null {
+  if (!isValidDateString(s)) return null;
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+/** `s` shifted by `days` (may be negative), as a `YYYY-MM-DD` string. Invalid input is returned
+ * UNCHANGED - it must never silently fall back to today, which would fabricate a valid-looking date. */
+export function addDays(s: string, days: number): string {
+  const date = parseDateString(s);
+  if (!date) return s;
+  date.setUTCDate(date.getUTCDate() + days);
+  return toDateString(date);
+}
+
+/** Inclusive day count of a range (from == to is 1 day). Returns 0 for an inverted or invalid range. */
+export function diffDaysInclusive(from: string, to: string): number {
+  const a = parseDateString(from);
+  const b = parseDateString(to);
+  if (!a || !b) return 0;
+  const days = Math.round((b.getTime() - a.getTime()) / (24 * 60 * 60 * 1000)) + 1;
+  return days > 0 ? days : 0;
+}
+
+/**
+ * A preset ending on the latest settled Sunday. The 7- and 28-day presets are whole settled weeks, so
+ * their start lands on a Monday; 90 and 180 are EXACT day counts ending on the same settled Sunday,
+ * never rounded to whole weeks. E.g. preset 28 -> the four fully-settled Monday-Sunday weeks.
+ */
+export function presetRange(days: PresetDays, now: Date = new Date()): DateRange {
+  const to = settledEndString(now);
+  return { from: addDays(to, -(days - 1)), to };
+}
+
+/** The preset a range corresponds to, or null when it is a genuine custom range. */
+export function matchPreset(range: DateRange, now: Date = new Date()): PresetDays | null {
+  return (
+    PRESETS.find((p) => {
+      const preset = presetRange(p, now);
+      return preset.from === range.from && preset.to === range.to;
+    }) ?? null
+  );
+}
+
+/** The outcome of validating a custom range: either OK, or a single human-readable reason. */
+export type RangeValidation = { ok: true } | { ok: false; error: string };
+
+/**
+ * Validate a custom range against the backend's rules: both ends real dates, not inverted, ending
+ * before today, and within [minDays, maxDays]. Returns the first problem found, phrased for display.
+ */
+export function validateRange(
+  range: DateRange,
+  opts: { now?: Date; minDays?: number; maxDays?: number } = {},
+): RangeValidation {
+  const now = opts.now ?? new Date();
+  const minDays = opts.minDays ?? DEFAULT_MIN_DAYS;
+  const maxDays = opts.maxDays ?? DEFAULT_MAX_DAYS;
+
+  if (!isValidDateString(range.from) || !isValidDateString(range.to)) {
+    return { ok: false, error: 'Enter both a start and end date.' };
+  }
+  if (range.from < MIN_SUPPORTED_DATE) {
+    return { ok: false, error: `The earliest supported date is ${MIN_SUPPORTED_DATE}.` };
+  }
+  if (range.from > range.to) {
+    return { ok: false, error: 'The start date must be on or before the end date.' };
+  }
+  if (range.to > latestEndString(now)) {
+    return { ok: false, error: 'The end date must be before today (reporting covers whole past days).' };
+  }
+  const span = diffDaysInclusive(range.from, range.to);
+  if (span < minDays) {
+    return { ok: false, error: `The range must be at least ${minDays} days.` };
+  }
+  if (span > maxDays) {
+    return { ok: false, error: `The range cannot be longer than ${maxDays} days.` };
+  }
+  return { ok: true };
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/demographicOptions.test.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/demographicOptions.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mergeDemographicOptions,
+  EMPTY_CATALOGUE,
+  DEMOGRAPHIC_OPTION_CAP,
+  type DemographicCatalogue,
+  type DemographicOption,
+} from './demographicOptions';
+
+/** A bounded (<=50) backend reply: `count` groups starting at id `base`. */
+function reply(base: number, count = 50, prefix = 'G'): DemographicOption[] {
+  return Array.from({ length: count }, (_, i) => ({ id: base + i, name: `${prefix}${base + i}` }));
+}
+
+const ids = (c: DemographicCatalogue): number[] => c.options.map((o) => o.id).sort((a, b) => a - b);
+
+describe('mergeDemographicOptions', () => {
+  it('unions bounded replies under the cap so you can switch between groups, and takes the newest name', () => {
+    let cat = EMPTY_CATALOGUE;
+
+    // Unfiltered reply with two groups (one Unicode) -> both are options.
+    cat = mergeDemographicOptions(
+      cat,
+      [
+        { id: 1, name: 'Sales' },
+        { id: 2, name: '\u039c\u03b7\u03c7\u03b1\u03bd\u03b9\u03ba\u03bf\u03af' }, // Μηχανικοί
+      ],
+      { unfilteredForDimension: true, selectedId: null },
+    );
+    expect(new Set(ids(cat))).toEqual(new Set([1, 2]));
+    expect(cat.truncated).toBe(false);
+
+    // A scoped reply for id 1 (contains ONLY id 1) still leaves id 2 selectable - the X->Y case.
+    cat = mergeDemographicOptions(cat, [{ id: 1, name: 'Sales' }], { unfilteredForDimension: false, selectedId: 1 });
+    expect(cat.options.some((o) => o.id === 2)).toBe(true);
+
+    // A newer name for id 2 wins (Unicode preserved).
+    cat = mergeDemographicOptions(
+      cat,
+      [{ id: 2, name: '\u039c\u03b7\u03c7\u03b1\u03bd\u03b9\u03ba\u03bf\u03af \u0391\u0395' }], // Μηχανικοί ΑΕ
+      { unfilteredForDimension: false, selectedId: 2 },
+    );
+    expect(cat.options.find((o) => o.id === 2)!.name).toBe('\u039c\u03b7\u03c7\u03b1\u03bd\u03b9\u03ba\u03bf\u03af \u0391\u0395');
+    expect(cat.truncated).toBe(false);
+  });
+
+  it('never exceeds the cap across many bounded replies, and signals the truncation', () => {
+    let cat = EMPTY_CATALOGUE;
+    cat = mergeDemographicOptions(cat, reply(0), { unfilteredForDimension: true, selectedId: null });
+    expect(cat.options.length).toBe(50);
+    expect(cat.truncated).toBe(false);
+
+    // Second disjoint reply of 50 -> exactly 100 distinct, still fits (no eviction yet).
+    cat = mergeDemographicOptions(cat, reply(100), { unfilteredForDimension: false, selectedId: null });
+    expect(cat.options.length).toBe(DEMOGRAPHIC_OPTION_CAP);
+    expect(cat.truncated).toBe(false);
+
+    // Third disjoint reply of 50 -> 150 distinct, must evict down to the cap and flag it.
+    cat = mergeDemographicOptions(cat, reply(200), { unfilteredForDimension: false, selectedId: null });
+    expect(cat.options.length).toBe(DEMOGRAPHIC_OPTION_CAP);
+    expect(cat.options.length).toBeLessThanOrEqual(100);
+    expect(cat.truncated).toBe(true);
+
+    // Truncation is sticky: a later fully-overlapping reply does not clear the signal.
+    cat = mergeDemographicOptions(cat, reply(0), { unfilteredForDimension: false, selectedId: null });
+    expect(cat.truncated).toBe(true);
+  });
+
+  it('keeps the latest unfiltered catalogue and the current selection even when evicting to the cap', () => {
+    let cat = EMPTY_CATALOGUE;
+
+    // Authoritative unfiltered base of 50 (ids 0..49).
+    cat = mergeDemographicOptions(cat, reply(0), { unfilteredForDimension: true, selectedId: null });
+
+    // Select a NON-base group, then flood with two more bounded scoped replies of fresh names.
+    cat = mergeDemographicOptions(cat, [{ id: 1000, name: 'Picked' }], { unfilteredForDimension: false, selectedId: 1000 });
+    cat = mergeDemographicOptions(cat, reply(500, 50, 'New'), { unfilteredForDimension: false, selectedId: 1000 });
+    cat = mergeDemographicOptions(cat, reply(700, 50, 'Extra'), { unfilteredForDimension: false, selectedId: 1000 });
+
+    expect(cat.options.length).toBeLessThanOrEqual(DEMOGRAPHIC_OPTION_CAP);
+    // Every unfiltered-base id survived eviction...
+    for (let i = 0; i < 50; i++) expect(cat.options.some((o) => o.id === i)).toBe(true);
+    // ...and so did the current selection, so the user can still switch away from it.
+    expect(cat.options.some((o) => o.id === 1000)).toBe(true);
+    expect(cat.truncated).toBe(true);
+  });
+
+  it('pins a selected id of 0 (unknown/first group), never treating it as "no selection"', () => {
+    let cat = EMPTY_CATALOGUE;
+    // An "unknown" group whose id is the falsy 0, kept as the current selection...
+    cat = mergeDemographicOptions(cat, [{ id: 0, name: 'Unknown' }], { unfilteredForDimension: false, selectedId: 0 });
+    expect(cat.options.some((o) => o.id === 0)).toBe(true);
+    // ...survives eviction while >100 fresh groups arrive across bounded replies (a `if (selectedId)`
+    // falsy-check bug would drop id 0 here).
+    cat = mergeDemographicOptions(cat, reply(100), { unfilteredForDimension: false, selectedId: 0 });
+    cat = mergeDemographicOptions(cat, reply(200), { unfilteredForDimension: false, selectedId: 0 });
+    cat = mergeDemographicOptions(cat, reply(300), { unfilteredForDimension: false, selectedId: 0 });
+    expect(cat.options.length).toBeLessThanOrEqual(DEMOGRAPHIC_OPTION_CAP);
+    expect(cat.options.some((o) => o.id === 0)).toBe(true);
+  });
+
+  it('replaces the retained base when a NEW unfiltered reply arrives, and does not mutate its inputs', () => {
+    const prev: DemographicCatalogue = { options: [{ id: 1, name: 'Old' }], baseIds: [1], truncated: false };
+    const frozenNext: DemographicOption[] = [{ id: 2, name: 'New' }];
+
+    const cat = mergeDemographicOptions(prev, frozenNext, { unfilteredForDimension: true, selectedId: null });
+
+    // New unfiltered base is now id 2; id 1 remains (under cap) but is no longer part of the base.
+    expect(cat.baseIds).toEqual([2]);
+    expect(new Set(ids(cat))).toEqual(new Set([1, 2]));
+
+    // Inputs untouched.
+    expect(prev.options).toEqual([{ id: 1, name: 'Old' }]);
+    expect(prev.baseIds).toEqual([1]);
+    expect(frozenNext).toEqual([{ id: 2, name: 'New' }]);
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/demographicOptions.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/demographicOptions.ts
@@ -1,0 +1,101 @@
+// The department/country FILTER option catalogue for the Licence activity report.
+//
+// The backend deliberately returns only the demographic groups WITHIN the current scope (filtering by
+// department X returns just X), so the drop-downs can't simply mirror the latest reply or they'd
+// collapse to the selected group and strand the user unable to switch straight to another. We instead
+// keep a running, merged catalogue of every group seen - but BOUNDED, so a long session of scoped
+// filters can't grow it without limit. Names only: a per-scope count would be misleading across a
+// cross-scope catalogue, so counts live in the demographic breakdown, never in these labels.
+
+/** A single filter option: id + display name only (no scope-specific count). */
+export interface DemographicOption {
+  id: number;
+  name: string;
+}
+
+/**
+ * The catalogue for one dimension (departments OR countries):
+ *  - `options`  the capped, name-sorted list rendered in the drop-down;
+ *  - `baseIds`  the ids from the latest UNFILTERED reply for this dimension - the authoritative
+ *               in-scope list (backend-bounded to <=50), always retained across later scoped replies;
+ *  - `truncated` whether some known name has had to be evicted (sticky), so the UI can show an honest
+ *               "options limited" note rather than silently hiding groups.
+ */
+export interface DemographicCatalogue {
+  options: DemographicOption[];
+  baseIds: number[];
+  truncated: boolean;
+}
+
+export const EMPTY_CATALOGUE: DemographicCatalogue = { options: [], baseIds: [], truncated: false };
+
+/** The hard cap on retained option NAMES per dimension. Each backend reply is itself <=50, so this
+ *  bounds a whole session of scoped filters to a scannable, responsive drop-down at 50-SKU scale. */
+export const DEMOGRAPHIC_OPTION_CAP = 100;
+
+export interface MergeDemographicOptions {
+  /** True when this reply's OWN filter for the dimension is null, i.e. it is the authoritative
+   *  in-scope catalogue for that dimension (its ids become the retained base). */
+  unfilteredForDimension: boolean;
+  /** The id currently selected for this dimension (null = "All"); always pinned so it can't be
+   *  evicted, guaranteeing the user can switch away from their own selection. */
+  selectedId: number | null;
+  cap?: number;
+}
+
+/**
+ * Merge an incoming (bounded, <=50) demographic reply into the running catalogue, capped per
+ * dimension. Retention priority when at capacity, highest first:
+ *   1. the latest UNFILTERED catalogue (`baseIds`), so the real in-scope list always survives;
+ *   2. the current `selectedId`;
+ *   3. the current scoped incoming names (`next`, freshest);
+ *   4. older, previously-retained names, only within remaining capacity (oldest evicted first).
+ *
+ * Pure and non-mutating. `truncated` is sticky: once any name is evicted it stays set, because the
+ * catalogue is then known not to be exhaustive.
+ */
+export function mergeDemographicOptions(
+  prev: DemographicCatalogue,
+  next: readonly DemographicOption[],
+  opts: MergeDemographicOptions,
+): DemographicCatalogue {
+  const cap = opts.cap ?? DEMOGRAPHIC_OPTION_CAP;
+
+  // De-duplicate by id in freshest-first order: incoming scoped names first (newest name wins), then
+  // the previously-retained names.
+  const byId = new Map<number, DemographicOption>();
+  const order: number[] = [];
+  const consider = (o: DemographicOption): void => {
+    if (byId.has(o.id)) return; // first occurrence wins, and `next` is considered first, so the freshest name is kept
+    order.push(o.id);
+    byId.set(o.id, { id: o.id, name: o.name });
+  };
+  for (const d of next) consider({ id: d.id, name: d.name });
+  for (const o of prev.options) consider(o);
+
+  // The authoritative unfiltered catalogue: replaced when a new unfiltered reply arrives, else carried.
+  const baseIds = opts.unfilteredForDimension ? next.map((d) => d.id) : prev.baseIds;
+
+  // Everything that must survive eviction.
+  const pinned = new Set<number>();
+  for (const id of baseIds) if (byId.has(id)) pinned.add(id);
+  if (opts.selectedId != null && byId.has(opts.selectedId)) pinned.add(opts.selectedId);
+
+  // Keep all pins (in candidate order), then fill the remaining capacity with the freshest non-pins.
+  const kept: number[] = [];
+  for (const id of order) if (pinned.has(id)) kept.push(id);
+  for (const id of order) {
+    if (kept.length >= cap) break;
+    if (!pinned.has(id)) kept.push(id);
+  }
+
+  const evicted = kept.length < order.length;
+  const keptSet = new Set(kept);
+  const options = kept.map((id) => byId.get(id)!).sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    options,
+    baseIds: baseIds.filter((id) => keptSet.has(id)),
+    truncated: prev.truncated || evicted,
+  };
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/format.test.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/format.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DASH,
+  UNKNOWN_TEXT,
+  daysAgo,
+  formatAge,
+  formatCount,
+  formatDate,
+  formatMaybeCount,
+  formatPct,
+  ratioPct,
+} from './format';
+
+describe('format helpers', () => {
+  it('formats whole counts with thousands separators', () => {
+    expect(formatCount(12345)).toBe('12,345');
+    expect(formatCount(0)).toBe('0');
+  });
+
+  describe('unknown is not zero', () => {
+    it('renders null as the unknown marker, not 0', () => {
+      expect(formatMaybeCount(null)).toBe(UNKNOWN_TEXT);
+      expect(formatMaybeCount(undefined)).toBe(UNKNOWN_TEXT);
+    });
+
+    it('renders a measured zero as 0, not unknown', () => {
+      expect(formatMaybeCount(0)).toBe('0');
+    });
+
+    it('renders a real count normally', () => {
+      expect(formatMaybeCount(42)).toBe('42');
+    });
+
+    it('ratioPct returns null (not 0) when an operand is unknown or the denominator is 0', () => {
+      expect(ratioPct(null, 100)).toBeNull();
+      expect(ratioPct(10, null)).toBeNull();
+      expect(ratioPct(10, 0)).toBeNull();
+      expect(ratioPct(0, 100)).toBe(0); // a measured 0% is a real value
+      expect(ratioPct(50, 200)).toBe(25);
+    });
+  });
+
+  it('formats percentages, dropping a trailing .0', () => {
+    expect(formatPct(12)).toBe('12%');
+    expect(formatPct(12.34)).toBe('12.3%');
+  });
+
+  it('formats or dashes dates', () => {
+    expect(formatDate(null)).toBe(DASH);
+    expect(formatDate('not-a-date')).toBe(DASH);
+    expect(formatDate('2026-05-20T00:00:00Z')).toMatch(/2026/);
+  });
+
+  it('computes whole days ago and a friendly age, treating unknown as unknown', () => {
+    const now = new Date('2026-05-20T12:00:00Z');
+    expect(daysAgo(null, now)).toBeNull();
+    expect(formatAge(null, now)).toBe(UNKNOWN_TEXT);
+    expect(formatAge('2026-05-20T00:00:00Z', now)).toBe('today');
+    expect(formatAge('2026-05-19T00:00:00Z', now)).toBe('yesterday');
+    expect(formatAge('2026-05-10T00:00:00Z', now)).toBe('10 days ago');
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/format.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/format.ts
@@ -1,0 +1,92 @@
+// Formatting helpers for the Licence activity report.
+//
+// The point of this module is the treatment of UNKNOWN. A value that is genuinely unknown (an import
+// switched off, a source that didn't cover a user) must never render as "0" - that would assert
+// "nobody did this" when the truth is "we didn't measure it". These helpers force the caller to be
+// explicit about the null case rather than letting `null` coerce to 0 somewhere in a template.
+
+/** Rendered for a value that is genuinely unknown, as opposed to a measured zero. */
+export const UNKNOWN_TEXT = 'Unknown';
+
+/** An em dash, for an unknown value in a dense table cell where the word "Unknown" is too heavy. */
+export const DASH = '\u2014';
+
+/** A whole number with thousands separators, e.g. 12345 -> "12,345". */
+export function formatCount(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+/**
+ * A possibly-unknown count. Null/undefined -> the unknown marker; a real number (including 0) ->
+ * that number. This is the workhorse for "Unknown is not zero".
+ */
+export function formatMaybeCount(value: number | null | undefined, unknown: string = UNKNOWN_TEXT): string {
+  return value == null ? unknown : formatCount(value);
+}
+
+/** A percentage to one decimal place, dropping a trailing ".0" (e.g. 12 -> "12%", 12.34 -> "12.3%"). */
+export function formatPct(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return `${rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toFixed(1)}%`;
+}
+
+/**
+ * `active` as a percentage of `total`, or null when the percentage itself is unknown.
+ *
+ * Returns null (not 0) when either operand is unknown or the denominator is 0, so a caller can show
+ * "Unknown" rather than a misleading "0%".
+ */
+export function ratioPct(active: number | null | undefined, total: number | null | undefined): number | null {
+  if (active == null || total == null || total <= 0) return null;
+  return (active / total) * 100;
+}
+
+/** A UTC ISO timestamp as a short local-format date, or the unknown marker when absent. */
+export function formatDate(iso: string | null | undefined, unknown: string = DASH): string {
+  if (!iso) return unknown;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return unknown;
+  return date.toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** A UTC ISO timestamp as a short local date-and-time, or the unknown marker when absent. */
+export function formatDateTime(iso: string | null | undefined, unknown: string = DASH): string {
+  if (!iso) return unknown;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return unknown;
+  return date.toLocaleString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'UTC',
+  });
+}
+
+/**
+ * Whole days between a past UTC ISO timestamp and now, or null when the input is absent/invalid.
+ * Used for "generated 3 days ago" style captions; null keeps an unknown time from reading as "today".
+ */
+export function daysAgo(iso: string | null | undefined, now: Date = new Date()): number | null {
+  if (!iso) return null;
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return null;
+  const ms = now.getTime() - then.getTime();
+  if (ms < 0) return 0;
+  return Math.floor(ms / (24 * 60 * 60 * 1000));
+}
+
+/** "today" / "yesterday" / "N days ago" for a past UTC timestamp, or the unknown marker when absent. */
+export function formatAge(iso: string | null | undefined, now: Date = new Date(), unknown: string = UNKNOWN_TEXT): string {
+  const days = daysAgo(iso, now);
+  if (days == null) return unknown;
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  return `${days.toLocaleString()} days ago`;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/statuses.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/statuses.ts
@@ -1,0 +1,57 @@
+// Friendly rendering of the backend coverage/evidence status vocabulary
+// (LicenceActivityCoverage.Status / LicenceActivityEvidence.Status):
+// available | partial | missingCoverage | unmatchableIdentity | notImported | disabled.
+// Shared so the coverage panel and the per-user evidence detail explain a status the same way.
+
+export type StatusTone = 'success' | 'warning' | 'informative' | 'subtle';
+
+export interface StatusMeta {
+  tone: StatusTone;
+  label: string;
+  /** Why the data is in this state, so an "Unknown"/partial figure is never shown without a reason. */
+  explanation: string;
+}
+
+const STATUS_META: Record<string, StatusMeta> = {
+  available: {
+    tone: 'success',
+    label: 'Available',
+    explanation: 'Measured with complete coverage of the period.',
+  },
+  partial: {
+    tone: 'warning',
+    label: 'Partial',
+    explanation: 'Some reporting samples were missing, so this is a partial view and activity may be understated.',
+  },
+  missingCoverage: {
+    tone: 'warning',
+    label: 'Missing coverage',
+    explanation: 'The period was not fully covered by snapshots, so users cannot be ranked as inactive here.',
+  },
+  unmatchableIdentity: {
+    tone: 'warning',
+    label: 'Unmatchable identity',
+    explanation: 'The user could not be matched to this workload\u2019s identity, so their activity is unknown.',
+  },
+  notImported: {
+    tone: 'subtle',
+    label: 'Not imported',
+    explanation: 'This workload\u2019s usage source is not imported on this deployment.',
+  },
+  disabled: {
+    tone: 'subtle',
+    label: 'Import disabled',
+    explanation: 'This workload\u2019s import is switched off.',
+  },
+  unknown: {
+    tone: 'subtle',
+    label: 'Unknown',
+    explanation: 'Not measured for this user - this is not the same as measured zero activity.',
+  },
+};
+
+/** Tone/label/explanation for a status string, with a neutral fallback for anything unlisted. */
+export function statusMeta(status: string | null | undefined): StatusMeta {
+  if (!status) return { tone: 'informative', label: 'Unknown', explanation: '' };
+  return STATUS_META[status] ?? { tone: 'informative', label: status, explanation: '' };
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/tableStyles.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/tableStyles.ts
@@ -1,0 +1,65 @@
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+/**
+ * Shared table styling for the Licence activity tables (SKU assignments, drill-down users), so the
+ * two look and behave identically. Mirrors the compact, dependency-free table style used elsewhere
+ * in the portal rather than pulling in the heavier DataGrid.
+ */
+export const useLaTableStyles = makeStyles({
+  wrap: {
+    overflowX: 'auto',
+  },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+  },
+  th: {
+    textAlign: 'left',
+    padding: '6px 10px',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: tokens.colorNeutralStroke2,
+    color: tokens.colorNeutralForeground3,
+    fontWeight: tokens.fontWeightSemibold,
+    whiteSpace: 'nowrap',
+  },
+  thNumeric: {
+    textAlign: 'right',
+  },
+  td: {
+    padding: '6px 10px',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: tokens.colorNeutralStroke3,
+    verticalAlign: 'middle',
+  },
+  tdNumeric: {
+    textAlign: 'right',
+    fontVariantNumeric: 'tabular-nums',
+  },
+  selectableRow: {
+    cursor: 'pointer',
+    ':hover': {
+      backgroundColor: tokens.colorNeutralBackground2Hover,
+    },
+  },
+  selectedRow: {
+    backgroundColor: tokens.colorBrandBackground2,
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  miniTrack: {
+    position: 'relative',
+    height: '8px',
+    minWidth: '60px',
+    borderRadius: tokens.borderRadiusSmall,
+    backgroundColor: tokens.colorNeutralBackground3,
+    overflow: 'hidden',
+  },
+  miniBar: {
+    height: '100%',
+    borderRadius: tokens.borderRadiusSmall,
+    backgroundColor: tokens.colorBrandBackground,
+  },
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/useUsersQuery.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/useUsersQuery.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import { useUsersQuery } from './useUsersQuery';
+import { fetchUsers } from '../../api/licenceActivityApi';
+import type { LicenceActivityQueryEcho, LicenceActivityUsers, UsersParams } from '../../types/licenceActivity';
+
+vi.mock('../../api/licenceActivityApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/licenceActivityApi')>();
+  return { ...actual, fetchUsers: vi.fn() };
+});
+
+const mockedFetch = vi.mocked(fetchUsers);
+
+const echo: LicenceActivityQueryEcho = {
+  from: '2026-05-01',
+  to: '2026-05-19',
+  departmentId: null,
+  countryId: null,
+  licenceTypeId: 1,
+  workload: 'teams',
+  search: '',
+  sort: 'activity',
+  direction: 'desc',
+  top: 10,
+  page: 1,
+  pageSize: 50,
+};
+
+interface Deferred {
+  resolve: (page: LicenceActivityUsers) => void;
+  reject: (error: unknown) => void;
+  signal: AbortSignal;
+}
+
+let deferreds: Deferred[] = [];
+
+function usersSnapshot(id: string): LicenceActivityUsers {
+  return {
+    snapshotId: id,
+    generatedUtc: '2026-05-20T00:00:00Z',
+    expiresUtc: '2026-05-20T00:02:00Z',
+    overviewId: 'ov',
+    query: echo,
+    totalUsers: 0,
+    rankedUsers: 0,
+    mostActive: [],
+    leastActive: [],
+    users: [],
+    messages: [],
+  };
+}
+
+function Harness({ params }: { params: UsersParams | null }) {
+  const { data } = useUsersQuery(params);
+  return <span data-testid="snap">{data?.snapshotId ?? 'none'}</span>;
+}
+
+const A: UsersParams = { overviewId: 'ov', licenceTypeId: 1, workload: 'teams', top: 10, sort: 'activity', direction: 'desc', page: 1, pageSize: 50 };
+const B: UsersParams = { ...A, licenceTypeId: 2 };
+
+beforeEach(() => {
+  deferreds = [];
+  mockedFetch.mockReset();
+  mockedFetch.mockImplementation(
+    (_params, signal) =>
+      new Promise<LicenceActivityUsers>((resolve, reject) => {
+        deferreds.push({ resolve, reject, signal: signal as AbortSignal });
+      }),
+  );
+});
+
+describe('useUsersQuery', () => {
+  it('aborts the in-flight request when the parameters change', () => {
+    const { rerender } = renderWithProvider(<Harness params={A} />);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    rerender(<Harness params={B} />);
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    expect(deferreds[0].signal.aborted).toBe(true);
+  });
+
+  it('rejects a stale result: a superseded request resolving late does not overwrite the newer one', async () => {
+    const { rerender } = renderWithProvider(<Harness params={A} />);
+    rerender(<Harness params={B} />);
+
+    await act(async () => deferreds[1].resolve(usersSnapshot('B')));
+    expect(screen.getByTestId('snap')).toHaveTextContent('B');
+
+    await act(async () => deferreds[0].resolve(usersSnapshot('A')));
+    expect(screen.getByTestId('snap')).toHaveTextContent('B');
+  });
+
+  it('issues no request when params are null', () => {
+    renderWithProvider(<Harness params={null} />);
+    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(screen.getByTestId('snap')).toHaveTextContent('none');
+  });
+
+  it('does not show or export the previous licence while its replacement loads or fails', async () => {
+    const { rerender } = renderWithProvider(<Harness params={A} />);
+    await act(async () => deferreds[0].resolve(usersSnapshot('A')));
+    expect(screen.getByTestId('snap')).toHaveTextContent('A');
+
+    rerender(<Harness params={B} />);
+    expect(screen.getByTestId('snap')).toHaveTextContent('none');
+    await act(async () => deferreds[1].reject(new Error('synthetic request failure')));
+    expect(screen.getByTestId('snap')).toHaveTextContent('none');
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/useUsersQuery.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/useUsersQuery.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from 'react';
+import { fetchUsers } from '../../api/licenceActivityApi';
+import type { LicenceActivityUsers, UsersParams } from '../../types/licenceActivity';
+
+export interface UsersQueryState {
+  data: LicenceActivityUsers | null;
+  loading: boolean;
+  error: unknown;
+  reload: () => void;
+}
+
+interface KeyedResult {
+  key: string;
+  data: LicenceActivityUsers | null;
+  error: unknown;
+}
+
+/**
+ * Owns a single drill-down users request, with three guarantees the correctness pass calls for:
+ *
+ *  - CANCELLABLE: each run gets its own AbortController and the effect cleanup aborts it, so changing
+ *    the licence / workload / page (or unmounting) actually stops the in-flight request.
+ *  - STALE-SAFE: a monotonic sequence number drops any superseded response that still resolves.
+ *  - REQUEST-SCOPE BOUND: the loaded result is tagged with the params key it was fetched for, and only
+ *    surfaced while that key is still current. When the key changes (a new licence/workload/filter),
+ *    the previous result's rows AND snapshot id are hidden on THAT SAME render - before the new fetch
+ *    even starts - so an old licence can never be shown or exported against the new selection, and a
+ *    different-key failure cannot fall back to the old population. Old data is preserved only across a
+ *    same-key manual reload.
+ */
+export function useUsersQuery(params: UsersParams | null): UsersQueryState {
+  const key = params ? JSON.stringify(params) : null;
+  const [result, setResult] = useState<KeyedResult | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const seqRef = useRef(0);
+
+  useEffect(() => {
+    // Bump on every run (including going idle) so a late/aborted response from any prior run is dropped.
+    const mySeq = (seqRef.current += 1);
+    if (!params || key === null) return;
+
+    const controller = new AbortController();
+    fetchUsers(params, controller.signal)
+      .then((r) => {
+        if (mySeq !== seqRef.current) return; // superseded
+        setResult({ key, data: r, error: null });
+      })
+      .catch((e) => {
+        if (mySeq !== seqRef.current || controller.signal.aborted) return;
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        setResult({ key, data: null, error: e });
+      });
+
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, reloadKey]);
+
+  // Only surface a result that belongs to the CURRENT key. A key change hides the previous key's data
+  // and error on this render, before the effect that fetches the new key runs.
+  const belongs = result !== null && result.key === key;
+  const data = belongs ? result!.data : null;
+  const error = belongs ? result!.error : null;
+  const loading = key !== null && !belongs;
+
+  return { data, loading, error, reload: () => setReloadKey((k) => k + 1) };
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/global.d.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/global.d.ts
@@ -18,6 +18,8 @@ declare global {
     o365AnalyticsReportsAPI: string;
     /** Base endpoint for the Copilot licence-adoption API (summary, user lists, CSV exports). */
     o365AnalyticsCopilotAdoptionAPI: string;
+    /** Base endpoint for the Licence activity API (availability, overview, users, Excel export). */
+    o365AnalyticsLicenceActivityAPI: string;
     /** Endpoint for the system-health ("is it working?") API. */
     o365AnalyticsHealthAPI: string;
     /** Endpoint for the "is there a newer release?" check. */

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { renderWithProvider } from '../test/renderWithProvider';
+import LicenceActivityPage from './LicenceActivityPage';
+import {
+  fetchAvailability,
+  fetchOverview,
+  fetchUsers,
+  downloadExport,
+  LicenceActivityApiError,
+} from '../api/licenceActivityApi';
+import { WORKLOADS } from '../types/licenceActivity';
+import type {
+  LicenceActivityAvailability,
+  LicenceActivityDistribution,
+  LicenceActivityOverview,
+  LicenceActivityQueryEcho,
+  LicenceActivityUser,
+  LicenceActivityUsers,
+  WorkloadKey,
+} from '../types/licenceActivity';
+
+vi.mock('../api/licenceActivityApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/licenceActivityApi')>();
+  return {
+    ...actual,
+    fetchAvailability: vi.fn(),
+    fetchOverview: vi.fn(),
+    fetchUsers: vi.fn(),
+    downloadExport: vi.fn(),
+  };
+});
+
+const mockAvailability = vi.mocked(fetchAvailability);
+const mockOverview = vi.mocked(fetchOverview);
+const mockUsers = vi.mocked(fetchUsers);
+const mockDownload = vi.mocked(downloadExport);
+
+const echo: LicenceActivityQueryEcho = {
+  from: '2026-04-22',
+  to: '2026-05-19',
+  departmentId: null,
+  countryId: null,
+  licenceTypeId: 10,
+  workload: 'teams',
+  search: '',
+  sort: 'activity',
+  direction: 'desc',
+  top: 10,
+  page: 1,
+  pageSize: 50,
+};
+
+function dist(workload: WorkloadKey): LicenceActivityDistribution {
+  return { workload, high: 5, moderate: 3, low: 2, zero: 4, unknown: 1 };
+}
+
+function availability(over: Partial<LicenceActivityAvailability> = {}): LicenceActivityAvailability {
+  return { available: true, canViewUsers: true, minimumDays: 7, maximumDays: 180, messages: [], ...over };
+}
+
+function overview(over: Partial<LicenceActivityOverview> = {}): LicenceActivityOverview {
+  return {
+    snapshotId: 'ov1',
+    generatedUtc: '2026-05-20T10:00:00Z',
+    expiresUtc: '2026-05-20T10:05:00Z',
+    query: echo,
+    distinctAssignedUsers: 120,
+    licences: [
+      { licenceTypeId: 10, name: 'E5', skuId: 'ENTERPRISEPREMIUM', assignedUsers: 100, workloads: WORKLOADS.map((w) => dist(w.key)) },
+      { licenceTypeId: 20, name: 'F3', skuId: 'DESKLESSPACK', assignedUsers: 50, workloads: WORKLOADS.map((w) => dist(w.key)) },
+    ],
+    coverage: [
+      {
+        workload: 'teams',
+        status: 'ok',
+        source: 'Usage reports',
+        measure: 'active days',
+        granularity: 'daily',
+        message: null,
+        effectiveFromUtc: '2026-04-22T00:00:00Z',
+        effectiveToUtc: '2026-05-19T00:00:00Z',
+        latestImportUtc: '2026-05-20T00:00:00Z',
+        lagDays: 1,
+        reportPeriodDays: 28,
+        expectedSamples: 100,
+        observedSamples: 95,
+        unmatchedUsers: 2,
+        snapshotDates: [],
+      },
+    ],
+    departments: [{ id: 1, name: 'Μηχανικοί', assignedUsers: 60, workloads: [] }],
+    countries: [{ id: 1, name: 'Ελλάδα', assignedUsers: 60, workloads: [] }],
+    demographicsTruncated: false,
+    messages: [],
+    ...over,
+  };
+}
+
+function user(): LicenceActivityUser {
+  return {
+    userId: 1,
+    userPrincipalName: 'ada@contoso.com',
+    department: 'Engineering',
+    country: 'Greece',
+    accountEnabled: true,
+    workloads: [
+      {
+        workload: 'teams',
+        status: 'known',
+        band: 'high',
+        source: 'Usage reports',
+        measure: 'active days',
+        activeSamples: 12,
+        observedSamples: 20,
+        expectedSamples: 20,
+        averageActions: 4.2,
+        lastActivityUtc: '2026-05-19T00:00:00Z',
+      },
+    ],
+  };
+}
+
+function usersResponse(): LicenceActivityUsers {
+  return {
+    snapshotId: 'us1',
+    generatedUtc: '2026-05-20T10:00:00Z',
+    expiresUtc: '2026-05-20T10:02:00Z',
+    overviewId: 'ov1',
+    query: echo,
+    totalUsers: 1,
+    rankedUsers: 1,
+    mostActive: [user()],
+    leastActive: [user()],
+    users: [user()],
+    messages: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockOverview.mockResolvedValue(overview());
+  mockUsers.mockResolvedValue(usersResponse());
+  mockDownload.mockResolvedValue(undefined);
+});
+
+describe('LicenceActivityPage - availability', () => {
+  it('shows an unavailable message and no export when the report cannot run', async () => {
+    mockAvailability.mockResolvedValue(
+      availability({ available: false, canViewUsers: false, messages: ['Enable GraphUsersMetadata.'] }),
+    );
+    renderWithProvider(<LicenceActivityPage />);
+
+    expect(await screen.findByText(/not available on this deployment/i)).toBeInTheDocument();
+    expect(screen.getByText('Enable GraphUsersMetadata.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Export to Excel/i })).not.toBeInTheDocument();
+    expect(mockOverview).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an availability check failure', async () => {
+    mockAvailability.mockRejectedValue(new Error('availability boom'));
+    renderWithProvider(<LicenceActivityPage />);
+    expect(await screen.findByText('availability boom')).toBeInTheDocument();
+  });
+});
+
+describe('LicenceActivityPage - user-detail gating', () => {
+  it('shows aggregates but hides the drill-down without the ReadUsers role', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    renderWithProvider(<LicenceActivityPage />);
+
+    expect(await screen.findByText('Licence assignments')).toBeInTheDocument();
+    // Aggregate workload distributions are visible to everyone (renders after default licence select).
+    expect(await screen.findByText('Workload activity')).toBeInTheDocument();
+    // Non-Latin (Greek) demographic values render without corruption (in the filters and the breakdown).
+    expect(screen.getAllByText(/Μηχανικοί/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Ελλάδα/).length).toBeGreaterThan(0);
+    // But not the per-user drill-down.
+    expect(screen.queryByText('User drill-down')).not.toBeInTheDocument();
+    expect(screen.getByText(/aggregate view/i)).toBeInTheDocument();
+    expect(mockUsers).not.toHaveBeenCalled();
+  });
+
+  it('loads the drill-down for the default licence with the role', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    renderWithProvider(<LicenceActivityPage />);
+
+    expect(await screen.findByText('User drill-down')).toBeInTheDocument();
+    expect((await screen.findAllByText('ada@contoso.com')).length).toBeGreaterThan(0);
+    expect(mockUsers).toHaveBeenCalled();
+  });
+});
+
+describe('LicenceActivityPage - scale (50 SKUs)', () => {
+  it('holds all SKUs but issues exactly one users request, for the default (biggest) licence', async () => {
+    // The skewed distribution the load fixture uses: a few tenant-wide SKUs, many tiny ones.
+    const sizes = [1, 5, 25, 50, 100, 500, 5000, 15000, 60000];
+    const licences = Array.from({ length: 50 }, (_, i) => ({
+      licenceTypeId: i + 1,
+      name: `SKU ${i + 1}`,
+      skuId: `PART${i + 1}`,
+      assignedUsers: sizes[i % sizes.length] + i, // varied, with a unique maximum
+      workloads: WORKLOADS.map((w) => dist(w.key)),
+    }));
+    const biggest = [...licences].sort((a, b) => b.assignedUsers - a.assignedUsers)[0];
+
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockOverview.mockResolvedValue(overview({ licences }));
+    renderWithProvider(<LicenceActivityPage />);
+
+    // The drill-down loads for exactly ONE licence (the biggest), not one request per SKU. The
+    // longer timeout absorbs the heavier 50-SKU aggregate render under single-worker jsdom.
+    await screen.findAllByText('ada@contoso.com', undefined, { timeout: 8000 });
+    await act(async () => {});
+    expect(mockUsers).toHaveBeenCalledTimes(1);
+    expect(mockUsers.mock.calls[0][0].licenceTypeId).toBe(biggest.licenceTypeId);
+  });
+});
+
+describe('LicenceActivityPage - export', () => {
+  it('exports the aggregate snapshot (no usersId) for an aggregate-only viewer', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    renderWithProvider(<LicenceActivityPage />);
+
+    const exportBtn = await screen.findByRole('button', { name: /Export to Excel/i });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+    fireEvent.click(exportBtn);
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledWith({ overviewId: 'ov1', usersId: undefined }));
+  });
+
+  it('includes the current users snapshot once the drill-down has loaded', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    renderWithProvider(<LicenceActivityPage />);
+
+    await screen.findAllByText('ada@contoso.com'); // drill-down loaded -> usersId captured
+    await act(async () => {}); // flush the onUsersSnapshot effect + page state update
+
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledWith({ overviewId: 'ov1', usersId: 'us1' }));
+  });
+
+  it('shows a refresh prompt when the snapshot has expired', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    mockDownload.mockRejectedValue(
+      new LicenceActivityApiError('expired', 410, 'This snapshot has expired or was refreshed.'),
+    );
+    renderWithProvider(<LicenceActivityPage />);
+
+    const exportBtn = await screen.findByRole('button', { name: /Export to Excel/i });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+    fireEvent.click(exportBtn);
+
+    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+  });
+
+  it('disables export while the overview is still loading', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    mockOverview.mockReturnValue(new Promise(() => {})); // never resolves
+    renderWithProvider(<LicenceActivityPage />);
+
+    const exportBtn = await screen.findByRole('button', { name: /Export to Excel/i });
+    expect(exportBtn).toBeDisabled();
+  });
+});
+
+describe('LicenceActivityPage - export refresh after expiry', () => {
+  it('re-mints the users snapshot on Refresh (same cached overviewId) without silently re-exporting', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    // The overview stays cached: it returns the SAME snapshotId on reload, which is exactly the case
+    // that made the old Refresh a no-op (the snapshot-id-changed effect never fired).
+    mockOverview.mockResolvedValue(overview());
+    // Each users fetch mints a fresh snapshot id, so a genuine re-mint is observable.
+    const usersSnaps: string[] = [];
+    mockUsers.mockImplementation(async () => {
+      const id = `us${usersSnaps.length + 1}`;
+      usersSnaps.push(id);
+      return { ...usersResponse(), snapshotId: id };
+    });
+    // The first export fails as expired (users snapshots expire before the overview); later ones pass.
+    mockDownload
+      .mockRejectedValueOnce(
+        new LicenceActivityApiError('expired', 410, 'This snapshot has expired or was refreshed.'),
+      )
+      .mockResolvedValue(undefined);
+
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findAllByText('ada@contoso.com');
+    await act(async () => {}); // capture usersId = us1
+
+    // Export -> 410 -> a Refresh prompt appears.
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+
+    const usersBefore = mockUsers.mock.calls.length;
+    // The drill-down keeps its own "Refresh users" control (accessible name differs), so this exact
+    // match resolves the export bar's Refresh unambiguously.
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    // A fresh users request is issued (re-mint) and the error clears...
+    await waitFor(() => expect(mockUsers.mock.calls.length).toBeGreaterThan(usersBefore));
+    await waitFor(() => expect(screen.queryByText(/expired/i)).not.toBeInTheDocument());
+    await act(async () => {});
+    // ...but Refresh does NOT silently re-export (still just the one failed attempt).
+    expect(mockDownload).toHaveBeenCalledTimes(1);
+
+    // A subsequent explicit export uses the same cached overviewId and the NEW users snapshot.
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    await waitFor(() => {
+      const last = mockDownload.mock.calls[mockDownload.mock.calls.length - 1][0];
+      expect(last.overviewId).toBe('ov1');
+      expect(last.usersId).toBe(usersSnaps[usersSnaps.length - 1]);
+      expect(last.usersId).not.toBe('us1');
+    });
+    // Scope preserved across the refresh: still the same licence/overview.
+    const lastUsers = mockUsers.mock.calls[mockUsers.mock.calls.length - 1][0];
+    expect(lastUsers).toMatchObject({ overviewId: 'ov1', licenceTypeId: 10 });
+  });
+});
+
+describe('LicenceActivityPage - demographic filter options', () => {
+  it('keeps every department selectable after a scoped reply, so you can switch straight from one to another', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    const sales = { id: 1, name: 'Sales', assignedUsers: 60, workloads: [] };
+    const support = { id: 2, name: 'Support', assignedUsers: 40, workloads: [] };
+    // The backend only returns demographic groups WITHIN the current scope: filtering by a department
+    // returns just that one. The UI must not let that collapse the selectable catalogue.
+    mockOverview.mockImplementation(async (q) => {
+      const departments =
+        q.departmentId == null ? [sales, support] : [sales, support].filter((d) => d.id === q.departmentId);
+      return overview({ departments });
+    });
+
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findByText('Licence assignments');
+
+    const deptSelect = await screen.findByLabelText('Filter by department');
+    expect(screen.getByRole('option', { name: 'Sales' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Support' })).toBeInTheDocument();
+
+    // Select Sales -> overview refetches scoped to department 1 (its reply contains only Sales)...
+    fireEvent.change(deptSelect, { target: { value: '1' } });
+    await waitFor(() => expect(mockOverview.mock.calls.some((c) => c[0].departmentId === 1)).toBe(true));
+
+    // ...yet Support is STILL an option, so we can switch straight to it without going via "All".
+    await waitFor(() => expect(screen.getByRole('option', { name: 'Support' })).toBeInTheDocument());
+    fireEvent.change(deptSelect, { target: { value: '2' } });
+    await waitFor(() => expect(mockOverview.mock.calls.some((c) => c[0].departmentId === 2)).toBe(true));
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
@@ -1,0 +1,593 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  makeStyles,
+  tokens,
+  Title3,
+  Body1,
+  Text,
+  Card,
+  Select,
+  Button,
+  Tooltip,
+  MessageBar,
+  MessageBarBody,
+} from '@fluentui/react-components';
+import { ArrowDownload16Regular } from '@fluentui/react-icons';
+import { fetchAvailability, fetchOverview, downloadExport } from '../api/licenceActivityApi';
+import type {
+  DateRange,
+  LicenceActivityAvailability,
+  LicenceActivityOverview,
+} from '../types/licenceActivity';
+import Spinner from '../components/Spinner';
+import DateRangeControl from '../components/licenceActivity/DateRangeControl';
+import CoveragePanel from '../components/licenceActivity/CoveragePanel';
+import SkuAssignments from '../components/licenceActivity/SkuAssignments';
+import WorkloadDistributions from '../components/licenceActivity/WorkloadDistributions';
+import DemographicBreakdown from '../components/licenceActivity/DemographicBreakdown';
+import UsersDrillDown from '../components/licenceActivity/UsersDrillDown';
+import ApiErrorBar, { describeError } from '../components/licenceActivity/ApiErrorBar';
+import { presetRange } from '../components/licenceActivity/dateRange';
+import { formatCount } from '../components/licenceActivity/format';
+import {
+  mergeDemographicOptions,
+  EMPTY_CATALOGUE,
+  DEMOGRAPHIC_OPTION_CAP,
+  type DemographicCatalogue,
+} from '../components/licenceActivity/demographicOptions';
+
+const useStyles = makeStyles({
+  header: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  intro: {
+    marginTop: '8px',
+    maxWidth: '820px',
+  },
+  controlsCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    marginTop: '16px',
+    padding: '14px 16px',
+  },
+  controlRow: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    gap: '16px',
+    flexWrap: 'wrap',
+  },
+  field: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  fieldLabel: {
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: tokens.colorNeutralForeground3,
+  },
+  exportWrap: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    gap: '4px',
+  },
+  stack: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    marginTop: '16px',
+  },
+  sectionHead: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: '10px',
+    marginTop: '8px',
+    paddingBottom: '6px',
+    borderBottomWidth: '2px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: tokens.colorBrandStroke1,
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  center: {
+    textAlign: 'center',
+    padding: '32px',
+  },
+});
+
+/**
+ * Licence activity report (issues #436 / #437).
+ *
+ * Answers, for an IT / licensing admin: which licences are assigned, and how much are the people who
+ * hold them actually using each Microsoft 365 workload? It is deliberately an ACTIVITY report - no
+ * blended "productivity" score, no "remove this licence" button; it surfaces the evidence and leaves
+ * the decision with the admin.
+ *
+ * Everyone signed in sees the aggregates. Drilling into named individuals additionally requires the
+ * opt-in `LicenceActivity.ReadUsers` Entra role; the UI hides the drill-down without it, and the
+ * server enforces it regardless.
+ */
+export default function LicenceActivityPage() {
+  const styles = useStyles();
+
+  const [availability, setAvailability] = useState<LicenceActivityAvailability | null>(null);
+  const [availabilityError, setAvailabilityError] = useState<unknown>(null);
+  const [availabilityLoading, setAvailabilityLoading] = useState(true);
+  // Bumped whenever the viewer's ROLE may have changed under them, so availability (and therefore
+  // canViewUsers) is re-read instead of staying frozen at page load for the life of the tab.
+  const [availabilityKey, setAvailabilityKey] = useState(0);
+
+  // The reporting window lives here, so it is preserved across demographic-filter and licence
+  // changes - only the date control (or a preset click) ever changes it. Defaults to 28 days.
+  const [range, setRange] = useState<DateRange>(() => presetRange(28));
+  const [departmentId, setDepartmentId] = useState<number | null>(null);
+  const [countryId, setCountryId] = useState<number | null>(null);
+
+  const [overviewResult, setOverviewResult] = useState<{
+    key: string;
+    data: LicenceActivityOverview | null;
+    error: unknown;
+  } | null>(null);
+  const [overviewReloadKey, setOverviewReloadKey] = useState(0);
+
+  // Filter options are kept across overview reloads AND merged (never replaced) so the drop-downs
+  // don't collapse to just the selected group. The backend only returns demographic groups WITHIN the
+  // current scope (selecting department X returns just X), so replacing would strand the user unable to
+  // switch straight to Y. We keep a union of every id/name seen; the scope-specific COUNTS live in the
+  // demographic breakdown, not here, so these options carry names only and never mislabel a count.
+  const [departmentOptions, setDepartmentOptions] = useState<DemographicCatalogue>(EMPTY_CATALOGUE);
+  const [countryOptions, setCountryOptions] = useState<DemographicCatalogue>(EMPTY_CATALOGUE);
+
+  const [selectedLicenceTypeId, setSelectedLicenceTypeId] = useState<number | null>(null);
+  const [usersId, setUsersId] = useState<string | null>(null);
+  // Bumped to force the drill-down to re-mint its users snapshot after an expiry, without changing the
+  // params (which stay put so the admin's licence/workload/page/filters are preserved).
+  const [usersRefreshToken, setUsersRefreshToken] = useState(0);
+
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<unknown>(null);
+
+  const overviewSeqRef = useRef(0);
+
+  const canViewUsers = availability?.canViewUsers === true;
+
+  // --- Availability -------------------------------------------------------------------------------
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    setAvailabilityLoading(true);
+    setAvailabilityError(null);
+    fetchAvailability(controller.signal)
+      .then((a) => {
+        if (!cancelled) setAvailability(a);
+      })
+      .catch((e) => {
+        if (cancelled || controller.signal.aborted) return;
+        setAvailabilityError(e);
+      })
+      .finally(() => {
+        if (!cancelled) setAvailabilityLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [availabilityKey]);
+
+  // The scope key identifying the overview request. When it changes (date / department / country) the
+  // previous overview and its snapshot id must vanish on the SAME render, so nothing stale can be shown
+  // or exported against a scope the user has already moved on from.
+  const overviewKey = availability?.available
+    ? JSON.stringify({ from: range.from, to: range.to, departmentId, countryId })
+    : null;
+
+  // --- Overview (cancellable, stale-safe, request-scope bound) ------------------------------------
+  useEffect(() => {
+    // Bump on every run so a late/aborted response from a prior scope is dropped.
+    const mySeq = (overviewSeqRef.current += 1);
+    if (overviewKey === null) return;
+
+    const controller = new AbortController();
+    fetchOverview({ from: range.from, to: range.to, departmentId, countryId }, controller.signal)
+      .then((o) => {
+        if (mySeq === overviewSeqRef.current) setOverviewResult({ key: overviewKey, data: o, error: null });
+      })
+      .catch((err) => {
+        if (mySeq !== overviewSeqRef.current || controller.signal.aborted) return;
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setOverviewResult({ key: overviewKey, data: null, error: err });
+      });
+
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [overviewKey, overviewReloadKey]);
+
+  // Only surface an overview that belongs to the CURRENT scope key. A filter change hides the previous
+  // overview (and its export id) on this render, before the new request starts.
+  const overviewBelongs = overviewResult !== null && overviewResult.key === overviewKey;
+  const overview = overviewBelongs ? overviewResult!.data : null;
+  const overviewError = overviewBelongs ? overviewResult!.error : null;
+  const overviewLoading = overviewKey !== null && !overviewBelongs;
+
+  // Refresh persisted filter options and choose/validate the selected licence against a new overview.
+  // `overview` is request-scope bound, so when it is present the page's departmentId/countryId are the
+  // scope that produced it - which is exactly what tells each dimension whether this reply is its
+  // authoritative unfiltered catalogue, and which id to pin so the user can switch away from it.
+  useEffect(() => {
+    if (!overview) return;
+    setDepartmentOptions((prev) =>
+      mergeDemographicOptions(prev, overview.departments, {
+        unfilteredForDimension: departmentId == null,
+        selectedId: departmentId,
+      }),
+    );
+    setCountryOptions((prev) =>
+      mergeDemographicOptions(prev, overview.countries, {
+        unfilteredForDimension: countryId == null,
+        selectedId: countryId,
+      }),
+    );
+    setSelectedLicenceTypeId((prev) => {
+      if (prev != null && overview.licences.some((s) => s.licenceTypeId === prev)) return prev;
+      // Default to the most-assigned licence so the distributions show something immediately.
+      const biggest = [...overview.licences].sort((a, b) => b.assignedUsers - a.assignedUsers)[0];
+      return biggest ? biggest.licenceTypeId : null;
+    });
+  }, [overview, departmentId, countryId]);
+
+  // A new overview snapshot invalidates any users snapshot captured for the export.
+  useEffect(() => {
+    setUsersId(null);
+    setExportError(null);
+  }, [overview?.snapshotId]);
+
+  const reloadOverview = useCallback(() => setOverviewReloadKey((k) => k + 1), []);
+  const handleUsersSnapshot = useCallback((id: string | null) => setUsersId(id), []);
+
+  // The correct response to an EXPIRED snapshot (export 410, or a users 410): re-mint the snapshots in
+  // place. We drop the stale users id and error, force the drill-down to re-fetch a fresh users
+  // snapshot (its params are unchanged, so the licence/workload/page/filters are preserved), and reload
+  // the overview. The overview often comes back under the SAME cached id, which is exactly why clearing
+  // is explicit here rather than relying on the snapshot-id-changed effect. It deliberately does NOT
+  // re-export: an export must be an explicit action, never a silent re-query of freshly minted data.
+  const refreshSnapshots = useCallback(() => {
+    setExportError(null);
+    setUsersId(null);
+    setUsersRefreshToken((t) => t + 1);
+    setOverviewReloadKey((k) => k + 1);
+    // Re-read availability too. The feature contract for the 410/409 recovery path is "re-mint AND
+    // recheck role": a role granted or revoked mid-session must not stay invisible until the admin
+    // reloads the whole page. (The server enforces the role independently on every /users and every
+    // /export carrying a usersId, so this is a dead-end fix, not a security fix.)
+    setAvailabilityKey((k) => k + 1);
+  }, []);
+
+  const selectedLicence = useMemo(
+    () => overview?.licences.find((s) => s.licenceTypeId === selectedLicenceTypeId) ?? null,
+    [overview, selectedLicenceTypeId],
+  );
+
+  // Only attach a users snapshot to the export when the viewer is allowed per-user detail and is
+  // actually looking at a licence's list; otherwise the workbook is aggregate-only.
+  const exportUsersId = canViewUsers && selectedLicence ? usersId ?? undefined : undefined;
+
+  const onExport = async (): Promise<void> => {
+    if (!overview) return;
+    setExporting(true);
+    setExportError(null);
+    try {
+      await downloadExport({ overviewId: overview.snapshotId, usersId: exportUsersId });
+    } catch (err) {
+      setExportError(err);
+      // A 403 here means the LicenceActivity.ReadUsers role went away mid-session while the export
+      // was still attaching a usersId. Retrying unchanged would 403 forever, so drop the individual
+      // snapshot and re-read availability: the next export is then a valid aggregate-only workbook.
+      if (describeError(err, '').kind === 'forbidden') {
+        setUsersId(null);
+        setAvailabilityKey((k) => k + 1);
+      }
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const exportExpired = describeError(exportError, '').kind === 'expired';
+
+  return (
+    <div>
+      <div className={styles.header}>
+        <div>
+          <Title3>Licence activity</Title3>
+          <Body1 block className={styles.intro}>
+            Which licences are assigned, and how much are the people who hold them actually using each Microsoft 365
+            workload. Activity is shown per workload and never blended into a single score, and anything that was not
+            imported is shown as &quot;Unknown&quot; rather than zero.
+          </Body1>
+        </div>
+      </div>
+
+      {availabilityLoading && (
+        <div className={styles.center}>
+          <Spinner size={80} label="Checking availability..." />
+        </div>
+      )}
+
+      {availabilityError != null && (
+        <ApiErrorBar
+          error={availabilityError}
+          fallback="Failed to check licence activity availability."
+          onRetry={() => window.location.reload()}
+          retryLabel="Reload"
+        />
+      )}
+
+      {availability && !availability.available && (
+        <MessageBar intent="info" style={{ marginTop: '16px' }}>
+          <MessageBarBody>
+            Licence activity reporting is not available on this deployment.
+            {availability.messages.length > 0 && (
+              <ul style={{ margin: '6px 0 0 0', paddingInlineStart: '20px' }}>
+                {availability.messages.map((m) => (
+                  <li key={m}>{m}</li>
+                ))}
+              </ul>
+            )}
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      {availability?.available && (
+        <>
+          {availability.messages.length > 0 && (
+            <MessageBar intent="info" style={{ marginTop: '16px' }}>
+              <MessageBarBody>
+                <ul style={{ margin: 0, paddingInlineStart: '20px' }}>
+                  {availability.messages.map((m) => (
+                    <li key={m}>{m}</li>
+                  ))}
+                </ul>
+              </MessageBarBody>
+            </MessageBar>
+          )}
+
+          <Card className={styles.controlsCard}>
+            <div className={styles.controlRow}>
+              <div className={styles.field}>
+                <Text size={200} className={styles.fieldLabel}>
+                  Reporting window
+                </Text>
+                <DateRangeControl
+                  value={range}
+                  onChange={setRange}
+                  minDays={availability.minimumDays}
+                  maxDays={availability.maximumDays}
+                />
+              </div>
+
+              <div className={styles.field}>
+                <Text size={200} className={styles.fieldLabel}>
+                  Department
+                </Text>
+                <Select
+                  value={departmentId == null ? '' : String(departmentId)}
+                  aria-label="Filter by department"
+                  disabled={departmentOptions.options.length === 0}
+                  onChange={(_e, d) => setDepartmentId(d.value === '' ? null : Number(d.value))}
+                >
+                  <option value="">All departments</option>
+                  {departmentOptions.options.map((dept) => (
+                    <option key={dept.id} value={dept.id}>
+                      {dept.name}
+                    </option>
+                  ))}
+                </Select>
+                {departmentOptions.truncated && (
+                  <Text size={100} className={styles.muted}>
+                    Showing up to {formatCount(DEMOGRAPHIC_OPTION_CAP)} recent options; some may be hidden.
+                  </Text>
+                )}
+              </div>
+
+              <div className={styles.field}>
+                <Text size={200} className={styles.fieldLabel}>
+                  Country
+                </Text>
+                <Select
+                  value={countryId == null ? '' : String(countryId)}
+                  aria-label="Filter by country"
+                  disabled={countryOptions.options.length === 0}
+                  onChange={(_e, d) => setCountryId(d.value === '' ? null : Number(d.value))}
+                >
+                  <option value="">All countries</option>
+                  {countryOptions.options.map((country) => (
+                    <option key={country.id} value={country.id}>
+                      {country.name}
+                    </option>
+                  ))}
+                </Select>
+                {countryOptions.truncated && (
+                  <Text size={100} className={styles.muted}>
+                    Showing up to {formatCount(DEMOGRAPHIC_OPTION_CAP)} recent options; some may be hidden.
+                  </Text>
+                )}
+              </div>
+
+              <div style={{ flexGrow: 1 }} />
+
+              <div className={styles.exportWrap}>
+                <Tooltip
+                  relationship="description"
+                  content={
+                    overview
+                      ? exportUsersId
+                        ? 'Excel snapshot of the overview plus the exact user rows currently in view. Built from the cached snapshot, so it matches the screen rather than re-querying.'
+                        : 'Excel snapshot of the licence and workload overview (aggregate only). Built from the cached snapshot.'
+                      : 'Available once the overview has loaded.'
+                  }
+                >
+                  <Button
+                    appearance="primary"
+                    icon={<ArrowDownload16Regular />}
+                    disabled={!overview || exporting}
+                    onClick={onExport}
+                  >
+                    {exporting ? 'Exporting...' : 'Export to Excel'}
+                  </Button>
+                </Tooltip>
+              </div>
+            </div>
+
+            {exportError != null && (
+              <ApiErrorBar
+                error={exportError}
+                fallback="Couldn't export the workbook."
+                onRetry={exportExpired ? refreshSnapshots : onExport}
+                retryLabel={exportExpired ? 'Refresh' : 'Try again'}
+              />
+            )}
+          </Card>
+
+          {overviewLoading && (
+            <div className={styles.center}>
+              <Spinner size={80} label="Loading licence activity..." />
+            </div>
+          )}
+
+          {overviewError != null && (
+            <div style={{ marginTop: '16px' }}>
+              <ApiErrorBar
+                error={overviewError}
+                fallback="Failed to load the licence activity overview."
+                onRetry={reloadOverview}
+              />
+            </div>
+          )}
+
+          {overview && (
+            <div className={styles.stack}>
+              <CoveragePanel
+                generatedUtc={overview.generatedUtc}
+                expiresUtc={overview.expiresUtc}
+                coverage={overview.coverage}
+              />
+
+              {overview.messages.length > 0 && (
+                <MessageBar intent="info">
+                  <MessageBarBody>
+                    <ul style={{ margin: 0, paddingInlineStart: '20px' }}>
+                      {overview.messages.map((m) => (
+                        <li key={m}>{m}</li>
+                      ))}
+                    </ul>
+                  </MessageBarBody>
+                </MessageBar>
+              )}
+
+              <Text size={200} className={styles.muted}>
+                {formatCount(overview.distinctAssignedUsers)} distinct users hold a licence in this scope.
+                {overview.demographicsTruncated &&
+                  ' Department and country lists are capped and may not be exhaustive.'}
+              </Text>
+
+              <SkuAssignments
+                licences={overview.licences}
+                selectedLicenceTypeId={selectedLicenceTypeId}
+                onSelect={setSelectedLicenceTypeId}
+              />
+
+              {selectedLicence && (
+                <div>
+                  <div className={styles.sectionHead}>
+                    <Text weight="semibold" size={500}>
+                      Workload activity
+                    </Text>
+                    <Text size={200} className={styles.muted}>
+                      {selectedLicence.name} &middot; five workloads, measured separately
+                    </Text>
+                  </div>
+                  <div style={{ marginTop: '12px' }}>
+                    <WorkloadDistributions workloads={selectedLicence.workloads} />
+                  </div>
+                </div>
+              )}
+
+              {(overview.departments.length > 0 || overview.countries.length > 0) && (
+                <div>
+                  <div className={styles.sectionHead}>
+                    <Text weight="semibold" size={500}>
+                      Activity by demographic
+                    </Text>
+                    <Text size={200} className={styles.muted}>
+                      Assigned licences and workload activity by department and country
+                    </Text>
+                  </div>
+                  <div style={{ marginTop: '12px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+                    <DemographicBreakdown
+                      title="By department"
+                      segmentLabel="Department"
+                      rows={overview.departments}
+                      truncated={overview.demographicsTruncated}
+                    />
+                    <DemographicBreakdown
+                      title="By country"
+                      segmentLabel="Country"
+                      rows={overview.countries}
+                      truncated={overview.demographicsTruncated}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {canViewUsers ? (
+                <div>
+                  <div className={styles.sectionHead}>
+                    <Text weight="semibold" size={500}>
+                      User drill-down
+                    </Text>
+                    <Text size={200} className={styles.muted}>
+                      Who is and isn&apos;t using a licence
+                    </Text>
+                  </div>
+                  <div style={{ marginTop: '12px' }}>
+                    {selectedLicence ? (
+                      <UsersDrillDown
+                        key={selectedLicence.licenceTypeId}
+                        overviewId={overview.snapshotId}
+                        licence={selectedLicence}
+                        coverage={overview.coverage}
+                        onUsersSnapshot={handleUsersSnapshot}
+                        onRefreshOverview={refreshSnapshots}
+                        refreshToken={usersRefreshToken}
+                      />
+                    ) : (
+                      <Card>
+                        <Text className={styles.muted}>
+                          Select a licence in the assignments table above to see its most and least active users, or
+                          to browse everyone who holds it.
+                        </Text>
+                      </Card>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <MessageBar intent="info">
+                  <MessageBarBody>
+                    You&apos;re seeing the aggregate view. Listing the individual users behind these figures needs the
+                    opt-in <strong>LicenceActivity.ReadUsers</strong> role, which an administrator can grant in Entra.
+                  </MessageBarBody>
+                </MessageBar>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/ReportsPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/ReportsPage.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProvider } from '../test/renderWithProvider';
+import ReportsPage from './ReportsPage';
+import { fetchReportAreas, fetchReportArea } from '../api/reportsApi';
+import { fetchAvailability } from '../api/licenceActivityApi';
+import type { ReportAreaData, ReportAreas } from '../types/reports';
+import type { LicenceActivityAvailability } from '../types/licenceActivity';
+
+vi.mock('../api/reportsApi', () => ({ fetchReportAreas: vi.fn(), fetchReportArea: vi.fn() }));
+vi.mock('../api/licenceActivityApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/licenceActivityApi')>();
+  return {
+    ...actual,
+    fetchAvailability: vi.fn(),
+    fetchOverview: vi.fn(),
+    fetchUsers: vi.fn(),
+    downloadExport: vi.fn(),
+  };
+});
+
+const mockAreas = vi.mocked(fetchReportAreas);
+const mockArea = vi.mocked(fetchReportArea);
+const mockAvailability = vi.mocked(fetchAvailability);
+
+const NO_AREAS: ReportAreas = {
+  copilot: false,
+  usage: false,
+  spoAudit: false,
+  webTraffic: false,
+  calls: false,
+  emails: false,
+};
+
+const areaData: ReportAreaData = {
+  area: 'copilot',
+  months: 3,
+  fromWeek: '2026-01-05T00:00:00Z',
+  charts: [],
+  cognitiveConfigured: true,
+};
+
+function availability(over: Partial<LicenceActivityAvailability> = {}): LicenceActivityAvailability {
+  return { available: false, canViewUsers: false, minimumDays: 7, maximumDays: 180, messages: [], ...over };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockArea.mockResolvedValue(areaData);
+  // Licence activity resolves "not available" so the lazy panel settles quickly without an overview call.
+  mockAvailability.mockResolvedValue(availability());
+});
+
+describe('ReportsPage - Licence activity integration', () => {
+  it('always shows the Licence activity tab, even when no report imports are enabled', async () => {
+    mockAreas.mockResolvedValue(NO_AREAS);
+    renderWithProvider(<ReportsPage />);
+
+    // The tab exists despite every report-area flag being false...
+    expect(await screen.findByRole('tab', { name: 'Licence activity' })).toBeInTheDocument();
+    // ...it becomes the default, so its content loads...
+    expect(await screen.findByText(/not available on this deployment/i)).toBeInTheDocument();
+    // ...and the Reports month/period selector is hidden (it would look like it ignores the dates).
+    expect(screen.queryByLabelText('Reporting period')).not.toBeInTheDocument();
+  });
+
+  it('hides the Reports period selector when the Licence activity tab is chosen', async () => {
+    mockAreas.mockResolvedValue({ ...NO_AREAS, copilot: true });
+    renderWithProvider(<ReportsPage />);
+
+    // Default lands on the report area, so the period selector is shown.
+    expect(await screen.findByRole('tab', { name: 'Copilot' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Reporting period')).toBeInTheDocument();
+
+    // Switching to Licence activity hides it and loads the licence panel.
+    fireEvent.click(screen.getByRole('tab', { name: 'Licence activity' }));
+    expect(await screen.findByText(/not available on this deployment/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByLabelText('Reporting period')).not.toBeInTheDocument());
+  });
+
+  it('keeps a report-areas load failure visible even while the Licence activity tab is showing', async () => {
+    // The areas fetch fails; with no enabled areas the default lands on the always-present Licence tab.
+    mockAreas.mockRejectedValue(new Error('Boom: report areas failed to load (500).'));
+    renderWithProvider(<ReportsPage />);
+
+    // The error is rendered OUTSIDE the tab content, so it shows even though the Licence tab wins the
+    // content switch...
+    expect(await screen.findByText(/report areas failed to load/i)).toBeInTheDocument();
+    // ...and the Licence activity tab still works (its panel resolves)...
+    expect(await screen.findByText(/not available on this deployment/i)).toBeInTheDocument();
+    // ...with the error still visible alongside it, on the selected Licence tab.
+    expect(screen.getByText(/report areas failed to load/i)).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Licence activity' })).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/ReportsPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/ReportsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import {
   Title3,
   Body1,
@@ -23,6 +23,11 @@ import SqlPopover from '../components/SqlPopover';
 import TimeSeriesChart from '../components/charts/TimeSeriesChart';
 import CategoryBarChart from '../components/charts/CategoryBarChart';
 import WordCloud from '../components/charts/WordCloud';
+import { lazyWithReload } from '../lazyWithReload';
+
+// The Licence activity tab is an always-present part of Reports (it doesn't depend on any import
+// flag). Lazy-loaded so opening Reports for the charts doesn't pay for it until the tab is chosen.
+const LicenceActivityPage = lazyWithReload(() => import('./LicenceActivityPage'));
 
 /** The report areas in display order, with the enabled-flag they map to and their friendly copy. */
 const AREA_DEFS: { flag: keyof ReportAreas; key: ReportAreaKey; label: string; blurb: string }[] = [
@@ -40,6 +45,10 @@ const MONTH_OPTIONS = [
   { value: 3, label: 'Last 3 months' },
   { value: 6, label: 'Last 6 months' },
 ];
+
+/** Tab identity: one of the report areas, or the always-present Licence activity tab. */
+type ReportTab = ReportAreaKey | 'licence-activity';
+const LICENCE_TAB = 'licence-activity' as const;
 
 const useStyles = makeStyles({
   header: {
@@ -98,7 +107,7 @@ export default function ReportsPage() {
   const [areasLoading, setAreasLoading] = useState(true);
 
   const [months, setMonths] = useState(3);
-  const [selectedArea, setSelectedArea] = useState<ReportAreaKey | null>(null);
+  const [selectedTab, setSelectedTab] = useState<ReportTab | null>(null);
   const [topAgents, setTopAgents] = useState(8);
   const [agentNameDraft, setAgentNameDraft] = useState('');
   const [agentNameFilter, setAgentNameFilter] = useState('');
@@ -127,18 +136,20 @@ export default function ReportsPage() {
     [areas],
   );
 
-  // Default the selection to the first enabled area once we know which areas exist.
+  // The Licence activity tab is always present and independent of the report-area flags. Choose a
+  // default once areas resolve (or fail to): keep an explicit Licence choice, else land on the first
+  // enabled report area, falling back to Licence activity when no report imports are enabled.
   useEffect(() => {
-    if (enabledAreas.length === 0) {
-      setSelectedArea(null);
-      return;
-    }
-    setSelectedArea((current) =>
-      current && enabledAreas.some((a) => a.key === current) ? current : enabledAreas[0].key,
-    );
-  }, [enabledAreas]);
+    if (areas === null && !areasError) return; // still loading - don't pick a default yet
+    setSelectedTab((current) => {
+      if (current === LICENCE_TAB) return current;
+      if (current && enabledAreas.some((a) => a.key === current)) return current;
+      return enabledAreas.length > 0 ? enabledAreas[0].key : LICENCE_TAB;
+    });
+  }, [areas, areasError, enabledAreas]);
 
-  const onTabSelect: SelectTabEventHandler = (_e, data) => setSelectedArea(data.value as ReportAreaKey);
+  const onLicence = selectedTab === LICENCE_TAB;
+  const onTabSelect: SelectTabEventHandler = (_e, data) => setSelectedTab(data.value as ReportTab);
 
   return (
     <div>
@@ -146,64 +157,84 @@ export default function ReportsPage() {
         <div>
           <Title3>Reports</Title3>
           <Body1 block className={styles.intro}>
-            A quick, built-in view of how your Microsoft 365 usage is trending. Each section below appears only when its
-            data is being imported.
+            A quick, built-in view of how your Microsoft 365 usage is trending. The report charts appear only when
+            their data is being imported; the Licence activity tab is always shown and explains what it needs if a
+            prerequisite import is off.
           </Body1>
         </div>
-        <div className={styles.controls}>
-          <Text size={200} className={styles.muted}>
-            Period
-          </Text>
-          <Select
-            value={String(months)}
-            onChange={(_e, data) => setMonths(Number(data.value))}
-            aria-label="Reporting period"
-          >
-            {MONTH_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </Select>
-        </div>
+        {!onLicence && (
+          <div className={styles.controls}>
+            <Text size={200} className={styles.muted}>
+              Period
+            </Text>
+            <Select
+              value={String(months)}
+              onChange={(_e, data) => setMonths(Number(data.value))}
+              aria-label="Reporting period"
+            >
+              {MONTH_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+        )}
       </div>
 
-      {areasLoading && (
-        <div style={{ textAlign: 'center', padding: '32px' }}>
-          <Spinner size={80} label="Loading reports..." />
-        </div>
-      )}
+      {/* The tab strip is ALWAYS rendered - the Licence activity tab must exist even while the
+          report areas are loading, errored, or all disabled. Report-area tabs are added as they load. */}
+      <div className={styles.subTabs}>
+        <TabList selectedValue={selectedTab ?? ''} onTabSelect={onTabSelect}>
+          {enabledAreas.map((a) => (
+            <Tab key={a.key} value={a.key}>
+              {a.label}
+            </Tab>
+          ))}
+          <Tab value={LICENCE_TAB}>Licence activity</Tab>
+        </TabList>
+      </div>
 
+      {/* The report-areas load failure is rendered HERE, outside the tab content below, so it stays
+          visible even when the Licence activity tab (which does not depend on the report-area flags)
+          is the selected/default tab. Inside the content switch the Licence branch wins and the error
+          would never show. */}
       {areasError && (
         <MessageBar intent="error" style={{ marginTop: '16px' }}>
-          <MessageBarBody>{areasError}</MessageBarBody>
+          <MessageBarBody>
+            {areasError} This affects only the built-in report charts; the Licence activity tab is unaffected.
+          </MessageBarBody>
         </MessageBar>
       )}
 
       {!areasLoading && !areasError && enabledAreas.length === 0 && (
         <MessageBar intent="info" style={{ marginTop: '16px' }}>
           <MessageBarBody>
-            No reports are available yet because no data imports are enabled. Enable one or more imports (Copilot, usage
-            reports, SharePoint activity, website traffic, Teams calls or emails) in the installer to see reports here.
+            No built-in report charts are available yet because no data imports are enabled. Enable one or more
+            imports (Copilot, usage reports, SharePoint activity, website traffic, Teams calls or emails) in the
+            installer to see them. The Licence activity tab stays visible; open it to see licence and workload
+            activity, and it explains its own prerequisites if the licence import is off.
           </MessageBarBody>
         </MessageBar>
       )}
 
-      {!areasLoading && enabledAreas.length > 0 && selectedArea && (
-        <>
-          {enabledAreas.length > 1 && (
-            <div className={styles.subTabs}>
-              <TabList selectedValue={selectedArea} onTabSelect={onTabSelect}>
-                {enabledAreas.map((a) => (
-                  <Tab key={a.key} value={a.key}>
-                    {a.label}
-                  </Tab>
-                ))}
-              </TabList>
+      {onLicence ? (
+        <Suspense
+          fallback={
+            <div style={{ textAlign: 'center', padding: '32px' }}>
+              <Spinner size={80} label="Loading licence activity..." />
             </div>
-          )}
-
-          {selectedArea === 'copilot-agents' && (
+          }
+        >
+          <LicenceActivityPage />
+        </Suspense>
+      ) : areasLoading ? (
+        <div style={{ textAlign: 'center', padding: '32px' }}>
+          <Spinner size={80} label="Loading reports..." />
+        </div>
+      ) : areasError ? null : selectedTab && enabledAreas.some((a) => a.key === selectedTab) ? (
+        <>
+          {selectedTab === 'copilot-agents' && (
             <div className={styles.controls} style={{ marginTop: '16px', flexWrap: 'wrap' }}>
               <Text size={200} className={styles.muted}>
                 Top agents
@@ -228,10 +259,7 @@ export default function ReportsPage() {
                 placeholder="Filter by agent name"
                 aria-label="Filter Copilot agents by name"
               />
-              <Button
-                size="small"
-                onClick={() => setAgentNameFilter(agentNameDraft.trim())}
-              >
+              <Button size="small" onClick={() => setAgentNameFilter(agentNameDraft.trim())}>
                 Apply
               </Button>
               {agentNameFilter && (
@@ -250,15 +278,15 @@ export default function ReportsPage() {
           )}
 
           <ReportAreaView
-            key={selectedArea}
-            area={selectedArea}
+            key={selectedTab}
+            area={selectedTab as ReportAreaKey}
             months={months}
-            blurb={enabledAreas.find((a) => a.key === selectedArea)?.blurb ?? ''}
+            blurb={enabledAreas.find((a) => a.key === selectedTab)?.blurb ?? ''}
             topAgents={topAgents}
             agentName={agentNameFilter}
           />
         </>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/test/renderWithProvider.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/test/renderWithProvider.tsx
@@ -1,0 +1,19 @@
+import type { ReactElement } from 'react';
+import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+
+/**
+ * Render a component inside the same FluentProvider the real app uses (see src/main.tsx).
+ *
+ * Fluent v9 components read theme tokens and portal context from the provider, and Popover/Tooltip
+ * render into a portal that is parented off it. Rendering them bare "works" but logs noisy context
+ * warnings and can misplace portalled content, so every UI test goes through here.
+ */
+export function renderWithProvider(ui: ReactElement, options?: RenderOptions): RenderResult {
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <FluentProvider theme={webLightTheme}>{children}</FluentProvider>
+    ),
+    ...options,
+  });
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/test/setup.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/test/setup.ts
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Unmount anything a test rendered, so a component left mounted by one test can't leak DOM,
+// timers or module state into the next one.
+afterEach(() => {
+  cleanup();
+});
+
+// jsdom does not implement these browser APIs, and several Fluent UI v9 components touch them on
+// mount (media queries for responsive behaviour, ResizeObserver for overflow/positioning). Without
+// the shims those components throw during render and unrelated tests fail with confusing stacks.
+if (!window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+if (!('ResizeObserver' in window)) {
+  class ResizeObserverStub {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  (window as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/types/licenceActivity.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/types/licenceActivity.ts
@@ -1,0 +1,208 @@
+// Types for the Licence activity report (api/LicenceActivity), issues #436 / #437.
+//
+// These mirror the backend DTOs in Common/Entities/LicenceActivity/LicenceActivityModels.cs and
+// LicenceActivityQuery.cs (serialised camelCase). Two rules are baked into the model itself:
+//   1. UNKNOWN IS NOT ZERO. Every activity distribution carries `zero` (measured: no activity) and
+//      `unknown` (not measured) as SEPARATE counts, and each user's per-workload evidence has a
+//      `status`/`band` that can be "unknown". The UI must keep them visually distinct.
+//   2. NO DISPLAY NAMES. The backend does not import display names, so `LicenceActivityUser` has only
+//      a userPrincipalName. Nothing in the UI may synthesise a name.
+
+/** The five workloads whose activity is distributed separately. Matches LicenceActivityQuery.Workloads. */
+export type WorkloadKey = 'teams' | 'outlook' | 'onedrive' | 'sharepoint' | 'copilot';
+
+export const WORKLOADS: { key: WorkloadKey; label: string }[] = [
+  { key: 'teams', label: 'Teams' },
+  { key: 'outlook', label: 'Outlook' },
+  { key: 'onedrive', label: 'OneDrive' },
+  { key: 'sharepoint', label: 'SharePoint' },
+  { key: 'copilot', label: 'Copilot' },
+];
+
+/** Sort keys accepted by the users endpoint. Note: no "name" - there are no display names to sort by. */
+export type UsersSortKey = 'upn' | 'activity' | 'lastActivity';
+
+export type SortDirection = 'asc' | 'desc';
+
+/** An inclusive UTC date range as `YYYY-MM-DD` strings (the overview `from`/`to` params). */
+export interface DateRange {
+  from: string;
+  to: string;
+}
+
+/** The query the backend actually applied, echoed back on each snapshot. */
+export interface LicenceActivityQueryEcho {
+  from: string;
+  to: string;
+  departmentId: number | null;
+  countryId: number | null;
+  licenceTypeId: number | null;
+  workload: WorkloadKey;
+  search: string;
+  sort: UsersSortKey;
+  direction: SortDirection;
+  top: number;
+  page: number;
+  pageSize: number;
+}
+
+/**
+ * A per-workload activity distribution: how many assigned users fall in each engagement band.
+ *
+ * `zero` (measured inactivity) and `unknown` (no measurement for this user/workload) are deliberately
+ * separate, so the UI can render "not measured" differently from "measured, and it was zero".
+ */
+export interface LicenceActivityDistribution {
+  workload: WorkloadKey | string;
+  high: number;
+  moderate: number;
+  low: number;
+  zero: number;
+  unknown: number;
+}
+
+/** One licence SKU with how many hold it and its five workload distributions. */
+export interface LicenceActivitySku {
+  licenceTypeId: number;
+  name: string;
+  skuId: string | null;
+  assignedUsers: number;
+  workloads: LicenceActivityDistribution[];
+}
+
+/** A demographic slice (department or country): a filter option that also carries its distributions. */
+export interface LicenceActivityDemographic {
+  id: number;
+  name: string;
+  assignedUsers: number;
+  workloads: LicenceActivityDistribution[];
+}
+
+/**
+ * How a single workload's data was sourced for this snapshot, surfaced verbatim so no figure is quoted
+ * without its provenance and freshness. `status` is a backend string (rendered by value); the
+ * sample/user counts say how completely the source covered the scope.
+ */
+export interface LicenceActivityCoverage {
+  workload: WorkloadKey | string;
+  status: string;
+  source: string | null;
+  measure: string | null;
+  granularity: string | null;
+  message: string | null;
+  effectiveFromUtc: string | null;
+  effectiveToUtc: string | null;
+  latestImportUtc: string | null;
+  lagDays: number;
+  reportPeriodDays: number | null;
+  expectedSamples: number;
+  observedSamples: number;
+  unmatchedUsers: number;
+  snapshotDates: string[];
+}
+
+/** Fields on every snapshot: its id (used for the exact-snapshot export) and its lifetime. */
+export interface SnapshotEnvelope {
+  snapshotId: string;
+  generatedUtc: string;
+  /** When the cached snapshot expires; after this the export/users endpoints answer 410. */
+  expiresUtc: string;
+}
+
+/** Which parts of the tool this deployment / signed-in user can see. */
+export interface LicenceActivityAvailability {
+  /** False when the licence import (GraphUsersMetadata) is disabled - the tab stays, the report can't run. */
+  available: boolean;
+  /**
+   * True when the signed-in user holds the opt-in `LicenceActivity.ReadUsers` Entra app role. Gates the
+   * per-user drill-down in the UI; every signed-in user still gets the aggregates. The server enforces
+   * the role on the users/export endpoints regardless of this flag.
+   */
+  canViewUsers: boolean;
+  /** Smallest allowed custom window, in days (backend LicenceActivityQuery.MinimumDays). */
+  minimumDays: number;
+  /** Largest allowed custom window, in days (backend LicenceActivityQuery.MaximumDays). */
+  maximumDays: number;
+  messages: string[];
+}
+
+/** The executive overview: SKU assignments, five workload distributions and per-workload coverage. */
+export interface LicenceActivityOverview extends SnapshotEnvelope {
+  query: LicenceActivityQueryEcho;
+  distinctAssignedUsers: number;
+  licences: LicenceActivitySku[];
+  coverage: LicenceActivityCoverage[];
+  departments: LicenceActivityDemographic[];
+  countries: LicenceActivityDemographic[];
+  /** True when the department/country option lists were capped and are not exhaustive. */
+  demographicsTruncated: boolean;
+  messages: string[];
+}
+
+/** One user's activity evidence for a single workload. */
+export interface LicenceActivityEvidence {
+  workload: WorkloadKey | string;
+  /** Backend status string; "unknown" means not measured (distinct from a measured "zero" band). */
+  status: string;
+  /** Engagement band: high | moderate | low | zero | unknown. */
+  band: string;
+  source: string | null;
+  measure: string | null;
+  activeSamples: number;
+  observedSamples: number;
+  expectedSamples: number;
+  /** Average actions per observed sample, or null when unknown - never treated as 0. */
+  averageActions: number | null;
+  lastActivityUtc: string | null;
+}
+
+/** One user in the drill-down. There is no display name in the schema or import path - identify by
+ * UPN only, and never synthesise a name from it. */
+export interface LicenceActivityUser {
+  userId: number;
+  userPrincipalName: string;
+  department: string | null;
+  country: string | null;
+  accountEnabled: boolean | null;
+  workloads: LicenceActivityEvidence[];
+}
+
+/**
+ * The users snapshot for one licence. A single request returns the bounded most/least active lists
+ * AND the current browse page together, so the Excel export (which references this snapshot id) is
+ * exactly what is on screen.
+ */
+export interface LicenceActivityUsers extends SnapshotEnvelope {
+  overviewId: string;
+  query: LicenceActivityQueryEcho;
+  totalUsers: number;
+  rankedUsers: number;
+  mostActive: LicenceActivityUser[];
+  leastActive: LicenceActivityUser[];
+  users: LicenceActivityUser[];
+  messages: string[];
+}
+
+/** Parameters for the overview request. */
+export interface OverviewParams {
+  from: string;
+  to: string;
+  /** A demographic id, or 0 for the "unknown" bucket. Undefined/null means "all". */
+  departmentId?: number | null;
+  countryId?: number | null;
+}
+
+/** Parameters for the users request (one call returns most/least/browse). */
+export interface UsersParams {
+  overviewId: string;
+  licenceTypeId: number;
+  workload: WorkloadKey;
+  /** Bounds the most/least active lists (1..100). */
+  top: number;
+  search?: string;
+  sort: UsersSortKey;
+  direction: SortDirection;
+  /** 1-based page of the browse list. */
+  page: number;
+  pageSize: number;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/tsconfig.json
+++ b/src/AnalyticsEngine/Web/Scripts/portal/tsconfig.json
@@ -19,5 +19,7 @@
     "esModuleInterop": true,
     "isolatedModules": true
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts"],
+  "//": "Test files and the test harness are checked and run by Vitest (vitest.config.ts), not by the production `tsc --noEmit` build, so exclude them here to keep `npm run build` independent of the test-only toolchain types.",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"]
 }

--- a/src/AnalyticsEngine/Web/Scripts/portal/vitest.config.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+// Vitest config for the portal's UI tests. Kept separate from vite.config.ts so the production
+// build config (base path, output dir) stays focused on shipping assets, and so the test-only
+// jsdom environment and setup file never leak into a real build.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    // The Fluent components pull in a lot of CSS-in-JS; we don't assert on computed styles, so
+    // skipping CSS processing keeps the tests fast without changing what they verify.
+    css: false,
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Controllers\AccountController.cs" />
     <Compile Include="Controllers\BaseAPIController.cs" />
     <Compile Include="Controllers\CopilotAdoptionAPIController.cs" />
+    <Compile Include="Controllers\LicenceActivityAPIController.cs" />
     <Compile Include="Controllers\ImportConfigController.cs" />
     <Compile Include="Controllers\InstallLogAPIController.cs" />
     <Compile Include="Controllers\ProfilingStatusAPIController.cs" />
@@ -231,6 +232,8 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Models\AuthTeamRequest.cs" />
+    <Compile Include="Models\LicenceActivity\LicenceActivitySnapshotCache.cs" />
+    <Compile Include="Models\LicenceActivity\LicenceActivityTelemetry.cs" />
     <Compile Include="Models\CopilotAdoption\CopilotAdoptionAnalysisCoordinator.cs" />
     <Compile Include="Models\CopilotAdoption\CopilotAdoptionTelemetry.cs" />
     <Compile Include="Models\InstallLogModels.cs" />


### PR DESCRIPTION
## What this adds

An always-visible **Licence activity** sub-tab under Reports, answering one question: which licences are assigned, and how much are the people holding them actually using each Microsoft 365 workload.

It reports **distinct current assignments** read from the existing `license_types` / `user_license_type_lookups` tables, where SKUs overlap and one user can hold many. It is deliberately **not** capacity, ownership history, SKU attribution, or a productivity/ROI score. The five workloads (Teams, Outlook, OneDrive, SharePoint, Copilot) are always reported separately and never blended.

**No migration, no schema change, no installer config-schema change** (`CONFIG_VERSION` untouched). Nothing new is imported - this reads what the existing importers already store.

## Merged to dev; stable acceptance remains blocked

This PR was merged into `dev` at `b415bc088a4c7bc3017cc1dfd9c0507121d8e3cc` using the user's explicit admin-override authorisation. That was not approval to merge `main` or to treat performance acceptance as passed. The original LocalDB evidence below is retained as diagnostic history; the subsequent real Azure S4/S6 measurements are recorded at the end of this body and in draft release PR #458. No product schema change, range reduction or production-timeout relaxation was made.

Measured on a synthetic 300,000-user / 50-SKU database (7,800,000 rows in each of the five workload activity tables, 2,060,681 licence assignments), **in both index modes**:

| Scenario | B-tree fallback | Columnstore (production default) | Budget |
|---|---|---|---|
| 7-day adapter overview, first instrumented call | 19,670 ms | **15,203 ms** | HTTP target: 15,000 ms; this row is not an HTTP measurement |
| 7-day adapter overview, warm median (n=3) | 12,721 ms | 10,985 ms | - |
| 7-day logical reads | 1,011,562 | 1,011,562 | - |
| **180-day adapter overview** | **Execution Timeout Expired** | **Execution Timeout Expired** | 20,000 ms command timeout |

The 180-day window is an **offered preset**, and it exceeds the 20-second per-command production timeout (`LicenceActivitySql.CommandTimeoutSeconds`) in both index modes. Columnstore is the production index shape because `202608310800001_ColumnstoreUsageReportMetrics` is already on `dev`. Its observed 7-day first-call elapsed time was lower, but these shared-VM runs do not isolate an index-only causal improvement; the 180-day timeout occurred in both modes.

### Honest caveats on those numbers

These were audited by a separate reviewer specifically to stop me overclaiming, and several of my first-draft claims did not survive:

- This is **LocalDB, not Azure SQL**. Treat it as a relative signal, not a production SLA.
- "Cold" in the table means the **first adapter call in the measurement process**, not an HTTP response, a cold deployed web process, or a cold SQL buffer pool. The harness deliberately does not run `DBCC DROPCLEANBUFFERS`; SQL buffer and plan caches are retained/uncontrolled.
- Cold runs carry `SET STATISTICS IO/TIME` overhead; the warm median does not. The two are not perfectly comparable, and `logicalReads` comes from a separate instrumented call.
- The five workload loads run **concurrently at MAXDOP 1**, so per-operation elapsed **overlaps and is not additive**.
- Under the 600-second test-only diagnostic timeout the 180-day window returns in 106,095 ms, with the heaviest statements at about 37 s CPU vs about 90 s elapsed and about 82k logical reads each. **I first read that as tempdb spilling; that is not supported.** The CPU/elapsed gap alone does not distinguish CPU scheduling, memory-grant waits, I/O, blocking or spilling. Concurrent work can affect elapsed time; root cause and quiet acceptance remain unproven.
- No schema or production timeout was changed. The diagnostic probe explicitly used a 600-second test-only command timeout to collect failure evidence; that path reports **Inconclusive**, never Passed and never acceptance.

## Correctness properties that drove the design

- **Unknown is never rendered as zero.** A licensed user with no activity row is *unknown*; a user with a complete set of explicit zero rows is a *measured zero*, and only the latter may be ranked least-active.
- **Most/least active (1..100 inclusive) are always ranked by the selected workload**; the sort parameter affects the browse list only.
- M365 snapshot counters are **averages over the settled window, never a sum of daily events**. Copilot pins the actual date and period, requires a fully contained D7 window, and treats v1 frequency as unknown.
- Windows are inclusive UTC, 7..180 days ending before today; default 28 days ending the latest settled Sunday. **Custom ranges are never rounded.**
- There is no user displayName in the product, so search is by UPN/mail only and the UI never invents one.

## Access

Aggregates are available to every already-authenticated portal user. Individual detail and individual export require the optional Entra app role **`LicenceActivity.ReadUsers`**; without it the tab degrades to aggregates rather than disappearing. The role is **re-checked at export time**, so a snapshot minted while the role was held cannot be exported after it is revoked. This does not change authorization for any other portal area.

## Boundedness

16 overview snapshots (5 min) and 32 user snapshots (2 min, capped to the parent overview lifetime), four shared report loads, a 30-second admission deadline, 503 plus `Retry-After: 5` when busy, 410 for an expired snapshot, 409 for a snapshot mismatch. No session state, no 202 polling. Telemetry is allow-listed and sanitised - no search term, UPN or filter value reaches it.

## Tests

- **18** SQL semantics tests against a scratch database (dedup of overlapping memberships, unknown vs measured zero, Copilot coverage cases, deterministic tie-breaking, SKU cap, demographic bounding).
- **28** pure API/cache/domain/lifecycle tests (deadline, retained slot, late-generation eviction, telemetry flush, export 410/409).
- **85** portal tests, plus `tsc --noEmit` and `vite build` clean.
- An opt-in release-scale harness that now reports **Inconclusive** rather than Passed when it asserts nothing.

## Review rounds

Four independent models reviewed round 1 (backend correctness, upgrade/operability, UX, security/privacy). Backend, upgrade and security came back clean; UX found real defects, fixed here. Round 2 then found a **blocker in my own round-1 fix** - the search sanitiser called `.trim()` on every keystroke, making the space bar unusable - fixed and pinned with a keystroke-by-keystroke test.

## Reviewer hotspots

- `LicenceActivitySql.cs` (large): the wide-window score path is where the timeout lives.
- `LicenceActivitySnapshotCache.cs`: admission deadline, slot retention, late-generation publication.
- `LicenceActivityAPIController.cs`: role re-check on export and the cache scope derivation.

Addresses #436
Addresses #437

Diff: 65 files changed, 15708 insertions(+), 94 deletions(-)


## Final checkpoint and acceptance status

Feature source head: `f94fb84fe7e45f4efec3b2062cb01ba13db83769`; 3 commits, now merged into `dev` as `b415bc08`. Required CI is green. The user explicitly authorised the admin override for the dev merge; `main` remains untouched. The feature is actually included in **draft release PR #458**, whose performance hold is explicit. The later critique iterations fixed sequential-space typing and C1 control-character handling; those repairs are included at this head.

## Completed Azure SQL performance review: S4 / 200 DTUs and S6 / 400 DTUs

The user authorised a new isolated Azure benchmark environment, followed by mandatory deletion. The same verified synthetic corpus was tested sequentially on the two actual service objectives: 300,000 users, 50 SKUs, 2,060,681 current assignment links and 39 million workload rows. Product `b415bc08` was tested without schema, range, interface or production-timeout changes. Draft optimisation candidate #457 was **not** part of this Azure run.

**Both tiers failed acceptance.** The complete matrix requires 1,500 cold user cases and 1,500 immediate warm partners per tier; each tier completed the 750 narrow-window pairs, then stopped at the first exact 180-day overview returning 503. The measured process-memory growth also exceeded the predeclared 128-MiB limit.

| Measured case | S4 / 200 DTUs | S6 / 400 DTUs |
|---|---:|---:|
| Instrumented isolated 7-day cold HTTP median / max | 11.937 / 12.429 s | 7.341 / 7.910 s |
| Immediate warm overview median / max | 2 / 3 ms | 2 / 3 ms |
| Cold overview logical reads | 1,330,799 | 1,330,799 |
| Exact 180-day HTTP median / max, all 503 | 23.026 / 23.036 s | 21.736 / 21.755 s |
| Narrow cold users median / p95 / max | 2.559 / 5.970 / 8.399 s | 2.039 / 5.284 / 11.014 s |
| Narrow warm users median / p95 / max | 8 / 14 / 80 ms | 8 / 21 / 142 ms |
| Maximum user JSON | 489,852 bytes | 489,852 bytes |
| Four distinct cold loads, max group latency | 12.446 s | 8.250 s |
| Eight duplicate cold callers, max latency | 7.822 s | 6.381 s |
| Excel snapshot max latency | 189 ms | 169 ms |
| Managed / private process growth | 135.4 / 146.6 MiB | 152.4 / 160.5 MiB |
| Completed cold/warm pairs | 750 / 1,500 | 750 / 1,500 |

Warm views and Excel exports issued zero SQL loads/reads. Duplicate cold callers shared one store load; cancellation left the surviving caller successful. All narrow-window deep-page/search/demographic cases completed.

These HTTP measurements use the real attributed API/cache/store/export in a shared .NET Framework client/server test process, including the SQL network path and `STATISTICS IO/TIME`. SQL buffers and plan caches were retained/uncontrolled; this was not a SQL-cold or IIS/App Service/Entra deployment test. Crucially, the first following **uninstrumented** 7-day adapter repeat timed out at both tiers, so the instrumented narrow medians are not proof of reliable uninstrumented performance. No three-successful-repeat uninstrumented adapter median exists.

Actual plans captured wide per-sample hash-aggregation spills downstream of a fast existing columnstore scan, and wide common/tenant Teams queries selected millions of clustered-key lookups plus a sort spill despite an existing covering columnstore path. Query Store also captured plan differences for aborted single-sample Copilot statements. These establish optimisation targets, not that a permanent index or migration is necessary. A separately reviewed fix and new before/after measurements are still required.

All benchmark databases, logical servers, perimeter resources and dedicated resource groups were deleted. Independent Azure API reads confirmed every owned group absent; protected connection/token state was cleared. No customer/production data or existing resources were used.

The full evidence and stable-release hold are summarised in #458. Neither that release PR nor candidate #457 is authorised for an automatic merge.
