### PR TITLE
Fix Fluent UI test imports after portal dependency restore

### DIFF
--- a/src/AnalyticsEngine/Web/Scripts/portal/vitest.config.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    server: {
+      deps: {
+        // Fluent's ESM dependency graph uses extensionless imports that need Vite's resolver.
+        inline: [/@fluentui[\\/]/],
+      },
+    },
     // The Fluent components pull in a lot of CSS-in-JS; we don't assert on computed styles, so
     // skipping CSS processing keeps the tests fast without changing what they verify.
     css: false,


### PR DESCRIPTION
## Scope

Fix the portal-test integration regression after `90a91073` restored npm dependencies. Preserve that commit's dependency pins, lockfile and the refreshed npm-proxy troubleshooting guidance in `8e2907c0`.

Addresses #436 and #437; no change to application behavior, SQL, database migrations or saved configuration.

## Cause and change

Vitest 3 externalizes Fluent UI's ESM dependency graph to Node. The icon entry imports extensionless paths such as `./icons/chunk-0`; the installed `chunk-0.js` exists, but Node's native ESM resolver does not add that extension. The production Vite build succeeds while ten React test suites fail during module loading.

Inline the `@fluentui` dependency graph through Vite **in the test configuration only**. Inlining only `@fluentui/react-icons` was insufficient because externalized Fluent UI parents import it outside Vite's resolver. The scoped expression handles both Windows and POSIX path separators.

No dependency versions, registry settings, credentials, `.npmrc`, lockfiles or production bundler settings are changed.

## Integration evidence

- Public-registry `npm ci` and the production portal build succeeded using the preserved dependency pins.
- Before the fix: ten licence/Reports UI suites failed to load with the missing-extension error.
- After the fix: **15 suites / 102 tests passed**, plus TypeScript checking.
- The combined C# test project compiled with #455's added sources. **35** selected demo-generator/licence API/projection tests passed; **one explicitly opt-in benchmark was skipped**.
- The preview runtime/source files from #460 remain unchanged by the intervening demo-generator and dependency commits.

Only `vitest.config.ts` changes. `main` remains untouched.
