### PR TITLE
Reorganise the Licence activity report into tabs

### DIFF
--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DataSourceSummary.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DataSourceSummary.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import DataSourceSummary from './DataSourceSummary';
+import type { LicenceActivityCoverage } from '../../types/licenceActivity';
+
+function cov(over: Partial<LicenceActivityCoverage> = {}): LicenceActivityCoverage {
+  return {
+    workload: 'teams',
+    status: 'available',
+    source: 'microsoftGraphUsageReport',
+    measure: 'activity counted by Microsoft',
+    granularity: 'weeklySupportingSnapshot',
+    message: null,
+    effectiveFromUtc: '2026-04-22T00:00:00Z',
+    effectiveToUtc: '2026-05-19T00:00:00Z',
+    latestImportUtc: '2026-05-20T00:00:00Z',
+    lagDays: 1,
+    reportPeriodDays: 28,
+    expectedSamples: 100,
+    observedSamples: 95,
+    unmatchedUsers: 0,
+    snapshotDates: [],
+    ...over,
+  };
+}
+
+const NOW = new Date('2026-05-22T12:00:00Z');
+
+const FIVE: LicenceActivityCoverage[] = [
+  cov({ workload: 'teams', status: 'available' }),
+  cov({ workload: 'outlook', status: 'available' }),
+  cov({ workload: 'onedrive', status: 'available' }),
+  cov({ workload: 'sharepoint', status: 'partial' }),
+  cov({ workload: 'copilot', status: 'notImported' }),
+];
+
+describe('DataSourceSummary', () => {
+  it('is collapsed by default: a status summary is shown, the full detail is not', () => {
+    renderWithProvider(
+      <DataSourceSummary coverage={FIVE} generatedUtc="2026-05-20T10:00:00Z" expiresUtc="2026-05-20T10:05:00Z" now={NOW} />,
+    );
+
+    // The at-a-glance chip row summarises the services by status.
+    expect(screen.getByText(/3 Available/)).toBeInTheDocument();
+    expect(screen.getByText(/1 Partial/)).toBeInTheDocument();
+    expect(screen.getByText(/1 Not imported/)).toBeInTheDocument();
+    expect(screen.getByText(/prepared/i)).toBeInTheDocument();
+
+    // The full CoveragePanel (its "held for up to ..." caption is unique to it) stays hidden until asked for.
+    expect(screen.queryByText(/held for up to/i)).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: /show data sources/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expands to reveal the full per-service provenance, then collapses again', () => {
+    renderWithProvider(
+      <DataSourceSummary coverage={FIVE} generatedUtc="2026-05-20T10:00:00Z" expiresUtc="2026-05-20T10:05:00Z" now={NOW} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /show data sources/i }));
+
+    // The full panel is now present: its freshness caption and a translated source line appear.
+    expect(screen.getByText(/held for up to/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Microsoft 365 usage reports/).length).toBeGreaterThan(0);
+
+    const toggle = screen.getByRole('button', { name: /hide data sources/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(toggle);
+    expect(screen.queryByText(/held for up to/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /show data sources/i })).toBeInTheDocument();
+  });
+
+  it('handles an empty coverage list without crashing', () => {
+    renderWithProvider(
+      <DataSourceSummary coverage={[]} generatedUtc="2026-05-20T10:00:00Z" expiresUtc="2026-05-20T10:05:00Z" now={NOW} />,
+    );
+    expect(screen.getByText(/No source information was reported/i)).toBeInTheDocument();
+    // Nothing to expand into, but the control is still present and inert-safe.
+    expect(screen.getByRole('button', { name: /show data sources/i })).toBeInTheDocument();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DataSourceSummary.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/DataSourceSummary.tsx
@@ -1,0 +1,149 @@
+import { useId, useState } from 'react';
+import { makeStyles, tokens, Card, Text, Badge, Button } from '@fluentui/react-components';
+import { ChevronDown16Regular, ChevronRight16Regular } from '@fluentui/react-icons';
+import type { LicenceActivityCoverage } from '../../types/licenceActivity';
+import CoveragePanel from './CoveragePanel';
+import { statusMeta, type StatusTone } from './statuses';
+import { formatAge } from './format';
+
+const useStyles = makeStyles({
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    padding: '10px 14px',
+  },
+  head: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  headText: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  title: {
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: tokens.colorNeutralForeground3,
+  },
+  chips: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    flexWrap: 'wrap',
+  },
+  generated: {
+    color: tokens.colorNeutralForeground3,
+  },
+  panelWrap: {
+    marginTop: '2px',
+  },
+});
+
+interface DataSourceSummaryProps {
+  coverage: LicenceActivityCoverage[];
+  generatedUtc: string;
+  expiresUtc: string;
+  /** Injectable "now" for deterministic "prepared N days ago" captions in tests. */
+  now?: Date;
+}
+
+/** Group the per-workload coverage by status, in a fixed worst-last order, so the collapsed chip row
+ *  reads "3 Available · 1 Partial · 1 Not imported" rather than one badge per service. */
+const STATUS_ORDER: string[] = [
+  'available',
+  'partial',
+  'missingCoverage',
+  'unmatchableIdentity',
+  'notImported',
+  'disabled',
+];
+
+interface StatusCount {
+  status: string;
+  label: string;
+  tone: StatusTone;
+  count: number;
+}
+
+function summariseStatuses(coverage: LicenceActivityCoverage[]): StatusCount[] {
+  const counts = new Map<string, number>();
+  for (const entry of coverage) counts.set(entry.status, (counts.get(entry.status) ?? 0) + 1);
+
+  const ordered = [...counts.keys()].sort((a, b) => {
+    const ai = STATUS_ORDER.indexOf(a);
+    const bi = STATUS_ORDER.indexOf(b);
+    return (ai < 0 ? STATUS_ORDER.length : ai) - (bi < 0 ? STATUS_ORDER.length : bi);
+  });
+
+  return ordered.map((status) => {
+    const meta = statusMeta(status);
+    return { status, label: meta.label, tone: meta.tone, count: counts.get(status) ?? 0 };
+  });
+}
+
+/**
+ * A demoted, collapsible summary of where the figures came from.
+ *
+ * The full per-service provenance ({@link CoveragePanel}) is load-bearing for trust but is not the
+ * headline, so it is collapsed by default and kept discoverable behind a status chip row: an
+ * at-a-glance count of services per coverage status, plus how fresh the figures are. Expanding
+ * reveals the complete panel in place, without leaving the current tab.
+ */
+export default function DataSourceSummary({ coverage, generatedUtc, expiresUtc, now }: DataSourceSummaryProps) {
+  const styles = useStyles();
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  const statuses = summariseStatuses(coverage);
+  const available = statuses.find((s) => s.status === 'available')?.count ?? 0;
+  const total = coverage.length;
+
+  return (
+    <Card className={styles.card}>
+      <div className={styles.head}>
+        <div className={styles.headText}>
+          <Text size={200} weight="semibold" className={styles.title}>
+            Where these figures come from
+          </Text>
+          {total > 0 ? (
+            <div className={styles.chips} aria-label={`${available} of ${total} services measured in full`}>
+              {statuses.map((s) => (
+                <Badge key={s.status} appearance="tint" color={s.tone} size="small">
+                  {s.count} {s.label}
+                </Badge>
+              ))}
+              <Text size={200} className={styles.generated}>
+                &middot; prepared {formatAge(generatedUtc, now)}
+              </Text>
+            </div>
+          ) : (
+            <Text size={200} className={styles.generated}>
+              No source information was reported for these figures.
+            </Text>
+          )}
+        </div>
+        <Button
+          appearance="subtle"
+          size="small"
+          icon={open ? <ChevronDown16Regular /> : <ChevronRight16Regular />}
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={() => setOpen((v) => !v)}
+        >
+          {open ? 'Hide data sources' : 'Show data sources'}
+        </Button>
+      </div>
+
+      {open && (
+        <div id={panelId} className={styles.panelWrap}>
+          <CoveragePanel generatedUtc={generatedUtc} expiresUtc={expiresUtc} coverage={coverage} now={now} />
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/OverviewSummary.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/OverviewSummary.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import OverviewSummary from './OverviewSummary';
+import type { LicenceActivitySku } from '../../types/licenceActivity';
+
+const E5: LicenceActivitySku = {
+  licenceTypeId: 10,
+  name: 'E5',
+  skuId: 'ENTERPRISEPREMIUM',
+  assignedUsers: 1234,
+  workloads: [],
+};
+
+describe('OverviewSummary', () => {
+  it('shows the headline figures the report already computes', () => {
+    renderWithProvider(<OverviewSummary distinctAssignedUsers={9876} licenceCount={4} selectedLicence={E5} />);
+
+    expect(screen.getByText('People with a licence')).toBeInTheDocument();
+    expect(screen.getByText('9,876')).toBeInTheDocument();
+    expect(screen.getByText('Licence types')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+
+    // The selected licence and its own assigned count.
+    expect(screen.getByText('E5')).toBeInTheDocument();
+    expect(screen.getByText(/1,234 people hold it/)).toBeInTheDocument();
+  });
+
+  it('prompts to choose a licence when none is selected', () => {
+    renderWithProvider(<OverviewSummary distinctAssignedUsers={10} licenceCount={1} selectedLicence={null} />);
+    expect(screen.getByText('None chosen')).toBeInTheDocument();
+    expect(screen.getByText(/Choose a licence below/)).toBeInTheDocument();
+  });
+
+  it('renders a non-Latin (Greek) licence name without corruption', () => {
+    renderWithProvider(
+      <OverviewSummary
+        distinctAssignedUsers={5}
+        licenceCount={1}
+        selectedLicence={{ licenceTypeId: 30, name: 'Άδεια Καλημέρα', skuId: 'GREEK', assignedUsers: 5, workloads: [] }}
+      />,
+    );
+    expect(screen.getByText('Άδεια Καλημέρα')).toBeInTheDocument();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/OverviewSummary.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/OverviewSummary.tsx
@@ -1,0 +1,113 @@
+import { memo } from 'react';
+import { makeStyles, tokens, Card, Text } from '@fluentui/react-components';
+import type { LicenceActivitySku } from '../../types/licenceActivity';
+import { formatCount, licenceName } from './format';
+
+const useStyles = makeStyles({
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+    gap: '12px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    padding: '14px 16px',
+  },
+  label: {
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: tokens.colorNeutralForeground3,
+  },
+  value: {
+    color: tokens.colorNeutralForeground1,
+    lineHeight: '1.1',
+  },
+  valueMuted: {
+    color: tokens.colorNeutralForeground2,
+    lineHeight: '1.2',
+  },
+  caption: {
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+interface OverviewSummaryProps {
+  /** distinctAssignedUsers - people holding any licence in the current scope, counted once. */
+  distinctAssignedUsers: number;
+  /** How many licence SKUs are in scope. */
+  licenceCount: number;
+  /** The licence currently drilled into, or null when none is chosen yet. */
+  selectedLicence: LicenceActivitySku | null;
+}
+
+/**
+ * The headline strip for the Overview tab: a handful of at-a-glance figures so the reader gets the
+ * shape of the selection before the detailed tables below.
+ *
+ * Every value here is a figure the report already computes - the distinct assigned-user count, the
+ * number of licence types, and the selected licence's own assigned count. Nothing is blended across
+ * services into a single "productivity" number, deliberately: that is the same false comparison the
+ * separate per-service charts avoid.
+ */
+function OverviewSummary({ distinctAssignedUsers, licenceCount, selectedLicence }: OverviewSummaryProps) {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.grid}>
+      <Card className={styles.card}>
+        <Text size={200} weight="semibold" className={styles.label}>
+          People with a licence
+        </Text>
+        <Text size={800} weight="bold" className={styles.value}>
+          {formatCount(distinctAssignedUsers)}
+        </Text>
+        <Text size={200} className={styles.caption}>
+          in this selection, counting each person once
+        </Text>
+      </Card>
+
+      <Card className={styles.card}>
+        <Text size={200} weight="semibold" className={styles.label}>
+          Licence types
+        </Text>
+        <Text size={800} weight="bold" className={styles.value}>
+          {formatCount(licenceCount)}
+        </Text>
+        <Text size={200} className={styles.caption}>
+          {licenceCount === 1 ? 'assigned in this selection' : 'assigned, each measured separately'}
+        </Text>
+      </Card>
+
+      <Card className={styles.card}>
+        <Text size={200} weight="semibold" className={styles.label}>
+          Selected licence
+        </Text>
+        {selectedLicence ? (
+          <>
+            <Text size={500} weight="bold" className={styles.valueMuted}>
+              {licenceName(selectedLicence)}
+            </Text>
+            <Text size={200} className={styles.caption}>
+              {formatCount(selectedLicence.assignedUsers)} people hold it &middot; see By service and People
+            </Text>
+          </>
+        ) : (
+          <>
+            <Text size={500} weight="bold" className={styles.valueMuted}>
+              None chosen
+            </Text>
+            <Text size={200} className={styles.caption}>
+              Choose a licence below to see its services and people
+            </Text>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+// Memoised: the page re-renders on unrelated state (users snapshot id, export state); these three
+// figures only change when the scope or the selected licence does.
+export default memo(OverviewSummary);

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SelectedLicenceBar.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SelectedLicenceBar.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import SelectedLicenceBar from './SelectedLicenceBar';
+import type { LicenceActivitySku } from '../../types/licenceActivity';
+
+const licences: LicenceActivitySku[] = [
+  { licenceTypeId: 20, name: 'F3', skuId: 'DESKLESSPACK', assignedUsers: 50, workloads: [] },
+  { licenceTypeId: 10, name: 'E5', skuId: 'ENTERPRISEPREMIUM', assignedUsers: 100, workloads: [] },
+];
+
+describe('SelectedLicenceBar', () => {
+  it('lists licences biggest-first and reflects the current selection', () => {
+    renderWithProvider(<SelectedLicenceBar licences={licences} selectedLicenceTypeId={10} onSelect={vi.fn()} />);
+
+    const select = screen.getByLabelText('Selected licence') as HTMLSelectElement;
+    expect(select.value).toBe('10');
+    // Biggest first: E5 (100) before F3 (50).
+    const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+    expect(options).toEqual(['E5', 'F3']);
+
+    // The selected licence's own assigned count is shown as context.
+    expect(screen.getByText(/100 people hold this licence/)).toBeInTheDocument();
+  });
+
+  it('changes the licence via the dropdown', () => {
+    const onSelect = vi.fn();
+    renderWithProvider(<SelectedLicenceBar licences={licences} selectedLicenceTypeId={10} onSelect={onSelect} />);
+
+    fireEvent.change(screen.getByLabelText('Selected licence'), { target: { value: '20' } });
+    expect(onSelect).toHaveBeenCalledWith(20);
+  });
+
+  it('renders nothing when there are no licences', () => {
+    renderWithProvider(<SelectedLicenceBar licences={[]} selectedLicenceTypeId={null} onSelect={vi.fn()} />);
+    expect(screen.queryByLabelText('Selected licence')).not.toBeInTheDocument();
+  });
+
+  it('renders a non-Latin (Greek) licence name without corruption', () => {
+    renderWithProvider(
+      <SelectedLicenceBar
+        licences={[{ licenceTypeId: 30, name: 'Άδεια Καλημέρα', skuId: 'GREEK', assignedUsers: 5, workloads: [] }]}
+        selectedLicenceTypeId={30}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('option', { name: 'Άδεια Καλημέρα' })).toBeInTheDocument();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SelectedLicenceBar.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/SelectedLicenceBar.tsx
@@ -1,0 +1,87 @@
+import { memo, useMemo } from 'react';
+import { makeStyles, tokens, Card, Text, Select } from '@fluentui/react-components';
+import type { LicenceActivitySku } from '../../types/licenceActivity';
+import { formatCount, licenceName } from './format';
+
+const useStyles = makeStyles({
+  card: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+    flexWrap: 'wrap',
+    padding: '10px 14px',
+  },
+  label: {
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: tokens.colorNeutralForeground3,
+  },
+  select: {
+    minWidth: '260px',
+  },
+  caption: {
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+interface SelectedLicenceBarProps {
+  licences: LicenceActivitySku[];
+  selectedLicenceTypeId: number | null;
+  onSelect: (licenceTypeId: number) => void;
+}
+
+/**
+ * The persistent selected-licence context for the tabs that are scoped to one licence (By service,
+ * People). The Overview tab has the full assignments table to pick from; away from it, this keeps the
+ * chosen licence visible and switchable without going back, so the reader never loses their place in
+ * the tab they are reading.
+ *
+ * Licences are listed biggest-first (by assigned users), matching the assignments table's default
+ * order, so the same licence sits in the same relative place in both.
+ */
+function SelectedLicenceBar({ licences, selectedLicenceTypeId, onSelect }: SelectedLicenceBarProps) {
+  const styles = useStyles();
+
+  const sorted = useMemo(
+    () =>
+      [...licences].sort(
+        (a, b) => b.assignedUsers - a.assignedUsers || licenceName(a).localeCompare(licenceName(b)),
+      ),
+    [licences],
+  );
+
+  const selected = licences.find((s) => s.licenceTypeId === selectedLicenceTypeId) ?? null;
+
+  if (licences.length === 0) return null;
+
+  return (
+    <Card className={styles.card}>
+      <Text size={200} weight="semibold" className={styles.label}>
+        Licence
+      </Text>
+      <Select
+        className={styles.select}
+        value={selectedLicenceTypeId == null ? '' : String(selectedLicenceTypeId)}
+        aria-label="Selected licence"
+        onChange={(_e, d) => {
+          if (d.value !== '') onSelect(Number(d.value));
+        }}
+      >
+        {selectedLicenceTypeId == null && <option value="">Choose a licence</option>}
+        {sorted.map((sku) => (
+          <option key={sku.licenceTypeId} value={sku.licenceTypeId}>
+            {licenceName(sku)}
+          </option>
+        ))}
+      </Select>
+      {selected && (
+        <Text size={200} className={styles.caption}>
+          {formatCount(selected.assignedUsers)} people hold this licence
+        </Text>
+      )}
+    </Card>
+  );
+}
+
+// Memoised: renders only when the licence list or the selection changes, not on every page re-render.
+export default memo(SelectedLicenceBar);

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { screen, fireEvent, waitFor, act, within, configure } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from '../test/renderWithProvider';
 import LicenceActivityPage from './LicenceActivityPage';
@@ -36,6 +36,20 @@ const mockAvailability = vi.mocked(fetchAvailability);
 const mockOverview = vi.mocked(fetchOverview);
 const mockUsers = vi.mocked(fetchUsers);
 const mockDownload = vi.mocked(downloadExport);
+
+// The report now mounts a Fluent TabList and a headline summary above the drill-down, so the full
+// availability -> overview -> users settle chain does a little more work on first paint. Give the
+// async matchers headroom over the 1000ms default (the jsdom render of the Fluent tree is slow), and
+// the whole-page integration tests a longer per-test budget than the 5s default.
+configure({ asyncUtilTimeout: 3000 });
+vi.setConfig({ testTimeout: 20000 });
+
+/** Reveal the People tab, where the per-user drill-down controls live. The drill-down is mounted
+ *  eagerly (so the export snapshot and users load exactly as before), but its buttons only become
+ *  reachable to role queries once its panel is the visible one. */
+function showPeopleTab(): void {
+  fireEvent.click(screen.getByRole('tab', { name: 'People' }));
+}
 
 const echo: LicenceActivityQueryEcho = {
   from: '2026-04-22',
@@ -282,6 +296,7 @@ describe('LicenceActivityPage - export', () => {
     await act(async () => {});
 
     const events = userEvent.setup();
+    showPeopleTab();
     const top = screen.getByRole('spinbutton', { name: 'Number of people in each list' });
     await events.clear(top);
     await events.type(top, '25');
@@ -420,6 +435,7 @@ describe('LicenceActivityPage - browse page survives an expiry refresh', () => {
     await act(async () => {});
 
     // Move off the defaults: a non-default workload and sort and search, then browse to page 2.
+    showPeopleTab();
     fireEvent.change(screen.getByLabelText('Service'), { target: { value: 'outlook' } });
     await waitFor(() => expect(usersParams()).toMatchObject({ workload: 'outlook', page: 1 }));
     fireEvent.change(await screen.findByLabelText('Sort users'), { target: { value: 'upn:asc' } });
@@ -488,6 +504,7 @@ describe('LicenceActivityPage - a real scope change resets the browse page', () 
     await act(async () => {});
 
     // Browse to page 2 of the current (all-departments) scope.
+    showPeopleTab();
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     await waitFor(() => expect(usersParams()).toMatchObject({ overviewId: 'ov-dept-all', page: 2 }));
 
@@ -558,5 +575,115 @@ describe('LicenceActivityPage - preview label', () => {
     expect(note.textContent).toMatch(/5 minutes/i);
     expect(note.textContent).toMatch(/first look/i);
     expect(note.textContent).toMatch(/evidence of activity/i);
+  });
+});
+
+describe('LicenceActivityPage - information architecture (tabs)', () => {
+  // The single active (non-hidden) tab panel. Keep-mounted panels are hidden with the `hidden`
+  // attribute, so exactly one panel is exposed to the accessibility tree at a time.
+  const activePanel = () => screen.getByRole('tabpanel');
+
+  it('splits the report into four tabs and leads with a headline Overview', async () => {
+    mockAvailability.mockResolvedValue(availability());
+    renderWithProvider(<LicenceActivityPage />);
+
+    expect(await screen.findByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'By service' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /By department/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'People' })).toBeInTheDocument();
+
+    const overview = activePanel();
+    expect(overview).toHaveAttribute('id', 'la-panel-overview');
+    expect(within(overview).getByText('People with a licence')).toBeVisible();
+    expect(within(overview).getByText('120')).toBeVisible(); // distinctAssignedUsers headline
+    expect(within(overview).getByText('Licence assignments')).toBeVisible();
+  });
+
+  it('demotes the coverage panel to a collapsible summary that still reveals every field', async () => {
+    mockAvailability.mockResolvedValue(availability());
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findByRole('tab', { name: 'Overview' });
+
+    // Collapsed by default: the full provenance panel (its "held for up to" caption is unique to it)
+    // is not in the primary flow until asked for.
+    expect(screen.queryByText(/held for up to/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /show data sources/i }));
+    expect(screen.getByText(/held for up to/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Usage reports/).length).toBeGreaterThan(0);
+  });
+
+  it('keeps the per-service breakdown reachable, with the licence context, under By service', async () => {
+    mockAvailability.mockResolvedValue(availability());
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findByRole('tab', { name: 'Overview' });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'By service' }));
+
+    const panel = activePanel();
+    expect(panel).toHaveAttribute('id', 'la-panel-byService');
+    expect(within(panel).getByText('Activity by service')).toBeVisible();
+    expect(within(panel).getByLabelText('Selected licence')).toBeVisible();
+    for (const w of WORKLOADS) {
+      expect(within(panel).getAllByText(w.label).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps the department and country breakdowns reachable under their tab', async () => {
+    mockAvailability.mockResolvedValue(availability());
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findByRole('tab', { name: 'Overview' });
+
+    fireEvent.click(screen.getByRole('tab', { name: /By department/ }));
+
+    const panel = activePanel();
+    expect(panel).toHaveAttribute('id', 'la-panel-byDemographic');
+    expect(within(panel).getByText('Activity by department and country')).toBeVisible();
+    expect(within(panel).getByText('By department')).toBeVisible();
+    expect(within(panel).getByText('By country')).toBeVisible();
+    // Non-Latin (Greek) demographic values render, scoped to the breakdown (not the filter dropdown).
+    expect(within(panel).getByText('Μηχανικοί')).toBeVisible();
+    expect(within(panel).getByText('Ελλάδα')).toBeVisible();
+  });
+
+  it('keeps the per-user drill-down reachable under the People tab', async () => {
+    mockAvailability.mockResolvedValue(availability());
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findByRole('tab', { name: 'Overview' });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'People' }));
+
+    const panel = activePanel();
+    expect(panel).toHaveAttribute('id', 'la-panel-people');
+    expect(within(panel).getByText('People holding this licence')).toBeVisible();
+    expect(within(panel).getByLabelText('Selected licence')).toBeVisible();
+    await waitFor(() => expect(within(panel).getByText('Most active')).toBeVisible());
+    expect(within(panel).getByText('Least active')).toBeVisible();
+    expect(within(panel).getByText('Everyone with this licence')).toBeVisible();
+    expect(within(panel).getAllByText('ada@contoso.com').length).toBeGreaterThan(0);
+  });
+
+  it('switches the selected licence from the By service tab without leaving it', async () => {
+    mockAvailability.mockResolvedValue(availability());
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findByRole('tab', { name: 'Overview' });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'By service' }));
+    const select = within(activePanel()).getByLabelText('Selected licence') as HTMLSelectElement;
+    expect(select.value).toBe('10'); // defaults to the most-assigned licence (E5, 100 users)
+
+    fireEvent.change(select, { target: { value: '20' } });
+    expect(activePanel()).toHaveAttribute('id', 'la-panel-byService'); // still on By service
+    expect(within(activePanel()).getByLabelText('Selected licence')).toHaveValue('20');
+  });
+
+  it('keeps the reporting-window control visible above the tabs on every tab', async () => {
+    mockAvailability.mockResolvedValue(availability());
+    renderWithProvider(<LicenceActivityPage />);
+    await screen.findByRole('tab', { name: 'Overview' });
+
+    expect(screen.getByRole('button', { name: 'Last settled week' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: 'People' }));
+    expect(screen.getByRole('button', { name: 'Last settled week' })).toBeInTheDocument();
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/LicenceActivityPage.tsx
@@ -9,9 +9,12 @@ import {
   Card,
   Select,
   Button,
+  Tab,
+  TabList,
   Tooltip,
   MessageBar,
   MessageBarBody,
+  type SelectTabEventHandler,
 } from '@fluentui/react-components';
 import { ArrowDownload16Regular } from '@fluentui/react-icons';
 import { fetchAvailability, fetchOverview, downloadExport } from '../api/licenceActivityApi';
@@ -22,14 +25,16 @@ import type {
 } from '../types/licenceActivity';
 import Spinner from '../components/Spinner';
 import DateRangeControl from '../components/licenceActivity/DateRangeControl';
-import CoveragePanel from '../components/licenceActivity/CoveragePanel';
+import DataSourceSummary from '../components/licenceActivity/DataSourceSummary';
+import OverviewSummary from '../components/licenceActivity/OverviewSummary';
 import SkuAssignments from '../components/licenceActivity/SkuAssignments';
+import SelectedLicenceBar from '../components/licenceActivity/SelectedLicenceBar';
 import WorkloadDistributions from '../components/licenceActivity/WorkloadDistributions';
 import DemographicBreakdown from '../components/licenceActivity/DemographicBreakdown';
 import UsersDrillDown from '../components/licenceActivity/UsersDrillDown';
 import ApiErrorBar, { describeError } from '../components/licenceActivity/ApiErrorBar';
 import { presetRange } from '../components/licenceActivity/dateRange';
-import { formatCount, licenceName } from '../components/licenceActivity/format';
+import { formatCount } from '../components/licenceActivity/format';
 import {
   mergeDemographicOptions,
   EMPTY_CATALOGUE,
@@ -94,6 +99,14 @@ const useStyles = makeStyles({
     gap: '16px',
     marginTop: '16px',
   },
+  // A tab panel's own vertical rhythm. The panel <div> itself carries no `display` override so the
+  // `hidden` attribute can hide inactive panels (a `display: flex` on the panel would beat the UA
+  // `[hidden] { display: none }` rule and leak every panel onto the page at once).
+  panelInner: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+  },
   sectionHead: {
     display: 'flex',
     alignItems: 'baseline',
@@ -112,6 +125,13 @@ const useStyles = makeStyles({
     padding: '32px',
   },
 });
+
+/**
+ * The report's top-level sections, split into tabs so the default view answers "what is my licence
+ * usage like?" without scrolling past the detail. The reporting window, demographic filters and the
+ * data-source summary stay above the tabs because they scope every one of them.
+ */
+type LaTab = 'overview' | 'byService' | 'byDemographic' | 'people';
 
 /**
  * Licence activity report (issues #436 / #437).
@@ -161,6 +181,11 @@ export default function LicenceActivityPage() {
 
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<unknown>(null);
+
+  // Which top-level tab is showing. Kept out of the overview scope key so it survives a date/filter
+  // change - an admin reading the People tab stays on it when they widen the window.
+  const [tab, setTab] = useState<LaTab>('overview');
+  const onTabSelect: SelectTabEventHandler = (_e, data) => setTab(data.value as LaTab);
 
   const overviewSeqRef = useRef(0);
 
@@ -433,7 +458,7 @@ export default function LicenceActivityPage() {
                   content={
                     overview && !overviewLoading
                       ? exportUsersId
-                        ? 'An Excel copy of the summary plus the exact people currently listed below. Built from the figures already on screen, so it matches what you can see.'
+                        ? 'An Excel copy of the summary plus the exact people currently listed in the People tab. Built from the figures already on screen, so it matches what you can see.'
                         : 'An Excel copy of the licence and service summary (totals only). Built from the figures already on screen.'
                       : 'Available once the report has loaded.'
                   }
@@ -478,10 +503,10 @@ export default function LicenceActivityPage() {
 
           {overview && (
             <div className={styles.stack}>
-              <CoveragePanel
+              <DataSourceSummary
+                coverage={overview.coverage}
                 generatedUtc={overview.generatedUtc}
                 expiresUtc={overview.expiresUtc}
-                coverage={overview.coverage}
               />
 
               {overview.messages.length > 0 && (
@@ -496,37 +521,87 @@ export default function LicenceActivityPage() {
                 </MessageBar>
               )}
 
-              <Text size={200} className={styles.muted}>
-                {formatCount(overview.distinctAssignedUsers)} people hold a licence in this selection, counting
-                each person once.
-                {overview.demographicsTruncated &&
-                  ' The department and country lists are capped, so they may not show every one.'}
-              </Text>
+              <TabList selectedValue={tab} onTabSelect={onTabSelect}>
+                <Tab id="la-tab-overview" value="overview" aria-controls="la-panel-overview">
+                  Overview
+                </Tab>
+                <Tab id="la-tab-byService" value="byService" aria-controls="la-panel-byService">
+                  By service
+                </Tab>
+                <Tab id="la-tab-byDemographic" value="byDemographic" aria-controls="la-panel-byDemographic">
+                  By department &amp; country
+                </Tab>
+                <Tab id="la-tab-people" value="people" aria-controls="la-panel-people">
+                  People
+                </Tab>
+              </TabList>
 
-              <SkuAssignments
-                licences={overview.licences}
-                selectedLicenceTypeId={selectedLicenceTypeId}
-                onSelect={setSelectedLicenceTypeId}
-              />
+              {/* Overview: the headline figures plus the assignments table, which doubles as the
+                  licence picker for the By service and People tabs. Panels stay mounted (toggled with
+                  `hidden`) so the drill-down keeps its page, workload and search when tabs change. */}
+              <div
+                role="tabpanel"
+                id="la-panel-overview"
+                aria-labelledby="la-tab-overview"
+                hidden={tab !== 'overview'}
+              >
+                <div className={styles.panelInner}>
+                  <OverviewSummary
+                    distinctAssignedUsers={overview.distinctAssignedUsers}
+                    licenceCount={overview.licences.length}
+                    selectedLicence={selectedLicence}
+                  />
+                  <SkuAssignments
+                    licences={overview.licences}
+                    selectedLicenceTypeId={selectedLicenceTypeId}
+                    onSelect={setSelectedLicenceTypeId}
+                  />
+                </div>
+              </div>
 
-              {selectedLicence && (
-                <div>
+              {/* By service: the selected licence's five workload distributions. */}
+              <div
+                role="tabpanel"
+                id="la-panel-byService"
+                aria-labelledby="la-tab-byService"
+                hidden={tab !== 'byService'}
+              >
+                <div className={styles.panelInner}>
                   <div className={styles.sectionHead}>
                     <Text weight="semibold" size={500}>
                       Activity by service
                     </Text>
                     <Text size={200} className={styles.muted}>
-                      {licenceName(selectedLicence)} &middot; five services, each measured on its own
+                      Each Microsoft 365 service on its own, never blended into a single score
                     </Text>
                   </div>
-                  <div style={{ marginTop: '12px' }}>
-                    <WorkloadDistributions workloads={selectedLicence.workloads} />
-                  </div>
+                  {selectedLicence ? (
+                    <>
+                      <SelectedLicenceBar
+                        licences={overview.licences}
+                        selectedLicenceTypeId={selectedLicenceTypeId}
+                        onSelect={setSelectedLicenceTypeId}
+                      />
+                      <WorkloadDistributions workloads={selectedLicence.workloads} />
+                    </>
+                  ) : (
+                    <Card>
+                      <Text className={styles.muted}>
+                        Choose a licence on the Overview tab to see how much each service is used.
+                      </Text>
+                    </Card>
+                  )}
                 </div>
-              )}
+              </div>
 
-              {(overview.departments.length > 0 || overview.countries.length > 0) && (
-                <div>
+              {/* By department & country: the two aggregate demographic breakdowns. */}
+              <div
+                role="tabpanel"
+                id="la-panel-byDemographic"
+                aria-labelledby="la-tab-byDemographic"
+                hidden={tab !== 'byDemographic'}
+              >
+                <div className={styles.panelInner}>
                   <div className={styles.sectionHead}>
                     <Text weight="semibold" size={500}>
                       Activity by department and country
@@ -535,48 +610,74 @@ export default function LicenceActivityPage() {
                       Where the licences sit in the organisation, and how much they are being used
                     </Text>
                   </div>
-                  <div style={{ marginTop: '12px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
-                    <DemographicBreakdown
-                      title="By department"
-                      segmentLabel="Department"
-                      rows={overview.departments}
-                      truncated={overview.demographicsTruncated}
-                    />
-                    <DemographicBreakdown
-                      title="By country"
-                      segmentLabel="Country"
-                      rows={overview.countries}
-                      truncated={overview.demographicsTruncated}
-                    />
-                  </div>
-                </div>
-              )}
-
-              <div>
-                <div className={styles.sectionHead}>
-                  <Text weight="semibold" size={500}>
-                    People holding this licence
-                  </Text>
-                  <Text size={200} className={styles.muted}>
-                    Who is and isn&apos;t using a licence
-                  </Text>
-                </div>
-                <div style={{ marginTop: '12px' }}>
-                  {selectedLicence ? (
-                    <UsersDrillDown
-                      key={selectedLicence.licenceTypeId}
-                      overviewId={overview.snapshotId}
-                      overviewScope={overviewKey ?? ''}
-                      licence={selectedLicence}
-                      coverage={overview.coverage}
-                      onUsersSnapshot={handleUsersSnapshot}
-                      onRefreshOverview={refreshSnapshots}
-                      refreshToken={usersRefreshToken}
-                    />
+                  {overview.demographicsTruncated && (
+                    <Text size={200} className={styles.muted}>
+                      The department and country lists are capped, so they may not show every one.
+                    </Text>
+                  )}
+                  {overview.departments.length > 0 || overview.countries.length > 0 ? (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+                      <DemographicBreakdown
+                        title="By department"
+                        segmentLabel="Department"
+                        rows={overview.departments}
+                        truncated={overview.demographicsTruncated}
+                      />
+                      <DemographicBreakdown
+                        title="By country"
+                        segmentLabel="Country"
+                        rows={overview.countries}
+                        truncated={overview.demographicsTruncated}
+                      />
+                    </div>
                   ) : (
                     <Card>
                       <Text className={styles.muted}>
-                        Select a licence in the assignments table above to see who is most and least active, or to
+                        No department or country breakdown is available for this selection.
+                      </Text>
+                    </Card>
+                  )}
+                </div>
+              </div>
+
+              {/* People: the per-licence drill-down (most/least active and the browse table). */}
+              <div
+                role="tabpanel"
+                id="la-panel-people"
+                aria-labelledby="la-tab-people"
+                hidden={tab !== 'people'}
+              >
+                <div className={styles.panelInner}>
+                  <div className={styles.sectionHead}>
+                    <Text weight="semibold" size={500}>
+                      People holding this licence
+                    </Text>
+                    <Text size={200} className={styles.muted}>
+                      Who is and isn&apos;t using a licence
+                    </Text>
+                  </div>
+                  {selectedLicence ? (
+                    <>
+                      <SelectedLicenceBar
+                        licences={overview.licences}
+                        selectedLicenceTypeId={selectedLicenceTypeId}
+                        onSelect={setSelectedLicenceTypeId}
+                      />
+                      <UsersDrillDown
+                        key={selectedLicence.licenceTypeId}
+                        overviewId={overview.snapshotId}
+                        overviewScope={overviewKey ?? ''}
+                        licence={selectedLicence}
+                        coverage={overview.coverage}
+                        onUsersSnapshot={handleUsersSnapshot}
+                        onRefreshOverview={refreshSnapshots}
+                        refreshToken={usersRefreshToken}
+                      />
+                    </>
+                  ) : (
+                    <Card>
+                      <Text className={styles.muted}>
+                        Select a licence on the Overview tab to see who is most and least active, or to
                         browse everyone who holds it.
                       </Text>
                     </Card>


### PR DESCRIPTION
## What & why

The **Licence activity** admin report (`LicenceActivityPage`) stacked everything on one long scroll: the date-range control, a full-width coverage panel ("Where these figures come from"), SKU assignments, per-workload distributions, department/country breakdowns, and the per-user drill-down (most/least active + paged browse). This reorganises it so the default view answers *"what is my licence usage like?"* in one screen instead of a scroll.

**Presentation / information-architecture change only.** No backend, SQL or C# change; nothing about how any figure is computed changes. Every piece of information is preserved — relocated, collapsed, or behind a tab.

Related to #436 / #437 (the report this reorganises).

## New information architecture

Persistent **above** the tabs (they scope every section):

- Reporting-window control, Department/Country filters, **Export to Excel** button, availability/overview message bars.
- **Data-source summary** — the coverage panel is demoted to a collapsible chip (`DataSourceSummary`): an at-a-glance status-chip row (e.g. `3 Available · 1 Partial · 1 Not imported`) plus freshness, expanding **in place** to the full existing `CoveragePanel`. Collapsed by default; still discoverable, but out of the headline flow.

Four tabs:

| Tab | Content |
|---|---|
| **Overview** | New `OverviewSummary` headline KPI strip (people with a licence, licence types, selected licence) + `SkuAssignments` (which doubles as the licence picker) |
| **By service** | `WorkloadDistributions` for the selected licence |
| **By department & country** | the two `DemographicBreakdown` tables + the truncation note |
| **People** | `UsersDrillDown` (most/least active + paged browse) |

The **selected-licence context** (`SelectedLicenceBar`) rides onto the By service and People tabs so the licence stays visible and switchable without returning to Overview. On Overview the assignments table remains the picker (and the summary card names the selection).

## Components

- **New** in `components/licenceActivity/`: `DataSourceSummary`, `OverviewSummary`, `SelectedLicenceBar` — Fluent v9 + `makeStyles`/`tokens`, `memo` where the surrounding code memoises, British-English copy.
- **`LicenceActivityPage.tsx`**: replaced the single-scroll stack with a `TabList` + four keep-mounted panels; dropped the now-unused `CoveragePanel` / `licenceName` imports; export tooltip wording updated ("below" → "in the People tab").
- **Unchanged**: `CoveragePanel` (now rendered inside `DataSourceSummary`), `SkuAssignments`, `WorkloadDistributions`, `DemographicBreakdown`, `UsersDrillDown`, `UsersTable`, `MiniDistribution`, the API client and the shared types.

## Key design decisions (reviewer hotspots)

- **Panels stay mounted, hidden via the `hidden` attribute** (not conditional render). This preserves the drill-down's carefully-maintained state (page / workload / search / sort) across tab switches, and — importantly — keeps the eager users load and the **export-snapshot behaviour identical**: the export still attaches the current `usersId` exactly as before, so "the workbook matches what's on screen" is unchanged. The panel `<div>` deliberately carries **no** `display` override so the UA `[hidden] { display: none }` rule isn't beaten by a `display: flex` (see the `panelInner` comment).
- **No new or blended metric.** `OverviewSummary` only surfaces figures the report already computes (distinct assigned users, the SKU count, and the selected licence's own assigned count). No cross-workload "productivity" score — consistent with the report's deliberate per-service separation.

## Accessibility

- Tabs follow the WAI-ARIA pattern: `role="tabpanel"` + `aria-labelledby` on each panel and `aria-controls` on each tab; Fluent `TabList` supplies roving focus + arrow-key navigation. This is strictly better than the previous flat section stack.
- `DataSourceSummary`'s disclosure button has `aria-expanded` + `aria-controls`; the status chips reuse the shared `statusMeta` tone/label.
- Existing semantic headings and the accessible band foreground colours / `role="img"` / `aria-label` treatments are untouched.

## Tests

- **New**: `DataSourceSummary.test.tsx`, `OverviewSummary.test.tsx`, `SelectedLicenceBar.test.tsx`.
- **Extended** `LicenceActivityPage.test.tsx` with an `information architecture (tabs)` block asserting: the four tabs exist; each section's content is reachable via its tab (`toBeVisible` on the single active `tabpanel`); the coverage summary is collapsed by default and expands to the full panel; and the licence context switches from a tab without leaving it.
- The existing behaviour tests (export, expiry recovery, scope-change reset, 50-SKU scale) are all kept. Three that drive the drill-down's **role-based** controls (search / next / top-count) now first click into the **People** tab, where those controls now live (role queries skip content in a `hidden` panel; text/label queries still find it, which is why most assertions were untouched). Because the added tab bar does a little more first-render work, the file's async-settle timeout is nudged above the 1000 ms default and the per-test budget is raised.
- `npm run build` (`tsc --noEmit` + `vite build`) ✅. `npx vitest run` ✅ — **125 tests pass**. Note: this shared build box is heavily contended, so the suite was verified with `--no-file-parallelism`; under full parallelism unrelated files (e.g. `AgentsPanel`) also time out purely from CPU starvation, not from this change.

## Merge note

The concurrent branch **`sambetts/licence-activity-unknown`** edits `bands.ts` (`BAND_METHOD` / `BAND_DESCRIPTIONS`). This PR deliberately does **not** touch `bands.ts`, so the two should merge cleanly — the only shared surface is that both render licence-activity UI.

## Deferred

- No visual redesign of the individual panels beyond relocation into tabs.
