### PR TITLE
Improve licence query performance and snapshot consistency (acceptance pending)

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -87,6 +87,16 @@ namespace Common.Entities.LicenceActivity
                         SampleParameterName(workload, index));
                 }
             }
+            sql.Append(@"
+UPDATE #Samples
+SET m365_from = CASE WHEN DATEADD(DAY,
+        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), sample_date) % 7) + 7) % 7),
+        sample_date) < @from THEN @from ELSE DATEADD(DAY,
+        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), sample_date) % 7) + 7) % 7),
+        sample_date) END,
+    end_exclusive = DATEADD(DAY, 1, sample_date),
+    copilot_from = DATEADD(DAY, -6, sample_date);
+");
         }
 
         internal static string BuildUsers(
@@ -296,6 +306,19 @@ WHERE (@departmentId IS NULL
   AND EXISTS
       (SELECT 1 FROM dbo.user_license_type_lookups AS owned WHERE owned.user_id = u.id)
 OPTION (RECOMPILE);
+
+-- This shared, connection-scoped index enables batch aggregation without altering source tables.
+-- Editions that cannot index temporary tables as columnstores retain the rowstore primary key.
+IF (SELECT COUNT(*) FROM " + tableName + @") >= 32768
+BEGIN
+    BEGIN TRY
+        EXEC sp_executesql N'CREATE NONCLUSTERED COLUMNSTORE INDEX IX_LicenceActivity_EligibleBatch
+            ON " + tableName + @" (user_id, department_id, country_id);';
+    END TRY
+    BEGIN CATCH
+        PRINT N'Licence activity is using rowstore temporary eligibility.';
+    END CATCH;
+END;
 ");
             if (bandTables != null)
             {
@@ -1113,48 +1136,38 @@ BEGIN
         ;WITH PerSample AS
         (
             SELECT activity.user_id,
-                       activity.[date] AS sample_date,
-                       MAX(CASE
-                               WHEN activity.last_activity_date >=
-                                    CASE WHEN report_week.week_start < @from
-                                         THEN @from ELSE report_week.week_start END
-                                AND activity.last_activity_date < DATEADD(DAY, 1, activity.[date])
-                               THEN 1 ELSE 0
-                           END) AS was_active
-            FROM {1} AS activity
-            JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
-            CROSS APPLY
-            (
-                    SELECT DATEADD(
-                        DAY, 1 - DATEPART(WEEKDAY, activity.[date]), activity.[date]) AS week_start
-            ) AS report_week
-            WHERE activity.[date] >= @from
+                   chosen.sample_date,
+                   MAX(CASE WHEN activity.last_activity_date >= weeks.m365_from
+                             AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
+                            THEN 1 ELSE 0 END) AS was_active
+            FROM #Samples AS chosen
+            JOIN #Weeks AS weeks
+              ON chosen.sample_date = weeks.m365_to
+            JOIN {1} AS activity
+              ON CAST(activity.[date] AS date) = chosen.sample_date
+            WHERE chosen.workload = {0}
+              AND activity.[date] >= @from
               AND activity.[date] < @endExclusive
-              AND activity.[date] < DATEADD(DAY, 1, @settled)
-              AND
-              (
-                      activity.[date] = @to
-                      OR DATEPART(WEEKDAY, activity.[date]) = 7
-              )
-            GROUP BY activity.user_id, activity.[date]
+            GROUP BY activity.user_id, chosen.sample_date
         ),
         PerUser AS
         (
             SELECT user_id,
-                       SUM(was_active) AS active_samples,
-                       COUNT(*) AS observed_samples
+                   SUM(was_active) AS active_samples,
+                   COUNT(*) AS observed_samples
             FROM PerSample
             GROUP BY user_id
         )
         INSERT #Scores
             (workload, user_id, active_samples, observed_samples, frequency_known)
         SELECT {0},
-                   user_id,
+                   per_user.user_id,
                    active_samples,
                    observed_samples,
                    CAST(CASE WHEN observed_samples = @expected{0}
                              THEN 1 ELSE 0 END AS bit)
-        FROM PerUser
+        FROM PerUser AS per_user
+        JOIN #EligibleUsers AS eligible ON eligible.user_id = per_user.user_id
         OPTION (RECOMPILE, MAXDOP 1);
     END;
 END;
@@ -1508,6 +1521,8 @@ BEGIN
         BEGIN
             IF @copilotD7Expected = 1
             BEGIN
+                DECLARE @copilotSingleSample date =
+                    (SELECT sample_date FROM #Samples WHERE workload = 5);
                 INSERT #Scores
                     (workload, user_id, active_samples, observed_samples, frequency_known)
                 SELECT 5,
@@ -1526,12 +1541,10 @@ BEGIN
                            THEN 1 ELSE 0
                        END AS bit)
                 FROM dbo.copilot_usage_user_activity_log AS report
-                JOIN #Samples AS chosen
-                  ON chosen.workload = 5
-                 AND report.[date] >= chosen.sample_date
-                 AND report.[date] < DATEADD(DAY, 1, chosen.sample_date)
                 JOIN #EligibleUsers AS eligible ON eligible.user_id = report.user_id
                 WHERE report.report_period_days = 7
+                  AND report.[date] >= @copilotSingleSample
+                  AND report.[date] < DATEADD(DAY, 1, @copilotSingleSample)
                 OPTION (RECOMPILE, MAXDOP 1);
             END
             ELSE
@@ -1553,24 +1566,21 @@ BEGIN
                        COUNT(*),
                        CAST(CASE
                                 WHEN COUNT(*) = @copilotD7Expected
-                                 AND COUNT(report.active_usage_days) = COUNT(*)
-                                 AND MIN(report.active_usage_days) >= 0
-                                 AND MAX(report.active_usage_days) <= 7
-                                 AND (COUNT(report.prompts_all_apps) = 0
-                                      OR MIN(report.prompts_all_apps) >= 0)
+                                 AND MIN(CASE WHEN report.active_usage_days BETWEEN 0 AND 7
+                                               AND (report.prompts_all_apps IS NULL
+                                                    OR report.prompts_all_apps >= 0)
+                                              THEN 1 ELSE 0 END) = 1
                                 THEN 1 ELSE 0
                             END AS bit)
                 FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(0))
+                JOIN #Samples AS chosen
+                  ON chosen.workload = 5
+                 AND CAST(report.[date] AS date) = chosen.sample_date
                 JOIN #EligibleUsers AS eligible ON eligible.user_id = report.user_id
                 WHERE report.report_period_days = 7
                   AND report.[date] >= DATEADD(DAY, 6, @from)
                   AND report.[date] < @endExclusive
                   AND report.[date] < DATEADD(DAY, 1, @settled)
-                  AND
-                  (
-                      report.[date] = @to
-                      OR DATEPART(WEEKDAY, report.[date]) = 7
-                  )
                 GROUP BY report.user_id
                 OPTION (RECOMPILE, MAXDOP 4);
             END
@@ -2488,6 +2498,17 @@ WHERE owned.license_type_id = @licenceTypeId
        OR u.mail LIKE @searchPattern ESCAPE N'\')
 OPTION (RECOMPILE);
 
+IF (SELECT COUNT(*) FROM #EligibleUsers) >= 32768
+BEGIN
+    BEGIN TRY
+        EXEC sp_executesql N'CREATE NONCLUSTERED COLUMNSTORE INDEX IX_LicenceActivity_EligibleBatch
+            ON #EligibleUsers (user_id);';
+    END TRY
+    BEGIN CATCH
+        PRINT N'Licence activity is using rowstore temporary eligibility.';
+    END CATCH;
+END;
+
 CREATE TABLE #Coverage
 (
     workload tinyint NOT NULL PRIMARY KEY,
@@ -2514,6 +2535,9 @@ CREATE TABLE #Samples
 (
     workload tinyint NOT NULL,
     sample_date date NOT NULL,
+    m365_from date NULL,
+    end_exclusive date NULL,
+    copilot_from date NULL,
     PRIMARY KEY (workload, sample_date)
 );
 
@@ -2546,41 +2570,25 @@ CREATE TABLE #Scores
 ;WITH PerSample AS
 (
     SELECT activity.user_id,
-           CAST(activity.[date] AS date) AS sample_date,
+           chosen.sample_date,
            MAX({2}) AS actions,
            MAX(CASE
-                   WHEN activity.last_activity_date >= @from
-                    AND activity.last_activity_date < @endExclusive
-                    AND activity.last_activity_date < DATEADD(DAY, 1, CAST(activity.[date] AS date))
-                    AND activity.last_activity_date >= DATEADD(DAY,
-                        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
-                        CAST(activity.[date] AS date))
-                    AND activity.last_activity_date < DATEADD(DAY, 7,
-                        DATEADD(DAY,
-                            -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
-                            CAST(activity.[date] AS date)))
+                   WHEN activity.last_activity_date >= chosen.m365_from
+                    AND activity.last_activity_date < chosen.end_exclusive
                    THEN activity.last_activity_date
                END) AS last_activity_utc,
            MAX(CASE
-                   WHEN activity.last_activity_date >= @from
-                    AND activity.last_activity_date < @endExclusive
-                    AND activity.last_activity_date < DATEADD(DAY, 1, CAST(activity.[date] AS date))
-                    AND activity.last_activity_date >= DATEADD(DAY,
-                        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
-                        CAST(activity.[date] AS date))
-                    AND activity.last_activity_date < DATEADD(DAY, 7,
-                        DATEADD(DAY,
-                            -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
-                            CAST(activity.[date] AS date)))
+                   WHEN activity.last_activity_date >= chosen.m365_from
+                    AND activity.last_activity_date < chosen.end_exclusive
                    THEN 1 ELSE 0
                END) AS was_active
     FROM {1} AS activity
     JOIN #Samples AS chosen
       ON chosen.workload = {0}
-     AND activity.[date] >= chosen.sample_date
-     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
+     AND CAST(activity.[date] AS date) = chosen.sample_date
     JOIN {3} AS eligible ON eligible.user_id = activity.user_id
-    GROUP BY activity.user_id, CAST(activity.[date] AS date)
+    WHERE activity.[date] >= @from AND activity.[date] < @endExclusive
+    GROUP BY activity.user_id, chosen.sample_date
 )
 INSERT #Scores
     (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
@@ -2608,7 +2616,32 @@ OPTION (RECOMPILE);
                 && coverage.ReportPeriodDays.HasValue)
             {
                 if (coverage.ReportPeriodDays.Value == 7)
-                    sql.Append(CopilotD7Users.Replace("#ActivityScope", scopeTable));
+                {
+                    if (scopeTable == "#ReturnedUsers")
+                    {
+                        sql.Append(@"
+CREATE TABLE #CopilotReportIds (id int NOT NULL PRIMARY KEY);
+INSERT #CopilotReportIds (id)
+SELECT report.id
+FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(IX_date_user_id_report_period_days))
+JOIN #Samples AS chosen
+  ON chosen.workload = 5
+ AND report.[date] >= chosen.sample_date
+ AND report.[date] < DATEADD(DAY, 1, chosen.sample_date)
+JOIN #ReturnedUsers AS eligible ON eligible.user_id = report.user_id
+WHERE report.report_period_days = 7
+OPTION (RECOMPILE);
+");
+                        sql.Append(CopilotD7Users.Replace(
+                            "AS report WITH (INDEX(0))",
+                            "AS report JOIN #CopilotReportIds AS ids ON ids.id = report.id")
+                            .Replace("#ActivityScope", scopeTable));
+                    }
+                    else
+                    {
+                        sql.Append(CopilotD7Users.Replace("#ActivityScope", scopeTable));
+                    }
+                }
                 else
                     sql.Append(CopilotLongUsers.Replace("#ActivityScope", scopeTable));
                 return;
@@ -2625,14 +2658,18 @@ OPTION (RECOMPILE);
         }
 
         private static readonly string CopilotD7Users = @"
+DECLARE @copilotSampleFrom date =
+    (SELECT MIN(sample_date) FROM #Samples WHERE workload = 5);
+DECLARE @copilotSampleEnd date =
+    (SELECT MAX(end_exclusive) FROM #Samples WHERE workload = 5);
 INSERT #Scores
     (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
 SELECT 5, report.user_id,
        SUM(CASE
                WHEN report.active_usage_days BETWEEN 1 AND 7
                  OR report.prompts_all_apps > 0
-                 OR (report.last_activity_date >= DATEADD(DAY, -6, CAST(report.[date] AS date))
-                     AND report.last_activity_date < DATEADD(DAY, 1, CAST(report.[date] AS date)))
+                 OR (report.last_activity_date >= chosen.copilot_from
+                     AND report.last_activity_date < chosen.end_exclusive)
                THEN 1 ELSE 0
            END),
        COUNT(*),
@@ -2651,17 +2688,18 @@ SELECT 5, report.user_id,
                THEN AVG(CAST(report.prompts_all_apps AS float))
        END,
        MAX(CASE
-               WHEN report.last_activity_date >= DATEADD(DAY, -6, CAST(report.[date] AS date))
-                AND report.last_activity_date < DATEADD(DAY, 1, CAST(report.[date] AS date))
+               WHEN report.last_activity_date >= chosen.copilot_from
+                AND report.last_activity_date < chosen.end_exclusive
                THEN report.last_activity_date
            END)
 FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(0))
 JOIN #Samples AS chosen
   ON chosen.workload = 5
- AND report.[date] >= chosen.sample_date
- AND report.[date] < DATEADD(DAY, 1, chosen.sample_date)
+ AND CAST(report.[date] AS date) = chosen.sample_date
 JOIN #ActivityScope AS eligible ON eligible.user_id = report.user_id
 WHERE report.report_period_days = 7
+  AND report.[date] >= @copilotSampleFrom
+  AND report.[date] < @copilotSampleEnd
 GROUP BY report.user_id
 OPTION (RECOMPILE);
 ";

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -1118,7 +1118,8 @@ BEGIN
                        THEN 1 ELSE 0
                    END),
                1,
-               CAST(CASE WHEN COUNT(*) = 1 THEN 1 ELSE 0 END AS bit)
+               -- One pinned sample day: GROUP BY user already collapses duplicate report rows.
+               CAST(1 AS bit)
         FROM #Samples AS chosen
         JOIN #Weeks AS weeks
           ON chosen.sample_date >= weeks.m365_from
@@ -1394,6 +1395,20 @@ FROM PerUser
 OPTION (RECOMPILE);
 ";
 
+        private static string CopilotD7ActivityExpression(string from, string endExclusive)
+        {
+            // Counters describe this period; the user-level date is only a v1-shaped fallback.
+            return @"CASE
+                WHEN report.active_usage_days BETWEEN 1 AND 7
+                  OR report.prompts_all_apps > 0 THEN 1
+                WHEN report.active_usage_days IS NULL
+                 AND report.prompts_all_apps IS NULL
+                 AND report.last_activity_date >= " + from + @"
+                 AND report.last_activity_date < " + endExclusive + @" THEN 1
+                ELSE 0
+            END";
+        }
+
         private static readonly string CopilotOfficialOverview = @"
 DECLARE @copilotLogImported datetime = NULL;
 DECLARE @copilotLogObfuscated bit = 0;
@@ -1527,13 +1542,8 @@ BEGIN
                     (workload, user_id, active_samples, observed_samples, frequency_known)
                 SELECT 5,
                        report.user_id,
-                       CASE
-                           WHEN report.active_usage_days BETWEEN 1 AND 7
-                             OR report.prompts_all_apps > 0
-                             OR (report.last_activity_date >= DATEADD(DAY, -6, report.[date])
-                                 AND report.last_activity_date < DATEADD(DAY, 1, report.[date]))
-                           THEN 1 ELSE 0
-                       END,
+                       " + CopilotD7ActivityExpression(
+                           "DATEADD(DAY, -6, report.[date])", "DATEADD(DAY, 1, report.[date])") + @",
                        1,
                        CAST(CASE
                            WHEN report.active_usage_days BETWEEN 0 AND 7
@@ -1552,17 +1562,8 @@ BEGIN
                 INSERT #Scores
                     (workload, user_id, active_samples, observed_samples, frequency_known)
                 SELECT 5, report.user_id,
-                       SUM(CASE
-                               WHEN report.active_usage_days BETWEEN 1 AND 7
-                                 OR report.prompts_all_apps > 0
-                               THEN 1
-                               WHEN report.active_usage_days IS NULL
-                                AND report.prompts_all_apps IS NULL
-                                AND report.last_activity_date >= DATEADD(DAY, -6, report.[date])
-                                AND report.last_activity_date < DATEADD(DAY, 1, report.[date])
-                               THEN 1
-                               ELSE 0
-                           END),
+                       SUM(" + CopilotD7ActivityExpression(
+                           "DATEADD(DAY, -6, report.[date])", "DATEADD(DAY, 1, report.[date])") + @"),
                        COUNT(*),
                        CAST(CASE
                                 WHEN COUNT(*) = @copilotD7Expected
@@ -2665,13 +2666,7 @@ DECLARE @copilotSampleEnd date =
 INSERT #Scores
     (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
 SELECT 5, report.user_id,
-       SUM(CASE
-               WHEN report.active_usage_days BETWEEN 1 AND 7
-                 OR report.prompts_all_apps > 0
-                 OR (report.last_activity_date >= chosen.copilot_from
-                     AND report.last_activity_date < chosen.end_exclusive)
-               THEN 1 ELSE 0
-           END),
+       SUM(" + CopilotD7ActivityExpression("chosen.copilot_from", "chosen.end_exclusive") + @"),
        COUNT(*),
        CAST(CASE
                 WHEN COUNT(*) = @expected5

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
@@ -11,8 +11,9 @@ using System.Threading.Tasks;
 namespace Common.Entities.LicenceActivity
 {
     /// <summary>
-    /// Bounded ADO.NET adapter for licence activity. Each call owns one short-lived SQL connection and
-    /// executes one batch; no EF context or request synchronization context is shared.
+    /// Bounded ADO.NET adapter for licence activity. User calls own one connection and batch; overview
+    /// calls own a shared-scope connection and independently bounded workload connections.
+    /// No EF context or request synchronization context is shared.
     /// </summary>
     public sealed class SqlLicenceActivityStore : ILicenceActivityStore
     {
@@ -148,6 +149,7 @@ namespace Common.Entities.LicenceActivity
                     var sqlWatch = Stopwatch.StartNew();
                     diagnostics.Stage("UsersSqlStarted");
 
+                    using (_instrumentation?.TrackCommand())
                     using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                     {
                         var materialisationWatch = Stopwatch.StartNew();
@@ -192,7 +194,8 @@ namespace Common.Entities.LicenceActivity
                 })
                 {
                     AddScopeParameters(command, query, sources);
-                    await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                    using (_instrumentation?.TrackCommand())
+                        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 }
                 return connection;
             }
@@ -203,7 +206,7 @@ namespace Common.Entities.LicenceActivity
             }
         }
 
-        private static Task DropSharedEligibleUsersAsync(
+        private Task DropSharedEligibleUsersAsync(
             SqlConnection connection,
             string tableName)
         {
@@ -213,7 +216,8 @@ namespace Common.Entities.LicenceActivity
                 CommandTimeout = LicenceActivitySql.CommandTimeoutSeconds
             })
             {
-                command.ExecuteNonQuery();
+                using (_instrumentation?.TrackCommand())
+                    command.ExecuteNonQuery();
             }
             return Task.CompletedTask;
         }
@@ -508,6 +512,7 @@ namespace Common.Entities.LicenceActivity
                             })
                             {
                                 AddScopeParameters(command, query, sources);
+                                using (_instrumentation?.TrackCommand())
                                 using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                                     return await materialize(reader).ConfigureAwait(false);
                             }
@@ -1327,5 +1332,27 @@ namespace Common.Entities.LicenceActivity
         internal Action<string, long> OperationCompleted { get; set; }
         internal Action<string> ShowplanReceived { get; set; }
         internal int? CommandTimeoutSeconds { get; set; }
+        internal Action<bool> CommandActiveChanged { get; set; }
+
+        internal IDisposable TrackCommand()
+        {
+            return new CommandLifetime(CommandActiveChanged);
+        }
+
+        private sealed class CommandLifetime : IDisposable
+        {
+            private readonly Action<bool> _changed;
+
+            internal CommandLifetime(Action<bool> changed)
+            {
+                _changed = changed;
+                _changed?.Invoke(true);
+            }
+
+            public void Dispose()
+            {
+                _changed?.Invoke(false);
+            }
+        }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityPerformanceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityPerformanceTests.cs
@@ -99,21 +99,68 @@ namespace Tests.UnitTests
                             "wide",
                             StringComparison.OrdinalIgnoreCase);
                         var diagnosticQuery = diagnosticWide ? wideQuery : narrowQuery;
+                        if (int.TryParse(Environment.GetEnvironmentVariable(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_DEPARTMENT"), out var diagnosticDepartment))
+                        {
+                            diagnosticQuery = LicenceActivityQuery.Create(
+                                diagnosticQuery.From, diagnosticQuery.To, LicenceActivitySqlFixture.NowUtc,
+                                departmentId: diagnosticDepartment);
+                        }
                         var diagnosticScenario = diagnosticWide
                             ? "overview-wide-180d"
                             : "overview-narrow-7d";
+                        if (string.Equals(Environment.GetEnvironmentVariable(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_HTTP"), "1", StringComparison.Ordinal))
+                        {
+                            await DiagnoseHttpOverview(fixture, diagnosticQuery, sources);
+                            Assert.Inconclusive(
+                                "HTTP overview preflight only, with production SQL/response limits; "
+                                + "the complete acceptance matrix has NOT run.");
+                        }
                         var diagnostic = new LicenceActivitySqlMeasurement();
+                        var diagnosticUsers = string.Equals(
+                            Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_USERS"),
+                            "1", StringComparison.Ordinal);
+                        LicenceActivityOverview diagnosticOverview = null;
+                        if (diagnosticUsers)
+                        {
+                            diagnosticOverview = await fixture.Store(new SqlLicenceActivityStoreInstrumentation
+                                { CommandTimeoutSeconds = diagnosticTimeout })
+                                .LoadOverviewAsync(diagnosticQuery, sources,
+                                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                            diagnosticScenario = "users-" + diagnosticScenario;
+                        }
                         var includeShowplan = string.Equals(
                             Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_SHOWPLAN"),
                             "1",
                             StringComparison.Ordinal);
                         var diagnosticWatch = Stopwatch.StartNew();
-                        await fixture.Store(diagnostic.Instrumentation(
-                                includeShowplan: includeShowplan,
-                                commandTimeoutSeconds: diagnosticTimeout))
-                            .LoadOverviewAsync(
+                        var diagnosticStore = fixture.Store(diagnostic.Instrumentation(
+                            includeShowplan: includeShowplan, commandTimeoutSeconds: diagnosticTimeout));
+                        if (diagnosticUsers)
+                        {
+                            var sku = int.TryParse(Environment.GetEnvironmentVariable(
+                                "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_SKU"), out var configuredSku) ? configuredSku : 2;
+                            var workload = Environment.GetEnvironmentVariable(
+                                "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_WORKLOAD") ?? "teams";
+                            var users = await diagnosticStore.LoadUsersAsync(diagnosticOverview,
+                                diagnosticQuery.ForUsers(sku, workload, null, "activity", "desc",
+                                    100, 1, 100, LicenceActivitySqlFixture.NowUtc),
+                                sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                            var licence = diagnosticOverview.Licences.Single(l => l.LicenceTypeId == sku);
+                            var distribution = licence.Workloads.Single(w => w.Workload == workload);
+                            var positive = distribution.High + distribution.Moderate + distribution.Low;
+                            Assert.AreEqual(licence.AssignedUsers, users.TotalUsers);
+                            Assert.AreEqual(Math.Min(100, positive + distribution.Zero), users.LeastActive.Count);
+                            Assert.IsTrue(users.MostActive.Count >= Math.Min(100, positive));
+                            diagnosticScenario += "-sku" + sku + "-" + workload;
+                        }
+                        else
+                        {
+                            await diagnosticStore.LoadOverviewAsync(
                                 diagnosticQuery, sources,
                                 NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                        }
                         diagnosticWatch.Stop();
                         Console.WriteLine(
                             "LICENCE_ACTIVITY_PERF_DIAGNOSTIC scenario={0} elapsedMs={1} logicalReads={2} readsByOperation={3} operations={4}",
@@ -134,6 +181,10 @@ namespace Tests.UnitTests
                                         message.Split(
                                             (char[])null,
                                             StringSplitOptions.RemoveEmptyEntries)))));
+                        Console.WriteLine(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC innerSqlPeakCommands={0} innerSqlPeakConnections={1} activeCommands={2} activeConnections={3}",
+                            diagnostic.PeakCommands, diagnostic.PeakConnections,
+                            diagnostic.ActiveCommands, diagnostic.ActiveConnections);
                         if (includeShowplan)
                         {
                             Console.WriteLine(
@@ -247,13 +298,16 @@ namespace Tests.UnitTests
                     () => loadMeasurement.TotalLogicalReads,
                     message => Console.WriteLine("LICENCE_ACTIVITY_PERF " + message));
                     Console.WriteLine(
-                        "LICENCE_ACTIVITY_PERF httpLoadMs={0} assignments={1} peakConcurrentSql={2} "
-                        + "managedHeapDelta={3} privateMemoryDelta={4}",
+                        "LICENCE_ACTIVITY_PERF httpLoadMs={0} assignments={1} peakSharedReportLoads={2} "
+                        + "managedHeapDelta={3} privateMemoryDelta={4} innerSqlPeakCommands={5} innerSqlPeakConnections={6}",
                         load.ElapsedMs,
                         load.Assignments,
                         load.PeakConcurrentSqlLoads,
                         load.ManagedHeapDeltaBytes,
-                        load.PrivateMemoryDeltaBytes);
+                        load.PrivateMemoryDeltaBytes,
+                        loadMeasurement.PeakCommands, loadMeasurement.PeakConnections);
+                    Assert.AreEqual(0, loadMeasurement.ActiveCommands);
+                    Assert.AreEqual(0, loadMeasurement.ActiveConnections);
                 }
             }
             finally
@@ -330,6 +384,45 @@ namespace Tests.UnitTests
                 measurement.PlanCount,
                 measurement.Operators);
             return measurement;
+        }
+
+        private static async Task DiagnoseHttpOverview(
+            LicenceActivitySqlFixture fixture, LicenceActivityQuery query, LicenceActivitySources sources)
+        {
+            var measurement = new LicenceActivitySqlMeasurement();
+            var clock = Stopwatch.StartNew();
+            using (var host = new LicenceActivityHttpHost(
+                fixture.Store(measurement.Instrumentation(includeShowplan: false)), sources,
+                () => sources.NowUtc.Add(clock.Elapsed)))
+            {
+                var path = "api/LicenceActivity/overview?from=" + query.From + "&to=" + query.To;
+                if (query.DepartmentId.HasValue) path += "&departmentId=" + query.DepartmentId.Value;
+                if (query.CountryId.HasValue) path += "&countryId=" + query.CountryId.Value;
+                foreach (var temperature in new[] { "cold", "warm" })
+                {
+                    var reads = measurement.TotalLogicalReads;
+                    var watch = Stopwatch.StartNew();
+                    using (var response = await host.Client.GetAsync(path))
+                    {
+                        var content = await response.Content.ReadAsByteArrayAsync();
+                        watch.Stop();
+                        Console.WriteLine(
+                            "LICENCE_ACTIVITY_PERF_HTTP_PREFLIGHT state={0} status={1} elapsedMs={2} bytes={3} logicalReads={4} innerSqlPeakCommands={5} innerSqlPeakConnections={6}",
+                            temperature, (int)response.StatusCode, watch.ElapsedMilliseconds, content.Length,
+                            measurement.TotalLogicalReads - reads, measurement.PeakCommands, measurement.PeakConnections);
+                        if (!response.IsSuccessStatusCode) break;
+                        if (temperature == "warm")
+                            Assert.AreEqual(0L, measurement.TotalLogicalReads - reads,
+                                "A warm preflight must not re-read SQL.");
+                    }
+                }
+                var drain = Stopwatch.StartNew();
+                while ((measurement.ActiveCommands != 0 || measurement.ActiveConnections != 0)
+                    && drain.Elapsed < TimeSpan.FromMinutes(1))
+                    await Task.Delay(50);
+                Assert.AreEqual(0, measurement.ActiveCommands);
+                Assert.AreEqual(0, measurement.ActiveConnections);
+            }
         }
 
         private static void AssertMeasured(Measurement measurement)

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
@@ -891,6 +891,10 @@ DROP TABLE #SyntheticSamples;";
         private const int MaximumRetainedMessages = 128;
         private long _totalLogicalReads;
         private int _retainedMessages;
+        private int _activeConnections;
+        private int _peakConnections;
+        private int _activeCommands;
+        private int _peakCommands;
         private readonly ConcurrentDictionary<string, long> _logicalReadsByOperation =
             new ConcurrentDictionary<string, long>(StringComparer.Ordinal);
 
@@ -899,6 +903,10 @@ DROP TABLE #SyntheticSamples;";
         internal readonly ConcurrentQueue<string> Operations = new ConcurrentQueue<string>();
 
         internal long TotalLogicalReads => Interlocked.Read(ref _totalLogicalReads);
+        internal int ActiveConnections => Volatile.Read(ref _activeConnections);
+        internal int PeakConnections => Volatile.Read(ref _peakConnections);
+        internal int ActiveCommands => Volatile.Read(ref _activeCommands);
+        internal int PeakCommands => Volatile.Read(ref _peakCommands);
         internal IEnumerable<string> LogicalReadsByOperation =>
             _logicalReadsByOperation
                 .OrderBy(pair => pair.Key, StringComparer.Ordinal)
@@ -936,6 +944,12 @@ DROP TABLE #SyntheticSamples;";
         {
             Action<SqlConnection, string> configure = (connection, operation) =>
             {
+                RecordPeak(ref _peakConnections, Interlocked.Increment(ref _activeConnections));
+                connection.StateChange += (sender, args) =>
+                {
+                    if (args.CurrentState == System.Data.ConnectionState.Closed)
+                        Interlocked.Decrement(ref _activeConnections);
+                };
                 connection.InfoMessage += (sender, args) => RecordMessage(args.Message, operation);
                 using (var command = new SqlCommand(
                     includeShowplan
@@ -950,12 +964,37 @@ DROP TABLE #SyntheticSamples;";
             return new SqlLicenceActivityStoreInstrumentation
             {
                 CommandTimeoutSeconds = commandTimeoutSeconds,
+                CommandActiveChanged = active =>
+                {
+                    if (active) RecordPeak(ref _peakCommands, Interlocked.Increment(ref _activeCommands));
+                    else Interlocked.Decrement(ref _activeCommands);
+                },
                 ConnectionOpened = connection => configure(connection, null),
                 ConnectionOpenedForOperation = configure,
                 OperationCompleted = (operation, elapsedMs) =>
                     Operations.Enqueue(operation + "=" + elapsedMs.ToString(CultureInfo.InvariantCulture) + "ms"),
-                ShowplanReceived = plan => Showplans.Enqueue(plan)
+                ShowplanReceived = plan =>
+                {
+                    Showplans.Enqueue(plan);
+                    var directory = Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_PLAN_DIRECTORY");
+                    if (!string.IsNullOrWhiteSpace(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                        File.WriteAllText(Path.Combine(directory, Guid.NewGuid().ToString("N") + ".sqlplan"), plan);
+                    }
+                }
             };
+        }
+
+        private static void RecordPeak(ref int peak, int value)
+        {
+            int previous;
+            do
+            {
+                previous = Volatile.Read(ref peak);
+                if (previous >= value) return;
+            }
+            while (Interlocked.CompareExchange(ref peak, value, previous) != previous);
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -282,6 +282,80 @@ CREATE TABLE #probe
             }
         }
 
+        [DataTestMethod]
+        [DataRow("teams", false)]
+        [DataRow("outlook", false)]
+        [DataRow("onedrive", false)]
+        [DataRow("sharepoint", false)]
+        [DataRow("teams", true)]
+        [DataRow("outlook", true)]
+        [DataRow("onedrive", true)]
+        [DataRow("sharepoint", true)]
+        public async Task SingleWeek_DuplicateReportDaysAgreeWithDrilldown(
+            string workload, bool columnstore)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create(
+                "LicenceSingleDayDuplicates", columnstore
+                    ? LicenceActivityUsageIndexMode.Columnstore
+                    : LicenceActivityUsageIndexMode.BTreeFallback))
+            {
+                SeedDirectory(fixture);
+                var table = workload + "_user_activity_log";
+                SeedOneUsageTable(fixture, table, new[] { "2000-06-25", "2000-06-25" });
+                fixture.Execute($@"
+UPDATE dbo.{table}
+SET [date] = DATEADD(HOUR, 12, [date])
+WHERE id IN (SELECT MAX(id) FROM dbo.{table} GROUP BY user_id);
+UPDATE dbo.{table} SET last_activity_date = '2000-06-18' WHERE user_id = 2;
+DELETE dbo.{table} WHERE user_id = 3;
+DELETE dbo.{table} WHERE user_id = 5 AND [date] = '2000-06-25T12:00:00';");
+
+                var query = LicenceActivityQuery.Create(
+                    "2000-06-19", "2000-06-25", LicenceActivitySqlFixture.NowUtc);
+                var sources = Sources(usageReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview, query.ForUsers(1, workload, null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == workload);
+                var coverage = overview.Coverage.Single(c => c.Workload == workload);
+                Assert.AreEqual("available", coverage.Status);
+                Assert.AreEqual(1, coverage.ExpectedSamples);
+                Assert.AreEqual(1, coverage.ObservedSamples);
+                Assert.AreEqual(1, distribution.High,
+                    "Duplicate rows on the one pinned day are still one observed active sample.");
+                Assert.AreEqual(3, distribution.Zero);
+                Assert.AreEqual(1, distribution.Unknown);
+                Assert.AreEqual(0, distribution.Moderate + distribution.Low);
+                Assert.AreEqual(5, users.TotalUsers);
+                foreach (var user in users.Users)
+                {
+                    var evidence = user.Workloads.Single(w => w.Workload == workload);
+                    var expectedBand = user.UserId == 1 ? "high"
+                        : user.UserId == 3 ? "unknown" : "zero";
+                    Assert.AreEqual(expectedBand, evidence.Band);
+                    Assert.AreEqual(user.UserId == 3 ? 0 : 1, evidence.ObservedSamples);
+                    Assert.AreEqual(user.UserId == 1 ? 1 : 0, evidence.ActiveSamples);
+                }
+                var active = users.Users.Single(u => u.UserId == 1)
+                    .Workloads.Single(w => w.Workload == workload);
+                Assert.AreEqual(workload == "teams" || workload == "outlook" ? 5d : 4d,
+                    active.AverageActions.Value,
+                    "Duplicate rolling counters are snapshot evidence, not additional actions.");
+                CollectionAssert.AreEquivalent(new[] { 1 },
+                    users.MostActive.Where(u => u.Workloads.Single(w => w.Workload == workload)
+                        .ActiveSamples > 0).Select(u => u.UserId).ToArray());
+                Assert.IsFalse(users.MostActive.Any(u => u.UserId == 3));
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 4, 5 },
+                    users.LeastActive.Select(u => u.UserId).ToArray());
+                Assert.IsNull(users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == workload).AverageActions);
+            }
+        }
+
         [TestMethod]
         public async Task SqlCommandMeasurements_DrainOnSuccessAndSiblingFailure()
         {
@@ -568,6 +642,79 @@ VALUES (7, 0, 0, 0, 1, '{date}', NULL);");
                 Assert.AreEqual(0, users.LeastActive.Count);
                 Assert.AreEqual("unknown", users.Users.Single(u => u.UserId == 1)
                     .Workloads.Single(w => w.Workload == "copilot").Band);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(1)]
+        [DataRow(8)]
+        public async Task Copilot_D7CountersTakePrecedenceOverUserLastActivityAcrossQueryPaths(int weeks)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotCounterAuthority"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v2', N'D7',
+     '2000-07-01T01:00:00', 4, 4, 0, NULL);");
+                foreach (var date in CopilotD7Dates.Skip(CopilotD7Dates.Length - weeks))
+                {
+                    // Counters belong to the period; lastActivityDate comes from the user envelope.
+                    // A v1-shaped row has neither counter and supplies positive evidence, not frequency.
+                    fixture.Execute($@"
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+VALUES
+    (7, 0, 0, 0, 1, '{date}', '{date}'),
+    (7, 12, 0, 0, 2, '{date}', NULL),
+    (7, NULL, NULL, 0, 3, '{date}', '{date}'),
+    (7, 0, 0, 0, 4, '{date}', NULL);");
+                }
+
+                var query = weeks == 8 ? OverviewQuery() : LicenceActivityQuery.Create(
+                    "2000-06-19", "2000-06-25", LicenceActivitySqlFixture.NowUtc);
+                var sources = Sources(usageReports: false, copilotReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview, query.ForUsers(1, "copilot", null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual("available", overview.Coverage.Single(c => c.Workload == "copilot").Status);
+                Assert.AreEqual(1, distribution.High,
+                    "An explicit D7 zero must not become active because the user-level date is in range.");
+                Assert.AreEqual(2, distribution.Zero);
+                Assert.AreEqual(2, distribution.Unknown);
+                Assert.AreEqual(0, distribution.Moderate + distribution.Low);
+                foreach (var user in users.Users)
+                {
+                    var evidence = user.Workloads.Single(w => w.Workload == "copilot");
+                    var expectedBand = user.UserId == 2 ? "high"
+                        : user.UserId == 1 || user.UserId == 4 ? "zero" : "unknown";
+                    Assert.AreEqual(expectedBand, evidence.Band,
+                        "Overview and drilldown must use the same D7 activity rule for user " + user.UserId);
+                    Assert.AreEqual(user.UserId == 2 || user.UserId == 3 ? weeks : 0,
+                        evidence.ActiveSamples);
+                    Assert.AreEqual(user.UserId == 5 ? 0 : weeks, evidence.ObservedSamples);
+                }
+                Assert.AreEqual("partial", users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == "copilot").Status);
+                Assert.IsNull(users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == "copilot").AverageActions);
+                Assert.AreEqual(12d, users.Users.Single(u => u.UserId == 2)
+                    .Workloads.Single(w => w.Workload == "copilot").AverageActions.Value);
+                CollectionAssert.AreEquivalent(new[] { 2, 3 },
+                    users.MostActive.Where(u => u.Workloads.Single(w => w.Workload == "copilot")
+                        .ActiveSamples > 0).Select(u => u.UserId).ToArray());
+                Assert.IsFalse(users.MostActive.Any(u => u.UserId == 5));
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 4 },
+                    users.LeastActive.Select(u => u.UserId).ToArray());
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -193,6 +193,67 @@ INSERT dbo.user_license_type_lookups (user_id, license_type_id) VALUES (1, 1);")
             }
         }
 
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task CustomSampleWindows_DeduplicateReportDaysAndPreserveMissingVersusZero(bool columnstore)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create(
+                "LicenceSampleWindows", columnstore
+                    ? LicenceActivityUsageIndexMode.Columnstore
+                    : LicenceActivityUsageIndexMode.BTreeFallback))
+            {
+                SeedDirectory(fixture);
+                SeedOneUsageTable(fixture, "onedrive_user_activity_log",
+                    new[] { "2000-06-18", "2000-06-23" });
+                fixture.Execute(@"
+INSERT dbo.onedrive_user_activity_log
+    (viewed_or_edited, synced, shared_internally, shared_externally, user_id, [date], last_activity_date)
+VALUES
+    (20, 0, 0, 0, 1, '2000-06-18T12:00:00', '2000-06-18T23:59:59'),
+    (3000, 0, 0, 0, 2, '2000-06-16', '2000-06-16'),
+    (3000, 0, 0, 0, 2, '2000-06-24', '2000-06-24');
+UPDATE dbo.onedrive_user_activity_log
+SET last_activity_date = CASE WHEN [date] = '2000-06-18'
+                             THEN '2000-06-13' ELSE '2000-06-24' END
+WHERE user_id = 2 AND [date] IN ('2000-06-18', '2000-06-23');
+UPDATE dbo.onedrive_user_activity_log SET last_activity_date = '2000-06-19'
+WHERE user_id = 4;
+DELETE dbo.onedrive_user_activity_log WHERE user_id = 3 AND [date] = '2000-06-23';");
+
+                var query = LicenceActivityQuery.Create(
+                    "2000-06-14", "2000-06-23", LicenceActivitySqlFixture.NowUtc);
+                var sources = Sources(usageReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "onedrive");
+                Assert.AreEqual(1, distribution.High);
+                Assert.AreEqual(1, distribution.Moderate);
+                Assert.AreEqual(2, distribution.Zero);
+                Assert.AreEqual(1, distribution.Unknown);
+                CollectionAssert.AreEqual(new[] { "2000-06-18", "2000-06-23" },
+                    overview.Coverage.Single(c => c.Workload == "onedrive")
+                        .SnapshotDates.Select(d => d.ToString("yyyy-MM-dd")).ToArray());
+
+                var users = await fixture.Store().LoadUsersAsync(overview,
+                    query.ForUsers(1, "onedrive", null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var active = users.Users.Single(u => u.UserId == 1)
+                    .Workloads.Single(w => w.Workload == "onedrive");
+                Assert.AreEqual(2, active.ActiveSamples);
+                Assert.AreEqual(12d, active.AverageActions.Value,
+                    "Average the per-day maxima (20 and 4), never sum or double-count duplicate snapshots.");
+                Assert.AreEqual(0, users.Users.Single(u => u.UserId == 2)
+                    .Workloads.Single(w => w.Workload == "onedrive").ActiveSamples);
+                Assert.IsTrue(users.MostActive.Any(u => u.UserId == 3),
+                    "A missing sample must not erase positive partial evidence.");
+                Assert.IsFalse(users.LeastActive.Any(u => u.UserId == 3));
+                Assert.AreEqual(4, users.LeastActive.Count);
+            }
+        }
+
         [TestMethod]
         public async Task ConcurrentConnections_DoNotCollideOnTempTableConstraintNames()
         {
@@ -218,6 +279,33 @@ CREATE TABLE #probe
                         NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
                     Assert.AreEqual(3, overview.Licences.Count);
                 }
+            }
+        }
+
+        [TestMethod]
+        public async Task SqlCommandMeasurements_DrainOnSuccessAndSiblingFailure()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceSqlLifetime"))
+            {
+                SeedDirectory(fixture);
+                var measurement = new LicenceActivitySqlMeasurement();
+                var store = fixture.Store(measurement.Instrumentation(includeShowplan: false));
+                await store.LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual(0, measurement.ActiveCommands);
+                Assert.AreEqual(0, measurement.ActiveConnections);
+                Assert.IsTrue(measurement.PeakCommands >= 1);
+                Assert.IsTrue(measurement.PeakConnections >= 2);
+
+                fixture.Execute("DROP TABLE dbo.onedrive_user_activity_log;");
+                await Assert.ThrowsExceptionAsync<SqlException>(() => store.LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None));
+                Assert.AreEqual(0, measurement.ActiveCommands,
+                    "All sibling commands must drain before the store reports failure.");
+                Assert.AreEqual(0, measurement.ActiveConnections,
+                    "The shared eligibility connection must also be disposed after failure.");
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -715,6 +715,23 @@ VALUES
                 Assert.IsFalse(users.MostActive.Any(u => u.UserId == 5));
                 CollectionAssert.AreEquivalent(new[] { 1, 2, 4 },
                     users.LeastActive.Select(u => u.UserId).ToArray());
+
+                // Selecting another workload takes the bounded #ReturnedUsers/#CopilotReportIds
+                // supporting-evidence path rather than Copilot's #EligibleUsers ranking path.
+                var nonCopilot = await fixture.Store().LoadUsersAsync(
+                    overview, query.ForUsers(1, "teams", null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                foreach (var expectedUser in users.Users)
+                {
+                    var expected = expectedUser.Workloads.Single(w => w.Workload == "copilot");
+                    var supporting = nonCopilot.Users.Single(u => u.UserId == expectedUser.UserId)
+                        .Workloads.Single(w => w.Workload == "copilot");
+                    Assert.AreEqual(expected.Band, supporting.Band);
+                    Assert.AreEqual(expected.ActiveSamples, supporting.ActiveSamples);
+                    Assert.AreEqual(expected.ObservedSamples, supporting.ObservedSamples);
+                    Assert.AreEqual(expected.AverageActions, supporting.AverageActions);
+                }
             }
         }
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ComponentProps } from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../test/renderWithProvider';
 import UsersDrillDown from './UsersDrillDown';
@@ -52,7 +53,7 @@ function user(upn: string, workload: string): LicenceActivityUser {
 
 function usersResponse(params: UsersParams): LicenceActivityUsers {
   return {
-    snapshotId: `snap-${params.page}-${params.top}-${params.workload}`,
+    snapshotId: `snap-${params.overviewId}-${params.page}-${params.top}-${params.workload}`,
     generatedUtc: '2026-05-20T00:00:00Z',
     expiresUtc: '2026-05-20T00:02:00Z',
     overviewId: params.overviewId,
@@ -110,14 +111,19 @@ function coverageEntry(over: Partial<LicenceActivityCoverage> = {}): LicenceActi
   };
 }
 
-function renderDrill(coverage: LicenceActivityCoverage[] = []) {
+function renderDrill(
+  coverage: LicenceActivityCoverage[] = [],
+  props: Partial<ComponentProps<typeof UsersDrillDown>> = {},
+) {
   return renderWithProvider(
     <UsersDrillDown
       overviewId="ov1"
+      overviewScope="scope-a"
       licence={licence}
       coverage={coverage}
       onUsersSnapshot={vi.fn()}
       onRefreshOverview={vi.fn()}
+      {...props}
     />,
   );
 }
@@ -289,5 +295,96 @@ describe('UsersDrillDown', () => {
     }));
     renderDrill();
     expect(await screen.findByText(/limited by partial coverage/)).toBeInTheDocument();
+  });
+
+  // Regression for the expiry-recovery page-reset bug. `overviewId` is a per-snapshot generation id:
+  // an expired snapshot is re-fetched under a NEW id for the SAME logical query. Keying the page
+  // reset off `overviewId` bounced an admin browsing page 2 straight back to page 1 every time the
+  // snapshot re-minted. The reset must key off `overviewScope` (the logical window/demographic
+  // identity), which is unchanged by a re-mint.
+  it('keeps the browse page - and the workload/search/sort - when the overview re-mints under a NEW id for the SAME scope', async () => {
+    const onUsersSnapshot = vi.fn();
+    const { rerender } = renderDrill([], { overviewId: 'ov1', overviewScope: 'scope-a', onUsersSnapshot });
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    // Move well away from the defaults: a non-default workload, sort and search, then page 2.
+    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    await waitFor(() => expect(lastParams()).toMatchObject({ workload: 'outlook', page: 1 }));
+    fireEvent.change(screen.getByLabelText('Sort users'), { target: { value: 'upn:asc' } });
+    await waitFor(() => expect(lastParams()).toMatchObject({ sort: 'upn', direction: 'asc' }));
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'ada' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada', page: 1 }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() =>
+      expect(lastParams()).toMatchObject({
+        overviewId: 'ov1',
+        page: 2,
+        workload: 'outlook',
+        sort: 'upn',
+        direction: 'asc',
+        search: 'ada',
+      }),
+    );
+
+    const callsBefore = mockUsers.mock.calls.length;
+    onUsersSnapshot.mockClear();
+
+    // The overview snapshot expired and was re-minted under a new id - but the reporting window,
+    // demographics and licence (its logical scope) are unchanged.
+    rerender(
+      <UsersDrillDown
+        overviewId="ov2"
+        overviewScope="scope-a"
+        licence={licence}
+        coverage={[]}
+        onUsersSnapshot={onUsersSnapshot}
+        onRefreshOverview={vi.fn()}
+      />,
+    );
+
+    // The new id forces a fresh users fetch, but the admin stays on page 2 with the same view...
+    await waitFor(() => expect(mockUsers.mock.calls.length).toBeGreaterThan(callsBefore));
+    expect(lastParams()).toMatchObject({
+      overviewId: 'ov2',
+      page: 2,
+      workload: 'outlook',
+      sort: 'upn',
+      direction: 'asc',
+      search: 'ada',
+    });
+
+    // ...and the export snapshot follows the freshly minted list (a NEW snapshot bound to ov2). The
+    // final reported snapshot is the ov2 one, so the export can only reference the fresh list.
+    const freshSnapshot = `snap-ov2-2-10-outlook`;
+    await waitFor(() => {
+      const calls = onUsersSnapshot.mock.calls;
+      expect(calls[calls.length - 1][0]).toBe(freshSnapshot);
+    });
+  });
+
+  // The opposite direction: a genuine logical-scope change (a new reporting window or demographic
+  // filter, surfaced here as a changed `overviewScope`) MUST reset to page 1, and the fresh fetch
+  // must go against the new snapshot - no old page, no old rows carried over.
+  it('resets to page 1 when the logical scope actually changes', async () => {
+    const { rerender } = renderDrill([], { overviewId: 'ov1', overviewScope: 'scope-a' });
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ overviewId: 'ov1', page: 2 }));
+
+    const callsBefore = mockUsers.mock.calls.length;
+    // A new reporting window / demographic filter: BOTH the snapshot id and the logical scope change.
+    rerender(
+      <UsersDrillDown
+        overviewId="ov2"
+        overviewScope="scope-b"
+        licence={licence}
+        coverage={[]}
+        onUsersSnapshot={vi.fn()}
+        onRefreshOverview={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(mockUsers.mock.calls.length).toBeGreaterThan(callsBefore));
+    expect(lastParams()).toMatchObject({ overviewId: 'ov2', page: 1 });
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
@@ -363,6 +363,45 @@ describe('UsersDrillDown', () => {
     });
   });
 
+  it.each([40, 0])('reloads a valid page when a renewed population shrinks to %i users', async (remaining) => {
+    mockUsers.mockImplementation(async (params) => {
+      const result = usersResponse(params);
+      if (params.overviewId === 'ov2') {
+        result.totalUsers = remaining;
+        result.rankedUsers = remaining;
+        result.users = params.page === 1 && remaining > 0 ? result.users : [];
+      }
+      return result;
+    });
+    const onUsersSnapshot = vi.fn();
+    const { rerender } = renderDrill([], { overviewScope: 'scope-a', onUsersSnapshot });
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ overviewId: 'ov1', page: 2 }));
+    onUsersSnapshot.mockClear();
+
+    rerender(
+      <UsersDrillDown
+        overviewId="ov2"
+        overviewScope="scope-a"
+        licence={licence}
+        coverage={[]}
+        onUsersSnapshot={onUsersSnapshot}
+        onRefreshOverview={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(lastParams()).toMatchObject({ overviewId: 'ov2', page: 1 }));
+    await waitFor(() => {
+      const calls = onUsersSnapshot.mock.calls;
+      expect(calls[calls.length - 1][0]).toBe('snap-ov2-1-10-teams');
+    });
+    expect(onUsersSnapshot.mock.calls.some(([id]) => id === 'snap-ov2-2-10-teams')).toBe(false);
+    expect(screen.queryByText('Page 2 of 1')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Showing 51/)).not.toBeInTheDocument();
+    if (remaining > 0) expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+  });
+
   // The opposite direction: a genuine logical-scope change (a new reporting window or demographic
   // filter, surfaced here as a changed `overviewScope`) MUST reset to page 1, and the fresh fetch
   // must go against the new snapshot - no old page, no old rows carried over.

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -160,6 +160,15 @@ function TopCountInput({ value, onCommit, disabled }: { value: number; onCommit:
 
 interface UsersDrillDownProps {
   overviewId: string;
+  /** The overview's LOGICAL scope identity - the reporting window and demographic filters that
+   *  define WHICH population this drill-down is browsing. Unlike `overviewId` (a per-snapshot
+   *  generation id that is re-minted every time the snapshot expires and is re-fetched), this is
+   *  stable across a same-query re-mint. It, not `overviewId`, decides when the browse page must
+   *  reset: a genuine scope change (new window / department / country) resets to page 1, but
+   *  re-minting the identical logical query under a fresh `overviewId` - e.g. the export-410
+   *  recovery - must NOT, or an admin browsing page 2 is silently bounced back to page 1 by a
+   *  refresh that changed nothing they can see. */
+  overviewScope: string;
   licence: LicenceActivitySku;
   /** The overview's per-workload coverage, used to explain why a workload can't be ranked. */
   coverage: LicenceActivityCoverage[];
@@ -182,6 +191,7 @@ interface UsersDrillDownProps {
  */
 export default function UsersDrillDown({
   overviewId,
+  overviewScope,
   licence,
   coverage,
   onUsersSnapshot,
@@ -226,7 +236,14 @@ export default function UsersDrillDown({
   // Reset the page atomically when the scope (licence / workload / browse filter) changes, DURING
   // render - so `params` never briefly pairs a new scope with the old page, which would fire a wasted
   // SQL load before the page-1 reset. This is the React "adjust state during render" pattern.
-  const scopeKey = `${overviewId}\n${licence.licenceTypeId}\n${workload}\n${search}\n${sort}\n${direction}`;
+  //
+  // The scope is keyed off `overviewScope` (the overview's logical window + demographic identity),
+  // NOT `overviewId`. `overviewId` is a per-snapshot generation id that changes whenever the snapshot
+  // is re-minted (an expiry refresh re-fetches the SAME logical query under a new id); keying the
+  // reset off it would bounce an admin on page 2 back to page 1 on every recovery. `overviewId` still
+  // flows through `params` below, so a re-mint re-fetches the current page against the fresh snapshot
+  // without discarding the admin's place, workload, search or sort.
+  const scopeKey = `${overviewScope}\n${licence.licenceTypeId}\n${workload}\n${search}\n${sort}\n${direction}`;
   const [scope, setScope] = useState(scopeKey);
   if (scope !== scopeKey) {
     setScope(scopeKey);

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -267,6 +267,12 @@ export default function UsersDrillDown({
 
   const { data, loading, error, reload } = useUsersQuery(params);
 
+  const totalPages = data ? Math.max(1, Math.ceil(data.totalUsers / PAGE_SIZE)) : 1;
+  // Preserve a renewed page only while it still exists. Adjust during render so an expired
+  // population's empty out-of-range page is never displayed or published as the export snapshot;
+  // the scope-bound hook will fetch the last valid page (page 1 for an empty population).
+  if (data && page > totalPages) setPage(totalPages);
+
   // A parent-driven forced refresh (e.g. after an export 410). Re-mint the current view's snapshot
   // without changing any params, so the licence/workload/page/filters the admin is looking at are all
   // preserved. Skip the initial mount (token 0/undefined) so this never double-fetches on first load.
@@ -283,7 +289,6 @@ export default function UsersDrillDown({
     onUsersSnapshot(data?.snapshotId ?? null);
   }, [data?.snapshotId, onUsersSnapshot]);
 
-  const totalPages = data ? Math.max(1, Math.ceil(data.totalUsers / PAGE_SIZE)) : 1;
   const retry = describeError(error, '').kind === 'expired' ? onRefreshOverview : reload;
 
   return (

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
@@ -318,6 +318,142 @@ describe('LicenceActivityPage - export refresh after expiry', () => {
   });
 });
 
+describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
+  const usersParams = () => mockUsers.mock.calls[mockUsers.mock.calls.length - 1][0];
+
+  it('keeps the admin on page 2 (and workload/sort/search) when Refresh re-mints the overview under a NEW id', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+
+    // The overview re-mints on reload: ov1 first, ov2 after Refresh. A brand-new id per reload is
+    // exactly the case that used to reset the browse page (the drill-down treated the id as scope).
+    let ovCount = 0;
+    mockOverview.mockImplementation(async () => {
+      ovCount += 1;
+      return overview({ snapshotId: ovCount === 1 ? 'ov1' : 'ov2' });
+    });
+
+    // A multi-page list whose snapshot id is bound to the overview id + page, so a re-mint is visible.
+    mockUsers.mockImplementation(async (params) => ({
+      ...usersResponse(),
+      overviewId: params.overviewId,
+      snapshotId: `us-${params.overviewId}-p${params.page}`,
+      totalUsers: 120,
+      query: {
+        ...echo,
+        licenceTypeId: params.licenceTypeId,
+        workload: params.workload,
+        search: params.search ?? '',
+        sort: params.sort,
+        direction: params.direction,
+        top: params.top,
+        page: params.page,
+        pageSize: params.pageSize,
+      },
+    }));
+
+    // The first export fails as expired (users snapshots expire before the overview); later ones pass.
+    mockDownload
+      .mockRejectedValueOnce(
+        new LicenceActivityApiError('expired', 410, 'This snapshot has expired or was refreshed.'),
+      )
+      .mockResolvedValue(undefined);
+
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findAllByText('ada@contoso.com');
+    await act(async () => {});
+
+    // Move off the defaults: a non-default workload and sort and search, then browse to page 2.
+    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    await waitFor(() => expect(usersParams()).toMatchObject({ workload: 'outlook', page: 1 }));
+    fireEvent.change(screen.getByLabelText('Sort users'), { target: { value: 'upn:asc' } });
+    await waitFor(() => expect(usersParams()).toMatchObject({ sort: 'upn', direction: 'asc' }));
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'ada' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(usersParams()).toMatchObject({ search: 'ada', page: 1 }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(usersParams()).toMatchObject({ overviewId: 'ov1', page: 2 }));
+
+    // Export -> 410 -> a Refresh prompt appears.
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+
+    const usersBefore = mockUsers.mock.calls.length;
+    // Exact 'Refresh' resolves the export bar's button (the drill-down's is 'Refresh users').
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    // The overview re-mints to ov2 and the list is re-fetched - but the admin is STILL on page 2 with
+    // the same workload/sort/search. (With the bug the fresh id reset this to page 1.)
+    await waitFor(() => expect(usersParams().overviewId).toBe('ov2'));
+    expect(mockUsers.mock.calls.length).toBeGreaterThan(usersBefore);
+    expect(usersParams()).toMatchObject({
+      overviewId: 'ov2',
+      page: 2,
+      workload: 'outlook',
+      sort: 'upn',
+      direction: 'asc',
+      search: 'ada',
+    });
+
+    await waitFor(() => expect(screen.queryByText(/expired/i)).not.toBeInTheDocument());
+    await act(async () => {});
+    // Refresh alone must not silently re-export.
+    expect(mockDownload).toHaveBeenCalledTimes(1);
+
+    // A subsequent explicit export references the fresh overview id AND the fresh users snapshot.
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    await waitFor(() => {
+      const last = mockDownload.mock.calls[mockDownload.mock.calls.length - 1][0];
+      expect(last.overviewId).toBe('ov2');
+      expect(last.usersId).toBe('us-ov2-p2');
+    });
+  });
+});
+
+describe('LicenceActivityPage - a real scope change resets the browse page', () => {
+  const usersParams = () => mockUsers.mock.calls[mockUsers.mock.calls.length - 1][0];
+
+  it('returns to page 1 and drops the stale export id when the demographic filter changes', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    // A distinct overview id per demographic scope; department 1 stays in the catalogue so it remains
+    // selectable after the scoped reply.
+    mockOverview.mockImplementation(async (q) => overview({ snapshotId: `ov-dept-${q.departmentId ?? 'all'}` }));
+    mockUsers.mockImplementation(async (params) => ({
+      ...usersResponse(),
+      overviewId: params.overviewId,
+      snapshotId: `us-${params.overviewId}-p${params.page}`,
+      totalUsers: 120,
+      query: { ...echo, page: params.page },
+    }));
+
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findAllByText('ada@contoso.com');
+    await act(async () => {});
+
+    // Browse to page 2 of the current (all-departments) scope.
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(usersParams()).toMatchObject({ overviewId: 'ov-dept-all', page: 2 }));
+
+    // Change the department filter: a genuine scope change, NOT a re-mint of the same query.
+    fireEvent.change(screen.getByLabelText('Filter by department'), { target: { value: '1' } });
+    await waitFor(() => expect(mockOverview.mock.calls.some((c) => c[0].departmentId === 1)).toBe(true));
+
+    // The re-scoped list is fetched fresh at PAGE 1 against the NEW overview - never the old page/id.
+    await waitFor(() => expect(usersParams()).toMatchObject({ overviewId: 'ov-dept-1', page: 1 }));
+
+    // Let the fresh page-1 list settle (its snapshot id is captured for the export).
+    await screen.findAllByText('ada@contoso.com');
+    await act(async () => {});
+
+    // And an export now references the new scope's ids, never the pre-change ones.
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    await waitFor(() => {
+      const last = mockDownload.mock.calls[mockDownload.mock.calls.length - 1][0];
+      expect(last.overviewId).toBe('ov-dept-1');
+      expect(last.usersId).toBe('us-ov-dept-1-p1');
+    });
+  });
+});
+
 describe('LicenceActivityPage - demographic filter options', () => {
   it('keeps every department selectable after a scoped reply, so you can switch straight from one to another', async () => {
     mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
@@ -560,6 +560,7 @@ export default function LicenceActivityPage() {
                       <UsersDrillDown
                         key={selectedLicence.licenceTypeId}
                         overviewId={overview.snapshotId}
+                        overviewScope={overviewKey ?? ''}
                         licence={selectedLicence}
                         coverage={overview.coverage}
                         onUsersSnapshot={handleUsersSnapshot}


### PR DESCRIPTION
## Draft: measured query-only improvement, not performance acceptance

Follow-up to #456. This preserves a tested improvement while the full release-scale acceptance remains unresolved. **Do not merge or treat this as release-ready.** No migration, persistent index, summary table, saved-config change, shortened reporting range or production-timeout increase is proposed.

Addresses #436
Addresses #437

## Changes

- Join activity to the actual pinned report days and precompute the evidence-window boundaries once per sample instead of repeating that arithmetic per fact row.
- Preserve report-day de-duplication, exact custom boundaries, missing-versus-zero evidence, positive partial evidence and least-active eligibility.
- Use connection-scoped temporary eligibility columnstore indexes to enable batch aggregation where supported. Dynamic SQL plus a guarded rowstore fallback handles unsupported editions; source tables and their permanent indexes are unchanged.
- Stage the bounded returned users' Copilot report IDs before retrieving supporting evidence, avoiding repeated large lookups.
- Instrument actual SQL command and connection lifetimes separately from the four shared report admissions. Add success/failure-drain and sample-window regressions.

## Validation

- **74 official MSTest cases passed**, including **31 SQL test instances**; one performance opt-out is correctly Inconclusive, not Passed.
- Both new custom sample-day regression cases fail against the verified baseline and pass the candidate, in B-tree and columnstore fixture shapes.
- Independent reviews: an Opus review's filter-pushdown hypothesis was checked against actual plans in both index shapes and was not reproduced; a fresh Sonnet review and a further independent GPT review found no verified new defects.
- No custom test adapter, copied-test-body workaround or skipped assertion is counted as acceptance.
- The owned local synthetic database and its state file were removed after verification.

## Measured diagnostics

Synthetic fixture: 300,000 users, 50 SKUs, millions of current overlapping assignments and 39 million explicit workload rows. These are **LocalDB diagnostic adapter medians**, not Azure 200/400-DTU acceptance or HTTP latency. Before/candidate identity was checked with binary hashes, actual plans and negative controls; misleading intermediate artifact labels were corrected rather than trusted.

| Overview scenario | Baseline median ms / logical reads | Candidate median ms / logical reads |
|---|---:|---:|
| B-tree, 7 days | 18,862 / 1,037,723 | 10,405 / 224,540 |
| Columnstore, 7 days | 16,047 / 1,031,216 | 9,441 / 224,544 |
| Columnstore, 180 days | 46,977 / 286,343 | 27,660 / 264,259 |

The actual baseline plans show substantial cardinality underestimation and hash spills. Remaining Copilot plans still scan the large rowstore fact table; some plans explicitly report `NoParallelPlansInDesktopOrExpressEdition`. Those observations **do not establish that a permanent index/migration is required, nor that Azure SQL at the approved tiers will fail**.

## Acceptance is still blocked

Real in-process HTTP preflight using the unchanged production limits:

- B-tree 7-day application-cache-cold overview: **200, 8,624 ms, 63,308 bytes**.
- Its immediate warm request: **200, 2 ms, zero SQL logical reads**.
- B-tree 180-day overview: **503 after 22,944 ms** under the existing 20-second SQL command timeout.
- One overview observed **5 active SQL commands / 6 leased connections**, all subsequently drained.

The complete **1,500 cold SKU/workload cases and 1,500 immediate warm partners have not run to completion**. No full-run memory, four-distinct concurrency or all-cell performance pass is claimed. Production SQL timeout remains 20 seconds, response/publication deadline remains 30 seconds, and the fixed HTTP/JSON/memory budgets are unchanged.

The approved isolated Azure 200/400-DTU benchmark is separately owned. This candidate is not yet part of `dev` or any release diff. A passing target-tier benchmark and the normal required CI/review gates are still needed; no evidence waiver or main merge is implied.


## Hosted correctness check

The explicitly dispatched **Tests** workflow [33983218547](https://github.com/pnp/Microsoft365-Analytics-Insights/actions/runs/33983218547) completed successfully at head `32f822beae459545639048e00b4e906a5021f075`: `test_dotnet (Release)` and `test_aitracker` both succeeded. This was **not** the Release workflow, and does not execute or substitute for the opt-in Azure-tier scale acceptance. This PR remains **draft, unmerged and performance-blocked**.

## Correctness follow-up at the current head

The fresh full parallel review found and reproduced three additional issues, repaired without a schema, range or budget change:

- Copilot D7 single-week, multiweek and drill-down activity now share the existing period-counter-authoritative rule. The user-envelope last-activity date is fallback evidence only for v1-shaped rows with both counters absent. Ten new SQL regression instances fail before the repair and pass afterward, including the M365 cases below.
- Duplicate physical M365 records on a single pinned report day remain one observed sample, consistently with multiweek and drill-down aggregation. All four workloads are checked in B-tree and columnstore shapes.
- A new overview generation for the same logical query preserves the browse page and controls. True query-scope changes still reset pagination. If the renewed population shrinks so the retained page no longer exists, the last valid page is fetched before presenting its footer or publishing its export snapshot. Both non-empty and empty shrink regressions fail before this repair.

Current local results: **74 .NET cases passed + one deliberate performance skip; 93 portal tests passed; TypeScript and Vite build passed**. Additional real SQL checks exercise Copilot supporting evidence while another workload is selected. The final parallel SQL, UI/operability and security re-review returned no new verified blockers. That code-review result is **not performance acceptance**.

The diagnostic performance table above applies to the earlier query-optimization checkpoint `32f822be`; it has not been re-measured for the current correctness head. The previously linked passing hosted Tests run also belongs to `32f822be`, not the current head. A new Tests-only run is being dispatched. The PR remains draft, unmerged, and outside the release diff pending target-tier acceptance and delivery gates.

Current head: `830ccc36ee17f2dd2d07dfbf83ced07d6f27e6b7`. Diff against dev: 9 files, 852 additions, 113 deletions; 4 commits.

## Azure baseline review completed — this candidate was not tested there

The separately authorised synthetic benchmark tested **dev `b415bc08` / feature `f94fb84f`**, unchanged, at actual **S4/200 DTUs and S6/400 DTUs**. It did **not** test this PR's `32f822be` or current `830ccc36` candidate. Neither tier passed acceptance:

| Baseline observation | S4 / 200 DTUs | S6 / 400 DTUs |
|---|---:|---:|
| Completed cold/warm user pairs | 750 / 1,500 required | 750 / 1,500 required |
| Exact 180-day overview, three repeats | HTTP 503 each | HTTP 503 each |
| Exact 180-day HTTP median / maximum | 23.026 / 23.036 s | 21.736 / 21.755 s |
| Managed / private process growth | 135.4 / 146.6 MiB | 152.4 / 160.5 MiB |

The completed subset covers all narrow-window SKU/workload/repeat combinations, paging, searches, demographics, concurrency and exports. SQL network time is included; the HTTP API/client share the test process. SQL caches were retained. Instrumented narrow results are not proof of reliable uninstrumented performance: the first uninstrumented 7-day adapter repeat also timed out at both tiers. No full wide user matrix or memory pass is claimed.

Actual Azure plans identified downstream per-sample aggregation spills and expensive lookup/sort paths despite existing source columnstore indexes; the representative M365 source scan itself was inexpensive. **Those observations do not establish that a new persistent index or migration is necessary.** Any next candidate benchmark is a fresh, separately coordinated scope; no such provisioning or experimental product DDL is authorised by this PR.

The benchmark owner and parent independently verified every owned database/server/perimeter/resource group absent and cleared private connection state. No resource or access identifiers are included here. [Draft release PR #458](https://github.com/pnp/Microsoft365-Analytics-Insights/pull/458) documents the tested dev baseline and remains held; this follow-up is still unmerged and excluded from that release diff.

## Current-head hosted correctness result

**Tests workflow [33989178429](https://github.com/pnp/Microsoft365-Analytics-Insights/actions/runs/33989178429) succeeded at `830ccc36ee17f2dd2d07dfbf83ced07d6f27e6b7`**, including `test_dotnet (Release)` and `test_aitracker`. This is the current-head result, superseding the earlier `32f822be` correctness run. No Release workflow was invoked. The PR remains **draft and unmerged**: the current candidate has not passed the required Azure-tier scale matrix or memory gate, and is not included in #458.
