### PR TITLE
Preserve missing licence evidence and safely render unnamed SKUs

### DIFF
--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.test.tsx
@@ -112,4 +112,20 @@ describe('SkuAssignments', () => {
     fireEvent.click(screen.getByText('Άδεια σπάνια'));
     expect(onSelect).toHaveBeenCalledWith(99);
   });
+
+  it('filters and selects unnamed SKUs using a real identifier fallback', () => {
+    const many: LicenceActivitySku[] = Array.from({ length: 9 }, (_, i) => ({
+      licenceTypeId: i + 1, name: i < 2 ? null : `SKU ${i}`,
+      skuId: i === 0 ? 'CONTOSO_UNKNOWN' : null,
+      assignedUsers: i + 1, workloads: [],
+    }));
+    const onSelect = vi.fn();
+    renderWithProvider(<SkuAssignments licences={many} selectedLicenceTypeId={null} onSelect={onSelect} />);
+    fireEvent.change(screen.getByLabelText('Filter licences'), { target: { value: 'CONTOSO_UNKNOWN' } });
+    const identifier = screen.getByRole('button', { name: /CONTOSO_UNKNOWN/ });
+    fireEvent.click(identifier);
+    expect(onSelect).toHaveBeenCalledWith(1);
+    fireEvent.change(screen.getByLabelText('Filter licences'), { target: { value: 'Licence 2' } });
+    expect(screen.getByRole('button', { name: 'Licence 2' })).toBeInTheDocument();
+  });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo, useState, type CSSProperties } from 'react';
 import { makeStyles, tokens, Card, Text, Input } from '@fluentui/react-components';
 import type { LicenceActivityDistribution, LicenceActivitySku } from '../../types/licenceActivity';
 import { WORKLOADS } from '../../types/licenceActivity';
-import { formatCount } from './format';
+import { formatCount, licenceName } from './format';
 import { useLaTableStyles } from './tableStyles';
 import { MiniDistribution, BandLegend } from './MiniDistribution';
 
@@ -94,7 +94,7 @@ function SkuAssignments({ licences, selectedLicenceTypeId, onSelect }: SkuAssign
   const [filter, setFilter] = useState('');
 
   const sorted = useMemo(
-    () => [...licences].sort((a, b) => b.assignedUsers - a.assignedUsers || a.name.localeCompare(b.name)),
+    () => [...licences].sort((a, b) => b.assignedUsers - a.assignedUsers || licenceName(a).localeCompare(licenceName(b))),
     [licences],
   );
 
@@ -102,7 +102,7 @@ function SkuAssignments({ licences, selectedLicenceTypeId, onSelect }: SkuAssign
     const q = filter.trim().toLocaleLowerCase();
     if (!q) return sorted;
     return sorted.filter(
-      (s) => s.name.toLocaleLowerCase().includes(q) || (s.skuId ?? '').toLocaleLowerCase().includes(q),
+      (s) => licenceName(s).toLocaleLowerCase().includes(q) || (s.skuId ?? '').toLocaleLowerCase().includes(q),
     );
   }, [sorted, filter]);
 
@@ -187,9 +187,9 @@ function SkuAssignments({ licences, selectedLicenceTypeId, onSelect }: SkuAssign
                     >
                       <span className={styles.sku}>
                         <Text size={300} weight="semibold">
-                          {sku.name}
+                          {licenceName(sku)}
                         </Text>
-                        {sku.skuId && (
+                        {sku.skuId && sku.skuId !== licenceName(sku) && (
                           <Text size={100} className={styles.muted}>
                             {sku.skuId}
                           </Text>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -25,7 +25,7 @@ import UsersTable from './UsersTable';
 import ApiErrorBar, { describeError } from './ApiErrorBar';
 import { useUsersQuery } from './useUsersQuery';
 import { statusMeta } from './statuses';
-import { formatCount } from './format';
+import { formatCount, licenceName } from './format';
 
 const PAGE_SIZE = 50;
 const MIN_TOP = 1;
@@ -274,7 +274,7 @@ export default function UsersDrillDown({
       <div className={styles.head}>
         <div className={styles.headText}>
           <Text weight="semibold" size={400}>
-            {licence.name}
+            {licenceName(licence)}
           </Text>
           <Text size={200} className={styles.muted}>
             {formatCount(licence.assignedUsers)} users hold this licence. Choose a workload to rank them by its

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.test.tsx
@@ -91,4 +91,20 @@ describe('UsersTable', () => {
     }
     expect(screen.getByText('Not imported')).toBeInTheDocument();
   });
+
+  it('keeps the expected sample count visible when no per-user observations exist', () => {
+    renderWithProvider(
+      <UsersTable
+        rows={[usr({ workloads: [evidence({
+          status: 'missingCoverage', band: 'unknown', activeSamples: 0,
+          observedSamples: 0, expectedSamples: 8, averageActions: null, lastActivityUtc: null,
+        })] })]}
+        workload="teams"
+        workloadLabel="Teams"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Show all workloads/ }));
+    expect(screen.getAllByText(/0 observed of 8 expected/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Unknown').length).toBeGreaterThan(0);
+  });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.tsx
@@ -88,7 +88,7 @@ function formatAverage(value: number | null | undefined): string {
 /** Active/observed samples with expected context, distinguishing "nothing observed" from a real 0. */
 function formatSamples(ev: LicenceActivityEvidence | null): string {
   if (!ev) return UNKNOWN_TEXT;
-  if (ev.observedSamples <= 0) return DASH; // nothing observed - not a measured zero
+  if (ev.observedSamples <= 0) return `${DASH}; ${ev.observedSamples} observed of ${ev.expectedSamples} expected`;
   const base = `${ev.activeSamples} / ${ev.observedSamples}`;
   return ev.observedSamples !== ev.expectedSamples ? `${base} of ${ev.expectedSamples}` : base;
 }
@@ -135,7 +135,7 @@ function AllWorkloadsDetail({ user }: { user: LicenceActivityUser }) {
             <th className={styles.detailHead}>Coverage</th>
             <th className={styles.detailHead}>Band</th>
             <th className={styles.detailHead}>Source &middot; Measure</th>
-            <th className={styles.detailHead}>Active / observed</th>
+            <th className={styles.detailHead}>Active / observed (expected)</th>
             <th className={styles.detailHead}>Avg</th>
             <th className={styles.detailHead}>Last activity</th>
           </tr>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/format.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/format.ts
@@ -5,6 +5,15 @@
 // "nobody did this" when the truth is "we didn't measure it". These helpers force the caller to be
 // explicit about the null case rather than letting `null` coerce to 0 somewhere in a template.
 
+import type { LicenceActivitySku } from '../../types/licenceActivity';
+
+/** A licence name can be absent in storage; use an actual identifier rather than invent a product. */
+export function licenceName(sku: LicenceActivitySku): string {
+  if (sku.name?.trim()) return sku.name;
+  if (sku.skuId?.trim()) return sku.skuId;
+  return `Licence ${sku.licenceTypeId}`;
+}
+
 /** Rendered for a value that is genuinely unknown, as opposed to a measured zero. */
 export const UNKNOWN_TEXT = 'Unknown';
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from '../test/renderWithProvider';
 import LicenceActivityPage from './LicenceActivityPage';
 import {
@@ -261,6 +262,24 @@ describe('LicenceActivityPage - export', () => {
 
     const exportBtn = await screen.findByRole('button', { name: /Export to Excel/i });
     expect(exportBtn).toBeDisabled();
+  });
+
+  it('does not export the old users snapshot when clicking Export commits a new top count on blur', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockUsers.mockResolvedValueOnce(usersResponse()).mockReturnValue(new Promise(() => {}));
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findAllByText('ada@contoso.com');
+    await act(async () => {});
+
+    const events = userEvent.setup();
+    const top = screen.getByRole('spinbutton', { name: 'Number of users in each list' });
+    await events.clear(top);
+    await events.type(top, '25');
+    await events.click(screen.getByRole('button', { name: /Export to Excel/i }));
+
+    await waitFor(() => expect(mockUsers.mock.calls.at(-1)?.[0].top).toBe(25));
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledTimes(1));
+    expect(mockDownload.mock.calls[0][0].usersId).not.toBe('us1');
   });
 });
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
@@ -28,7 +28,7 @@ import DemographicBreakdown from '../components/licenceActivity/DemographicBreak
 import UsersDrillDown from '../components/licenceActivity/UsersDrillDown';
 import ApiErrorBar, { describeError } from '../components/licenceActivity/ApiErrorBar';
 import { presetRange } from '../components/licenceActivity/dateRange';
-import { formatCount } from '../components/licenceActivity/format';
+import { formatCount, licenceName } from '../components/licenceActivity/format';
 import {
   mergeDemographicOptions,
   EMPTY_CATALOGUE,
@@ -509,7 +509,7 @@ export default function LicenceActivityPage() {
                       Workload activity
                     </Text>
                     <Text size={200} className={styles.muted}>
-                      {selectedLicence.name} &middot; five workloads, measured separately
+                      {licenceName(selectedLicence)} &middot; five workloads, measured separately
                     </Text>
                   </div>
                   <div style={{ marginTop: '12px' }}>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/types/licenceActivity.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/types/licenceActivity.ts
@@ -64,7 +64,7 @@ export interface LicenceActivityDistribution {
 /** One licence SKU with how many hold it and its five workload distributions. */
 export interface LicenceActivitySku {
   licenceTypeId: number;
-  name: string;
+  name: string | null;
   skuId: string | null;
   assignedUsers: number;
   workloads: LicenceActivityDistribution[];


### PR DESCRIPTION
## Scope

Follow-up to #456: preserve the expected sample count when per-user observations are missing, and safely display/filter unnamed SKUs.

Previously `formatSamples` returned only a dash for `observedSamples == 0`, hiding the distinction between no expected observations and a missing set of expected observations. It now keeps the unknown-active marker while showing, for example, `0 observed of 8 expected`; the detail header labels that context. Existing measured/partial positive formats are unchanged.

The persisted `license_types.name` column is nullable and the API preserves that null. The frontend type now reflects the contract. A shared display helper uses the actual non-empty name, then SKU identifier, then numeric licence identifier; all relevant filtering, sorting and titles use it. This fixes the reproduced `toLocaleLowerCase` null-reference failure without inventing a product name.

## Verification

- Reproduced the missing-context defect and nullable-name filter exception with failing tests, then fixed both.
- Added an interaction regression for changing the top count and clicking Export, which commits the count on blur. It passed on the unchanged production handlers, so no speculative event-timing repair was introduced.
- All 46 affected page, user-table, SKU, drill-down and formatting tests pass; TypeScript and production Vite build pass.
- A fresh parallel final round across Claude Sonnet 5, GPT-5.4 mini and Grok 4.6 found no actionable issues. Prior full-feature rounds covered the unchanged SQL/API/lifetime/schema surfaces.
- All required hosted CI checks pass at `3c535436c014edd7f09a77c89206cf1a91d6664c`. This follow-up is intentionally unmerged pending its required approving review or new explicit merge authorisation.

No SQL/query, API, date-range, schema, migration, installer-config, permission or timeout changes. This small presentation repair does **not** resolve or change the Azure S4/S6 performance hold documented in #458.

Addresses #436
Addresses #437
