### PR TITLE
Fix Copilot adoption table layout and add agent inventory search

### DIFF
--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/AgentsPanel.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/AgentsPanel.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import AgentsPanel from './AgentsPanel';
+import { AgentHealth } from '../../types/copilotAdoption';
+import type {
+  AgentEstateSummary,
+  AgentUsageRow,
+  CopilotAdoptionOptions,
+} from '../../types/copilotAdoption';
+
+const OPTIONS: CopilotAdoptionOptions = {
+  windowDays: 30,
+  historyDays: 365,
+  workingDaysPerWeek: 5,
+  frequencyTargetRatio: 0.6,
+  depthTargetInteractionsPerActiveDay: 5,
+  breadthTargetApps: 3,
+  frequencyWeight: 40,
+  depthWeight: 35,
+  breadthWeight: 25,
+  championScore: 75,
+  establishedScore: 50,
+  developingScore: 25,
+  habitBucketNormalisationDays: 28,
+  habitModerateMinDays: 4,
+  habitFrequentMinDays: 8,
+  habitDailyMinDays: 16,
+  agentReviewInactiveDays: 30,
+  agentRetireInactiveDays: 60,
+  agentNewDays: 14,
+  agentMinUsers: 3,
+  agentHistoryDays: 120,
+  opportunityUnlicensedCopilotWeight: 40,
+  opportunityCollaborationWeight: 25,
+  opportunityEmailWeight: 20,
+  opportunityDocumentWeight: 15,
+  opportunityCopilotTarget: 20,
+  opportunityCollaborationTarget: 30,
+  opportunityEmailTarget: 40,
+  opportunityDocumentTarget: 20,
+  opportunityRecommendScore: 60,
+  usageReportLagDays: 3,
+  topSegments: 10,
+  minSeatsPerSegment: 5,
+  maxLicensedUsersScored: 50000,
+  maxOpportunityCandidates: 50000,
+  maxAgents: 1000,
+  maxUnlicensedUsersScored: 50000,
+};
+
+/** A machine-generated identifier of the length that used to push the rest of the table off screen. */
+const LONG_KEY = `CopilotStudio.Declarative.T_${'0'.repeat(180)}.gpt.${'a'.repeat(60)}`;
+
+function agent(over: Partial<AgentUsageRow>): AgentUsageRow {
+  return {
+    agentId: 1,
+    name: 'Contoso Agent',
+    agentKey: null,
+    isCustomAgent: true,
+    interactions: 100,
+    users: 10,
+    licensedUsers: 4,
+    activeDays: 12,
+    appsUsed: 2,
+    interactionsPerUser: 10,
+    firstUsedUtc: '2026-01-01T00:00:00Z',
+    lastUsedUtc: '2026-02-01T00:00:00Z',
+    daysSinceLastUse: 3,
+    health: AgentHealth.Keep,
+    healthName: 'Keep',
+    healthReason: 'Used recently by enough people.',
+    ...over,
+  };
+}
+
+const AGENTS: AgentUsageRow[] = [
+  agent({ agentId: 1, name: 'Contoso Expenses Helper', agentKey: 'CopilotStudio.Declarative.T_expenses' }),
+  agent({ agentId: 2, name: 'Fabrikam Travel Booker', agentKey: LONG_KEY }),
+  agent({ agentId: 3, name: 'Northwind Ticket Triage', agentKey: null, isCustomAgent: false }),
+];
+
+const ESTATE: AgentEstateSummary = {
+  historyDays: 120,
+  activeAgents: 3,
+  knownAgents: 3,
+  customAgents: 2,
+  agentUsers: 25,
+  licensedAgentUsers: 10,
+  agentInteractions: 300,
+  interactionsPerAgentUser: 12,
+  mostPopularAgent: null,
+  mostVersatileAgent: null,
+  healthBreakdown: [{ label: 'Keep', value: 3 }],
+  // Left empty on purpose: the treemap and the department chart would otherwise render the same
+  // agent names as the table, and a name assertion could then pass without the table filtering.
+  usageByDepartment: [],
+  usageByAgent: [],
+  agents: AGENTS,
+};
+
+function renderPanel() {
+  return renderWithProvider(
+    <AgentsPanel estate={ESTATE} agents={AGENTS} options={OPTIONS} windowDays={30} sql={null} />,
+  );
+}
+
+describe('AgentsPanel inventory', () => {
+  it('filters the inventory by agent name as you type', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    expect(screen.getByText('3 of 3 agents')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Search agents by name or ID'), 'travel');
+
+    expect(screen.getByText('Fabrikam Travel Booker')).toBeInTheDocument();
+    expect(screen.queryByText('Contoso Expenses Helper')).not.toBeInTheDocument();
+    expect(screen.queryByText('Northwind Ticket Triage')).not.toBeInTheDocument();
+    expect(screen.getByText('1 of 3 agents')).toBeInTheDocument();
+  });
+
+  it('matches on the agent ID too, so an identifier copied from elsewhere finds its agent', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.type(screen.getByLabelText('Search agents by name or ID'), 'T_EXPENSES');
+
+    expect(screen.getByText('Contoso Expenses Helper')).toBeInTheDocument();
+    expect(screen.queryByText('Fabrikam Travel Booker')).not.toBeInTheDocument();
+  });
+
+  it('says so when nothing matches, and restores the list when the search is cleared', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.type(screen.getByLabelText('Search agents by name or ID'), 'no such agent');
+    expect(screen.getByText('No agents match these filters.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear agent search' }));
+
+    expect(screen.getByText('Contoso Expenses Helper')).toBeInTheDocument();
+    expect(screen.getByText('3 of 3 agents')).toBeInTheDocument();
+  });
+
+  it('keeps the full agent ID reachable on hover, since the column truncates it', () => {
+    renderPanel();
+
+    expect(screen.getByText(LONG_KEY)).toHaveAttribute('title', LONG_KEY);
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/AgentsPanel.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/AgentsPanel.test.tsx
@@ -147,6 +147,9 @@ describe('AgentsPanel inventory', () => {
   it('keeps the full agent ID reachable on hover, since the column truncates it', () => {
     renderPanel();
 
+    // Only the affordance is assertable here: vitest runs with `css: false` and jsdom has no layout
+    // engine, so the truncation itself (max-width + text-overflow) cannot be verified from a test.
+    // That was checked in a headless browser against a 180-character key.
     expect(screen.getByText(LONG_KEY)).toHaveAttribute('title', LONG_KEY);
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/AgentsPanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/AgentsPanel.tsx
@@ -1,5 +1,17 @@
 import { useMemo, useState } from 'react';
-import { makeStyles, tokens, Text, Card, Badge, Select, Checkbox, Tooltip } from '@fluentui/react-components';
+import {
+  makeStyles,
+  tokens,
+  Text,
+  Card,
+  Badge,
+  Button,
+  Input,
+  Select,
+  Checkbox,
+  Tooltip,
+} from '@fluentui/react-components';
+import { Dismiss16Regular, Search16Regular } from '@fluentui/react-icons';
 import type { AgentEstateSummary, AgentUsageRow, CopilotAdoptionOptions } from '../../types/copilotAdoption';
 import { AgentHealth } from '../../types/copilotAdoption';
 import CategoryBarChart from '../charts/CategoryBarChart';
@@ -73,6 +85,21 @@ const useStyles = makeStyles({
   agentName: {
     display: 'flex',
     flexDirection: 'column',
+    // Agent identifiers are machine-generated and can run to several hundred characters with no
+    // break opportunity in them. Left unbounded, one such row stretches this column until every
+    // other column is pushed off the right-hand side of the screen.
+    maxWidth: '360px',
+  },
+  agentKey: {
+    display: 'block',
+    maxWidth: '360px',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    color: tokens.colorNeutralForeground3,
+  },
+  search: {
+    minWidth: '240px',
   },
   reason: {
     maxWidth: '320px',
@@ -133,12 +160,22 @@ export default function AgentsPanel({
 
   const [health, setHealth] = useState<'' | string>('');
   const [customOnly, setCustomOnly] = useState(false);
+  const [search, setSearch] = useState('');
+
+  // Filtered in the browser rather than on the server: the whole inventory is already in memory,
+  // so a name filter is instant and a round trip would only make it feel slower.
+  const needle = search.trim().toLowerCase();
 
   const visible = useMemo(() => {
     return agents.filter(
-      (a) => (health === '' || a.health === Number(health)) && (!customOnly || a.isCustomAgent),
+      (a) =>
+        (health === '' || a.health === Number(health)) &&
+        (!customOnly || a.isCustomAgent) &&
+        (needle === '' ||
+          a.name.toLowerCase().includes(needle) ||
+          (a.agentKey ?? '').toLowerCase().includes(needle)),
     );
-  }, [agents, health, customOnly]);
+  }, [agents, health, customOnly, needle]);
 
   const legendStates = useMemo(() => {
     const present = new Set(visible.map((a) => a.health));
@@ -284,6 +321,25 @@ export default function AgentsPanel({
 
         <div className={styles.cardBody}>
           <div className={styles.filters}>
+            <Input
+              className={styles.search}
+              value={search}
+              placeholder="Search agent name or ID"
+              aria-label="Search agents by name or ID"
+              contentBefore={<Search16Regular />}
+              contentAfter={
+                search ? (
+                  <Button
+                    appearance="transparent"
+                    size="small"
+                    icon={<Dismiss16Regular />}
+                    aria-label="Clear agent search"
+                    onClick={() => setSearch('')}
+                  />
+                ) : undefined
+              }
+              onChange={(_e, d) => setSearch(d.value)}
+            />
             <Select
               value={health}
               aria-label="Filter agents by health"
@@ -339,7 +395,7 @@ export default function AgentsPanel({
                               {agent.name}
                             </Text>
                             {agent.agentKey && (
-                              <Text size={100} className={styles.muted}>
+                              <Text size={100} className={styles.agentKey} title={agent.agentKey}>
                                 {agent.agentKey}
                               </Text>
                             )}
@@ -348,7 +404,7 @@ export default function AgentsPanel({
                         <td className={table.td}>{agent.isCustomAgent ? 'Custom' : 'Microsoft'}</td>
                         <td className={`${table.td} ${table.tdNumeric}`}>
                           {formatCount(agent.users)}
-                          <Text size={100} block className={styles.muted}>
+                          <Text size={100} block className={table.tdSub}>
                             {formatCount(agent.licensedUsers)} licensed
                           </Text>
                         </td>
@@ -358,7 +414,7 @@ export default function AgentsPanel({
                         <td className={table.td}>
                           {formatDate(agent.lastUsedUtc)}
                           {agent.daysSinceLastUse !== null && agent.daysSinceLastUse > 0 && (
-                            <Text size={100} block className={styles.muted}>
+                            <Text size={100} block className={table.tdSub}>
                               {agent.daysSinceLastUse} days ago
                             </Text>
                           )}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/AgentsPanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/AgentsPanel.tsx
@@ -89,6 +89,10 @@ const useStyles = makeStyles({
     // break opportunity in them. Left unbounded, one such row stretches this column until every
     // other column is pushed off the right-hand side of the screen.
     maxWidth: '360px',
+    // The name is tenant-supplied, so it can be a single unbreakable token too. It wraps rather
+    // than truncates - a name is what a reader identifies the agent by, so losing the end of it is
+    // worse than a taller row. (No effect on the key below, which is nowrap.)
+    overflowWrap: 'anywhere',
   },
   agentKey: {
     display: 'block',

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/CombinedViews.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/CombinedViews.tsx
@@ -100,6 +100,11 @@ const useStyles = makeStyles({
     fontVariantNumeric: 'tabular-nums',
     textAlign: 'right',
     padding: '6px 10px',
+    // Matches the shared table cell (see adoptionShared's `td`). This class deliberately does not
+    // reuse `table.td` because it carries its own shading, so the size has to be kept in step by
+    // hand - without it these two cells render a size larger than the six around them.
+    fontSize: tokens.fontSizeBase200,
+    lineHeight: tokens.lineHeightBase200,
     borderBottomWidth: '1px',
     borderBottomStyle: 'solid',
     borderBottomColor: tokens.colorNeutralStroke3,

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/LicensedUsersPanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/LicensedUsersPanel.tsx
@@ -462,7 +462,7 @@ export default function LicensedUsersPanel({
                   <td className={table.td}>
                     {formatDate(row.lastInteractionUtc)}
                     {row.daysSinceLastUse !== null && row.daysSinceLastUse > 0 && (
-                      <Text size={100} block className={styles.muted}>
+                      <Text size={100} block className={table.tdSub}>
                         {row.daysSinceLastUse} days ago
                       </Text>
                     )}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/OpportunitiesPanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/OpportunitiesPanel.tsx
@@ -448,13 +448,13 @@ export default function OpportunitiesPanel({
                   </td>
                   <td className={`${table.td} ${table.tdNumeric}`}>
                     {formatCount(row.teamsMessages)}
-                    <Text size={100} block className={styles.muted}>
+                    <Text size={100} block className={table.tdSub}>
                       {formatCount(row.teamsMeetings)} mtgs
                     </Text>
                   </td>
                   <td className={`${table.td} ${table.tdNumeric}`}>
                     {formatCount(row.emailsSent)}
-                    <Text size={100} block className={styles.muted}>
+                    <Text size={100} block className={table.tdSub}>
                       {formatCount(row.emailsRead)} read
                     </Text>
                   </td>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/adoptionShared.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/adoptionShared.tsx
@@ -67,6 +67,11 @@ const useStyles = makeStyles({
     borderBottomStyle: 'solid',
     borderBottomColor: tokens.colorNeutralStroke2,
     color: tokens.colorNeutralForeground3,
+    // Pinned to the same size as the <Text size={200}> used inside the cells. Without this the
+    // table inherits the provider's base300 size, so a bare value like a row count rendered a
+    // size larger than the names and badges sitting next to it in the same row.
+    fontSize: tokens.fontSizeBase200,
+    lineHeight: tokens.lineHeightBase200,
     fontWeight: tokens.fontWeightSemibold,
     whiteSpace: 'nowrap',
   },
@@ -79,10 +84,22 @@ const useStyles = makeStyles({
     borderBottomStyle: 'solid',
     borderBottomColor: tokens.colorNeutralStroke3,
     verticalAlign: 'middle',
+    fontSize: tokens.fontSizeBase200,
+    lineHeight: tokens.lineHeightBase200,
   },
   tdNumeric: {
     textAlign: 'right',
     fontVariantNumeric: 'tabular-nums',
+  },
+  /**
+   * The smaller second line inside a cell - "0 mtgs" under the Teams count, "12 licensed" under the
+   * user count. Fluent's Text hard-codes `text-align: start`, so without the explicit `inherit` the
+   * sub-line left-aligns inside a right-aligned numeric cell and the two halves of a single value
+   * end up at opposite ends of the column.
+   */
+  tdSub: {
+    color: tokens.colorNeutralForeground3,
+    textAlign: 'inherit',
   },
   empty: {
     color: tokens.colorNeutralForeground3,


### PR DESCRIPTION
Three Copilot Adoption portal fixes, all in `Web/Scripts/portal`. No API, schema, config or migration changes.

## 1. Agent inventory — a long agent ID pushed the rest of the table off screen

`AgentUsageRow.agentKey` is a machine-generated identifier that in a real tenant runs to several hundred characters (`Notebook_...`, `CopilotStudio.Declarative.T_<guid>.gpt.<guid>`) with no break opportunity in it. It was rendered unbounded inside the Agent cell, so table auto-layout sized that column to the widest key and every other column (Type, Users, Interactions, Per user, Surfaces, Last used, Verdict) ended up beyond the right edge of `tableWrap`'s horizontal scroll.

`AgentsPanel.tsx`: the name cell and the key are now capped at `max-width: 360px`, and the key gets `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`. The full value is put on the element's `title`, so it is still readable on hover and still present in the DOM for copy/inspect.

The `max-width` is what actually fixes the column: intrinsic contributions are clamped by `max-width`, so the cell's max-content width — and therefore the column — can no longer exceed it. Verified in a headless browser against a 180-character key: the ellipsis appears and all eight columns fit at a 1000px viewport.

## 2. Agent inventory — search by agent name or ID

New `Input` in the existing filter row, alongside the verdict `Select` and the "Custom agents only" checkbox. Case-insensitive `includes` against `name` and `agentKey`, applied inside the same `useMemo` as the other two filters, so the existing "N of M agents" counter and the "No agents match these filters." empty state work unchanged.

Deliberately client-side: `agents` is already fully materialised in the panel's props (the analysis returns the whole inventory), so filtering in the browser is instant and a server round trip would only make it feel slower. A `contentAfter` dismiss button clears it.

## 3. Adoption tables — stacked cell values were mismatched in size and alignment

Two separate causes, both in the shared `useAdoptionTableStyles`:

- **Size.** A bare interpolated value in a cell (`{formatCount(row.teamsMessages)}`) inherits the `FluentProvider`'s `fontSizeBase300`, while every `<Text size={200}>` in the same row renders at `fontSizeBase200`. The primary numbers were therefore a size larger than the user names, badges and rationale beside them. `th`/`td` now pin `fontSizeBase200` / `lineHeightBase200`.
- **Alignment.** Fluent's `Text` hard-codes `text-align: start` on its root (`useTextStyles.styles`), which beats the inherited `text-align: right` from `tdNumeric`. So in "Teams (per day)" the count sat at the right edge and its `0 mtgs` sub-line sat at the left edge of the same cell. New `tdSub` class sets `text-align: inherit` (plus the muted foreground it already had); because the caller's class is merged last, Griffel gives it precedence over Fluent's own rule.

Applied to the stacked cells in `OpportunitiesPanel` (Teams / Email), `AgentsPanel` (Users, Last used) and `LicensedUsersPanel` (Last interaction). Only `copilotAdoption` tables are affected — the Licence activity tables have their own `useLaTableStyles`.

## Tests

New `AgentsPanel.test.tsx` (4 tests) covering the search: filters by name as you type, matches on the ID too, shows the empty state and restores the list on clear, and keeps the full ID on `title` given the column truncates. Fixtures are synthetic (`Contoso` / `Fabrikam` / `Northwind`, zeroed GUID-shaped IDs).

`npm run build` (`tsc --noEmit && vite build`) clean; full portal suite `106 passed (16 files)`.

The size and alignment fix is CSS, so it is not directly assertable — `vitest.config.ts` sets `css: false` and jsdom has no layout engine. It was verified in a headless browser instead.

## Reviewer notes

- `adoptionShared.tsx` is shared by five panels, so the font-size pin changes every Copilot Adoption table, not just the two in the screenshots. That is the intent: it makes the bare values agree with the `Text size={200}` already used throughout those tables.
- The search matches `agentKey` as well as `name`. The placeholder and `aria-label` say so ("Search agent name or ID"); the reason is that an admin chasing an agent usually has the identifier copied from somewhere else, not the display name.
- Row height in Licence opportunities is unchanged — that is driven by the Justification column and is already documented in the user guide.

Addresses the two Copilot Adoption UI issues reported in-product.
