### PR TITLE
Offer the synthetic demo generator from the FakeDataGen menu

### DIFF
--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoInteractive.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoInteractive.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Tests.FakeDataGen.Demo
+{
+    /// <summary>
+    /// Console I/O for the interactive demo option, isolated behind an interface so the question
+    /// sequence and the argument list it produces can be tested without a console.
+    /// </summary>
+    internal interface IDemoPrompt
+    {
+        void Write(string message);
+
+        /// <summary>Asks a question and returns the raw answer. Null (end of input) means "take the default".</summary>
+        string Ask(string question);
+    }
+
+    internal sealed class ConsoleDemoPrompt : IDemoPrompt
+    {
+        public void Write(string message) => Console.WriteLine(message);
+
+        public string Ask(string question)
+        {
+            Console.Write(question);
+            return Console.ReadLine();
+        }
+    }
+
+    /// <summary>
+    /// Menu front end for the same generator that <c>Tests.FakeDataGen.exe demo ...</c> runs, so the demo
+    /// data set can be produced without knowing the flags. It only collects answers: the argument list it
+    /// builds is handed to <see cref="DemoCommand"/>, which keeps parsing, validation, the LocalDB-only
+    /// target rule and the completed-target no-op as the single authority for both entry points.
+    /// </summary>
+    internal static class DemoInteractive
+    {
+        internal const string MenuTitle = "Generate a complete synthetic demo database (Contoso, new LocalDB database)";
+
+        public static void Run()
+        {
+            var prompt = new ConsoleDemoPrompt();
+            int exitCode = Run(prompt, DateTime.UtcNow);
+            if (exitCode != 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                prompt.Write($"Demo generation did not complete (exit code {exitCode}).");
+                Console.ResetColor();
+            }
+        }
+
+        /// <summary>
+        /// Asks for the options, then runs the demo generator. Returns the same exit code the
+        /// <c>demo</c> command line returns, or 0 when the user chose not to start.
+        /// </summary>
+        internal static int Run(IDemoPrompt prompt, DateTime utcNow)
+        {
+            var args = BuildArgs(prompt, utcNow);
+            if (args == null)
+            {
+                prompt.Write("Cancelled. No database was created and nothing was changed.");
+                return 0;
+            }
+
+            prompt.Write(string.Empty);
+            return DemoCommand.Run(args);
+        }
+
+        /// <summary>
+        /// Runs the question sequence and returns the equivalent <c>demo</c> argument list, or null if the
+        /// user declined to start. <c>--as-of</c> is emitted even when it was never asked for, because it
+        /// otherwise defaults to the clock: without it the printed line would name a different window when
+        /// it is read on a later day.
+        /// </summary>
+        internal static string[] BuildArgs(IDemoPrompt prompt, DateTime utcNow)
+        {
+            var defaults = new DemoOptions();
+
+            prompt.Write(string.Empty);
+            prompt.Write("Generates the same rounded, entirely synthetic Contoso data set as");
+            prompt.Write("'Tests.FakeDataGen.exe demo': licences, daily workload activity, Copilot adoption");
+            prompt.Write("and D28 snapshots, metadata-only interactions, SharePoint facts and weekly Power BI");
+            prompt.Write("profiles. No prompt or response text is generated.");
+            prompt.Write(string.Empty);
+            prompt.Write(@"It only ever creates a NEW database on (localdb)\MSSQLLocalDB. It ignores the");
+            prompt.Write("connection string this tool was started with, never writes to an existing database,");
+            prompt.Write("and has no reset option - re-running a completed target is a read-only no-op.");
+            prompt.Write(string.Empty);
+
+            bool preview = AskYesNo(prompt, "Preview only (count the rows, write no SQL at all)?", false);
+
+            string database = null;
+            if (!preview)
+            {
+                database = AskDatabaseName(prompt, DefaultDatabaseName(utcNow));
+            }
+
+            var asOf = utcNow.Date;
+            int users = defaults.Users;
+            int skus = defaults.Skus;
+            int days = defaults.Days;
+            int seed = defaults.Seed;
+            int copilotPercent = defaults.CopilotPercent;
+            int batchSize = defaults.BatchSize;
+            string mix = string.Join(",", defaults.Mix);
+            bool compileProfiles = defaults.CompileProfiles;
+            string output = null;
+
+            prompt.Write(string.Empty);
+            if (AskYesNo(prompt, "Customise the data set (size, history, seed, licence mix)?", false))
+            {
+                users = AskInt(prompt, "Users", users, DemoOptions.MinUsers, DemoOptions.MaxUsers);
+                skus = AskInt(prompt, "Licence SKUs (current assignments, not purchased capacity)", skus,
+                    DemoOptions.MinSkus, DemoOptions.MaxSkus);
+                days = AskInt(prompt, "Days of history", days, DemoOptions.MinDays, DemoOptions.MaxDays);
+                asOf = AskDate(prompt, "End of the generated window, exclusive (yyyy-MM-dd)", asOf);
+                seed = AskInt(prompt, "Random seed", seed, DemoOptions.MinSeed, DemoOptions.MaxSeed);
+                copilotPercent = AskInt(prompt, "Percentage of users with a current Copilot seat", copilotPercent,
+                    DemoOptions.MinCopilotPercent, DemoOptions.MaxCopilotPercent);
+                mix = AskMix(prompt, mix);
+
+                if (!preview)
+                {
+                    compileProfiles = AskYesNo(prompt,
+                        "Compile the weekly Power BI profiles afterwards (slower, but the reports need them)?",
+                        compileProfiles);
+                    batchSize = AskInt(prompt, "SQL insert batch size", batchSize,
+                        DemoOptions.MinBatchSize, DemoOptions.MaxBatchSize);
+                }
+
+                output = AskOutputPath(prompt, "JSON summary file to write (must not already exist; blank for none)");
+            }
+
+            var args = new List<string>();
+            if (preview)
+            {
+                args.Add("--preview");
+            }
+            else
+            {
+                args.Add("--database");
+                args.Add(database);
+            }
+            args.Add("--as-of");
+            args.Add(asOf.ToString(DemoOptions.DateFormat, CultureInfo.InvariantCulture));
+            AddValue(args, "--users", users);
+            AddValue(args, "--skus", skus);
+            AddValue(args, "--days", days);
+            AddValue(args, "--seed", seed);
+            AddValue(args, "--copilot-percent", copilotPercent);
+            args.Add("--mix");
+            args.Add(mix);
+            if (!preview)
+            {
+                AddValue(args, "--batch-size", batchSize);
+                if (!compileProfiles) args.Add("--no-profiles");
+            }
+            if (!string.IsNullOrEmpty(output))
+            {
+                args.Add("--output");
+                args.Add(output);
+            }
+
+            prompt.Write(string.Empty);
+            prompt.Write("About to generate:");
+            prompt.Write("  Target             " + (preview
+                ? "preview only - no database, no rows, no weekly profiles"
+                : database + @" (new database on (localdb)\MSSQLLocalDB)"));
+            prompt.Write($"  Users / SKUs       {users:N0} / {skus:N0}");
+            prompt.Write($"  History            {days:N0} days ending {asOf.ToString(DemoOptions.DateFormat, CultureInfo.InvariantCulture)} (exclusive)");
+            prompt.Write($"  Seed               {seed}");
+            prompt.Write($"  Copilot seats      {copilotPercent}% of users");
+            prompt.Write($"  Activity mix       {mix} (high,moderate,low,never-active,inactive)");
+            if (!preview)
+            {
+                prompt.Write("  Weekly profiles    " + (compileProfiles ? "compiled after generation" : "skipped"));
+            }
+            prompt.Write("  JSON summary       " + (string.IsNullOrEmpty(output) ? "(none)" : output));
+            prompt.Write(string.Empty);
+            prompt.Write("Equivalent command line: Tests.FakeDataGen.exe demo " + CommandLine(args));
+            prompt.Write(string.Empty);
+            prompt.Write("Large populations or long histories can exceed LocalDB's storage limit; preview first if unsure.");
+            prompt.Write(string.Empty);
+
+            return AskYesNo(prompt, "Start generating now?", true) ? args.ToArray() : null;
+        }
+
+        /// <summary>
+        /// A valid target name every time the option is opened. Targets are never reset, so defaulting to a
+        /// timestamped name keeps repeat runs working without suggesting a name that is likely to collide.
+        /// </summary>
+        internal static string DefaultDatabaseName(DateTime utcNow) =>
+            "ContosoDemo_" + utcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+
+        /// <summary>
+        /// Renders the built argument list for display. Values that are not plain identifiers, numbers or
+        /// paths are wrapped in double quotes so a copied line survives spaces and command separators. This
+        /// is a convenience, not an escaping contract - a shell still expands its own variable syntax inside
+        /// double quotes, and the generator is always handed the argument array itself rather than this text.
+        /// </summary>
+        internal static string CommandLine(IEnumerable<string> args) => string.Join(" ", args.Select(Quote));
+
+        private static string Quote(string value) =>
+            value.Length > 0 && value.All(IsPlain) ? value : "\"" + value + "\"";
+
+        private static bool IsPlain(char c) =>
+            (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+            || @"_-.:,\/".IndexOf(c) >= 0;
+
+        private static void AddValue(List<string> args, string option, int value)
+        {
+            args.Add(option);
+            args.Add(value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private static string AskDatabaseName(IDemoPrompt prompt, string defaultValue)
+        {
+            while (true)
+            {
+                var answer = AskText(prompt, "New database name", defaultValue);
+                if (DemoOptions.IsValidDatabaseName(answer)) return answer;
+                prompt.Write("Names must start with ContosoDemo_ and use only letters, digits and underscores.");
+            }
+        }
+
+        private static string AskMix(IDemoPrompt prompt, string defaultValue)
+        {
+            while (true)
+            {
+                var answer = AskText(prompt, "Activity mix high,moderate,low,never-active,inactive", defaultValue);
+                var parts = answer.Split(',');
+                var parsed = new List<int>();
+                foreach (var part in parts)
+                {
+                    if (int.TryParse(part.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out var band)
+                        && band <= 100)
+                    {
+                        parsed.Add(band);
+                    }
+                }
+                if (parsed.Count == parts.Length && parsed.Count == DemoOptions.MixBands && parsed.Sum() == 100)
+                {
+                    return string.Join(",", parsed);
+                }
+                prompt.Write($"Enter {DemoOptions.MixBands} percentages, separated by commas, totalling 100.");
+            }
+        }
+
+        private static DateTime AskDate(IDemoPrompt prompt, string question, DateTime defaultValue)
+        {
+            while (true)
+            {
+                var answer = AskText(prompt, question, defaultValue.ToString(DemoOptions.DateFormat, CultureInfo.InvariantCulture));
+                if (DateTime.TryParseExact(answer, DemoOptions.DateFormat, CultureInfo.InvariantCulture,
+                        DateTimeStyles.None, out var parsed)
+                    && parsed.Year >= DemoOptions.MinYear && parsed.Year <= DemoOptions.MaxYear)
+                {
+                    return parsed;
+                }
+                prompt.Write($"Enter a date as yyyy-MM-dd between {DemoOptions.MinYear} and {DemoOptions.MaxYear}.");
+            }
+        }
+
+        private static int AskInt(IDemoPrompt prompt, string question, int defaultValue, int min, int max)
+        {
+            while (true)
+            {
+                var answer = AskText(prompt, question, defaultValue.ToString(CultureInfo.InvariantCulture));
+                if (int.TryParse(answer, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
+                    && parsed >= min && parsed <= max)
+                {
+                    return parsed;
+                }
+                prompt.Write($"Enter a whole number from {min:N0} to {max:N0}.");
+            }
+        }
+
+        private static bool AskYesNo(IDemoPrompt prompt, string question, bool defaultValue)
+        {
+            while (true)
+            {
+                var answer = prompt.Ask($"{question} [{(defaultValue ? "Y/n" : "y/N")}]: ");
+                if (string.IsNullOrWhiteSpace(answer)) return defaultValue;
+
+                var trimmed = answer.Trim();
+                if (trimmed.StartsWith("y", StringComparison.OrdinalIgnoreCase)) return true;
+                if (trimmed.StartsWith("n", StringComparison.OrdinalIgnoreCase)) return false;
+                prompt.Write("Please answer y or n.");
+            }
+        }
+
+        private static string AskText(IDemoPrompt prompt, string question, string defaultValue)
+        {
+            var answer = prompt.Ask($"{question} [{defaultValue}]: ");
+            return string.IsNullOrWhiteSpace(answer) ? defaultValue : answer.Trim();
+        }
+
+        private static string AskOutputPath(IDemoPrompt prompt, string question)
+        {
+            while (true)
+            {
+                var answer = prompt.Ask(question + ": ");
+                if (string.IsNullOrWhiteSpace(answer)) return null;
+
+                var trimmed = answer.Trim();
+                // The parser reads a token starting with "--" as the next option, so such a path would
+                // build an argument list it then refuses.
+                if (!trimmed.StartsWith("--", StringComparison.Ordinal)) return trimmed;
+                prompt.Write("A summary file path cannot start with '--'.");
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoOptions.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoOptions.cs
@@ -12,6 +12,20 @@ namespace Tests.FakeDataGen.Demo
     {
         // Bump when generation rules change: completed targets must not silently reuse an older shape.
         public const string FormatVersion = "contoso-demo-v1";
+
+        // Accepted ranges, shared with the interactive menu (DemoInteractive) so the two entry points
+        // cannot drift apart and offer a value the other refuses.
+        internal const int MinUsers = 1, MaxUsers = 1000000;
+        internal const int MinSkus = 10, MaxSkus = 1000;
+        internal const int MinDays = 31, MaxDays = 730;
+        internal const int MinSeed = 0, MaxSeed = int.MaxValue;
+        internal const int MinCopilotPercent = 1, MaxCopilotPercent = 99;
+        internal const int MinBatchSize = 1, MaxBatchSize = 1000;
+        internal const int MixBands = 5;
+        internal const int MinYear = 2002, MaxYear = 2100;
+        internal const string DateFormat = "yyyy-MM-dd";
+        internal const string DatabaseNamePattern = @"\AContosoDemo_[A-Za-z0-9_]{1,70}\z";
+
         public int Users { get; private set; } = 1000;
         public int Skus { get; private set; } = 50;
         public int Days { get; private set; } = 180;
@@ -47,21 +61,21 @@ namespace Tests.FakeDataGen.Demo
                 {
                     case "--database": result.Database = value; break;
                     case "--output": result.Output = value; break;
-                    case "--users": result.Users = Integer(key, value, 1, 1000000); break;
-                    case "--skus": result.Skus = Integer(key, value, 10, 1000); break;
-                    case "--days": result.Days = Integer(key, value, 31, 730); break;
-                    case "--seed": result.Seed = Integer(key, value, 0, int.MaxValue); break;
-                    case "--copilot-percent": result.CopilotPercent = Integer(key, value, 1, 99); break;
-                    case "--batch-size": result.BatchSize = Integer(key, value, 1, 1000); break;
+                    case "--users": result.Users = Integer(key, value, MinUsers, MaxUsers); break;
+                    case "--skus": result.Skus = Integer(key, value, MinSkus, MaxSkus); break;
+                    case "--days": result.Days = Integer(key, value, MinDays, MaxDays); break;
+                    case "--seed": result.Seed = Integer(key, value, MinSeed, MaxSeed); break;
+                    case "--copilot-percent": result.CopilotPercent = Integer(key, value, MinCopilotPercent, MaxCopilotPercent); break;
+                    case "--batch-size": result.BatchSize = Integer(key, value, MinBatchSize, MaxBatchSize); break;
                     case "--as-of":
-                        if (!DateTime.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture,
-                            DateTimeStyles.None, out var date) || date.Year < 2002 || date.Year > 2100)
+                        if (!DateTime.TryParseExact(value, DateFormat, CultureInfo.InvariantCulture,
+                            DateTimeStyles.None, out var date) || date.Year < MinYear || date.Year > MaxYear)
                             throw new ArgumentException("--as-of must be yyyy-MM-dd between 2002 and 2100.");
                         result.AsOf = DateTime.SpecifyKind(date, DateTimeKind.Utc);
                         break;
                     case "--mix":
                         result.Mix = value.Split(',').Select(v => Integer(key, v, 0, 100)).ToArray();
-                        if (result.Mix.Length != 5 || result.Mix.Sum() != 100)
+                        if (result.Mix.Length != MixBands || result.Mix.Sum() != 100)
                             throw new ArgumentException("--mix needs five percentages totalling 100: high,moderate,low,zero,inactive.");
                         break;
                     default: throw new ArgumentException("Unknown demo option: " + key + ". Use demo --help.");
@@ -69,10 +83,18 @@ namespace Tests.FakeDataGen.Demo
             }
             if (!result.Help && !result.Preview && string.IsNullOrWhiteSpace(result.Database))
                 throw new ArgumentException("Use --database ContosoDemo_<name> for a NEW local demo database, or --preview for no SQL.");
-            if (result.Database != null && !Regex.IsMatch(result.Database, @"\AContosoDemo_[A-Za-z0-9_]{1,70}\z"))
+            if (result.Database != null && !IsValidDatabaseName(result.Database))
                 throw new ArgumentException("--database must start with ContosoDemo_ and contain only ASCII letters, digits and underscores.");
             return result;
         }
+
+        /// <summary>
+        /// The only accepted shape for a demo target name. Deliberately a fixed prefix plus ASCII
+        /// identifier characters: the name is concatenated into <c>CREATE DATABASE</c>, so nothing that
+        /// could carry quoting, path or statement separators may reach SQL.
+        /// </summary>
+        internal static bool IsValidDatabaseName(string name) =>
+            name != null && Regex.IsMatch(name, DatabaseNamePattern);
 
         private static int Integer(string key, string value, int min, int max)
         {
@@ -97,6 +119,9 @@ namespace Tests.FakeDataGen.Demo
   Tests.FakeDataGen.exe demo --database ContosoDemo_Example
   Tests.FakeDataGen.exe demo --preview --users 300000 --skus 50 --days 31
   Tests.FakeDataGen.exe demo --database ContosoDemo_Repeatable --as-of 2026-09-01 --seed 42
+
+Or run Tests.FakeDataGen.exe with no arguments and pick the demo option from the menu: it
+asks for the same values, prints the equivalent command line, and runs this same generator.
 
   --database NAME          NEW database on (localdb)\MSSQLLocalDB only. Required unless preview.
   --preview                Stream the same rows to counters; no SQL, config or external services.

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
@@ -25,6 +25,8 @@ namespace Tests.FakeDataGen
         private static readonly List<MenuItem> MenuItems = new List<MenuItem>
         {
             // Data generation
+            new MenuItem(DemoInteractive.MenuTitle, MenuCategory.DataGeneration,
+                ctx => DemoInteractive.Run()),
             new MenuItem("Generate fake Copilot activity", MenuCategory.DataGeneration,
                 ctx => RunCopilotActivityGenerator(ctx.RequireConnectionString())),
             new MenuItem("Generate fake O365 audit activity", MenuCategory.DataGeneration,
@@ -84,9 +86,10 @@ namespace Tests.FakeDataGen
             else
             {
                 Console.WriteLine("No SQL connection string provided.");
-                Console.WriteLine("Stress tests that don't need SQL will still run; everything else will be disabled.");
+                Console.WriteLine("The synthetic demo option (which creates its own new LocalDB database) and the");
+                Console.WriteLine("stress tests that don't need SQL will still run; everything else will be disabled.");
                 Console.WriteLine("Usage: Tests.FakeDataGen.exe \"<SQL Connection String>\" [--run <copilot|copilotadoption|activityapi|activityapidb|powerplatform|sentemail|useractivity>]");
-                Console.WriteLine("Safe one-command demo: Tests.FakeDataGen.exe demo --help");
+                Console.WriteLine("Safe one-command demo: Tests.FakeDataGen.exe demo --help (or pick it from the menu below)");
             }
             Console.WriteLine();
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/README.md
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/README.md
@@ -25,6 +25,10 @@ Exact completed reruns are read-only no-ops; other existing targets are refused.
 reproducibility. `--help` lists all flags and the deliberately unsupported datasets.
 The operator guide lives in the wiki: [Synthetic demo data](https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Synthetic-demo-data).
 
+The same demo is the **first option on the interactive menu**, so it can be run
+without knowing any of the flags - see
+[Full synthetic demo](#full-synthetic-demo-contoso) below.
+
 The older, independent interactive generator/stress-test menu is still available:
 
 ```
@@ -32,7 +36,8 @@ Tests.FakeDataGen.exe "<SQL Connection String>"
 ```
 
 The connection string is optional. Options that need SQL will refuse to run
-without one; stress tests that work in-memory still run.
+without one; stress tests that work in-memory still run. The synthetic demo
+option never uses it - it always creates its own new LocalDB database.
 
 The first time a menu option that needs the database runs in a session, the
 host invokes `App.ControlPanel.Engine.DatabaseUpgrader.CheckDbUpgraded` against
@@ -47,17 +52,20 @@ When launched, an interactive menu is shown:
 
 ```
 DATA GENERATION
-  1. Generate fake Copilot activity
-  2. Generate fake O365 audit activity
-  3. Generate combined profiling data (O365 + Copilot)
+  1. Generate a complete synthetic demo database (Contoso, new LocalDB database)
+  2. Generate fake Copilot activity
+  3. Generate fake O365 audit activity
+  4. Generate combined profiling data (O365 + Copilot)
+  5. Generate fake Copilot prompt history (AI interaction history)
 
 STRESS TESTS
-  4. ActivityAPI import stress test
-  5. ActivityAPI import stress test (DB-backed, COLD+WARM)
-  6. Copilot event import stress test
-  7. Power Platform event import stress test
-  8. Sent email importer stress test
-  9. User activity data stress test (profiling SQL inputs)
+  6. ActivityAPI import stress test
+  7. ActivityAPI import stress test (DB-backed, COLD+WARM)
+  8. Copilot event import stress test
+  9. Copilot Adoption page performance test (read-only, before/after)
+  10. Power Platform event import stress test
+  11. Sent email importer stress test
+  12. User activity data stress test (profiling SQL inputs)
 
   0. Exit
 ```
@@ -70,7 +78,7 @@ Tests.FakeDataGen/
 ├── App.config                # EF + Azure binding redirects
 ├── Copilot/                  # realistic Copilot data generators
 │   └── SQL/                  # refusal-only compatibility stub for the retired shaper
-├── Demo/                     # safe single-command generator, calendar, plan and bounded SQL sink
+├── Demo/                     # safe single-command + menu generator, calendar, plan and bounded SQL sink
 ├── Generation/               # shared synthetic activity helpers
 ├── Office365/                # O365 audit activity generator
 ├── Seeding/                  # shared user / license / lookup seed data
@@ -97,6 +105,38 @@ a company, a realistic account-enabled state, a UPN on one of several tenant
 domains, and a manager in their own company.
 
 ## Data generation
+
+### Full synthetic demo (Contoso)
+
+Menu option 1 is the interactive front end for the `demo` command. It asks for
+the values the flags carry - preview or a new database name, then optionally
+population size, SKU count, history length, end date, seed, Copilot licence
+percentage, activity mix, weekly profile compilation, SQL batch size and a JSON
+summary path. Every question that shapes the data offers the command line's own
+default, so pressing Enter through the prompts produces exactly the documented
+`demo` data set. The only menu-invented default is the timestamped target name,
+because the command line has no default target.
+
+Before it starts, it prints a summary and the **equivalent command line**, which
+records exactly what was chosen:
+
+```
+Equivalent command line: Tests.FakeDataGen.exe demo --database ContosoDemo_20260901_134530
+  --as-of 2026-09-01 --users 1000 --skus 50 --days 180 --seed 42 --copilot-percent 60
+  --mix 30,35,20,8,7 --batch-size 250
+```
+
+`--as-of` is always emitted explicitly, so the line still describes the same
+window on a later day. To generate another copy from it, give `--database` (and
+`--output`, if one was chosen) new names: a completed target is a read-only
+no-op and an existing summary file is never overwritten. The default target name
+is timestamped because demo targets are never reset.
+
+The menu option only chooses flag values: `DemoCommand` still parses and
+validates them, so the LocalDB-only rule, the `ContosoDemo_` name restriction,
+the refusal of unmarked or changed targets and the read-only no-op on an
+identical rerun apply exactly as they do on the command line. It ignores the
+connection string the tool was started with.
 
 ### Copilot activity
 
@@ -199,12 +239,13 @@ behaviour, verbosity) and reports:
 
 | # | Test | Purpose |
 | - | ---- | ------- |
-| 4 | `ActivityAPIStressTest` | Drives the ActivityAPI ingestion pipeline with fake loaders to detect leaks and benchmark the batch save path. |
-| 5 | `ActivityApiDbStressTest` | Drives the real SQL persistence path through repeatable cold and warm scenarios. |
-| 6 | `CopilotStressTest` | Exercises `CopilotAuditEventManager` at scale and validates the accessed-resources SQL path under load. |
-| 7 | `PowerPlatformStressTest` | Exercises `PowerPlatformAuditEventManager` across the four Power Platform workloads (Power Apps, Power Automate, Power BI, Copilot Studio). |
-| 8 | `SentEmailImporterStressTest` | Exercises sent-email persistence and sentiment-scoring boundaries with synthetic messages. |
-| 9 | `UserActivityStressTest` | Bulk-loads the user + license + per-workload activity tables so the profiling SQL in `App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql` can be exercised against realistic volumes. After the seed, optionally invokes `[profiling].[usp_CompileWeekly]` to roll the daily rows into the weekly profiling tables straight away (the same proc that `WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Weekly.ps1` runs on schedule). |
+| 6 | `ActivityAPIStressTest` | Drives the ActivityAPI ingestion pipeline with fake loaders to detect leaks and benchmark the batch save path. |
+| 7 | `ActivityApiDbStressTest` | Drives the real SQL persistence path through repeatable cold and warm scenarios. |
+| 8 | `CopilotStressTest` | Exercises `CopilotAuditEventManager` at scale and validates the accessed-resources SQL path under load. |
+| 9 | `CopilotAdoptionPerfTest` | Read-only before/after timing of the Copilot Adoption page's analysis against an existing database. |
+| 10 | `PowerPlatformStressTest` | Exercises `PowerPlatformAuditEventManager` across the four Power Platform workloads (Power Apps, Power Automate, Power BI, Copilot Studio). |
+| 11 | `SentEmailImporterStressTest` | Exercises sent-email persistence and sentiment-scoring boundaries with synthetic messages. |
+| 12 | `UserActivityStressTest` | Bulk-loads the user + license + per-workload activity tables so the profiling SQL in `App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql` can be exercised against realistic volumes. After the seed, optionally invokes `[profiling].[usp_CompileWeekly]` to roll the daily rows into the weekly profiling tables straight away (the same proc that `WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Weekly.ps1` runs on schedule). |
 
 ### Adding a new stress test
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Demo\DemoCalendar.cs" />
     <Compile Include="Demo\DemoCommand.cs" />
     <Compile Include="Demo\DemoGenerator.cs" />
+    <Compile Include="Demo\DemoInteractive.cs" />
     <Compile Include="Demo\DemoOptions.cs" />
     <Compile Include="Demo\DemoPopulation.cs" />
     <Compile Include="Demo\DemoTables.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoInteractiveTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoInteractiveTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tests.FakeDataGen.Demo;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The interactive menu option must stay a pure front end for the <c>demo</c> command line: it may only
+    /// choose flag values, never relax the target rules or drift away from the command line's defaults.
+    /// </summary>
+    [TestClass]
+    [TestCategory("DemoGenerator")]
+    public class DemoInteractiveTests
+    {
+        private static readonly DateTime Now = new DateTime(2026, 9, 1, 13, 45, 30, DateTimeKind.Utc);
+
+        [TestMethod]
+        public void DefaultAnswers_ProduceExactlyTheCommandLineDefaultsAgainstANewTarget()
+        {
+            var prompt = new ScriptedPrompt();
+            var args = DemoInteractive.BuildArgs(prompt, Now);
+
+            var options = DemoOptions.Parse(args, Now);
+            var commandLineDefaults = DemoOptions.Parse(
+                new[] { "--database", "ContosoDemo_Reference", "--as-of", "2026-09-01" }, Now);
+
+            // The fingerprint covers every input that changes the generated data, so one comparison proves
+            // an operator who just presses Enter gets the documented command line's data set.
+            Assert.AreEqual(commandLineDefaults.Fingerprint, options.Fingerprint);
+            Assert.AreEqual(commandLineDefaults.BatchSize, options.BatchSize);
+            Assert.IsFalse(options.Preview);
+            Assert.IsNull(options.Output);
+            Assert.AreEqual("ContosoDemo_20260901_134530", options.Database);
+            Assert.AreEqual(DateTimeKind.Utc, options.AsOf.Kind);
+
+            // --as-of is emitted even though it was never asked for, so the printed line still names the
+            // same window when it is read on a later day.
+            CollectionAssert.Contains(args, "--as-of");
+            CollectionAssert.Contains(args, "2026-09-01");
+            Assert.IsTrue(prompt.Output.Any(line => line.Contains("Tests.FakeDataGen.exe demo --database ContosoDemo_20260901_134530")),
+                "The equivalent command line should be shown before the run starts.");
+        }
+
+        [TestMethod]
+        public void Preview_OmitsTheTargetAndEverySqlOnlyOption()
+        {
+            var args = DemoInteractive.BuildArgs(new ScriptedPrompt("yes"), Now);
+
+            CollectionAssert.Contains(args, "--preview");
+            CollectionAssert.DoesNotContain(args, "--database");
+            CollectionAssert.DoesNotContain(args, "--batch-size");
+            CollectionAssert.DoesNotContain(args, "--no-profiles");
+
+            var options = DemoOptions.Parse(args, Now);
+            Assert.IsTrue(options.Preview);
+            Assert.IsNull(options.Database);
+        }
+
+        [TestMethod]
+        public void UnsafeTargetNames_AreRefusedAndReAskedRatherThanPassedOn()
+        {
+            var args = DemoInteractive.BuildArgs(new ScriptedPrompt(
+                "no", "CustomerProduction", "ContosoDemo_x];DROP DATABASE master;--", "ContosoDemo_Καλημέρα",
+                "ContosoDemo_Good"), Now);
+
+            Assert.AreEqual("ContosoDemo_Good", DemoOptions.Parse(args, Now).Database);
+            Assert.IsFalse(args.Any(a => a.IndexOf("DROP", StringComparison.OrdinalIgnoreCase) >= 0
+                || a.Contains("Customer") || a.Contains("Καλημέρα")));
+        }
+
+        [TestMethod]
+        public void CustomAnswers_ReachTheParsedOptionsAndTheRejectedOnesAreReAsked()
+        {
+            var args = DemoInteractive.BuildArgs(new ScriptedPrompt(
+                "n",                          // preview?
+                "ContosoDemo_Custom",         // target
+                "y",                          // customise?
+                "0", "40",                    // users: below the minimum, then valid
+                "12",                         // skus
+                "30", "35",                   // days: below the minimum, then valid
+                "2026-02-30", "2026-09-01",   // as-of: not a real date, then valid
+                "7",                          // seed
+                "25",                         // copilot percent
+                "50,50", "10,20,30,20,20",    // mix: wrong band count, then valid
+                "n",                          // compile weekly profiles?
+                "10",                         // batch size
+                @"C:\temp\demo summary.json", // JSON summary
+                ""), Now);                    // start now? (default yes)
+
+            var options = DemoOptions.Parse(args, Now);
+            Assert.AreEqual("ContosoDemo_Custom", options.Database);
+            Assert.AreEqual(40, options.Users);
+            Assert.AreEqual(12, options.Skus);
+            Assert.AreEqual(35, options.Days);
+            Assert.AreEqual(new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), options.AsOf);
+            Assert.AreEqual(7, options.Seed);
+            Assert.AreEqual(25, options.CopilotPercent);
+            CollectionAssert.AreEqual(new[] { 10, 20, 30, 20, 20 }, options.Mix);
+            Assert.IsFalse(options.CompileProfiles);
+            Assert.AreEqual(10, options.BatchSize);
+            Assert.AreEqual(@"C:\temp\demo summary.json", options.Output);
+
+            Assert.AreEqual(
+                @"demo --database ContosoDemo_Custom --as-of 2026-09-01 --users 40 --skus 12 --days 35 --seed 7 " +
+                @"--copilot-percent 25 --mix 10,20,30,20,20 --batch-size 10 --no-profiles --output ""C:\temp\demo summary.json""",
+                "demo " + DemoInteractive.CommandLine(args));
+        }
+
+        [TestMethod]
+        public void CommandLine_QuotesValuesThatAreNotPlainIdentifiersNumbersOrPaths()
+        {
+            Assert.AreEqual("--mix 30,35,20,8,7", DemoInteractive.CommandLine(new[] { "--mix", "30,35,20,8,7" }));
+            Assert.AreEqual(@"--database ContosoDemo_Example", DemoInteractive.CommandLine(new[] { "--database", "ContosoDemo_Example" }));
+            Assert.AreEqual("--output \"C:\\Exports\\R&D.json\"",
+                DemoInteractive.CommandLine(new[] { "--output", @"C:\Exports\R&D.json" }));
+            Assert.AreEqual("--output \"C:\\Exports\\demo summary.json\"",
+                DemoInteractive.CommandLine(new[] { "--output", @"C:\Exports\demo summary.json" }));
+        }
+
+        [TestMethod]
+        public void SummaryPathStartingWithADash_IsReAskedSoTheBuiltArgumentsStillParse()
+        {
+            var answers = new List<string> { "n", "ContosoDemo_Output", "y" };
+            // Accept the default for users, SKUs, days, as-of, seed, Copilot percent, mix,
+            // weekly profiles and batch size, which leaves only the summary path to answer.
+            answers.AddRange(Enumerable.Repeat(string.Empty, 9));
+            answers.Add("--summary.json");
+            answers.Add(@"C:\temp\summary.json");
+
+            var args = DemoInteractive.BuildArgs(new ScriptedPrompt(answers.ToArray()), Now);
+
+            // A value starting with "--" is read by the parser as the next option, so passing it on would
+            // build an argument list that DemoCommand then refuses.
+            Assert.AreEqual(@"C:\temp\summary.json", DemoOptions.Parse(args, Now).Output);
+            CollectionAssert.DoesNotContain(args, "--summary.json");
+        }
+
+        [TestMethod]
+        public void DecliningTheConfirmation_GeneratesNothing()
+        {
+            Assert.IsNull(DemoInteractive.BuildArgs(new ScriptedPrompt("n", "", "n", "n"), Now));
+        }
+
+        [TestMethod]
+        public void DefaultTargetName_IsAlwaysAValidTargetAndFollowsTheClock()
+        {
+            var first = DemoInteractive.DefaultDatabaseName(Now);
+            var second = DemoInteractive.DefaultDatabaseName(Now.AddSeconds(1));
+            Assert.IsTrue(DemoOptions.IsValidDatabaseName(first));
+            Assert.IsTrue(DemoOptions.IsValidDatabaseName(second));
+            Assert.AreNotEqual(first, second);
+        }
+
+        /// <summary>
+        /// Answers the questions from a fixed script. Once the script is exhausted it returns null, which is
+        /// what <c>Console.ReadLine</c> returns at end of input, so every prompt falls back to its default
+        /// instead of looping forever.
+        /// </summary>
+        private sealed class ScriptedPrompt : IDemoPrompt
+        {
+            private readonly Queue<string> _answers;
+            public List<string> Output { get; } = new List<string>();
+
+            public ScriptedPrompt(params string[] answers) => _answers = new Queue<string>(answers);
+
+            public void Write(string message) => Output.Add(message);
+
+            public string Ask(string question) => _answers.Count > 0 ? _answers.Dequeue() : null;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="CopilotDroppedAuditFieldsTests.cs" />
     <Compile Include="DemoGeneratorTests.cs" />
     <Compile Include="DemoGeneratorSqlTests.cs" />
+    <Compile Include="DemoInteractiveTests.cs" />
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoCalendar.cs">
       <Link>DemoGenerator\DemoCalendar.cs</Link>
     </Compile>
@@ -165,6 +166,9 @@
     </Compile>
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoGenerator.cs">
       <Link>DemoGenerator\DemoGenerator.cs</Link>
+    </Compile>
+    <Compile Include="..\Tests.FakeDataGen\Demo\DemoInteractive.cs">
+      <Link>DemoGenerator\DemoInteractive.cs</Link>
     </Compile>
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoOptions.cs">
       <Link>DemoGenerator\DemoOptions.cs</Link>


### PR DESCRIPTION
## Problem

The rounded synthetic demo data set could only be produced non-interactively:

```
Tests.FakeDataGen.exe demo --database ContosoDemo_Example [--users N --skus N --days N ...]
```

Running `Tests.FakeDataGen.exe` normally shows an interactive menu that did **not**
list it at all, so the demo generator was effectively undiscoverable without reading
the source or knowing to type `demo --help`. The menu's own data generators are the
older random-scatter ones, which produce importer-shaped volume rather than a
demonstrable tenant.

## Change

Adds `Demo/DemoInteractive.cs`, an interactive front end for the **same** generator,
registered as the first `DATA GENERATION` menu item in `Program.cs`.

It is deliberately only a question sequence. The argument list it builds is handed to
the existing `DemoCommand.Run(args)`, so parsing, validation, the LocalDB-only target
rule, the `ContosoDemo_` name restriction, the refusal of unmarked/changed targets and
the read-only no-op on an identical rerun stay in one place and cannot drift between
the two entry points. Nothing about the generator, the schema or the emitted data
changes.

Flow (fast path is menu `1` then Enter x4):

```
Preview only (count the rows, write no SQL at all)? [y/N]:
New database name [ContosoDemo_20260908_091936]:
Customise the data set (size, history, seed, licence mix)? [y/N]:

About to generate:
  Target             ContosoDemo_20260908_091936 (new database on (localdb)\MSSQLLocalDB)
  Users / SKUs       1,000 / 50
  History            180 days ending 2026-09-08 (exclusive)
  ...
Equivalent command line: Tests.FakeDataGen.exe demo --database ContosoDemo_20260908_091936 --as-of 2026-09-08 --users 1000 --skus 50 --days 180 --seed 42 --copilot-percent 60 --mix 30,35,20,8,7 --batch-size 250

Start generating now? [Y/n]:
```

Answering `y` to *Customise* exposes every remaining flag: users, SKUs, days, as-of,
seed, Copilot licence percentage, activity mix, weekly profile compilation, SQL batch
size and a JSON summary path.

## Architecture / code notes for reviewers

- **`IDemoPrompt` / `ConsoleDemoPrompt`** isolate console I/O, so the question sequence
  and the argument list it produces are unit-testable without a console.
- **The menu item does not call `RequireConnectionString`.** The demo always creates its
  own new LocalDB database and ignores the connection string the tool was started with;
  the no-connection-string banner now says so.
- **`DemoOptions` gains internal consts** for the accepted ranges, the date format and
  the target-name regex, plus `IsValidDatabaseName`, so the prompts validate against the
  same values `Parse` enforces rather than a second copy of the numbers. The extracted
  literals are byte-for-byte the previous inline values; the existing
  `Options_RejectUnsafeTargetsAndInvalidOrDuplicateFlags` still passes unchanged.
- **`DemoInteractive.cs` is registered in both projects** - as `<Compile>` in
  `Tests.FakeDataGen.csproj`, and *linked* into `Tests.UnitTests.csproj`, matching how
  the other `Demo/*.cs` sources are already consumed by the tests.

Prompt behaviours that are load-bearing rather than cosmetic:

| Behaviour | Why |
| --- | --- |
| Every prompt treats `Console.ReadLine` returning `null` as "take the default" | End of redirected/exhausted input would otherwise spin a re-ask loop forever |
| The summary-path prompt re-asks on a value starting with `--` | `DemoOptions.Parse` reads such a token as the *next option*, so passing it on would build an argument list it then refuses ("Missing value for --output") |
| `--as-of` is emitted even when it was never asked for | It otherwise defaults to the clock, so the printed line would name a different window when read on a later day |
| The default target name is timestamped | Demo targets are never reset, so a fixed default would collide on the second run |
| `CommandLine` quotes values that are not plain identifiers, numbers or paths | A copied line must survive spaces and command separators (`C:\Exports\R&D.json` splits at `&` in cmd). Display only - the generator is handed the argument array, and this is explicitly *not* an escaping contract: a shell still expands `$var` / `%VAR%` inside double quotes |

## Safety

No target-safety rule is relaxed. Unsafe names are re-asked, never forwarded -
`UnsafeTargetNames_AreRefusedAndReAskedRatherThanPassedOn` feeds
`CustomerProduction`, `ContosoDemo_x];DROP DATABASE master;--` and a non-ASCII name and
asserts none of them reaches the argument list. There is still no reset option and no
path to a configured production connection.

## Tests

8 new tests in `Tests.UnitTests/DemoInteractiveTests.cs`:

- `DefaultAnswers_ProduceExactlyTheCommandLineDefaultsAgainstANewTarget` - compares the
  **fingerprint** of the menu's all-defaults options against the CLI's, which covers
  every input that changes generated data in one assertion.
- `Preview_OmitsTheTargetAndEverySqlOnlyOption`
- `UnsafeTargetNames_AreRefusedAndReAskedRatherThanPassedOn`
- `CustomAnswers_ReachTheParsedOptionsAndTheRejectedOnesAreReAsked` - also pins the
  exact rendered command line
- `CommandLine_QuotesValuesThatAreNotPlainIdentifiersNumbersOrPaths`
- `SummaryPathStartingWithADash_IsReAskedSoTheBuiltArgumentsStillParse`
- `DecliningTheConfirmation_GeneratesNothing`
- `DefaultTargetName_IsAlwaysAValidTargetAndFollowsTheClock`

Local run: 27 passed / 1 skipped (the opt-in `RUN_DEMO_SCALE` benchmark) across
`DemoInteractiveTests`, `DemoGeneratorTests` and `DemoGeneratorSqlTests`.

**Manual end-to-end verification.** Drove the built exe through the new menu option
twice: once in preview, and once against a real new LocalDB database. The SQL run
applied the schema, wrote 16,994 source rows, compiled 3 complete weekly Power BI
profiling weeks, reported `Status=Complete`, and produced the **same fingerprint** as
the preview run with the same inputs - i.e. the menu path and the command line generate
the identical data set. The temporary database was then dropped via the generator's
ownership marker.

## Schema / config

None. No migrations, no `Create DB.sql` change, no `CONFIG_VERSION` change - this is a
test-tooling console app only. `DemoOptions.FormatVersion` is deliberately **not**
bumped: the generated data shape is unchanged, so previously completed demo targets
remain valid no-ops.

## Docs

`Tests.FakeDataGen/README.md` documents the new option, and corrects the menu listing
and stress-test numbering, which were already stale before this change (the menu was
missing the Copilot prompt-history generator and the Copilot Adoption perf test).

## Review

Reviewed by three models over four rounds until a round returned clean. Findings fixed
along the way: the `--output` value starting with `--`, shell-metacharacter quoting in
the printed command line, and three doc/comment statements that over-claimed
reproducibility.

Addresses the gap reported by @sambetts: the demo data set was not reachable from the
normal interactive menu.
