### PR TITLE
Preview: memory-backed licence activity without database migrations

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -87,6 +87,10 @@
     <Compile Include="LicenceActivity\LicenceActivityWorkbook.cs" />
     <Compile Include="LicenceActivity\LicenceActivitySql.cs" />
     <Compile Include="LicenceActivity\SqlLicenceActivityStore.cs" />
+    <Compile Include="LicenceActivity\SqlLicenceActivityReadModelLoader.cs" />
+    <Compile Include="LicenceActivity\LicenceActivityReadModel.cs" />
+    <Compile Include="LicenceActivity\LicenceActivityReadModelCache.cs" />
+    <Compile Include="LicenceActivity\CachedLicenceActivityStore.cs" />
     <Compile Include="Config\AppConfig.cs" />
     <Compile Include="Config\AppConnectionStrings.cs" />
     <Compile Include="CopilotAdoption\AdoptionBand.cs" />

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/CachedLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/CachedLicenceActivityStore.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Common.Entities.LicenceActivity
+{
+    public interface ILicenceActivitySnapshotValidator
+    {
+        bool IsCurrent(LicenceActivityOverview overview, LicenceActivitySources sources);
+    }
+
+    public sealed class CachedLicenceActivityStore : ILicenceActivityStore, ILicenceActivitySnapshotValidator
+    {
+        private readonly ILicenceActivityReadModelLoader _loader;
+        private readonly LicenceActivityReadModelCache _cache;
+        private readonly string _scope;
+
+        public CachedLicenceActivityStore(
+            ILicenceActivityReadModelLoader loader, LicenceActivityReadModelCache cache, string scope)
+        {
+            _loader = loader ?? throw new ArgumentNullException(nameof(loader));
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            if (string.IsNullOrWhiteSpace(scope)) throw new ArgumentException("A cache scope is required.", nameof(scope));
+            _scope = scope;
+        }
+
+        public async Task<LicenceActivityOverview> LoadOverviewAsync(
+            LicenceActivityQuery query, LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken)
+        {
+            Validate(query, sources);
+            diagnostics = diagnostics ?? NullLicenceActivityDiagnostics.Instance;
+            var range = LicenceActivityQuery.Create(query.From, query.To, sources.NowUtc);
+            var capturedSources = Capture(sources);
+            var lease = await _cache.GetAsync(
+                Scope(capturedSources), range.From + "\n" + range.To,
+                token => _loader.LoadReadModelAsync(range, capturedSources, diagnostics, token),
+                cancellationToken).ConfigureAwait(false);
+            var watch = Stopwatch.StartNew();
+            var overview = lease.Model.BuildOverview(query, cancellationToken);
+            overview.ReadModelId = lease.Model.Id;
+            overview.SourceExpiresUtc = lease.ExpiresUtc;
+            diagnostics.Stage("ProjectionCompleted", watch.ElapsedMilliseconds);
+            return overview;
+        }
+
+        public Task<LicenceActivityUsers> LoadUsersAsync(
+            LicenceActivityOverview overview, LicenceActivityQuery query, LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken)
+        {
+            Validate(query, sources);
+            if (overview == null) throw new ArgumentNullException(nameof(overview));
+            cancellationToken.ThrowIfCancellationRequested();
+            var lease = _cache.Find(Scope(sources), overview.ReadModelId);
+            var watch = Stopwatch.StartNew();
+            var users = lease.Model.BuildUsers(overview, query, cancellationToken);
+            users.SourceExpiresUtc = lease.ExpiresUtc;
+            (diagnostics ?? NullLicenceActivityDiagnostics.Instance).Stage("ProjectionCompleted", watch.ElapsedMilliseconds);
+            return Task.FromResult(users);
+        }
+
+        private string Scope(LicenceActivitySources sources) => _scope + "\n" + sources.CacheKey;
+
+        public bool IsCurrent(LicenceActivityOverview overview, LicenceActivitySources sources) =>
+            _cache.Contains(Scope(sources), overview.ReadModelId);
+
+        private static void Validate(LicenceActivityQuery query, LicenceActivitySources sources)
+        {
+            if (query == null) throw new ArgumentNullException(nameof(query));
+            if (sources == null) throw new ArgumentNullException(nameof(sources));
+            if (!sources.UserMetadata)
+                throw new InvalidOperationException("Licence activity requires the user metadata import.");
+        }
+
+        private static LicenceActivitySources Capture(LicenceActivitySources sources) =>
+            new LicenceActivitySources
+            {
+                UserMetadata = sources.UserMetadata,
+                UsageReports = sources.UsageReports,
+                CopilotUsageReports = sources.CopilotUsageReports,
+                CopilotAudit = sources.CopilotAudit,
+                CopilotInteractions = sources.CopilotInteractions,
+                NowUtc = sources.NowUtc
+            };
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityModels.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityModels.cs
@@ -21,11 +21,17 @@ namespace Common.Entities.LicenceActivity
         public string SnapshotId { get; set; }
         public DateTime GeneratedUtc { get; set; }
         public DateTime ExpiresUtc { get; set; }
+
+        [JsonIgnore]
+        public DateTime? SourceExpiresUtc { get; set; }
     }
 
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public sealed class LicenceActivityOverview : LicenceActivitySnapshot
     {
+        [JsonIgnore]
+        public string ReadModelId { get; set; }
+
         public LicenceActivityQuery Query { get; set; }
         public int DistinctAssignedUsers { get; set; }
         public List<LicenceActivitySku> Licences { get; set; } = new List<LicenceActivitySku>();

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityReadModel.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityReadModel.cs
@@ -1,0 +1,936 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Common.Entities.LicenceActivity
+{
+    public sealed class LicenceActivityDirectoryUser
+    {
+        public int UserId { get; set; }
+        public string UserPrincipalName { get; set; }
+        public string Mail { get; set; }
+        public int DepartmentId { get; set; }
+        public int CountryId { get; set; }
+        public string Department { get; set; }
+        public string Country { get; set; }
+        public bool? AccountEnabled { get; set; }
+    }
+
+    public readonly struct LicenceActivityMembership
+    {
+        public LicenceActivityMembership(int userId, int licenceTypeId)
+        {
+            UserId = userId;
+            LicenceTypeId = licenceTypeId;
+        }
+
+        public int UserId { get; }
+        public int LicenceTypeId { get; }
+    }
+
+    public readonly struct LicenceActivityScore
+    {
+        public LicenceActivityScore(
+            int activeSamples, int observedSamples, bool frequencyKnown,
+            double? averageActions, DateTime? lastActivityUtc)
+        {
+            ActiveSamples = activeSamples;
+            ObservedSamples = observedSamples;
+            FrequencyKnown = frequencyKnown;
+            AverageActions = averageActions;
+            LastActivityUtc = lastActivityUtc;
+        }
+
+        public int ActiveSamples { get; }
+        public int ObservedSamples { get; }
+        public bool FrequencyKnown { get; }
+        public double? AverageActions { get; }
+        public DateTime? LastActivityUtc { get; }
+    }
+
+    /// <summary>
+    /// Immutable, unique-user projection shared by every filter and licence drill-down for one exact date range.
+    /// Ranking always uses ordinal-ignore-case UPN ordering followed by user ID, so equal names are deterministic.
+    /// </summary>
+    public sealed class LicenceActivityReadModel
+    {
+        private const sbyte UnknownBand = -1;
+        private readonly string _from;
+        private readonly string _to;
+        private readonly DirectoryEntry[] _users;
+        private readonly bool[] _eligible;
+        private readonly SkuEntry[] _licences;
+        private readonly Dictionary<int, int[]> _membersByLicence;
+        private readonly Dictionary<int, int> _licenceSlotById;
+        private readonly int[] _licenceOffsetsByUser;
+        private readonly int[] _licenceSlotsByUser;
+        private readonly LicenceActivityCoverage[] _coverage;
+        private readonly IReadOnlyDictionary<int, LicenceActivityScore>[] _scores;
+        private readonly sbyte[][] _bands;
+        private readonly RankValue[][] _rankValues;
+        private readonly object _rankingGate = new object();
+        private readonly ConcurrentDictionary<string, RankingIndex> _rankings =
+            new ConcurrentDictionary<string, RankingIndex>(StringComparer.Ordinal);
+
+        public LicenceActivityReadModel(
+            LicenceActivityQuery range,
+            IReadOnlyList<LicenceActivitySku> licences,
+            IReadOnlyList<LicenceActivityDirectoryUser> users,
+            IReadOnlyList<LicenceActivityMembership> memberships,
+            IReadOnlyList<LicenceActivityCoverage> coverage,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>> scores)
+        {
+            if (range == null) throw new ArgumentNullException(nameof(range));
+            if (licences == null) throw new ArgumentNullException(nameof(licences));
+            if (users == null) throw new ArgumentNullException(nameof(users));
+            if (memberships == null) throw new ArgumentNullException(nameof(memberships));
+            if (coverage == null) throw new ArgumentNullException(nameof(coverage));
+            if (scores == null) throw new ArgumentNullException(nameof(scores));
+            if (range.DepartmentId.HasValue || range.CountryId.HasValue || range.LicenceTypeId.HasValue)
+                throw new ArgumentException("A licence activity read model must cover an unfiltered date range.", nameof(range));
+
+            _from = range.From;
+            _to = range.To;
+            Id = Guid.NewGuid().ToString("N");
+
+            var userIndexes = new Dictionary<int, int>(users.Count);
+            _users = new DirectoryEntry[users.Count];
+            for (var index = 0; index < users.Count; index++)
+            {
+                var user = users[index] ?? throw new ArgumentException("Directory users cannot contain null.", nameof(users));
+                if (userIndexes.ContainsKey(user.UserId))
+                    throw new ArgumentException("Directory user IDs must be unique.", nameof(users));
+                userIndexes.Add(user.UserId, index);
+                _users[index] = new DirectoryEntry(user);
+            }
+
+            var licenceIds = new HashSet<int>();
+            _licences = licences.Select(licence =>
+            {
+                if (licence == null) throw new ArgumentException("Licences cannot contain null.", nameof(licences));
+                if (!licenceIds.Add(licence.LicenceTypeId))
+                    throw new ArgumentException("Licence type IDs must be unique.", nameof(licences));
+                return new SkuEntry(licence);
+            }).OrderBy(licence => licence.Name, NullFirstOrdinalIgnoreCaseComparer.Instance)
+              .ThenBy(licence => licence.LicenceTypeId)
+              .ToArray();
+            _licenceSlotById = _licences
+                .Select((licence, slot) => new { licence.LicenceTypeId, Slot = slot })
+                .ToDictionary(item => item.LicenceTypeId, item => item.Slot);
+
+            var membershipLists = _licences.ToDictionary(
+                licence => licence.LicenceTypeId, licence => new List<int>());
+            _eligible = new bool[_users.Length];
+            foreach (var membership in memberships)
+            {
+                int userIndex;
+                if (!userIndexes.TryGetValue(membership.UserId, out userIndex)) continue;
+                _eligible[userIndex] = true;
+                List<int> list;
+                if (membershipLists.TryGetValue(membership.LicenceTypeId, out list))
+                    list.Add(userIndex);
+            }
+
+            _membersByLicence = new Dictionary<int, int[]>(membershipLists.Count);
+            foreach (var pair in membershipLists)
+            {
+                pair.Value.Sort();
+                var write = 0;
+                for (var read = 0; read < pair.Value.Count; read++)
+                {
+                    if (write == 0 || pair.Value[read] != pair.Value[write - 1])
+                        pair.Value[write++] = pair.Value[read];
+                }
+                if (write < pair.Value.Count)
+                    pair.Value.RemoveRange(write, pair.Value.Count - write);
+                _membersByLicence.Add(pair.Key, pair.Value.ToArray());
+            }
+            _licenceOffsetsByUser = new int[_users.Length + 1];
+            foreach (var pair in _membersByLicence)
+                foreach (var user in pair.Value)
+                    _licenceOffsetsByUser[user + 1]++;
+            for (var user = 1; user < _licenceOffsetsByUser.Length; user++)
+                _licenceOffsetsByUser[user] += _licenceOffsetsByUser[user - 1];
+            _licenceSlotsByUser = new int[_licenceOffsetsByUser[_users.Length]];
+            var nextLicence = (int[])_licenceOffsetsByUser.Clone();
+            foreach (var pair in _membersByLicence)
+            {
+                var slot = _licenceSlotById[pair.Key];
+                foreach (var user in pair.Value)
+                    _licenceSlotsByUser[nextLicence[user]++] = slot;
+            }
+
+            _coverage = new LicenceActivityCoverage[LicenceActivityQuery.Workloads.Length];
+            var suppliedCoverage = new Dictionary<string, LicenceActivityCoverage>(StringComparer.Ordinal);
+            foreach (var item in coverage)
+            {
+                if (item == null || !LicenceActivityQuery.Workloads.Contains(item.Workload, StringComparer.Ordinal))
+                    continue;
+                if (suppliedCoverage.ContainsKey(item.Workload))
+                    throw new ArgumentException("Coverage workloads must be unique.", nameof(coverage));
+                suppliedCoverage.Add(item.Workload, item);
+            }
+
+            _scores = new IReadOnlyDictionary<int, LicenceActivityScore>[LicenceActivityQuery.Workloads.Length];
+            _bands = new sbyte[LicenceActivityQuery.Workloads.Length][];
+            _rankValues = new RankValue[LicenceActivityQuery.Workloads.Length][];
+            for (var workload = 0; workload < LicenceActivityQuery.Workloads.Length; workload++)
+            {
+                var name = LicenceActivityQuery.Workloads[workload];
+                LicenceActivityCoverage item;
+                _coverage[workload] = suppliedCoverage.TryGetValue(name, out item)
+                    ? CloneCoverage(item)
+                    : MissingCoverage(name);
+                IReadOnlyDictionary<int, LicenceActivityScore> workloadScores;
+                _scores[workload] = scores.TryGetValue(name, out workloadScores) && workloadScores != null
+                    ? workloadScores
+                    : EmptyScores.Instance;
+                _bands[workload] = new sbyte[_users.Length];
+                _rankValues[workload] = new RankValue[_users.Length];
+                for (var user = 0; user < _users.Length; user++)
+                {
+                    if (!_eligible[user])
+                    {
+                        _bands[workload][user] = UnknownBand;
+                        continue;
+                    }
+                    var evidence = Evidence(workload, user);
+                    _bands[workload][user] = BandCode(evidence);
+                    _rankValues[workload][user] = new RankValue(evidence);
+                }
+            }
+        }
+
+        public string Id { get; }
+
+        public LicenceActivityOverview BuildOverview(
+            LicenceActivityQuery query, CancellationToken cancellationToken)
+        {
+            ValidateRange(query);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var included = new bool[_users.Length];
+            var includedCount = 0;
+            for (var index = 0; index < _users.Length; index++)
+            {
+                if ((index & 4095) == 0) cancellationToken.ThrowIfCancellationRequested();
+                if (_eligible[index] && InCohort(_users[index], query))
+                {
+                    included[index] = true;
+                    includedCount++;
+                }
+            }
+
+            var overview = new LicenceActivityOverview
+            {
+                ReadModelId = Id,
+                Query = query,
+                DistinctAssignedUsers = includedCount,
+                Coverage = _coverage.Select(CloneCoverage).ToList()
+            };
+
+            foreach (var licence in _licences)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var result = new LicenceActivitySku
+                {
+                    LicenceTypeId = licence.LicenceTypeId,
+                    Name = licence.Name,
+                    SkuId = licence.SkuId
+                };
+                var distributions = NewDistributions();
+                int[] members;
+                if (_membersByLicence.TryGetValue(licence.LicenceTypeId, out members))
+                {
+                    foreach (var user in members)
+                    {
+                        if (!included[user]) continue;
+                        result.AssignedUsers++;
+                        AddBands(distributions, user);
+                    }
+                }
+                result.Workloads = ToDistributions(distributions, result.AssignedUsers);
+                overview.Licences.Add(result);
+            }
+
+            var departments = BuildDemographics(included, true, cancellationToken);
+            var countries = BuildDemographics(included, false, cancellationToken);
+            overview.DemographicsTruncated = departments.Count > 50 || countries.Count > 50;
+            overview.Departments = ProjectDemographics(departments, cancellationToken);
+            overview.Countries = ProjectDemographics(countries, cancellationToken);
+
+            if (overview.Licences.Count == 0)
+                overview.Messages.Add("No imported licence types are available.");
+            else if (overview.DistinctAssignedUsers == 0)
+                overview.Messages.Add("Licence types are imported, but no users in the selected scope currently hold one.");
+            overview.Messages.Add(
+                "User display names are not imported by this solution. Individual results use the user principal name; search also checks the stored mail address.");
+            foreach (var item in overview.Coverage.Where(item => item.Status != LicenceActivitySql.Available))
+            {
+                if (!string.IsNullOrWhiteSpace(item.Message))
+                    overview.Messages.Add(item.Workload + ": " + item.Message);
+            }
+            if (overview.DemographicsTruncated)
+                overview.Messages.Add("Department or country breakdowns are limited to the 50 largest values.");
+            cancellationToken.ThrowIfCancellationRequested();
+            return overview;
+        }
+
+        public LicenceActivityUsers BuildUsers(
+            LicenceActivityOverview overview,
+            LicenceActivityQuery query,
+            CancellationToken cancellationToken)
+        {
+            if (overview == null) throw new ArgumentNullException(nameof(overview));
+            ValidateRange(query);
+            ValidateOverviewScope(overview, query);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var result = new LicenceActivityUsers
+            {
+                OverviewId = overview.SnapshotId,
+                Query = query
+            };
+            if (!query.LicenceTypeId.HasValue)
+                throw new ArgumentException("A licenceTypeId is required for individual users.", nameof(query));
+            if (!overview.Licences.Any(licence => licence.LicenceTypeId == query.LicenceTypeId.Value))
+                throw new ArgumentException("The selected licence is not present in this overview.", nameof(query));
+
+            int[] members;
+            int licenceSlot;
+            if (!_membersByLicence.TryGetValue(query.LicenceTypeId.Value, out members)
+                || !_licenceSlotById.TryGetValue(query.LicenceTypeId.Value, out licenceSlot))
+                throw new ArgumentException("The selected licence is not present in this read model.", nameof(query));
+
+            var workload = WorkloadIndex(query.Workload);
+            var visited = 0;
+            foreach (var index in members)
+            {
+                if ((visited++ & 4095) == 0) cancellationToken.ThrowIfCancellationRequested();
+                var user = _users[index];
+                if (!InCohort(user, query) || !MatchesSearch(user, query.Search)) continue;
+                result.TotalUsers++;
+                if (_rankValues[workload][index].CanRankMost) result.RankedUsers++;
+            }
+            if (result.TotalUsers == 0)
+            {
+                AddUserMessages(result, query.Workload);
+                return result;
+            }
+
+            var most = Pick(
+                GetRanking(workload, RankingKind.Most, null, null, cancellationToken)
+                    .ByLicence[licenceSlot],
+                query, 0, query.Top, cancellationToken);
+            var least = Pick(
+                GetRanking(workload, RankingKind.Least, null, null, cancellationToken)
+                    .ByLicence[licenceSlot],
+                query, 0, query.Top, cancellationToken);
+            var offset = (query.Page - 1) * query.PageSize;
+            var page = Pick(
+                GetRanking(workload, RankingKind.Page, query.Sort, query.Direction, cancellationToken)
+                    .ByLicence[licenceSlot],
+                query, offset, query.PageSize, cancellationToken);
+
+            result.MostActive = most.Select(MaterializeUser).ToList();
+            result.LeastActive = least.Select(MaterializeUser).ToList();
+            result.Users = page.Select(MaterializeUser).ToList();
+            AddUserMessages(result, query.Workload);
+            cancellationToken.ThrowIfCancellationRequested();
+            return result;
+        }
+
+        private void ValidateRange(LicenceActivityQuery query)
+        {
+            if (query == null) throw new ArgumentNullException(nameof(query));
+            if (query.From != _from || query.To != _to)
+                throw new ArgumentException("The query date range does not match this licence activity read model.", nameof(query));
+        }
+
+        private void ValidateOverviewScope(LicenceActivityOverview overview, LicenceActivityQuery query)
+        {
+            if (!string.IsNullOrEmpty(overview.ReadModelId) && overview.ReadModelId != Id)
+                throw new ArgumentException("The overview belongs to a different licence activity read model.", nameof(overview));
+            if (overview.Query == null || overview.Query.From != _from || overview.Query.To != _to)
+                throw new ArgumentException("The overview date range does not match this licence activity read model.", nameof(overview));
+            if (overview.Query.DepartmentId != query.DepartmentId || overview.Query.CountryId != query.CountryId)
+                throw new ArgumentException("The user query must use the overview's exact demographic scope.", nameof(query));
+        }
+
+        private List<DemographicAccumulator> BuildDemographics(
+            bool[] included, bool department, CancellationToken cancellationToken)
+        {
+            var values = new Dictionary<int, DemographicAccumulator>();
+            for (var index = 0; index < _users.Length; index++)
+            {
+                if ((index & 4095) == 0) cancellationToken.ThrowIfCancellationRequested();
+                if (!included[index]) continue;
+                var user = _users[index];
+                var id = department ? user.DepartmentId : user.CountryId;
+                var name = department ? user.Department : user.Country;
+                if (id == 0) name = "Unknown";
+                DemographicAccumulator value;
+                if (!values.TryGetValue(id, out value))
+                {
+                    value = new DemographicAccumulator(id, string.IsNullOrEmpty(name) ? "Unknown" : name);
+                    values.Add(id, value);
+                }
+                value.AssignedUsers++;
+                AddBands(value.Distributions, index);
+            }
+            return values.Values
+                .OrderByDescending(value => value.AssignedUsers)
+                .ThenBy(value => value.Name, NullFirstOrdinalIgnoreCaseComparer.Instance)
+                .ThenBy(value => value.Id)
+                .ToList();
+        }
+
+        private static List<LicenceActivityDemographic> ProjectDemographics(
+            List<DemographicAccumulator> values, CancellationToken cancellationToken)
+        {
+            var count = Math.Min(50, values.Count);
+            var result = new List<LicenceActivityDemographic>(count);
+            for (var index = 0; index < count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var value = values[index];
+                result.Add(new LicenceActivityDemographic
+                {
+                    Id = value.Id,
+                    Name = value.Name,
+                    AssignedUsers = value.AssignedUsers,
+                    Workloads = ToDistributions(value.Distributions, value.AssignedUsers)
+                });
+            }
+            return result;
+        }
+
+        private RankingIndex GetRanking(
+            int workload, RankingKind kind, string sort, string direction,
+            CancellationToken cancellationToken)
+        {
+            var key = kind == RankingKind.Page && sort == "upn"
+                ? "page|upn|" + direction
+                : workload + "|" + kind + "|" + sort + "|" + direction;
+            RankingIndex cached;
+            if (_rankings.TryGetValue(key, out cached)) return cached;
+            lock (_rankingGate)
+            {
+                if (_rankings.TryGetValue(key, out cached)) return cached;
+                cancellationToken.ThrowIfCancellationRequested();
+                cached = BuildRanking(workload, kind, sort, direction, cancellationToken);
+                _rankings.TryAdd(key, cached);
+                return cached;
+            }
+        }
+
+        private RankingIndex BuildRanking(
+            int workload, RankingKind kind, string sort, string direction,
+            CancellationToken cancellationToken)
+        {
+            var indexes = new List<int>();
+            for (var index = 0; index < _users.Length; index++)
+            {
+                if ((index & 4095) == 0) cancellationToken.ThrowIfCancellationRequested();
+                if (!_eligible[index]) continue;
+                var rank = _rankValues[workload][index];
+                if (kind == RankingKind.Most && !rank.CanRankMost) continue;
+                if (kind == RankingKind.Least && !rank.Available) continue;
+                indexes.Add(index);
+            }
+            var built = indexes.ToArray();
+            Array.Sort(built, new RankingComparer(this, workload, kind, sort, direction));
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Build every SKU intersection in one pass over the shared ordering. Subsequent
+            // licence, search, cohort and page requests scan compact ID arrays without re-sorting.
+            var counts = new int[_licences.Length];
+            var visited = 0;
+            foreach (var user in built)
+            {
+                if ((visited++ & 4095) == 0) cancellationToken.ThrowIfCancellationRequested();
+                for (var offset = _licenceOffsetsByUser[user];
+                    offset < _licenceOffsetsByUser[user + 1];
+                    offset++)
+                {
+                    counts[_licenceSlotsByUser[offset]]++;
+                }
+            }
+            var byLicence = new int[_licences.Length][];
+            for (var slot = 0; slot < byLicence.Length; slot++)
+                byLicence[slot] = new int[counts[slot]];
+            Array.Clear(counts, 0, counts.Length);
+            visited = 0;
+            foreach (var user in built)
+            {
+                if ((visited++ & 4095) == 0) cancellationToken.ThrowIfCancellationRequested();
+                for (var offset = _licenceOffsetsByUser[user];
+                    offset < _licenceOffsetsByUser[user + 1];
+                    offset++)
+                {
+                    var slot = _licenceSlotsByUser[offset];
+                    byLicence[slot][counts[slot]++] = user;
+                }
+            }
+            return new RankingIndex(byLicence);
+        }
+
+        private List<int> Pick(
+            int[] ordered, LicenceActivityQuery query, int skip, int take,
+            CancellationToken cancellationToken)
+        {
+            var result = new List<int>(take);
+            var seen = 0;
+            for (var index = 0; index < ordered.Length && result.Count < take; index++)
+            {
+                if ((index & 4095) == 0) cancellationToken.ThrowIfCancellationRequested();
+                var user = ordered[index];
+                if (!InCohort(_users[user], query)
+                    || !MatchesSearch(_users[user], query.Search))
+                {
+                    continue;
+                }
+                if (seen++ < skip) continue;
+                result.Add(user);
+            }
+            return result;
+        }
+
+        private LicenceActivityUser MaterializeUser(int index)
+        {
+            var source = _users[index];
+            var result = new LicenceActivityUser
+            {
+                UserId = source.UserId,
+                UserPrincipalName = source.UserPrincipalName,
+                Department = source.Department,
+                Country = source.Country,
+                AccountEnabled = source.AccountEnabled
+            };
+            for (var workload = 0; workload < LicenceActivityQuery.Workloads.Length; workload++)
+            {
+                var evidence = Evidence(workload, index);
+                result.Workloads.Add(new LicenceActivityEvidence
+                {
+                    Workload = LicenceActivityQuery.Workloads[workload],
+                    Status = evidence.Status,
+                    Band = evidence.Available
+                        ? LicenceActivityRules.Band(
+                            evidence.ActiveSamples, evidence.ObservedSamples, _coverage[workload].ExpectedSamples)
+                        : "unknown",
+                    Source = _coverage[workload].Source,
+                    Measure = _coverage[workload].Measure,
+                    ActiveSamples = evidence.ActiveSamples,
+                    ObservedSamples = evidence.ObservedSamples,
+                    ExpectedSamples = _coverage[workload].ExpectedSamples,
+                    AverageActions = evidence.AverageActions,
+                    LastActivityUtc = evidence.LastActivityUtc
+                });
+            }
+            return result;
+        }
+
+        private void AddUserMessages(LicenceActivityUsers result, string workload)
+        {
+            result.Messages.Add(
+                "Most/least lists rank the selected workload by active supporting samples, then average actions and last activity. Complete positive measurements rank before partial positive evidence, which still ranks above measured zero; unknown or incomplete evidence is excluded from least-active.");
+            var selected = _coverage[WorkloadIndex(workload)];
+            if (selected.Status != LicenceActivitySql.Available && !string.IsNullOrWhiteSpace(selected.Message))
+                result.Messages.Add(selected.Message);
+            if (result.TotalUsers > 0 && result.RankedUsers == 0)
+                result.Messages.Add("No user has complete or positive evidence for the selected workload and range.");
+        }
+
+        private EvidenceState Evidence(int workload, int userIndex)
+        {
+            var coverage = _coverage[workload];
+            LicenceActivityScore score;
+            var present = _scores[workload].TryGetValue(_users[userIndex].UserId, out score);
+            var status = coverage.Status ?? LicenceActivitySql.MissingCoverage;
+            var active = present ? score.ActiveSamples : 0;
+            var observed = coverage.ObservedSamples;
+            if (IsOfficialReport(coverage.Source))
+            {
+                observed = present ? score.ObservedSamples : 0;
+                if (status == LicenceActivitySql.Available)
+                {
+                    if (!present)
+                        status = LicenceActivitySql.MissingCoverage;
+                    else if (!score.FrequencyKnown || observed != coverage.ExpectedSamples)
+                        status = LicenceActivitySql.Partial;
+                }
+            }
+            return new EvidenceState(
+                status, active, observed, coverage.ExpectedSamples,
+                present ? score.AverageActions : null,
+                present ? score.LastActivityUtc : null,
+                !present && status == LicenceActivitySql.Available && !IsOfficialReport(coverage.Source)
+                    ? 0d
+                    : present ? score.AverageActions : null);
+        }
+
+        private static sbyte BandCode(EvidenceState evidence)
+        {
+            if (!evidence.Available) return UnknownBand;
+            switch (LicenceActivityRules.Band(
+                evidence.ActiveSamples, evidence.ObservedSamples, evidence.ExpectedSamples))
+            {
+                case "zero": return 0;
+                case "low": return 1;
+                case "moderate": return 2;
+                case "high": return 3;
+                default: return UnknownBand;
+            }
+        }
+
+        private void AddBands(DistributionAccumulator[] distributions, int user)
+        {
+            for (var workload = 0; workload < distributions.Length; workload++)
+                distributions[workload].Add(_bands[workload][user]);
+        }
+
+        private static DistributionAccumulator[] NewDistributions()
+        {
+            var result = new DistributionAccumulator[LicenceActivityQuery.Workloads.Length];
+            for (var index = 0; index < result.Length; index++)
+                result[index] = new DistributionAccumulator();
+            return result;
+        }
+
+        private static List<LicenceActivityDistribution> ToDistributions(
+            DistributionAccumulator[] source, int assignedUsers)
+        {
+            var result = new List<LicenceActivityDistribution>(LicenceActivityQuery.Workloads.Length);
+            for (var workload = 0; workload < LicenceActivityQuery.Workloads.Length; workload++)
+            {
+                var counts = source[workload];
+                result.Add(new LicenceActivityDistribution
+                {
+                    Workload = LicenceActivityQuery.Workloads[workload],
+                    High = counts.High,
+                    Moderate = counts.Moderate,
+                    Low = counts.Low,
+                    Zero = counts.Zero,
+                    Unknown = assignedUsers - counts.Known
+                });
+            }
+            return result;
+        }
+
+        private static bool InCohort(DirectoryEntry user, LicenceActivityQuery query) =>
+            (!query.DepartmentId.HasValue || user.DepartmentId == query.DepartmentId.Value)
+            && (!query.CountryId.HasValue || user.CountryId == query.CountryId.Value);
+
+        private static bool MatchesSearch(DirectoryEntry user, string search)
+        {
+            if (string.IsNullOrEmpty(search)) return true;
+            return user.UserPrincipalName.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0
+                || (!string.IsNullOrEmpty(user.Mail)
+                    && user.Mail.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        private static bool IsOfficialReport(string source) =>
+            source == LicenceActivitySql.M365ReportSource
+            || source == LicenceActivitySql.CopilotReportSource;
+
+        private static int WorkloadIndex(string workload)
+        {
+            for (var index = 0; index < LicenceActivityQuery.Workloads.Length; index++)
+                if (LicenceActivityQuery.Workloads[index] == workload) return index;
+            throw new ArgumentException("Unknown licence activity workload.", nameof(workload));
+        }
+
+        private static LicenceActivityCoverage MissingCoverage(string workload) =>
+            new LicenceActivityCoverage
+            {
+                Workload = workload,
+                Status = LicenceActivitySql.MissingCoverage,
+                Source = string.Empty,
+                Measure = string.Empty
+            };
+
+        private static LicenceActivityCoverage CloneCoverage(LicenceActivityCoverage source) =>
+            new LicenceActivityCoverage
+            {
+                Workload = source.Workload,
+                Status = source.Status,
+                Source = source.Source,
+                Measure = source.Measure,
+                Granularity = source.Granularity,
+                Message = source.Message,
+                EffectiveFromUtc = source.EffectiveFromUtc,
+                EffectiveToUtc = source.EffectiveToUtc,
+                LatestImportUtc = source.LatestImportUtc,
+                LagDays = source.LagDays,
+                ReportPeriodDays = source.ReportPeriodDays,
+                ExpectedSamples = source.ExpectedSamples,
+                ObservedSamples = source.ObservedSamples,
+                UnmatchedUsers = source.UnmatchedUsers,
+                SnapshotDates = source.SnapshotDates == null
+                    ? new List<DateTime>()
+                    : new List<DateTime>(source.SnapshotDates)
+            };
+
+        private sealed class DirectoryEntry
+        {
+            internal DirectoryEntry(LicenceActivityDirectoryUser source)
+            {
+                UserId = source.UserId;
+                UserPrincipalName = source.UserPrincipalName ?? string.Empty;
+                Mail = source.Mail;
+                DepartmentId = source.DepartmentId;
+                CountryId = source.CountryId;
+                Department = source.Department;
+                Country = source.Country;
+                AccountEnabled = source.AccountEnabled;
+            }
+
+            internal int UserId { get; }
+            internal string UserPrincipalName { get; }
+            internal string Mail { get; }
+            internal int DepartmentId { get; }
+            internal int CountryId { get; }
+            internal string Department { get; }
+            internal string Country { get; }
+            internal bool? AccountEnabled { get; }
+        }
+
+        private sealed class SkuEntry
+        {
+            internal SkuEntry(LicenceActivitySku source)
+            {
+                LicenceTypeId = source.LicenceTypeId;
+                Name = source.Name;
+                SkuId = source.SkuId;
+            }
+
+            internal int LicenceTypeId { get; }
+            internal string Name { get; }
+            internal string SkuId { get; }
+        }
+
+        private sealed class DemographicAccumulator
+        {
+            internal DemographicAccumulator(int id, string name)
+            {
+                Id = id;
+                Name = name;
+                Distributions = NewDistributions();
+            }
+
+            internal int Id { get; }
+            internal string Name { get; }
+            internal int AssignedUsers { get; set; }
+            internal DistributionAccumulator[] Distributions { get; }
+        }
+
+        private sealed class DistributionAccumulator
+        {
+            internal int High;
+            internal int Moderate;
+            internal int Low;
+            internal int Zero;
+            internal int Known => High + Moderate + Low + Zero;
+
+            internal void Add(sbyte band)
+            {
+                switch (band)
+                {
+                    case 3: High++; break;
+                    case 2: Moderate++; break;
+                    case 1: Low++; break;
+                    case 0: Zero++; break;
+                }
+            }
+        }
+
+        private readonly struct EvidenceState
+        {
+            internal EvidenceState(
+                string status, int activeSamples, int observedSamples, int expectedSamples,
+                double? averageActions, DateTime? lastActivityUtc, double? rankAverageActions)
+            {
+                Status = status;
+                ActiveSamples = activeSamples;
+                ObservedSamples = observedSamples;
+                ExpectedSamples = expectedSamples;
+                AverageActions = averageActions;
+                LastActivityUtc = lastActivityUtc;
+                RankAverageActions = rankAverageActions;
+            }
+
+            internal string Status { get; }
+            internal bool Available => Status == LicenceActivitySql.Available;
+            internal int ActiveSamples { get; }
+            internal int ObservedSamples { get; }
+            internal double? AverageActions { get; }
+            internal DateTime? LastActivityUtc { get; }
+            internal double? RankAverageActions { get; }
+            internal int ExpectedSamples { get; }
+        }
+
+        private readonly struct RankValue
+        {
+            internal RankValue(EvidenceState evidence)
+            {
+                ActiveSamples = evidence.ActiveSamples;
+                AverageActions = evidence.RankAverageActions;
+                LastActivityUtc = evidence.LastActivityUtc;
+                Available = evidence.Available;
+                CanRankMost = evidence.Available || evidence.ActiveSamples > 0;
+                Category = evidence.Available
+                    ? evidence.ActiveSamples > 0 ? (byte)0 : (byte)2
+                    : evidence.ActiveSamples > 0 ? (byte)1 : (byte)3;
+            }
+
+            internal int ActiveSamples { get; }
+            internal double? AverageActions { get; }
+            internal DateTime? LastActivityUtc { get; }
+            internal bool Available { get; }
+            internal bool CanRankMost { get; }
+            internal byte Category { get; }
+        }
+
+        private enum RankingKind
+        {
+            Most,
+            Least,
+            Page
+        }
+
+        private sealed class RankingIndex
+        {
+            internal RankingIndex(int[][] byLicence)
+            {
+                ByLicence = byLicence;
+            }
+
+            internal int[][] ByLicence { get; }
+        }
+
+        private sealed class RankingComparer : IComparer<int>
+        {
+            private readonly LicenceActivityReadModel _owner;
+            private readonly int _workload;
+            private readonly RankingKind _kind;
+            private readonly string _sort;
+            private readonly int _direction;
+
+            internal RankingComparer(
+                LicenceActivityReadModel owner, int workload, RankingKind kind,
+                string sort, string direction)
+            {
+                _owner = owner;
+                _workload = workload;
+                _kind = kind;
+                _sort = sort;
+                _direction = direction == "desc" ? -1 : 1;
+            }
+
+            public int Compare(int left, int right)
+            {
+                var leftEvidence = _owner._rankValues[_workload][left];
+                var rightEvidence = _owner._rankValues[_workload][right];
+                int compared;
+
+                if (_kind == RankingKind.Most)
+                {
+                    compared = leftEvidence.Category.CompareTo(rightEvidence.Category);
+                    if (compared != 0) return compared;
+                    compared = rightEvidence.ActiveSamples.CompareTo(leftEvidence.ActiveSamples);
+                    if (compared != 0) return compared;
+                    compared = CompareNullable(rightEvidence.AverageActions, leftEvidence.AverageActions);
+                    if (compared != 0) return compared;
+                    compared = CompareNullable(rightEvidence.LastActivityUtc, leftEvidence.LastActivityUtc);
+                    if (compared != 0) return compared;
+                }
+                else if (_kind == RankingKind.Least)
+                {
+                    compared = leftEvidence.ActiveSamples.CompareTo(rightEvidence.ActiveSamples);
+                    if (compared != 0) return compared;
+                    compared = CompareNullable(leftEvidence.AverageActions, rightEvidence.AverageActions);
+                    if (compared != 0) return compared;
+                    compared = CompareNullable(leftEvidence.LastActivityUtc, rightEvidence.LastActivityUtc);
+                    if (compared != 0) return compared;
+                }
+                else if (_sort == "activity")
+                {
+                    compared = leftEvidence.Category.CompareTo(rightEvidence.Category);
+                    if (compared != 0) return compared;
+                    compared = _direction * leftEvidence.ActiveSamples.CompareTo(rightEvidence.ActiveSamples);
+                    if (compared != 0) return compared;
+                    compared = _direction * CompareNullable(
+                        leftEvidence.AverageActions, rightEvidence.AverageActions);
+                    if (compared != 0) return compared;
+                    compared = _direction * CompareNullable(
+                        leftEvidence.LastActivityUtc, rightEvidence.LastActivityUtc);
+                    if (compared != 0) return compared;
+                }
+                else if (_sort == "lastActivity")
+                {
+                    compared = leftEvidence.Category.CompareTo(rightEvidence.Category);
+                    if (compared != 0) return compared;
+                    compared = _direction * CompareNullable(
+                        leftEvidence.LastActivityUtc, rightEvidence.LastActivityUtc);
+                    if (compared != 0) return compared;
+                    compared = _direction * leftEvidence.ActiveSamples.CompareTo(rightEvidence.ActiveSamples);
+                    if (compared != 0) return compared;
+                    compared = _direction * CompareNullable(
+                        leftEvidence.AverageActions, rightEvidence.AverageActions);
+                    if (compared != 0) return compared;
+                }
+                else
+                {
+                    compared = _direction * StringComparer.OrdinalIgnoreCase.Compare(
+                        _owner._users[left].UserPrincipalName, _owner._users[right].UserPrincipalName);
+                    if (compared != 0) return compared;
+                    return _owner._users[left].UserId.CompareTo(_owner._users[right].UserId);
+                }
+
+                compared = StringComparer.OrdinalIgnoreCase.Compare(
+                    _owner._users[left].UserPrincipalName, _owner._users[right].UserPrincipalName);
+                return compared != 0
+                    ? compared
+                    : _owner._users[left].UserId.CompareTo(_owner._users[right].UserId);
+            }
+
+            private static int CompareNullable<T>(T? left, T? right) where T : struct, IComparable<T>
+            {
+                if (!left.HasValue) return right.HasValue ? -1 : 0;
+                return right.HasValue ? left.Value.CompareTo(right.Value) : 1;
+            }
+        }
+
+        private sealed class NullFirstOrdinalIgnoreCaseComparer : IComparer<string>
+        {
+            internal static readonly NullFirstOrdinalIgnoreCaseComparer Instance =
+                new NullFirstOrdinalIgnoreCaseComparer();
+
+            public int Compare(string left, string right)
+            {
+                if (left == null) return right == null ? 0 : -1;
+                return right == null ? 1 : StringComparer.OrdinalIgnoreCase.Compare(left, right);
+            }
+        }
+
+        private sealed class EmptyScores : IReadOnlyDictionary<int, LicenceActivityScore>
+        {
+            internal static readonly EmptyScores Instance = new EmptyScores();
+            public int Count => 0;
+            public IEnumerable<int> Keys => Enumerable.Empty<int>();
+            public IEnumerable<LicenceActivityScore> Values => Enumerable.Empty<LicenceActivityScore>();
+            public LicenceActivityScore this[int key] => throw new KeyNotFoundException();
+            public bool ContainsKey(int key) => false;
+            public IEnumerator<KeyValuePair<int, LicenceActivityScore>> GetEnumerator() =>
+                Enumerable.Empty<KeyValuePair<int, LicenceActivityScore>>().GetEnumerator();
+            public bool TryGetValue(int key, out LicenceActivityScore value)
+            {
+                value = default(LicenceActivityScore);
+                return false;
+            }
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityReadModelCache.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityReadModelCache.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Common.Entities.LicenceActivity
+{
+    public sealed class LicenceActivityReadModelExpiredException : Exception
+    {
+        public LicenceActivityReadModelExpiredException()
+            : base("The source snapshot expired or was evicted. Refresh the licence report.") { }
+    }
+
+    public sealed class LicenceActivityReadModelBusyException : Exception
+    {
+        public LicenceActivityReadModelBusyException()
+            : base("Another licence report snapshot is loading. Retry in a few seconds.") { }
+    }
+
+    public sealed class LicenceActivityReadModelLease
+    {
+        internal LicenceActivityReadModelLease(LicenceActivityReadModel model, DateTime expiresUtc)
+        {
+            Model = model;
+            ExpiresUtc = expiresUtc;
+        }
+
+        public LicenceActivityReadModel Model { get; }
+        public DateTime ExpiresUtc { get; }
+    }
+
+    /// <summary>
+    /// Holds unique-user facts, compact memberships and ranking IDs, not a user-by-SKU object graph.
+    /// Completed HTTP snapshots retain only the model ID, so eviction also releases the large model.
+    /// </summary>
+    public sealed class LicenceActivityReadModelCache
+    {
+        public const int DefaultCapacity = 2;
+        public static readonly TimeSpan DefaultLifetime = TimeSpan.FromMinutes(5);
+        private readonly object _gate = new object();
+        private readonly Dictionary<string, Entry> _entries = new Dictionary<string, Entry>(StringComparer.Ordinal);
+        private readonly int _capacity;
+        private readonly TimeSpan _lifetime;
+        private readonly TimeSpan _loadTimeout;
+        private readonly Func<DateTime> _utcNow;
+        private int _activeLoads;
+
+        public LicenceActivityReadModelCache(
+            int capacity = DefaultCapacity, TimeSpan? lifetime = null,
+            Func<DateTime> utcNow = null, TimeSpan? loadTimeout = null)
+        {
+            if (capacity < 1) throw new ArgumentOutOfRangeException(nameof(capacity));
+            _capacity = capacity;
+            _lifetime = lifetime ?? DefaultLifetime;
+            _loadTimeout = loadTimeout ?? TimeSpan.FromSeconds(30);
+            if (_lifetime <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(lifetime));
+            if (_loadTimeout <= TimeSpan.Zero || _loadTimeout.TotalMilliseconds > int.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(loadTimeout));
+            _utcNow = utcNow ?? (() => DateTime.UtcNow);
+        }
+
+        public Task<LicenceActivityReadModelLease> GetAsync(
+            string scope, string key, Func<CancellationToken, Task<LicenceActivityReadModel>> load,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(scope)) throw new ArgumentException("A cache scope is required.", nameof(scope));
+            if (string.IsNullOrEmpty(key)) throw new ArgumentException("A cache key is required.", nameof(key));
+            if (load == null) throw new ArgumentNullException(nameof(load));
+            cancellationToken.ThrowIfCancellationRequested();
+            var compoundKey = scope + "\n" + key;
+            Entry entry;
+            var start = false;
+            lock (_gate)
+            {
+                Prune();
+                if (!_entries.TryGetValue(compoundKey, out entry))
+                {
+                    // One cold model fans out to five bounded workload queries. Do not multiply
+                    // that SQL pressure when several administrators select different ranges.
+                    if (_activeLoads != 0) throw new LicenceActivityReadModelBusyException();
+                    if (_entries.Count >= _capacity)
+                    {
+                        var oldest = _entries.Values.OrderBy(e => e.Value.ExpiresUtc).First();
+                        _entries.Remove(oldest.Key);
+                    }
+                    entry = new Entry(compoundKey, scope, _loadTimeout);
+                    _entries.Add(compoundKey, entry);
+                    _activeLoads++;
+                    start = true;
+                }
+            }
+            if (start)
+                _ = Task.Run(() => LoadAsync(entry, load));
+            return WaitForCallerAsync(entry.Completion.Task, cancellationToken);
+        }
+
+        public LicenceActivityReadModelLease Find(string scope, string modelId)
+        {
+            lock (_gate)
+            {
+                Prune();
+                var entry = _entries.Values.FirstOrDefault(e =>
+                    e.Scope == scope && e.Value != null && e.Value.Model.Id == modelId);
+                return entry?.Value ?? throw new LicenceActivityReadModelExpiredException();
+            }
+        }
+
+        public bool Contains(string scope, string modelId)
+        {
+            lock (_gate)
+            {
+                Prune();
+                return _entries.Values.Any(e =>
+                    e.Scope == scope && e.Value != null && e.Value.Model.Id == modelId);
+            }
+        }
+
+        private async Task LoadAsync(Entry entry, Func<CancellationToken, Task<LicenceActivityReadModel>> load)
+        {
+            LicenceActivityReadModelLease value = null;
+            Exception failure = null;
+            try
+            {
+                entry.Lifetime.Token.ThrowIfCancellationRequested();
+                var model = await load(entry.Lifetime.Token).ConfigureAwait(false);
+                entry.Lifetime.Token.ThrowIfCancellationRequested();
+                if (model == null) throw new InvalidOperationException("The licence read-model loader returned no data.");
+                value = new LicenceActivityReadModelLease(model, _utcNow().Add(_lifetime));
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                entry.Lifetime.Dispose();
+            }
+            lock (_gate)
+            {
+                // Release before publication: a resumed caller can immediately admit another range.
+                // The loader has already cancelled/disposed all SQL work before reaching this point.
+                _activeLoads--;
+                if (failure == null)
+                {
+                    entry.Value = value;
+                    entry.Completion.TrySetResult(value);
+                }
+                else
+                {
+                    _entries.Remove(entry.Key);
+                    entry.Completion.TrySetException(failure);
+                    _ = entry.Completion.Task.Exception;
+                }
+            }
+        }
+
+        private static async Task<T> WaitForCallerAsync<T>(Task<T> shared, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!cancellationToken.CanBeCanceled) return await shared.ConfigureAwait(false);
+            var cancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (cancellationToken.Register(() => cancelled.TrySetResult(true)))
+            {
+                if (await Task.WhenAny(shared, cancelled.Task).ConfigureAwait(false) != shared)
+                    throw new OperationCanceledException(cancellationToken);
+                return await shared.ConfigureAwait(false);
+            }
+        }
+
+        private void Prune()
+        {
+            var now = _utcNow();
+            foreach (var key in _entries.Where(e => e.Value.Value != null && e.Value.Value.ExpiresUtc <= now)
+                .Select(e => e.Key).ToArray())
+                _entries.Remove(key);
+        }
+
+        private sealed class Entry
+        {
+            internal Entry(string key, string scope, TimeSpan timeout)
+            {
+                Key = key;
+                Scope = scope;
+                Lifetime = new CancellationTokenSource(timeout);
+            }
+            internal string Key { get; }
+            internal string Scope { get; }
+            internal CancellationTokenSource Lifetime { get; }
+            internal LicenceActivityReadModelLease Value { get; set; }
+            internal TaskCompletionSource<LicenceActivityReadModelLease> Completion { get; } =
+                new TaskCompletionSource<LicenceActivityReadModelLease>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -87,6 +87,16 @@ namespace Common.Entities.LicenceActivity
                         SampleParameterName(workload, index));
                 }
             }
+            sql.Append(@"
+UPDATE #Samples
+SET m365_from = CASE WHEN DATEADD(DAY,
+        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), sample_date) % 7) + 7) % 7),
+        sample_date) < @from THEN @from ELSE DATEADD(DAY,
+        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), sample_date) % 7) + 7) % 7),
+        sample_date) END,
+    end_exclusive = DATEADD(DAY, 1, sample_date),
+    copilot_from = DATEADD(DAY, -6, sample_date);
+");
         }
 
         internal static string BuildUsers(
@@ -195,7 +205,8 @@ CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserScores
         internal static string BuildM365OverviewPart(
             int workload,
             string eligibleTable = "#EligibleUsers",
-            string bandTable = null)
+            string bandTable = null,
+            int maximumSamples = 27)
         {
             var sql = new StringBuilder(14000);
             AppendOverviewPartPreamble(sql, eligibleTable);
@@ -208,7 +219,7 @@ CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserScores
                         "average published message and meeting counters across supporting snapshots",
                         true);
                     AppendM365OverviewScore(
-                        sql, Teams, "dbo.teams_user_activity_log");
+                        sql, Teams, "dbo.teams_user_activity_log", maximumSamples);
                     break;
                 case Outlook:
                     AppendM365Overview(
@@ -216,7 +227,7 @@ CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserScores
                         "average published sent and read counters across supporting snapshots",
                         true);
                     AppendM365OverviewScore(
-                        sql, Outlook, "dbo.outlook_user_activity_log");
+                        sql, Outlook, "dbo.outlook_user_activity_log", maximumSamples);
                     break;
                 case OneDrive:
                     AppendM365Overview(
@@ -224,7 +235,7 @@ CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserScores
                         "average published viewed-or-edited counter across supporting snapshots",
                         true);
                     AppendM365OverviewScore(
-                        sql, OneDrive, "dbo.onedrive_user_activity_log");
+                        sql, OneDrive, "dbo.onedrive_user_activity_log", maximumSamples);
                     break;
                 case SharePoint:
                     AppendM365Overview(
@@ -232,7 +243,7 @@ CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserScores
                         "average published viewed-or-edited counter across supporting snapshots",
                         true);
                     AppendM365OverviewScore(
-                        sql, SharePoint, "dbo.sharepoint_user_activity_log");
+                        sql, SharePoint, "dbo.sharepoint_user_activity_log", maximumSamples);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(workload));
@@ -296,6 +307,19 @@ WHERE (@departmentId IS NULL
   AND EXISTS
       (SELECT 1 FROM dbo.user_license_type_lookups AS owned WHERE owned.user_id = u.id)
 OPTION (RECOMPILE);
+
+-- This shared, connection-scoped index enables batch aggregation without altering source tables.
+-- Editions that cannot index temporary tables as columnstores retain the rowstore primary key.
+IF (SELECT COUNT(*) FROM " + tableName + @") >= 32768
+BEGIN
+    BEGIN TRY
+        EXEC sp_executesql N'CREATE NONCLUSTERED COLUMNSTORE INDEX IX_LicenceActivity_EligibleBatch
+            ON " + tableName + @" (user_id, department_id, country_id);';
+    END TRY
+    BEGIN CATCH
+        PRINT N'Licence activity is using rowstore temporary eligibility.';
+    END CATCH;
+END;
 ");
             if (bandTables != null)
             {
@@ -1075,8 +1099,21 @@ CROSS APPLY
         private static void AppendM365OverviewScore(
             StringBuilder sql,
             int workload,
-            string table)
+            string table,
+            int maximumSamples = 27)
         {
+            if (maximumSamples < 1 || maximumSamples > 27)
+                throw new ArgumentOutOfRangeException(nameof(maximumSamples));
+            var samples = Enumerable.Range(1, maximumSamples).ToArray();
+            var aggregates = string.Join(",\r\n", samples.Select(sample =>
+                "MAX(CASE WHEN chosen.sample_number = " + sample.ToString(CultureInfo.InvariantCulture)
+                + @" THEN CASE WHEN activity.last_activity_date >= chosen.m365_from
+                                AND activity.last_activity_date < chosen.end_exclusive
+                               THEN 2 ELSE 1 END ELSE 0 END) AS sample" + sample));
+            var observed = string.Join(" + ", samples.Select(sample =>
+                "CASE WHEN sample" + sample + " > 0 THEN 1 ELSE 0 END"));
+            var active = string.Join(" + ", samples.Select(sample =>
+                "CASE WHEN sample" + sample + " = 2 THEN 1 ELSE 0 END"));
             sql.AppendFormat(
                 CultureInfo.InvariantCulture,
                 @"
@@ -1095,7 +1132,8 @@ BEGIN
                        THEN 1 ELSE 0
                    END),
                1,
-               CAST(CASE WHEN COUNT(*) = 1 THEN 1 ELSE 0 END AS bit)
+               -- One pinned sample day: GROUP BY user already collapses duplicate report rows.
+               CAST(1 AS bit)
         FROM #Samples AS chosen
         JOIN #Weeks AS weeks
           ON chosen.sample_date >= weeks.m365_from
@@ -1110,56 +1148,54 @@ BEGIN
     END
     ELSE
     BEGIN
-        ;WITH PerSample AS
+        -- A bounded pivot has one group per user, not one per user/report day.
+        -- MAX retains duplicate-day evidence: 0 absent, 1 observed zero, 2 positive.
+        -- Preserve the eligible population through aggregation so sample-join selectivity
+        -- cannot shrink its group estimate and memory grant. Remove absent groups afterward.
+        ;WITH Chosen AS
         (
-            SELECT activity.user_id,
-                       activity.[date] AS sample_date,
-                       MAX(CASE
-                               WHEN activity.last_activity_date >=
-                                    CASE WHEN report_week.week_start < @from
-                                         THEN @from ELSE report_week.week_start END
-                                AND activity.last_activity_date < DATEADD(DAY, 1, activity.[date])
-                               THEN 1 ELSE 0
-                           END) AS was_active
-            FROM {1} AS activity
-            JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
-            CROSS APPLY
-            (
-                    SELECT DATEADD(
-                        DAY, 1 - DATEPART(WEEKDAY, activity.[date]), activity.[date]) AS week_start
-            ) AS report_week
-            WHERE activity.[date] >= @from
-              AND activity.[date] < @endExclusive
-              AND activity.[date] < DATEADD(DAY, 1, @settled)
-              AND
-              (
-                      activity.[date] = @to
-                      OR DATEPART(WEEKDAY, activity.[date]) = 7
-              )
-            GROUP BY activity.user_id, activity.[date]
+            SELECT samples.sample_date, weeks.m365_from,
+                   DATEADD(DAY, 1, samples.sample_date) AS end_exclusive,
+                   ROW_NUMBER() OVER (ORDER BY samples.sample_date) AS sample_number
+            FROM #Samples AS samples
+            JOIN #Weeks AS weeks
+              ON samples.sample_date = weeks.m365_to
+            WHERE samples.workload = {0}
         ),
         PerUser AS
         (
-            SELECT user_id,
-                       SUM(was_active) AS active_samples,
-                       COUNT(*) AS observed_samples
-            FROM PerSample
-            GROUP BY user_id
+            SELECT eligible.user_id, {2}
+            FROM #EligibleUsers AS eligible
+            LEFT JOIN
+            (
+                {1} AS activity
+                JOIN Chosen AS chosen
+                  ON CAST(activity.[date] AS date) = chosen.sample_date
+                 AND activity.[date] >= @from
+                 AND activity.[date] < @endExclusive
+            ) ON activity.user_id = eligible.user_id
+            GROUP BY eligible.user_id
+        ),
+        Totals AS
+        (
+            SELECT user_id, {3} AS active_samples, {4} AS observed_samples
+            FROM PerUser
         )
         INSERT #Scores
             (workload, user_id, active_samples, observed_samples, frequency_known)
         SELECT {0},
-                   user_id,
+                   per_user.user_id,
                    active_samples,
                    observed_samples,
                    CAST(CASE WHEN observed_samples = @expected{0}
                              THEN 1 ELSE 0 END AS bit)
-        FROM PerUser
+        FROM Totals AS per_user
+        WHERE observed_samples > 0
         OPTION (RECOMPILE, MAXDOP 1);
     END;
 END;
 ",
-                workload, table);
+                workload, table, aggregates, active, observed);
         }
 
         private static void AppendCopilotOverview(StringBuilder sql, LicenceActivitySources sources)
@@ -1381,6 +1417,20 @@ FROM PerUser
 OPTION (RECOMPILE);
 ";
 
+        private static string CopilotD7ActivityExpression(string from, string endExclusive)
+        {
+            // Counters describe this period; the user-level date is only a v1-shaped fallback.
+            return @"CASE
+                WHEN report.active_usage_days BETWEEN 1 AND 7
+                  OR report.prompts_all_apps > 0 THEN 1
+                WHEN report.active_usage_days IS NULL
+                 AND report.prompts_all_apps IS NULL
+                 AND report.last_activity_date >= " + from + @"
+                 AND report.last_activity_date < " + endExclusive + @" THEN 1
+                ELSE 0
+            END";
+        }
+
         private static readonly string CopilotOfficialOverview = @"
 DECLARE @copilotLogImported datetime = NULL;
 DECLARE @copilotLogObfuscated bit = 0;
@@ -1508,17 +1558,14 @@ BEGIN
         BEGIN
             IF @copilotD7Expected = 1
             BEGIN
+                DECLARE @copilotSingleSample date =
+                    (SELECT sample_date FROM #Samples WHERE workload = 5);
                 INSERT #Scores
                     (workload, user_id, active_samples, observed_samples, frequency_known)
                 SELECT 5,
                        report.user_id,
-                       CASE
-                           WHEN report.active_usage_days BETWEEN 1 AND 7
-                             OR report.prompts_all_apps > 0
-                             OR (report.last_activity_date >= DATEADD(DAY, -6, report.[date])
-                                 AND report.last_activity_date < DATEADD(DAY, 1, report.[date]))
-                           THEN 1 ELSE 0
-                       END,
+                       " + CopilotD7ActivityExpression(
+                           "DATEADD(DAY, -6, report.[date])", "DATEADD(DAY, 1, report.[date])") + @",
                        1,
                        CAST(CASE
                            WHEN report.active_usage_days BETWEEN 0 AND 7
@@ -1526,12 +1573,10 @@ BEGIN
                            THEN 1 ELSE 0
                        END AS bit)
                 FROM dbo.copilot_usage_user_activity_log AS report
-                JOIN #Samples AS chosen
-                  ON chosen.workload = 5
-                 AND report.[date] >= chosen.sample_date
-                 AND report.[date] < DATEADD(DAY, 1, chosen.sample_date)
                 JOIN #EligibleUsers AS eligible ON eligible.user_id = report.user_id
                 WHERE report.report_period_days = 7
+                  AND report.[date] >= @copilotSingleSample
+                  AND report.[date] < DATEADD(DAY, 1, @copilotSingleSample)
                 OPTION (RECOMPILE, MAXDOP 1);
             END
             ELSE
@@ -1539,38 +1584,26 @@ BEGIN
                 INSERT #Scores
                     (workload, user_id, active_samples, observed_samples, frequency_known)
                 SELECT 5, report.user_id,
-                       SUM(CASE
-                               WHEN report.active_usage_days BETWEEN 1 AND 7
-                                 OR report.prompts_all_apps > 0
-                               THEN 1
-                               WHEN report.active_usage_days IS NULL
-                                AND report.prompts_all_apps IS NULL
-                                AND report.last_activity_date >= DATEADD(DAY, -6, report.[date])
-                                AND report.last_activity_date < DATEADD(DAY, 1, report.[date])
-                               THEN 1
-                               ELSE 0
-                           END),
+                       SUM(" + CopilotD7ActivityExpression(
+                           "DATEADD(DAY, -6, report.[date])", "DATEADD(DAY, 1, report.[date])") + @"),
                        COUNT(*),
                        CAST(CASE
                                 WHEN COUNT(*) = @copilotD7Expected
-                                 AND COUNT(report.active_usage_days) = COUNT(*)
-                                 AND MIN(report.active_usage_days) >= 0
-                                 AND MAX(report.active_usage_days) <= 7
-                                 AND (COUNT(report.prompts_all_apps) = 0
-                                      OR MIN(report.prompts_all_apps) >= 0)
+                                 AND MIN(CASE WHEN report.active_usage_days BETWEEN 0 AND 7
+                                               AND (report.prompts_all_apps IS NULL
+                                                    OR report.prompts_all_apps >= 0)
+                                              THEN 1 ELSE 0 END) = 1
                                 THEN 1 ELSE 0
                             END AS bit)
                 FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(0))
+                JOIN #Samples AS chosen
+                  ON chosen.workload = 5
+                 AND CAST(report.[date] AS date) = chosen.sample_date
                 JOIN #EligibleUsers AS eligible ON eligible.user_id = report.user_id
                 WHERE report.report_period_days = 7
                   AND report.[date] >= DATEADD(DAY, 6, @from)
                   AND report.[date] < @endExclusive
                   AND report.[date] < DATEADD(DAY, 1, @settled)
-                  AND
-                  (
-                      report.[date] = @to
-                      OR DATEPART(WEEKDAY, report.[date]) = 7
-                  )
                 GROUP BY report.user_id
                 OPTION (RECOMPILE, MAXDOP 4);
             END
@@ -2488,6 +2521,17 @@ WHERE owned.license_type_id = @licenceTypeId
        OR u.mail LIKE @searchPattern ESCAPE N'\')
 OPTION (RECOMPILE);
 
+IF (SELECT COUNT(*) FROM #EligibleUsers) >= 32768
+BEGIN
+    BEGIN TRY
+        EXEC sp_executesql N'CREATE NONCLUSTERED COLUMNSTORE INDEX IX_LicenceActivity_EligibleBatch
+            ON #EligibleUsers (user_id);';
+    END TRY
+    BEGIN CATCH
+        PRINT N'Licence activity is using rowstore temporary eligibility.';
+    END CATCH;
+END;
+
 CREATE TABLE #Coverage
 (
     workload tinyint NOT NULL PRIMARY KEY,
@@ -2514,6 +2558,9 @@ CREATE TABLE #Samples
 (
     workload tinyint NOT NULL,
     sample_date date NOT NULL,
+    m365_from date NULL,
+    end_exclusive date NULL,
+    copilot_from date NULL,
     PRIMARY KEY (workload, sample_date)
 );
 
@@ -2540,47 +2587,48 @@ CREATE TABLE #Scores
             if (coverage.SnapshotDates == null || coverage.SnapshotDates.Count == 0)
                 return;
 
+            var samples = Enumerable.Range(0, coverage.SnapshotDates.Count).ToArray();
+            var aggregates = string.Join("\r\nUNION ALL\r\n", samples.Select(sample =>
+            {
+                var date = SampleParameterName(workload, sample);
+                return @"SELECT eligible.user_id, MAX(" + actionExpression + @") AS actions,
+                    MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
+                              AND activity.last_activity_date < chosen.end_exclusive
+                             THEN activity.last_activity_date END) AS last_activity_utc,
+                    MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
+                              AND activity.last_activity_date < chosen.end_exclusive
+                             THEN 1 ELSE 0 END) AS was_active
+                FROM " + table + @" AS activity
+                JOIN " + scopeTable + @" AS eligible ON eligible.user_id = activity.user_id
+                JOIN #Samples AS chosen ON chosen.workload = " + workload + @"
+                    AND chosen.sample_date = " + date + @"
+                WHERE activity.[date] >= " + date + @"
+                  AND activity.[date] < DATEADD(DAY, 1, " + date + @")
+                GROUP BY eligible.user_id";
+            }));
+            if (scopeTable == "#ReturnedUsers")
+            {
+                // At most 300 returned users: this hash is bounded to 300 x 27 samples.
+                aggregates = @"SELECT eligible.user_id, MAX(" + actionExpression + @") AS actions,
+                    MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
+                              AND activity.last_activity_date < chosen.end_exclusive
+                             THEN activity.last_activity_date END) AS last_activity_utc,
+                    MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
+                              AND activity.last_activity_date < chosen.end_exclusive
+                             THEN 1 ELSE 0 END) AS was_active
+                FROM " + table + @" AS activity
+                JOIN #ReturnedUsers AS eligible ON eligible.user_id = activity.user_id
+                JOIN #Samples AS chosen ON chosen.workload = " + workload + @"
+                    AND CAST(activity.[date] AS date) = chosen.sample_date
+                WHERE activity.[date] >= @from AND activity.[date] < @endExclusive
+                GROUP BY eligible.user_id, chosen.sample_date";
+            }
             sql.AppendFormat(
                 CultureInfo.InvariantCulture,
                 @"
 ;WITH PerSample AS
 (
-    SELECT activity.user_id,
-           CAST(activity.[date] AS date) AS sample_date,
-           MAX({2}) AS actions,
-           MAX(CASE
-                   WHEN activity.last_activity_date >= @from
-                    AND activity.last_activity_date < @endExclusive
-                    AND activity.last_activity_date < DATEADD(DAY, 1, CAST(activity.[date] AS date))
-                    AND activity.last_activity_date >= DATEADD(DAY,
-                        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
-                        CAST(activity.[date] AS date))
-                    AND activity.last_activity_date < DATEADD(DAY, 7,
-                        DATEADD(DAY,
-                            -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
-                            CAST(activity.[date] AS date)))
-                   THEN activity.last_activity_date
-               END) AS last_activity_utc,
-           MAX(CASE
-                   WHEN activity.last_activity_date >= @from
-                    AND activity.last_activity_date < @endExclusive
-                    AND activity.last_activity_date < DATEADD(DAY, 1, CAST(activity.[date] AS date))
-                    AND activity.last_activity_date >= DATEADD(DAY,
-                        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
-                        CAST(activity.[date] AS date))
-                    AND activity.last_activity_date < DATEADD(DAY, 7,
-                        DATEADD(DAY,
-                            -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), CAST(activity.[date] AS date)) % 7) + 7) % 7),
-                            CAST(activity.[date] AS date)))
-                   THEN 1 ELSE 0
-               END) AS was_active
-    FROM {1} AS activity
-    JOIN #Samples AS chosen
-      ON chosen.workload = {0}
-     AND activity.[date] >= chosen.sample_date
-     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
-    JOIN {3} AS eligible ON eligible.user_id = activity.user_id
-    GROUP BY activity.user_id, CAST(activity.[date] AS date)
+    {1}
 )
 INSERT #Scores
     (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
@@ -2594,7 +2642,7 @@ FROM PerSample
 GROUP BY user_id
 OPTION (RECOMPILE);
 ",
-                workload, table, actionExpression, scopeTable);
+                workload, aggregates);
         }
 
         private static void AppendCopilotUsers(
@@ -2608,7 +2656,32 @@ OPTION (RECOMPILE);
                 && coverage.ReportPeriodDays.HasValue)
             {
                 if (coverage.ReportPeriodDays.Value == 7)
-                    sql.Append(CopilotD7Users.Replace("#ActivityScope", scopeTable));
+                {
+                    if (scopeTable == "#ReturnedUsers")
+                    {
+                        sql.Append(@"
+CREATE TABLE #CopilotReportIds (id int NOT NULL PRIMARY KEY);
+INSERT #CopilotReportIds (id)
+SELECT report.id
+FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(IX_date_user_id_report_period_days))
+JOIN #Samples AS chosen
+  ON chosen.workload = 5
+ AND report.[date] >= chosen.sample_date
+ AND report.[date] < DATEADD(DAY, 1, chosen.sample_date)
+JOIN #ReturnedUsers AS eligible ON eligible.user_id = report.user_id
+WHERE report.report_period_days = 7
+OPTION (RECOMPILE);
+");
+                        sql.Append(CopilotD7Users.Replace(
+                            "AS report WITH (INDEX(0))",
+                            "AS report JOIN #CopilotReportIds AS ids ON ids.id = report.id")
+                            .Replace("#ActivityScope", scopeTable));
+                    }
+                    else
+                    {
+                        sql.Append(CopilotD7Users.Replace("#ActivityScope", scopeTable));
+                    }
+                }
                 else
                     sql.Append(CopilotLongUsers.Replace("#ActivityScope", scopeTable));
                 return;
@@ -2625,16 +2698,14 @@ OPTION (RECOMPILE);
         }
 
         private static readonly string CopilotD7Users = @"
+DECLARE @copilotSampleFrom date =
+    (SELECT MIN(sample_date) FROM #Samples WHERE workload = 5);
+DECLARE @copilotSampleEnd date =
+    (SELECT MAX(end_exclusive) FROM #Samples WHERE workload = 5);
 INSERT #Scores
     (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
 SELECT 5, report.user_id,
-       SUM(CASE
-               WHEN report.active_usage_days BETWEEN 1 AND 7
-                 OR report.prompts_all_apps > 0
-                 OR (report.last_activity_date >= DATEADD(DAY, -6, CAST(report.[date] AS date))
-                     AND report.last_activity_date < DATEADD(DAY, 1, CAST(report.[date] AS date)))
-               THEN 1 ELSE 0
-           END),
+       SUM(" + CopilotD7ActivityExpression("chosen.copilot_from", "chosen.end_exclusive") + @"),
        COUNT(*),
        CAST(CASE
                 WHEN COUNT(*) = @expected5
@@ -2651,17 +2722,18 @@ SELECT 5, report.user_id,
                THEN AVG(CAST(report.prompts_all_apps AS float))
        END,
        MAX(CASE
-               WHEN report.last_activity_date >= DATEADD(DAY, -6, CAST(report.[date] AS date))
-                AND report.last_activity_date < DATEADD(DAY, 1, CAST(report.[date] AS date))
+               WHEN report.last_activity_date >= chosen.copilot_from
+                AND report.last_activity_date < chosen.end_exclusive
                THEN report.last_activity_date
            END)
 FROM dbo.copilot_usage_user_activity_log AS report WITH (INDEX(0))
 JOIN #Samples AS chosen
   ON chosen.workload = 5
- AND report.[date] >= chosen.sample_date
- AND report.[date] < DATEADD(DAY, 1, chosen.sample_date)
+ AND CAST(report.[date] AS date) = chosen.sample_date
 JOIN #ActivityScope AS eligible ON eligible.user_id = report.user_id
 WHERE report.report_period_days = 7
+  AND report.[date] >= @copilotSampleFrom
+  AND report.[date] < @copilotSampleEnd
 GROUP BY report.user_id
 OPTION (RECOMPILE);
 ";

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -1104,16 +1104,6 @@ CROSS APPLY
         {
             if (maximumSamples < 1 || maximumSamples > 27)
                 throw new ArgumentOutOfRangeException(nameof(maximumSamples));
-            var samples = Enumerable.Range(1, maximumSamples).ToArray();
-            var aggregates = string.Join(",\r\n", samples.Select(sample =>
-                "MAX(CASE WHEN chosen.sample_number = " + sample.ToString(CultureInfo.InvariantCulture)
-                + @" THEN CASE WHEN activity.last_activity_date >= chosen.m365_from
-                                AND activity.last_activity_date < chosen.end_exclusive
-                               THEN 2 ELSE 1 END ELSE 0 END) AS sample" + sample));
-            var observed = string.Join(" + ", samples.Select(sample =>
-                "CASE WHEN sample" + sample + " > 0 THEN 1 ELSE 0 END"));
-            var active = string.Join(" + ", samples.Select(sample =>
-                "CASE WHEN sample" + sample + " = 2 THEN 1 ELSE 0 END"));
             sql.AppendFormat(
                 CultureInfo.InvariantCulture,
                 @"
@@ -1148,8 +1138,12 @@ BEGIN
     END
     ELSE
     BEGIN
-        -- A bounded pivot has one group per user, not one per user/report day.
-        -- MAX retains duplicate-day evidence: 0 absent, 1 observed zero, 2 positive.
+        -- One group per user, not one per user/report day. Counting DISTINCT pinned sample
+        -- numbers retains duplicate-day evidence exactly as the previous per-sample MAX pivot
+        -- did: a sample observed by any duplicate row counts once, and a sample positive in any
+        -- duplicate row counts as active once. COUNT(DISTINCT ...) ignores the NULLs produced by
+        -- the anchor's LEFT JOIN, so an eligible user with no matching row still scores zero
+        -- observed samples and is removed below, keeping absent distinct from observed-zero.
         -- Preserve the eligible population through aggregation so sample-join selectivity
         -- cannot shrink its group estimate and memory grant. Remove absent groups afterward.
         ;WITH Chosen AS
@@ -1164,7 +1158,11 @@ BEGIN
         ),
         PerUser AS
         (
-            SELECT eligible.user_id, {2}
+            SELECT eligible.user_id,
+                   COUNT(DISTINCT CASE WHEN activity.last_activity_date >= chosen.m365_from
+                                        AND activity.last_activity_date < chosen.end_exclusive
+                                       THEN chosen.sample_number END) AS active_samples,
+                   COUNT(DISTINCT chosen.sample_number) AS observed_samples
             FROM #EligibleUsers AS eligible
             LEFT JOIN
             (
@@ -1175,11 +1173,6 @@ BEGIN
                  AND activity.[date] < @endExclusive
             ) ON activity.user_id = eligible.user_id
             GROUP BY eligible.user_id
-        ),
-        Totals AS
-        (
-            SELECT user_id, {3} AS active_samples, {4} AS observed_samples
-            FROM PerUser
         )
         INSERT #Scores
             (workload, user_id, active_samples, observed_samples, frequency_known)
@@ -1189,13 +1182,13 @@ BEGIN
                    observed_samples,
                    CAST(CASE WHEN observed_samples = @expected{0}
                              THEN 1 ELSE 0 END AS bit)
-        FROM Totals AS per_user
+        FROM PerUser AS per_user
         WHERE observed_samples > 0
         OPTION (RECOMPILE, MAXDOP 1);
     END;
 END;
 ",
-                workload, table, aggregates, active, observed);
+                workload, table);
         }
 
         private static void AppendCopilotOverview(StringBuilder sql, LicenceActivitySources sources)

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -131,6 +131,74 @@ CREATE UNIQUE CLUSTERED INDEX IX_LicenceActivity_UserScores
             return sql.ToString();
         }
 
+        internal static string BuildReadModelDirectory(string eligibleTable)
+        {
+            ValidateSharedEligibleTableName(eligibleTable);
+            return @"
+SET NOCOUNT ON;
+SELECT licence.id, licence.name, licence.sku_id
+FROM dbo.license_types AS licence
+ORDER BY licence.id;
+
+SELECT eligible.user_id, users.user_name, users.mail,
+       eligible.department_id, department.name,
+       eligible.country_id, country.name, users.account_enabled
+FROM " + eligibleTable + @" AS eligible
+JOIN dbo.users AS users ON users.id = eligible.user_id
+LEFT JOIN dbo.user_departments AS department ON department.id = eligible.department_id
+LEFT JOIN dbo.user_country_or_region AS country ON country.id = eligible.country_id;
+
+SELECT DISTINCT owned.user_id, owned.license_type_id
+FROM dbo.user_license_type_lookups AS owned
+JOIN " + eligibleTable + @" AS eligible ON eligible.user_id = owned.user_id
+OPTION (RECOMPILE);";
+        }
+
+        internal static string BuildReadModelCoverage(LicenceActivitySources sources, string eligibleTable)
+        {
+            var sql = new StringBuilder(18000);
+            AppendOverviewPartPreamble(sql, eligibleTable);
+            AppendM365Overview(sql, Teams, "teams", "dbo.teams_user_activity_log",
+                "average published message and meeting counters across supporting snapshots", sources.UsageReports);
+            AppendM365Overview(sql, Outlook, "outlook", "dbo.outlook_user_activity_log",
+                "average published sent and read counters across supporting snapshots", sources.UsageReports);
+            AppendM365Overview(sql, OneDrive, "onedrive", "dbo.onedrive_user_activity_log",
+                "average published viewed-or-edited counter across supporting snapshots", sources.UsageReports);
+            AppendM365Overview(sql, SharePoint, "sharepoint", "dbo.sharepoint_user_activity_log",
+                "average published viewed-or-edited counter across supporting snapshots", sources.UsageReports);
+            AppendCopilotOverview(sql, sources, includeScores: false);
+            sql.Append(@"
+SELECT workload_name AS Workload, status AS Status, source AS Source,
+       measure AS Measure, granularity AS Granularity, message AS Message,
+       effective_from_utc AS EffectiveFromUtc, effective_to_utc AS EffectiveToUtc,
+       latest_import_utc AS LatestImportUtc, lag_days AS LagDays,
+       report_period_days AS ReportPeriodDays, expected_samples AS ExpectedSamples,
+       observed_samples AS ObservedSamples, unmatched_users AS UnmatchedUsers
+FROM #Coverage ORDER BY workload;
+SELECT coverage.workload_name AS WorkloadName, samples.sample_date AS SnapshotDate
+FROM #Samples AS samples
+JOIN #Coverage AS coverage ON coverage.workload = samples.workload
+ORDER BY samples.workload, samples.sample_date;");
+            return sql.ToString().Replace("#EligibleUsers", eligibleTable);
+        }
+
+        internal static string BuildReadModelEvidence(
+            LicenceActivityOverview overview, LicenceActivityCoverage coverage, string eligibleTable)
+        {
+            ValidateSharedEligibleTableName(eligibleTable);
+            var start = UsersPreamble.IndexOf("CREATE TABLE #Coverage", StringComparison.Ordinal);
+            if (start < 0) throw new InvalidOperationException("The user evidence SQL preamble is malformed.");
+            var sql = new StringBuilder("SET NOCOUNT ON;\r\nSET XACT_ABORT ON;\r\n");
+            sql.Append(UsersPreamble.Substring(start));
+            AppendSampleInserts(sql, overview);
+            AppendWorkloadUsers(sql, coverage, "#EligibleUsers", readModel: true);
+            sql.Append(@"
+SELECT user_id, active_samples, observed_samples, frequency_known,
+       average_actions, last_activity_utc
+FROM #Scores;");
+            return sql.ToString().Replace("#EligibleUsers", eligibleTable);
+        }
+
         internal static string BuildOverviewBase(string eligibleTable = "#EligibleUsers")
         {
             if (eligibleTable == "#EligibleUsers") return OverviewBaseSql;
@@ -658,7 +726,8 @@ VALUES
         private static void AppendWorkloadUsers(
             StringBuilder sql,
             LicenceActivityCoverage coverage,
-            string scopeTable)
+            string scopeTable,
+            bool readModel = false)
         {
             var workload = WorkloadId(coverage.Workload);
             if (workload == Teams)
@@ -670,30 +739,30 @@ VALUES
                     + " + CAST(ISNULL(activity.reply_messages, 0) AS float)"
                     + " + CAST(ISNULL(activity.meetings_attended_count, 0) AS float)"
                     + " + CAST(ISNULL(activity.meetings_organized_count, 0) AS float)",
-                    scopeTable);
+                    scopeTable, readModel);
             }
             else if (workload == Outlook)
             {
                 AppendM365Users(sql, coverage, Outlook, "dbo.outlook_user_activity_log",
                     "CAST(ISNULL(activity.email_send_count, 0) AS float)"
                     + " + CAST(ISNULL(activity.email_read_count, 0) AS float)",
-                    scopeTable);
+                    scopeTable, readModel);
             }
             else if (workload == OneDrive)
             {
                 AppendM365Users(sql, coverage, OneDrive, "dbo.onedrive_user_activity_log",
                     "CAST(ISNULL(activity.viewed_or_edited, 0) AS float)",
-                    scopeTable);
+                    scopeTable, readModel);
             }
             else if (workload == SharePoint)
             {
                 AppendM365Users(sql, coverage, SharePoint, "dbo.sharepoint_user_activity_log",
                     "CAST(ISNULL(activity.viewed_or_edited, 0) AS float)",
-                    scopeTable);
+                    scopeTable, readModel);
             }
             else if (workload == Copilot)
             {
-                AppendCopilotUsers(sql, coverage, scopeTable);
+                AppendCopilotUsers(sql, coverage, scopeTable, readModel);
             }
         }
 
@@ -1191,8 +1260,10 @@ END;
                 workload, table);
         }
 
-        private static void AppendCopilotOverview(StringBuilder sql, LicenceActivitySources sources)
+        private static void AppendCopilotOverview(
+            StringBuilder sql, LicenceActivitySources sources, bool includeScores = true)
         {
+            sql.Append("DECLARE @copilotIncludeScores bit = " + (includeScores ? "1" : "0") + ";\r\n");
             if (sources.CopilotUsageReports)
             {
                 sql.Append(CopilotOfficialOverview);
@@ -1547,7 +1618,7 @@ BEGIN
                7, @copilotD7Expected, @copilotD7Observed, 0
         FROM (SELECT sample_date FROM #Samples WHERE workload = 5) AS samples;
 
-        IF @copilotPreferredStatus = 'available'
+        IF @copilotPreferredStatus = 'available' AND @copilotIncludeScores = 1
         BEGIN
             IF @copilotD7Expected = 1
             BEGIN
@@ -1660,6 +1731,7 @@ BEGIN
                 @copilotLongPeriod, @copilotLongPeriod, @copilotLongPeriod, 0
             );
 
+            IF @copilotIncludeScores = 1
             INSERT #Scores
                 (workload, user_id, active_samples, observed_samples, frequency_known)
             SELECT 5,
@@ -1714,6 +1786,8 @@ BEGIN
              ELSE N'Copilot audit events provide positive evidence only; no database signal proves complete event coverage, so absent users remain unknown.'
         END;
 
+    IF @copilotIncludeScores = 1
+    BEGIN
     ;WITH EventWeeks AS
     (
         SELECT chats.user_id,
@@ -1737,6 +1811,7 @@ BEGIN
     FROM EventWeeks
     GROUP BY user_id
     OPTION (RECOMPILE);
+    END;
 
     INSERT #Coverage
     (
@@ -1775,6 +1850,8 @@ BEGIN
              ELSE N'Copilot interaction history provides positive evidence only; no database signal proves complete history for every user, so absent users remain unknown.'
         END;
 
+    IF @copilotIncludeScores = 1
+    BEGIN
     ;WITH EventWeeks AS
     (
         SELECT interactions.user_id,
@@ -1798,6 +1875,7 @@ BEGIN
     FROM EventWeeks
     GROUP BY user_id
     OPTION (RECOMPILE);
+    END;
 
     INSERT #Coverage
     (
@@ -2575,10 +2653,17 @@ CREATE TABLE #Scores
             int workload,
             string table,
             string actionExpression,
-            string scopeTable)
+            string scopeTable,
+            bool readModel = false)
         {
             if (coverage.SnapshotDates == null || coverage.SnapshotDates.Count == 0)
                 return;
+
+            if (readModel)
+            {
+                AppendM365ReadModel(sql, coverage, workload, table, actionExpression, scopeTable);
+                return;
+            }
 
             var samples = Enumerable.Range(0, coverage.SnapshotDates.Count).ToArray();
             var aggregates = string.Join("\r\nUNION ALL\r\n", samples.Select(sample =>
@@ -2638,10 +2723,58 @@ OPTION (RECOMPILE);
                 workload, aggregates);
         }
 
+        private static void AppendM365ReadModel(
+            StringBuilder sql, LicenceActivityCoverage coverage, int workload,
+            string table, string actionExpression, string scopeTable)
+        {
+            // Two ordered aggregations over a single pass of the activity table. The inner group
+            // collapses every row for one (user, pinned snapshot) to a single sample - MAX actions,
+            // MAX activity flag and MAX clipped last-activity retain duplicate-day evidence exactly
+            // as the legacy per-date UNION ALL did. The outer group then counts the distinct samples
+            // and averages them per user. Unlike the previous per-sample pivot this emits only two
+            // predicates per row rather than one CASE pair per snapshot, so a columnstore metrics
+            // index (the Azure default) can service it in batch mode instead of scanning a wide
+            // per-snapshot projection. It is also faithful to the row-by-row scoring semantics:
+            // sample counts once, any positive duplicate is active, and frequency_known compares the
+            // distinct observed samples against the expected count for the workload.
+            sql.Append(@"
+;WITH PerUserDay AS
+(
+    SELECT activity.user_id, chosen.sample_date,
+           MAX(" + actionExpression + @") AS actions,
+           MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
+                     AND activity.last_activity_date < chosen.end_exclusive
+                    THEN 1 ELSE 0 END) AS was_active,
+           MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
+                     AND activity.last_activity_date < chosen.end_exclusive
+                    THEN activity.last_activity_date END) AS last_activity_utc
+    FROM " + table + @" AS activity
+    JOIN #Samples AS chosen
+      ON chosen.workload = " + workload + @"
+     AND CAST(activity.[date] AS date) = chosen.sample_date
+    JOIN " + scopeTable + @" AS eligible ON eligible.user_id = activity.user_id
+    WHERE activity.[date] >= @from AND activity.[date] < @endExclusive
+    GROUP BY activity.user_id, chosen.sample_date
+)
+INSERT #Scores
+    (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
+SELECT " + workload + @", user_id,
+       SUM(was_active),
+       COUNT(*),
+       CAST(CASE WHEN COUNT(*) = @expected" + workload + @" THEN 1 ELSE 0 END AS bit),
+       AVG(actions),
+       MAX(last_activity_utc)
+FROM PerUserDay
+GROUP BY user_id
+OPTION (RECOMPILE);
+");
+        }
+
         private static void AppendCopilotUsers(
             StringBuilder sql,
             LicenceActivityCoverage coverage,
-            string scopeTable)
+            string scopeTable,
+            bool readModel = false)
         {
             if (coverage.Source == CopilotReportSource
                 && coverage.SnapshotDates != null
@@ -2672,7 +2805,18 @@ OPTION (RECOMPILE);
                     }
                     else
                     {
-                        sql.Append(CopilotD7Users.Replace("#ActivityScope", scopeTable));
+                        var query = CopilotD7Users.Replace("#ActivityScope", scopeTable);
+                        if (readModel)
+                            // Let the optimiser choose the access path for every read-model D7 shape.
+                            // The forced clustered scan (INDEX(0)) blocked batch mode; the single-snapshot
+                            // IX seek looked cheaper but does ~930k key lookups (~6.7s). Measured at 300k
+                            // users a columnstore metrics index (the Azure default) instead gives batch mode
+                            // with rowgroup elimination on the date predicate: one snapshot reads a single
+                            // segment and skips the rest (~0.5s), and the full 180-day window aggregates in
+                            // batch (~2s vs ~15s). In pure rowstore the optimiser still lands on a scan, so
+                            // this only removes rowstore-era hints that a columnstore deployment must not pay.
+                            query = query.Replace(" WITH (INDEX(0))", string.Empty);
+                        sql.Append(query);
                     }
                 }
                 else

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityReadModelLoader.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityReadModelLoader.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Common.Entities.LicenceActivity
+{
+    public interface ILicenceActivityReadModelLoader
+    {
+        Task<LicenceActivityReadModel> LoadReadModelAsync(
+            LicenceActivityQuery range, LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken);
+    }
+
+    public sealed partial class SqlLicenceActivityStore
+    {
+        public async Task<LicenceActivityReadModel> LoadReadModelAsync(
+            LicenceActivityQuery range, LicenceActivitySources sources,
+            ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken)
+        {
+            if (range == null) throw new ArgumentNullException(nameof(range));
+            if (sources == null) throw new ArgumentNullException(nameof(sources));
+            if (!sources.UserMetadata)
+                throw new InvalidOperationException("Licence activity requires the user metadata import.");
+            if (range.DepartmentId.HasValue || range.CountryId.HasValue || range.LicenceTypeId.HasValue)
+                throw new ArgumentException("A shared read model must cover the unfiltered date range.", nameof(range));
+
+            diagnostics = diagnostics ?? NullLicenceActivityDiagnostics.Instance;
+            var watch = Stopwatch.StartNew();
+            diagnostics.Stage("OverviewSqlStarted");
+            var eligibleTable = "##LicenceActivityEligible_" + Guid.NewGuid().ToString("N");
+            using (var owner = await CreateSharedEligibleUsersAsync(
+                eligibleTable, range, sources, diagnostics, cancellationToken).ConfigureAwait(false))
+            {
+                _instrumentation?.OperationCompleted?.Invoke("eligible", watch.ElapsedMilliseconds);
+                try
+                {
+                    var directoryTask = LoadReadModelDirectoryAsync(eligibleTable, cancellationToken);
+                    var factsTask = LoadReadModelFactsAsync(range, sources, eligibleTable, diagnostics, cancellationToken);
+                    // Observe both branches before releasing their shared table, including on failure.
+                    await Task.WhenAll(directoryTask, factsTask).ConfigureAwait(false);
+                    var directory = await directoryTask.ConfigureAwait(false);
+                    var facts = await factsTask.ConfigureAwait(false);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    diagnostics.Stage("MaterialisationStarted");
+                    var partWatch = Stopwatch.StartNew();
+                    var model = new LicenceActivityReadModel(
+                        range, directory.Licences, directory.Users, directory.Memberships,
+                        facts.Overview.Coverage, facts.Scores);
+                    _instrumentation?.OperationCompleted?.Invoke("read-model", partWatch.ElapsedMilliseconds);
+                    diagnostics.Stage("MaterialisationCompleted", watch.ElapsedMilliseconds);
+                    diagnostics.Stage("OverviewSqlCompleted", watch.ElapsedMilliseconds);
+                    return model;
+                }
+                finally
+                {
+                    var releaseWatch = Stopwatch.StartNew();
+                    await DropSharedEligibleUsersAsync(owner, eligibleTable).ConfigureAwait(false);
+                    _instrumentation?.OperationCompleted?.Invoke("release-eligible", releaseWatch.ElapsedMilliseconds);
+                }
+            }
+        }
+
+        private async Task<ReadModelFacts> LoadReadModelFactsAsync(
+            LicenceActivityQuery range, LicenceActivitySources sources, string eligibleTable,
+            ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken)
+        {
+            diagnostics.Stage("CoverageStarted");
+            var watch = Stopwatch.StartNew();
+            var overview = await ExecuteOverviewSqlAsync(
+                LicenceActivitySql.BuildReadModelCoverage(sources, eligibleTable),
+                "coverage", range, sources, diagnostics,
+                reader => ReadModelCoverageAsync(reader, range, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+            if (!sources.UsageReports)
+            {
+                overview.Coverage.RemoveAll(c => c.Workload != "copilot");
+                overview.Coverage.InsertRange(0, Enumerable.Range(LicenceActivitySql.Teams, 4)
+                    .Select(workload => DisabledM365Part(workload, range).Coverage));
+            }
+            diagnostics.Stage("CoverageCompleted", watch.ElapsedMilliseconds);
+            var tasks = overview.Coverage.Select(async coverage =>
+            {
+                var scores = await LoadReadModelEvidenceAsync(
+                    overview, coverage, eligibleTable, sources, diagnostics, cancellationToken).ConfigureAwait(false);
+                return new KeyValuePair<string, IReadOnlyDictionary<int, LicenceActivityScore>>(coverage.Workload, scores);
+            }).ToArray();
+            var evidence = await Task.WhenAll(tasks).ConfigureAwait(false);
+            return new ReadModelFacts
+            {
+                Overview = overview,
+                Scores = evidence.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
+            };
+        }
+
+        private async Task<ReadModelDirectory> LoadReadModelDirectoryAsync(
+            string eligibleTable, CancellationToken cancellationToken)
+        {
+            await OverviewSqlSlots.WaitAsync(cancellationToken).ConfigureAwait(false);
+            var watch = Stopwatch.StartNew();
+            var directory = new ReadModelDirectory();
+            try
+            {
+                using (var connection = new SqlConnection(_connectionString))
+                {
+                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                    if (_instrumentation?.ConnectionOpenedForOperation != null)
+                        _instrumentation.ConnectionOpenedForOperation(connection, "directory");
+                    else
+                        _instrumentation?.ConnectionOpened?.Invoke(connection);
+                    using (var command = new SqlCommand(LicenceActivitySql.BuildReadModelDirectory(eligibleTable), connection)
+                    {
+                        CommandTimeout = _instrumentation?.CommandTimeoutSeconds ?? LicenceActivitySql.CommandTimeoutSeconds
+                    })
+                    using (_instrumentation?.TrackCommand())
+                    using (cancellationToken.Register(command.Cancel))
+                    using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        await RequireResultAsync(reader, true, cancellationToken, "id", "name", "sku_id").ConfigureAwait(false);
+                        while (ReadModelRow(reader, cancellationToken))
+                            directory.Licences.Add(new LicenceActivitySku
+                            {
+                                LicenceTypeId = reader.GetInt32(0),
+                                Name = reader.IsDBNull(1) ? null : reader.GetString(1),
+                                SkuId = reader.IsDBNull(2) ? null : reader.GetString(2)
+                            });
+                        await RequireResultAsync(reader, false, cancellationToken, "user_id", "user_name", "mail").ConfigureAwait(false);
+                        while (ReadModelRow(reader, cancellationToken))
+                            directory.Users.Add(new LicenceActivityDirectoryUser
+                            {
+                                UserId = reader.GetInt32(0),
+                                UserPrincipalName = reader.GetString(1),
+                                Mail = reader.IsDBNull(2) ? null : reader.GetString(2),
+                                DepartmentId = reader.GetInt32(3),
+                                Department = reader.IsDBNull(4) ? null : reader.GetString(4),
+                                CountryId = reader.GetInt32(5),
+                                Country = reader.IsDBNull(6) ? null : reader.GetString(6),
+                                AccountEnabled = reader.IsDBNull(7) ? (bool?)null : reader.GetBoolean(7)
+                            });
+                        await RequireResultAsync(reader, false, cancellationToken, "user_id", "license_type_id").ConfigureAwait(false);
+                        while (ReadModelRow(reader, cancellationToken))
+                            directory.Memberships.Add(new LicenceActivityMembership(reader.GetInt32(0), reader.GetInt32(1)));
+                        await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                return directory;
+            }
+            finally
+            {
+                _instrumentation?.OperationCompleted?.Invoke("directory", watch.ElapsedMilliseconds);
+                OverviewSqlSlots.Release();
+            }
+        }
+
+        private async Task<LicenceActivityOverview> ReadModelCoverageAsync(
+            SqlDataReader reader, LicenceActivityQuery range, CancellationToken cancellationToken)
+        {
+            var result = new LicenceActivityOverview { Query = range };
+            await RequireResultAsync(reader, true, cancellationToken,
+                "Workload", "Status", "Source", "ExpectedSamples").ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                result.Coverage.Add(new LicenceActivityCoverage
+                {
+                    Workload = ReadString(reader, "Workload"),
+                    Status = ReadString(reader, "Status"),
+                    Source = ReadString(reader, "Source"),
+                    Measure = ReadString(reader, "Measure"),
+                    Granularity = ReadString(reader, "Granularity"),
+                    Message = ReadNullableString(reader, "Message"),
+                    EffectiveFromUtc = ReadNullableUtc(reader, "EffectiveFromUtc"),
+                    EffectiveToUtc = ReadNullableUtc(reader, "EffectiveToUtc"),
+                    LatestImportUtc = ReadNullableUtc(reader, "LatestImportUtc"),
+                    LagDays = ReadInt32(reader, "LagDays"),
+                    ReportPeriodDays = ReadNullableInt32(reader, "ReportPeriodDays"),
+                    ExpectedSamples = ReadInt32(reader, "ExpectedSamples"),
+                    ObservedSamples = ReadInt32(reader, "ObservedSamples"),
+                    UnmatchedUsers = ReadInt32(reader, "UnmatchedUsers")
+                });
+            await RequireResultAsync(reader, false, cancellationToken, "WorkloadName", "SnapshotDate").ConfigureAwait(false);
+            var byWorkload = result.Coverage.ToDictionary(c => c.Workload, StringComparer.Ordinal);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                byWorkload[ReadString(reader, "WorkloadName")].SnapshotDates.Add(ReadUtc(reader, "SnapshotDate"));
+            await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+
+        private async Task<IReadOnlyDictionary<int, LicenceActivityScore>> LoadReadModelEvidenceAsync(
+            LicenceActivityOverview overview, LicenceActivityCoverage coverage, string eligibleTable,
+            LicenceActivitySources sources, ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken)
+        {
+            if (coverage.SnapshotDates.Count == 0
+                && (coverage.Source == LicenceActivitySql.M365ReportSource
+                    || coverage.Source == LicenceActivitySql.CopilotReportSource))
+                return new Dictionary<int, LicenceActivityScore>();
+            await OverviewSqlSlots.WaitAsync(cancellationToken).ConfigureAwait(false);
+            var watch = Stopwatch.StartNew();
+            try
+            {
+                using (var connection = new SqlConnection(_connectionString))
+                {
+                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                    if (_instrumentation?.ConnectionOpenedForOperation != null)
+                        _instrumentation.ConnectionOpenedForOperation(connection, coverage.Workload);
+                    else
+                        _instrumentation?.ConnectionOpened?.Invoke(connection);
+                    using (var command = new SqlCommand(
+                        LicenceActivitySql.BuildReadModelEvidence(overview, coverage, eligibleTable), connection)
+                    {
+                        CommandTimeout = _instrumentation?.CommandTimeoutSeconds ?? LicenceActivitySql.CommandTimeoutSeconds
+                    })
+                    {
+                        AddScopeParameters(command, overview.Query, sources);
+                        AddCoverageParameters(command, overview);
+                        using (_instrumentation?.TrackCommand())
+                        using (cancellationToken.Register(command.Cancel))
+                        using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+                        {
+                            await RequireResultAsync(reader, true, cancellationToken,
+                                "user_id", "active_samples", "observed_samples").ConfigureAwait(false);
+                            var scores = new Dictionary<int, LicenceActivityScore>();
+                            while (ReadModelRow(reader, cancellationToken))
+                                scores.Add(reader.GetInt32(0), new LicenceActivityScore(
+                                    reader.GetInt32(1), reader.GetInt32(2), reader.GetBoolean(3),
+                                    reader.IsDBNull(4) ? (double?)null : reader.GetDouble(4),
+                                    reader.IsDBNull(5) ? (DateTime?)null : DateTime.SpecifyKind(reader.GetDateTime(5), DateTimeKind.Utc)));
+                            await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
+                            return scores;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                _instrumentation?.OperationCompleted?.Invoke(coverage.Workload, watch.ElapsedMilliseconds);
+                OverviewSqlSlots.Release();
+            }
+        }
+
+        private static bool ReadModelRow(SqlDataReader reader, CancellationToken cancellationToken)
+        {
+            // These bulk reads run on bounded background workers. Avoid an async state machine
+            // per scalar row; the command cancellation registration interrupts blocked I/O.
+            cancellationToken.ThrowIfCancellationRequested();
+            return reader.Read();
+        }
+
+        private sealed class ReadModelDirectory
+        {
+            internal List<LicenceActivitySku> Licences { get; } = new List<LicenceActivitySku>();
+            internal List<LicenceActivityDirectoryUser> Users { get; } = new List<LicenceActivityDirectoryUser>();
+            internal List<LicenceActivityMembership> Memberships { get; } = new List<LicenceActivityMembership>();
+        }
+
+        private sealed class ReadModelFacts
+        {
+            internal LicenceActivityOverview Overview { get; set; }
+            internal IReadOnlyDictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>> Scores { get; set; }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
@@ -11,8 +11,9 @@ using System.Threading.Tasks;
 namespace Common.Entities.LicenceActivity
 {
     /// <summary>
-    /// Bounded ADO.NET adapter for licence activity. Each call owns one short-lived SQL connection and
-    /// executes one batch; no EF context or request synchronization context is shared.
+    /// Bounded ADO.NET adapter for licence activity. User calls own one connection and batch; overview
+    /// calls own a shared-scope connection and independently bounded workload connections.
+    /// No EF context or request synchronization context is shared.
     /// </summary>
     public sealed class SqlLicenceActivityStore : ILicenceActivityStore
     {
@@ -67,7 +68,8 @@ namespace Common.Entities.LicenceActivity
                             workload++)
                         {
                             partTasks.Add(ExecuteOverviewPartAsync(
-                                LicenceActivitySql.BuildM365OverviewPart(workload, eligibleTable),
+                                LicenceActivitySql.BuildM365OverviewPart(workload, eligibleTable,
+                                    maximumSamples: (query.Days + ((int)query.FromUtc.DayOfWeek + 6) % 7 + 6) / 7),
                                 LicenceActivitySql.WorkloadName(workload),
                                 query, sources, diagnostics, cancellationToken));
                         }
@@ -148,6 +150,7 @@ namespace Common.Entities.LicenceActivity
                     var sqlWatch = Stopwatch.StartNew();
                     diagnostics.Stage("UsersSqlStarted");
 
+                    using (_instrumentation?.TrackCommand())
                     using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                     {
                         var materialisationWatch = Stopwatch.StartNew();
@@ -192,7 +195,8 @@ namespace Common.Entities.LicenceActivity
                 })
                 {
                     AddScopeParameters(command, query, sources);
-                    await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                    using (_instrumentation?.TrackCommand())
+                        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 }
                 return connection;
             }
@@ -203,7 +207,7 @@ namespace Common.Entities.LicenceActivity
             }
         }
 
-        private static Task DropSharedEligibleUsersAsync(
+        private Task DropSharedEligibleUsersAsync(
             SqlConnection connection,
             string tableName)
         {
@@ -213,7 +217,8 @@ namespace Common.Entities.LicenceActivity
                 CommandTimeout = LicenceActivitySql.CommandTimeoutSeconds
             })
             {
-                command.ExecuteNonQuery();
+                using (_instrumentation?.TrackCommand())
+                    command.ExecuteNonQuery();
             }
             return Task.CompletedTask;
         }
@@ -508,6 +513,7 @@ namespace Common.Entities.LicenceActivity
                             })
                             {
                                 AddScopeParameters(command, query, sources);
+                                using (_instrumentation?.TrackCommand())
                                 using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
                                     return await materialize(reader).ConfigureAwait(false);
                             }
@@ -1327,5 +1333,27 @@ namespace Common.Entities.LicenceActivity
         internal Action<string, long> OperationCompleted { get; set; }
         internal Action<string> ShowplanReceived { get; set; }
         internal int? CommandTimeoutSeconds { get; set; }
+        internal Action<bool> CommandActiveChanged { get; set; }
+
+        internal IDisposable TrackCommand()
+        {
+            return new CommandLifetime(CommandActiveChanged);
+        }
+
+        private sealed class CommandLifetime : IDisposable
+        {
+            private readonly Action<bool> _changed;
+
+            internal CommandLifetime(Action<bool> changed)
+            {
+                _changed = changed;
+                _changed?.Invoke(true);
+            }
+
+            public void Dispose()
+            {
+                _changed?.Invoke(false);
+            }
+        }
     }
 }

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
@@ -15,7 +15,7 @@ namespace Common.Entities.LicenceActivity
     /// calls own a shared-scope connection and independently bounded workload connections.
     /// No EF context or request synchronization context is shared.
     /// </summary>
-    public sealed class SqlLicenceActivityStore : ILicenceActivityStore
+    public sealed partial class SqlLicenceActivityStore : ILicenceActivityStore, ILicenceActivityReadModelLoader
     {
         private static readonly SemaphoreSlim OverviewSqlSlots = new SemaphoreSlim(6, 6);
         private readonly string _connectionString;
@@ -816,6 +816,11 @@ namespace Common.Entities.LicenceActivity
             command.Parameters.Add("@searchPattern", SqlDbType.NVarChar, 202).Value =
                 escapedSearch.Length == 0 ? string.Empty : "%" + escapedSearch + "%";
 
+            AddCoverageParameters(command, overview);
+        }
+
+        private static void AddCoverageParameters(SqlCommand command, LicenceActivityOverview overview)
+        {
             var byWorkload = overview.Coverage.ToDictionary(c => c.Workload, StringComparer.Ordinal);
             for (var workload = LicenceActivitySql.Teams; workload <= LicenceActivitySql.Copilot; workload++)
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityLoadTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityLoadTests.cs
@@ -22,13 +22,16 @@ namespace Tests.UnitTests
     internal static class LicenceActivityLoadTests
     {
         internal const int ColdBudgetMs = 15000;
+        internal const int PreparationBudgetMs = 30000;
         internal const int WarmBudgetMs = 500;
         internal const int ConcurrentBudgetMs = 25000;
-        internal const long MemoryDeltaBudgetBytes = 128L * 1024 * 1024;
+        // Preview trades bounded web memory for SQL work at 300k users; includes the HTTP test client.
+        internal const long MemoryDeltaBudgetBytes = 2L * 1024 * 1024 * 1024;
 
         internal static async Task<LoadResult> RunAsync(
             ILicenceActivityStore sqlStore, LicenceActivitySources sources, DateTime endUtc,
-            Func<long> logicalReads, Action<string> progress = null)
+            Func<long> logicalReads, Action<string> progress = null,
+            Func<Func<DateTime>, ILicenceActivityStore> freshStore = null)
         {
             if (logicalReads == null) throw new ArgumentNullException(nameof(logicalReads));
             var result = new LoadResult();
@@ -43,13 +46,14 @@ namespace Tests.UnitTests
                     progress?.Invoke("HTTP load: " + days + "-day window, 50 SKUs, repeat " + run.Repeat + "/3.");
                     var hostStart = elapsed.Elapsed;
                     Func<DateTime> hostNow = () => sources.NowUtc.Add(elapsed.Elapsed - hostStart);
+                    if (freshStore != null) store = new MeteredStore(freshStore(hostNow));
                     using (var host = new LicenceActivityHttpHost(store, sources, hostNow))
                     {
                         var query = "from=" + endUtc.AddDays(1 - days).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
                             + "&to=" + endUtc.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
                         var overviewPath = "api/LicenceActivity/overview?" + query;
                         var overview = await Measure(host.Client, overviewPath, "overview-cold", days, 300000,
-                            store, logicalReads, result, ColdBudgetMs);
+                            store, logicalReads, result, PreparationBudgetMs);
                         Assert.AreEqual(300000, (int)overview["distinctAssignedUsers"], "Load fixture must contain 300,000 distinct licence holders.");
                         var skus = ((JArray)overview["licences"]).OrderBy(s => (int)s["assignedUsers"]).ToArray();
                         Assert.AreEqual(50, skus.Length, "The current acceptance target is 50, not 20, licence types.");
@@ -83,7 +87,7 @@ namespace Tests.UnitTests
                             if (delay.Value > TimeSpan.Zero) await Task.Delay(delay.Value);
                             var previousId = overviewId;
                             overview = await Measure(host.Client, overviewPath, "overview-expiry-renewal", days, 300000,
-                                store, logicalReads, result, ColdBudgetMs);
+                                store, logicalReads, result, PreparationBudgetMs);
                             overviewId = (string)overview["snapshotId"];
                             Assert.AreNotEqual(previousId, overviewId, "An expired overview must be replaced, not reused.");
                             Assert.AreEqual(300000, (int)overview["distinctAssignedUsers"]);
@@ -184,6 +188,7 @@ namespace Tests.UnitTests
                         Assert.IsTrue(export.Bytes > 0);
                         result.Observations.Add(Group("excel-snapshot", days, new[] { export }, 0, 0));
                     }
+                    result.PeakConcurrentSqlLoads = Math.Max(result.PeakConcurrentSqlLoads, store.PeakActive);
                 }
                 memory.Sample();
                 result.ManagedHeapDeltaBytes = Math.Max(0, memory.PeakManagedBytes - memory.InitialManagedBytes);
@@ -196,7 +201,6 @@ namespace Tests.UnitTests
             Assert.AreEqual(result.RequiredMatrixCells, result.CompletedMatrixCells,
                 "Acceptance requires all 50 SKUs x 5 workloads x 2 windows x 3 fresh-host repeats, with immediate warm partners.");
             result.ElapsedMs = elapsed.ElapsedMilliseconds;
-            result.PeakConcurrentSqlLoads = store.PeakActive;
             var output = Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_LOAD_RESULTS");
             if (!string.IsNullOrWhiteSpace(output))
                 File.WriteAllText(Path.GetFullPath(output), JsonConvert.SerializeObject(result, Formatting.Indented),
@@ -320,9 +324,12 @@ namespace Tests.UnitTests
             public int Users { get; set; } = 300000;
             public int LicenceTypes { get; set; } = 50;
             public long Assignments { get; set; }
-            public string Scope { get; set; } = "In-process attributed HTTP API, real SQL adapter, production cache and Excel writer; synthetic database only. Client and server share the measured process. Cold means fresh application caches/HttpServer, not a fresh OS process or cold SQL. Not an IIS/network/Entra deployment test or an Azure capacity guarantee.";
+            public string Scope { get; set; } = "In-process attributed HTTP API, real SQL adapter, production cache and Excel writer; synthetic database only. Client and server share the measured process. Cold means fresh application caches/HttpServer, not a fresh OS process or cold SQL. Preview source preparation has a separate 30-second budget (the existing response deadline); interactive response-cache misses retain the 15-second gate. This is not the former blanket 15-second cold-load acceptance, an IIS/network/Entra deployment test, or an Azure capacity guarantee.";
+            public int SourcePreparationBudgetMs { get; set; } = PreparationBudgetMs;
+            public int InteractiveColdBudgetMs { get; set; } = ColdBudgetMs;
+            public int InteractiveWarmBudgetMs { get; set; } = WarmBudgetMs;
             public string SqlBufferPool { get; set; } = "Retained/uncontrolled SQL buffer and plan caches; no DBCC cache clearing. Not SQL-cold evidence.";
-            public string ConcurrencyUnit { get; set; } = "SqlLoads counts shared store/report loads, not individual SQL commands or connections; each load can issue multiple commands.";
+            public string ConcurrencyUnit { get; set; } = "SqlLoads counts shared store/report calls, not individual SQL commands or connections. A cached read-model projection issues no SQL; use LogicalReads and SQL instrumentation for database work.";
             public int MemorySampleIntervalMs { get; set; } = 50;
             public int RequiredMatrixCells { get; set; } = 50 * 5 * 2 * 3;
             public int CompletedMatrixCells { get; set; }
@@ -359,7 +366,7 @@ namespace Tests.UnitTests
             internal JObject Json;
         }
 
-        private sealed class MeteredStore : ILicenceActivityStore
+        private sealed class MeteredStore : ILicenceActivityStore, ILicenceActivitySnapshotValidator
         {
             private readonly ILicenceActivityStore _inner;
             private int _calls;
@@ -384,6 +391,8 @@ namespace Tests.UnitTests
             public Task<LicenceActivityUsers> LoadUsersAsync(LicenceActivityOverview overview, LicenceActivityQuery query,
                 LicenceActivitySources sources, ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken) =>
                 Run(() => _inner.LoadUsersAsync(overview, query, sources, diagnostics, cancellationToken));
+            public bool IsCurrent(LicenceActivityOverview overview, LicenceActivitySources sources) =>
+                !(_inner is ILicenceActivitySnapshotValidator validator) || validator.IsCurrent(overview, sources);
         }
 
         private sealed class MemorySampler : IDisposable
@@ -471,7 +480,7 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public void EvidenceScope_DeclaresMatrixAndColdnessWithoutWeakeningBudgets()
+        public void EvidenceScope_DeclaresMatrixAndPreviewBudgets()
         {
             var result = new LicenceActivityLoadTests.LoadResult();
             Assert.AreEqual(1500, result.RequiredMatrixCells);
@@ -480,9 +489,10 @@ namespace Tests.UnitTests
             StringAssert.Contains(result.ConcurrencyUnit, "not individual SQL commands");
             Assert.AreEqual(50, result.MemorySampleIntervalMs);
             Assert.AreEqual(15000, LicenceActivityLoadTests.ColdBudgetMs);
+            Assert.AreEqual(30000, LicenceActivityLoadTests.PreparationBudgetMs);
             Assert.AreEqual(500, LicenceActivityLoadTests.WarmBudgetMs);
             Assert.AreEqual(25000, LicenceActivityLoadTests.ConcurrentBudgetMs);
-            Assert.AreEqual(128L * 1024 * 1024, LicenceActivityLoadTests.MemoryDeltaBudgetBytes);
+            Assert.AreEqual(2L * 1024 * 1024 * 1024, LicenceActivityLoadTests.MemoryDeltaBudgetBytes);
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityPerformanceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityPerformanceTests.cs
@@ -89,39 +89,102 @@ namespace Tests.UnitTests
                         LicenceActivitySqlFixture.WideToUtc.ToString("yyyy-MM-dd"),
                         LicenceActivitySqlFixture.NowUtc);
 
+                    var diagnosticTimeout = LicenceActivitySql.CommandTimeoutSeconds;
                     if (int.TryParse(
                         Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_TIMEOUT"),
-                        out var diagnosticTimeout)
-                        && diagnosticTimeout > LicenceActivitySql.CommandTimeoutSeconds)
+                        out var configuredDiagnosticTimeout)
+                        && configuredDiagnosticTimeout > diagnosticTimeout)
+                        diagnosticTimeout = configuredDiagnosticTimeout;
+                    if (string.Equals(Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC"),
+                            "1", StringComparison.Ordinal)
+                        || diagnosticTimeout > LicenceActivitySql.CommandTimeoutSeconds)
                     {
                         var diagnosticWide = string.Equals(
                             Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_WINDOW"),
                             "wide",
                             StringComparison.OrdinalIgnoreCase);
                         var diagnosticQuery = diagnosticWide ? wideQuery : narrowQuery;
+                        if (int.TryParse(Environment.GetEnvironmentVariable(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_DEPARTMENT"), out var diagnosticDepartment))
+                        {
+                            diagnosticQuery = LicenceActivityQuery.Create(
+                                diagnosticQuery.From, diagnosticQuery.To, LicenceActivitySqlFixture.NowUtc,
+                                departmentId: diagnosticDepartment);
+                        }
                         var diagnosticScenario = diagnosticWide
                             ? "overview-wide-180d"
                             : "overview-narrow-7d";
+                        if (string.Equals(Environment.GetEnvironmentVariable(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_HTTP"), "1", StringComparison.Ordinal))
+                        {
+                            await DiagnoseHttpOverview(fixture, diagnosticQuery, sources);
+                            Assert.Inconclusive(
+                                "HTTP overview preflight only, with production SQL/response limits; "
+                                + "the complete acceptance matrix has NOT run.");
+                        }
                         var diagnostic = new LicenceActivitySqlMeasurement();
+                        var diagnosticUsers = string.Equals(
+                            Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_USERS"),
+                            "1", StringComparison.Ordinal);
+                        LicenceActivityOverview diagnosticOverview = null;
+                        if (diagnosticUsers)
+                        {
+                            diagnosticOverview = await fixture.Store(new SqlLicenceActivityStoreInstrumentation
+                                { CommandTimeoutSeconds = diagnosticTimeout })
+                                .LoadOverviewAsync(diagnosticQuery, sources,
+                                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                            diagnosticScenario = "users-" + diagnosticScenario;
+                        }
                         var includeShowplan = string.Equals(
                             Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_SHOWPLAN"),
                             "1",
                             StringComparison.Ordinal);
                         var diagnosticWatch = Stopwatch.StartNew();
-                        await fixture.Store(diagnostic.Instrumentation(
-                                includeShowplan: includeShowplan,
-                                commandTimeoutSeconds: diagnosticTimeout))
-                            .LoadOverviewAsync(
+                        var uninstrumented = string.Equals(Environment.GetEnvironmentVariable(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_UNINSTRUMENTED"), "1", StringComparison.Ordinal);
+                        if (uninstrumented) diagnosticTimeout = LicenceActivitySql.CommandTimeoutSeconds;
+                        var diagnosticStore = uninstrumented ? fixture.Store()
+                            : fixture.Store(diagnostic.Instrumentation(
+                                includeShowplan: includeShowplan, commandTimeoutSeconds: diagnosticTimeout));
+                        try
+                        {
+                        if (diagnosticUsers)
+                        {
+                            var sku = int.TryParse(Environment.GetEnvironmentVariable(
+                                "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_SKU"), out var configuredSku) ? configuredSku : 2;
+                            var workload = Environment.GetEnvironmentVariable(
+                                "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_WORKLOAD") ?? "teams";
+                            var users = await diagnosticStore.LoadUsersAsync(diagnosticOverview,
+                                diagnosticQuery.ForUsers(sku, workload, null, "activity", "desc",
+                                    100, 1, 100, LicenceActivitySqlFixture.NowUtc),
+                                sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                            var licence = diagnosticOverview.Licences.Single(l => l.LicenceTypeId == sku);
+                            var distribution = licence.Workloads.Single(w => w.Workload == workload);
+                            var positive = distribution.High + distribution.Moderate + distribution.Low;
+                            Assert.AreEqual(licence.AssignedUsers, users.TotalUsers);
+                            Assert.AreEqual(Math.Min(100, positive + distribution.Zero), users.LeastActive.Count);
+                            Assert.IsTrue(users.MostActive.Count >= Math.Min(100, positive));
+                            diagnosticScenario += "-sku" + sku + "-" + workload;
+                        }
+                        else
+                        {
+                            await diagnosticStore.LoadOverviewAsync(
                                 diagnosticQuery, sources,
                                 NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                        }
+                        }
+                        finally
+                        {
                         diagnosticWatch.Stop();
                         Console.WriteLine(
-                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC scenario={0} elapsedMs={1} logicalReads={2} readsByOperation={3} operations={4}",
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC scenario={0} elapsedMs={1} logicalReads={2} readsByOperation={3} operations={4} instrumented={5}",
                             diagnosticScenario,
                             diagnosticWatch.ElapsedMilliseconds,
-                            diagnostic.TotalLogicalReads,
+                            uninstrumented ? "unmeasured"
+                                : diagnostic.TotalLogicalReads.ToString(CultureInfo.InvariantCulture),
                             string.Join(",", diagnostic.LogicalReadsByOperation),
-                            string.Join(",", diagnostic.Operations));
+                            string.Join(",", diagnostic.Operations),
+                            !uninstrumented);
                         Console.WriteLine(
                             "LICENCE_ACTIVITY_PERF_DIAGNOSTIC statementTimings={0}",
                             string.Join(
@@ -134,20 +197,40 @@ namespace Tests.UnitTests
                                         message.Split(
                                             (char[])null,
                                             StringSplitOptions.RemoveEmptyEntries)))));
-                        if (includeShowplan)
+                        if (!uninstrumented)
+                            Console.WriteLine(
+                                "LICENCE_ACTIVITY_PERF_DIAGNOSTIC innerSqlPeakCommands={0} innerSqlPeakConnections={1} activeCommands={2} activeConnections={3}",
+                                diagnostic.PeakCommands, diagnostic.PeakConnections,
+                                diagnostic.ActiveCommands, diagnostic.ActiveConnections);
+                        if (includeShowplan && !uninstrumented)
                         {
                             Console.WriteLine(
                                 "LICENCE_ACTIVITY_PERF_DIAGNOSTIC operators={0}",
                                 string.Join(",", PlanOperators(diagnostic.Showplans)));
+                            var plans = diagnostic.Showplans.Select(XDocument.Parse).ToArray();
+                            var aggregateRows = plans.SelectMany(plan => plan.Descendants()
+                                .Where(node => node.Name.LocalName == "RelOp"
+                                    && (string)node.Attribute("LogicalOp") == "Aggregate"))
+                                .Select(node => node.Elements()
+                                    .Where(child => child.Name.LocalName == "RunTimeInformation")
+                                    .SelectMany(child => child.Elements())
+                                    .Sum(counter => (double?)counter.Attribute("ActualRows") ?? 0))
+                                .DefaultIfEmpty(0).Max();
+                            Console.WriteLine(
+                                "LICENCE_ACTIVITY_PERF_DIAGNOSTIC maximumAggregateRows={0} spillWarnings={1} maximumGrantedMemoryKb={2}",
+                                aggregateRows,
+                                plans.Sum(plan => plan.Descendants()
+                                    .Count(node => node.Name.LocalName == "SpillToTempDb")),
+                                plans.SelectMany(plan => plan.Descendants()
+                                    .Where(node => node.Name.LocalName == "MemoryGrantInfo"))
+                                    .Select(node => (long?)node.Attribute("GrantedMemory") ?? 0)
+                                    .DefaultIfEmpty(0).Max());
                         }
-                        // A long diagnostic timeout deliberately exceeds the production command
-                        // timeout so a slow plan can be root-caused instead of being cut off. That is
-                        // legitimate, but it means the acceptance assertions below were NEVER reached
-                        // and the production budgets were NOT honoured. Reporting Passed here would
-                        // turn a root-cause probe into fake acceptance evidence, so end the run as
-                        // Inconclusive with the diagnostics already written to the console above.
+                        }
+                        // Diagnostics can retain the production timeout. They still do not execute
+                        // the full acceptance matrix and must never be reported as a passing test.
                         Assert.Inconclusive(
-                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC run only (scenario={0}, commandTimeoutSeconds={1} > production {2}). "
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC run only (scenario={0}, commandTimeoutSeconds={1}, production={2}). "
                             + "Diagnostics were captured but NO acceptance assertion or HTTP load was executed, "
                             + "so this run is NOT Azure SQL 200-400 DTU acceptance evidence.",
                             diagnosticScenario,
@@ -247,13 +330,16 @@ namespace Tests.UnitTests
                     () => loadMeasurement.TotalLogicalReads,
                     message => Console.WriteLine("LICENCE_ACTIVITY_PERF " + message));
                     Console.WriteLine(
-                        "LICENCE_ACTIVITY_PERF httpLoadMs={0} assignments={1} peakConcurrentSql={2} "
-                        + "managedHeapDelta={3} privateMemoryDelta={4}",
+                        "LICENCE_ACTIVITY_PERF httpLoadMs={0} assignments={1} peakSharedReportLoads={2} "
+                        + "managedHeapDelta={3} privateMemoryDelta={4} innerSqlPeakCommands={5} innerSqlPeakConnections={6}",
                         load.ElapsedMs,
                         load.Assignments,
                         load.PeakConcurrentSqlLoads,
                         load.ManagedHeapDeltaBytes,
-                        load.PrivateMemoryDeltaBytes);
+                        load.PrivateMemoryDeltaBytes,
+                        loadMeasurement.PeakCommands, loadMeasurement.PeakConnections);
+                    Assert.AreEqual(0, loadMeasurement.ActiveCommands);
+                    Assert.AreEqual(0, loadMeasurement.ActiveConnections);
                 }
             }
             finally
@@ -330,6 +416,45 @@ namespace Tests.UnitTests
                 measurement.PlanCount,
                 measurement.Operators);
             return measurement;
+        }
+
+        private static async Task DiagnoseHttpOverview(
+            LicenceActivitySqlFixture fixture, LicenceActivityQuery query, LicenceActivitySources sources)
+        {
+            var measurement = new LicenceActivitySqlMeasurement();
+            var clock = Stopwatch.StartNew();
+            using (var host = new LicenceActivityHttpHost(
+                fixture.Store(measurement.Instrumentation(includeShowplan: false)), sources,
+                () => sources.NowUtc.Add(clock.Elapsed)))
+            {
+                var path = "api/LicenceActivity/overview?from=" + query.From + "&to=" + query.To;
+                if (query.DepartmentId.HasValue) path += "&departmentId=" + query.DepartmentId.Value;
+                if (query.CountryId.HasValue) path += "&countryId=" + query.CountryId.Value;
+                foreach (var temperature in new[] { "cold", "warm" })
+                {
+                    var reads = measurement.TotalLogicalReads;
+                    var watch = Stopwatch.StartNew();
+                    using (var response = await host.Client.GetAsync(path))
+                    {
+                        var content = await response.Content.ReadAsByteArrayAsync();
+                        watch.Stop();
+                        Console.WriteLine(
+                            "LICENCE_ACTIVITY_PERF_HTTP_PREFLIGHT state={0} status={1} elapsedMs={2} bytes={3} logicalReads={4} innerSqlPeakCommands={5} innerSqlPeakConnections={6}",
+                            temperature, (int)response.StatusCode, watch.ElapsedMilliseconds, content.Length,
+                            measurement.TotalLogicalReads - reads, measurement.PeakCommands, measurement.PeakConnections);
+                        if (!response.IsSuccessStatusCode) break;
+                        if (temperature == "warm")
+                            Assert.AreEqual(0L, measurement.TotalLogicalReads - reads,
+                                "A warm preflight must not re-read SQL.");
+                    }
+                }
+                var drain = Stopwatch.StartNew();
+                while ((measurement.ActiveCommands != 0 || measurement.ActiveConnections != 0)
+                    && drain.Elapsed < TimeSpan.FromMinutes(1))
+                    await Task.Delay(50);
+                Assert.AreEqual(0, measurement.ActiveCommands);
+                Assert.AreEqual(0, measurement.ActiveConnections);
+            }
         }
 
         private static void AssertMeasured(Measurement measurement)

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityPerformanceTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityPerformanceTests.cs
@@ -27,6 +27,83 @@ namespace Tests.UnitTests
     {
         [TestMethod]
         [TestCategory("Performance")]
+        public async Task CachedReadModel_AtReleaseScale_PassesTheCompleteHttpMatrix()
+        {
+            if (!string.Equals(Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF"), "1", StringComparison.Ordinal))
+                Assert.Inconclusive("Set LICENCE_ACTIVITY_PERF=1 to run the synthetic 300k-user preview matrix.");
+            using (var fixture = LicenceActivitySqlFixture.CreateScale("LicenceCachedScale", ReadIndexMode()))
+            {
+                Assert.AreEqual(300000, Convert.ToInt32(fixture.Scalar("SELECT COUNT(*) FROM dbo.users;")));
+                Assert.AreEqual(50, Convert.ToInt32(fixture.Scalar("SELECT COUNT(*) FROM dbo.license_types;")));
+                Assert.IsTrue(Convert.ToInt64(fixture.Scalar(
+                    "SELECT COUNT_BIG(*) FROM dbo.user_license_type_lookups;")) >= 2000000);
+                Assert.AreEqual(0, Convert.ToInt32(fixture.Scalar(
+                    "SELECT COUNT(*) FROM sys.indexes WHERE object_id=OBJECT_ID(N'dbo.copilot_usage_user_activity_log') AND type=6;")),
+                    "The shipped Copilot usage table has no columnstore index; an experimental fixture index cannot prove release performance.");
+                var sources = new LicenceActivitySources
+                {
+                    UserMetadata = true, UsageReports = true, CopilotUsageReports = true,
+                    NowUtc = LicenceActivitySqlFixture.NowUtc
+                };
+                var measurements = new LicenceActivitySqlMeasurement();
+                try
+                {
+                    if (string.Equals(Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_READ_MODEL_DIAGNOSTIC"),
+                        "1", StringComparison.Ordinal))
+                    {
+                        var diagnosticTimeout = int.TryParse(Environment.GetEnvironmentVariable(
+                            "LICENCE_ACTIVITY_PERF_DIAGNOSTIC_TIMEOUT"), out var seconds)
+                            ? seconds : LicenceActivitySql.CommandTimeoutSeconds;
+                        var showplan = Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_DIAGNOSTIC_SHOWPLAN") == "1";
+                        foreach (var days in new[] { 7, 180 })
+                        {
+                            var query = LicenceActivityQuery.Create(
+                                LicenceActivitySqlFixture.WideToUtc.AddDays(1 - days).ToString("yyyy-MM-dd"),
+                                LicenceActivitySqlFixture.WideToUtc.ToString("yyyy-MM-dd"), sources.NowUtc);
+                            var watch = Stopwatch.StartNew();
+                            var model = await fixture.Store(measurements.Instrumentation(
+                                    includeShowplan: showplan, commandTimeoutSeconds: diagnosticTimeout))
+                                .LoadReadModelAsync(query, sources, null, CancellationToken.None);
+                            Console.WriteLine("READ_MODEL_DIAGNOSTIC days={0} loadMs={1}", days, watch.ElapsedMilliseconds);
+                            watch.Restart();
+                            var overview = model.BuildOverview(query, CancellationToken.None);
+                            Console.WriteLine("READ_MODEL_DIAGNOSTIC days={0} overviewMs={1} users={2}",
+                                days, watch.ElapsedMilliseconds, overview.DistinctAssignedUsers);
+                        }
+                        Assert.Inconclusive("Read-model diagnostics only; the HTTP acceptance matrix has not run.");
+                    }
+                    var result = await LicenceActivityLoadTests.RunAsync(
+                        fixture.Store(), sources, LicenceActivitySqlFixture.WideToUtc,
+                        () => measurements.TotalLogicalReads, Console.WriteLine,
+                        clock => new CachedLicenceActivityStore(
+                            fixture.Store(measurements.Instrumentation(includeShowplan: false)),
+                            new LicenceActivityReadModelCache(utcNow: clock), "synthetic-scale"));
+                    Assert.AreEqual(1500, result.CompletedMatrixCells);
+                    Assert.IsTrue(result.Observations.Where(observation =>
+                            observation.Scenario == "users-cold" || observation.Scenario == "department"
+                            || observation.Scenario == "country" || observation.Scenario == "workload-ranking")
+                        .All(observation => observation.LogicalReads == 0),
+                        "SKU, workload, filter, search and ranking changes must reuse the read model instead of querying SQL.");
+                    Assert.AreEqual(0, measurements.ActiveCommands);
+                    Assert.AreEqual(0, measurements.ActiveConnections);
+                    Console.WriteLine("LICENCE_ACTIVITY_CACHED_PERF environment=LocalDB azureLatency=unmeasured "
+                        + "cells={0} elapsedMs={1} managedGrowthBytes={2} privateGrowthBytes={3} logicalReads={4}",
+                        result.CompletedMatrixCells, result.ElapsedMs, result.ManagedHeapDeltaBytes,
+                        result.PrivateMemoryDeltaBytes, measurements.TotalLogicalReads);
+                }
+                finally
+                {
+                    Console.WriteLine("LICENCE_ACTIVITY_CACHED_PERF operations={0} readsByOperation={1}",
+                        string.Join(",", measurements.Operations), string.Join(",", measurements.LogicalReadsByOperation));
+                    if (measurements.Showplans.Count > 0)
+                        Console.WriteLine("READ_MODEL_DIAGNOSTIC operators={0}",
+                            string.Join(",", PlanOperators(measurements.Showplans)));
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Performance")]
         public async Task SqlStore_AtReleaseScale_RecordsElapsedReadsAndPlansAcrossWindowsAndSkuSizes()
         {
             if (!string.Equals(

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelCacheTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelCacheTests.cs
@@ -1,0 +1,274 @@
+extern alias AnalyticsWeb;
+
+using AnalyticsWeb::Web.AnalyticsWeb.Models.LicenceActivity;
+using Common.Entities.LicenceActivity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class LicenceActivityReadModelCacheTests
+    {
+        private static readonly DateTime Now = new DateTime(2000, 7, 4, 0, 0, 0, DateTimeKind.Utc);
+
+        [TestMethod]
+        public async Task IdenticalRangesCoalesceAndCallerCancellationDoesNotCancelTheModel()
+        {
+            var cache = new LicenceActivityReadModelCache(utcNow: () => Now);
+            var started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var completion = new TaskCompletionSource<LicenceActivityReadModel>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var calls = 0;
+            CancellationToken sharedToken = default(CancellationToken);
+            Task<LicenceActivityReadModel> Load(CancellationToken token)
+            {
+                Interlocked.Increment(ref calls);
+                sharedToken = token;
+                started.TrySetResult(true);
+                return completion.Task;
+            }
+            using (var caller = new CancellationTokenSource())
+            {
+                var first = cache.GetAsync("scope", "range", Load, caller.Token);
+                await started.Task;
+                var others = Enumerable.Range(0, 8)
+                    .Select(_ => cache.GetAsync("scope", "range", Load, CancellationToken.None)).ToArray();
+                caller.Cancel();
+                await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => first);
+                Assert.IsFalse(sharedToken.IsCancellationRequested);
+                var model = EmptyModel();
+                completion.SetResult(model);
+                var leases = await Task.WhenAll(others);
+                Assert.AreEqual(1, calls);
+                Assert.IsTrue(leases.All(lease => ReferenceEquals(model, lease.Model)));
+                Assert.AreSame(model, cache.Find("scope", model.Id).Model);
+            }
+        }
+
+        [TestMethod]
+        public async Task DistinctColdLoadsAreBoundedUntilTheActualLoaderFinishes()
+        {
+            var cache = new LicenceActivityReadModelCache(utcNow: () => Now);
+            var completion = new TaskCompletionSource<LicenceActivityReadModel>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var first = cache.GetAsync("scope", "first", _ => completion.Task, CancellationToken.None);
+            Assert.ThrowsException<LicenceActivityReadModelBusyException>(() =>
+                cache.GetAsync("scope", "second", _ => Task.FromResult(EmptyModel()), CancellationToken.None));
+            completion.SetResult(EmptyModel());
+            await first;
+            var next = await cache.GetAsync("scope", "second", _ => Task.FromResult(EmptyModel()), CancellationToken.None);
+            Assert.IsNotNull(next.Model);
+        }
+
+        [TestMethod]
+        public async Task FailureIsNotCachedAndCanBeRetried()
+        {
+            var cache = new LicenceActivityReadModelCache(utcNow: () => Now);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => cache.GetAsync(
+                "scope", "range", _ => Task.FromException<LicenceActivityReadModel>(new InvalidOperationException("synthetic")),
+                CancellationToken.None));
+            var lease = await cache.GetAsync("scope", "range", _ => Task.FromResult(EmptyModel()), CancellationToken.None);
+            Assert.IsNotNull(lease.Model);
+        }
+
+        [TestMethod]
+        public async Task DeadlineCancelsTheLoaderAndNeverPublishesLateData()
+        {
+            var cache = new LicenceActivityReadModelCache(
+                utcNow: () => Now, loadTimeout: TimeSpan.FromMilliseconds(40));
+            var cancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var finish = new TaskCompletionSource<LicenceActivityReadModel>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pending = cache.GetAsync("scope", "range", async token =>
+            {
+                using (token.Register(() => cancelled.TrySetResult(true)))
+                    return await finish.Task;
+            }, CancellationToken.None);
+            Assert.AreSame(cancelled.Task, await Task.WhenAny(cancelled.Task, pending),
+                "The synthetic loader must start before its response deadline.");
+            Assert.ThrowsException<LicenceActivityReadModelBusyException>(() =>
+                cache.GetAsync("scope", "other", _ => Task.FromResult(EmptyModel()), CancellationToken.None));
+            var late = EmptyModel();
+            finish.SetResult(late);
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => pending);
+            Assert.ThrowsException<LicenceActivityReadModelExpiredException>(() => cache.Find("scope", late.Id));
+        }
+
+        [TestMethod]
+        public async Task ExpiryEvictionAndScopeIsolationDoNotRetainOldModels()
+        {
+            var now = Now;
+            var cache = new LicenceActivityReadModelCache(utcNow: () => now);
+            var first = await cache.GetAsync("scope-a", "range", _ => Task.FromResult(EmptyModel()), CancellationToken.None);
+            now = now.AddSeconds(1);
+            var second = await cache.GetAsync("scope-b", "range", _ => Task.FromResult(EmptyModel()), CancellationToken.None);
+            Assert.AreNotEqual(first.Model.Id, second.Model.Id);
+            Assert.ThrowsException<LicenceActivityReadModelExpiredException>(() => cache.Find("scope-b", first.Model.Id));
+            now = now.AddSeconds(1);
+            var third = await cache.GetAsync("scope-a", "other", _ => Task.FromResult(EmptyModel()), CancellationToken.None);
+            Assert.ThrowsException<LicenceActivityReadModelExpiredException>(() => cache.Find("scope-a", first.Model.Id));
+            Assert.AreSame(second.Model, cache.Find("scope-b", second.Model.Id).Model);
+            now = third.ExpiresUtc;
+            Assert.ThrowsException<LicenceActivityReadModelExpiredException>(() => cache.Find("scope-a", third.Model.Id));
+            var refreshed = await cache.GetAsync("scope-a", "other", _ => Task.FromResult(EmptyModel()), CancellationToken.None);
+            Assert.AreNotEqual(third.Model.Id, refreshed.Model.Id);
+        }
+
+        [TestMethod]
+        public async Task SharedLoaderDoesNotCaptureTheRequestSynchronizationContext()
+        {
+            var previous = SynchronizationContext.Current;
+            var cache = new LicenceActivityReadModelCache(utcNow: () => Now);
+            Task<LicenceActivityReadModelLease> task;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(new RejectingContext());
+                task = cache.GetAsync("scope", "range", async token =>
+                {
+                    Assert.IsNull(SynchronizationContext.Current);
+                    await Task.Delay(1, token);
+                    Assert.IsNull(SynchronizationContext.Current);
+                    return EmptyModel();
+                }, CancellationToken.None);
+            }
+            finally { SynchronizationContext.SetSynchronizationContext(previous); }
+            Assert.IsNotNull((await task).Model);
+        }
+
+        [TestMethod]
+        public async Task HttpSnapshotCannotOutliveItsSourceAndInternalKeysAreNotSerialized()
+        {
+            var cache = new LicenceActivitySnapshotCache<LicenceActivityOverview>(
+                2, TimeSpan.FromMinutes(5), utcNow: () => Now,
+                diagnostics: _ => null, reportFailure: (_, __) => { });
+            var sourceExpiry = Now.AddSeconds(15);
+            var snapshot = await cache.GetAsync("scope", "range", (_, __) =>
+                Task.FromResult(new LicenceActivityOverview
+                {
+                    ReadModelId = "internal-synthetic-key",
+                    SourceExpiresUtc = sourceExpiry
+                }));
+            Assert.AreEqual(sourceExpiry, snapshot.ExpiresUtc);
+            var json = JsonConvert.SerializeObject(snapshot);
+            Assert.IsFalse(json.Contains("internal-synthetic-key"));
+            Assert.IsFalse(json.Contains("sourceExpiresUtc"));
+            Assert.IsFalse(json.Contains("readModelId"));
+        }
+
+        [TestMethod]
+        public async Task EvictedSourceInvalidatesOverviewSoRefreshDoesNotRepeatAnExpiredId()
+        {
+            var cache = new LicenceActivitySnapshotCache<LicenceActivityOverview>(
+                2, TimeSpan.FromMinutes(5), utcNow: () => Now,
+                diagnostics: _ => null, reportFailure: (_, __) => { });
+            var current = true;
+            var loads = 0;
+            Task<LicenceActivityOverview> Load(ILicenceActivityDiagnostics _, CancellationToken __)
+            {
+                loads++;
+                return Task.FromResult(new LicenceActivityOverview());
+            }
+            var first = await cache.GetAsync("scope", "range", Load, isCurrent: _ => current);
+            var warm = await cache.GetAsync("scope", "range", Load, isCurrent: _ => current);
+            Assert.AreEqual(first.SnapshotId, warm.SnapshotId);
+            current = false;
+            var refreshed = await cache.GetAsync("scope", "range", Load, isCurrent: _ => current);
+            Assert.AreNotEqual(first.SnapshotId, refreshed.SnapshotId);
+            Assert.AreEqual(2, loads);
+            Assert.ThrowsException<LicenceActivityExpiredException>(() => cache.Find("scope", first.SnapshotId));
+        }
+
+        [TestMethod]
+        public async Task DemographicQueriesReuseTheRangeButSourceChangesDoNot()
+        {
+            var sources = new LicenceActivitySources { UserMetadata = true, NowUtc = Now };
+            var loader = new EmptyLoader();
+            var store = new CachedLicenceActivityStore(loader, new LicenceActivityReadModelCache(utcNow: () => Now), "scope");
+            var query = LicenceActivityQuery.Create("2000-06-19", "2000-06-25", Now);
+            var first = await store.LoadOverviewAsync(query, sources, null, CancellationToken.None);
+            var filtered = await store.LoadOverviewAsync(
+                LicenceActivityQuery.Create(query.From, query.To, Now, departmentId: 0), sources, null, CancellationToken.None);
+            Assert.AreEqual(first.ReadModelId, filtered.ReadModelId);
+            Assert.AreEqual(1, loader.Calls);
+            sources.UsageReports = true;
+            var changed = await store.LoadOverviewAsync(query, sources, null, CancellationToken.None);
+            Assert.AreNotEqual(first.ReadModelId, changed.ReadModelId);
+            Assert.AreEqual(2, loader.Calls);
+        }
+
+        [TestMethod]
+        public async Task HttpRefreshReplacesAnEvictedReadModelAndDrilldownRecovers()
+        {
+            var sources = new LicenceActivitySources { UserMetadata = true, NowUtc = Now };
+            var store = new CachedLicenceActivityStore(
+                new OneUserLoader(), new LicenceActivityReadModelCache(capacity: 1, utcNow: () => Now), "scope");
+            using (var host = new LicenceActivityHttpHost(store, sources, () => Now))
+            {
+                const string path = "api/LicenceActivity/overview?from=2000-06-19&to=2000-06-25";
+                var original = JObject.Parse(await host.Client.GetStringAsync(path));
+                await host.Client.GetStringAsync("api/LicenceActivity/overview?from=2000-06-12&to=2000-06-18");
+                using (var expired = await host.Client.GetAsync(
+                    "api/LicenceActivity/users?overviewId=" + original["snapshotId"] + "&licenceTypeId=1"))
+                    Assert.AreEqual(HttpStatusCode.Gone, expired.StatusCode);
+                var refreshed = JObject.Parse(await host.Client.GetStringAsync(path));
+                Assert.AreNotEqual((string)original["snapshotId"], (string)refreshed["snapshotId"]);
+                var users = JObject.Parse(await host.Client.GetStringAsync(
+                    "api/LicenceActivity/users?overviewId=" + refreshed["snapshotId"] + "&licenceTypeId=1"));
+                Assert.AreEqual(1, (int)users["totalUsers"]);
+                Assert.AreEqual("synthetic@contoso.example", (string)users["users"][0]["userPrincipalName"]);
+            }
+        }
+
+        private static LicenceActivityReadModel EmptyModel() => new LicenceActivityReadModel(
+            LicenceActivityQuery.Create("2000-06-19", "2000-06-25", Now),
+            Array.Empty<LicenceActivitySku>(), Array.Empty<LicenceActivityDirectoryUser>(),
+            Array.Empty<LicenceActivityMembership>(),
+            LicenceActivityQuery.Workloads.Select(workload => new LicenceActivityCoverage
+            {
+                Workload = workload, Status = "disabled", Source = "microsoftGraphUsageReport",
+                Measure = "synthetic", ExpectedSamples = 1
+            }).ToArray(),
+            new Dictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>>());
+
+        private sealed class EmptyLoader : ILicenceActivityReadModelLoader
+        {
+            internal int Calls;
+            public Task<LicenceActivityReadModel> LoadReadModelAsync(
+                LicenceActivityQuery range, LicenceActivitySources sources,
+                ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken)
+            {
+                Calls++;
+                return Task.FromResult(EmptyModel());
+            }
+        }
+
+        private sealed class OneUserLoader : ILicenceActivityReadModelLoader
+        {
+            public Task<LicenceActivityReadModel> LoadReadModelAsync(
+                LicenceActivityQuery range, LicenceActivitySources sources,
+                ILicenceActivityDiagnostics diagnostics, CancellationToken cancellationToken) =>
+                Task.FromResult(new LicenceActivityReadModel(
+                    range,
+                    new[] { new LicenceActivitySku { LicenceTypeId = 1, Name = "Contoso Suite" } },
+                    new[] { new LicenceActivityDirectoryUser { UserId = 1, UserPrincipalName = "synthetic@contoso.example" } },
+                    new[] { new LicenceActivityMembership(1, 1) },
+                    LicenceActivityQuery.Workloads.Select(workload => new LicenceActivityCoverage
+                    {
+                        Workload = workload, Status = "disabled", Source = "microsoftGraphUsageReport",
+                        Measure = "synthetic", ExpectedSamples = 1
+                    }).ToArray(),
+                    new Dictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>>()));
+        }
+
+        private sealed class RejectingContext : SynchronizationContext
+        {
+            public override void Post(SendOrPostCallback d, object state) =>
+                throw new InvalidOperationException("A shared load captured its initiating request.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelSqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelSqlTests.cs
@@ -1,0 +1,287 @@
+using Common.Entities.LicenceActivity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    [DoNotParallelize]
+    public class LicenceActivityReadModelSqlTests
+    {
+        private static readonly DateTime Now = LicenceActivitySqlFixture.NowUtc;
+
+        [TestMethod]
+        public async Task CachedReadModelMatchesSqlAcrossSkuWorkloadSearchSortAndPageShapes()
+        {
+            using (var fixture = LicenceActivitySqlTests.CreateMeasuredFixture())
+            {
+                var sources = Sources();
+                var query = Query();
+                var sql = fixture.Store();
+                var model = await sql.LoadReadModelAsync(query, sources, null, CancellationToken.None);
+                await Compare(sql, model, query, sources);
+                foreach (var department in new int?[] { 0, 1, 2 })
+                    await Compare(sql, model,
+                        LicenceActivityQuery.Create(query.From, query.To, Now, departmentId: department), sources);
+                await Compare(sql, model,
+                    LicenceActivityQuery.Create(query.From, query.To, Now, countryId: 2), sources);
+            }
+        }
+
+        [TestMethod]
+        public async Task MissingDuplicateAndPartialSamplesRemainDistinctFromMeasuredZero()
+        {
+            using (var fixture = LicenceActivitySqlTests.CreateMeasuredFixture())
+            {
+                fixture.Execute(@"
+DELETE dbo.onedrive_user_activity_log WHERE user_id = 2;
+DELETE dbo.sharepoint_user_activity_log WHERE user_id = 3 AND [date] = '2000-05-07';
+DELETE dbo.outlook_user_activity_log WHERE [date] = '2000-06-25';
+DROP INDEX IX_license_type_id_user_id ON dbo.user_license_type_lookups;
+INSERT dbo.user_license_type_lookups(user_id, license_type_id) VALUES(1, 1);");
+                LicenceActivitySqlTests.SeedOneUsageTable(fixture, "onedrive_user_activity_log",
+                    new[] { "2000-05-07", "2000-05-07" });
+                var sql = fixture.Store();
+                foreach (var from in new[] { "2000-05-01", "2000-05-03" })
+                {
+                    var query = LicenceActivityQuery.Create(from, "2000-06-25", Now);
+                    var model = await sql.LoadReadModelAsync(query, Sources(), null, CancellationToken.None);
+                    await Compare(sql, model, query, Sources());
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(7, false, false)]
+        [DataRow(7, true, false)]
+        [DataRow(28, false, false)]
+        [DataRow(90, false, false)]
+        [DataRow(180, false, false)]
+        [DataRow(7, false, true)]
+        public async Task OfficialCopilotSourcesPreservePeriodAuthorityAndUnknownEvidence(
+            int period, bool customGap, bool invalidCounters)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCachedCopilot"))
+            {
+                LicenceActivitySqlTests.SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+ (report_name, report_refresh_date, report_version, report_period, imported_utc,
+  rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v2', N'D7',
+ '2000-07-01T01:00:00', 5, 5, 0, NULL);");
+                var end = new DateTime(2000, 6, 25);
+                var start = end.AddDays(1 - (period == 7 ? 56 : period));
+                var dates = period == 7
+                    ? Enumerable.Range(0, 8).Select(index => start.AddDays(6 + index * 7))
+                    : new[] { end };
+                foreach (var date in dates)
+                {
+                    fixture.Execute($@"
+INSERT dbo.copilot_usage_user_activity_log
+ (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+  user_id, [date], last_activity_date)
+VALUES
+ ({period}, 12, 2, 0, 1, '{date:yyyy-MM-dd}', NULL),
+ ({period}, 0, 0, 0, 4, '{date:yyyy-MM-dd}', '{date:yyyy-MM-dd}'),
+ ({period}, NULL, NULL, 0, 3, '{date:yyyy-MM-dd}', '{date:yyyy-MM-dd}');");
+                }
+                if (invalidCounters)
+                    fixture.Execute("UPDATE dbo.copilot_usage_user_activity_log SET active_usage_days=-1, prompts_all_apps=-2 WHERE user_id=1 AND [date]='2000-05-07';");
+                var query = LicenceActivityQuery.Create(start.AddDays(customGap ? 1 : 0).ToString("yyyy-MM-dd"),
+                    end.ToString("yyyy-MM-dd"), Now);
+                var sources = Sources(usageReports: false, copilotReports: true);
+                var sql = fixture.Store();
+                var model = await sql.LoadReadModelAsync(query, sources, null, CancellationToken.None);
+                await Compare(sql, model, query, sources);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task DisabledAndUnpopulatedSourcesNeverBecomeMeasuredZero(bool enabled)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCachedUnavailable"))
+            {
+                LicenceActivitySqlTests.SeedDirectory(fixture);
+                var sources = Sources(enabled, enabled);
+                var sql = fixture.Store();
+                var model = await sql.LoadReadModelAsync(Query(), sources, null, CancellationToken.None);
+                await Compare(sql, model, Query(), sources);
+                Assert.IsTrue(model.BuildOverview(Query(), CancellationToken.None).Licences
+                    .SelectMany(sku => sku.Workloads).All(workload => workload.Zero == 0));
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task CopilotEventFallbacksRemainPositiveOnly(bool interactions)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCachedFallback"))
+            {
+                LicenceActivitySqlTests.SeedDirectory(fixture);
+                if (interactions)
+                {
+                    fixture.Execute(@"
+INSERT dbo.copilot_interactions
+ (graph_interaction_id, session_id, user_id, created_utc,
+  body_char_count, body_word_count, attachment_count, link_count, mention_count, context_count)
+VALUES (N'synthetic-interaction', 1, 2, '2000-06-20', 20, 4, 0, 0, 0, 0);");
+                }
+                else
+                {
+                    fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+ (report_name, report_refresh_date, report_version, report_period, imported_utc,
+  rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-30', N'v2', N'D28',
+ '2000-07-01T01:00:00', 5, 0, 1, NULL);
+INSERT dbo.copilot_chats(event_id, app_host, user_id, time_stamp)
+VALUES ('00000000-0000-0000-0000-000000000001', N'Teams', 1, '2000-06-20');");
+                }
+                var sources = Sources(usageReports: false, copilotReports: !interactions);
+                sources.CopilotAudit = !interactions;
+                sources.CopilotInteractions = interactions;
+                var sql = fixture.Store();
+                var model = await sql.LoadReadModelAsync(Query(), sources, null, CancellationToken.None);
+                await Compare(sql, model, Query(), sources);
+                var overview = model.BuildOverview(Query(), CancellationToken.None);
+                var users = model.BuildUsers(overview,
+                    Query().ForUsers(1, "copilot", null, "activity", "desc", 10, 1, 100, Now),
+                    CancellationToken.None);
+                Assert.AreEqual(1, users.MostActive.Count);
+                Assert.AreEqual(0, users.LeastActive.Count);
+                Assert.IsTrue(users.Users.SelectMany(user => user.Workloads).All(workload => workload.Band == "unknown"));
+            }
+        }
+
+        [TestMethod]
+        public async Task FilterAndDrilldownReusePinnedDataWithoutMoreSqlUntilExpiry()
+        {
+            using (var fixture = LicenceActivitySqlTests.CreateMeasuredFixture())
+            {
+                var now = Now;
+                var opened = 0;
+                var loader = fixture.Store(new SqlLicenceActivityStoreInstrumentation
+                {
+                    ConnectionOpened = _ => Interlocked.Increment(ref opened)
+                });
+                var cache = new LicenceActivityReadModelCache(utcNow: () => now);
+                var store = new CachedLicenceActivityStore(loader, cache, "synthetic-scope");
+                var overview = await store.LoadOverviewAsync(Query(), Sources(), null, CancellationToken.None);
+                var afterLoad = opened;
+                Assert.IsTrue(afterLoad > 0);
+                var userQuery = Query().ForUsers(1, "teams", null, "upn", "asc", 10, 1, 100, Now);
+                var users = await store.LoadUsersAsync(overview, userQuery, Sources(), null, CancellationToken.None);
+                fixture.Execute(@"
+DELETE dbo.user_license_type_lookups WHERE user_id=1;
+UPDATE dbo.users SET department_id=NULL WHERE id=1;
+UPDATE dbo.teams_user_activity_log SET last_activity_date=NULL WHERE user_id=1;");
+                var again = await store.LoadUsersAsync(overview, userQuery, Sources(), null, CancellationToken.None);
+                AssertUsersEqual(users, again);
+                var filtered = await store.LoadOverviewAsync(
+                    LicenceActivityQuery.Create(Query().From, Query().To, Now, departmentId: 1),
+                    Sources(), null, CancellationToken.None);
+                Assert.AreEqual(overview.ReadModelId, filtered.ReadModelId);
+                Assert.AreEqual(afterLoad, opened, "Licence, filter, search and ranking changes must not re-query SQL.");
+                now = overview.SourceExpiresUtc.Value;
+                await Assert.ThrowsExceptionAsync<LicenceActivityReadModelExpiredException>(() =>
+                    store.LoadUsersAsync(overview, userQuery, Sources(), null, CancellationToken.None));
+                var refreshed = await store.LoadOverviewAsync(Query(), Sources(), null, CancellationToken.None);
+                Assert.AreNotEqual(overview.ReadModelId, refreshed.ReadModelId);
+                Assert.AreEqual(4, refreshed.DistinctAssignedUsers);
+                Assert.IsTrue(opened > afterLoad);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task ParallelReadModelBranchesReleaseConnectionsOnSuccessAndFailure(bool failCoverage)
+        {
+            using (var fixture = LicenceActivitySqlTests.CreateMeasuredFixture())
+            {
+                if (failCoverage) fixture.Execute("DROP TABLE dbo.outlook_user_activity_log;");
+                var measurements = new LicenceActivitySqlMeasurement();
+                var pending = fixture.Store(measurements.Instrumentation(includeShowplan: false))
+                    .LoadReadModelAsync(Query(), Sources(), null, CancellationToken.None);
+                if (failCoverage)
+                    await Assert.ThrowsExceptionAsync<System.Data.SqlClient.SqlException>(() => pending);
+                else
+                    Assert.AreEqual(5, (await pending).BuildOverview(Query(), CancellationToken.None).DistinctAssignedUsers);
+                Assert.AreEqual(0, measurements.ActiveCommands);
+                Assert.AreEqual(0, measurements.ActiveConnections);
+                Assert.IsTrue(measurements.Operations.Any(operation => operation.StartsWith("directory=", StringComparison.Ordinal)));
+            }
+        }
+
+        private static async Task Compare(
+            SqlLicenceActivityStore sql, LicenceActivityReadModel model,
+            LicenceActivityQuery query, LicenceActivitySources sources)
+        {
+            var expected = await sql.LoadOverviewAsync(query, sources, null, CancellationToken.None);
+            var actual = model.BuildOverview(query, CancellationToken.None);
+            Assert.AreEqual(OverviewShape(expected), OverviewShape(actual));
+            foreach (var sku in expected.Licences)
+                foreach (var workload in LicenceActivityQuery.Workloads)
+                    foreach (var shape in new[]
+                    {
+                        new { Sort = "upn", Direction = "asc", Search = "", Page = 1 },
+                        new { Sort = "upn", Direction = "desc", Search = "", Page = 2 },
+                        new { Sort = "activity", Direction = "desc", Search = "", Page = 1 },
+                        new { Sort = "activity", Direction = "asc", Search = "", Page = 1 },
+                        new { Sort = "lastActivity", Direction = "desc", Search = "", Page = 2 },
+                        new { Sort = "lastActivity", Direction = "asc", Search = "", Page = 1 },
+                        new { Sort = "upn", Direction = "asc", Search = "ALIAS.SEARCH", Page = 1 },
+                        new { Sort = "upn", Direction = "asc", Search = "_user", Page = 1 },
+                        new { Sort = "upn", Direction = "asc", Search = "%[missing]", Page = 1 }
+                    })
+                    {
+                        var userQuery = query.ForUsers(sku.LicenceTypeId, workload, shape.Search,
+                            shape.Sort, shape.Direction, 2, shape.Page, 2, Now);
+                        var expectedUsers = await sql.LoadUsersAsync(expected, userQuery, sources, null, CancellationToken.None);
+                        var actualUsers = model.BuildUsers(actual, userQuery, CancellationToken.None);
+                        AssertUsersEqual(expectedUsers, actualUsers);
+                    }
+        }
+
+        private static string OverviewShape(LicenceActivityOverview overview) => JsonConvert.SerializeObject(new
+        {
+            overview.DistinctAssignedUsers,
+            overview.DemographicsTruncated,
+            Licences = overview.Licences.OrderBy(sku => sku.LicenceTypeId).Select(sku => new
+            {
+                sku.LicenceTypeId, sku.Name, sku.SkuId, sku.AssignedUsers,
+                Workloads = sku.Workloads.OrderBy(workload => workload.Workload)
+            }),
+            Coverage = overview.Coverage.OrderBy(coverage => coverage.Workload),
+            Departments = overview.Departments.OrderBy(value => value.Id),
+            Countries = overview.Countries.OrderBy(value => value.Id)
+        });
+
+        private static void AssertUsersEqual(LicenceActivityUsers expected, LicenceActivityUsers actual)
+        {
+            Assert.AreEqual(expected.TotalUsers, actual.TotalUsers);
+            Assert.AreEqual(expected.RankedUsers, actual.RankedUsers);
+            Assert.AreEqual(JsonConvert.SerializeObject(expected.MostActive), JsonConvert.SerializeObject(actual.MostActive));
+            Assert.AreEqual(JsonConvert.SerializeObject(expected.LeastActive), JsonConvert.SerializeObject(actual.LeastActive));
+            Assert.AreEqual(JsonConvert.SerializeObject(expected.Users), JsonConvert.SerializeObject(actual.Users));
+        }
+
+        private static LicenceActivityQuery Query() =>
+            LicenceActivityQuery.Create("2000-05-01", "2000-06-25", Now);
+
+        private static LicenceActivitySources Sources(bool usageReports = true, bool copilotReports = false) =>
+            new LicenceActivitySources
+            {
+                UserMetadata = true, UsageReports = usageReports, CopilotUsageReports = copilotReports, NowUtc = Now
+            };
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelTests.cs
@@ -1,0 +1,414 @@
+using Common.Entities.LicenceActivity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class LicenceActivityReadModelTests
+    {
+        private static readonly DateTime Now =
+            new DateTime(2000, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        [TestMethod]
+        public void OverviewUsesUniqueUsersForOverlappingAndDuplicateAssignments()
+        {
+            var users = Users(1, 2, 3);
+            var model = Model(
+                new[]
+                {
+                    Sku(1, "Contoso E1"),
+                    Sku(2, "Contoso E3")
+                },
+                users,
+                new[]
+                {
+                    Member(1, 1), Member(1, 1), Member(1, 2),
+                    Member(2, 1), Member(3, 2)
+                },
+                AvailableCoverage(),
+                Scores(("teams", 1, Score(4, 4)), ("teams", 2, Score(0, 4))));
+
+            var overview = model.BuildOverview(Query(), CancellationToken.None);
+
+            Assert.AreEqual(3, overview.DistinctAssignedUsers);
+            Assert.AreEqual(2, overview.Licences.Single(sku => sku.LicenceTypeId == 1).AssignedUsers);
+            Assert.AreEqual(2, overview.Licences.Single(sku => sku.LicenceTypeId == 2).AssignedUsers);
+            Assert.AreEqual(3, overview.Departments.Sum(value => value.AssignedUsers));
+            Assert.AreEqual(5, overview.Licences[0].Workloads.Count);
+        }
+
+        [TestMethod]
+        public void EvidenceSeparatesMeasuredZeroAbsentPartialDisabledAndPositiveFallback()
+        {
+            var coverage = AvailableCoverage();
+            coverage.Single(item => item.Workload == "outlook").Status = "disabled";
+            coverage.Single(item => item.Workload == "outlook").Message = "Import is disabled.";
+            var copilot = coverage.Single(item => item.Workload == "copilot");
+            copilot.Status = "partial";
+            copilot.Source = "copilotAudit";
+            copilot.Message = "Event evidence is positive-only.";
+            var model = Model(
+                new[] { Sku(1, "Contoso") },
+                Users(1, 2, 3, 4),
+                Enumerable.Range(1, 4).Select(id => Member(id, 1)).ToArray(),
+                coverage,
+                Scores(
+                    ("teams", 1, Score(0, 4)),
+                    ("teams", 3, Score(2, 3)),
+                    ("outlook", 4, Score(2, 4)),
+                    ("copilot", 2, Score(1, 0, false))));
+            var overview = model.BuildOverview(Query(), CancellationToken.None);
+            var query = Query().ForUsers(
+                1, "teams", null, "activity", "desc", 10, 1, 100, Now);
+
+            var result = model.BuildUsers(overview, query, CancellationToken.None);
+
+            AssertEvidence(result, 1, "teams", "available", "zero");
+            AssertEvidence(result, 2, "teams", "missingCoverage", "unknown");
+            AssertEvidence(result, 3, "teams", "partial", "unknown");
+            AssertEvidence(result, 4, "outlook", "disabled", "unknown");
+            AssertEvidence(result, 2, "copilot", "partial", "unknown");
+            CollectionAssert.Contains(result.MostActive.Select(user => user.UserId).ToList(), 3);
+            CollectionAssert.DoesNotContain(result.LeastActive.Select(user => user.UserId).ToList(), 2);
+            CollectionAssert.DoesNotContain(result.LeastActive.Select(user => user.UserId).ToList(), 3);
+
+            var teams = overview.Licences.Single().Workloads.Single(item => item.Workload == "teams");
+            Assert.AreEqual(1, teams.Zero);
+            Assert.AreEqual(3, teams.Unknown);
+            Assert.AreEqual(0, overview.Licences.Single().Workloads
+                .Single(item => item.Workload == "copilot").Zero);
+        }
+
+        [TestMethod]
+        public void ExactRangeAndOverviewScopeAreRequired()
+        {
+            var model = Model(
+                new[] { Sku(1, "Contoso") },
+                new[] { User(1, departmentId: 7) },
+                new[] { Member(1, 1) },
+                AvailableCoverage(),
+                Scores());
+            var filtered = LicenceActivityQuery.Create(
+                Query().From, Query().To, Now, departmentId: 7);
+            var overview = model.BuildOverview(filtered, CancellationToken.None);
+
+            Assert.ThrowsException<ArgumentException>(() =>
+                model.BuildOverview(
+                    LicenceActivityQuery.Create("2000-05-02", "2000-06-25", Now),
+                    CancellationToken.None));
+            Assert.ThrowsException<ArgumentException>(() =>
+                model.BuildUsers(
+                    overview,
+                    Query().ForUsers(1, "teams", null, "upn", "asc", 10, 1, 50, Now),
+                    CancellationToken.None));
+            var other = Model(
+                new[] { Sku(1, "Contoso") }, new[] { User(1) },
+                new[] { Member(1, 1) }, AvailableCoverage(), Scores());
+            Assert.ThrowsException<ArgumentException>(() =>
+                other.BuildUsers(
+                    overview,
+                    filtered.ForUsers(1, "teams", null, "upn", "asc", 10, 1, 50, Now),
+                    CancellationToken.None));
+        }
+
+        [TestMethod]
+        public void DemographicsAreBoundedAndSelectedCohortsRemainVisible()
+        {
+            var users = Enumerable.Range(1, 51)
+                .Select(id => User(
+                    id,
+                    departmentId: id,
+                    department: "Department " + id,
+                    countryId: id,
+                    country: "Country " + id))
+                .ToArray();
+            var model = Model(
+                new[] { Sku(1, "Contoso") },
+                users,
+                users.Select(user => Member(user.UserId, 1)).ToArray(),
+                AvailableCoverage(),
+                Scores());
+
+            var all = model.BuildOverview(Query(), CancellationToken.None);
+            var selectedQuery = LicenceActivityQuery.Create(
+                Query().From, Query().To, Now, departmentId: 51);
+            var selected = model.BuildOverview(selectedQuery, CancellationToken.None);
+
+            Assert.AreEqual(50, all.Departments.Count);
+            Assert.AreEqual(50, all.Countries.Count);
+            Assert.IsTrue(all.DemographicsTruncated);
+            Assert.AreEqual(1, selected.Departments.Count);
+            Assert.AreEqual(51, selected.Departments[0].Id);
+            Assert.AreEqual(1, selected.Departments[0].AssignedUsers);
+        }
+
+        [TestMethod]
+        public void RankingIsDeterministicAcrossTiesAndPaging()
+        {
+            var users = new[]
+            {
+                User(3, upn: "same@contoso.example"),
+                User(1, upn: "SAME@contoso.example"),
+                User(4, upn: "z@contoso.example"),
+                User(2, upn: "a@contoso.example")
+            };
+            var model = Model(
+                new[] { Sku(1, "Contoso") },
+                users,
+                users.Select(user => Member(user.UserId, 1)).ToArray(),
+                AvailableCoverage(),
+                Scores(
+                    ("teams", 1, Score(2, 4, true, 5, Now.AddDays(-1))),
+                    ("teams", 2, Score(2, 4, true, 5, Now.AddDays(-1))),
+                    ("teams", 3, Score(2, 4, true, 5, Now.AddDays(-1))),
+                    ("teams", 4, Score(2, 4, true, 5, Now.AddDays(-1)))));
+            var overview = model.BuildOverview(Query(), CancellationToken.None);
+
+            var first = model.BuildUsers(overview,
+                Query().ForUsers(1, "teams", null, "activity", "desc", 4, 1, 2, Now),
+                CancellationToken.None);
+            var second = model.BuildUsers(overview,
+                Query().ForUsers(1, "teams", null, "activity", "desc", 4, 2, 2, Now),
+                CancellationToken.None);
+
+            CollectionAssert.AreEqual(new[] { 2, 1 }, first.Users.Select(user => user.UserId).ToArray());
+            CollectionAssert.AreEqual(new[] { 3, 4 }, second.Users.Select(user => user.UserId).ToArray());
+            CollectionAssert.AreEqual(new[] { 2, 1, 3, 4 },
+                first.MostActive.Select(user => user.UserId).ToArray());
+        }
+
+        [TestMethod]
+        public void SearchIsLiteralCaseInsensitiveAndChecksUnicodeMail()
+        {
+            var users = new[]
+            {
+                User(1, upn: "percent%_user@contoso.example", mail: "alias@contoso.example",
+                    department: "Καλημέρα κόσμε"),
+                User(2, upn: "other@contoso.example", mail: "Καλημέρα@contoso.example")
+            };
+            var model = Model(
+                new[] { Sku(1, "Contoso") },
+                users,
+                users.Select(user => Member(user.UserId, 1)).ToArray(),
+                AvailableCoverage(),
+                Scores());
+            var overview = model.BuildOverview(Query(), CancellationToken.None);
+
+            var literal = model.BuildUsers(overview,
+                Query().ForUsers(1, "teams", "%_", "upn", "asc", 10, 1, 50, Now),
+                CancellationToken.None);
+            var unicode = model.BuildUsers(overview,
+                Query().ForUsers(1, "teams", "ΚΑΛΗΜΈΡΑ", "upn", "asc", 10, 1, 50, Now),
+                CancellationToken.None);
+
+            CollectionAssert.AreEqual(new[] { 1 }, literal.Users.Select(user => user.UserId).ToArray());
+            CollectionAssert.AreEqual(new[] { 2 }, unicode.Users.Select(user => user.UserId).ToArray());
+            Assert.AreEqual("Καλημέρα κόσμε",
+                model.BuildOverview(Query(), CancellationToken.None).Departments.Single().Name);
+        }
+
+        [TestMethod]
+        public void EmptySkuAndNullNameRemainInTheFixedProjection()
+        {
+            var model = Model(
+                new[] { Sku(2, "Contoso"), Sku(1, null) },
+                new[] { User(1, departmentId: 0, department: "Must not leak") },
+                new[] { Member(1, 2) },
+                AvailableCoverage(),
+                Scores());
+
+            var overview = model.BuildOverview(Query(), CancellationToken.None);
+
+            Assert.AreEqual(1, overview.Licences[0].LicenceTypeId);
+            Assert.IsNull(overview.Licences[0].Name);
+            Assert.AreEqual(0, overview.Licences[0].AssignedUsers);
+            Assert.IsTrue(overview.Licences[0].Workloads.All(item =>
+                item.High == 0 && item.Moderate == 0 && item.Low == 0
+                && item.Zero == 0 && item.Unknown == 0));
+            Assert.AreEqual("Unknown", overview.Departments.Single().Name);
+            var empty = model.BuildUsers(overview,
+                Query().ForUsers(1, "teams", null, "upn", "asc", 10, 1, 50, Now), CancellationToken.None);
+            Assert.AreEqual(0, empty.TotalUsers);
+            Assert.AreEqual(0, empty.Users.Count);
+            Assert.ThrowsException<ArgumentException>(() =>
+                model.BuildUsers(overview, Query(), CancellationToken.None));
+            Assert.ThrowsException<ArgumentException>(() =>
+                model.BuildUsers(overview,
+                    Query().ForUsers(99, "teams", null, "upn", "asc", 10, 1, 50, Now), CancellationToken.None));
+        }
+
+        [TestMethod]
+        public void CancellationIsObservedBeforeProjectionWork()
+        {
+            var model = Model(
+                new[] { Sku(1, "Contoso") }, Users(1),
+                new[] { Member(1, 1) }, AvailableCoverage(), Scores());
+            var cancelled = new CancellationToken(true);
+
+            Assert.ThrowsException<OperationCanceledException>(() =>
+                model.BuildOverview(Query(), cancelled));
+            var overview = model.BuildOverview(Query(), CancellationToken.None);
+            Assert.ThrowsException<OperationCanceledException>(() =>
+                model.BuildUsers(
+                    overview,
+                    Query().ForUsers(1, "teams", null, "upn", "asc", 10, 1, 50, Now),
+                    cancelled));
+        }
+
+        [TestMethod]
+        public void ReturnedMutableCollectionsNeverExposePinnedModelState()
+        {
+            var coverage = AvailableCoverage();
+            coverage[0].SnapshotDates.Add(new DateTime(2000, 6, 25));
+            var model = Model(
+                new[] { Sku(1, "Contoso") }, Users(1),
+                new[] { Member(1, 1) }, coverage,
+                Scores(("teams", 1, Score(4, 4))));
+            var first = model.BuildOverview(Query(), CancellationToken.None);
+            first.Coverage[0].Status = "mutated";
+            first.Coverage[0].SnapshotDates.Clear();
+            first.Licences[0].Workloads[0].High = 999;
+            var second = model.BuildOverview(Query(), CancellationToken.None);
+
+            Assert.AreEqual("available", second.Coverage[0].Status);
+            Assert.AreEqual(1, second.Coverage[0].SnapshotDates.Count);
+            Assert.AreEqual(1, second.Licences[0].Workloads[0].High);
+
+            var query = Query().ForUsers(
+                1, "teams", null, "upn", "asc", 10, 1, 50, Now);
+            var firstUsers = model.BuildUsers(second, query, CancellationToken.None);
+            firstUsers.Users[0].Workloads[0].Status = "mutated";
+            firstUsers.Users.Clear();
+            var secondUsers = model.BuildUsers(second, query, CancellationToken.None);
+            Assert.AreEqual(1, secondUsers.Users.Count);
+            Assert.AreEqual("available", secondUsers.Users[0].Workloads[0].Status);
+        }
+
+        [TestMethod]
+        [TestCategory("Performance")]
+        public void ThreeHundredThousandUsersReuseBoundedGlobalRankIndexes()
+        {
+            const int count = 300000;
+            const int licenceCount = 50;
+            const int assignmentsPerUser = 7;
+            var users = new LicenceActivityDirectoryUser[count];
+            var memberships = new LicenceActivityMembership[count * assignmentsPerUser];
+            for (var index = 0; index < count; index++)
+            {
+                var id = index + 1;
+                users[index] = User(id, upn: "user" + id.ToString("D6") + "@contoso.example");
+                for (var assignment = 0; assignment < assignmentsPerUser; assignment++)
+                    memberships[index * assignmentsPerUser + assignment] =
+                        Member(id, ((index + assignment) % licenceCount) + 1);
+            }
+            var model = Model(
+                Enumerable.Range(1, licenceCount)
+                    .Select(id => Sku(id, "Contoso " + id))
+                    .ToArray(),
+                users, memberships,
+                AvailableCoverage("inMemoryCounter"), Scores());
+            var overview = model.BuildOverview(Query(), CancellationToken.None);
+            var query = Query().ForUsers(
+                1, "teams", null, "activity", "desc", 100, 420, 100, Now);
+
+            var first = model.BuildUsers(overview, query, CancellationToken.None);
+            var second = model.BuildUsers(overview, query, CancellationToken.None);
+            var anotherLicence = model.BuildUsers(
+                overview,
+                Query().ForUsers(2, "teams", "USER2", "activity", "desc", 100, 1, 100, Now),
+                CancellationToken.None);
+
+            Assert.AreEqual(count, overview.DistinctAssignedUsers);
+            Assert.AreEqual(42000, first.TotalUsers);
+            Assert.AreEqual(42000, first.RankedUsers);
+            Assert.AreEqual(100, first.Users.Count);
+            Assert.IsTrue(anotherLicence.TotalUsers > 0);
+            CollectionAssert.AreEqual(
+                first.Users.Select(user => user.UserId).ToArray(),
+                second.Users.Select(user => user.UserId).ToArray());
+        }
+
+        private static void AssertEvidence(
+            LicenceActivityUsers result, int userId, string workload, string status, string band)
+        {
+            var evidence = result.Users.Single(user => user.UserId == userId)
+                .Workloads.Single(item => item.Workload == workload);
+            Assert.AreEqual(status, evidence.Status);
+            Assert.AreEqual(band, evidence.Band);
+        }
+
+        private static LicenceActivityReadModel Model(
+            IReadOnlyList<LicenceActivitySku> licences,
+            IReadOnlyList<LicenceActivityDirectoryUser> users,
+            IReadOnlyList<LicenceActivityMembership> memberships,
+            IReadOnlyList<LicenceActivityCoverage> coverage,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>> scores) =>
+            new LicenceActivityReadModel(Query(), licences, users, memberships, coverage, scores);
+
+        private static LicenceActivityQuery Query() =>
+            LicenceActivityQuery.Create("2000-05-01", "2000-06-25", Now);
+
+        private static LicenceActivitySku Sku(int id, string name) =>
+            new LicenceActivitySku { LicenceTypeId = id, Name = name, SkuId = "SYNTHETIC_" + id };
+
+        private static LicenceActivityDirectoryUser[] Users(params int[] ids) =>
+            ids.Select(id => User(id)).ToArray();
+
+        private static LicenceActivityDirectoryUser User(
+            int id, string upn = null, string mail = null,
+            int departmentId = 1, string department = "Contoso Engineering",
+            int countryId = 1, string country = "Contoso Country") =>
+            new LicenceActivityDirectoryUser
+            {
+                UserId = id,
+                UserPrincipalName = upn ?? "user" + id + "@contoso.example",
+                Mail = mail,
+                DepartmentId = departmentId,
+                Department = department,
+                CountryId = countryId,
+                Country = country,
+                AccountEnabled = true
+            };
+
+        private static LicenceActivityMembership Member(int userId, int licenceTypeId) =>
+            new LicenceActivityMembership(userId, licenceTypeId);
+
+        private static LicenceActivityScore Score(
+            int active, int observed, bool frequencyKnown = true,
+            double? average = null, DateTime? last = null) =>
+            new LicenceActivityScore(active, observed, frequencyKnown, average, last);
+
+        private static List<LicenceActivityCoverage> AvailableCoverage(
+            string source = "microsoftGraphUsageReport") =>
+            LicenceActivityQuery.Workloads.Select(workload => new LicenceActivityCoverage
+            {
+                Workload = workload,
+                Status = "available",
+                Source = workload == "copilot" && source == "microsoftGraphUsageReport"
+                    ? "microsoftGraphCopilotUsageReport"
+                    : source,
+                Measure = "synthetic activity",
+                Granularity = "weekly",
+                ExpectedSamples = 4,
+                ObservedSamples = 4
+            }).ToList();
+
+        private static IReadOnlyDictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>> Scores(
+            params (string Workload, int UserId, LicenceActivityScore Score)[] values)
+        {
+            var result = LicenceActivityQuery.Workloads.ToDictionary(
+                workload => workload,
+                workload => (IReadOnlyDictionary<int, LicenceActivityScore>)
+                    new Dictionary<int, LicenceActivityScore>(),
+                StringComparer.Ordinal);
+            foreach (var value in values)
+                ((Dictionary<int, LicenceActivityScore>)result[value.Workload])
+                    .Add(value.UserId, value.Score);
+            return result;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
@@ -891,6 +891,10 @@ DROP TABLE #SyntheticSamples;";
         private const int MaximumRetainedMessages = 128;
         private long _totalLogicalReads;
         private int _retainedMessages;
+        private int _activeConnections;
+        private int _peakConnections;
+        private int _activeCommands;
+        private int _peakCommands;
         private readonly ConcurrentDictionary<string, long> _logicalReadsByOperation =
             new ConcurrentDictionary<string, long>(StringComparer.Ordinal);
 
@@ -899,6 +903,10 @@ DROP TABLE #SyntheticSamples;";
         internal readonly ConcurrentQueue<string> Operations = new ConcurrentQueue<string>();
 
         internal long TotalLogicalReads => Interlocked.Read(ref _totalLogicalReads);
+        internal int ActiveConnections => Volatile.Read(ref _activeConnections);
+        internal int PeakConnections => Volatile.Read(ref _peakConnections);
+        internal int ActiveCommands => Volatile.Read(ref _activeCommands);
+        internal int PeakCommands => Volatile.Read(ref _peakCommands);
         internal IEnumerable<string> LogicalReadsByOperation =>
             _logicalReadsByOperation
                 .OrderBy(pair => pair.Key, StringComparer.Ordinal)
@@ -936,6 +944,12 @@ DROP TABLE #SyntheticSamples;";
         {
             Action<SqlConnection, string> configure = (connection, operation) =>
             {
+                RecordPeak(ref _peakConnections, Interlocked.Increment(ref _activeConnections));
+                connection.StateChange += (sender, args) =>
+                {
+                    if (args.CurrentState == System.Data.ConnectionState.Closed)
+                        Interlocked.Decrement(ref _activeConnections);
+                };
                 connection.InfoMessage += (sender, args) => RecordMessage(args.Message, operation);
                 using (var command = new SqlCommand(
                     includeShowplan
@@ -950,12 +964,37 @@ DROP TABLE #SyntheticSamples;";
             return new SqlLicenceActivityStoreInstrumentation
             {
                 CommandTimeoutSeconds = commandTimeoutSeconds,
+                CommandActiveChanged = active =>
+                {
+                    if (active) RecordPeak(ref _peakCommands, Interlocked.Increment(ref _activeCommands));
+                    else Interlocked.Decrement(ref _activeCommands);
+                },
                 ConnectionOpened = connection => configure(connection, null),
                 ConnectionOpenedForOperation = configure,
                 OperationCompleted = (operation, elapsedMs) =>
                     Operations.Enqueue(operation + "=" + elapsedMs.ToString(CultureInfo.InvariantCulture) + "ms"),
-                ShowplanReceived = plan => Showplans.Enqueue(plan)
+                ShowplanReceived = plan =>
+                {
+                    Showplans.Enqueue(plan);
+                    var directory = Environment.GetEnvironmentVariable("LICENCE_ACTIVITY_PERF_PLAN_DIRECTORY");
+                    if (!string.IsNullOrWhiteSpace(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                        File.WriteAllText(Path.Combine(directory, Guid.NewGuid().ToString("N") + ".sqlplan"), plan);
+                    }
+                }
             };
+        }
+
+        private static void RecordPeak(ref int peak, int value)
+        {
+            int previous;
+            do
+            {
+                previous = Volatile.Read(ref peak);
+                if (previous >= value) return;
+            }
+            while (Interlocked.CompareExchange(ref peak, value, previous) != previous);
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
@@ -370,7 +370,8 @@ WHERE object_id IN
     OBJECT_ID(N'dbo.teams_user_activity_log'),
     OBJECT_ID(N'dbo.outlook_user_activity_log'),
     OBJECT_ID(N'dbo.onedrive_user_activity_log'),
-    OBJECT_ID(N'dbo.sharepoint_user_activity_log')
+    OBJECT_ID(N'dbo.sharepoint_user_activity_log'),
+    OBJECT_ID(N'dbo.copilot_usage_user_activity_log')
 );"), CultureInfo.InvariantCulture);
             switch (mode)
             {

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -193,6 +193,67 @@ INSERT dbo.user_license_type_lookups (user_id, license_type_id) VALUES (1, 1);")
             }
         }
 
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task CustomSampleWindows_DeduplicateReportDaysAndPreserveMissingVersusZero(bool columnstore)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create(
+                "LicenceSampleWindows", columnstore
+                    ? LicenceActivityUsageIndexMode.Columnstore
+                    : LicenceActivityUsageIndexMode.BTreeFallback))
+            {
+                SeedDirectory(fixture);
+                SeedOneUsageTable(fixture, "onedrive_user_activity_log",
+                    new[] { "2000-06-18", "2000-06-23" });
+                fixture.Execute(@"
+INSERT dbo.onedrive_user_activity_log
+    (viewed_or_edited, synced, shared_internally, shared_externally, user_id, [date], last_activity_date)
+VALUES
+    (20, 0, 0, 0, 1, '2000-06-18T12:00:00', '2000-06-18T23:59:59'),
+    (3000, 0, 0, 0, 2, '2000-06-16', '2000-06-16'),
+    (3000, 0, 0, 0, 2, '2000-06-24', '2000-06-24');
+UPDATE dbo.onedrive_user_activity_log
+SET last_activity_date = CASE WHEN [date] = '2000-06-18'
+                             THEN '2000-06-13' ELSE '2000-06-24' END
+WHERE user_id = 2 AND [date] IN ('2000-06-18', '2000-06-23');
+UPDATE dbo.onedrive_user_activity_log SET last_activity_date = '2000-06-19'
+WHERE user_id = 4;
+DELETE dbo.onedrive_user_activity_log WHERE user_id = 3 AND [date] = '2000-06-23';");
+
+                var query = LicenceActivityQuery.Create(
+                    "2000-06-14", "2000-06-23", LicenceActivitySqlFixture.NowUtc);
+                var sources = Sources(usageReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "onedrive");
+                Assert.AreEqual(1, distribution.High);
+                Assert.AreEqual(1, distribution.Moderate);
+                Assert.AreEqual(2, distribution.Zero);
+                Assert.AreEqual(1, distribution.Unknown);
+                CollectionAssert.AreEqual(new[] { "2000-06-18", "2000-06-23" },
+                    overview.Coverage.Single(c => c.Workload == "onedrive")
+                        .SnapshotDates.Select(d => d.ToString("yyyy-MM-dd")).ToArray());
+
+                var users = await fixture.Store().LoadUsersAsync(overview,
+                    query.ForUsers(1, "onedrive", null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var active = users.Users.Single(u => u.UserId == 1)
+                    .Workloads.Single(w => w.Workload == "onedrive");
+                Assert.AreEqual(2, active.ActiveSamples);
+                Assert.AreEqual(12d, active.AverageActions.Value,
+                    "Average the per-day maxima (20 and 4), never sum or double-count duplicate snapshots.");
+                Assert.AreEqual(0, users.Users.Single(u => u.UserId == 2)
+                    .Workloads.Single(w => w.Workload == "onedrive").ActiveSamples);
+                Assert.IsTrue(users.MostActive.Any(u => u.UserId == 3),
+                    "A missing sample must not erase positive partial evidence.");
+                Assert.IsFalse(users.LeastActive.Any(u => u.UserId == 3));
+                Assert.AreEqual(4, users.LeastActive.Count);
+            }
+        }
+
         [TestMethod]
         public async Task ConcurrentConnections_DoNotCollideOnTempTableConstraintNames()
         {
@@ -218,6 +279,178 @@ CREATE TABLE #probe
                         NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
                     Assert.AreEqual(3, overview.Licences.Count);
                 }
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(7, false)]
+        [DataRow(28, false)]
+        [DataRow(90, false)]
+        [DataRow(180, false)]
+        [DataRow(7, true)]
+        [DataRow(28, true)]
+        [DataRow(90, true)]
+        [DataRow(180, true)]
+        public async Task BoundedSamplePivot_PreservesEveryEdgeWeekAndDuplicateCounterMaximum(
+            int days, bool columnstore)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create(
+                "LicencePivotEdges", columnstore
+                    ? LicenceActivityUsageIndexMode.Columnstore
+                    : LicenceActivityUsageIndexMode.BTreeFallback))
+            {
+                SeedDirectory(fixture);
+                var from = new DateTime(2000, 1, 2); // A Sunday start exercises both partial edge weeks.
+                var to = from.AddDays(days - 1);
+                var dates = Enumerable.Range(0, days).Select(day => from.AddDays(day))
+                    .Where(date => date.DayOfWeek == DayOfWeek.Sunday || date == to)
+                    .Select(date => date.ToString("yyyy-MM-dd")).ToArray();
+                if (days == 180) Assert.AreEqual(27, dates.Length);
+                var workloads = new[] { "teams", "outlook", "onedrive", "sharepoint" };
+                foreach (var workload in workloads)
+                {
+                    var table = workload + "_user_activity_log";
+                    SeedOneUsageTable(fixture, table, dates);
+                    SeedOneUsageTable(fixture, table, dates);
+                    var metric = workload == "teams" ? "private_chat_count"
+                        : workload == "outlook" ? "email_send_count" : "viewed_or_edited";
+                    fixture.Execute($@"
+UPDATE dbo.{table} SET [date] = DATEADD(HOUR, 12, [date])
+WHERE id IN (SELECT MAX(id) FROM dbo.{table} GROUP BY user_id, [date]);
+UPDATE dbo.{table} SET {metric} = {metric} + 16
+WHERE user_id = 1 AND [date] = '{dates.Last()}T12:00:00';
+DELETE dbo.{table} WHERE user_id = 5
+    OR (user_id = 3 AND CAST([date] AS date) = '{dates.Last()}');");
+                }
+                var query = LicenceActivityQuery.Create(
+                    from.ToString("yyyy-MM-dd"), to.ToString("yyyy-MM-dd"), LicenceActivitySqlFixture.NowUtc);
+                var sources = Sources(usageReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                foreach (var workload in workloads)
+                {
+                    var coverage = overview.Coverage.Single(c => c.Workload == workload);
+                    Assert.AreEqual("available", coverage.Status);
+                    Assert.AreEqual(dates.Length, coverage.ExpectedSamples);
+                    var users = await fixture.Store().LoadUsersAsync(
+                        overview, query.ForUsers(1, workload, null, "activity", "desc", 5, 1, 20,
+                            LicenceActivitySqlFixture.NowUtc),
+                        sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                    var active = users.Users.Single(u => u.UserId == 1).Workloads.Single(w => w.Workload == workload);
+                    Assert.AreEqual(dates.Length, active.ActiveSamples);
+                    Assert.AreEqual(dates.Length, active.ObservedSamples);
+                    Assert.AreEqual((workload == "teams" || workload == "outlook" ? 5d : 4d)
+                        + 16d / dates.Length, active.AverageActions.Value, 0.000001);
+                    Assert.AreEqual("zero", users.Users.Single(u => u.UserId == 4)
+                        .Workloads.Single(w => w.Workload == workload).Band);
+                    Assert.AreEqual(dates.Length - 1, users.Users.Single(u => u.UserId == 3)
+                        .Workloads.Single(w => w.Workload == workload).ObservedSamples);
+                    Assert.IsFalse(users.LeastActive.Any(u => u.UserId == 3 || u.UserId == 5));
+                    Assert.IsTrue(users.MostActive.Any(u => u.UserId == 3));
+                    Assert.IsNull(users.Users.Single(u => u.UserId == 5)
+                        .Workloads.Single(w => w.Workload == workload).AverageActions);
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("teams", false)]
+        [DataRow("outlook", false)]
+        [DataRow("onedrive", false)]
+        [DataRow("sharepoint", false)]
+        [DataRow("teams", true)]
+        [DataRow("outlook", true)]
+        [DataRow("onedrive", true)]
+        [DataRow("sharepoint", true)]
+        public async Task SingleWeek_DuplicateReportDaysAgreeWithDrilldown(
+            string workload, bool columnstore)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create(
+                "LicenceSingleDayDuplicates", columnstore
+                    ? LicenceActivityUsageIndexMode.Columnstore
+                    : LicenceActivityUsageIndexMode.BTreeFallback))
+            {
+                SeedDirectory(fixture);
+                var table = workload + "_user_activity_log";
+                SeedOneUsageTable(fixture, table, new[] { "2000-06-25", "2000-06-25" });
+                fixture.Execute($@"
+UPDATE dbo.{table}
+SET [date] = DATEADD(HOUR, 12, [date])
+WHERE id IN (SELECT MAX(id) FROM dbo.{table} GROUP BY user_id);
+UPDATE dbo.{table} SET last_activity_date = '2000-06-18' WHERE user_id = 2;
+DELETE dbo.{table} WHERE user_id = 3;
+DELETE dbo.{table} WHERE user_id = 5 AND [date] = '2000-06-25T12:00:00';");
+
+                var query = LicenceActivityQuery.Create(
+                    "2000-06-19", "2000-06-25", LicenceActivitySqlFixture.NowUtc);
+                var sources = Sources(usageReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview, query.ForUsers(1, workload, null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == workload);
+                var coverage = overview.Coverage.Single(c => c.Workload == workload);
+                Assert.AreEqual("available", coverage.Status);
+                Assert.AreEqual(1, coverage.ExpectedSamples);
+                Assert.AreEqual(1, coverage.ObservedSamples);
+                Assert.AreEqual(1, distribution.High,
+                    "Duplicate rows on the one pinned day are still one observed active sample.");
+                Assert.AreEqual(3, distribution.Zero);
+                Assert.AreEqual(1, distribution.Unknown);
+                Assert.AreEqual(0, distribution.Moderate + distribution.Low);
+                Assert.AreEqual(5, users.TotalUsers);
+                foreach (var user in users.Users)
+                {
+                    var evidence = user.Workloads.Single(w => w.Workload == workload);
+                    var expectedBand = user.UserId == 1 ? "high"
+                        : user.UserId == 3 ? "unknown" : "zero";
+                    Assert.AreEqual(expectedBand, evidence.Band);
+                    Assert.AreEqual(user.UserId == 3 ? 0 : 1, evidence.ObservedSamples);
+                    Assert.AreEqual(user.UserId == 1 ? 1 : 0, evidence.ActiveSamples);
+                }
+                var active = users.Users.Single(u => u.UserId == 1)
+                    .Workloads.Single(w => w.Workload == workload);
+                Assert.AreEqual(workload == "teams" || workload == "outlook" ? 5d : 4d,
+                    active.AverageActions.Value,
+                    "Duplicate rolling counters are snapshot evidence, not additional actions.");
+                CollectionAssert.AreEquivalent(new[] { 1 },
+                    users.MostActive.Where(u => u.Workloads.Single(w => w.Workload == workload)
+                        .ActiveSamples > 0).Select(u => u.UserId).ToArray());
+                Assert.IsFalse(users.MostActive.Any(u => u.UserId == 3));
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 4, 5 },
+                    users.LeastActive.Select(u => u.UserId).ToArray());
+                Assert.IsNull(users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == workload).AverageActions);
+            }
+        }
+
+        [TestMethod]
+        public async Task SqlCommandMeasurements_DrainOnSuccessAndSiblingFailure()
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceSqlLifetime"))
+            {
+                SeedDirectory(fixture);
+                var measurement = new LicenceActivitySqlMeasurement();
+                var store = fixture.Store(measurement.Instrumentation(includeShowplan: false));
+                await store.LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                Assert.AreEqual(0, measurement.ActiveCommands);
+                Assert.AreEqual(0, measurement.ActiveConnections);
+                Assert.IsTrue(measurement.PeakCommands >= 1);
+                Assert.IsTrue(measurement.PeakConnections >= 2);
+
+                fixture.Execute("DROP TABLE dbo.onedrive_user_activity_log;");
+                await Assert.ThrowsExceptionAsync<SqlException>(() => store.LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None));
+                Assert.AreEqual(0, measurement.ActiveCommands,
+                    "All sibling commands must drain before the store reports failure.");
+                Assert.AreEqual(0, measurement.ActiveConnections,
+                    "The shared eligibility connection must also be disposed after failure.");
             }
         }
 
@@ -480,6 +713,96 @@ VALUES (7, 0, 0, 0, 1, '{date}', NULL);");
                 Assert.AreEqual(0, users.LeastActive.Count);
                 Assert.AreEqual("unknown", users.Users.Single(u => u.UserId == 1)
                     .Workloads.Single(w => w.Workload == "copilot").Band);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(1)]
+        [DataRow(8)]
+        public async Task Copilot_D7CountersTakePrecedenceOverUserLastActivityAcrossQueryPaths(int weeks)
+        {
+            using (var fixture = LicenceActivitySqlFixture.Create("LicenceCopilotCounterAuthority"))
+            {
+                SeedDirectory(fixture);
+                fixture.Execute(@"
+INSERT dbo.copilot_usage_report_import_log
+    (report_name, report_refresh_date, report_version, report_period, imported_utc,
+     rows_read, rows_saved, is_upn_obfuscated, error)
+VALUES
+    (N'getMicrosoft365CopilotUsageUserDetail', '2000-06-25', N'v2', N'D7',
+     '2000-07-01T01:00:00', 4, 4, 0, NULL);");
+                foreach (var date in CopilotD7Dates.Skip(CopilotD7Dates.Length - weeks))
+                {
+                    // Counters belong to the period; lastActivityDate comes from the user envelope.
+                    // A v1-shaped row has neither counter and supplies positive evidence, not frequency.
+                    fixture.Execute($@"
+INSERT dbo.copilot_usage_user_activity_log
+    (report_period_days, prompts_all_apps, active_usage_days, is_upn_obfuscated,
+     user_id, [date], last_activity_date)
+VALUES
+    (7, 0, 0, 0, 1, '{date}', '{date}'),
+    (7, 12, 0, 0, 2, '{date}', NULL),
+    (7, NULL, NULL, 0, 3, '{date}', '{date}'),
+    (7, 0, 0, 0, 4, '{date}', NULL);");
+                }
+
+                var query = weeks == 8 ? OverviewQuery() : LicenceActivityQuery.Create(
+                    "2000-06-19", "2000-06-25", LicenceActivitySqlFixture.NowUtc);
+                var sources = Sources(usageReports: false, copilotReports: true);
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    query, sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var users = await fixture.Store().LoadUsersAsync(
+                    overview, query.ForUsers(1, "copilot", null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "copilot");
+                Assert.AreEqual("available", overview.Coverage.Single(c => c.Workload == "copilot").Status);
+                Assert.AreEqual(1, distribution.High,
+                    "An explicit D7 zero must not become active because the user-level date is in range.");
+                Assert.AreEqual(2, distribution.Zero);
+                Assert.AreEqual(2, distribution.Unknown);
+                Assert.AreEqual(0, distribution.Moderate + distribution.Low);
+                foreach (var user in users.Users)
+                {
+                    var evidence = user.Workloads.Single(w => w.Workload == "copilot");
+                    var expectedBand = user.UserId == 2 ? "high"
+                        : user.UserId == 1 || user.UserId == 4 ? "zero" : "unknown";
+                    Assert.AreEqual(expectedBand, evidence.Band,
+                        "Overview and drilldown must use the same D7 activity rule for user " + user.UserId);
+                    Assert.AreEqual(user.UserId == 2 || user.UserId == 3 ? weeks : 0,
+                        evidence.ActiveSamples);
+                    Assert.AreEqual(user.UserId == 5 ? 0 : weeks, evidence.ObservedSamples);
+                }
+                Assert.AreEqual("partial", users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == "copilot").Status);
+                Assert.IsNull(users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == "copilot").AverageActions);
+                Assert.AreEqual(12d, users.Users.Single(u => u.UserId == 2)
+                    .Workloads.Single(w => w.Workload == "copilot").AverageActions.Value);
+                CollectionAssert.AreEquivalent(new[] { 2, 3 },
+                    users.MostActive.Where(u => u.Workloads.Single(w => w.Workload == "copilot")
+                        .ActiveSamples > 0).Select(u => u.UserId).ToArray());
+                Assert.IsFalse(users.MostActive.Any(u => u.UserId == 5));
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 4 },
+                    users.LeastActive.Select(u => u.UserId).ToArray());
+
+                // Selecting another workload takes the bounded #ReturnedUsers/#CopilotReportIds
+                // supporting-evidence path rather than Copilot's #EligibleUsers ranking path.
+                var nonCopilot = await fixture.Store().LoadUsersAsync(
+                    overview, query.ForUsers(1, "teams", null, "upn", "asc", 5, 1, 20,
+                        LicenceActivitySqlFixture.NowUtc),
+                    sources, NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+                foreach (var expectedUser in users.Users)
+                {
+                    var expected = expectedUser.Workloads.Single(w => w.Workload == "copilot");
+                    var supporting = nonCopilot.Users.Single(u => u.UserId == expectedUser.UserId)
+                        .Workloads.Single(w => w.Workload == "copilot");
+                    Assert.AreEqual(expected.Band, supporting.Band);
+                    Assert.AreEqual(expected.ActiveSamples, supporting.ActiveSamples);
+                    Assert.AreEqual(expected.ObservedSamples, supporting.ObservedSamples);
+                    Assert.AreEqual(expected.AverageActions, supporting.AverageActions);
+                }
             }
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -291,11 +291,11 @@ CREATE TABLE #probe
         [DataRow(28, true)]
         [DataRow(90, true)]
         [DataRow(180, true)]
-        public async Task BoundedSamplePivot_PreservesEveryEdgeWeekAndDuplicateCounterMaximum(
+        public async Task DistinctPinnedSampleCounts_PreserveMissingZeroDuplicatesAndExpectedBoundary(
             int days, bool columnstore)
         {
             using (var fixture = LicenceActivitySqlFixture.Create(
-                "LicencePivotEdges", columnstore
+                "LicenceDistinctSampleCounts", columnstore
                     ? LicenceActivityUsageIndexMode.Columnstore
                     : LicenceActivityUsageIndexMode.BTreeFallback))
             {
@@ -305,6 +305,8 @@ CREATE TABLE #probe
                 var dates = Enumerable.Range(0, days).Select(day => from.AddDays(day))
                     .Where(date => date.DayOfWeek == DayOfWeek.Sunday || date == to)
                     .Select(date => date.ToString("yyyy-MM-dd")).ToArray();
+                Assert.IsTrue(dates.Length > 1,
+                    "This regression must execute the multi-sample distinct-count branch.");
                 if (days == 180) Assert.AreEqual(27, dates.Length);
                 var workloads = new[] { "teams", "outlook", "onedrive", "sharepoint" };
                 foreach (var workload in workloads)
@@ -312,13 +314,33 @@ CREATE TABLE #probe
                     var table = workload + "_user_activity_log";
                     SeedOneUsageTable(fixture, table, dates);
                     SeedOneUsageTable(fixture, table, dates);
+                    SeedOneUsageTable(fixture, table, dates);
                     var metric = workload == "teams" ? "private_chat_count"
                         : workload == "outlook" ? "email_send_count" : "viewed_or_edited";
                     fixture.Execute($@"
-UPDATE dbo.{table} SET [date] = DATEADD(HOUR, 12, [date])
-WHERE id IN (SELECT MAX(id) FROM dbo.{table} GROUP BY user_id, [date]);
-UPDATE dbo.{table} SET {metric} = {metric} + 16
-WHERE user_id = 1 AND [date] = '{dates.Last()}T12:00:00';
+;WITH DuplicateRows AS
+(
+    SELECT id,
+           ROW_NUMBER() OVER
+               (PARTITION BY user_id, CAST([date] AS date) ORDER BY id) AS duplicate_number
+    FROM dbo.{table}
+)
+UPDATE activity
+SET [date] = DATEADD(HOUR, (duplicates.duplicate_number - 1) * 6, activity.[date])
+FROM dbo.{table} AS activity
+JOIN DuplicateRows AS duplicates ON duplicates.id = activity.id;
+
+UPDATE dbo.{table}
+SET {metric} = CASE WHEN [date] = '{dates.Last()}T00:00:00' THEN {metric} + 16 ELSE 0 END,
+    last_activity_date =
+        CASE
+            WHEN [date] = '{dates.Last()}T00:00:00' THEN '{dates.Last()}'
+            WHEN [date] = '{dates.Last()}T06:00:00' THEN DATEADD(DAY, -7, CAST([date] AS date))
+            ELSE NULL
+        END
+WHERE user_id = 1
+  AND CAST([date] AS date) = '{dates.Last()}';
+
 DELETE dbo.{table} WHERE user_id = 5
     OR (user_id = 3 AND CAST([date] AS date) = '{dates.Last()}');");
                 }
@@ -332,6 +354,15 @@ DELETE dbo.{table} WHERE user_id = 5
                     var coverage = overview.Coverage.Single(c => c.Workload == workload);
                     Assert.AreEqual("available", coverage.Status);
                     Assert.AreEqual(dates.Length, coverage.ExpectedSamples);
+                    var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
+                        .Workloads.Single(w => w.Workload == workload);
+                    Assert.AreEqual(1, distribution.Zero);
+                    Assert.AreEqual(2, distribution.Unknown);
+                    Assert.AreEqual(2, distribution.High + distribution.Moderate + distribution.Low,
+                        "Two complete users have positive evidence.");
+                    Assert.AreEqual(3,
+                        distribution.High + distribution.Moderate + distribution.Low + distribution.Zero,
+                        "Exactly three users have complete evidence at the expected-sample boundary.");
                     var users = await fixture.Store().LoadUsersAsync(
                         overview, query.ForUsers(1, workload, null, "activity", "desc", 5, 1, 20,
                             LicenceActivitySqlFixture.NowUtc),
@@ -341,14 +372,23 @@ DELETE dbo.{table} WHERE user_id = 5
                     Assert.AreEqual(dates.Length, active.ObservedSamples);
                     Assert.AreEqual((workload == "teams" || workload == "outlook" ? 5d : 4d)
                         + 16d / dates.Length, active.AverageActions.Value, 0.000001);
-                    Assert.AreEqual("zero", users.Users.Single(u => u.UserId == 4)
-                        .Workloads.Single(w => w.Workload == workload).Band);
-                    Assert.AreEqual(dates.Length - 1, users.Users.Single(u => u.UserId == 3)
-                        .Workloads.Single(w => w.Workload == workload).ObservedSamples);
+                    var explicitZero = users.Users.Single(u => u.UserId == 4)
+                        .Workloads.Single(w => w.Workload == workload);
+                    Assert.AreEqual("zero", explicitZero.Band);
+                    Assert.AreEqual(dates.Length, explicitZero.ObservedSamples);
+                    Assert.AreEqual(0, explicitZero.ActiveSamples);
+                    var partial = users.Users.Single(u => u.UserId == 3)
+                        .Workloads.Single(w => w.Workload == workload);
+                    Assert.AreEqual("partial", partial.Status);
+                    Assert.AreEqual(dates.Length - 1, partial.ObservedSamples);
                     Assert.IsFalse(users.LeastActive.Any(u => u.UserId == 3 || u.UserId == 5));
                     Assert.IsTrue(users.MostActive.Any(u => u.UserId == 3));
-                    Assert.IsNull(users.Users.Single(u => u.UserId == 5)
-                        .Workloads.Single(w => w.Workload == workload).AverageActions);
+                    var absent = users.Users.Single(u => u.UserId == 5)
+                        .Workloads.Single(w => w.Workload == workload);
+                    Assert.AreEqual("missingCoverage", absent.Status);
+                    Assert.AreEqual(0, absent.ObservedSamples);
+                    Assert.AreEqual(0, absent.ActiveSamples);
+                    Assert.IsNull(absent.AverageActions);
                 }
             }
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -1331,7 +1331,7 @@ SELECT id, 1 FROM dbo.users;");
             }
         }
 
-        private static LicenceActivitySqlFixture CreateMeasuredFixture()
+        internal static LicenceActivitySqlFixture CreateMeasuredFixture()
         {
             var fixture = LicenceActivitySqlFixture.Create("LicenceMeasured");
             SeedDirectory(fixture);
@@ -1353,7 +1353,7 @@ VALUES
             return fixture;
         }
 
-        private static void SeedDirectory(LicenceActivitySqlFixture fixture)
+        internal static void SeedDirectory(LicenceActivitySqlFixture fixture)
         {
             fixture.Execute(@"
 INSERT dbo.user_departments (name)
@@ -1392,7 +1392,7 @@ VALUES
             SeedOneUsageTable(fixture, "sharepoint_user_activity_log", sampleDates);
         }
 
-        private static void SeedOneUsageTable(
+        internal static void SeedOneUsageTable(
             LicenceActivitySqlFixture fixture,
             string table,
             string[] sampleDates)

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityTests.cs
@@ -24,6 +24,24 @@ namespace Tests.UnitTests
     {
         internal static readonly DateTime Now = new DateTime(2000, 7, 1, 0, 0, 0, DateTimeKind.Utc);
 
+        [DataTestMethod]
+        [DataRow("x")]
+        [DataRow("Καλημέρα κόσμε")]
+        [DataRow("𐐀😀")]
+        [DataRow("\"\\\r\n")]
+        public void JsonSizeBudget_MatchesSerializedUtf8IncludingEscapesAndSurrogatePairs(string text)
+        {
+            var budget = LicenceActivitySnapshotCache<LicenceActivityOverview>.MaximumJsonBytes;
+            var repetitions = 4097;
+            var prefix = string.Concat(Enumerable.Repeat(text, repetitions));
+            var prefixBytes = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(prefix));
+            var exact = prefix + new string('x', budget - prefixBytes);
+            Assert.AreEqual(budget, Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(exact)));
+            LicenceActivitySnapshotCache<LicenceActivityOverview>.EnsureJsonWithinBudget(exact);
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                LicenceActivitySnapshotCache<LicenceActivityOverview>.EnsureJsonWithinBudget(exact + "x"));
+        }
+
         [TestMethod]
         public void CustomDates_AreExactUtcAndNeverRounded()
         {

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -38,6 +38,9 @@
     <Compile Include="LicenceActivitySqlFixture.cs" />
     <Compile Include="LicenceActivitySqlTests.cs" />
     <Compile Include="LicenceActivityPerformanceTests.cs" />
+    <Compile Include="LicenceActivityReadModelTests.cs" />
+    <Compile Include="LicenceActivityReadModelCacheTests.cs" />
+    <Compile Include="LicenceActivityReadModelSqlTests.cs" />
     <Compile Include="PreInstallAdvisorTests.cs" />
     <Compile Include="ImportCadenceTests.cs" />
     <Compile Include="AppInsightsApiClientTests.cs" />

--- a/src/AnalyticsEngine/Web/Controllers/LicenceActivityAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/LicenceActivityAPIController.cs
@@ -25,6 +25,7 @@ namespace Web.AnalyticsWeb.Controllers
             new LicenceActivitySnapshotCache<LicenceActivityOverview>(16, TimeSpan.FromMinutes(5));
         private static readonly LicenceActivitySnapshotCache<LicenceActivityUsers> UsersCache =
             new LicenceActivitySnapshotCache<LicenceActivityUsers>(32, TimeSpan.FromMinutes(2));
+        private static readonly LicenceActivityReadModelCache ReadModelCache = new LicenceActivityReadModelCache();
 
         private readonly Func<LicenceActivityRequestContext> _context;
         private readonly LicenceActivitySnapshotCache<LicenceActivityOverview> _overviews;
@@ -72,7 +73,8 @@ namespace Web.AnalyticsWeb.Controllers
                     result.Messages.Add(LicenceActivityRules.InterpretationCaveat);
                     result.Messages.Add(LicenceActivityRules.Method);
                     return result;
-                });
+                }, isCurrent: snapshot => !(context.Store is ILicenceActivitySnapshotValidator validator)
+                    || validator.IsCurrent(snapshot, context.Sources));
                 return Reply(HttpStatusCode.OK,
                     await LicenceActivitySnapshotCache<LicenceActivityOverview>.WaitForCallerAsync(task, cancellationToken));
             });
@@ -142,6 +144,14 @@ namespace Web.AnalyticsWeb.Controllers
             {
                 return Reply(HttpStatusCode.Gone, new { message = "This snapshot has expired or was evicted. Refresh the current view before continuing or exporting." });
             }
+            catch (LicenceActivityReadModelExpiredException)
+            {
+                return Reply(HttpStatusCode.Gone, new { message = "The source snapshot expired or was evicted. Refresh the current view before continuing." });
+            }
+            catch (LicenceActivityReadModelBusyException)
+            {
+                return Reply(HttpStatusCode.ServiceUnavailable, new { message = "Another licence report snapshot is loading. Retry in a few seconds." }, true);
+            }
             catch (LicenceActivityBusyException)
             {
                 return Reply(HttpStatusCode.ServiceUnavailable, new { message = "Licence reporting is busy. Retry in a few seconds." }, true);
@@ -181,7 +191,8 @@ namespace Web.AnalyticsWeb.Controllers
                 scope = Convert.ToBase64String(sha.ComputeHash(Encoding.UTF8.GetBytes(
                     config.TenantGUID + "\n" + config.ConnectionStrings.DatabaseConnectionString + "\n" + sources.CacheKey)));
             return new LicenceActivityRequestContext(scope, sources,
-                new SqlLicenceActivityStore(config.ConnectionStrings.DatabaseConnectionString));
+                new CachedLicenceActivityStore(
+                    new SqlLicenceActivityStore(config.ConnectionStrings.DatabaseConnectionString), ReadModelCache, scope));
         }
     }
 

--- a/src/AnalyticsEngine/Web/Models/LicenceActivity/LicenceActivitySnapshotCache.cs
+++ b/src/AnalyticsEngine/Web/Models/LicenceActivity/LicenceActivitySnapshotCache.cs
@@ -2,6 +2,7 @@ using Common.Entities.LicenceActivity;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -133,8 +134,7 @@ namespace Web.AnalyticsWeb.Models.LicenceActivity
                 value.ExpiresUtc = value.GeneratedUtc.Add(_ttl);
                 if (notAfterUtc.HasValue && value.ExpiresUtc > notAfterUtc.Value) value.ExpiresUtc = notAfterUtc.Value;
                 if (value.ExpiresUtc <= value.GeneratedUtc) throw new LicenceActivityExpiredException();
-                if (Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(value)) > MaximumJsonBytes)
-                    throw new InvalidOperationException("The bounded report response exceeds its size budget.");
+                EnsureJsonWithinBudget(value);
                 entry.Lifetime.Token.ThrowIfCancellationRequested();
             }
             catch (Exception ex)
@@ -174,6 +174,37 @@ namespace Web.AnalyticsWeb.Models.LicenceActivity
                 entry.Deadline.Dispose();
                 entry.Lifetime.Dispose();
                 diagnostics?.Dispose();
+            }
+        }
+
+        internal static void EnsureJsonWithinBudget(object value)
+        {
+            // Count the same UTF-8 JSON without allocating a response-sized UTF-16 string on the LOH.
+            using (var stream = new JsonSizeStream())
+            using (var text = new StreamWriter(stream, new UTF8Encoding(false), 4096))
+            using (var json = new JsonTextWriter(text))
+            {
+                JsonSerializer.CreateDefault().Serialize(json, value);
+            }
+        }
+
+        private sealed class JsonSizeStream : Stream
+        {
+            private long _length;
+            public override bool CanRead => false;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => _length;
+            public override long Position { get => _length; set => throw new NotSupportedException(); }
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                _length += count;
+                if (_length > MaximumJsonBytes)
+                    throw new InvalidOperationException("The bounded report response exceeds its size budget.");
             }
         }
 

--- a/src/AnalyticsEngine/Web/Models/LicenceActivity/LicenceActivitySnapshotCache.cs
+++ b/src/AnalyticsEngine/Web/Models/LicenceActivity/LicenceActivitySnapshotCache.cs
@@ -57,7 +57,7 @@ namespace Web.AnalyticsWeb.Models.LicenceActivity
 
         internal Task<T> GetAsync(
             string scope, string key, Func<ILicenceActivityDiagnostics, CancellationToken, Task<T>> load,
-            DateTime? notAfterUtc = null)
+            DateTime? notAfterUtc = null, Func<T, bool> isCurrent = null)
         {
             if (load == null) throw new ArgumentNullException(nameof(load));
             Entry entry;
@@ -67,7 +67,12 @@ namespace Web.AnalyticsWeb.Models.LicenceActivity
                 Prune();
                 if (notAfterUtc.HasValue && notAfterUtc <= _utcNow())
                     throw new LicenceActivityExpiredException();
-                if (_entries.TryGetValue(compoundKey, out var existing)) return existing.Completion.Task;
+                if (_entries.TryGetValue(compoundKey, out var existing))
+                {
+                    if (existing.Value == null || isCurrent == null || isCurrent(existing.Value))
+                        return existing.Completion.Task;
+                    _entries.Remove(compoundKey);
+                }
                 Entry oldest = null;
                 if (_entries.Count >= _capacity)
                 {
@@ -132,6 +137,8 @@ namespace Web.AnalyticsWeb.Models.LicenceActivity
                 value.SnapshotId = Guid.NewGuid().ToString("N");
                 value.GeneratedUtc = _utcNow();
                 value.ExpiresUtc = value.GeneratedUtc.Add(_ttl);
+                if (value.SourceExpiresUtc.HasValue && value.ExpiresUtc > value.SourceExpiresUtc.Value)
+                    value.ExpiresUtc = value.SourceExpiresUtc.Value;
                 if (notAfterUtc.HasValue && value.ExpiresUtc > notAfterUtc.Value) value.ExpiresUtc = notAfterUtc.Value;
                 if (value.ExpiresUtc <= value.GeneratedUtc) throw new LicenceActivityExpiredException();
                 EnsureJsonWithinBudget(value);
@@ -233,6 +240,7 @@ namespace Web.AnalyticsWeb.Models.LicenceActivity
                 if (_entries.TryGetValue(entry.Key, out var current) && ReferenceEquals(current, entry))
                     _entries.Remove(entry.Key);
                 entry.Completion.TrySetException(failure is LicenceActivityExpiredException
+                    || failure is LicenceActivityReadModelExpiredException || failure is LicenceActivityReadModelBusyException
                     ? failure : new LicenceActivityFailedException(entry.RunId));
                 _ = entry.Completion.Task.Exception;
             }

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.test.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.test.ts
@@ -86,6 +86,17 @@ describe('licenceActivityApi error mapping', () => {
       message: expect.stringMatching(/busy/i),
     });
   });
+
+  it('surfaces cold-range admission pressure without inventing a query timeout or polling', async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({
+      message: 'Another licence report snapshot is loading. Retry in a few seconds.',
+    }, 503));
+    await expect(fetchOverview({ from: '2026-05-01', to: '2026-05-19' })).rejects.toMatchObject({
+      kind: 'busy',
+      message: 'Another licence report snapshot is loading. Retry in a few seconds.',
+    });
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('downloadExport', () => {

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.ts
@@ -12,9 +12,8 @@ const baseUrl = (): string =>
 
 /**
  * How a Licence-activity request failed, so callers can react to the case rather than a raw status.
- *   - `busy`       503: the query hit its finite timeout on a large tenant. This tool does NOT poll
- *                       (a bounded, killable query is simpler than a long-poll); the UI offers a
- *                       manual "Try again".
+ *   - `busy`       503: reporting capacity is busy or a report load failed. This tool does NOT poll;
+ *                       the UI offers a manual "Try again".
  *   - `expired`    410/409/404: the cached snapshot the request referenced is gone, superseded, or no
  *                       longer contains that licence. The caller must NOT silently re-query - it must
  *                       tell the user to refresh so the exported file always matches the screen.
@@ -66,7 +65,7 @@ function kindForStatus(status: number): LicenceActivityErrorKind {
 function fallbackMessage(kind: LicenceActivityErrorKind, status: number, what: string): string {
   switch (kind) {
     case 'busy':
-      return `The server is busy and ${what} timed out. Try again in a moment, or narrow the date range.`;
+      return `The server is busy or could not prepare ${what}. Try again in a moment.`;
     case 'expired':
       return `This snapshot has expired or was refreshed. Reload to get a current one.`;
     case 'forbidden':

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ComponentProps } from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../test/renderWithProvider';
 import UsersDrillDown from './UsersDrillDown';
@@ -52,7 +53,7 @@ function user(upn: string, workload: string): LicenceActivityUser {
 
 function usersResponse(params: UsersParams): LicenceActivityUsers {
   return {
-    snapshotId: `snap-${params.page}-${params.top}-${params.workload}`,
+    snapshotId: `snap-${params.overviewId}-${params.page}-${params.top}-${params.workload}`,
     generatedUtc: '2026-05-20T00:00:00Z',
     expiresUtc: '2026-05-20T00:02:00Z',
     overviewId: params.overviewId,
@@ -110,14 +111,19 @@ function coverageEntry(over: Partial<LicenceActivityCoverage> = {}): LicenceActi
   };
 }
 
-function renderDrill(coverage: LicenceActivityCoverage[] = []) {
+function renderDrill(
+  coverage: LicenceActivityCoverage[] = [],
+  props: Partial<ComponentProps<typeof UsersDrillDown>> = {},
+) {
   return renderWithProvider(
     <UsersDrillDown
       overviewId="ov1"
+      overviewScope="scope-a"
       licence={licence}
       coverage={coverage}
       onUsersSnapshot={vi.fn()}
       onRefreshOverview={vi.fn()}
+      {...props}
     />,
   );
 }
@@ -289,5 +295,135 @@ describe('UsersDrillDown', () => {
     }));
     renderDrill();
     expect(await screen.findByText(/limited by partial coverage/)).toBeInTheDocument();
+  });
+
+  // Regression for the expiry-recovery page-reset bug. `overviewId` is a per-snapshot generation id:
+  // an expired snapshot is re-fetched under a NEW id for the SAME logical query. Keying the page
+  // reset off `overviewId` bounced an admin browsing page 2 straight back to page 1 every time the
+  // snapshot re-minted. The reset must key off `overviewScope` (the logical window/demographic
+  // identity), which is unchanged by a re-mint.
+  it('keeps the browse page - and the workload/search/sort - when the overview re-mints under a NEW id for the SAME scope', async () => {
+    const onUsersSnapshot = vi.fn();
+    const { rerender } = renderDrill([], { overviewId: 'ov1', overviewScope: 'scope-a', onUsersSnapshot });
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+
+    // Move well away from the defaults: a non-default workload, sort and search, then page 2.
+    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    await waitFor(() => expect(lastParams()).toMatchObject({ workload: 'outlook', page: 1 }));
+    fireEvent.change(screen.getByLabelText('Sort users'), { target: { value: 'upn:asc' } });
+    await waitFor(() => expect(lastParams()).toMatchObject({ sort: 'upn', direction: 'asc' }));
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'ada' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ search: 'ada', page: 1 }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() =>
+      expect(lastParams()).toMatchObject({
+        overviewId: 'ov1',
+        page: 2,
+        workload: 'outlook',
+        sort: 'upn',
+        direction: 'asc',
+        search: 'ada',
+      }),
+    );
+
+    const callsBefore = mockUsers.mock.calls.length;
+    onUsersSnapshot.mockClear();
+
+    // The overview snapshot expired and was re-minted under a new id - but the reporting window,
+    // demographics and licence (its logical scope) are unchanged.
+    rerender(
+      <UsersDrillDown
+        overviewId="ov2"
+        overviewScope="scope-a"
+        licence={licence}
+        coverage={[]}
+        onUsersSnapshot={onUsersSnapshot}
+        onRefreshOverview={vi.fn()}
+      />,
+    );
+
+    // The new id forces a fresh users fetch, but the admin stays on page 2 with the same view...
+    await waitFor(() => expect(mockUsers.mock.calls.length).toBeGreaterThan(callsBefore));
+    expect(lastParams()).toMatchObject({
+      overviewId: 'ov2',
+      page: 2,
+      workload: 'outlook',
+      sort: 'upn',
+      direction: 'asc',
+      search: 'ada',
+    });
+
+    // ...and the export snapshot follows the freshly minted list (a NEW snapshot bound to ov2). The
+    // final reported snapshot is the ov2 one, so the export can only reference the fresh list.
+    const freshSnapshot = `snap-ov2-2-10-outlook`;
+    await waitFor(() => {
+      const calls = onUsersSnapshot.mock.calls;
+      expect(calls[calls.length - 1][0]).toBe(freshSnapshot);
+    });
+  });
+
+  it.each([40, 0])('reloads a valid page when a renewed population shrinks to %i users', async (remaining) => {
+    mockUsers.mockImplementation(async (params) => {
+      const result = usersResponse(params);
+      if (params.overviewId === 'ov2') {
+        result.totalUsers = remaining;
+        result.rankedUsers = remaining;
+        result.users = params.page === 1 && remaining > 0 ? result.users : [];
+      }
+      return result;
+    });
+    const onUsersSnapshot = vi.fn();
+    const { rerender } = renderDrill([], { overviewScope: 'scope-a', onUsersSnapshot });
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ overviewId: 'ov1', page: 2 }));
+    onUsersSnapshot.mockClear();
+
+    rerender(
+      <UsersDrillDown
+        overviewId="ov2"
+        overviewScope="scope-a"
+        licence={licence}
+        coverage={[]}
+        onUsersSnapshot={onUsersSnapshot}
+        onRefreshOverview={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(lastParams()).toMatchObject({ overviewId: 'ov2', page: 1 }));
+    await waitFor(() => {
+      const calls = onUsersSnapshot.mock.calls;
+      expect(calls[calls.length - 1][0]).toBe('snap-ov2-1-10-teams');
+    });
+    expect(onUsersSnapshot.mock.calls.some(([id]) => id === 'snap-ov2-2-10-teams')).toBe(false);
+    expect(screen.queryByText('Page 2 of 1')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Showing 51/)).not.toBeInTheDocument();
+    if (remaining > 0) expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
+  });
+
+  // The opposite direction: a genuine logical-scope change (a new reporting window or demographic
+  // filter, surfaced here as a changed `overviewScope`) MUST reset to page 1, and the fresh fetch
+  // must go against the new snapshot - no old page, no old rows carried over.
+  it('resets to page 1 when the logical scope actually changes', async () => {
+    const { rerender } = renderDrill([], { overviewId: 'ov1', overviewScope: 'scope-a' });
+    await waitFor(() => expect(mockUsers).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(lastParams()).toMatchObject({ overviewId: 'ov1', page: 2 }));
+
+    const callsBefore = mockUsers.mock.calls.length;
+    // A new reporting window / demographic filter: BOTH the snapshot id and the logical scope change.
+    rerender(
+      <UsersDrillDown
+        overviewId="ov2"
+        overviewScope="scope-b"
+        licence={licence}
+        coverage={[]}
+        onUsersSnapshot={vi.fn()}
+        onRefreshOverview={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(mockUsers.mock.calls.length).toBeGreaterThan(callsBefore));
+    expect(lastParams()).toMatchObject({ overviewId: 'ov2', page: 1 });
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -160,6 +160,15 @@ function TopCountInput({ value, onCommit, disabled }: { value: number; onCommit:
 
 interface UsersDrillDownProps {
   overviewId: string;
+  /** The overview's LOGICAL scope identity - the reporting window and demographic filters that
+   *  define WHICH population this drill-down is browsing. Unlike `overviewId` (a per-snapshot
+   *  generation id that is re-minted every time the snapshot expires and is re-fetched), this is
+   *  stable across a same-query re-mint. It, not `overviewId`, decides when the browse page must
+   *  reset: a genuine scope change (new window / department / country) resets to page 1, but
+   *  re-minting the identical logical query under a fresh `overviewId` - e.g. the export-410
+   *  recovery - must NOT, or an admin browsing page 2 is silently bounced back to page 1 by a
+   *  refresh that changed nothing they can see. */
+  overviewScope: string;
   licence: LicenceActivitySku;
   /** The overview's per-workload coverage, used to explain why a workload can't be ranked. */
   coverage: LicenceActivityCoverage[];
@@ -182,6 +191,7 @@ interface UsersDrillDownProps {
  */
 export default function UsersDrillDown({
   overviewId,
+  overviewScope,
   licence,
   coverage,
   onUsersSnapshot,
@@ -226,7 +236,14 @@ export default function UsersDrillDown({
   // Reset the page atomically when the scope (licence / workload / browse filter) changes, DURING
   // render - so `params` never briefly pairs a new scope with the old page, which would fire a wasted
   // SQL load before the page-1 reset. This is the React "adjust state during render" pattern.
-  const scopeKey = `${overviewId}\n${licence.licenceTypeId}\n${workload}\n${search}\n${sort}\n${direction}`;
+  //
+  // The scope is keyed off `overviewScope` (the overview's logical window + demographic identity),
+  // NOT `overviewId`. `overviewId` is a per-snapshot generation id that changes whenever the snapshot
+  // is re-minted (an expiry refresh re-fetches the SAME logical query under a new id); keying the
+  // reset off it would bounce an admin on page 2 back to page 1 on every recovery. `overviewId` still
+  // flows through `params` below, so a re-mint re-fetches the current page against the fresh snapshot
+  // without discarding the admin's place, workload, search or sort.
+  const scopeKey = `${overviewScope}\n${licence.licenceTypeId}\n${workload}\n${search}\n${sort}\n${direction}`;
   const [scope, setScope] = useState(scopeKey);
   if (scope !== scopeKey) {
     setScope(scopeKey);
@@ -250,6 +267,12 @@ export default function UsersDrillDown({
 
   const { data, loading, error, reload } = useUsersQuery(params);
 
+  const totalPages = data ? Math.max(1, Math.ceil(data.totalUsers / PAGE_SIZE)) : 1;
+  // Preserve a renewed page only while it still exists. Adjust during render so an expired
+  // population's empty out-of-range page is never displayed or published as the export snapshot;
+  // the scope-bound hook will fetch the last valid page (page 1 for an empty population).
+  if (data && page > totalPages) setPage(totalPages);
+
   // A parent-driven forced refresh (e.g. after an export 410). Re-mint the current view's snapshot
   // without changing any params, so the licence/workload/page/filters the admin is looking at are all
   // preserved. Skip the initial mount (token 0/undefined) so this never double-fetches on first load.
@@ -266,7 +289,6 @@ export default function UsersDrillDown({
     onUsersSnapshot(data?.snapshotId ?? null);
   }, [data?.snapshotId, onUsersSnapshot]);
 
-  const totalPages = data ? Math.max(1, Math.ceil(data.totalUsers / PAGE_SIZE)) : 1;
   const retry = describeError(error, '').kind === 'expired' ? onRefreshOverview : reload;
 
   return (

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -177,6 +177,8 @@ interface UsersDrillDownProps {
   onUsersSnapshot: (usersId: string | null) => void;
   /** Reloads the overview - the correct fix when a users request fails because the snapshot expired. */
   onRefreshOverview: () => void;
+  /** Rechecks detail permission after a current users request is forbidden. */
+  onForbidden?: () => void;
   /** Bumped by the parent to force a fresh users fetch (re-mint) even when the params are otherwise
    *  unchanged - e.g. after an export 410, when the overview is still cached under the same id so the
    *  params never change on their own. A same-key reload keeps the current rows on screen while the
@@ -196,6 +198,7 @@ export default function UsersDrillDown({
   coverage,
   onUsersSnapshot,
   onRefreshOverview,
+  onForbidden,
   refreshToken,
 }: UsersDrillDownProps) {
   const styles = useStyles();
@@ -289,7 +292,13 @@ export default function UsersDrillDown({
     onUsersSnapshot(data?.snapshotId ?? null);
   }, [data?.snapshotId, onUsersSnapshot]);
 
-  const retry = describeError(error, '').kind === 'expired' ? onRefreshOverview : reload;
+  const errorKind = describeError(error, '').kind;
+  useEffect(() => {
+    if (errorKind === 'forbidden') onForbidden?.();
+  }, [errorKind, onForbidden]);
+
+  const retry = errorKind === 'expired' ? onRefreshOverview
+    : errorKind === 'forbidden' && onForbidden ? onForbidden : reload;
 
   return (
     <Card className={styles.card}>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
@@ -318,6 +318,142 @@ describe('LicenceActivityPage - export refresh after expiry', () => {
   });
 });
 
+describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
+  const usersParams = () => mockUsers.mock.calls[mockUsers.mock.calls.length - 1][0];
+
+  it('keeps the admin on page 2 (and workload/sort/search) when Refresh re-mints the overview under a NEW id', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+
+    // The overview re-mints on reload: ov1 first, ov2 after Refresh. A brand-new id per reload is
+    // exactly the case that used to reset the browse page (the drill-down treated the id as scope).
+    let ovCount = 0;
+    mockOverview.mockImplementation(async () => {
+      ovCount += 1;
+      return overview({ snapshotId: ovCount === 1 ? 'ov1' : 'ov2' });
+    });
+
+    // A multi-page list whose snapshot id is bound to the overview id + page, so a re-mint is visible.
+    mockUsers.mockImplementation(async (params) => ({
+      ...usersResponse(),
+      overviewId: params.overviewId,
+      snapshotId: `us-${params.overviewId}-p${params.page}`,
+      totalUsers: 120,
+      query: {
+        ...echo,
+        licenceTypeId: params.licenceTypeId,
+        workload: params.workload,
+        search: params.search ?? '',
+        sort: params.sort,
+        direction: params.direction,
+        top: params.top,
+        page: params.page,
+        pageSize: params.pageSize,
+      },
+    }));
+
+    // The first export fails as expired (users snapshots expire before the overview); later ones pass.
+    mockDownload
+      .mockRejectedValueOnce(
+        new LicenceActivityApiError('expired', 410, 'This snapshot has expired or was refreshed.'),
+      )
+      .mockResolvedValue(undefined);
+
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findAllByText('ada@contoso.com');
+    await act(async () => {});
+
+    // Move off the defaults: a non-default workload and sort and search, then browse to page 2.
+    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    await waitFor(() => expect(usersParams()).toMatchObject({ workload: 'outlook', page: 1 }));
+    fireEvent.change(screen.getByLabelText('Sort users'), { target: { value: 'upn:asc' } });
+    await waitFor(() => expect(usersParams()).toMatchObject({ sort: 'upn', direction: 'asc' }));
+    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'ada' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(usersParams()).toMatchObject({ search: 'ada', page: 1 }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(usersParams()).toMatchObject({ overviewId: 'ov1', page: 2 }));
+
+    // Export -> 410 -> a Refresh prompt appears.
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+
+    const usersBefore = mockUsers.mock.calls.length;
+    // Exact 'Refresh' resolves the export bar's button (the drill-down's is 'Refresh users').
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    // The overview re-mints to ov2 and the list is re-fetched - but the admin is STILL on page 2 with
+    // the same workload/sort/search. (With the bug the fresh id reset this to page 1.)
+    await waitFor(() => expect(usersParams().overviewId).toBe('ov2'));
+    expect(mockUsers.mock.calls.length).toBeGreaterThan(usersBefore);
+    expect(usersParams()).toMatchObject({
+      overviewId: 'ov2',
+      page: 2,
+      workload: 'outlook',
+      sort: 'upn',
+      direction: 'asc',
+      search: 'ada',
+    });
+
+    await waitFor(() => expect(screen.queryByText(/expired/i)).not.toBeInTheDocument());
+    await act(async () => {});
+    // Refresh alone must not silently re-export.
+    expect(mockDownload).toHaveBeenCalledTimes(1);
+
+    // A subsequent explicit export references the fresh overview id AND the fresh users snapshot.
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    await waitFor(() => {
+      const last = mockDownload.mock.calls[mockDownload.mock.calls.length - 1][0];
+      expect(last.overviewId).toBe('ov2');
+      expect(last.usersId).toBe('us-ov2-p2');
+    });
+  });
+});
+
+describe('LicenceActivityPage - a real scope change resets the browse page', () => {
+  const usersParams = () => mockUsers.mock.calls[mockUsers.mock.calls.length - 1][0];
+
+  it('returns to page 1 and drops the stale export id when the demographic filter changes', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    // A distinct overview id per demographic scope; department 1 stays in the catalogue so it remains
+    // selectable after the scoped reply.
+    mockOverview.mockImplementation(async (q) => overview({ snapshotId: `ov-dept-${q.departmentId ?? 'all'}` }));
+    mockUsers.mockImplementation(async (params) => ({
+      ...usersResponse(),
+      overviewId: params.overviewId,
+      snapshotId: `us-${params.overviewId}-p${params.page}`,
+      totalUsers: 120,
+      query: { ...echo, page: params.page },
+    }));
+
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findAllByText('ada@contoso.com');
+    await act(async () => {});
+
+    // Browse to page 2 of the current (all-departments) scope.
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(usersParams()).toMatchObject({ overviewId: 'ov-dept-all', page: 2 }));
+
+    // Change the department filter: a genuine scope change, NOT a re-mint of the same query.
+    fireEvent.change(screen.getByLabelText('Filter by department'), { target: { value: '1' } });
+    await waitFor(() => expect(mockOverview.mock.calls.some((c) => c[0].departmentId === 1)).toBe(true));
+
+    // The re-scoped list is fetched fresh at PAGE 1 against the NEW overview - never the old page/id.
+    await waitFor(() => expect(usersParams()).toMatchObject({ overviewId: 'ov-dept-1', page: 1 }));
+
+    // Let the fresh page-1 list settle (its snapshot id is captured for the export).
+    await screen.findAllByText('ada@contoso.com');
+    await act(async () => {});
+
+    // And an export now references the new scope's ids, never the pre-change ones.
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    await waitFor(() => {
+      const last = mockDownload.mock.calls[mockDownload.mock.calls.length - 1][0];
+      expect(last.overviewId).toBe('ov-dept-1');
+      expect(last.usersId).toBe('us-ov-dept-1-p1');
+    });
+  });
+});
+
 describe('LicenceActivityPage - demographic filter options', () => {
   it('keeps every department selectable after a scoped reply, so you can switch straight from one to another', async () => {
     mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
@@ -190,6 +190,43 @@ describe('LicenceActivityPage - user-detail gating', () => {
     expect((await screen.findAllByText('ada@contoso.com')).length).toBeGreaterThan(0);
     expect(mockUsers).toHaveBeenCalled();
   });
+
+  it('drops revoked user detail on a users 403 while retaining aggregates and rechecking availability', async () => {
+    let finishAvailability!: (value: LicenceActivityAvailability) => void;
+    const recheck = new Promise<LicenceActivityAvailability>((resolve) => { finishAvailability = resolve; });
+    mockAvailability.mockResolvedValueOnce(availability({ canViewUsers: true })).mockReturnValueOnce(recheck);
+    mockUsers.mockResolvedValueOnce(usersResponse()).mockRejectedValueOnce(
+      new LicenceActivityApiError('forbidden', 403, 'Individual user detail is forbidden.'),
+    );
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findAllByText('ada@contoso.com');
+
+    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    await waitFor(() => expect(mockAvailability).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText('User drill-down')).not.toBeInTheDocument();
+    expect(screen.queryByText('ada@contoso.com')).not.toBeInTheDocument();
+    expect(screen.getByText('Licence assignments')).toBeInTheDocument();
+    expect(screen.getByText(/aggregate view/i)).toBeInTheDocument();
+
+    await act(async () => { finishAvailability(availability({ canViewUsers: false })); });
+    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledWith({ overviewId: 'ov1', usersId: undefined }));
+    expect(mockUsers).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not discard user-detail permission for a transient users failure', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockUsers.mockResolvedValueOnce(usersResponse()).mockRejectedValueOnce(
+      new LicenceActivityApiError('busy', 503, 'Reporting is busy.'),
+    );
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findAllByText('ada@contoso.com');
+
+    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    expect(await screen.findByText('Reporting is busy.')).toBeInTheDocument();
+    expect(screen.getByText('User drill-down')).toBeInTheDocument();
+    expect(mockAvailability).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('LicenceActivityPage - scale (50 SKUs)', () => {
@@ -284,6 +321,33 @@ describe('LicenceActivityPage - export', () => {
 });
 
 describe('LicenceActivityPage - export refresh after expiry', () => {
+  it('disables aggregate export until a pending expiry refresh supplies a fresh overview', async () => {
+    let finishOverview!: (value: LicenceActivityOverview) => void;
+    const renewal = new Promise<LicenceActivityOverview>((resolve) => { finishOverview = resolve; });
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    mockOverview.mockResolvedValueOnce(overview()).mockReturnValueOnce(renewal);
+    mockDownload.mockRejectedValueOnce(
+      new LicenceActivityApiError('expired', 410, 'The overview expired.'),
+    ).mockResolvedValue(undefined);
+    renderWithProvider(<LicenceActivityPage />);
+    const exportButton = await screen.findByRole('button', { name: /Export to Excel/i });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+    fireEvent.click(exportButton);
+    await screen.findByText('The overview expired.');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(exportButton).toBeDisabled();
+    fireEvent.click(exportButton);
+    expect(mockDownload).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Licence assignments')).toBeInTheDocument();
+    await waitFor(() => expect(mockOverview).toHaveBeenCalledTimes(2));
+
+    await act(async () => { finishOverview(overview({ snapshotId: 'ov2' })); });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+    fireEvent.click(exportButton);
+    await waitFor(() => expect(mockDownload).toHaveBeenLastCalledWith({ overviewId: 'ov2', usersId: undefined }));
+  });
+
   it('re-mints the users snapshot on Refresh (same cached overviewId) without silently re-exporting', async () => {
     mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
     // The overview stays cached: it returns the SAME snapshotId on reload, which is exactly the case
@@ -384,15 +448,16 @@ describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
     // Move off the defaults: a non-default workload and sort and search, then browse to page 2.
     fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
     await waitFor(() => expect(usersParams()).toMatchObject({ workload: 'outlook', page: 1 }));
-    fireEvent.change(screen.getByLabelText('Sort users'), { target: { value: 'upn:asc' } });
+    fireEvent.change(await screen.findByLabelText('Sort users'), { target: { value: 'upn:asc' } });
     await waitFor(() => expect(usersParams()).toMatchObject({ sort: 'upn', direction: 'asc' }));
-    fireEvent.change(screen.getByLabelText('Search users'), { target: { value: 'ada' } });
+    fireEvent.change(await screen.findByLabelText('Search users'), { target: { value: 'ada' } });
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
     await waitFor(() => expect(usersParams()).toMatchObject({ search: 'ada', page: 1 }));
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Next' }));
     await waitFor(() => expect(usersParams()).toMatchObject({ overviewId: 'ov1', page: 2 }));
 
     // Export -> 410 -> a Refresh prompt appears.
+    await waitFor(() => expect(screen.getByRole('button', { name: /Export to Excel/i })).toBeEnabled());
     fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
     expect(await screen.findByText(/expired/i)).toBeInTheDocument();
 
@@ -501,5 +566,23 @@ describe('LicenceActivityPage - demographic filter options', () => {
     await waitFor(() => expect(screen.getByRole('option', { name: 'Support' })).toBeInTheDocument());
     fireEvent.change(deptSelect, { target: { value: '2' } });
     await waitFor(() => expect(mockOverview.mock.calls.some((c) => c[0].departmentId === 2)).toBe(true));
+  });
+});
+
+describe('LicenceActivityPage - preview label', () => {
+  it('shows a Preview badge next to the Licence activity heading', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    await act(async () => { renderWithProvider(<LicenceActivityPage />); });
+    expect(screen.getByText('Preview')).toBeInTheDocument();
+    expect(screen.getByText('Licence activity')).toBeInTheDocument();
+  });
+
+  it('explains cache lag, cold-load behaviour, and the no-judgement note', async () => {
+    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    await act(async () => { renderWithProvider(<LicenceActivityPage />); });
+    const note = screen.getByRole('note');
+    expect(note.textContent).toMatch(/5 minutes/i);
+    expect(note.textContent).toMatch(/first load/i);
+    expect(note.textContent).toMatch(/activity evidence/i);
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
@@ -560,6 +560,7 @@ export default function LicenceActivityPage() {
                       <UsersDrillDown
                         key={selectedLicence.licenceTypeId}
                         overviewId={overview.snapshotId}
+                        overviewScope={overviewKey ?? ''}
                         licence={selectedLicence}
                         coverage={overview.coverage}
                         onUsersSnapshot={handleUsersSnapshot}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   makeStyles,
   tokens,
+  Badge,
   Title3,
   Body1,
   Text,
@@ -44,9 +45,19 @@ const useStyles = makeStyles({
     gap: '12px',
     flexWrap: 'wrap',
   },
+  titleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+  },
   intro: {
     marginTop: '8px',
     maxWidth: '820px',
+  },
+  previewNote: {
+    marginTop: '6px',
+    maxWidth: '820px',
+    color: tokens.colorNeutralForeground3,
   },
   controlsCard: {
     display: 'flex',
@@ -132,6 +143,7 @@ export default function LicenceActivityPage() {
 
   const [overviewResult, setOverviewResult] = useState<{
     key: string;
+    generation: number;
     data: LicenceActivityOverview | null;
     error: unknown;
   } | null>(null);
@@ -197,12 +209,13 @@ export default function LicenceActivityPage() {
     const controller = new AbortController();
     fetchOverview({ from: range.from, to: range.to, departmentId, countryId }, controller.signal)
       .then((o) => {
-        if (mySeq === overviewSeqRef.current) setOverviewResult({ key: overviewKey, data: o, error: null });
+        if (mySeq === overviewSeqRef.current)
+          setOverviewResult({ key: overviewKey, generation: overviewReloadKey, data: o, error: null });
       })
       .catch((err) => {
         if (mySeq !== overviewSeqRef.current || controller.signal.aborted) return;
         if (err instanceof DOMException && err.name === 'AbortError') return;
-        setOverviewResult({ key: overviewKey, data: null, error: err });
+        setOverviewResult({ key: overviewKey, generation: overviewReloadKey, data: null, error: err });
       });
 
     return () => controller.abort();
@@ -212,9 +225,11 @@ export default function LicenceActivityPage() {
   // Only surface an overview that belongs to the CURRENT scope key. A filter change hides the previous
   // overview (and its export id) on this render, before the new request starts.
   const overviewBelongs = overviewResult !== null && overviewResult.key === overviewKey;
+  const overviewCurrent = overviewBelongs && overviewResult.generation === overviewReloadKey;
   const overview = overviewBelongs ? overviewResult!.data : null;
-  const overviewError = overviewBelongs ? overviewResult!.error : null;
-  const overviewLoading = overviewKey !== null && !overviewBelongs;
+  const overviewError = overviewCurrent ? overviewResult!.error : null;
+  // Keep the same-scope drill-down mounted to preserve its page, but do not export a retiring generation.
+  const overviewLoading = overviewKey !== null && !overviewCurrent;
 
   // Refresh persisted filter options and choose/validate the selected licence against a new overview.
   // `overview` is request-scope bound, so when it is present the page's departmentId/countryId are the
@@ -250,6 +265,11 @@ export default function LicenceActivityPage() {
 
   const reloadOverview = useCallback(() => setOverviewReloadKey((k) => k + 1), []);
   const handleUsersSnapshot = useCallback((id: string | null) => setUsersId(id), []);
+  const handleUsersForbidden = useCallback(() => {
+    setUsersId(null);
+    setAvailability((previous) => previous ? { ...previous, canViewUsers: false } : previous);
+    setAvailabilityKey((k) => k + 1);
+  }, []);
 
   // The correct response to an EXPIRED snapshot (export 410, or a users 410): re-mint the snapshots in
   // place. We drop the stale users id and error, force the drill-down to re-fetch a fresh users
@@ -279,7 +299,7 @@ export default function LicenceActivityPage() {
   const exportUsersId = canViewUsers && selectedLicence ? usersId ?? undefined : undefined;
 
   const onExport = async (): Promise<void> => {
-    if (!overview) return;
+    if (!overview || overviewLoading) return;
     setExporting(true);
     setExportError(null);
     try {
@@ -290,8 +310,7 @@ export default function LicenceActivityPage() {
       // was still attaching a usersId. Retrying unchanged would 403 forever, so drop the individual
       // snapshot and re-read availability: the next export is then a valid aggregate-only workbook.
       if (describeError(err, '').kind === 'forbidden') {
-        setUsersId(null);
-        setAvailabilityKey((k) => k + 1);
+        handleUsersForbidden();
       }
     } finally {
       setExporting(false);
@@ -304,12 +323,21 @@ export default function LicenceActivityPage() {
     <div>
       <div className={styles.header}>
         <div>
-          <Title3>Licence activity</Title3>
+          <div className={styles.titleRow}>
+            <Title3>Licence activity</Title3>
+            <Badge appearance="tint" color="brand" size="medium">Preview</Badge>
+          </div>
           <Body1 block className={styles.intro}>
             Which licences are assigned, and how much are the people who hold them actually using each Microsoft 365
             workload. Activity is shown per workload and never blended into a single score, and anything that was not
             imported is shown as &quot;Unknown&quot; rather than zero.
           </Body1>
+          <Text role="note" block size={200} className={styles.previewNote}>
+            This report is in preview. Results are cached in memory for up to 5 minutes, so recent imports may not
+            yet appear. The first load for a new date range may take longer. Nothing shown implies a productivity
+            assessment or a recommendation to remove a licence —
+            it is activity evidence only.
+          </Text>
         </div>
       </div>
 
@@ -425,7 +453,7 @@ export default function LicenceActivityPage() {
                 <Tooltip
                   relationship="description"
                   content={
-                    overview
+                    overview && !overviewLoading
                       ? exportUsersId
                         ? 'Excel snapshot of the overview plus the exact user rows currently in view. Built from the cached snapshot, so it matches the screen rather than re-querying.'
                         : 'Excel snapshot of the licence and workload overview (aggregate only). Built from the cached snapshot.'
@@ -435,7 +463,7 @@ export default function LicenceActivityPage() {
                   <Button
                     appearance="primary"
                     icon={<ArrowDownload16Regular />}
-                    disabled={!overview || exporting}
+                    disabled={!overview || overviewLoading || exporting}
                     onClick={onExport}
                   >
                     {exporting ? 'Exporting...' : 'Export to Excel'}
@@ -565,6 +593,7 @@ export default function LicenceActivityPage() {
                         coverage={overview.coverage}
                         onUsersSnapshot={handleUsersSnapshot}
                         onRefreshOverview={refreshSnapshots}
+                        onForbidden={handleUsersForbidden}
                         refreshToken={usersRefreshToken}
                       />
                     ) : (


### PR DESCRIPTION
## Scope

Addresses #436 and #437. Continues the licence-activity feature in #456, supersedes #457, and incorporates the presentation fixes from #459 (now merged into `dev`).

This is a **preview**, deliberately trading bounded web-process memory and a slower initial source-preparation step for fast licence selection, ranking, filtering, search and paging. It adds **no database migration, permanent index or table, or saved installer-config property**. `main` remains held for the maintainer's manual review in #458.

## Implementation

- The production controller now composes `CachedLicenceActivityStore` with `ILicenceActivityReadModelLoader`. SQL extraction remains an adapter; cohort selection, evidence classification, ranking and paging are independently testable in-memory logic.
- One read model captures the unique-user directory, compact deduplicated licence memberships, pinned reporting samples and per-workload scores for an exact reporting range. It is shared across SKU/workload/demographic/search/page requests rather than re-running the population queries for each shape.
- The cache is scoped by tenant/database and import-source configuration. It holds at most **two** exact-range models per web process, with a **five-minute absolute lifetime** and **one cold model load at a time**. Identical cold requests share a load. It has no Redis dependency.
- Ranking families cache compact user-ID orderings and SKU intersections, not a duplicated user-by-licence object graph. Search is a literal, ordinal-ignore-case UPN/mail match in the web process. UPN and user ID provide deterministic tie-breaks.
- SQL uses the existing source/index schema. M365 evidence uses a two-stage aggregate: `MAX` within a pinned user/report day, then active/observed sample counts, average per-day maximum counters and latest in-window activity per user. This preserves legacy duplicate-day semantics without the experimental wide per-user pivot. The read-model Copilot query lets the optimizer select its access path; the legacy SQL query path remains available as a parity oracle.
- Directory and evidence loading overlap on bounded, separately owned connections. `Task.WhenAll` observes both branches before the connection-scoped eligible-user table is released. Bulk scalar materialization uses synchronous reader iteration on background workers, with explicit command cancellation to interrupt blocked I/O.
- Shared work starts outside the ASP.NET request synchronization context. Caller cancellation stops its wait, not another caller's shared preparation. SQL command timeouts remain **20 seconds** and shared HTTP response deadlines remain **30 seconds**.
- HTTP snapshots retain only a source-model ID, not the large model. Expiry is clipped to source/overview lifetime. An overview cache hit is revalidated against its source model, avoiding a `410 -> Refresh -> same expired ID` loop.
- Preview UI preserves unavailable/partial evidence versus measured zero, unnamed SKU fallbacks, exact reporting dates and bounded exports. It disables export while an expired overview is being replaced without unmounting the same-scope drill-down or resetting its page. A current users/export 403 removes detail mode and refreshes availability while retaining aggregates.

## Explicit preview performance contract

**The former blanket 15-second cold-load acceptance is not met and is not claimed.** Initial source preparation now has a separately reported **30-second preview budget**, matching the existing response deadline; no production timeout was increased to achieve it. Interactive response-cache misses retain the **15-second** gate, warm responses **500 ms**, concurrent requests **25 seconds**, and JSON responses **1 MiB**.

This distinction matters: preparing an exact range reads its SQL evidence once; subsequent SKU, workload, demographic, search and page operations use that captured model and issue no SQL. The maintainer requested a no-migration preview with a higher expected memory footprint at 300,000 users.

### Complete synthetic HTTP matrix

The real controller, cache, SQL adapter and Excel writer were exercised against **300,000 synthetic users, 50 SKUs, approximately 2.1 million overlapping memberships and 39 million workload rows**.

- **1,500/1,500** SKU/workload/window/repeat cells completed, each with an immediate warm partner: 50 SKUs x 5 workloads x 7-/180-day ranges x three fresh response- and source-cache instances.
- Additional coverage included deep paging, search hits/misses, demographic filters, changing ranking shapes, eight identical concurrent callers, four distinct concurrent calls and exact-snapshot Excel export.
- The fixture used the **four already-shipped M365 columnstore metrics indexes** and the existing rowstore Copilot indexes. **No Copilot columnstore index was present.** The harness now rejects that unshipped experimental index as release evidence.

| Boundary | Observed maximum |
| --- | ---: |
| Source preparation / initial overview | 25,396 ms (six runs ranged from 12,721 to 25,396 ms) |
| New user-query shape, including lazy rank-index construction | 4,365 ms |
| Warm user response | 80 ms |
| Warm overview | 12 ms |
| Demographic overview projection | 33 ms |
| Search | 325 ms |
| Four distinct concurrent calls | 55 ms |
| Eight identical concurrent callers | 98 ms |
| Excel export | 471 ms |
| JSON response | 515,365 bytes |
| Private-memory growth, including the in-process HTTP client | 1,013,100,544 bytes (about 966 MiB) |
| Managed-heap growth | 985,461,736 bytes (about 940 MiB) |

Every measured interactive SKU/workload/search/filter/page/concurrency operation had **zero SQL logical reads** after source preparation. The full exercise took approximately 13 minutes. The preview memory-growth gate is **2 GiB**, replacing the former 128 MiB restriction in accordance with the requested memory tradeoff; response-size bounds were not relaxed.

These are **LocalDB synthetic measurements**, not an Azure DTU/vCore guarantee, a cold OS/SQL-buffer test, or an IIS/App Service/Entra end-to-end measurement. SQL buffers were retained/uncontrolled. The rowstore-only large-tenant/180-day performance path is not established by these columnstore-mode results.

## Correctness and regression coverage

The final Release build passed, as did **105/105** targeted .NET licence tests and **44/44** focused portal recovery/API tests plus TypeScript checking. The complete 1,500-cell performance run above is separate from those functional counts.

- Differential SQL-versus-memory coverage for memberships, duplicate report days, missing/zero/partial evidence, all five workloads, exact/custom ranges, filters, search escaping semantics, ordering and paging.
- Copilot D7/28/90/180 period authority, missing/v1/negative counters, concealed identities and positive-only audit/interaction fallbacks.
- Single-flight sharing, caller cancellation, preparation deadlines, failure retry, tenant/source isolation, eviction, HTTP expiry recovery and serialization of internal source identifiers.
- Parallel directory/evidence connection cleanup on success and failure.
- Portal coverage for prerequisite/role gating, nullable SKU names, partial evidence, top/search/page controls, deferred expiry refresh, user-detail role loss and transient-failure recovery.
- Multi-model static critique uses separate SQL, projection, cache/API and portal/documentation scopes. Runtime performance evidence is tracked separately from clean static reviews.

## Configuration and operator effects

There is **no database migration, fresh-install schema change or saved config-schema change**. No manual SQL upgrade asset is required for this feature. The installer already configures a 64-bit web worker.

Aggregate reporting keeps its existing sign-in and `GraphUsersMetadata` prerequisites. **Optional named-user drill-down and user-list Excel exports require manual Entra configuration**: create the enabled `LicenceActivity.ReadUsers` application role on the runtime registration matching the web app's `ClientID`, allow Users/Groups, assign it through the corresponding Enterprise application, then sign out/in to refresh claims. The installer does not create this role. Server authorization remains enforced on every detail/export request, including cache hits.

## Risks and reviewer focus

- First source preparation is visibly slower than cached browsing. The old sub-15-second first-load target and Azure S4/S6 capacity validation are not asserted as completed acceptance.
- Memory is intentionally higher; the measured roughly 1 GiB process growth also includes the test client and is not a per-tenant sizing guarantee. Leave headroom for the rest of the portal.
- Caches are per worker. Recycles and newly added workers start cold; no distributed-cache coordination is claimed.
- A captured read-model generation is stable after publication, but its underlying SQL reads are not one serializable database transaction.
- Review sample de-duplication, incomplete-evidence ranking exclusions, source-expiry propagation, cancellation/resource ownership, and the overview-refresh/user-role recovery paths.
- Do not merge or auto-merge #458 into `main`; this PR prepares the preview in `dev` for manual testing first.
