### PR TITLE
Reword Licence activity for its audience and drop the LicenceActivity.ReadUsers role

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/ILicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/ILicenceActivityStore.cs
@@ -43,17 +43,20 @@ namespace Common.Entities.LicenceActivity
     public static class LicenceActivityRules
     {
         public const string Method =
-            "Activity bands describe the share of observed reporting samples with activity: zero = none, "
-            + "low = below 25%, moderate = 25% to below 75%, high = at least 75%. "
-            + "Incomplete evidence is unknown, not zero. Counts are workload-specific snapshot averages, not daily events.";
+            "Activity levels describe how much of the measured period someone was active in: "
+            + "No activity = never, Low = under a quarter, Moderate = a quarter to under three quarters, "
+            + "High = three quarters or more. Where the period could not be measured in full the level is "
+            + "Unknown, not zero.";
 
         public const string AssignmentCaveat =
-            "Historical activity is shown against currently imported licence assignments, not historical ownership. "
-            + "A user can hold several SKUs; summed assignments are not a unique-user total. Assigned seats are not purchased capacity.";
+            "Past activity is shown against who holds each licence today, not who held it at the time. "
+            + "One person can hold several licences, so adding the assignment figures together will count some people twice. "
+            + "Assigned licences are not the same as the number of licences you have bought.";
 
         public const string InterpretationCaveat =
-            "Activity by a licence holder does not prove that this SKU enabled it. These estimates do not measure productivity, "
-            + "ROI or compliance and are not sufficient evidence to remove a licence.";
+            "Activity by someone who holds a licence does not prove that this licence is what enabled it. These figures "
+            + "do not measure productivity, return on investment or compliance, and are not enough on their own to justify "
+            + "removing anyone's licence.";
 
         public static string Band(int activeSamples, int observedSamples, int expectedSamples)
         {
@@ -62,6 +65,141 @@ namespace Common.Entities.LicenceActivity
             if (activeSamples == 0) return "zero";
             if ((long)activeSamples * 4 < expectedSamples) return "low";
             return (long)activeSamples * 4 < (long)expectedSamples * 3 ? "moderate" : "high";
+        }
+
+        /// <summary>
+        /// Where a workload's figures came from, named the way a business reader or Microsoft 365
+        /// administrator would recognise it.
+        ///
+        /// <see cref="LicenceActivityCoverage.Source"/> carries a STABLE IDENTIFIER (<c>LicenceActivitySql.M365ReportSource</c>
+        /// and friends) because both the coverage SQL and <c>LicenceActivityReadModel.IsOfficialReport</c>
+        /// match on it. Those identifiers are Graph API names, and this report is read by business
+        /// leaders and M365 admins, so they are translated here at the point of display. Anything
+        /// unrecognised is returned unchanged, so a new source degrades to showing its identifier
+        /// rather than disappearing.
+        ///
+        /// Mirrored in the portal by <c>components/licenceActivity/sources.ts</c>, exactly as the
+        /// coverage status vocabulary is mirrored by <c>statuses.ts</c>.
+        /// </summary>
+        public static string SourceLabel(string source)
+        {
+            switch (source)
+            {
+                case LicenceActivitySql.M365ReportSource: return "Microsoft 365 usage reports";
+                case LicenceActivitySql.CopilotReportSource: return "Microsoft 365 Copilot usage report";
+                case LicenceActivitySql.CopilotAuditSource: return "Copilot audit log";
+                case LicenceActivitySql.CopilotInteractionSource: return "Copilot chat history";
+                default: return source;
+            }
+        }
+
+        /// <summary>How often that source was read, in plain English. See <see cref="SourceLabel"/>.</summary>
+        public static string GranularityLabel(string granularity)
+        {
+            switch (granularity)
+            {
+                case "weeklySupportingSnapshot": return "one reading per week";
+                case "singleRollingWindow": return "a single rolling report";
+                case "weeklySampleOfRolling7DayReport": return "one 7-day report read per week";
+                case "eventPositiveOnly": return "recorded activity only";
+                case "unknown": return "not applicable";
+                default: return granularity;
+            }
+        }
+
+        /// <summary>
+        /// The notes shown above the report. Defined here because there are TWO paths that build an
+        /// overview - <c>SqlLicenceActivityStore</c> (direct) and <c>LicenceActivityReadModel</c> (the
+        /// cached path the controller actually uses) - and they previously carried duplicate copies of
+        /// these strings, so a wording fix applied to one silently missed production.
+        /// </summary>
+        public static class Notes
+        {
+            public const string NoLicences = "No licences have been imported yet.";
+
+            public const string NobodyHoldsALicence =
+                "Licences have been imported, but nobody in this selection currently holds one.";
+
+            public const string NoDisplayNames =
+                "Staff names aren't collected by this product, so people are listed by their sign-in address. "
+                + "Search also checks their stored email address.";
+
+            public const string DemographicsCapped =
+                "The department and country breakdowns show only the 50 largest of each.";
+
+            public const string RankingMethod =
+                "The most and least active lists rank people by how often they were active in the chosen service, "
+                + "then by their average activity, then by when they were last active. In the most active list, "
+                + "people with recorded activity across a fully measured period come first, then people with "
+                + "recorded activity whose period was only partly measured, then people measured across the whole "
+                + "period as doing nothing at all. Anyone whose activity could not be measured is left out of the "
+                + "least active list rather than being assumed inactive.";
+
+            public const string NobodyRankable =
+                "Nobody could be ranked for this service and date range: there is no recorded activity, and no "
+                + "complete measurement proving there was none.";
+
+            /// <summary>A per-service coverage note, prefixed with the service's display name.</summary>
+            public static string ForService(string workload, string message)
+            {
+                return WorkloadLabel(workload) + ": " + message;
+            }
+        }
+
+        /// <summary>
+        /// A Microsoft 365 service name as a reader would recognise it ("teams" -> "Teams"). The raw
+        /// value is the backend workload key, which the SQL, the read model and the portal all match on.
+        /// Mirrors <c>WORKLOADS</c> in the portal's <c>types/licenceActivity.ts</c>.
+        /// </summary>
+        public static string WorkloadLabel(string workload)
+        {
+            switch (workload)
+            {
+                case "teams": return "Teams";
+                case "outlook": return "Outlook";
+                case "onedrive": return "OneDrive";
+                case "sharepoint": return "SharePoint";
+                case "copilot": return "Copilot";
+                default: return workload;
+            }
+        }
+
+        /// <summary>
+        /// The coverage/evidence status, spelled out for a business reader. Mirrors the portal's
+        /// <c>components/licenceActivity/statuses.ts</c>; the raw value is a backend vocabulary word
+        /// (<c>available | partial | missingCoverage | unmatchableIdentity | notImported | disabled</c>)
+        /// that both the SQL and the read model compare on, so it is translated only for display.
+        /// </summary>
+        public static string StatusLabel(string status)
+        {
+            switch (status)
+            {
+                case "available": return "Available";
+                case "partial": return "Partial";
+                case "missingCoverage": return "Missing coverage";
+                case "unmatchableIdentity": return "Identities could not be matched";
+                case "notImported": return "Not imported";
+                case "disabled": return "Import switched off";
+                case "unknown": return "Unknown";
+                default: return status;
+            }
+        }
+
+        /// <summary>
+        /// An activity level, spelled out for a business reader. Mirrors the portal's
+        /// <c>components/licenceActivity/bands.ts</c>. The raw value is what <see cref="Band"/> returns.
+        /// </summary>
+        public static string BandLabel(string band)
+        {
+            switch (band)
+            {
+                case "high": return "High";
+                case "moderate": return "Moderate";
+                case "low": return "Low";
+                case "zero": return "No activity";
+                case "unknown": return "Unknown";
+                default: return band;
+            }
         }
     }
 }

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityModels.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityModels.cs
@@ -9,7 +9,6 @@ namespace Common.Entities.LicenceActivity
     public sealed class LicenceActivityAvailability
     {
         public bool Available { get; set; }
-        public bool CanViewUsers { get; set; }
         public int MinimumDays { get; set; } = LicenceActivityQuery.MinimumDays;
         public int MaximumDays { get; set; } = LicenceActivityQuery.MaximumDays;
         public List<string> Messages { get; set; } = new List<string>();

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityReadModel.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityReadModel.cs
@@ -262,18 +262,17 @@ namespace Common.Entities.LicenceActivity
             overview.Countries = ProjectDemographics(countries, cancellationToken);
 
             if (overview.Licences.Count == 0)
-                overview.Messages.Add("No imported licence types are available.");
+                overview.Messages.Add(LicenceActivityRules.Notes.NoLicences);
             else if (overview.DistinctAssignedUsers == 0)
-                overview.Messages.Add("Licence types are imported, but no users in the selected scope currently hold one.");
-            overview.Messages.Add(
-                "User display names are not imported by this solution. Individual results use the user principal name; search also checks the stored mail address.");
+                overview.Messages.Add(LicenceActivityRules.Notes.NobodyHoldsALicence);
+            overview.Messages.Add(LicenceActivityRules.Notes.NoDisplayNames);
             foreach (var item in overview.Coverage.Where(item => item.Status != LicenceActivitySql.Available))
             {
                 if (!string.IsNullOrWhiteSpace(item.Message))
-                    overview.Messages.Add(item.Workload + ": " + item.Message);
+                    overview.Messages.Add(LicenceActivityRules.Notes.ForService(item.Workload, item.Message));
             }
             if (overview.DemographicsTruncated)
-                overview.Messages.Add("Department or country breakdowns are limited to the 50 largest values.");
+                overview.Messages.Add(LicenceActivityRules.Notes.DemographicsCapped);
             cancellationToken.ThrowIfCancellationRequested();
             return overview;
         }
@@ -534,13 +533,12 @@ namespace Common.Entities.LicenceActivity
 
         private void AddUserMessages(LicenceActivityUsers result, string workload)
         {
-            result.Messages.Add(
-                "Most/least lists rank the selected workload by active supporting samples, then average actions and last activity. Complete positive measurements rank before partial positive evidence, which still ranks above measured zero; unknown or incomplete evidence is excluded from least-active.");
+            result.Messages.Add(LicenceActivityRules.Notes.RankingMethod);
             var selected = _coverage[WorkloadIndex(workload)];
             if (selected.Status != LicenceActivitySql.Available && !string.IsNullOrWhiteSpace(selected.Message))
                 result.Messages.Add(selected.Message);
             if (result.TotalUsers > 0 && result.RankedUsers == 0)
-                result.Messages.Add("No user has complete or positive evidence for the selected workload and range.");
+                result.Messages.Add(LicenceActivityRules.Notes.NobodyRankable);
         }
 
         private EvidenceState Evidence(int workload, int userIndex)

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -41,22 +41,22 @@ namespace Common.Entities.LicenceActivity
 
             AppendM365Overview(
                 sql, Teams, "teams", "dbo.teams_user_activity_log",
-                "average published message and meeting counters across supporting snapshots",
+                "Teams messages and meetings counted by Microsoft, averaged across the readings",
                 sources.UsageReports);
 
             AppendM365Overview(
                 sql, Outlook, "outlook", "dbo.outlook_user_activity_log",
-                "average published sent and read counters across supporting snapshots",
+                "emails sent and read counted by Microsoft, averaged across the readings",
                 sources.UsageReports);
 
             AppendM365Overview(
                 sql, OneDrive, "onedrive", "dbo.onedrive_user_activity_log",
-                "average published viewed-or-edited counter across supporting snapshots",
+                "files viewed or edited counted by Microsoft, averaged across the readings",
                 sources.UsageReports);
 
             AppendM365Overview(
                 sql, SharePoint, "sharepoint", "dbo.sharepoint_user_activity_log",
-                "average published viewed-or-edited counter across supporting snapshots",
+                "files viewed or edited counted by Microsoft, averaged across the readings",
                 sources.UsageReports);
 
             if (sources.UsageReports) sql.Append(M365OverviewScores);
@@ -159,13 +159,13 @@ OPTION (RECOMPILE);";
             var sql = new StringBuilder(18000);
             AppendOverviewPartPreamble(sql, eligibleTable);
             AppendM365Overview(sql, Teams, "teams", "dbo.teams_user_activity_log",
-                "average published message and meeting counters across supporting snapshots", sources.UsageReports);
+                "Teams messages and meetings counted by Microsoft, averaged across the readings", sources.UsageReports);
             AppendM365Overview(sql, Outlook, "outlook", "dbo.outlook_user_activity_log",
-                "average published sent and read counters across supporting snapshots", sources.UsageReports);
+                "emails sent and read counted by Microsoft, averaged across the readings", sources.UsageReports);
             AppendM365Overview(sql, OneDrive, "onedrive", "dbo.onedrive_user_activity_log",
-                "average published viewed-or-edited counter across supporting snapshots", sources.UsageReports);
+                "files viewed or edited counted by Microsoft, averaged across the readings", sources.UsageReports);
             AppendM365Overview(sql, SharePoint, "sharepoint", "dbo.sharepoint_user_activity_log",
-                "average published viewed-or-edited counter across supporting snapshots", sources.UsageReports);
+                "files viewed or edited counted by Microsoft, averaged across the readings", sources.UsageReports);
             AppendCopilotOverview(sql, sources, includeScores: false);
             sql.Append(@"
 SELECT workload_name AS Workload, status AS Status, source AS Source,
@@ -231,7 +231,7 @@ FROM #Scores;");
                     case Teams:
                         AppendM365Overview(
                             sql, Teams, "teams", "dbo.teams_user_activity_log",
-                            "average published message and meeting counters across supporting snapshots",
+                            "Teams messages and meetings counted by Microsoft, averaged across the readings",
                             true);
                         AppendM365OverviewScore(
                             sql, Teams, "dbo.teams_user_activity_log");
@@ -239,7 +239,7 @@ FROM #Scores;");
                     case Outlook:
                         AppendM365Overview(
                             sql, Outlook, "outlook", "dbo.outlook_user_activity_log",
-                            "average published sent and read counters across supporting snapshots",
+                            "emails sent and read counted by Microsoft, averaged across the readings",
                             true);
                         AppendM365OverviewScore(
                             sql, Outlook, "dbo.outlook_user_activity_log");
@@ -247,7 +247,7 @@ FROM #Scores;");
                     case OneDrive:
                         AppendM365Overview(
                             sql, OneDrive, "onedrive", "dbo.onedrive_user_activity_log",
-                            "average published viewed-or-edited counter across supporting snapshots",
+                            "files viewed or edited counted by Microsoft, averaged across the readings",
                             true);
                         AppendM365OverviewScore(
                             sql, OneDrive, "dbo.onedrive_user_activity_log");
@@ -255,7 +255,7 @@ FROM #Scores;");
                     case SharePoint:
                         AppendM365Overview(
                             sql, SharePoint, "sharepoint", "dbo.sharepoint_user_activity_log",
-                            "average published viewed-or-edited counter across supporting snapshots",
+                            "files viewed or edited counted by Microsoft, averaged across the readings",
                             true);
                         AppendM365OverviewScore(
                             sql, SharePoint, "dbo.sharepoint_user_activity_log");
@@ -284,7 +284,7 @@ FROM #Scores;");
                 case Teams:
                     AppendM365Overview(
                         sql, Teams, "teams", "dbo.teams_user_activity_log",
-                        "average published message and meeting counters across supporting snapshots",
+                        "Teams messages and meetings counted by Microsoft, averaged across the readings",
                         true);
                     AppendM365OverviewScore(
                         sql, Teams, "dbo.teams_user_activity_log", maximumSamples);
@@ -292,7 +292,7 @@ FROM #Scores;");
                 case Outlook:
                     AppendM365Overview(
                         sql, Outlook, "outlook", "dbo.outlook_user_activity_log",
-                        "average published sent and read counters across supporting snapshots",
+                        "emails sent and read counted by Microsoft, averaged across the readings",
                         true);
                     AppendM365OverviewScore(
                         sql, Outlook, "dbo.outlook_user_activity_log", maximumSamples);
@@ -300,7 +300,7 @@ FROM #Scores;");
                 case OneDrive:
                     AppendM365Overview(
                         sql, OneDrive, "onedrive", "dbo.onedrive_user_activity_log",
-                        "average published viewed-or-edited counter across supporting snapshots",
+                        "files viewed or edited counted by Microsoft, averaged across the readings",
                         true);
                     AppendM365OverviewScore(
                         sql, OneDrive, "dbo.onedrive_user_activity_log", maximumSamples);
@@ -308,7 +308,7 @@ FROM #Scores;");
                 case SharePoint:
                     AppendM365Overview(
                         sql, SharePoint, "sharepoint", "dbo.sharepoint_user_activity_log",
-                        "average published viewed-or-edited counter across supporting snapshots",
+                        "files viewed or edited counted by Microsoft, averaged across the readings",
                         true);
                     AppendM365OverviewScore(
                         sql, SharePoint, "dbo.sharepoint_user_activity_log", maximumSamples);
@@ -1084,7 +1084,7 @@ VALUES
 (
     {0}, '{1}', 'disabled', 'microsoftGraphUsageReport',
     N'{2}', 'weeklySupportingSnapshot',
-    N'The Microsoft 365 usage-report import is disabled. Absence cannot be interpreted as zero.',
+    N'The Microsoft 365 usage-report import is switched off, so nothing can be measured for this service. That is not the same as nobody using it.',
     NULL, NULL, NULL, 0, NULL, @expected{0}, 0, 0
 );
 ",
@@ -1142,10 +1142,10 @@ INSERT #Coverage
 SELECT {0}, '{2}', @status{0}, 'microsoftGraphUsageReport',
        N'{3}', 'weeklySupportingSnapshot',
        CASE @status{0}
-           WHEN 'available' THEN N'One settled report-date snapshot was sampled per calendar week. Frequency uses same-week last_activity_date only. Published counters are averaged as snapshot evidence and are never summed or relabelled as daily events. These tables store report dates, not an import-completion timestamp.'
-           WHEN 'partial' THEN N'At least one requested Monday-week portion lacks a settled snapshot on its exact end date. Earlier snapshots are as-of evidence only; all bands remain unknown and no user is ranked least-active.'
-           WHEN 'notImported' THEN N'The import is enabled but this workload has not stored a report yet.'
-           ELSE N'No settled report snapshot covers this requested range.'
+           WHEN 'available' THEN N'One of Microsoft''s published readings was taken for each week in the period. Someone counts as active in a week only if Microsoft recorded activity for them in that same week. The published counts are averaged across the readings, never added up and never presented as a daily total.'
+           WHEN 'partial' THEN N'At least one week in the period has no reading on its end date. Earlier readings are still shown as evidence, but activity levels stay Unknown and nobody is listed as least active for this service.'
+           WHEN 'notImported' THEN N'Collection is switched on for this service, but no report has arrived yet.'
+           ELSE N'No published reading covers the dates you selected.'
        END,
        MIN(CAST(CASE WHEN sampled_week.week_start < @from
                      THEN @from ELSE sampled_week.week_start END AS datetime)),
@@ -1276,9 +1276,10 @@ END;
                 var initialStatus = sources.CopilotAudit || sources.CopilotInteractions
                     ? NotImported
                     : Disabled;
+                // Interpolated into N'{2}' below, so these must not contain an apostrophe.
                 var initialMessage = sources.CopilotAudit || sources.CopilotInteractions
-                    ? "The enabled Copilot event source has not stored evidence in this range."
-                    : "Every per-user Copilot source is disabled.";
+                    ? "Collection is switched on for Copilot, but no Copilot activity has arrived for these dates yet."
+                    : "Copilot collection is switched off on this deployment, so nothing can be measured. That is not the same as nobody using Copilot.";
 
                 sql.AppendFormat(
                     CultureInfo.InvariantCulture,
@@ -1311,7 +1312,7 @@ IF @copilotNeedsFallback = 1
 BEGIN
     SET @copilotPreferredStatus = 'missingCoverage';
     SET @copilotPreferredMessage =
-        N'Copilot audit data exists, but no event falls in the requested range; absence cannot be interpreted as zero.';
+        N'Copilot audit records exist, but none fall inside the dates you selected. That is not the same as nobody using Copilot.';
 END;
 ");
                 if (sources.CopilotInteractions)
@@ -1324,7 +1325,7 @@ BEGIN
     SET @copilotPreferredStatus = 'missingCoverage';
     SET @copilotPreferredSource = 'copilotInteractions';
     SET @copilotPreferredMessage =
-        N'Copilot interaction history exists, but no event falls in the requested range; absence cannot be interpreted as zero.';
+        N'Copilot chat history exists, but none of it falls inside the dates you selected. That is not the same as nobody using Copilot.';
 END;
 ");
                 }
@@ -1337,7 +1338,7 @@ IF @copilotNeedsFallback = 1
 BEGIN
     SET @copilotPreferredStatus = 'missingCoverage';
     SET @copilotPreferredMessage =
-        N'Copilot interaction history exists, but no event falls in the requested range; absence cannot be interpreted as zero.';
+        N'Copilot chat history exists, but none of it falls inside the dates you selected. That is not the same as nobody using Copilot.';
 END;
 ");
             }
@@ -1354,7 +1355,7 @@ BEGIN
     VALUES
     (
         5, 'copilot', @copilotPreferredStatus, @copilotPreferredSource,
-        N'positive Copilot evidence only', 'unknown',
+        N'recorded Copilot activity only', 'unknown',
         @copilotPreferredMessage, NULL, NULL, @copilotLatestImport, 0, NULL,
         (SELECT COUNT(*) FROM #Weeks), 0,
         @copilotUnmatched
@@ -1521,12 +1522,12 @@ DECLARE @copilotPreferredSource varchar(64) = 'microsoftGraphCopilotUsageReport'
 DECLARE @copilotPreferredMessage nvarchar(800) =
     CASE
         WHEN @copilotLogObfuscated = 1
-            THEN N'The official Copilot report concealed every user identity, so it cannot be joined to licence holders.'
+            THEN N'Microsoft''s Copilot usage report hid every person''s identity, so its activity cannot be tied back to the people holding the licence. To fix this, turn off ''Display concealed user, group and site names in all reports'' in the Microsoft 365 admin centre (Settings > Org settings > Reports).'
         WHEN @copilotLogImported IS NULL
-            THEN N'The official per-user Copilot usage report has not been imported.'
+            THEN N'Microsoft''s per-person Copilot usage report has never been collected on this deployment.'
         WHEN @copilotLogError IS NOT NULL
-            THEN N'The latest official per-user Copilot report import failed; absence cannot be interpreted as zero.'
-        ELSE N'No fully-contained official Copilot report window covers the requested range.'
+            THEN N'The last attempt to collect Microsoft''s per-person Copilot usage report failed, so Copilot activity is unknown rather than zero.'
+        ELSE N'None of Microsoft''s Copilot usage reports fits entirely inside the dates you selected.'
     END;
 DECLARE @copilotLatestImport datetime = @copilotLogImported;
 DECLARE @copilotUnmatched int =
@@ -1605,11 +1606,11 @@ BEGIN
             report_period_days, expected_samples, observed_samples, unmatched_users
         )
         SELECT 5, 'copilot', @copilotPreferredStatus, 'microsoftGraphCopilotUsageReport',
-               N'average prompts in sampled rolling 7-day reports',
+               N'Copilot prompts counted by Microsoft, averaged across the readings',
                'weeklySampleOfRolling7DayReport',
                CASE WHEN @copilotPreferredStatus = 'available'
-                    THEN N'The latest settled, fully-contained D7 report was sampled once per calendar week; overlapping counts are averaged, never summed. Missing user rows and rows without v2 counters remain unknown. The official report covers Copilot-licensed users only.'
-                    ELSE N'At least one requested D7 window lacks a settled snapshot on its exact end date. Earlier snapshots are as-of evidence only; all bands remain unknown and no user is ranked least-active.'
+                    THEN N'Microsoft''s most recent 7-day Copilot report was read once per week; where those reports overlap the counts are averaged, never added up. People Microsoft did not list, and older reports that predate the current counters, stay Unknown. Microsoft only reports on people who hold a Copilot licence.'
+                    ELSE N'At least one week in the period has no Copilot reading on its end date. Earlier readings are still shown as evidence, but activity levels stay Unknown and nobody is listed as least active for Copilot.'
                END,
                CAST(@copilotD7EffectiveFrom AS datetime),
                CAST(@copilotD7EffectiveTo AS datetime),
@@ -1718,11 +1719,11 @@ BEGIN
             VALUES
             (
                 5, 'copilot', @copilotPreferredStatus, 'microsoftGraphCopilotUsageReport',
-                N'prompts and active usage days in one rolling report',
+                N'Copilot prompts and days used, from one rolling report',
                 'singleRollingWindow',
                 CASE WHEN @copilotPreferredStatus = 'available'
-                     THEN N'The requested dates exactly match one official rolling Copilot report window. Missing user rows and rows without active_usage_days remain unknown. The official report covers Copilot-licensed users only.'
-                     ELSE N'The source only has a longer rolling window inside the request. Its evidence is shown with the exact effective dates, but bands remain unknown for the custom range.'
+                     THEN N'The dates you selected match one of Microsoft''s rolling Copilot reports exactly. People Microsoft did not list, and reports that do not record days used, stay Unknown. Microsoft only reports on people who hold a Copilot licence.'
+                     ELSE N'Microsoft only published a longer rolling report inside the dates you selected. It is shown here with the dates it really covers, but activity levels stay Unknown for your custom range.'
                 END,
                 DATEADD(DAY, 1 - @copilotLongPeriod, CAST(@copilotLongDate AS datetime)),
                 CAST(@copilotLongDate AS datetime),
@@ -1782,8 +1783,8 @@ BEGIN
              THEN 'unmatchableIdentity' ELSE 'partial' END;
     SET @copilotPreferredMessage =
         CASE WHEN @copilotPreferredStatus = 'unmatchableIdentity'
-             THEN N'The official report identities are concealed. Audit events provide positive evidence, but their absence is not a measured zero.'
-             ELSE N'Copilot audit events provide positive evidence only; no database signal proves complete event coverage, so absent users remain unknown.'
+             THEN N'Microsoft''s Copilot report hid every person''s identity, so Copilot audit records are used instead. They prove who DID use Copilot, but cannot prove that anybody else did not.'
+             ELSE N'Copilot audit records prove who DID use Copilot, but nothing confirms that every Copilot event was captured, so anyone absent stays Unknown rather than inactive.'
         END;
 
     IF @copilotIncludeScores = 1
@@ -1820,7 +1821,7 @@ BEGIN
         report_period_days, expected_samples, observed_samples, unmatched_users
     )
     SELECT 5, 'copilot', @copilotPreferredStatus, 'copilotAudit',
-           N'interactions per active calendar week', 'eventPositiveOnly',
+           N'Copilot use counted per active week', 'eventPositiveOnly',
            @copilotPreferredMessage, MIN(time_stamp), MAX(time_stamp),
            NULL,
            DATEDIFF(DAY, MAX(CAST(time_stamp AS date)), @now),
@@ -1846,8 +1847,8 @@ BEGIN
              THEN 'unmatchableIdentity' ELSE 'partial' END;
     SET @copilotPreferredMessage =
         CASE WHEN @copilotPreferredStatus = 'unmatchableIdentity'
-             THEN N'The official report identities are concealed. Interaction history provides positive evidence, but its absence is not a measured zero.'
-             ELSE N'Copilot interaction history provides positive evidence only; no database signal proves complete history for every user, so absent users remain unknown.'
+             THEN N'Microsoft''s Copilot report hid every person''s identity, so Copilot chat history is used instead. It proves who DID use Copilot, but cannot prove that anybody else did not.'
+             ELSE N'Copilot chat history proves who DID use Copilot, but nothing confirms the history is complete for everybody, so anyone absent stays Unknown rather than inactive.'
         END;
 
     IF @copilotIncludeScores = 1
@@ -1884,7 +1885,7 @@ BEGIN
         report_period_days, expected_samples, observed_samples, unmatched_users
     )
     SELECT 5, 'copilot', @copilotPreferredStatus, 'copilotInteractions',
-           N'interaction rows per active calendar week', 'eventPositiveOnly',
+           N'Copilot activity counted per active week', 'eventPositiveOnly',
            @copilotPreferredMessage, MIN(created_utc), MAX(created_utc),
            (SELECT MAX(run_finished_utc) FROM dbo.copilot_interaction_import_log),
            CASE WHEN MAX(CAST(created_utc AS date)) IS NULL THEN 0

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityWorkbook.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityWorkbook.cs
@@ -16,36 +16,38 @@ namespace Common.Entities.LicenceActivity
 
             using (var book = new XlsxWriter())
             {
-                var report = book.AddSheet("Snapshot").SetColumnWidths(32, 40, 100);
+                var report = book.AddSheet("Summary").SetColumnWidths(32, 40, 100);
                 report.AddTitle("Microsoft 365 licence activity");
                 report.AddHeaderRow("Property", "Value", "Meaning");
-                report.AddRow("Overview generated (UTC)", overview.GeneratedUtc.ToString("O"), "The values displayed on screen; export does not re-query the database.");
-                report.AddRow("Requested from (UTC)", overview.Query.From, "Inclusive UTC date.");
-                report.AddRow("Requested to (UTC)", overview.Query.To, "Inclusive UTC date; actual source coverage is on the Workload coverage sheet.");
-                report.AddRow("Department filter ID", overview.Query.DepartmentId, "Blank = all; 0 = unknown metadata.");
-                report.AddRow("Country filter ID", overview.Query.CountryId, "Blank = all; 0 = unknown metadata.");
-                report.AddRow("Distinct assigned users", overview.DistinctAssignedUsers, "Unique people across the selected demographic population.");
-                report.AddRow("Demographics truncated", overview.DemographicsTruncated, "Only the largest demographic groups are displayed when the bound is reached.");
-                report.AddRow("Current assignments", null, XlsxCell.Wrapped(LicenceActivityRules.AssignmentCaveat));
-                report.AddRow("Interpretation", null, XlsxCell.Wrapped(LicenceActivityRules.InterpretationCaveat));
-                report.AddRow("Activity bands", null, XlsxCell.Wrapped(LicenceActivityRules.Method));
+                report.AddRow("Report prepared (UTC)", overview.GeneratedUtc.ToString("O"), "The figures shown on screen; exporting does not re-run the report.");
+                report.AddRow("From (UTC)", overview.Query.From, "First day included.");
+                report.AddRow("To (UTC)", overview.Query.To, "Last day included; the dates each source represents are on the \"Where the figures come from\" sheet.");
+                report.AddRow("Department filter", overview.Query.DepartmentId, "Blank = all departments; 0 = people with no department recorded.");
+                report.AddRow("Country filter", overview.Query.CountryId, "Blank = all countries; 0 = people with no country recorded.");
+                report.AddRow("People holding a licence", overview.DistinctAssignedUsers, "Each person counted once across the selected population.");
+                report.AddRow("Department/country lists capped", overview.DemographicsTruncated, "TRUE means only the largest departments and countries are listed.");
+                report.AddRow("Who holds each licence", null, XlsxCell.Wrapped(LicenceActivityRules.AssignmentCaveat));
+                report.AddRow("How to read this", null, XlsxCell.Wrapped(LicenceActivityRules.InterpretationCaveat));
+                report.AddRow("Activity levels", null, XlsxCell.Wrapped(LicenceActivityRules.Method));
                 foreach (var message in overview.Messages) report.AddRow("Note", null, XlsxCell.Wrapped(message));
 
                 var licences = book.AddSheet("Licences");
-                licences.AddHeaderRow("Licence", "SKU ID", "Assigned users", "Workload", "High", "Moderate", "Low", "No activity", "Unknown");
+                licences.AddHeaderRow("Licence", "Licence code", "People assigned", "Service", "High", "Moderate", "Low", "No activity", "Unknown");
                 foreach (var sku in overview.Licences)
                     foreach (var distribution in sku.Workloads)
-                        licences.AddRow(sku.Name, sku.SkuId, sku.AssignedUsers, distribution.Workload,
+                        licences.AddRow(sku.Name, sku.SkuId, sku.AssignedUsers, LicenceActivityRules.WorkloadLabel(distribution.Workload),
                             distribution.High, distribution.Moderate, distribution.Low, distribution.Zero, distribution.Unknown);
                 FormatTable(licences, 9);
-                report.AddRow("Licence sheet", null, "One row per SKU and workload. Assigned users repeat across workloads; do not sum this column.");
+                report.AddRow("Licences sheet", null, "One row per licence and service. The \"People assigned\" figure repeats on each of that licence's rows, so do not add that column up.");
 
-                var coverage = book.AddSheet("Workload coverage");
-                coverage.AddHeaderRow("Workload", "Status", "Source", "Measure", "Granularity", "Effective from (UTC)",
-                    "Effective through (UTC)", "Latest import (UTC)", "Lag days", "Report period days", "Observed samples",
-                    "Expected samples", "Unmatched users", "Snapshot dates (UTC)", "Notes");
+                var coverage = book.AddSheet("Where the figures come from");
+                coverage.AddHeaderRow("Service", "Data", "Source", "What was measured", "How often it was measured", "Data from (UTC)",
+                    "Data to (UTC)", "Last imported (UTC)", "Days old", "Days each report covers", "Measurements taken",
+                    "Measurements expected", "People who couldn't be matched", "Dates measured (UTC)", "Notes");
                 foreach (var source in overview.Coverage)
-                    coverage.AddRow(source.Workload, source.Status, source.Source, source.Measure, source.Granularity,
+                    coverage.AddRow(LicenceActivityRules.WorkloadLabel(source.Workload),
+                        LicenceActivityRules.StatusLabel(source.Status), LicenceActivityRules.SourceLabel(source.Source),
+                        source.Measure, LicenceActivityRules.GranularityLabel(source.Granularity),
                         source.EffectiveFromUtc, source.EffectiveToUtc, source.LatestImportUtc, source.LagDays,
                         source.ReportPeriodDays, source.ObservedSamples, source.ExpectedSamples, source.UnmatchedUsers,
                         string.Join(", ", source.SnapshotDates.Select(d => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))),
@@ -60,33 +62,46 @@ namespace Common.Entities.LicenceActivity
                         || users.LeastActive.Count > LicenceActivityQuery.MaximumRows
                         || users.Users.Count > LicenceActivityQuery.MaximumRows)
                         throw new ArgumentException("User snapshot exceeds the export row limit.", nameof(users));
-                    report.AddRow("Users generated (UTC)", users.GeneratedUtc.ToString("O"), "Current bounded lists and browse page, not the entire assigned population.");
+                    report.AddRow("People list prepared (UTC)", users.GeneratedUtc.ToString("O"), "The lists and page currently on screen, not everyone holding the licence.");
                     report.AddRow("Selected licence ID", users.Query.LicenceTypeId);
-                    report.AddRow("Ranking workload", users.Query.Workload, "Workloads are not combined into a score.");
-                    report.AddRow("Most/least count", users.Query.Top);
+                    report.AddRow("Ranked by service", LicenceActivityRules.WorkloadLabel(users.Query.Workload), "Services are never combined into a single score.");
+                    report.AddRow("Size of each list", users.Query.Top);
                     report.AddRow("Search", users.Query.Search);
-                    report.AddRow("Browse sort", users.Query.Sort + " " + users.Query.Direction);
-                    report.AddRow("Browse page", users.Query.Page);
-                    report.AddRow("Page size", users.Query.PageSize);
-                    report.AddRow("Matching users", users.TotalUsers);
-                    report.AddRow("Users with rankable evidence", users.RankedUsers, "Missing evidence is excluded from least-active ranking.");
-                    foreach (var message in users.Messages) report.AddRow("User note", null, XlsxCell.Wrapped(message));
+                    report.AddRow("Sorted by", SortLabel(users.Query.Sort, users.Query.Direction));
+                    report.AddRow("Page", users.Query.Page);
+                    report.AddRow("People per page", users.Query.PageSize);
+                    report.AddRow("People matching", users.TotalUsers);
+                    report.AddRow("People who can be ranked", users.RankedUsers, "Anyone without enough evidence is left out of the least-active list.");
+                    foreach (var message in users.Messages) report.AddRow("Note about people", null, XlsxCell.Wrapped(message));
                     WriteUsers(book, "Most active", users.MostActive);
                     WriteUsers(book, "Least active", users.LeastActive);
-                    WriteUsers(book, "User page", users.Users);
+                    WriteUsers(book, "People page", users.Users);
                 }
-                else report.AddRow("Individual users", "Not included", "Aggregate-only snapshot.");
+                else report.AddRow("Individual people", "Not included", "Totals only.");
                 return book.ToArray();
+            }
+        }
+
+        /// <summary>The browse ordering, worded as the drop-down on screen words it.</summary>
+        private static string SortLabel(string sort, string direction)
+        {
+            var descending = string.Equals(direction, "desc", StringComparison.OrdinalIgnoreCase);
+            switch (sort)
+            {
+                case "activity": return descending ? "Most active first" : "Least active first";
+                case "lastActivity": return descending ? "Most recently active" : "Longest since active";
+                case "upn": return descending ? "Sign-in address (Z-A)" : "Sign-in address (A-Z)";
+                default: return sort + " " + direction;
             }
         }
 
         private static void WriteDemographics(XlsxWriter book, string name, IEnumerable<LicenceActivityDemographic> groups)
         {
             var sheet = book.AddSheet(name);
-            sheet.AddHeaderRow("Group ID", "Group", "Distinct assigned users", "Workload", "High", "Moderate", "Low", "No activity", "Unknown");
+            sheet.AddHeaderRow("Group ID", "Group", "People assigned", "Service", "High", "Moderate", "Low", "No activity", "Unknown");
             foreach (var group in groups)
                 foreach (var distribution in group.Workloads)
-                    sheet.AddRow(group.Id, group.Name, group.AssignedUsers, distribution.Workload,
+                    sheet.AddRow(group.Id, group.Name, group.AssignedUsers, LicenceActivityRules.WorkloadLabel(distribution.Workload),
                         distribution.High, distribution.Moderate, distribution.Low, distribution.Zero, distribution.Unknown);
             FormatTable(sheet, 9);
         }
@@ -94,13 +109,15 @@ namespace Common.Entities.LicenceActivity
         private static void WriteUsers(XlsxWriter book, string name, IEnumerable<LicenceActivityUser> users)
         {
             var sheet = book.AddSheet(name);
-            sheet.AddHeaderRow("User ID", "UPN", "Department", "Country", "Account enabled",
-                "Workload", "Coverage", "Band", "Source", "Measure", "Active samples", "Observed samples", "Expected samples",
-                "Average actions per observed sample", "Last activity (UTC)");
+            sheet.AddHeaderRow("Person ID", "Sign-in address", "Department", "Country", "Account enabled",
+                "Service", "Data", "Activity", "Source", "What was measured", "Times active", "Measurements taken",
+                "Measurements expected", "Average actions", "Last active (UTC)");
             foreach (var user in users)
                 foreach (var evidence in user.Workloads)
                     sheet.AddRow(user.UserId, user.UserPrincipalName, user.Department, user.Country, user.AccountEnabled,
-                        evidence.Workload, evidence.Status, evidence.Band, evidence.Source, evidence.Measure, evidence.ActiveSamples,
+                        LicenceActivityRules.WorkloadLabel(evidence.Workload), LicenceActivityRules.StatusLabel(evidence.Status),
+                        LicenceActivityRules.BandLabel(evidence.Band), LicenceActivityRules.SourceLabel(evidence.Source),
+                        evidence.Measure, evidence.ActiveSamples,
                         evidence.ObservedSamples, evidence.ExpectedSamples, evidence.AverageActions, evidence.LastActivityUtc);
             FormatTable(sheet, 15);
         }

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
@@ -625,18 +625,17 @@ namespace Common.Entities.LicenceActivity
                     }
 
                     if (overview.Licences.Count == 0)
-                        overview.Messages.Add("No imported licence types are available.");
+                        overview.Messages.Add(LicenceActivityRules.Notes.NoLicences);
                     else if (overview.DistinctAssignedUsers == 0)
-                        overview.Messages.Add("Licence types are imported, but no users in the selected scope currently hold one.");
-                    overview.Messages.Add(
-                        "User display names are not imported by this solution. Individual results use the user principal name; search also checks the stored mail address.");
+                        overview.Messages.Add(LicenceActivityRules.Notes.NobodyHoldsALicence);
+                    overview.Messages.Add(LicenceActivityRules.Notes.NoDisplayNames);
                     foreach (var coverage in overview.Coverage.Where(c => c.Status != LicenceActivitySql.Available))
                     {
                         if (!string.IsNullOrWhiteSpace(coverage.Message))
-                            overview.Messages.Add(coverage.Workload + ": " + coverage.Message);
+                            overview.Messages.Add(LicenceActivityRules.Notes.ForService(coverage.Workload, coverage.Message));
                     }
                     if (overview.DemographicsTruncated)
-                        overview.Messages.Add("Department or country breakdowns are limited to the 50 largest values.");
+                        overview.Messages.Add(LicenceActivityRules.Notes.DemographicsCapped);
                     return overview;
                 }
 
@@ -746,19 +745,18 @@ namespace Common.Entities.LicenceActivity
 
             overview.Messages.Clear();
             if (overview.Licences.Count == 0)
-                overview.Messages.Add("No imported licence types are available.");
+                overview.Messages.Add(LicenceActivityRules.Notes.NoLicences);
             else if (overview.DistinctAssignedUsers == 0)
-                overview.Messages.Add("Licence types are imported, but no users in the selected scope currently hold one.");
-            overview.Messages.Add(
-                "User display names are not imported by this solution. Individual results use the user principal name; search also checks the stored mail address.");
+                overview.Messages.Add(LicenceActivityRules.Notes.NobodyHoldsALicence);
+            overview.Messages.Add(LicenceActivityRules.Notes.NoDisplayNames);
             foreach (var coverage in overview.Coverage.Where(
                 coverage => coverage.Status != LicenceActivitySql.Available))
             {
                 if (!string.IsNullOrWhiteSpace(coverage.Message))
-                    overview.Messages.Add(coverage.Workload + ": " + coverage.Message);
+                    overview.Messages.Add(LicenceActivityRules.Notes.ForService(coverage.Workload, coverage.Message));
             }
             if (overview.DemographicsTruncated)
-                overview.Messages.Add("Department or country breakdowns are limited to the 50 largest values.");
+                overview.Messages.Add(LicenceActivityRules.Notes.DemographicsCapped);
         }
 
         private static OverviewPart DisabledM365Part(int workload, LicenceActivityQuery query)
@@ -770,9 +768,9 @@ namespace Common.Entities.LicenceActivity
                             Workload = LicenceActivitySql.WorkloadName(workload),
                             Status = LicenceActivitySql.Disabled,
                             Source = LicenceActivitySql.M365ReportSource,
-                            Measure = "published usage-report snapshot evidence",
+                            Measure = "counts published by Microsoft",
                             Granularity = "weeklySupportingSnapshot",
-                            Message = "The Microsoft 365 usage-report import is disabled. Absence cannot be interpreted as zero.",
+                            Message = "The Microsoft 365 usage-report import is switched off, so nothing can be measured for this service. That is not the same as nobody using it.",
                             ExpectedSamples = WeekPortionCount(query)
                         }
                     };
@@ -976,21 +974,20 @@ namespace Common.Entities.LicenceActivity
             await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
 
             if (overview.Licences.Count == 0)
-                overview.Messages.Add("No imported licence types are available.");
+                overview.Messages.Add(LicenceActivityRules.Notes.NoLicences);
             else if (overview.DistinctAssignedUsers == 0)
-                overview.Messages.Add("Licence types are imported, but no users in the selected scope currently hold one.");
+                overview.Messages.Add(LicenceActivityRules.Notes.NobodyHoldsALicence);
 
-            overview.Messages.Add(
-                "User display names are not imported by this solution. Individual results use the user principal name; search also checks the stored mail address.");
+            overview.Messages.Add(LicenceActivityRules.Notes.NoDisplayNames);
 
             foreach (var coverage in overview.Coverage.Where(c => c.Status != LicenceActivitySql.Available))
             {
                 if (!string.IsNullOrWhiteSpace(coverage.Message))
-                    overview.Messages.Add(coverage.Workload + ": " + coverage.Message);
+                    overview.Messages.Add(LicenceActivityRules.Notes.ForService(coverage.Workload, coverage.Message));
             }
 
             if (overview.DemographicsTruncated)
-                overview.Messages.Add("Department or country breakdowns are limited to the 50 largest values.");
+                overview.Messages.Add(LicenceActivityRules.Notes.DemographicsCapped);
 
             diagnostics.Stage("ProjectionCompleted");
             return overview;
@@ -1038,8 +1035,7 @@ namespace Common.Entities.LicenceActivity
             }
             await DrainRemainingResultsAsync(reader, cancellationToken).ConfigureAwait(false);
 
-            result.Messages.Add(
-                "Most/least lists rank the selected workload by active supporting samples, then average actions and last activity. Complete positive measurements rank before partial positive evidence, which still ranks above measured zero; unknown or incomplete evidence is excluded from least-active.");
+            result.Messages.Add(LicenceActivityRules.Notes.RankingMethod);
 
             LicenceActivityCoverage selectedCoverage;
             if (coverage.TryGetValue(query.Workload, out selectedCoverage)
@@ -1049,7 +1045,7 @@ namespace Common.Entities.LicenceActivity
                 result.Messages.Add(selectedCoverage.Message);
             }
             if (result.TotalUsers > 0 && result.RankedUsers == 0)
-                result.Messages.Add("No user has complete or positive evidence for the selected workload and range.");
+                result.Messages.Add(LicenceActivityRules.Notes.NobodyRankable);
 
             diagnostics.Stage("ProjectionCompleted");
             return result;

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityApiTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityApiTests.cs
@@ -25,7 +25,7 @@ namespace Tests.UnitTests
     public class LicenceActivityApiTests
     {
         [TestMethod]
-        public async Task AnonymousRequestsAreDenied_AggregatesDoNotRequireTheDetailRole()
+        public async Task AnonymousRequestsAreDenied_ButEverySignedInReaderSeesTheWholeReport()
         {
             using (var app = new Harness())
             {
@@ -33,13 +33,16 @@ namespace Tests.UnitTests
                 Assert.AreEqual(HttpStatusCode.Unauthorized, (await app.Client.GetAsync("api/LicenceActivity/availability")).StatusCode);
                 app.Principal = SignedIn();
                 var availability = await app.Json("api/LicenceActivity/availability");
-                Assert.AreEqual(false, (bool)availability["canViewUsers"]);
                 Assert.AreEqual(true, (bool)availability["available"]);
+                Assert.IsNull(availability["canViewUsers"], "The report has no second permission level to advertise.");
                 var overview = await app.Json("api/LicenceActivity/overview");
                 Assert.IsNotNull(overview["snapshotId"]);
-                Assert.AreEqual(HttpStatusCode.Forbidden,
-                    (await app.Client.GetAsync("api/LicenceActivity/users?overviewId=" + overview["snapshotId"] + "&licenceTypeId=1")).StatusCode);
-                Assert.AreEqual(0, app.Store.UserCalls);
+
+                // A reader holding no application role at all still gets the per-person list: everyone
+                // who can open the portal sees everything this report knows.
+                var users = await app.Client.GetAsync("api/LicenceActivity/users?overviewId=" + overview["snapshotId"] + "&licenceTypeId=1");
+                Assert.AreEqual(HttpStatusCode.OK, users.StatusCode);
+                Assert.AreEqual(1, app.Store.UserCalls);
             }
         }
 
@@ -51,7 +54,10 @@ namespace Tests.UnitTests
                 app.Sources.UserMetadata = false;
                 var availability = await app.Json("api/LicenceActivity/availability");
                 Assert.AreEqual(false, (bool)availability["available"]);
-                StringAssert.Contains(availability["messages"].ToString(), "GraphUsersMetadata");
+                var messages = availability["messages"].ToString();
+                StringAssert.Contains(messages, "user details import");
+                Assert.IsFalse(messages.Contains("GraphUsersMetadata"),
+                    "This report is read by business leaders and M365 admins, so it must not quote internal setting names.");
                 Assert.AreEqual(HttpStatusCode.PreconditionFailed, (await app.Client.GetAsync("api/LicenceActivity/overview")).StatusCode);
                 Assert.AreEqual(0, app.Store.OverviewCalls);
             }
@@ -94,7 +100,6 @@ namespace Tests.UnitTests
                 Assert.AreEqual(HttpStatusCode.BadRequest,
                     (await app.Client.GetAsync("api/LicenceActivity/overview?departmentId=not-an-integer")).StatusCode);
                 Assert.AreEqual(0, app.Store.OverviewCalls);
-                app.Principal = SignedIn(LicenceActivityAPIController.UserDetailRole);
                 var overview = await app.Json("api/LicenceActivity/overview?from=2000-05-02&to=2000-06-22&departmentId=7&countryId=0");
                 var id = (string)overview["snapshotId"];
                 var users = await app.Json("api/LicenceActivity/users?overviewId=" + id + "&licenceTypeId=1&workload=outlook&top=25&search=Contoso&page=2&pageSize=10&sort=activity&direction=desc");
@@ -113,11 +118,10 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
-        public async Task Excel_IsTheCachedCurrentSnapshot_RechecksDetailAccess_AndRefusesExpiry()
+        public async Task Excel_IsTheCachedCurrentReport_AndRefusesExpiry()
         {
             using (var app = new Harness())
             {
-                app.Principal = SignedIn(LicenceActivityAPIController.UserDetailRole);
                 var overview = await app.Json("api/LicenceActivity/overview");
                 var id = (string)overview["snapshotId"];
                 var users = await app.Json("api/LicenceActivity/users?overviewId=" + id + "&licenceTypeId=1");
@@ -130,8 +134,6 @@ namespace Tests.UnitTests
                     Assert.IsNotNull(zip.GetEntry("xl/workbook.xml"));
                 Assert.AreEqual(1, app.Store.OverviewCalls, "Export must not run a fresh overview query.");
                 Assert.AreEqual(1, app.Store.UserCalls, "Export must not run a fresh user query.");
-                app.Principal = SignedIn();
-                Assert.AreEqual(HttpStatusCode.Forbidden, (await app.Client.GetAsync(exportUrl)).StatusCode);
                 Assert.AreEqual(HttpStatusCode.OK, (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + id)).StatusCode);
                 app.Now = app.Now.AddMinutes(6);
                 Assert.AreEqual(HttpStatusCode.Gone, (await app.Client.GetAsync("api/LicenceActivity/export?overviewId=" + id)).StatusCode);
@@ -144,7 +146,6 @@ namespace Tests.UnitTests
         {
             using (var app = new Harness())
             {
-                app.Principal = SignedIn(LicenceActivityAPIController.UserDetailRole);
                 var overview = await app.Json("api/LicenceActivity/overview");
                 var overviewId = (string)overview["snapshotId"];
                 var usersUrl = "api/LicenceActivity/users?overviewId=" + overviewId + "&licenceTypeId=1";

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityHttpHost.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityHttpHost.cs
@@ -48,7 +48,6 @@ namespace Tests.UnitTests
         {
             var identity = new ClaimsIdentity("synthetic-load-test");
             identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "synthetic-administrator"));
-            identity.AddClaim(new Claim(ClaimTypes.Role, LicenceActivityAPIController.UserDetailRole));
             return new ClaimsPrincipal(identity);
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityTests.cs
@@ -24,6 +24,51 @@ namespace Tests.UnitTests
     {
         internal static readonly DateTime Now = new DateTime(2000, 7, 1, 0, 0, 0, DateTimeKind.Utc);
 
+        /// <summary>
+        /// This report is read by business leaders and Microsoft 365 admins, so no backend identifier may
+        /// reach the screen or the Excel export. `source`, `granularity`, `status` and `band` stay stable
+        /// identifiers on the wire (SQL and the read model match on them) and are translated only for
+        /// display, so the translation tables must cover EVERY value the backend can emit. Two of the
+        /// granularities were missed first time round and rendered verbatim as "weeklySampleOfRolling7DayReport".
+        /// The portal mirrors are guarded by CoveragePanel.test.tsx; this guards the Excel path.
+        /// </summary>
+        [TestMethod]
+        public void DisplayLabels_TranslateEveryBackendVocabularyValue_SoNoIdentifierReachesTheReader()
+        {
+            var sources = new[]
+            {
+                "microsoftGraphUsageReport", "microsoftGraphCopilotUsageReport",
+                "copilotAudit", "copilotInteractions"
+            };
+            var granularities = new[]
+            {
+                "weeklySupportingSnapshot", "singleRollingWindow",
+                "weeklySampleOfRolling7DayReport", "eventPositiveOnly", "unknown"
+            };
+            var statuses = new[]
+            {
+                "available", "partial", "missingCoverage",
+                "unmatchableIdentity", "notImported", "disabled", "unknown"
+            };
+            var bands = new[] { "high", "moderate", "low", "zero", "unknown" };
+
+            foreach (var value in sources)
+                Assert.AreNotEqual(value, LicenceActivityRules.SourceLabel(value), "Untranslated source: " + value);
+            foreach (var value in granularities)
+                Assert.AreNotEqual(value, LicenceActivityRules.GranularityLabel(value), "Untranslated granularity: " + value);
+            foreach (var value in statuses)
+                Assert.AreNotEqual(value, LicenceActivityRules.StatusLabel(value), "Untranslated status: " + value);
+            foreach (var value in bands)
+                Assert.AreNotEqual(value, LicenceActivityRules.BandLabel(value), "Untranslated activity level: " + value);
+            foreach (var value in LicenceActivityQuery.Workloads)
+                Assert.AreNotEqual(value, LicenceActivityRules.WorkloadLabel(value), "Untranslated service: " + value);
+
+            // A value the backend has never emitted must still show SOMETHING rather than vanish, so an
+            // unmapped future source degrades to its identifier instead of a blank cell.
+            Assert.AreEqual("somethingNew", LicenceActivityRules.SourceLabel("somethingNew"));
+            Assert.AreEqual("somethingNew", LicenceActivityRules.GranularityLabel("somethingNew"));
+        }
+
         [DataTestMethod]
         [DataRow("x")]
         [DataRow("Καλημέρα κόσμε")]
@@ -145,7 +190,7 @@ namespace Tests.UnitTests
                 Assert.IsFalse(xml.Contains("<f>"), "Tenant text must be inline strings, never spreadsheet formulae.");
                 var workbook = Read(archive.GetEntry("xl/workbook.xml"));
                 StringAssert.Contains(workbook, "Least active");
-                StringAssert.Contains(workbook, "Workload coverage");
+                StringAssert.Contains(workbook, "Where the figures come from");
             }
             using (var archive = new ZipArchive(new MemoryStream(LicenceActivityWorkbook.Build(overview))))
                 Assert.IsFalse(Read(archive.GetEntry("xl/workbook.xml")).Contains("Least active"));

--- a/src/AnalyticsEngine/Web/Controllers/LicenceActivityAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/LicenceActivityAPIController.cs
@@ -5,9 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Security.Claims;
 using System.Security.Cryptography;
-using System.Security.Principal;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,7 +18,6 @@ namespace Web.AnalyticsWeb.Controllers
     [RoutePrefix("api/LicenceActivity")]
     public sealed class LicenceActivityAPIController : ApiController
     {
-        public const string UserDetailRole = "LicenceActivity.ReadUsers";
         private static readonly LicenceActivitySnapshotCache<LicenceActivityOverview> OverviewCache =
             new LicenceActivitySnapshotCache<LicenceActivityOverview>(16, TimeSpan.FromMinutes(5));
         private static readonly LicenceActivitySnapshotCache<LicenceActivityUsers> UsersCache =
@@ -47,12 +44,10 @@ namespace Web.AnalyticsWeb.Controllers
         public IHttpActionResult Availability()
         {
             var sources = _context().Sources;
-            var result = new LicenceActivityAvailability { Available = sources.UserMetadata, CanViewUsers = CanViewUsers(User) };
+            var result = new LicenceActivityAvailability { Available = sources.UserMetadata };
             if (!sources.UserMetadata)
-                result.Messages.Add("Enable GraphUsersMetadata (user metadata) in the installer to import licence-to-user assignments. This tab remains visible while the prerequisite is disabled.");
-            if (!result.CanViewUsers)
-                result.Messages.Add("Individual users require the LicenceActivity.ReadUsers application role. Aggregate reports and aggregate Excel snapshots remain available.");
-            result.Messages.Add("User display names are not imported. Search uses UPN or email; department and country filters use imported metadata.");
+                result.Messages.Add("This report needs the user details import turned on, so that licences can be matched to the people who hold them. Ask whoever installed the product to tick \"User Entra ID extended metadata\" in the installer. The tab stays visible in the meantime.");
+            result.Messages.Add("People are identified by their sign-in address. Staff names are not collected, so search and the user lists show the sign-in address instead. Department and country come from your directory.");
             return Reply(HttpStatusCode.OK, result);
         }
 
@@ -86,12 +81,11 @@ namespace Web.AnalyticsWeb.Controllers
             CancellationToken cancellationToken = default(CancellationToken)) =>
             ExecuteAsync(async () =>
             {
-                if (!CanViewUsers(User)) return ForbiddenUsers();
                 var context = _context();
                 if (!context.Sources.UserMetadata) return MissingMetadata();
                 var overview = _overviews.Find(context.Scope, overviewId);
                 if (!overview.Licences.Any(sku => sku.LicenceTypeId == licenceTypeId))
-                    return Reply(HttpStatusCode.NotFound, new { message = "That licence is not part of this snapshot." });
+                    return Reply(HttpStatusCode.NotFound, new { message = "That licence is not part of the figures currently on screen. Refresh the report and try again." });
                 var query = overview.Query.ForUsers(licenceTypeId, workload, search, sort, direction, top, page, pageSize, context.Sources.NowUtc);
                 var task = _users.GetAsync(context.Scope, overviewId + "\n" + query.CacheKey(), async (diagnostics, lifetime) =>
                 {
@@ -108,13 +102,12 @@ namespace Web.AnalyticsWeb.Controllers
         public Task<IHttpActionResult> Export(string overviewId, string usersId = null) =>
             ExecuteAsync(() =>
             {
-                if (usersId != null && !CanViewUsers(User)) return Task.FromResult(ForbiddenUsers());
                 var context = _context();
                 if (!context.Sources.UserMetadata) return Task.FromResult(MissingMetadata());
                 var overview = _overviews.Find(context.Scope, overviewId);
                 var users = usersId == null ? null : _users.Find(context.Scope, usersId);
                 if (users != null && users.OverviewId != overviewId)
-                    return Task.FromResult(Reply(HttpStatusCode.Conflict, new { message = "The snapshots do not match. Refresh the current view before exporting." }));
+                    return Task.FromResult(Reply(HttpStatusCode.Conflict, new { message = "The summary and the user list are no longer from the same set of figures. Refresh the report before exporting." }));
                 var response = Request.CreateResponse(HttpStatusCode.OK);
                 response.Content = new ByteArrayContent(LicenceActivityWorkbook.Build(overview, users));
                 response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
@@ -126,35 +119,26 @@ namespace Web.AnalyticsWeb.Controllers
                 return Task.FromResult<IHttpActionResult>(ResponseMessage(response));
             });
 
-        internal static bool CanViewUsers(IPrincipal principal)
-        {
-            if (principal?.Identity?.IsAuthenticated != true) return false;
-            if (principal.IsInRole(UserDetailRole)) return true;
-            var claims = principal as ClaimsPrincipal;
-            return claims?.Claims.Any(c => (c.Type == "roles" || c.Type == ClaimTypes.Role)
-                && c.Value == UserDetailRole) == true;
-        }
-
         private async Task<IHttpActionResult> ExecuteAsync(Func<Task<IHttpActionResult>> action)
         {
-            if (!ModelState.IsValid) return Reply(HttpStatusCode.BadRequest, new { message = "The request contains an invalid parameter." });
+            if (!ModelState.IsValid) return Reply(HttpStatusCode.BadRequest, new { message = "That request wasn't valid. Check the selected dates and filters." });
             try { return await action(); }
             catch (ArgumentException ex) { return Reply(HttpStatusCode.BadRequest, new { message = ex.Message }); }
             catch (LicenceActivityExpiredException)
             {
-                return Reply(HttpStatusCode.Gone, new { message = "This snapshot has expired or was evicted. Refresh the current view before continuing or exporting." });
+                return Reply(HttpStatusCode.Gone, new { message = "These figures are no longer being held. Refresh the report to bring back an up-to-date set before continuing or exporting." });
             }
             catch (LicenceActivityReadModelExpiredException)
             {
-                return Reply(HttpStatusCode.Gone, new { message = "The source snapshot expired or was evicted. Refresh the current view before continuing." });
+                return Reply(HttpStatusCode.Gone, new { message = "These figures are no longer being held. Refresh the report to bring back an up-to-date set." });
             }
             catch (LicenceActivityReadModelBusyException)
             {
-                return Reply(HttpStatusCode.ServiceUnavailable, new { message = "Another licence report snapshot is loading. Retry in a few seconds." }, true);
+                return Reply(HttpStatusCode.ServiceUnavailable, new { message = "Another licence report is being prepared right now. Try again in a few seconds." }, true);
             }
             catch (LicenceActivityBusyException)
             {
-                return Reply(HttpStatusCode.ServiceUnavailable, new { message = "Licence reporting is busy. Retry in a few seconds." }, true);
+                return Reply(HttpStatusCode.ServiceUnavailable, new { message = "Licence reporting is busy. Try again in a few seconds." }, true);
             }
             catch (LicenceActivityFailedException ex)
             {
@@ -163,10 +147,7 @@ namespace Web.AnalyticsWeb.Controllers
         }
 
         private IHttpActionResult MissingMetadata() =>
-            Reply(HttpStatusCode.PreconditionFailed, new { message = "Enable GraphUsersMetadata to import licence assignments." });
-
-        private IHttpActionResult ForbiddenUsers() =>
-            Reply(HttpStatusCode.Forbidden, new { message = "Individual licence activity requires the LicenceActivity.ReadUsers application role." });
+            Reply(HttpStatusCode.PreconditionFailed, new { message = "This report needs the user details import turned on, so that licences can be matched to the people who hold them." });
 
         private IHttpActionResult Reply(HttpStatusCode status, object body, bool retry = false)
         {

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/api/licenceActivityApi.ts
@@ -14,11 +14,12 @@ const baseUrl = (): string =>
  * How a Licence-activity request failed, so callers can react to the case rather than a raw status.
  *   - `busy`       503: reporting capacity is busy or a report load failed. This tool does NOT poll;
  *                       the UI offers a manual "Try again".
- *   - `expired`    410/409/404: the cached snapshot the request referenced is gone, superseded, or no
- *                       longer contains that licence. The caller must NOT silently re-query - it must
+ *   - `expired`    410/409/404: the cached figures the request referenced are gone, superseded, or no
+ *                       longer contain that licence. The caller must NOT silently re-query - it must
  *                       tell the user to refresh so the exported file always matches the screen.
- *   - `forbidden`  403: the user lacks the LicenceActivity.ReadUsers role.
- *   - `precondition` 412: the licence import (GraphUsersMetadata) is disabled.
+ *   - `forbidden`  403: sign-in was rejected for this request (e.g. by the site's own access rules).
+ *                       The report itself imposes no extra permission of its own.
+ *   - `precondition` 412: the user details import is switched off on this deployment.
  *   - `badRequest` 400: an invalid parameter (e.g. a range outside 7..180 days).
  *   - `http`       anything else.
  */
@@ -67,11 +68,11 @@ function fallbackMessage(kind: LicenceActivityErrorKind, status: number, what: s
     case 'busy':
       return `The server is busy or could not prepare ${what}. Try again in a moment.`;
     case 'expired':
-      return `This snapshot has expired or was refreshed. Reload to get a current one.`;
+      return `These figures are no longer being held. Refresh the report to bring back an up-to-date set.`;
     case 'forbidden':
-      return `You do not have permission to view ${what}. Individual user detail needs the "LicenceActivity.ReadUsers" role.`;
+      return `You do not have permission to view ${what}.`;
     case 'precondition':
-      return `Licence activity is not available: the licence import is disabled on this deployment.`;
+      return `Licence activity is not available: the user details import is switched off on this deployment.`;
     case 'badRequest':
       return `That request was rejected. Check the selected dates and filters.`;
     default:
@@ -110,7 +111,7 @@ async function getJson<T>(path: string, what: string, signal?: AbortSignal): Pro
   return response.json() as Promise<T>;
 }
 
-/** Which parts of the tool this deployment / signed-in user can see, and the allowed window bounds. */
+/** Which parts of the tool this deployment can show, and the allowed window bounds. */
 export function fetchAvailability(signal?: AbortSignal): Promise<LicenceActivityAvailability> {
   return getJson<LicenceActivityAvailability>('/availability', 'the licence activity availability', signal);
 }
@@ -123,7 +124,7 @@ function overviewQuery(params: OverviewParams): URLSearchParams {
   return qs;
 }
 
-/** The executive overview: SKU assignments, five workload distributions and per-workload coverage. */
+/** The executive overview: licence assignments, five workload distributions and per-workload coverage. */
 export function fetchOverview(params: OverviewParams, signal?: AbortSignal): Promise<LicenceActivityOverview> {
   return getJson<LicenceActivityOverview>(
     `/overview?${overviewQuery(params)}`,
@@ -148,9 +149,8 @@ function usersQuery(params: UsersParams): URLSearchParams {
 }
 
 /**
- * The users snapshot for the selected licence: one request returns the bounded most/least active
- * lists and the current browse page together. Individual user data needs the
- * `LicenceActivity.ReadUsers` role; a caller without it gets a `forbidden` error.
+ * The users list for the selected licence: one request returns the bounded most/least active
+ * lists and the current browse page together.
  */
 export function fetchUsers(params: UsersParams, signal?: AbortSignal): Promise<LicenceActivityUsers> {
   return getJson<LicenceActivityUsers>(`/users?${usersQuery(params)}`, 'the licensed users', signal);

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/CoveragePanel.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/CoveragePanel.test.tsx
@@ -9,7 +9,7 @@ function cov(over: Partial<LicenceActivityCoverage> = {}): LicenceActivityCovera
     workload: 'teams',
     status: 'available',
     source: 'Usage reports',
-    measure: 'reporting samples',
+    measure: 'activity counted by Microsoft',
     granularity: 'weekly',
     message: null,
     effectiveFromUtc: '2026-04-22T00:00:00Z',
@@ -28,7 +28,7 @@ function cov(over: Partial<LicenceActivityCoverage> = {}): LicenceActivityCovera
 const NOW = new Date('2026-05-20T12:00:00Z');
 
 describe('CoveragePanel', () => {
-  it('renders each backend status with a friendly label and shows the snapshot lifetime', () => {
+  it('renders each backend status with a friendly label and shows how long the figures last', () => {
     renderWithProvider(
       <CoveragePanel
         generatedUtc="2026-05-20T10:00:00Z"
@@ -47,13 +47,13 @@ describe('CoveragePanel', () => {
     expect(screen.getByText('Available')).toBeInTheDocument();
     expect(screen.getByText('Partial')).toBeInTheDocument();
     expect(screen.getByText('Missing coverage')).toBeInTheDocument();
-    expect(screen.getByText('Unmatchable identity')).toBeInTheDocument();
+    expect(screen.getByText('Identities could not be matched')).toBeInTheDocument();
     expect(screen.getByText('Not imported')).toBeInTheDocument();
 
-    // Sources/coverage are explicit: workloads, source and snapshot lifetime are all shown.
+    // Sources/coverage are explicit: services, source and how long the figures last are all shown.
     expect(screen.getByText('Teams')).toBeInTheDocument();
     expect(screen.getAllByText(/Usage reports/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/generated/i)).toBeInTheDocument();
+    expect(screen.getByText(/prepared/i)).toBeInTheDocument();
   });
 
   it('labels a disabled import distinctly', () => {
@@ -65,6 +65,44 @@ describe('CoveragePanel', () => {
         coverage={[cov({ workload: 'teams', status: 'disabled' })]}
       />,
     );
-    expect(screen.getByText('Import disabled')).toBeInTheDocument();
+    expect(screen.getByText('Import switched off')).toBeInTheDocument();
+  });
+
+  it('translates every backend source and sampling identifier into plain English', () => {
+    // Every `granularity` the coverage SQL can emit. A camelCase identifier reaching this panel is the
+    // exact defect this report was fixed for, so the guard covers all of them, not just the M365 one.
+    const granularities = [
+      'weeklySupportingSnapshot',
+      'weeklySampleOfRolling7DayReport',
+      'eventPositiveOnly',
+      'singleRollingWindow',
+      'unknown',
+    ];
+    renderWithProvider(
+      <CoveragePanel
+        generatedUtc="2026-05-20T10:00:00Z"
+        expiresUtc="2026-05-20T10:05:00Z"
+        now={NOW}
+        coverage={[
+          cov({ workload: 'teams', source: 'microsoftGraphUsageReport', granularity: granularities[0] }),
+          cov({ workload: 'outlook', source: 'microsoftGraphCopilotUsageReport', granularity: granularities[1] }),
+          cov({ workload: 'onedrive', source: 'copilotAudit', granularity: granularities[2] }),
+          cov({ workload: 'sharepoint', source: 'copilotInteractions', granularity: granularities[3] }),
+          cov({ workload: 'copilot', source: 'microsoftGraphCopilotUsageReport', granularity: granularities[4] }),
+        ]}
+      />,
+    );
+
+    for (const id of granularities) {
+      expect(screen.queryByText(new RegExp(id))).not.toBeInTheDocument();
+    }
+    for (const id of ['microsoftGraphUsageReport', 'microsoftGraphCopilotUsageReport', 'copilotAudit', 'copilotInteractions']) {
+      expect(screen.queryByText(new RegExp(id))).not.toBeInTheDocument();
+    }
+    expect(screen.getByText(/Microsoft 365 usage reports/)).toBeInTheDocument();
+    expect(screen.getByText(/one reading per week/)).toBeInTheDocument();
+    expect(screen.getByText(/one 7-day report read per week/)).toBeInTheDocument();
+    expect(screen.getByText(/Copilot audit log/)).toBeInTheDocument();
+    expect(screen.getByText(/Copilot chat history/)).toBeInTheDocument();
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/CoveragePanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/CoveragePanel.tsx
@@ -3,6 +3,7 @@ import type { LicenceActivityCoverage, WorkloadKey } from '../../types/licenceAc
 import { WORKLOADS } from '../../types/licenceActivity';
 import { DASH, formatAge, formatDate, formatDateTime, formatMaybeCount } from './format';
 import { statusMeta } from './statuses';
+import { granularityLabel, sourceLabel } from './sources';
 
 const useStyles = makeStyles({
   card: {
@@ -76,12 +77,13 @@ interface CoveragePanelProps {
 }
 
 /**
- * States, per workload, exactly which import fed the figures and how fresh and complete it is.
+ * States, per Microsoft 365 service, exactly where the figures came from and how fresh and complete
+ * they are.
  *
- * This is load-bearing, not decoration: a workload's distribution can legitimately be all "Unknown"
- * because its source was not imported or did not cover some users, and the reader needs to see that
- * cause here rather than mistake it for an absence of activity. Every field the backend provides -
- * source, measure, freshness, sample counts, unmatched users, and the raw status - is shown.
+ * This is load-bearing, not decoration: a service's chart can legitimately be all "Unknown" because
+ * its source was never imported or did not cover some people, and the reader needs to see that cause
+ * here rather than mistake it for an absence of activity. Every field the backend provides - source,
+ * measure, freshness, reading counts, unmatched people and the status - is shown.
  */
 export default function CoveragePanel({ generatedUtc, expiresUtc, coverage, now }: CoveragePanelProps) {
   const styles = useStyles();
@@ -90,17 +92,17 @@ export default function CoveragePanel({ generatedUtc, expiresUtc, coverage, now 
     <Card className={styles.card}>
       <div className={styles.head}>
         <Text size={200} weight="semibold" className={styles.title}>
-          Data sources &amp; coverage
+          Where these figures come from
         </Text>
         <Text size={200} className={styles.generated}>
-          Snapshot generated {formatDateTime(generatedUtc)} ({formatAge(generatedUtc, now)}); expires{' '}
+          Prepared {formatDateTime(generatedUtc)} ({formatAge(generatedUtc, now)}); held for up to{' '}
           {formatDateTime(expiresUtc)}
         </Text>
       </div>
 
       {coverage.length === 0 ? (
         <Text size={200} className={styles.sub}>
-          No per-workload coverage was reported for this snapshot.
+          No source information was reported for these figures.
         </Text>
       ) : (
         <div className={styles.grid}>
@@ -116,26 +118,29 @@ export default function CoveragePanel({ generatedUtc, expiresUtc, coverage, now 
               </div>
 
               <Text size={200} className={styles.line}>
-                Source: {entry.source || DASH}
+                Source: {sourceLabel(entry.source) || DASH}
                 {entry.measure ? ` \u00b7 ${entry.measure}` : ''}
-                {entry.granularity ? ` (${entry.granularity})` : ''}
+                {entry.granularity ? ` \u00b7 ${granularityLabel(entry.granularity)}` : ''}
               </Text>
 
               <Text size={100} className={styles.sub}>
-                Imported {formatDate(entry.latestImportUtc)}
-                {entry.lagDays > 0 ? ` \u00b7 ${entry.lagDays}d lag` : ''}
-                {entry.reportPeriodDays ? ` \u00b7 ${entry.reportPeriodDays}d period` : ''}
+                Last imported {formatDate(entry.latestImportUtc)}
+                {entry.lagDays > 0 ? ` \u00b7 most recent data is ${entry.lagDays} days old` : ''}
+                {entry.reportPeriodDays ? ` \u00b7 covers ${entry.reportPeriodDays} days` : ''}
               </Text>
 
               <Text size={100} className={styles.sub}>
-                Covers {formatDate(entry.effectiveFromUtc)}
+                Data from {formatDate(entry.effectiveFromUtc)}
                 {' \u2013 '}
                 {formatDate(entry.effectiveToUtc)}
               </Text>
 
               <Text size={100} className={styles.sub}>
-                {formatMaybeCount(entry.observedSamples)} / {formatMaybeCount(entry.expectedSamples)} samples
-                {entry.unmatchedUsers > 0 ? ` \u00b7 ${entry.unmatchedUsers.toLocaleString()} unmatched` : ''}
+                {formatMaybeCount(entry.observedSamples)} of {formatMaybeCount(entry.expectedSamples)} measurements
+                taken
+                {entry.unmatchedUsers > 0
+                  ? ` \u00b7 ${entry.unmatchedUsers.toLocaleString()} people couldn't be matched`
+                  : ''}
               </Text>
 
               {entry.message && (

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DemographicBreakdown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DemographicBreakdown.test.tsx
@@ -45,7 +45,7 @@ describe('DemographicBreakdown', () => {
     renderWithProvider(
       <DemographicBreakdown title="By country" segmentLabel="Country" rows={[demo()]} truncated />,
     );
-    expect(screen.getByText(/truncated/i)).toBeInTheDocument();
+    expect(screen.getByText(/not the full list/i)).toBeInTheDocument();
   });
 
   it('caps at 50 rows and says so', () => {
@@ -53,6 +53,6 @@ describe('DemographicBreakdown', () => {
     renderWithProvider(
       <DemographicBreakdown title="By department" segmentLabel="Department" rows={many} truncated={false} />,
     );
-    expect(screen.getByText(/top 50/i)).toBeInTheDocument();
+    expect(screen.getByText(/Showing only the 50 largest/i)).toBeInTheDocument();
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DemographicBreakdown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DemographicBreakdown.tsx
@@ -72,7 +72,8 @@ function DemographicBreakdown({ title, segmentLabel, rows, truncated }: Demograp
           {title}
         </Text>
         <Text size={200} className={styles.muted}>
-          Assigned users and per-workload activity by {segmentLabel.toLowerCase()}, largest first.
+          People assigned a licence and how much they use each service, by {segmentLabel.toLowerCase()}, largest
+          first.
         </Text>
         <BandLegend />
       </div>
@@ -80,8 +81,8 @@ function DemographicBreakdown({ title, segmentLabel, rows, truncated }: Demograp
       {capped && (
         <MessageBar intent="info">
           <MessageBarBody>
-            Showing the top {formatCount(shown.length)} {segmentLabel.toLowerCase()} by assigned users; the full list
-            is truncated.
+            Showing only the {formatCount(shown.length)} largest by number of people assigned &mdash; this is not the
+            full list.
           </MessageBarBody>
         </MessageBar>
       )}
@@ -91,7 +92,7 @@ function DemographicBreakdown({ title, segmentLabel, rows, truncated }: Demograp
           <thead className={styles.stickyHead}>
             <tr>
               <th className={table.th}>{segmentLabel}</th>
-              <th className={`${table.th} ${table.thNumeric}`}>Assigned</th>
+              <th className={`${table.th} ${table.thNumeric}`}>People assigned</th>
               {WORKLOADS.map((w) => (
                 <th key={w.key} className={table.th}>
                   {w.label}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SkuAssignments.tsx
@@ -111,7 +111,7 @@ function SkuAssignments({ licences, selectedLicenceTypeId, onSelect }: SkuAssign
   if (licences.length === 0) {
     return (
       <Card className={styles.card}>
-        <Text className={styles.muted}>No licence assignments were found for this scope.</Text>
+        <Text className={styles.muted}>No licence assignments were found for this selection.</Text>
       </Card>
     );
   }
@@ -124,7 +124,7 @@ function SkuAssignments({ licences, selectedLicenceTypeId, onSelect }: SkuAssign
             Licence assignments
           </Text>
           <Text size={200} className={styles.muted}>
-            Select a licence to see its workload activity and, with the required role, who holds it.
+            Select a licence to see how much each service is used, and who holds it.
             {showFilter ? ` Showing ${formatCount(visible.length)} of ${formatCount(licences.length)}.` : ''}
           </Text>
         </div>
@@ -132,7 +132,7 @@ function SkuAssignments({ licences, selectedLicenceTypeId, onSelect }: SkuAssign
           <Input
             className={styles.filter}
             value={filter}
-            placeholder="Filter by name or SKU"
+            placeholder="Filter by licence name or code"
             aria-label="Filter licences"
             onChange={(_e, d) => setFilter(d.value)}
           />
@@ -146,7 +146,7 @@ function SkuAssignments({ licences, selectedLicenceTypeId, onSelect }: SkuAssign
           <thead className={showFilter ? styles.stickyHead : undefined}>
             <tr>
               <th className={table.th}>Licence</th>
-              <th className={`${table.th} ${table.thNumeric}`}>Assigned users</th>
+              <th className={`${table.th} ${table.thNumeric}`}>People assigned</th>
               {WORKLOADS.map((w) => (
                 <th key={w.key} className={table.th}>
                   {w.label}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.test.tsx
@@ -141,7 +141,7 @@ describe('UsersDrillDown', () => {
       pageSize: 50,
     });
 
-    const topInput = screen.getByLabelText('Number of users in each list');
+    const topInput = screen.getByLabelText('Number of people in each list');
     fireEvent.change(topInput, { target: { value: '25' } });
     fireEvent.blur(topInput);
     await waitFor(() => expect(lastParams()).toMatchObject({ top: 25 }));
@@ -154,7 +154,7 @@ describe('UsersDrillDown', () => {
   it('changes the workload', async () => {
     renderDrill();
     await waitFor(() => expect(mockUsers).toHaveBeenCalled());
-    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    fireEvent.change(screen.getByLabelText('Service'), { target: { value: 'outlook' } });
     await waitFor(() => expect(lastParams()).toMatchObject({ workload: 'outlook' }));
   });
 
@@ -308,7 +308,7 @@ describe('UsersDrillDown', () => {
     await waitFor(() => expect(mockUsers).toHaveBeenCalled());
 
     // Move well away from the defaults: a non-default workload, sort and search, then page 2.
-    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    fireEvent.change(screen.getByLabelText('Service'), { target: { value: 'outlook' } });
     await waitFor(() => expect(lastParams()).toMatchObject({ workload: 'outlook', page: 1 }));
     fireEvent.change(screen.getByLabelText('Sort users'), { target: { value: 'upn:asc' } });
     await waitFor(() => expect(lastParams()).toMatchObject({ sort: 'upn', direction: 'asc' }));

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersDrillDown.tsx
@@ -38,8 +38,8 @@ const BROWSE_SORTS: { value: string; label: string }[] = [
   { value: 'activity:asc', label: 'Least active first' },
   { value: 'lastActivity:desc', label: 'Most recently active' },
   { value: 'lastActivity:asc', label: 'Longest since active' },
-  { value: 'upn:asc', label: 'UPN (A\u2013Z)' },
-  { value: 'upn:desc', label: 'UPN (Z\u2013A)' },
+  { value: 'upn:asc', label: 'Sign-in address (A\u2013Z)' },
+  { value: 'upn:desc', label: 'Sign-in address (Z\u2013A)' },
 ];
 
 const useStyles = makeStyles({
@@ -145,7 +145,7 @@ function TopCountInput({ value, onCommit, disabled }: { value: number; onCommit:
       max={MAX_TOP}
       value={text}
       disabled={disabled}
-      aria-label="Number of users in each list"
+      aria-label="Number of people in each list"
       onChange={(_e, d) => setText(d.value)}
       onBlur={commit}
       onKeyDown={(e) => {
@@ -175,14 +175,13 @@ interface UsersDrillDownProps {
   /** Reports the snapshot id of the loaded users list, for the exact-snapshot export. Null while
    *  loading / on error. Should be a stable reference. */
   onUsersSnapshot: (usersId: string | null) => void;
-  /** Reloads the overview - the correct fix when a users request fails because the snapshot expired. */
+  /** Reloads the overview - the correct fix when a users request fails because the figures it
+   *  referenced are no longer held. */
   onRefreshOverview: () => void;
-  /** Rechecks detail permission after a current users request is forbidden. */
-  onForbidden?: () => void;
-  /** Bumped by the parent to force a fresh users fetch (re-mint) even when the params are otherwise
+  /** Bumped by the parent to force a fresh users fetch even when the params are otherwise
    *  unchanged - e.g. after an export 410, when the overview is still cached under the same id so the
    *  params never change on their own. A same-key reload keeps the current rows on screen while the
-   *  new snapshot loads. Undefined/0 means "no forced refresh yet". */
+   *  new list loads. Undefined/0 means "no forced refresh yet". */
   refreshToken?: number;
 }
 
@@ -198,7 +197,6 @@ export default function UsersDrillDown({
   coverage,
   onUsersSnapshot,
   onRefreshOverview,
-  onForbidden,
   refreshToken,
 }: UsersDrillDownProps) {
   const styles = useStyles();
@@ -233,8 +231,8 @@ export default function UsersDrillDown({
   const workloadCoverage = coverage.find((c) => c.workload === workload) ?? null;
   const coverageIncomplete = workloadCoverage != null && workloadCoverage.status !== 'available';
   const rankEmptyText = coverageIncomplete
-    ? `${workloadLabel} activity is not fully measured, so users can't be ranked here - see the note above.`
-    : 'No users to rank for this workload.';
+    ? `${workloadLabel} activity isn't fully measured, so people can't be ranked here - see the note above.`
+    : 'Nobody can be ranked for this service.';
 
   // Reset the page atomically when the scope (licence / workload / browse filter) changes, DURING
   // render - so `params` never briefly pairs a new scope with the old page, which would fire a wasted
@@ -293,12 +291,7 @@ export default function UsersDrillDown({
   }, [data?.snapshotId, onUsersSnapshot]);
 
   const errorKind = describeError(error, '').kind;
-  useEffect(() => {
-    if (errorKind === 'forbidden') onForbidden?.();
-  }, [errorKind, onForbidden]);
-
-  const retry = errorKind === 'expired' ? onRefreshOverview
-    : errorKind === 'forbidden' && onForbidden ? onForbidden : reload;
+  const retry = errorKind === 'expired' ? onRefreshOverview : reload;
 
   return (
     <Card className={styles.card}>
@@ -308,16 +301,16 @@ export default function UsersDrillDown({
             {licenceName(licence)}
           </Text>
           <Text size={200} className={styles.muted}>
-            {formatCount(licence.assignedUsers)} users hold this licence. Choose a workload to rank them by its
-            activity.
+            {formatCount(licence.assignedUsers)} people hold this licence. Choose a service to rank them by how much they
+            use it.
           </Text>
         </div>
         <div className={styles.controls}>
           <div className={styles.field}>
             <Text size={200} className={styles.muted}>
-              Workload
+              Service
             </Text>
-            <Select value={workload} aria-label="Workload" onChange={(_e, d) => setWorkload(d.value as WorkloadKey)}>
+            <Select value={workload} aria-label="Service" onChange={(_e, d) => setWorkload(d.value as WorkloadKey)}>
               {WORKLOADS.map((w) => (
                 <option key={w.key} value={w.key}>
                   {w.label}
@@ -339,14 +332,14 @@ export default function UsersDrillDown({
             appearance="subtle"
             icon={<ArrowClockwise16Regular />}
             onClick={reload}
-            aria-label="Refresh users"
+            aria-label="Refresh the list"
           >
             Refresh
           </Button>
         </div>
       </div>
 
-      {error != null && <ApiErrorBar error={error} fallback="Couldn't load the users." onRetry={retry} />}
+      {error != null && <ApiErrorBar error={error} fallback="Couldn't load the people holding this licence." onRetry={retry} />}
 
       {/* A failed load unmounts the browse controls below (they live inside `data && ...`), which
           would otherwise strand an admin whose SEARCH TERM caused the failure: every surviving
@@ -374,8 +367,8 @@ export default function UsersDrillDown({
               {workloadLabel}: {statusMeta(workloadCoverage.status).label}.
             </strong>{' '}
             {statusMeta(workloadCoverage.status).explanation}
-            {workloadCoverage.message ? ` ${workloadCoverage.message}` : ''} Users with positive evidence still appear
-            as most active; nobody is ranked least active for this workload.
+            {workloadCoverage.message ? ` ${workloadCoverage.message}` : ''} People with recorded activity still appear
+            as most active; nobody is listed as least active for this service.
           </MessageBarBody>
         </MessageBar>
       )}
@@ -394,7 +387,7 @@ export default function UsersDrillDown({
 
       {loading && !data && (
         <div className={styles.center}>
-          <Spinner size="small" label="Loading users..." />
+          <Spinner size="small" label="Loading people..." />
         </div>
       )}
 
@@ -440,16 +433,16 @@ export default function UsersDrillDown({
           <div className={styles.browse}>
             <div className={styles.panelHead}>
               <Text weight="semibold" size={300}>
-                Browse all
+                Everyone with this licence
               </Text>
               <Text size={200} className={styles.muted}>
-                {formatCount(data.totalUsers)} users
+                {formatCount(data.totalUsers)} people
               </Text>
             </div>
 
             <Text size={100} className={styles.muted}>
-              User display names are not imported; search uses UPN or email. This is a deliberate limitation, not a
-              missing name.
+              Staff names aren&apos;t collected by this product, so people are listed and searched by their sign-in
+              address.
             </Text>
 
             <div className={styles.browseControls}>
@@ -457,7 +450,7 @@ export default function UsersDrillDown({
                 className={styles.grow}
                 value={searchDraft}
                 maxLength={MAX_SEARCH}
-                placeholder="Search UPN or email"
+                placeholder="Search by sign-in address"
                 aria-label="Search users"
                 onChange={(_e, d) => setSearchDraft(sanitiseDraft(d.value))}
                 onKeyDown={(e) => {
@@ -490,7 +483,7 @@ export default function UsersDrillDown({
               workloadLabel={workloadLabel}
               startRank={(data.query.page - 1) * data.query.pageSize + 1}
               showRank
-              emptyText={search ? 'No users match your search.' : 'No users to show for this selection.'}
+              emptyText={search ? 'Nobody matches your search.' : 'Nobody to show for this selection.'}
             />
 
             {data.totalUsers > 0 && (
@@ -498,7 +491,7 @@ export default function UsersDrillDown({
                 <Text size={200} className={styles.muted}>
                   Showing {formatCount((data.query.page - 1) * data.query.pageSize + 1)}&ndash;
                   {formatCount(Math.min(data.query.page * data.query.pageSize, data.totalUsers))} of{' '}
-                  {formatCount(data.totalUsers)} users
+                  {formatCount(data.totalUsers)} people
                 </Text>
                 <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
                   <Button size="small" disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.test.tsx
@@ -11,7 +11,7 @@ function evidence(over: Partial<LicenceActivityEvidence> = {}): LicenceActivityE
     status: 'known',
     band: 'high',
     source: 'Usage reports',
-    measure: 'reporting samples',
+    measure: 'activity counted by Microsoft',
     activeSamples: 15,
     observedSamples: 20,
     expectedSamples: 20,
@@ -34,7 +34,7 @@ function usr(over: Partial<LicenceActivityUser> = {}): LicenceActivityUser {
 }
 
 describe('UsersTable', () => {
-  it('identifies the user by UPN only (no display names exist to show or invent)', () => {
+  it('identifies the person by sign-in address only (no display names exist to show or invent)', () => {
     renderWithProvider(<UsersTable rows={[usr()]} workload="teams" workloadLabel="Teams" />);
     expect(screen.getByText('ada@contoso.com')).toBeInTheDocument();
   });
@@ -47,9 +47,9 @@ describe('UsersTable', () => {
     expect(screen.getByText('Καλημέρα κόσμε')).toBeInTheDocument();
   });
 
-  it('shows the active-sample frequency and a coloured band', () => {
+  it('shows how often the person was active and a coloured activity badge', () => {
     renderWithProvider(<UsersTable rows={[usr()]} workload="teams" workloadLabel="Teams" />);
-    // 15 / 20 observed samples = 75% (the parenthesised cell value, not the band-method tooltip).
+    // Active in 15 of the 20 measurements taken = 75% (the parenthesised cell value, not the tooltip).
     expect(screen.getByText('(75%)')).toBeInTheDocument();
     expect(screen.getByText('High')).toBeInTheDocument();
   });
@@ -83,7 +83,7 @@ describe('UsersTable', () => {
     // Collapsed: only the selected workload is summarised, so the not-imported one isn't shown yet.
     expect(screen.queryByText('Not imported')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Show all workloads/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Show all services/ }));
 
     // Expanded: every workload is listed with its coverage status.
     for (const w of WORKLOADS) {
@@ -103,8 +103,8 @@ describe('UsersTable', () => {
         workloadLabel="Teams"
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: /Show all workloads/ }));
-    expect(screen.getAllByText(/0 observed of 8 expected/).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole('button', { name: /Show all services/ }));
+    expect(screen.getAllByText(/0 of 8 measured/).length).toBeGreaterThan(0);
     expect(screen.getAllByText('Unknown').length).toBeGreaterThan(0);
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/UsersTable.tsx
@@ -6,6 +6,7 @@ import { WORKLOADS } from '../../types/licenceActivity';
 import { BAND_METHOD, bandColour, bandForeground, bandLabel, frequencyPct } from './bands';
 import { DASH, UNKNOWN_TEXT, formatAge, formatDate } from './format';
 import { statusMeta } from './statuses';
+import { sourceLabel } from './sources';
 import { useLaTableStyles } from './tableStyles';
 
 const useStyles = makeStyles({
@@ -85,10 +86,10 @@ function formatAverage(value: number | null | undefined): string {
   return (Math.round(value * 10) / 10).toLocaleString();
 }
 
-/** Active/observed samples with expected context, distinguishing "nothing observed" from a real 0. */
+/** Active/measured counts with expected context, distinguishing "nothing measured" from a real 0. */
 function formatSamples(ev: LicenceActivityEvidence | null): string {
   if (!ev) return UNKNOWN_TEXT;
-  if (ev.observedSamples <= 0) return `${DASH}; ${ev.observedSamples} observed of ${ev.expectedSamples} expected`;
+  if (ev.observedSamples <= 0) return `${DASH}; ${ev.observedSamples} of ${ev.expectedSamples} measured`;
   const base = `${ev.activeSamples} / ${ev.observedSamples}`;
   return ev.observedSamples !== ev.expectedSamples ? `${base} of ${ev.expectedSamples}` : base;
 }
@@ -126,18 +127,18 @@ function AllWorkloadsDetail({ user }: { user: LicenceActivityUser }) {
   return (
     <div className={styles.detailInner}>
       <Text size={200} weight="semibold" block className={styles.detailTitle}>
-        All workloads for {user.userPrincipalName}
+        Every service for {user.userPrincipalName}
       </Text>
       <table className={styles.detailTable}>
         <thead>
           <tr>
-            <th className={styles.detailHead}>Workload</th>
-            <th className={styles.detailHead}>Coverage</th>
-            <th className={styles.detailHead}>Band</th>
-            <th className={styles.detailHead}>Source &middot; Measure</th>
-            <th className={styles.detailHead}>Active / observed (expected)</th>
-            <th className={styles.detailHead}>Avg</th>
-            <th className={styles.detailHead}>Last activity</th>
+            <th className={styles.detailHead}>Service</th>
+            <th className={styles.detailHead}>Data</th>
+            <th className={styles.detailHead}>Activity</th>
+            <th className={styles.detailHead}>Where it comes from</th>
+            <th className={styles.detailHead}>Active / measured (expected)</th>
+            <th className={styles.detailHead}>Average</th>
+            <th className={styles.detailHead}>Last active</th>
           </tr>
         </thead>
         <tbody>
@@ -164,7 +165,7 @@ function AllWorkloadsDetail({ user }: { user: LicenceActivityUser }) {
                 </td>
                 <td className={styles.detailCell}>
                   <Text size={200}>
-                    {ev?.source || DASH}
+                    {sourceLabel(ev?.source) || DASH}
                     {ev?.measure ? ` \u00b7 ${ev.measure}` : ''}
                   </Text>
                 </td>
@@ -213,7 +214,7 @@ export default function UsersTable({
   workloadLabel,
   showRank,
   startRank = 1,
-  emptyText = 'No users match this selection.',
+  emptyText = 'Nobody to show for this selection.',
 }: UsersTableProps) {
   const styles = useStyles();
   const table = useLaTableStyles();
@@ -240,18 +241,18 @@ export default function UsersTable({
           <tr>
             <th className={table.th} aria-label="Expand" />
             {showRank && <th className={`${table.th} ${table.thNumeric}`}>#</th>}
-            <th className={table.th}>User</th>
+            <th className={table.th}>Person</th>
             <th className={table.th}>Department</th>
             <th className={table.th}>
               <Tooltip relationship="description" content={BAND_METHOD}>
                 <span style={{ borderBottom: `1px dotted ${tokens.colorNeutralForeground4}`, cursor: 'help' }}>
-                  {workloadLabel} band
+                  {workloadLabel} activity
                 </span>
               </Tooltip>
             </th>
-            <th className={`${table.th} ${table.thNumeric}`}>Avg actions</th>
-            <th className={`${table.th} ${table.thNumeric}`}>Active samples</th>
-            <th className={table.th}>Last activity</th>
+            <th className={`${table.th} ${table.thNumeric}`}>Average actions</th>
+            <th className={`${table.th} ${table.thNumeric}`}>Active / measured</th>
+            <th className={table.th}>Last active</th>
           </tr>
         </thead>
         <tbody>
@@ -268,7 +269,7 @@ export default function UsersTable({
                       size="small"
                       icon={open ? <ChevronDown16Regular /> : <ChevronRight16Regular />}
                       aria-expanded={open}
-                      aria-label={`Show all workloads for ${row.userPrincipalName}`}
+                      aria-label={`Show all services for ${row.userPrincipalName}`}
                       onClick={() => toggle(row.userId)}
                     />
                   </td>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/WorkloadDistributions.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/WorkloadDistributions.test.tsx
@@ -22,6 +22,8 @@ describe('WorkloadDistributions', () => {
     renderWithProvider(<WorkloadDistributions workloads={[dist('copilot', { unknown: 10 })]} />);
     expect(screen.getByText('Not measured')).toBeInTheDocument();
     expect(screen.getByText('Unknown 10')).toBeInTheDocument();
-    expect(screen.queryByText(/of .* active/)).not.toBeInTheDocument();
+    // The card's summary line is `N of M active (P%)`. Match that shape specifically: a looser
+    // /of .* active/ also matches the explanatory method note, which legitimately contains both words.
+    expect(screen.queryByText(/\d+ of \d+ active/)).not.toBeInTheDocument();
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/WorkloadDistributions.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/WorkloadDistributions.tsx
@@ -140,13 +140,14 @@ function WorkloadDistributions({ workloads }: WorkloadDistributionsProps) {
   );
 
   if (ordered.length === 0) {
-    return <Text className={styles.muted}>No workload activity is available for this licence.</Text>;
+    return <Text className={styles.muted}>No activity is available for this licence.</Text>;
   }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
       <Text size={100} className={styles.muted}>
-        {BAND_METHOD} Active counts are users with any measured activity, out of those with complete coverage.
+        {BAND_METHOD} The &quot;active&quot; count is everyone with any measured activity, out of the people whose
+        whole period could be measured.
       </Text>
       <div className={styles.grid}>
         {ordered.map((distribution) => (

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/bands.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/bands.ts
@@ -30,23 +30,23 @@ export const ACTIVITY_BANDS: BandDef[] = [
 const BY_KEY: Record<string, BandDef> = Object.fromEntries(ACTIVITY_BANDS.map((b) => [b.key, b]));
 
 /**
- * The official band definitions, mirroring LicenceActivityRules.Method on the backend. These describe
- * a share of observed reporting SAMPLES with activity - deliberately not "active days", which the
- * measure only becomes if a workload's source/measure says so.
+ * The official activity-level definitions, mirroring LicenceActivityRules.Method on the backend. They
+ * describe how often someone was active across the READINGS taken in the period - deliberately not
+ * "active days", which the figures only become if a service's source says so.
  */
 export const BAND_DESCRIPTIONS: Record<BandKey, string> = {
-  high: 'Active in at least 75% of observed samples.',
-  moderate: 'Active in 25% to under 75% of observed samples.',
-  low: 'Active in under 25% of observed samples (but more than none).',
-  zero: 'No activity in any sample, with complete coverage of the period.',
-  unknown: 'Coverage was incomplete, so activity could not be determined - this is not zero.',
+  high: 'Active across three quarters or more of what was measured.',
+  moderate: 'Active across a quarter to under three quarters of what was measured.',
+  low: 'Active across under a quarter of what was measured, but active at least once.',
+  zero: 'Never active, across a period that was measured in full.',
+  unknown: 'The period could not be measured in full, so activity is not known - this does not mean zero.',
 };
 
-/** A one-line summary of the banding, for a column tooltip. */
+/** A one-line summary of how the levels are worked out, for a column tooltip. */
 export const BAND_METHOD =
-  'Bands are the share of observed reporting samples with activity: high \u2265 75%, moderate 25\u201374%, ' +
-  'low under 25%, zero none (with complete coverage). Incomplete coverage is Unknown, not zero. ' +
-  'These are sample frequencies, not daily events.';
+  'Activity levels describe how much of the measured period someone was active in: ' +
+  'High = 75% or more, Moderate = 25\u201374%, Low = under 25%, No activity = never (across a period measured in full). ' +
+  'Where the period could not be measured in full the level is Unknown, not zero.';
 
 export function bandLabel(band: string): string {
   return BY_KEY[band]?.label ?? band;

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/sources.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/sources.ts
@@ -1,0 +1,37 @@
+// Plain-English rendering of the backend's data-source and sampling vocabulary.
+//
+// The backend emits STABLE IDENTIFIERS for `LicenceActivityCoverage.source` and `.granularity`
+// (LicenceActivitySql.M365ReportSource etc.) because its own SQL matches on them. Those identifiers
+// are developer-facing API names - "microsoftGraphUsageReport", "weeklySupportingSnapshot" - and this
+// report is read by business leaders and Microsoft 365 administrators, not by people who call Graph.
+// So the identifier stays on the wire and is translated here, at the point of display.
+//
+// Mirrors `statuses.ts`, which does the same for the status vocabulary. Both fall through to the raw
+// value for anything unlisted, so a new backend source degrades to showing its id rather than blank.
+
+const SOURCE_LABELS: Record<string, string> = {
+  microsoftGraphUsageReport: 'Microsoft 365 usage reports',
+  microsoftGraphCopilotUsageReport: 'Microsoft 365 Copilot usage report',
+  copilotAudit: 'Copilot audit log',
+  copilotInteractions: 'Copilot chat history',
+};
+
+const GRANULARITY_LABELS: Record<string, string> = {
+  weeklySupportingSnapshot: 'one reading per week',
+  singleRollingWindow: 'a single rolling report',
+  weeklySampleOfRolling7DayReport: 'one 7-day report read per week',
+  eventPositiveOnly: 'recorded activity only',
+  unknown: 'not applicable',
+};
+
+/** Where a workload's figures came from, named the way Microsoft 365 admins would recognise it. */
+export function sourceLabel(source: string | null | undefined): string | null {
+  if (!source) return null;
+  return SOURCE_LABELS[source] ?? source;
+}
+
+/** How often that source was read, in plain English. */
+export function granularityLabel(granularity: string | null | undefined): string | null {
+  if (!granularity) return null;
+  return GRANULARITY_LABELS[granularity] ?? granularity;
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/statuses.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/statuses.ts
@@ -16,37 +16,39 @@ const STATUS_META: Record<string, StatusMeta> = {
   available: {
     tone: 'success',
     label: 'Available',
-    explanation: 'Measured with complete coverage of the period.',
+    explanation: 'Measured across the whole period.',
   },
   partial: {
     tone: 'warning',
     label: 'Partial',
-    explanation: 'Some reporting samples were missing, so this is a partial view and activity may be understated.',
+    explanation: 'Part of this period could not be measured in full, so activity here may be understated.',
   },
   missingCoverage: {
     tone: 'warning',
     label: 'Missing coverage',
-    explanation: 'The period was not fully covered by snapshots, so users cannot be ranked as inactive here.',
+    explanation:
+      'Part of the chosen period has no measurement behind it, so nobody can be shown as inactive for this service.',
   },
   unmatchableIdentity: {
     tone: 'warning',
-    label: 'Unmatchable identity',
-    explanation: 'The user could not be matched to this workload\u2019s identity, so their activity is unknown.',
+    label: 'Identities could not be matched',
+    explanation:
+      'Microsoft hid the identities in this report, so its activity cannot be tied back to the people holding the licence.',
   },
   notImported: {
     tone: 'subtle',
     label: 'Not imported',
-    explanation: 'This workload\u2019s usage source is not imported on this deployment.',
+    explanation: 'This service\u2019s usage data has never been collected on this deployment.',
   },
   disabled: {
     tone: 'subtle',
-    label: 'Import disabled',
-    explanation: 'This workload\u2019s import is switched off.',
+    label: 'Import switched off',
+    explanation: 'Collection for this service is switched off in the installer.',
   },
   unknown: {
     tone: 'subtle',
     label: 'Unknown',
-    explanation: 'Not measured for this user - this is not the same as measured zero activity.',
+    explanation: 'Not measured for this person \u2013 which is not the same as measured as no activity.',
   },
 };
 

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
@@ -57,7 +57,7 @@ function dist(workload: WorkloadKey): LicenceActivityDistribution {
 }
 
 function availability(over: Partial<LicenceActivityAvailability> = {}): LicenceActivityAvailability {
-  return { available: true, canViewUsers: true, minimumDays: 7, maximumDays: 180, messages: [], ...over };
+  return { available: true, minimumDays: 7, maximumDays: 180, messages: [], ...over };
 }
 
 function overview(over: Partial<LicenceActivityOverview> = {}): LicenceActivityOverview {
@@ -148,12 +148,12 @@ beforeEach(() => {
 describe('LicenceActivityPage - availability', () => {
   it('shows an unavailable message and no export when the report cannot run', async () => {
     mockAvailability.mockResolvedValue(
-      availability({ available: false, canViewUsers: false, messages: ['Enable GraphUsersMetadata.'] }),
+      availability({ available: false, messages: ['This report needs the user details import turned on.'] }),
     );
     renderWithProvider(<LicenceActivityPage />);
 
     expect(await screen.findByText(/not available on this deployment/i)).toBeInTheDocument();
-    expect(screen.getByText('Enable GraphUsersMetadata.')).toBeInTheDocument();
+    expect(screen.getByText('This report needs the user details import turned on.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Export to Excel/i })).not.toBeInTheDocument();
     expect(mockOverview).not.toHaveBeenCalled();
   });
@@ -165,66 +165,38 @@ describe('LicenceActivityPage - availability', () => {
   });
 });
 
-describe('LicenceActivityPage - user-detail gating', () => {
-  it('shows aggregates but hides the drill-down without the ReadUsers role', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+describe('LicenceActivityPage - everyone sees the whole report', () => {
+  it('shows the totals AND the per-person list to every reader, with no second permission level', async () => {
+    mockAvailability.mockResolvedValue(availability());
     renderWithProvider(<LicenceActivityPage />);
 
     expect(await screen.findByText('Licence assignments')).toBeInTheDocument();
-    // Aggregate workload distributions are visible to everyone (renders after default licence select).
-    expect(await screen.findByText('Workload activity')).toBeInTheDocument();
+    expect(await screen.findByText('Activity by service')).toBeInTheDocument();
     // Non-Latin (Greek) demographic values render without corruption (in the filters and the breakdown).
     expect(screen.getAllByText(/Μηχανικοί/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Ελλάδα/).length).toBeGreaterThan(0);
-    // But not the per-user drill-down.
-    expect(screen.queryByText('User drill-down')).not.toBeInTheDocument();
-    expect(screen.getByText(/aggregate view/i)).toBeInTheDocument();
-    expect(mockUsers).not.toHaveBeenCalled();
-  });
 
-  it('loads the drill-down for the default licence with the role', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
-    renderWithProvider(<LicenceActivityPage />);
-
-    expect(await screen.findByText('User drill-down')).toBeInTheDocument();
+    // The per-person list is part of the same report - it is not gated behind an extra role, and the
+    // page must never tell a reader to go and ask for one.
+    expect(await screen.findByText('People holding this licence')).toBeInTheDocument();
     expect((await screen.findAllByText('ada@contoso.com')).length).toBeGreaterThan(0);
     expect(mockUsers).toHaveBeenCalled();
+    expect(screen.queryByText(/ReadUsers/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/aggregate view/i)).not.toBeInTheDocument();
   });
 
-  it('drops revoked user detail on a users 403 while retaining aggregates and rechecking availability', async () => {
-    let finishAvailability!: (value: LicenceActivityAvailability) => void;
-    const recheck = new Promise<LicenceActivityAvailability>((resolve) => { finishAvailability = resolve; });
-    mockAvailability.mockResolvedValueOnce(availability({ canViewUsers: true })).mockReturnValueOnce(recheck);
-    mockUsers.mockResolvedValueOnce(usersResponse()).mockRejectedValueOnce(
-      new LicenceActivityApiError('forbidden', 403, 'Individual user detail is forbidden.'),
-    );
-    renderWithProvider(<LicenceActivityPage />);
-    await screen.findAllByText('ada@contoso.com');
-
-    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
-    await waitFor(() => expect(mockAvailability).toHaveBeenCalledTimes(2));
-    expect(screen.queryByText('User drill-down')).not.toBeInTheDocument();
-    expect(screen.queryByText('ada@contoso.com')).not.toBeInTheDocument();
-    expect(screen.getByText('Licence assignments')).toBeInTheDocument();
-    expect(screen.getByText(/aggregate view/i)).toBeInTheDocument();
-
-    await act(async () => { finishAvailability(availability({ canViewUsers: false })); });
-    fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
-    await waitFor(() => expect(mockDownload).toHaveBeenCalledWith({ overviewId: 'ov1', usersId: undefined }));
-    expect(mockUsers).toHaveBeenCalledTimes(2);
-  });
-
-  it('does not discard user-detail permission for a transient users failure', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+  it('keeps the people list on screen through a transient users failure', async () => {
+    mockAvailability.mockResolvedValue(availability());
     mockUsers.mockResolvedValueOnce(usersResponse()).mockRejectedValueOnce(
       new LicenceActivityApiError('busy', 503, 'Reporting is busy.'),
     );
     renderWithProvider(<LicenceActivityPage />);
     await screen.findAllByText('ada@contoso.com');
 
-    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    fireEvent.change(screen.getByLabelText('Service'), { target: { value: 'outlook' } });
     expect(await screen.findByText('Reporting is busy.')).toBeInTheDocument();
-    expect(screen.getByText('User drill-down')).toBeInTheDocument();
+    expect(screen.getByText('People holding this licence')).toBeInTheDocument();
+    // Availability is read once per page load: nothing about the viewer can change under them now.
     expect(mockAvailability).toHaveBeenCalledTimes(1);
   });
 });
@@ -242,7 +214,7 @@ describe('LicenceActivityPage - scale (50 SKUs)', () => {
     }));
     const biggest = [...licences].sort((a, b) => b.assignedUsers - a.assignedUsers)[0];
 
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockAvailability.mockResolvedValue(availability());
     mockOverview.mockResolvedValue(overview({ licences }));
     renderWithProvider(<LicenceActivityPage />);
 
@@ -256,8 +228,9 @@ describe('LicenceActivityPage - scale (50 SKUs)', () => {
 });
 
 describe('LicenceActivityPage - export', () => {
-  it('exports the aggregate snapshot (no usersId) for an aggregate-only viewer', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+  it('exports the totals only while the people list has not loaded yet', async () => {
+    mockAvailability.mockResolvedValue(availability());
+    mockUsers.mockReturnValue(new Promise(() => {})); // never resolves -> no people list to attach
     renderWithProvider(<LicenceActivityPage />);
 
     const exportBtn = await screen.findByRole('button', { name: /Export to Excel/i });
@@ -267,7 +240,7 @@ describe('LicenceActivityPage - export', () => {
   });
 
   it('includes the current users snapshot once the drill-down has loaded', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockAvailability.mockResolvedValue(availability());
     renderWithProvider(<LicenceActivityPage />);
 
     await screen.findAllByText('ada@contoso.com'); // drill-down loaded -> usersId captured
@@ -277,10 +250,10 @@ describe('LicenceActivityPage - export', () => {
     await waitFor(() => expect(mockDownload).toHaveBeenCalledWith({ overviewId: 'ov1', usersId: 'us1' }));
   });
 
-  it('shows a refresh prompt when the snapshot has expired', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+  it('shows a refresh prompt when the figures are no longer held', async () => {
+    mockAvailability.mockResolvedValue(availability());
     mockDownload.mockRejectedValue(
-      new LicenceActivityApiError('expired', 410, 'This snapshot has expired or was refreshed.'),
+      new LicenceActivityApiError('expired', 410, 'These figures are no longer being held.'),
     );
     renderWithProvider(<LicenceActivityPage />);
 
@@ -288,12 +261,12 @@ describe('LicenceActivityPage - export', () => {
     await waitFor(() => expect(exportBtn).toBeEnabled());
     fireEvent.click(exportBtn);
 
-    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no longer being held/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
   });
 
   it('disables export while the overview is still loading', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    mockAvailability.mockResolvedValue(availability());
     mockOverview.mockReturnValue(new Promise(() => {})); // never resolves
     renderWithProvider(<LicenceActivityPage />);
 
@@ -302,14 +275,14 @@ describe('LicenceActivityPage - export', () => {
   });
 
   it('does not export the old users snapshot when clicking Export commits a new top count on blur', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockAvailability.mockResolvedValue(availability());
     mockUsers.mockResolvedValueOnce(usersResponse()).mockReturnValue(new Promise(() => {}));
     renderWithProvider(<LicenceActivityPage />);
     await screen.findAllByText('ada@contoso.com');
     await act(async () => {});
 
     const events = userEvent.setup();
-    const top = screen.getByRole('spinbutton', { name: 'Number of users in each list' });
+    const top = screen.getByRole('spinbutton', { name: 'Number of people in each list' });
     await events.clear(top);
     await events.type(top, '25');
     await events.click(screen.getByRole('button', { name: /Export to Excel/i }));
@@ -321,10 +294,11 @@ describe('LicenceActivityPage - export', () => {
 });
 
 describe('LicenceActivityPage - export refresh after expiry', () => {
-  it('disables aggregate export until a pending expiry refresh supplies a fresh overview', async () => {
+  it('disables the totals-only export until a pending expiry refresh supplies a fresh overview', async () => {
     let finishOverview!: (value: LicenceActivityOverview) => void;
     const renewal = new Promise<LicenceActivityOverview>((resolve) => { finishOverview = resolve; });
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    mockAvailability.mockResolvedValue(availability());
+    mockUsers.mockReturnValue(new Promise(() => {})); // no people list to attach, so the export is totals-only
     mockOverview.mockResolvedValueOnce(overview()).mockReturnValueOnce(renewal);
     mockDownload.mockRejectedValueOnce(
       new LicenceActivityApiError('expired', 410, 'The overview expired.'),
@@ -349,7 +323,7 @@ describe('LicenceActivityPage - export refresh after expiry', () => {
   });
 
   it('re-mints the users snapshot on Refresh (same cached overviewId) without silently re-exporting', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockAvailability.mockResolvedValue(availability());
     // The overview stays cached: it returns the SAME snapshotId on reload, which is exactly the case
     // that made the old Refresh a no-op (the snapshot-id-changed effect never fired).
     mockOverview.mockResolvedValue(overview());
@@ -363,7 +337,7 @@ describe('LicenceActivityPage - export refresh after expiry', () => {
     // The first export fails as expired (users snapshots expire before the overview); later ones pass.
     mockDownload
       .mockRejectedValueOnce(
-        new LicenceActivityApiError('expired', 410, 'This snapshot has expired or was refreshed.'),
+        new LicenceActivityApiError('expired', 410, 'These figures are no longer being held.'),
       )
       .mockResolvedValue(undefined);
 
@@ -373,16 +347,16 @@ describe('LicenceActivityPage - export refresh after expiry', () => {
 
     // Export -> 410 -> a Refresh prompt appears.
     fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
-    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no longer being held/i)).toBeInTheDocument();
 
     const usersBefore = mockUsers.mock.calls.length;
-    // The drill-down keeps its own "Refresh users" control (accessible name differs), so this exact
+    // The drill-down keeps its own refresh control (its accessible name differs), so this exact
     // match resolves the export bar's Refresh unambiguously.
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
     // A fresh users request is issued (re-mint) and the error clears...
     await waitFor(() => expect(mockUsers.mock.calls.length).toBeGreaterThan(usersBefore));
-    await waitFor(() => expect(screen.queryByText(/expired/i)).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/no longer being held/i)).not.toBeInTheDocument());
     await act(async () => {});
     // ...but Refresh does NOT silently re-export (still just the one failed attempt).
     expect(mockDownload).toHaveBeenCalledTimes(1);
@@ -405,7 +379,7 @@ describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
   const usersParams = () => mockUsers.mock.calls[mockUsers.mock.calls.length - 1][0];
 
   it('keeps the admin on page 2 (and workload/sort/search) when Refresh re-mints the overview under a NEW id', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockAvailability.mockResolvedValue(availability());
 
     // The overview re-mints on reload: ov1 first, ov2 after Refresh. A brand-new id per reload is
     // exactly the case that used to reset the browse page (the drill-down treated the id as scope).
@@ -437,7 +411,7 @@ describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
     // The first export fails as expired (users snapshots expire before the overview); later ones pass.
     mockDownload
       .mockRejectedValueOnce(
-        new LicenceActivityApiError('expired', 410, 'This snapshot has expired or was refreshed.'),
+        new LicenceActivityApiError('expired', 410, 'These figures are no longer being held.'),
       )
       .mockResolvedValue(undefined);
 
@@ -446,7 +420,7 @@ describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
     await act(async () => {});
 
     // Move off the defaults: a non-default workload and sort and search, then browse to page 2.
-    fireEvent.change(screen.getByLabelText('Workload'), { target: { value: 'outlook' } });
+    fireEvent.change(screen.getByLabelText('Service'), { target: { value: 'outlook' } });
     await waitFor(() => expect(usersParams()).toMatchObject({ workload: 'outlook', page: 1 }));
     fireEvent.change(await screen.findByLabelText('Sort users'), { target: { value: 'upn:asc' } });
     await waitFor(() => expect(usersParams()).toMatchObject({ sort: 'upn', direction: 'asc' }));
@@ -459,10 +433,10 @@ describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
     // Export -> 410 -> a Refresh prompt appears.
     await waitFor(() => expect(screen.getByRole('button', { name: /Export to Excel/i })).toBeEnabled());
     fireEvent.click(screen.getByRole('button', { name: /Export to Excel/i }));
-    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no longer being held/i)).toBeInTheDocument();
 
     const usersBefore = mockUsers.mock.calls.length;
-    // Exact 'Refresh' resolves the export bar's button (the drill-down's is 'Refresh users').
+    // Exact 'Refresh' resolves the export bar's button (the drill-down's is 'Refresh the list').
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
     // The overview re-mints to ov2 and the list is re-fetched - but the admin is STILL on page 2 with
@@ -478,7 +452,7 @@ describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
       search: 'ada',
     });
 
-    await waitFor(() => expect(screen.queryByText(/expired/i)).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/no longer being held/i)).not.toBeInTheDocument());
     await act(async () => {});
     // Refresh alone must not silently re-export.
     expect(mockDownload).toHaveBeenCalledTimes(1);
@@ -497,7 +471,7 @@ describe('LicenceActivityPage - a real scope change resets the browse page', () 
   const usersParams = () => mockUsers.mock.calls[mockUsers.mock.calls.length - 1][0];
 
   it('returns to page 1 and drops the stale export id when the demographic filter changes', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: true }));
+    mockAvailability.mockResolvedValue(availability());
     // A distinct overview id per demographic scope; department 1 stays in the catalogue so it remains
     // selectable after the scoped reply.
     mockOverview.mockImplementation(async (q) => overview({ snapshotId: `ov-dept-${q.departmentId ?? 'all'}` }));
@@ -540,7 +514,7 @@ describe('LicenceActivityPage - a real scope change resets the browse page', () 
 
 describe('LicenceActivityPage - demographic filter options', () => {
   it('keeps every department selectable after a scoped reply, so you can switch straight from one to another', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    mockAvailability.mockResolvedValue(availability());
     const sales = { id: 1, name: 'Sales', assignedUsers: 60, workloads: [] };
     const support = { id: 2, name: 'Support', assignedUsers: 40, workloads: [] };
     // The backend only returns demographic groups WITHIN the current scope: filtering by a department
@@ -571,18 +545,18 @@ describe('LicenceActivityPage - demographic filter options', () => {
 
 describe('LicenceActivityPage - preview label', () => {
   it('shows a Preview badge next to the Licence activity heading', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    mockAvailability.mockResolvedValue(availability());
     await act(async () => { renderWithProvider(<LicenceActivityPage />); });
     expect(screen.getByText('Preview')).toBeInTheDocument();
     expect(screen.getByText('Licence activity')).toBeInTheDocument();
   });
 
   it('explains cache lag, cold-load behaviour, and the no-judgement note', async () => {
-    mockAvailability.mockResolvedValue(availability({ canViewUsers: false }));
+    mockAvailability.mockResolvedValue(availability());
     await act(async () => { renderWithProvider(<LicenceActivityPage />); });
     const note = screen.getByRole('note');
     expect(note.textContent).toMatch(/5 minutes/i);
-    expect(note.textContent).toMatch(/first load/i);
-    expect(note.textContent).toMatch(/activity evidence/i);
+    expect(note.textContent).toMatch(/first look/i);
+    expect(note.textContent).toMatch(/evidence of activity/i);
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
@@ -116,14 +116,13 @@ const useStyles = makeStyles({
 /**
  * Licence activity report (issues #436 / #437).
  *
- * Answers, for an IT / licensing admin: which licences are assigned, and how much are the people who
- * hold them actually using each Microsoft 365 workload? It is deliberately an ACTIVITY report - no
- * blended "productivity" score, no "remove this licence" button; it surfaces the evidence and leaves
- * the decision with the admin.
+ * Answers, for a business leader or M365 admin: which licences are assigned, and how much are the
+ * people who hold them actually using each Microsoft 365 service? It is deliberately an ACTIVITY
+ * report - no blended "productivity" score, no "remove this licence" button; it surfaces the evidence
+ * and leaves the decision with the reader.
  *
- * Everyone signed in sees the aggregates. Drilling into named individuals additionally requires the
- * opt-in `LicenceActivity.ReadUsers` Entra role; the UI hides the drill-down without it, and the
- * server enforces it regardless.
+ * Everyone who can open the portal sees the whole report, including the per-person lists. There is no
+ * second permission level.
  */
 export default function LicenceActivityPage() {
   const styles = useStyles();
@@ -131,9 +130,6 @@ export default function LicenceActivityPage() {
   const [availability, setAvailability] = useState<LicenceActivityAvailability | null>(null);
   const [availabilityError, setAvailabilityError] = useState<unknown>(null);
   const [availabilityLoading, setAvailabilityLoading] = useState(true);
-  // Bumped whenever the viewer's ROLE may have changed under them, so availability (and therefore
-  // canViewUsers) is re-read instead of staying frozen at page load for the life of the tab.
-  const [availabilityKey, setAvailabilityKey] = useState(0);
 
   // The reporting window lives here, so it is preserved across demographic-filter and licence
   // changes - only the date control (or a preset click) ever changes it. Defaults to 28 days.
@@ -168,8 +164,6 @@ export default function LicenceActivityPage() {
 
   const overviewSeqRef = useRef(0);
 
-  const canViewUsers = availability?.canViewUsers === true;
-
   // --- Availability -------------------------------------------------------------------------------
   useEffect(() => {
     let cancelled = false;
@@ -191,7 +185,7 @@ export default function LicenceActivityPage() {
       cancelled = true;
       controller.abort();
     };
-  }, [availabilityKey]);
+  }, []);
 
   // The scope key identifying the overview request. When it changes (date / department / country) the
   // previous overview and its snapshot id must vanish on the SAME render, so nothing stale can be shown
@@ -265,28 +259,18 @@ export default function LicenceActivityPage() {
 
   const reloadOverview = useCallback(() => setOverviewReloadKey((k) => k + 1), []);
   const handleUsersSnapshot = useCallback((id: string | null) => setUsersId(id), []);
-  const handleUsersForbidden = useCallback(() => {
-    setUsersId(null);
-    setAvailability((previous) => previous ? { ...previous, canViewUsers: false } : previous);
-    setAvailabilityKey((k) => k + 1);
-  }, []);
 
-  // The correct response to an EXPIRED snapshot (export 410, or a users 410): re-mint the snapshots in
-  // place. We drop the stale users id and error, force the drill-down to re-fetch a fresh users
-  // snapshot (its params are unchanged, so the licence/workload/page/filters are preserved), and reload
-  // the overview. The overview often comes back under the SAME cached id, which is exactly why clearing
-  // is explicit here rather than relying on the snapshot-id-changed effect. It deliberately does NOT
-  // re-export: an export must be an explicit action, never a silent re-query of freshly minted data.
+  // The correct response to figures the server no longer holds (an export 410, or a users 410): pull a
+  // fresh set in place. We drop the stale users id and error, force the drill-down to re-fetch (its
+  // params are unchanged, so the licence/workload/page/filters are preserved), and reload the
+  // overview. The overview often comes back under the SAME cached id, which is exactly why clearing is
+  // explicit here rather than relying on the id-changed effect. It deliberately does NOT re-export: an
+  // export must be an explicit action, never a silent re-query of freshly loaded figures.
   const refreshSnapshots = useCallback(() => {
     setExportError(null);
     setUsersId(null);
     setUsersRefreshToken((t) => t + 1);
     setOverviewReloadKey((k) => k + 1);
-    // Re-read availability too. The feature contract for the 410/409 recovery path is "re-mint AND
-    // recheck role": a role granted or revoked mid-session must not stay invisible until the admin
-    // reloads the whole page. (The server enforces the role independently on every /users and every
-    // /export carrying a usersId, so this is a dead-end fix, not a security fix.)
-    setAvailabilityKey((k) => k + 1);
   }, []);
 
   const selectedLicence = useMemo(
@@ -294,9 +278,9 @@ export default function LicenceActivityPage() {
     [overview, selectedLicenceTypeId],
   );
 
-  // Only attach a users snapshot to the export when the viewer is allowed per-user detail and is
-  // actually looking at a licence's list; otherwise the workbook is aggregate-only.
-  const exportUsersId = canViewUsers && selectedLicence ? usersId ?? undefined : undefined;
+  // Attach the current user list to the export whenever the reader is looking at a licence's list;
+  // otherwise the workbook is totals-only.
+  const exportUsersId = selectedLicence ? usersId ?? undefined : undefined;
 
   const onExport = async (): Promise<void> => {
     if (!overview || overviewLoading) return;
@@ -306,12 +290,6 @@ export default function LicenceActivityPage() {
       await downloadExport({ overviewId: overview.snapshotId, usersId: exportUsersId });
     } catch (err) {
       setExportError(err);
-      // A 403 here means the LicenceActivity.ReadUsers role went away mid-session while the export
-      // was still attaching a usersId. Retrying unchanged would 403 forever, so drop the individual
-      // snapshot and re-read availability: the next export is then a valid aggregate-only workbook.
-      if (describeError(err, '').kind === 'forbidden') {
-        handleUsersForbidden();
-      }
     } finally {
       setExporting(false);
     }
@@ -329,14 +307,14 @@ export default function LicenceActivityPage() {
           </div>
           <Body1 block className={styles.intro}>
             Which licences are assigned, and how much are the people who hold them actually using each Microsoft 365
-            workload. Activity is shown per workload and never blended into a single score, and anything that was not
-            imported is shown as &quot;Unknown&quot; rather than zero.
+            service. Each service is shown on its own and never blended into a single score, and anything that
+            couldn&apos;t be measured is shown as &quot;Unknown&quot; rather than as zero.
           </Body1>
           <Text role="note" block size={200} className={styles.previewNote}>
-            This report is in preview. Results are cached in memory for up to 5 minutes, so recent imports may not
-            yet appear. The first load for a new date range may take longer. Nothing shown implies a productivity
-            assessment or a recommendation to remove a licence —
-            it is activity evidence only.
+            This report is in preview. Figures are kept for up to 5 minutes before being worked out again, so a very
+            recent import may not appear straight away, and the first look at a new date range takes longer. Nothing
+            here is a judgement of anyone&apos;s productivity, or a recommendation to take a licence away &mdash; it is
+            evidence of activity only.
           </Text>
         </div>
       </div>
@@ -455,9 +433,9 @@ export default function LicenceActivityPage() {
                   content={
                     overview && !overviewLoading
                       ? exportUsersId
-                        ? 'Excel snapshot of the overview plus the exact user rows currently in view. Built from the cached snapshot, so it matches the screen rather than re-querying.'
-                        : 'Excel snapshot of the licence and workload overview (aggregate only). Built from the cached snapshot.'
-                      : 'Available once the overview has loaded.'
+                        ? 'An Excel copy of the summary plus the exact people currently listed below. Built from the figures already on screen, so it matches what you can see.'
+                        : 'An Excel copy of the licence and service summary (totals only). Built from the figures already on screen.'
+                      : 'Available once the report has loaded.'
                   }
                 >
                   <Button
@@ -519,9 +497,10 @@ export default function LicenceActivityPage() {
               )}
 
               <Text size={200} className={styles.muted}>
-                {formatCount(overview.distinctAssignedUsers)} distinct users hold a licence in this scope.
+                {formatCount(overview.distinctAssignedUsers)} people hold a licence in this selection, counting
+                each person once.
                 {overview.demographicsTruncated &&
-                  ' Department and country lists are capped and may not be exhaustive.'}
+                  ' The department and country lists are capped, so they may not show every one.'}
               </Text>
 
               <SkuAssignments
@@ -534,10 +513,10 @@ export default function LicenceActivityPage() {
                 <div>
                   <div className={styles.sectionHead}>
                     <Text weight="semibold" size={500}>
-                      Workload activity
+                      Activity by service
                     </Text>
                     <Text size={200} className={styles.muted}>
-                      {licenceName(selectedLicence)} &middot; five workloads, measured separately
+                      {licenceName(selectedLicence)} &middot; five services, each measured on its own
                     </Text>
                   </div>
                   <div style={{ marginTop: '12px' }}>
@@ -550,10 +529,10 @@ export default function LicenceActivityPage() {
                 <div>
                   <div className={styles.sectionHead}>
                     <Text weight="semibold" size={500}>
-                      Activity by demographic
+                      Activity by department and country
                     </Text>
                     <Text size={200} className={styles.muted}>
-                      Assigned licences and workload activity by department and country
+                      Where the licences sit in the organisation, and how much they are being used
                     </Text>
                   </div>
                   <div style={{ marginTop: '12px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
@@ -573,47 +552,37 @@ export default function LicenceActivityPage() {
                 </div>
               )}
 
-              {canViewUsers ? (
-                <div>
-                  <div className={styles.sectionHead}>
-                    <Text weight="semibold" size={500}>
-                      User drill-down
-                    </Text>
-                    <Text size={200} className={styles.muted}>
-                      Who is and isn&apos;t using a licence
-                    </Text>
-                  </div>
-                  <div style={{ marginTop: '12px' }}>
-                    {selectedLicence ? (
-                      <UsersDrillDown
-                        key={selectedLicence.licenceTypeId}
-                        overviewId={overview.snapshotId}
-                        overviewScope={overviewKey ?? ''}
-                        licence={selectedLicence}
-                        coverage={overview.coverage}
-                        onUsersSnapshot={handleUsersSnapshot}
-                        onRefreshOverview={refreshSnapshots}
-                        onForbidden={handleUsersForbidden}
-                        refreshToken={usersRefreshToken}
-                      />
-                    ) : (
-                      <Card>
-                        <Text className={styles.muted}>
-                          Select a licence in the assignments table above to see its most and least active users, or
-                          to browse everyone who holds it.
-                        </Text>
-                      </Card>
-                    )}
-                  </div>
+              <div>
+                <div className={styles.sectionHead}>
+                  <Text weight="semibold" size={500}>
+                    People holding this licence
+                  </Text>
+                  <Text size={200} className={styles.muted}>
+                    Who is and isn&apos;t using a licence
+                  </Text>
                 </div>
-              ) : (
-                <MessageBar intent="info">
-                  <MessageBarBody>
-                    You&apos;re seeing the aggregate view. Listing the individual users behind these figures needs the
-                    opt-in <strong>LicenceActivity.ReadUsers</strong> role, which an administrator can grant in Entra.
-                  </MessageBarBody>
-                </MessageBar>
-              )}
+                <div style={{ marginTop: '12px' }}>
+                  {selectedLicence ? (
+                    <UsersDrillDown
+                      key={selectedLicence.licenceTypeId}
+                      overviewId={overview.snapshotId}
+                      overviewScope={overviewKey ?? ''}
+                      licence={selectedLicence}
+                      coverage={overview.coverage}
+                      onUsersSnapshot={handleUsersSnapshot}
+                      onRefreshOverview={refreshSnapshots}
+                      refreshToken={usersRefreshToken}
+                    />
+                  ) : (
+                    <Card>
+                      <Text className={styles.muted}>
+                        Select a licence in the assignments table above to see who is most and least active, or to
+                        browse everyone who holds it.
+                      </Text>
+                    </Card>
+                  )}
+                </div>
+              </div>
             </div>
           )}
         </>

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/ReportsPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/ReportsPage.test.tsx
@@ -41,7 +41,7 @@ const areaData: ReportAreaData = {
 };
 
 function availability(over: Partial<LicenceActivityAvailability> = {}): LicenceActivityAvailability {
-  return { available: false, canViewUsers: false, minimumDays: 7, maximumDays: 180, messages: [], ...over };
+  return { available: false, minimumDays: 7, maximumDays: 180, messages: [], ...over };
 }
 
 beforeEach(() => {

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/types/licenceActivity.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/types/licenceActivity.ts
@@ -109,16 +109,10 @@ export interface SnapshotEnvelope {
   expiresUtc: string;
 }
 
-/** Which parts of the tool this deployment / signed-in user can see. */
+/** Which parts of the tool this deployment can show. */
 export interface LicenceActivityAvailability {
-  /** False when the licence import (GraphUsersMetadata) is disabled - the tab stays, the report can't run. */
+  /** False when the user details import is switched off - the tab stays, the report can't run. */
   available: boolean;
-  /**
-   * True when the signed-in user holds the opt-in `LicenceActivity.ReadUsers` Entra app role. Gates the
-   * per-user drill-down in the UI; every signed-in user still gets the aggregates. The server enforces
-   * the role on the users/export endpoints regardless of this flag.
-   */
-  canViewUsers: boolean;
   /** Smallest allowed custom window, in days (backend LicenceActivityQuery.MinimumDays). */
   minimumDays: number;
   /** Largest allowed custom window, in days (backend LicenceActivityQuery.MaximumDays). */


### PR DESCRIPTION
## Why

The Licence activity report (#436 / #437) targets C-level staff and Microsoft 365 admins, but it rendered backend/Graph identifiers verbatim. The coverage panel literally showed:

> Source: **microsoftGraphUsageReport** · average published viewed-or-edited counter across supporting snapshots (**weeklySupportingSnapshot**)

and elsewhere quoted `GraphUsersMetadata`, `last_activity_date`, `D7`, `v2 counters`, `UPN` and `SKU` at the reader. It also gated the per-person drill-down behind an opt-in Entra app role that this product does not need.

## Scope

Licence activity only. **No schema, migration or `CONFIG_VERSION` change** — verified against `Migrations/`, `Create DB.sql` and `BaseSolutionInstallConfig.CONFIG_VERSION` in the `dev..HEAD` diff.

## 1. Remove the `LicenceActivity.ReadUsers` role

Everyone who can open the portal now sees the whole report, including the per-person lists.

- `LicenceActivityAPIController`: deleted `UserDetailRole`, `CanViewUsers`, `ForbiddenUsers` and both call sites (`Users`, `Export`), plus the now-unused `System.Security.Claims` / `System.Security.Principal` usings.
- `LicenceActivityAvailability.CanViewUsers` removed from the C# model; `canViewUsers` removed from the portal type.
- `UsersDrillDown` loses `onForbidden`; the page loses `availabilityKey` / `handleUsersForbidden` and the "ask an administrator for the role" message bar.
- `[Authorize]` on the controller class is now the sole gate. Anonymous still gets 401.

The portal deliberately **keeps** its `forbidden` (403) error kind. Nothing in this controller emits it any more, but a 403 can still arrive from an auth proxy, and `ApiErrorBar` renders it with a working retry rather than a dead end.

## 2. Translate identifiers at the point of display

`source`, `granularity`, `status`, `band` and `workload` must stay stable identifiers on the wire: the coverage SQL matches on them (`coverage.source IN ('microsoftGraphUsageReport', ...)`) and so does the read model (`IsOfficialReport`, `coverage.Source == CopilotReportSource`). They are therefore translated **only for display**, in two mirrored places — the same pattern `statuses.ts` already used:

| | portal | C# (Excel export) |
|---|---|---|
| new | `components/licenceActivity/sources.ts` | `LicenceActivityRules.SourceLabel` / `GranularityLabel` / `StatusLabel` / `BandLabel` / `WorkloadLabel` |

Both fall through to the raw value, so an unmapped future source degrades to its identifier rather than a blank cell.

## 3. Centralise the overview / drill-down notes

**Reviewer hotspot.** There are two paths that build an overview:

- `SqlLicenceActivityStore` (direct), and
- `LicenceActivityReadModel` — the path the controller **actually uses**, via `CachedLicenceActivityStore.LoadOverviewAsync` → `lease.Model.BuildOverview`.

Each carried its own copy of the same message strings, so fixing one would have left production unchanged. Both now use `LicenceActivityRules.Notes`; they cannot diverge again.

## 4. Wording corrections that were factual, not cosmetic

Several strings were wrong for at least one of the five source shapes (weekly M365 report, sampled Copilot D7 report, single rolling Copilot report, Copilot audit fallback, Copilot chat-history fallback):

| Was | Why it was wrong | Now |
|---|---|---|
| Ranking note put fully-measured ahead of partial | `RankValue.Category` is `0 = complete+active`, `1 = partial+active`, `2 = measured zero` — a fully measured but **inactive** person ranks *below* a partially measured active one | states the actual three-tier order |
| "Average actions per measurement" | for `singleRollingWindow`, `average_actions` is `report.prompts_all_apps`, a period **total** (no `AVG`, unlike the D7 path) | "Average actions" |
| "Microsoft published it N days behind" | for `copilotAudit` / `copilotInteractions`, `lag_days` is the age of the latest **event** and the effective dates are `MIN`/`MAX` event timestamps | "most recent data is N days old", "Data from X – Y" |
| "Product ID" | `UserLicenseProcessor` sets `LicenseType.SKUID = skuPartNumber`, i.e. `ENTERPRISEPACK`-style, not a GUID — an admin typing the real Product ID GUID would get no match | "licence code" |
| "held until" | `LicenceActivitySnapshotCache` evicts the entry with the earliest `ExpiresUtc` on capacity, and the users cache TTL (2 min) is shorter than the overview's (5 min) | "held for up to" |
| installer prerequisite named a checkbox that does not exist | real control text is `TargetSolutionConfigControl.Designer.cs:147` | quotes "User Entra ID extended metadata" |
| generic text claimed a sampling unit ("readings") | wrong for the single rolling Copilot report, whose samples are days | unit-neutral "measured" / "measurements" |

Where a string could not be made true for every source shape, it was made to **assert less** rather than be made source-aware.

## Tests

- `CoveragePanel.test.tsx` asserts that **every** source and granularity identifier the backend can emit is absent from the DOM (the first version of this change mapped only 2 of the 5 granularities, so `weeklySampleOfRolling7DayReport` and `eventPositiveOnly` still leaked).
- New `LicenceActivityTests.DisplayLabels_TranslateEveryBackendVocabularyValue_SoNoIdentifierReachesTheReader` covers the Excel path, including fall-through for an unknown value.
- `LicenceActivityApiTests.AnonymousRequestsAreDenied_ButEverySignedInReaderSeesTheWholeReport` proves anonymous → 401 and a signed-in reader **holding no role at all** → `/users` 200.
- `DisabledPrerequisite_IsExplicitAndDoesNotQueryStorage` now also asserts the message does **not** contain `GraphUsersMetadata`.
- Export tests that previously relied on `canViewUsers: false` to force a totals-only workbook now use a never-resolving `fetchUsers` mock instead.
- `WorkloadDistributions.test.tsx`'s `/of .* active/` regex was **tightened** to `/\d+ of \d+ active/` — it was matching the explanatory method note, which legitimately contains both words. It still fails if the card renders "0 of 0 active".

## Verification

| Check | Result |
|---|---|
| MSBuild Debug | exit 0 |
| `npx tsc --noEmit` | clean |
| Portal vitest (full suite, `--no-file-parallelism`) | 16/16 files |
| .NET `FullyQualifiedName~LicenceActivity` | 109 tests — 107 passed, 2 skipped (release-scale perf, skipped by design) |

Note: running the portal suite with default file parallelism on a loaded machine produces timing flakes in `LicenceActivityPage.test.tsx`. That is pre-existing — measured on unmodified `dev` it fails **9** of those tests under the same conditions, versus 4 on this branch — so `--no-file-parallelism` was used to get a clean signal. Nothing in this PR changes it.

## Review

Reviewed by four models (Claude Opus 4.8, GPT-5.6 Sol, Gemini 3.8 Flash, Grok 4.6) over five rounds until every reviewer returned clean. Four of the five rounds found a defect introduced by the previous round's fix — including the `LicenceActivityReadModel` duplication above, which would have shipped a wording change that never reached production.

Addresses #436, #437.
