### PR TITLE
Make the demo's Copilot activity measurable by the licence report

### DIFF
--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoCommand.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoCommand.cs
@@ -12,6 +12,7 @@ namespace Tests.FakeDataGen.Demo
         public static int Run(string[] args)
         {
             FileStream summaryFile = null;
+            string portalConnectionString = null;
             try
             {
                 var options = DemoOptions.Parse(args, DateTime.UtcNow);
@@ -47,6 +48,7 @@ namespace Tests.FakeDataGen.Demo
                                     database.ValidateAndComplete(summary, Console.WriteLine);
                                     summary.Status = "Complete";
                                 }
+                                portalConnectionString = database.ConnectionString;
                             }
                         }
                     }
@@ -60,6 +62,13 @@ namespace Tests.FakeDataGen.Demo
                 Console.WriteLine("Copilot audit bands (latest 28 audit days, real scorer): " + string.Join(", ", summary.AdoptionBands.Select(p => p.Key + "=" + p.Value)));
                 Console.WriteLine("Fingerprint: " + summary.Fingerprint);
                 if (options.Preview) Console.WriteLine("Preview only: no database or weekly profiles were written.");
+                if (portalConnectionString != null)
+                {
+                    // Deliberately the real clock, not the demo's as-of: this reports what a portal opened
+                    // now would be able to measure, which is different when a historical --as-of was used.
+                    DemoPortalReadiness.PrintMeasuredCoverage(portalConnectionString, DateTime.UtcNow, Console.WriteLine);
+                    DemoPortalReadiness.PrintPortalSetup(options.Database, Console.WriteLine);
+                }
                 if (summaryFile != null)
                 {
                     using (var writer = new StreamWriter(summaryFile)) writer.Write(JsonConvert.SerializeObject(summary, Formatting.Indented));

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoGenerator.cs
@@ -196,12 +196,16 @@ namespace Tests.FakeDataGen.Demo
             int interactions = 0, prior = 0, active = 0;
             DateTime? first = null, last = null;
             var hosts = new HashSet<int>();
-            for (int d = 0; d < timeline.Days.Length; d++)
+            // Starts before the window so the rolling 28-day Copilot counters below are already full on the
+            // window's first day. Warm-up days maintain the counters and last-activity dates but write no
+            // rows and do not feed adoption scoring, so the reported window is unchanged by their presence.
+            for (int d = -DemoTimeline.WarmupDays; d < _options.Days; d++)
             {
                 if (d % 28 == 0) _cancellation.ThrowIfCancellationRequested();
                 var date = _options.Start.AddDays(d);
-                var day = timeline.Days[d];
-                int bucket = d % 28;
+                var day = timeline.Day(d);
+                bool reported = d >= 0;
+                int bucket = ((d % 28) + 28) % 28;
                 for (int app = 0; app < 9; app++)
                 {
                     appWindow[app] -= appDays[bucket, app];
@@ -215,10 +219,13 @@ namespace Tests.FakeDataGen.Demo
                 {
                     appDays[bucket, 0] = 1;
                     lastApps[0] = date;
-                    if (!first.HasValue) first = date;
-                    last = date;
-                    if (d >= _options.Days - 28) { active++; interactions += day.CopilotTurns; }
-                    else prior += day.CopilotTurns;
+                    if (reported)
+                    {
+                        if (!first.HasValue) first = date;
+                        last = date;
+                        if (d >= _options.Days - 28) { active++; interactions += day.CopilotTurns; }
+                        else prior += day.CopilotTurns;
+                    }
                     for (int slot = 0; slot < day.CopilotTurns; slot++)
                     {
                         int host = timeline.HostIndex(d, slot);
@@ -227,32 +234,33 @@ namespace Tests.FakeDataGen.Demo
                         lastApps[app] = date;
                         if (host == 0) chatWindow[bucket]++;
                         if (timeline.Agent(d, slot) > 0) { appDays[bucket, 8] = 1; lastApps[8] = date; }
-                        if (d >= _options.Days - 28) hosts.Add(host);
+                        if (reported && d >= _options.Days - 28) hosts.Add(host);
                     }
-                    WriteCopilotEvents(user, timeline, d);
+                    if (reported) WriteCopilotEvents(user, timeline, d);
                 }
                 windowTurns += turnWindow[bucket];
                 windowChat += chatWindow[bucket];
                 for (int app = 0; app < 9; app++)
                 {
                     appWindow[app] += appDays[bucket, app];
-                    if (user.CopilotLicensed)
+                    if (reported && user.CopilotLicensed)
                     {
                         _dailyActive[d, app] += appDays[bucket, app];
                         if (appWindow[app] > 0) _rollingActive[d, app]++;
                     }
                 }
-                if (user.CopilotLicensed)
+                if (reported && user.CopilotLicensed)
                 {
                     _dailyPrompts[d] += day.CopilotTurns;
                     _rollingPrompts[d] += windowTurns;
                 }
+                if (!reported) continue;
                 if (day.SharePointFiles > 0) WriteWebEvents(user, d, day);
                 if (date > _options.ReportEnd) continue;
                 int appMask = 0;
                 for (int app = 1; app <= 7; app++) if (appDays[bucket, app] > 0) appMask |= 1 << app;
                 WriteWorkloadRows(user, d, day, lastWorkload, appMask, ref lastOffice, ref lastTeamsDevice);
-                if (user.CopilotLicensed && date >= _options.FirstCopilotReport)
+                if (user.CopilotLicensed)
                     _sink.Write(DemoTables.CopilotUsage, user.Id, date, lastApps[0], 28, windowTurns, windowChat, 0,
                         appWindow[0], lastApps[1], lastApps[2], lastApps[3], lastApps[4], lastApps[5], lastApps[6],
                         lastApps[7], lastApps[1], lastApps[8], false);
@@ -318,7 +326,7 @@ namespace Tests.FakeDataGen.Demo
 
         private void WriteCopilotEvents(DemoUser user, DemoTimeline timeline, int dayIndex)
         {
-            var day = timeline.Days[dayIndex];
+            var day = timeline.Day(dayIndex);
             int sessionId = (user.Id - 1) * _options.Days + dayIndex + 1;
             string thread = "contoso-demo-" + DemoRandom.Id(_options.Seed, 3, user.Id, dayIndex).ToString("N");
             if (user.CopilotLicensed) _sink.Write(DemoTables.InteractionSessions, sessionId, thread, user.Id);
@@ -376,11 +384,10 @@ namespace Tests.FakeDataGen.Demo
                 {
                     _sink.Write(DemoTables.CopilotCounts, _options.ReportEnd, date, "Trend", null,
                         DemoTimeline.ReportApps[app], licensed, _dailyActive[d, app], app == 0 ? (object)_dailyPrompts[d] : null, null);
-                    if (date >= _options.FirstCopilotReport)
-                        _sink.Write(DemoTables.CopilotCounts, date, date, "Summary", 28,
-                            DemoTimeline.ReportApps[app], licensed, _rollingActive[d, app],
-                            app == 0 ? (object)_rollingPrompts[d] : null,
-                            app == 0 && _rollingActive[d, 0] > 0 ? (object)((double)_rollingPrompts[d] / _rollingActive[d, 0]) : null);
+                    _sink.Write(DemoTables.CopilotCounts, date, date, "Summary", 28,
+                        DemoTimeline.ReportApps[app], licensed, _rollingActive[d, app],
+                        app == 0 ? (object)_rollingPrompts[d] : null,
+                        app == 0 && _rollingActive[d, 0] > 0 ? (object)((double)_rollingPrompts[d] / _rollingActive[d, 0]) : null);
                 }
             }
         }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoOptions.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoOptions.cs
@@ -11,7 +11,8 @@ namespace Tests.FakeDataGen.Demo
     internal sealed class DemoOptions
     {
         // Bump when generation rules change: completed targets must not silently reuse an older shape.
-        public const string FormatVersion = "contoso-demo-v1";
+        // History: contoso-demo-v2 - Copilot report rows now cover the whole window (28-day warm-up).
+        public const string FormatVersion = "contoso-demo-v2";
 
         // Accepted ranges, shared with the interactive menu (DemoInteractive) so the two entry points
         // cannot drift apart and offer a value the other refuses.
@@ -41,7 +42,6 @@ namespace Tests.FakeDataGen.Demo
         public int[] Mix { get; private set; } = new[] { 30, 35, 20, 8, 7 };
         public DateTime Start => AsOf.AddDays(-Days);
         public DateTime ReportEnd => AsOf.AddDays(-3);
-        public DateTime FirstCopilotReport => Start.AddDays(27);
 
         public static DemoOptions Parse(string[] args, DateTime utcToday)
         {
@@ -130,8 +130,9 @@ asks for the same values, prints the equivalent command line, and runs this same
   --days N                 31..730 preceding calendar days (default 180).
   --as-of yyyy-MM-dd        Exclusive UTC end date (default today's UTC date).
                            Workload snapshots stop three days before this date.
-                           D28 snapshots start after 28 complete generated days; they
-                           are rolling snapshots, NOT additive daily prompt counts.
+                           D28 snapshots cover every reported date: 28 hidden days before
+                           the window warm the rolling counters. They are rolling
+                           snapshots, NOT additive daily prompt counts.
   --seed N                 0..2147483647 (default 42). Specify as-of too for reproducibility.
   --mix H,M,L,Z,I           High/moderate/low/never-active/inactive percentages, sum 100.
                            Default 30,35,20,8,7. Small populations may not contain every band.

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoPortalReadiness.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoPortalReadiness.cs
@@ -1,0 +1,106 @@
+using Common.Entities.LicenceActivity;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+
+namespace Tests.FakeDataGen.Demo
+{
+    /// <summary>
+    /// Turns "the portal shows nothing" into an answer the operator gets while they are still looking at
+    /// the generator.
+    ///
+    /// The portal decides which workloads it can measure from the WEB APPLICATION's ImportJobSettings
+    /// app setting, not from the rows in the database. Every one of those flags is opt-in and defaults to
+    /// false, so a demo database full of Copilot activity still renders the Licence assignments report's
+    /// Copilot column as "Not measured" until the app is told the source exists. Nothing the generator
+    /// writes can change that, so it prints the setting instead - and then runs the report's own coverage
+    /// query so the operator can see what the portal will show before they wire anything up.
+    /// </summary>
+    internal static class DemoPortalReadiness
+    {
+        /// <summary>
+        /// The import toggles whose tables this generator actually fills. Deliberately not "everything":
+        /// a flag listed here but not generated would send an operator looking for data that is absent.
+        /// </summary>
+        internal const string RequiredImportJobSettings =
+            "GraphUsersMetadata=True;GraphUsageReports=True;GraphCopilotUsageReports=True;"
+            + "Copilot=True;CopilotInteractionHistory=True;ActivityLog=True;WebTraffic=True";
+
+        internal static void PrintPortalSetup(string database, Action<string> write)
+        {
+            if (write == null) return;
+            write(string.Empty);
+            write("To view this data, point a web application at it with:");
+            write($"  connectionStrings   SPOInsightsEntities = Server=(localdb)\\MSSQLLocalDB;Database={database};Integrated Security=True");
+            write("  appSettings         ImportJobSettings = " + RequiredImportJobSettings);
+            write(string.Empty);
+            write("Those toggles are how the portal decides which sources exist; they are all opt-in and");
+            write("default to false. In particular, WITHOUT GraphCopilotUsageReports=True the Licence");
+            write("assignments report shows Copilot as \"Not measured\" for every user even though this");
+            write("database is full of Copilot activity: the audit and interaction sources are positive");
+            write("evidence only and never produce activity bands.");
+        }
+
+        /// <summary>
+        /// Runs the Licence assignments report's own coverage query against the finished database and
+        /// prints, per workload, what the portal will be able to measure. Diagnostic only: any failure is
+        /// reported and swallowed, because the data is already generated and verified by this point.
+        /// </summary>
+        internal static void PrintMeasuredCoverage(string connectionString, DateTime nowUtc, Action<string> write)
+        {
+            if (write == null) return;
+            write(string.Empty);
+            write("Checking what the Licence assignments report can measure (its own query, all sources enabled)...");
+            var watch = Stopwatch.StartNew();
+            try
+            {
+                var query = LicenceActivityQuery.Create(null, null, nowUtc);
+                var sources = new LicenceActivitySources
+                {
+                    UserMetadata = true,
+                    UsageReports = true,
+                    CopilotUsageReports = true,
+                    CopilotAudit = true,
+                    CopilotInteractions = true,
+                    NowUtc = nowUtc
+                };
+                var overview = new SqlLicenceActivityStore(connectionString)
+                    .LoadOverviewAsync(query, sources, null, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+
+                var largest = overview.Licences.OrderByDescending(l => l.AssignedUsers).FirstOrDefault();
+                write($"Default reporting period {query.From} to {query.To}"
+                    + (largest == null ? ":" : $", licence \"{largest.Name}\" ({largest.AssignedUsers:N0} users):"));
+                foreach (var coverage in overview.Coverage)
+                {
+                    var bands = largest?.Workloads.FirstOrDefault(w => w.Workload == coverage.Workload);
+                    int measured = bands == null ? 0 : bands.High + bands.Moderate + bands.Low + bands.Zero;
+                    write($"  {coverage.Workload,-10} {coverage.Status,-16} "
+                        + (bands == null ? string.Empty : $"{measured:N0} measured, {bands.Unknown:N0} unknown"));
+                }
+                if (largest != null)
+                {
+                    var unmeasured = overview.Coverage
+                        .Where(c => (largest.Workloads.FirstOrDefault(w => w.Workload == c.Workload)?.Unknown ?? 0)
+                                    == largest.AssignedUsers)
+                        .Select(c => c.Workload)
+                        .ToList();
+                    if (unmeasured.Count > 0)
+                    {
+                        write("Unmeasured for every holder of that licence: " + string.Join(", ", unmeasured)
+                            + ". The portal renders these as \"Not measured\", not as zero activity.");
+                    }
+                }
+                write($"Coverage check took {watch.Elapsed.TotalSeconds:F1}s. The portal applies the same rules,");
+                write("but only to the sources its own ImportJobSettings enables.");
+            }
+            catch (Exception ex)
+            {
+                write("Coverage check could not be completed: " + ex.Message);
+                write("The generated data is unaffected; this step only reports what the portal would show.");
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoTimeline.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoTimeline.cs
@@ -14,23 +14,39 @@ namespace Tests.FakeDataGen.Demo
 
     internal sealed class DemoTimeline
     {
+        /// <summary>
+        /// Days of activity generated BEFORE the reported window starts. Nothing is written for them: they
+        /// exist only so the rolling 28-day Copilot counters are already full on the window's first day.
+        /// Without this the official report rows could only start 27 days in, which leaves the licence
+        /// report's Copilot column unmeasurable on any short history - the M365 workloads have no such
+        /// warm-up because their rows are daily, not rolling.
+        /// </summary>
+        internal const int WarmupDays = 28;
+
         public static readonly string[] Hosts = { "bizchat", "Teams", "Word", "Outlook", "Excel", "PowerPoint", "OneNote", "cowork" };
         public static readonly string[] ReportApps =
             { "Any App", "Copilot Chat (work)", "Microsoft Teams", "Word", "Outlook", "Excel", "PowerPoint", "OneNote", "Copilot agents" };
         private readonly DemoOptions _options;
         private readonly DemoUser _user;
-        public DemoDay[] Days { get; }
+        private readonly DemoDay[] _days;
+
+        /// <summary>The day at <paramref name="offset"/> days from the window start; negative is warm-up.</summary>
+        public DemoDay Day(int offset) => _days[offset + WarmupDays];
 
         public DemoTimeline(DemoOptions options, DemoUser user)
         {
             _options = options;
             _user = user;
-            Days = Enumerable.Range(0, options.Days).Select(_ => new DemoDay()).ToArray();
+            _days = Enumerable.Range(0, options.Days + WarmupDays).Select(_ => new DemoDay()).ToArray();
             PopulateCopilot();
-            for (int d = 0; d < Days.Length; d++)
+            // Workload activity is generated for reported days only. Warm-up days exist purely to fill the
+            // rolling Copilot counters, and nothing reads their M365 fields, so generating them would cost
+            // 28 extra days of hashing per user (millions of discarded draws at a 200k-user scale) for
+            // values that are then thrown away.
+            for (int d = 0; d < options.Days; d++)
             {
                 if (!DemoCalendar.IsWorkingDate(options.Start.AddDays(d))) continue;
-                var day = Days[d];
+                var day = Day(d);
                 int age = options.Days - d;
                 if (user.Cohort == DemoCohort.Zero || (user.Cohort == DemoCohort.Inactive && age <= 60)) continue;
                 var cohort = user.Cohort == DemoCohort.Inactive ? DemoCohort.Moderate : user.Cohort;
@@ -64,7 +80,16 @@ namespace Tests.FakeDataGen.Demo
 
         private uint Random(int day, int salt) => DemoRandom.Value(_options.Seed, _user.Id, day, salt);
 
-        public static bool IsOnLeave(int userId, int day) => (day / 7) % 26 == userId % 26;
+        /// <summary>
+        /// Leave is a repeating 26-week rota keyed on the user. Warm-up days are negative offsets, where
+        /// C# integer division truncates towards zero, so the week index is floored explicitly: without it
+        /// days -6..-1 would share week 0 with days 0..6 and produce a 13-day leave block.
+        /// </summary>
+        public static bool IsOnLeave(int userId, int day)
+        {
+            int week = day >= 0 ? day / 7 : (day - 6) / 7;
+            return ((week % 26) + 26) % 26 == userId % 26;
+        }
 
         private void PopulateCopilot()
         {
@@ -75,7 +100,7 @@ namespace Tests.FakeDataGen.Demo
             int wanted = _user.CopilotLicensed ? persona.ActiveDaysInWindow : 4 + _user.Id % 5;
             int perDay = _user.CopilotLicensed ? (int)Math.Round(persona.InteractionsPerActiveDay) : 2 + _user.Id % 2;
             var recent = new List<int>();
-            for (int d = Math.Max(0, Days.Length - 28); d < Days.Length; d++)
+            for (int d = Math.Max(0, _options.Days - 28); d < _options.Days; d++)
                 if (DemoCalendar.IsWorkingDate(_options.Start.AddDays(d)) && !IsOnLeave(_user.Id, d)) recent.Add(d);
             recent.Sort((a, b) =>
             {
@@ -83,7 +108,7 @@ namespace Tests.FakeDataGen.Demo
                 return compare == 0 ? a.CompareTo(b) : compare;
             });
             for (int i = 0; i < Math.Min(wanted, recent.Count); i++)
-                Days[recent[i]].CopilotTurns = Math.Max(1, perDay);
+                Day(recent[i]).CopilotTurns = Math.Max(1, perDay);
 
             int firstAge = _user.CopilotLicensed
                 ? persona.ExpectedBand == AdoptionBand.Champion ? 110 + _user.Id % 60
@@ -93,29 +118,30 @@ namespace Tests.FakeDataGen.Demo
                 : 45 + _user.Id % 40;
             int lastAge = persona.ExpectedBand == AdoptionBand.Dormant
                 ? (_user.Cohort == DemoCohort.Inactive ? 61 : 42 + _user.Id % 20) : 29;
-            for (int d = 0; d < Days.Length - 28; d++)
+            for (int d = -WarmupDays; d < _options.Days - 28; d++)
             {
-                int age = Days.Length - d;
+                int age = _options.Days - d;
                 if (age > firstAge || age < lastAge || !DemoCalendar.IsWorkingDate(_options.Start.AddDays(d)) || IsOnLeave(_user.Id, d)) continue;
                 int chance = 15 + (firstAge - age) * 50 / Math.Max(1, firstAge - lastAge);
                 if (Random(d, 32) % 100 < chance)
-                    Days[d].CopilotTurns = persona.ExpectedBand == AdoptionBand.Dormant ? 2 : Math.Max(1, perDay / 2);
+                    Day(d).CopilotTurns = persona.ExpectedBand == AdoptionBand.Dormant ? 2 : Math.Max(1, perDay / 2);
             }
+
+            // Sequences restart at the window start so the reported window's app spread does not depend on
+            // how much warm-up activity happened to precede it.
+            int warmup = 0;
+            for (int d = -WarmupDays; d < 0; d++) { Day(d).CopilotSequence = warmup; warmup += Day(d).CopilotTurns; }
             int sequence = 0;
-            foreach (var day in Days)
-            {
-                day.CopilotSequence = sequence;
-                sequence += day.CopilotTurns;
-            }
+            for (int d = 0; d < _options.Days; d++) { Day(d).CopilotSequence = sequence; sequence += Day(d).CopilotTurns; }
         }
 
         public int HostIndex(int day, int slot)
         {
             if (!_user.CopilotLicensed) return 0;
             if (_user.Persona.ExpectedBand == AdoptionBand.Champion && _user.Persona.InteractionsPerActiveDay >= 5
-                && _user.Persona.DistinctApps >= 3 && _user.Id % 3 == 0 && day >= Days.Length - 28 && slot == 0) return 7;
+                && _user.Persona.DistinctApps >= 3 && _user.Id % 3 == 0 && day >= _options.Days - 28 && slot == 0) return 7;
             int breadth = Math.Max(1, _user.Persona.DistinctApps);
-            return (_user.Department + (Days[day].CopilotSequence + slot) % breadth) % 7;
+            return (_user.Department + (Day(day).CopilotSequence + slot) % breadth) % 7;
         }
 
         public int Agent(int day, int slot)
@@ -123,7 +149,7 @@ namespace Tests.FakeDataGen.Demo
             if (!_user.CopilotLicensed) return 0;
             if (HostIndex(day, slot) == 7) return 5;
             if (Random(day, 40 + slot) % 100 >= 35) return 0;
-            int age = Days.Length - day;
+            int age = _options.Days - day;
             if (age <= 12 && _user.Id % 4 == 0) return 4;
             if (age >= 42 && age <= 80 && _user.Id % 4 == 1) return 2;
             if (age >= 96 && age <= 118 && _user.Id % 4 == 2) return 3;

--- a/src/AnalyticsEngine/Tests.FakeDataGen/README.md
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/README.md
@@ -138,6 +138,49 @@ the refusal of unmarked or changed targets and the read-only no-op on an
 identical rerun apply exactly as they do on the command line. It ignores the
 connection string the tool was started with.
 
+#### Viewing it in the portal
+
+A finished run prints the two settings a web application needs:
+
+```
+  connectionStrings   SPOInsightsEntities = Server=(localdb)\MSSQLLocalDB;Database=ContosoDemo_X;Integrated Security=True
+  appSettings         ImportJobSettings = GraphUsersMetadata=True;GraphUsageReports=True;GraphCopilotUsageReports=True;Copilot=True;CopilotInteractionHistory=True;ActivityLog=True;WebTraffic=True
+```
+
+**The portal decides which workloads it can measure from `ImportJobSettings`, not
+from the rows in the database**, and every one of those flags is opt-in with a
+default of `false`. Without `GraphCopilotUsageReports=True` the Licence
+assignments report renders Copilot as *"Not measured"* for every user even though
+the database is full of Copilot activity: the Copilot audit and interaction
+sources are positive evidence only and never produce activity bands. No
+generated data can change that, so the generator prints the setting instead.
+
+It then runs the Licence assignments report's **own coverage query** against the
+finished database and prints what the portal will be able to measure:
+
+```
+Default reporting period 2026-08-03 to 2026-08-30, licence "Contoso Demo Workplace" (40 users):
+  teams      available        40 measured, 0 unknown
+  ...
+  copilot    available        24 measured, 16 unknown
+```
+
+Copilot unknowns are expected and correct: the official per-user report covers
+Copilot-licensed users only. *Every* user unknown is the symptom to look for.
+
+Two further things are worth knowing when a workload reads as unmeasured:
+
+- The official Copilot report is a **rolling 28-day** snapshot, and nothing in
+  this product imports a `report_period_days = 7` row, so Copilot licence bands
+  are only produced for a **28-day** reporting period. Other periods report
+  `missingCoverage`, which the portal shows as "Not measured". This applies to
+  real tenants too, not just the demo.
+- The demo warms its rolling Copilot counters up over the 28 days *before* the
+  window starts, so the official report rows cover the whole generated window.
+  Before that warm-up existed they began 27 days in, which left short-history
+  demos (`--days 31` to `--days 35`) with no Copilot coverage at all while the
+  M365 workloads still measured fine.
+
 ### Copilot activity
 
 `CopilotActivityGenerator` inserts:

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Demo\DemoInteractive.cs" />
     <Compile Include="Demo\DemoOptions.cs" />
     <Compile Include="Demo\DemoPopulation.cs" />
+    <Compile Include="Demo\DemoPortalReadiness.cs" />
     <Compile Include="Demo\DemoTables.cs" />
     <Compile Include="Demo\DemoTimeline.cs" />
     <Compile Include="Demo\SqlDemoDatabase.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoGeneratorTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoGeneratorTests.cs
@@ -157,7 +157,7 @@ namespace Tests.UnitTests
                 Assert.IsTrue(user.Upn.All(c => c <= 127));
                 for (int d = 0; d < options.Days; d++)
                 {
-                    var day = timeline.Days[d];
+                    var day = timeline.Day(d);
                     if (!DemoCalendar.IsWorkingDate(options.Start.AddDays(d)) || DemoTimeline.IsOnLeave(id, d) || user.Cohort == DemoCohort.Zero
                         || (user.Cohort == DemoCohort.Inactive && options.Days - d <= 60))
                     {
@@ -189,7 +189,7 @@ namespace Tests.UnitTests
                     foreach (var row in group.OrderBy(r => (DateTime)r[1]))
                     {
                         var date = (DateTime)row[1];
-                        var day = timeline.Days[(int)(date - options.Start).TotalDays];
+                        var day = timeline.Day((int)(date - options.Start).TotalDays);
                         int total = table == DemoTables.Teams ? day.Messages + day.Meetings
                             : table == DemoTables.Outlook ? day.Sent + day.Read
                             : table == DemoTables.SharePoint ? day.SharePointFiles : day.OneDriveFiles;
@@ -209,7 +209,9 @@ namespace Tests.UnitTests
             var population = new DemoPopulation(options);
             var sink = Generate(options, t => t == DemoTables.CopilotUsage || t == DemoTables.CopilotCounts);
             var details = sink.For(DemoTables.CopilotUsage);
-            Assert.AreEqual(population.Skus[1].Members * (options.Days - 29), details.Count);
+            // The official report now covers every reported day, exactly like the M365 daily tables: the
+            // rolling 28-day counters are warmed up before the window starts rather than inside it.
+            Assert.AreEqual(population.Skus[1].Members * (options.Days - 2), details.Count);
             Assert.AreEqual(details.Count, details.Select(r => r[0] + "|" + r[1] + "|" + r[3]).Distinct().Count());
             foreach (var group in details.GroupBy(r => (int)r[0]))
             {
@@ -219,9 +221,9 @@ namespace Tests.UnitTests
                 foreach (var row in group)
                 {
                     var date = (DateTime)row[1];
-                    Assert.IsTrue(date >= options.FirstCopilotReport && date <= options.ReportEnd);
+                    Assert.IsTrue(date >= options.Start && date <= options.ReportEnd);
                     int end = (int)(date - options.Start).TotalDays;
-                    var window = timeline.Days.Skip(end - 27).Take(28).ToList();
+                    var window = Enumerable.Range(end - 27, 28).Select(timeline.Day).ToList();
                     Assert.AreEqual(28, row[3]);
                     Assert.AreEqual(window.Sum(d => d.CopilotTurns), row[4]);
                     Assert.AreEqual(window.Count(d => d.CopilotTurns > 0), row[7]);
@@ -310,7 +312,7 @@ namespace Tests.UnitTests
             {
                 var timeline = new DemoTimeline(options, population.User(id));
                 for (int day = options.Days - CopilotAdoptionOptions.Default.AgentHistoryDays; day < options.Days; day++)
-                    for (int slot = 0; slot < timeline.Days[day].CopilotTurns; slot++)
+                    for (int slot = 0; slot < timeline.Day(day).CopilotTurns; slot++)
                     {
                         int agent = timeline.Agent(day, slot);
                         if (agent == 0) continue;

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoLicenceActivityCoverageTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoLicenceActivityCoverageTests.cs
@@ -1,0 +1,99 @@
+using Common.Entities.LicenceActivity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading;
+using Tests.FakeDataGen.Demo;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The demo exists to be looked at in the portal, so "the rows are present" is not the property that
+    /// matters - "the report can measure them" is. This runs the Licence assignments report's own coverage
+    /// query against a generated database and asserts Copilot is measured, not merely stored.
+    /// </summary>
+    [TestClass]
+    [TestCategory("DemoGenerator")]
+    [TestCategory("Integration")]
+    [DoNotParallelize]
+    public class DemoLicenceActivityCoverageTests
+    {
+        // Fixed so the reporting window is deterministic: the default period is 28 days ending on the
+        // Sunday on or before (as-of - 3), which for 2026-09-01 is 2026-07-27..2026-08-23.
+        private static readonly DateTime AsOf = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        [TestMethod]
+        public void ShortHistory_StillLetsTheLicenceReportMeasureCopilot()
+        {
+            // 35 days is the case that used to break. The official Copilot rows began 27 days into the
+            // window (2026-08-24), one day AFTER the reporting window ends, so the report had no
+            // fully-contained snapshot and banded every user "unknown" - while the M365 workloads, whose
+            // rows are daily rather than rolling, stayed fully measured. That asymmetry is the bug.
+            string name = "ContosoDemo_Coverage_" + Guid.NewGuid().ToString("N");
+            var options = DemoOptions.Parse(new[] { "--database", name, "--users", "30", "--days", "35",
+                "--as-of", "2026-09-01", "--batch-size", "1000", "--no-profiles" }, DateTime.UtcNow);
+            try
+            {
+                using (var database = new SqlDemoDatabase(options, CancellationToken.None))
+                {
+                    database.Open(null);
+                    var summary = DemoCommand.NewSummary(options);
+                    using (var sink = new CountingDemoSink(summary, database.CreateSink()))
+                        new DemoGenerator(options).Generate(sink, summary, null);
+                    database.ValidateAndComplete(summary, null);
+                }
+
+                var query = LicenceActivityQuery.Create(null, null, AsOf);
+                Assert.AreEqual("2026-07-27", query.From);
+                Assert.AreEqual("2026-08-23", query.To);
+
+                var overview = new SqlLicenceActivityStore(SqlDemoDatabase.LocalConnection(name))
+                    .LoadOverviewAsync(query, AllSources(), null, CancellationToken.None)
+                    .GetAwaiter().GetResult();
+
+                var copilot = overview.Coverage.Single(c => c.Workload == "copilot");
+                Assert.AreEqual("available", copilot.Status,
+                    "Copilot must be measurable on the default reporting period: " + copilot.Message);
+                Assert.AreEqual("microsoftGraphCopilotUsageReport", copilot.Source,
+                    "The audit and interaction sources are positive evidence only and never produce bands.");
+
+                var licence = overview.Licences.OrderByDescending(l => l.AssignedUsers).First();
+                var bands = licence.Workloads.Single(w => w.Workload == "copilot");
+                int measured = bands.High + bands.Moderate + bands.Low + bands.Zero;
+                Assert.IsTrue(measured > 0,
+                    $"Every holder of {licence.SkuId} was unknown for Copilot; the portal renders that as \"Not measured\".");
+
+                // Only Copilot-licensed users appear in the official report, so some unknowns are correct -
+                // but they must not be the whole population, which is what the defect looked like.
+                Assert.IsTrue(bands.Unknown < licence.AssignedUsers);
+            }
+            finally { Drop(name); }
+        }
+
+        private static LicenceActivitySources AllSources() => new LicenceActivitySources
+        {
+            UserMetadata = true,
+            UsageReports = true,
+            CopilotUsageReports = true,
+            CopilotAudit = true,
+            CopilotInteractions = true,
+            NowUtc = AsOf
+        };
+
+        private static void Drop(string name)
+        {
+            using (var master = new SqlConnection(SqlDemoDatabase.LocalConnection("master")))
+            {
+                master.Open();
+                using (var command = master.CreateCommand())
+                {
+                    command.CommandText =
+                        "IF DB_ID(@name) IS NOT NULL EXEC('ALTER DATABASE [' + @name + '] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [' + @name + ']');";
+                    command.Parameters.AddWithValue("@name", name);
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="CopilotDroppedAuditFieldsTests.cs" />
     <Compile Include="DemoGeneratorTests.cs" />
     <Compile Include="DemoGeneratorSqlTests.cs" />
+    <Compile Include="DemoLicenceActivityCoverageTests.cs" />
     <Compile Include="DemoInteractiveTests.cs" />
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoCalendar.cs">
       <Link>DemoGenerator\DemoCalendar.cs</Link>
@@ -175,6 +176,9 @@
     </Compile>
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoPopulation.cs">
       <Link>DemoGenerator\DemoPopulation.cs</Link>
+    </Compile>
+    <Compile Include="..\Tests.FakeDataGen\Demo\DemoPortalReadiness.cs">
+      <Link>DemoGenerator\DemoPortalReadiness.cs</Link>
     </Compile>
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoTables.cs">
       <Link>DemoGenerator\DemoTables.cs</Link>


### PR DESCRIPTION
## Symptom

The portal's **Licence assignments** report showed the Copilot column as *"Not measured"* — every
user Unknown — against a generated demo database, while Teams, Outlook, OneDrive and SharePoint
were fully measured.

## Investigation

The generator was producing Copilot data all along: `copilot_chats` + `audit_events`,
`copilot_interactions`, `copilot_usage_user_activity_log` and `copilot_user_count_log`. I ran the
real `SqlLicenceActivityStore.LoadOverviewAsync` against generated databases rather than reasoning
from the SQL, and found **two independent causes**, either of which reproduces the screenshot.

### 1. The gate is configuration, not data (cannot be fixed by the generator)

`LicenceActivityAPIController.CreateContext` builds `LicenceActivitySources` from the **web
application's** `ImportJobSettings` app setting, and every `[ImportProp]` on `ImportTaskSettings`
defaults to `false`. `LicenceActivitySql.AppendCopilotOverview` gates the Copilot source on those
flags, so the rows in the database are irrelevant until the app is told the source exists.

Measured against one 180-day demo database, 60 users:

| Sources enabled | Copilot status | Bands for the top SKU |
|---|---|---|
| `GraphCopilotUsageReports` + `Copilot` + `CopilotInteractionHistory` | `available` | moderate 8, low 12, zero 16, unknown 24 |
| audit and/or interactions, no usage report | `partial` | **all 60 unknown** |
| none | `disabled` | **all 60 unknown** |

Only `GraphCopilotUsageReports` can produce bands — the audit and interaction sources are
deliberately *positive evidence only* ("no database signal proves complete event coverage, so absent
users remain unknown"). No generated data can change that, so this PR makes the generator **print
the setting** rather than let the portal fail silently.

### 2. A real generator gap (fixed here)

`copilot_usage_user_activity_log` rows only started at `Start + 27 days`, because the rolling 28-day
counters needed 27 days to fill. The report's default window is the 28 days ending on the Sunday on
or before `today - 3`. So on a short history no Copilot row landed in the window at all:

| `--days` | Teams | Copilot |
|---|---|---|
| 120 | `available`, 0 unknown | `available`, 24 measured |
| **35** | `available`, **0 unknown** | `partial` (fell back to audit), **all 60 unknown** |

The M365 workloads were unaffected because their rows are **daily**; only Copilot's are **rolling**.
That asymmetry is the bug.

## Changes

- **`DemoTimeline` generates `WarmupDays = 28` days before the window** (`Day(offset)`, offset may be
  negative). Randomness stays keyed on the day *offset*, so reported days keep their existing draws
  and only warm-up days are new. Warm-up days carry `CopilotTurns` only — the workload population
  loop still starts at `0`, because nothing reads their M365 fields. `CopilotSequence` restarts at
  offset 0 so the reported window's app spread does not depend on warm-up volume.
- **`IsOnLeave` floors the week index.** C# truncates towards zero, so `-1 / 7 == 0` would have put
  days `-6..-1` in the same 26-week rota slot as days `0..6`, giving users where `id % 26 == 0` a
  13-day leave block straddling the boundary. Provably a no-op for non-negative offsets.
- **`DemoGenerator.WriteTimeline` loops from `-WarmupDays`.** Warm-up days maintain the rolling
  counters and the per-app last-activity dates but write no rows and feed no adoption scoring, so
  `copilot_usage_user_activity_log` and the `copilot_user_count_log` *Summary* rows now cover every
  reported date — exactly like the M365 daily tables.
- **`DemoOptions.FirstCopilotReport` removed; `FormatVersion` bumped to `contoso-demo-v2`** so a
  completed v1 target is not silently reused under the new shape, and the `--as-of` help text no
  longer describes the removed 27-day delay.
- **New `DemoPortalReadiness`.** After a SQL run it prints the connection string and the
  `ImportJobSettings` the generated tables actually support, explains that without
  `GraphCopilotUsageReports=True` the Copilot column reads "Not measured", then runs the licence
  report's **own coverage query** and prints per-workload status with measured/unknown counts:

  ```
  Default reporting period 2026-08-03 to 2026-08-30, licence "Contoso Demo Workplace" (40 users):
    teams      available        40 measured, 0 unknown
    outlook    available        40 measured, 0 unknown
    onedrive   available        40 measured, 0 unknown
    sharepoint available        40 measured, 0 unknown
    copilot    available        24 measured, 16 unknown
  ```

  Diagnostic only: any failure is reported and swallowed, because the data is already generated and
  verified by that point. It took 0.1s on the 40-user run above.

## Reviewer hotspots

- **Negative array indexing.** `_dailyActive` / `_rollingActive` / `_dailyPrompts` / `_rollingPrompts`
  are sized `options.Days` and indexed by `d`; every write is behind the `reported` (`d >= 0`) flag.
- **Ring buffer across the `-1 -> 0` seam.** `bucket = ((d % 28) + 28) % 28`; at `d = 0` the buckets
  hold days `[-27, 0]`, which is what the test's `Enumerable.Range(end - 27, 28)` window asserts.
- **`IsOnLeave` equivalence** for `day >= 0` — if that were not exact, all existing generated data
  would silently change.

## Tests

- New `DemoLicenceActivityCoverageTests.ShortHistory_StillLetsTheLicenceReportMeasureCopilot`
  generates a 35-day demo into LocalDB and asserts the licence report reaches `available` from
  `microsoftGraphCopilotUsageReport` with more than zero measured users. **Verified by mutation that
  it fails without the fix** (restoring the 27-day gate makes it fail; the fix makes it pass). It is
  deterministic: `--as-of 2026-09-01` with `NowUtc = 2026-09-01`, so the window is fixed at
  2026-07-27..2026-08-23 regardless of when or where it runs.
- `OfficialCopilotSnapshots_...` now expects `Days - 2` snapshots per licensed user, not `Days - 29`.
- All 28 `DemoGenerator`-category tests pass (1 opt-in scale benchmark skipped).
- End-to-end through the interactive menu: a 35-day run now reports
  `copilot available 24 measured, 16 unknown` where it previously reported 0 measured and every user
  unknown. Remaining unknowns are users without a Copilot licence, which is correct — the official
  report covers licensed users only.

## Schema / config

None. No migrations, no `Create DB.sql` change, no installer `CONFIG_VERSION` change — this is
test-tooling only. `DemoOptions.FormatVersion` is bumped, which is the demo generator's own marker,
not the installer's config schema.

## Not fixed here — worth its own issue

Nothing in this product imports a `report_period_days = 7` row: `CopilotUsageUserDetailLoader` only
ever requests `DefaultRefreshPeriod = "D28"` (plus `D180` for the one-off trend backfill). So
`LicenceActivitySql`'s preferred D7 weekly-sampling path is unreachable in production, and Copilot
licence bands are only produced when the reporting period is **exactly 28 days** — 7/14/21-day
periods fall back to the audit source and 35/56/90-day periods return `missingCoverage`, both of
which the portal renders as "Not measured". Measured on the same database:

| Period | Copilot status |
|---|---|
| 7d / 14d / 21d | `partial` (audit fallback), all unknown |
| **28d** | `available`, measured |
| 35d / 56d / 90d | `missingCoverage`, all unknown |

This affects real tenants, not just the demo, so it is deliberately out of scope for this PR.

## Review

Reviewed by two models over two rounds until both returned clean. Findings fixed along the way: the
`IsOnLeave` truncation bug on negative offsets, warm-up days generating M365 activity that is never
read (~8.4M discarded day-iterations at 300k users), and a stale `--as-of` help paragraph.
