### PR TITLE
Stop treating Copilot's AccessedResources.Type as a content taxonomy (#468, #469)

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Copilot/CopilotAccessedResourceTaxonomy.cs
+++ b/src/AnalyticsEngine/Common/Entities/Copilot/CopilotAccessedResourceTaxonomy.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+
+namespace Common.Entities.Copilot
+{
+    /// <summary>
+    /// What a Copilot audit record's <c>AccessedResources[].Type</c> value actually describes.
+    ///
+    /// Microsoft does not publish an enumeration for that field. The Office 365 Management Activity
+    /// API schema declares it as an open <c>Edm.String</c>, and the Purview documentation describes
+    /// it as: "the type of resource that was accessed. It can contain values like the filetype
+    /// extension (pptx, docx, etc.) or describe the type of resource (for non-SharePoint resources)"
+    /// (https://learn.microsoft.com/en-us/purview/audit-copilot#common-properties-in-copilot-audit-logs,
+    /// https://learn.microsoft.com/en-us/office/office-365-management-api/copilot-schema).
+    ///
+    /// In practice the one field therefore carries values from several unrelated namespaces at once -
+    /// file kinds, Microsoft Graph entity names, how the resource was used, and grounding-source
+    /// markers - which is why nothing in this product may treat it as a single content taxonomy.
+    /// See issues #468 and #469.
+    /// </summary>
+    public enum CopilotResourceTypeKind
+    {
+        /// <summary>
+        /// A value this product does not recognise, including a missing one. The default, so a value
+        /// Microsoft has not used yet is visibly unclassified rather than silently folded into one of
+        /// the buckets below. Unclassified is NOT a synonym for "not tenant content".
+        /// </summary>
+        Unclassified = 0,
+
+        /// <summary>
+        /// The value names a kind of organisational content - a file kind (<c>docx</c>) or a Microsoft
+        /// Graph entity (<c>EmailMessage</c>). This is the only kind that answers "what content is
+        /// Copilot working on".
+        /// </summary>
+        TenantContent = 1,
+
+        /// <summary>
+        /// The value describes how the resource was used rather than what it is - <c>CITATION</c>
+        /// means it was shown to the user as a cited source. Says nothing about whether the resource
+        /// was tenant content or a web page, and a cited file is typed this way INSTEAD of by its
+        /// file kind, which is why the file-kind counts undercount real file references.
+        /// </summary>
+        UsageRole = 2,
+
+        /// <summary>
+        /// The value marks grounding from outside the tenant, e.g. <c>WebSearchQuery</c>. Not
+        /// organisational content.
+        /// </summary>
+        ExternalGrounding = 3,
+    }
+
+    /// <summary>
+    /// Interprets the fields of a Copilot audit record's <c>AccessedResources</c> entry.
+    ///
+    /// Deliberately one shared implementation: the credit estimate (which decides the 10-credit
+    /// tenant-graph charge) and the Copilot Adoption "what Copilot referenced" chart used to make the
+    /// same category error independently, in code that had no way of staying in step.
+    /// </summary>
+    public static class CopilotAccessedResourceTaxonomy
+    {
+        /// <summary>
+        /// The label used wherever a resource has no <c>Type</c> at all. Deliberately not "WebPage" or
+        /// any other guess: a missing type says nothing about where the resource came from.
+        /// </summary>
+        public const string UnknownTypeLabel = "(unknown)";
+
+        /// <summary>
+        /// Values that name a kind of organisational content. Every entry is either a file kind or a
+        /// Microsoft Graph entity name.
+        ///
+        /// This is a recognition list, not a specification: because Microsoft publishes no
+        /// enumeration, anything absent is <see cref="CopilotResourceTypeKind.Unclassified"/> and must
+        /// never be read as "not tenant content".
+        /// </summary>
+        private static readonly HashSet<string> TenantContentTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // SharePoint & OneDrive
+            "Site", "Web", "List", "ListItem", "Folder", "File", "Drive", "DriveItem", "LoopPage",
+
+            // File kinds. Purview documents the file extension as one of the things this field carries.
+            "docx", "xlsx", "pptx", "pdf", "txt", "doc", "xls", "ppt", "csv", "one", "msg",
+
+            // Email & calendar
+            "EmailMessage", "Email", "Message", "MailFolder", "Calendar", "Event",
+
+            // Teams
+            "Team", "Channel", "Chat", "TeamsMessage", "TeamsMeeting", "TeamsChat", "TeamsChannel",
+
+            // Other Microsoft Graph entities
+            "User", "Group", "Contact", "Task", "Planner", "OneNote",
+        };
+
+        /// <summary>
+        /// Values that describe how the resource was used rather than what it is. <c>CITATION</c> is
+        /// undocumented but is one of the most common values Microsoft emits in practice.
+        /// </summary>
+        private static readonly HashSet<string> UsageRoleTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "CITATION",
+        };
+
+        /// <summary>
+        /// Values that mark grounding from outside the tenant. Also undocumented; Microsoft's own
+        /// (experimental) ValueLens accelerator maps <c>websearchquery</c> to "Web Searching".
+        /// </summary>
+        private static readonly HashSet<string> ExternalGroundingTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "WebSearchQuery",
+        };
+
+        /// <summary>
+        /// Host suffixes that only ever serve content belonging to a Microsoft 365 tenant, across the
+        /// worldwide and sovereign clouds. Taken from Microsoft's published endpoint lists:
+        ///
+        /// - Worldwide (and GCC moderate, which uses the worldwide endpoints):
+        ///   https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges
+        /// - GCC High:
+        ///   https://learn.microsoft.com/en-us/microsoft-365/enterprise/microsoft-365-u-s-government-gcc-high-endpoints
+        /// - DoD:
+        ///   https://learn.microsoft.com/en-us/microsoft-365/enterprise/microsoft-365-u-s-government-dod-endpoints
+        /// - Operated by 21Vianet:
+        ///   https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges-21vianet
+        ///
+        /// <c>sharepoint.de</c> is included for the retired Microsoft Cloud Deutschland, because
+        /// historical audit data can still be imported.
+        ///
+        /// There is deliberately no <c>onedrive.</c> entry. OneDrive for Business content is served
+        /// from the tenant's personal SharePoint host (<c>contoso-my.sharepoint.com</c>), which the
+        /// SharePoint suffixes already cover, whereas <c>onedrive.live.com</c> is CONSUMER OneDrive
+        /// and is not tenant content at all.
+        /// </summary>
+        private static readonly string[] TenantContentHostSuffixes =
+        {
+            // SharePoint Online and OneDrive for Business
+            "sharepoint.com", "sharepoint.us", "sharepoint-mil.us", "dps.mil", "sharepoint.cn", "sharepoint.de",
+
+            // Exchange Online / Outlook
+            "outlook.office.com", "outlook.office365.com", "outlook.cloud.microsoft",
+            "outlook.office365.us", "outlook-dod.office365.us", "outlook.office.de",
+            "partner.outlook.cn", "apps.mil",
+
+            // Teams, including the async gateway that serves files shared in chats
+            "teams.microsoft.com", "teams.cloud.microsoft", "teams.microsoft.us", "teams.microsoftonline.cn",
+        };
+
+        /// <summary>
+        /// Hosts that Microsoft operates but which are not tied to one tenant's content, so they are
+        /// evidence of NOTHING - neither that a resource belongs to the tenant nor that it came from
+        /// outside it.
+        ///
+        /// This exists because <see cref="IsExternalWebUrl"/> works by exclusion, and
+        /// <see cref="TenantContentHostSuffixes"/> is necessarily incomplete: Microsoft can introduce
+        /// a content host at any time. Without this, a new Microsoft-operated host would be read as
+        /// confident proof of grounding from outside the tenant - reintroducing the under-estimate in
+        /// #469 by the opposite route. Being unsure is the safe answer here; claiming external is not.
+        ///
+        /// <c>microsoft</c> is the brand top-level domain ICANN delegated to Microsoft, so nothing
+        /// under it belongs to anyone else. It covers the user-content hosts (<c>usercontent.microsoft</c>,
+        /// <c>usgovcloud-usercontent.microsoft</c>) as well as <c>cloud.microsoft</c>.
+        /// </summary>
+        private static readonly string[] MicrosoftOperatedButNotTenantSpecificSuffixes =
+        {
+            "microsoft",
+            "sovcloud-usercontent.cn",
+        };
+
+        /// <summary>
+        /// Classifies a raw <c>AccessedResources[].Type</c> value. An unrecognised or missing value is
+        /// <see cref="CopilotResourceTypeKind.Unclassified"/>.
+        /// </summary>
+        public static CopilotResourceTypeKind Classify(string resourceType)
+        {
+            if (string.IsNullOrWhiteSpace(resourceType)) return CopilotResourceTypeKind.Unclassified;
+
+            var trimmed = resourceType.Trim();
+
+            if (TenantContentTypes.Contains(trimmed)) return CopilotResourceTypeKind.TenantContent;
+            if (UsageRoleTypes.Contains(trimmed)) return CopilotResourceTypeKind.UsageRole;
+            if (ExternalGroundingTypes.Contains(trimmed)) return CopilotResourceTypeKind.ExternalGrounding;
+
+            return CopilotResourceTypeKind.Unclassified;
+        }
+
+        /// <summary>
+        /// Whether a <c>SiteUrl</c> points at a host that only serves Microsoft 365 tenant content.
+        ///
+        /// Matches on the parsed host with a dot boundary rather than on a substring of the whole URL.
+        /// A substring test both misses the sovereign clouds and accepts hosts that merely contain the
+        /// text, so <c>https://sharepoint.com.example.invalid/x</c> would have counted as tenant
+        /// evidence.
+        /// </summary>
+        public static bool IsTenantContentUrl(string siteUrl)
+        {
+            var host = WebHostOf(siteUrl);
+            if (host == null) return false;
+
+            return MatchesAnySuffix(host, TenantContentHostSuffixes);
+        }
+
+        /// <summary>
+        /// Whether a <c>SiteUrl</c> positively places the resource OUTSIDE the tenant: it parses as an
+        /// absolute web URL, and its host is neither a Microsoft 365 tenant-content host nor any other
+        /// host Microsoft operates.
+        ///
+        /// This is the mirror of <see cref="IsTenantContentUrl"/> and exists so that "the record says
+        /// where this lives, and it is not in the tenant" is treated as evidence rather than as not
+        /// knowing. A resource with no <c>SiteUrl</c> at all is a different case entirely, and callers
+        /// must not conflate the two.
+        ///
+        /// A Microsoft-operated host that is not tenant-specific returns false here as well as from
+        /// <see cref="IsTenantContentUrl"/>: the honest answer for one of those is "cannot tell". See
+        /// <see cref="MicrosoftOperatedButNotTenantSpecificSuffixes"/>.
+        ///
+        /// Known limitation, deliberately accepted: content indexed through a Microsoft Graph
+        /// connector is tenant grounding but can carry the source system's own URL, so it reads as
+        /// external here. Recognising it would need a signal the audit record does not carry.
+        /// </summary>
+        public static bool IsExternalWebUrl(string siteUrl)
+        {
+            var host = WebHostOf(siteUrl);
+            if (host == null) return false;
+
+            if (MatchesAnySuffix(host, TenantContentHostSuffixes)) return false;
+
+            return !MatchesAnySuffix(host, MicrosoftOperatedButNotTenantSpecificSuffixes);
+        }
+
+        /// <summary>
+        /// The comparable host of an absolute http(s) URL, or null when the value is not one.
+        ///
+        /// Three normalisations matter, all verified against .NET's <see cref="Uri"/>:
+        /// the scheme is checked because <c>Uri.Host</c> is populated for <c>file:</c> and <c>ftp:</c>
+        /// too, and a non-web URL says nothing about a Microsoft 365 tenant either way;
+        /// <c>IdnHost</c> is used because <c>Host</c> preserves alternative Unicode dot separators
+        /// (a host written with U+3002 keeps it in <c>Host</c> but canonicalises in <c>IdnHost</c>);
+        /// and a trailing DNS root dot is removed because <c>Uri</c> keeps that on both properties.
+        /// Without these, a genuine tenant URL fails the suffix match and is read as external.
+        /// </summary>
+        private static string WebHostOf(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return null;
+
+            Uri uri;
+            if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out uri)) return null;
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) return null;
+
+            string host;
+            try
+            {
+                host = uri.IdnHost;
+            }
+            catch (ArgumentException)
+            {
+                // IdnHost throws on a host it cannot map; the raw host is still worth comparing.
+                host = uri.Host;
+            }
+
+            if (string.IsNullOrEmpty(host)) return null;
+
+            host = host.TrimEnd('.');
+            return host.Length == 0 ? null : host;
+        }
+
+        /// <summary>Exact host match, or a match at a dot boundary so a lookalike host cannot pass.</summary>
+        private static bool MatchesAnySuffix(string host, string[] suffixes)
+        {
+            foreach (var suffix in suffixes)
+            {
+                if (host.Equals(suffix, StringComparison.OrdinalIgnoreCase)) return true;
+                if (host.Length > suffix.Length
+                    && host.EndsWith("." + suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The heading this kind is reported under. Kept here so the Excel workbook and the portal
+        /// describe the same buckets with the same words.
+        /// </summary>
+        public static string KindLabel(CopilotResourceTypeKind kind)
+        {
+            switch (kind)
+            {
+                case CopilotResourceTypeKind.TenantContent: return "Tenant content";
+                case CopilotResourceTypeKind.UsageRole: return "How it was used";
+                case CopilotResourceTypeKind.ExternalGrounding: return "Grounding from outside the tenant";
+                default: return "Unclassified";
+            }
+        }
+
+        /// <summary>
+        /// One line explaining why the values under this heading are not comparable with the others.
+        /// </summary>
+        public static string KindExplanation(CopilotResourceTypeKind kind)
+        {
+            switch (kind)
+            {
+                case CopilotResourceTypeKind.TenantContent:
+                    return "Kinds of organisational content - file types and Microsoft Graph entities. "
+                        + "Undercounted: a file Copilot cited is typed CITATION instead of by its file type.";
+                case CopilotResourceTypeKind.UsageRole:
+                    return "How the resource was used, not what it is. A citation can be either tenant "
+                        + "content or a web page, so these references are counted here and nowhere else.";
+                case CopilotResourceTypeKind.ExternalGrounding:
+                    return "Grounding from outside the organisation. Not tenant content.";
+                default:
+                    return "Values this version does not recognise, and references whose type was empty. "
+                        + "Microsoft publishes no list of possible values and can add new ones at any time, "
+                        + "so these are shown as-is rather than counted as content.";
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
@@ -1,3 +1,4 @@
+using Common.Entities.Copilot;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
@@ -706,9 +707,13 @@ namespace Common.Entities.CopilotAdoption
         }
 
         /// <summary>
-        /// What kinds of tenant content Copilot actually grounded its answers in. The clearest
-        /// available evidence that Copilot is doing work on the organisation's own data rather than
-        /// answering generic questions any free chatbot could.
+        /// How Microsoft's audit log typed the resources Copilot referenced when answering, with each
+        /// value classified by what it actually describes.
+        ///
+        /// The classification is the point: <c>AccessedResources[].Type</c> mixes file kinds, Graph
+        /// entity names, how the resource was used (CITATION) and grounding from outside the tenant
+        /// (WebSearchQuery) in one field, so charting the raw values as "kinds of tenant content" was
+        /// wrong for the largest bucket. See <see cref="CopilotAccessedResourceTaxonomy"/> and #468.
         /// </summary>
         private async Task BuildResourceTypesAsync(
             CopilotAdoptionAnalysis analysis,
@@ -734,7 +739,15 @@ namespace Common.Entities.CopilotAdoption
             if (rows == null) return;
 
             analysis.Summary.TopResourceTypes = rows
-                .Select(r => new AdoptionCategory { Label = r.Label, Value = r.Value })
+                .Select(r => new AdoptionResourceTypeRow
+                {
+                    Label = r.Label,
+                    Value = r.Value,
+                    // The query already substituted its own label for a missing type, which the
+                    // taxonomy does not recognise and so classifies as Unclassified - which is what a
+                    // reference with no type is.
+                    Kind = CopilotAccessedResourceTaxonomy.Classify(r.Label),
+                })
                 .ToList();
         }
 

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSql.cs
@@ -950,20 +950,24 @@ namespace Common.Entities.CopilotAdoption
         }
 
         /// <summary>
-        /// The kinds of tenant content Copilot actually grounded its answers in (documents, meetings,
-        /// chats...). The clearest evidence that Copilot is doing work on the organisation's own data
-        /// rather than answering generic questions any free chatbot could.
+        /// How Microsoft's audit log typed the resources Copilot referenced when answering.
+        ///
+        /// Deliberately NOT described as "the kinds of tenant content Copilot grounded its answers
+        /// in". <c>AccessedResources[].Type</c> is one field carrying several unrelated taxonomies at
+        /// once, and two of its commonest values - CITATION and WebSearchQuery - are respectively a
+        /// usage role and grounding from outside the tenant. The caller classifies each value; see
+        /// <see cref="Common.Entities.Copilot.CopilotAccessedResourceTaxonomy"/> and issue #468.
         /// </summary>
         public static string TopResourceTypesSql()
         {
             return
-                "SELECT TOP (@top) ISNULL(rt.name, '(unknown)') AS Label,\r\n" +
+                "SELECT TOP (@top) ISNULL(rt.name, '" + Copilot.CopilotAccessedResourceTaxonomy.UnknownTypeLabel + "') AS Label,\r\n" +
                 "       CAST(COUNT_BIG(*) AS float) AS Value\r\n" +
                 "FROM dbo.copilot_event_accessed_resources AS ar\r\n" +
                 "JOIN dbo.copilot_chats AS c ON c.event_id = ar.copilot_chat_id\r\n" +
                 "LEFT JOIN dbo.copilot_event_accessed_resource_types AS rt ON rt.id = ar.resource_type_id\r\n" +
                 "WHERE c.time_stamp >= @from\r\n" +
-                "GROUP BY ISNULL(rt.name, '(unknown)')\r\n" +
+                "GROUP BY ISNULL(rt.name, '" + Copilot.CopilotAccessedResourceTaxonomy.UnknownTypeLabel + "')\r\n" +
                 "ORDER BY Value DESC\r\n" +
                 "OPTION (RECOMPILE);";
         }

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSummaryModels.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionSummaryModels.cs
@@ -1,3 +1,4 @@
+using Common.Entities.Copilot;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -157,6 +158,32 @@ namespace Common.Entities.CopilotAdoption
 
         [JsonProperty("value")]
         public double Value { get; set; }
+    }
+
+    /// <summary>
+    /// One row of the accessed-resource-type breakdown: a raw <c>AccessedResources[].Type</c> value
+    /// from Microsoft's Copilot audit log, how many references carried it, and what that value
+    /// actually describes.
+    ///
+    /// The kind exists because the field is not a single taxonomy - see
+    /// <see cref="CopilotResourceTypeKind"/>. Without it the chart puts a file kind, a citation and a
+    /// web search on one axis and invites the reader to compare them.
+    /// </summary>
+    public class AdoptionResourceTypeRow
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("value")]
+        public double Value { get; set; }
+
+        /// <summary>
+        /// What the label describes. <see cref="CopilotResourceTypeKind.Unclassified"/> for a value
+        /// this version does not recognise, which is the expected outcome for anything Microsoft adds
+        /// in future.
+        /// </summary>
+        [JsonProperty("kind")]
+        public CopilotResourceTypeKind Kind { get; set; }
     }
 
     /// <summary>
@@ -413,9 +440,13 @@ namespace Common.Entities.CopilotAdoption
         [JsonProperty("combinedByDepartment")]
         public List<AdoptionCombinedSegmentRow> CombinedByDepartment { get; set; } = new List<AdoptionCombinedSegmentRow>();
 
-        /// <summary>The kinds of tenant content Copilot grounded its answers in.</summary>
+        /// <summary>
+        /// How Microsoft's audit log typed the resources Copilot referenced, with each value's own
+        /// kind so a file type, a citation and a web search are not read as one taxonomy. See
+        /// <see cref="AdoptionResourceTypeRow"/>.
+        /// </summary>
         [JsonProperty("topResourceTypes")]
-        public List<AdoptionCategory> TopResourceTypes { get; set; } = new List<AdoptionCategory>();
+        public List<AdoptionResourceTypeRow> TopResourceTypes { get; set; } = new List<AdoptionResourceTypeRow>();
 
         /// <summary>
         /// The shape of engagement for the average active user and for the Champions, so the gap

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionWorkbook.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionWorkbook.cs
@@ -1,3 +1,4 @@
+using Common.Entities.Copilot;
 using Common.Entities.Xlsx;
 using System;
 using System.Collections.Generic;
@@ -619,12 +620,15 @@ namespace Common.Entities.CopilotAdoption
             {
                 sheet.AddBlankRow();
                 sheet.AddRow(XlsxCell.Wrapped(
-                    "What Copilot grounded its answers in. The clearest evidence available that Copilot is doing "
-                    + "work on your own content rather than answering generic questions any free chatbot could."));
-                sheet.AddHeaderRow("Resource type", "References");
+                    "What Copilot referenced. These are Microsoft's own AccessedResources.Type values from the "
+                    + "audit log, which are not one taxonomy: the Kind column says whether a value names a kind "
+                    + "of organisational content, describes how the resource was used, or marks grounding from "
+                    + "outside the tenant. A file Copilot cited is typed CITATION rather than by its file type, "
+                    + "so the file-type rows undercount real file references."));
+                sheet.AddHeaderRow("Resource type", "Kind", "References");
                 foreach (var type in summary.TopResourceTypes)
                 {
-                    sheet.AddRow(type.Label, type.Value);
+                    sheet.AddRow(type.Label, CopilotAccessedResourceTaxonomy.KindLabel(type.Kind), type.Value);
                 }
             }
         }

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -111,6 +111,7 @@
     <Compile Include="CopilotAdoption\CopilotLicenceClassifier.cs" />
     <Compile Include="CopilotAdoption\CopilotLicenceModels.cs" />
     <Compile Include="CopilotAdoption\CsvSerialiser.cs" />
+    <Compile Include="Copilot\CopilotAccessedResourceTaxonomy.cs" />
     <Compile Include="Config\ImportConfig.cs" />
     <Compile Include="Config\UserGroupsFilterModel.cs" />
     <Compile Include="Entities\AuditLog\CopilotEvents.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAccessedResourceTaxonomyTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAccessedResourceTaxonomyTests.cs
@@ -1,0 +1,292 @@
+using Common.Entities.Copilot;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// The shared reading of a Copilot audit record's AccessedResources entry.
+    ///
+    /// Microsoft publishes no enumeration for AccessedResources[].Type - the Purview docs describe it
+    /// as carrying "values like the filetype extension (pptx, docx, etc.) or ... the type of resource
+    /// (for non-SharePoint resources)" - so the contract these tests pin is not "we know every value".
+    /// It is: a value we do not recognise stays visibly unclassified, and is never quietly treated as
+    /// either content or web. See issues #468 and #469.
+    /// </summary>
+    [TestClass]
+    public class CopilotAccessedResourceTaxonomyTests
+    {
+        [TestMethod]
+        public void FileKindsAndGraphEntitiesAreTenantContent()
+        {
+            Assert.AreEqual(CopilotResourceTypeKind.TenantContent, CopilotAccessedResourceTaxonomy.Classify("docx"));
+            Assert.AreEqual(CopilotResourceTypeKind.TenantContent, CopilotAccessedResourceTaxonomy.Classify("pdf"));
+            Assert.AreEqual(CopilotResourceTypeKind.TenantContent, CopilotAccessedResourceTaxonomy.Classify("EmailMessage"));
+            Assert.AreEqual(CopilotResourceTypeKind.TenantContent, CopilotAccessedResourceTaxonomy.Classify("TeamsMessage"));
+        }
+
+        [TestMethod]
+        public void CitationIsAUsageRoleNotContent()
+        {
+            // The whole of #468 in one assertion. CITATION says the resource was shown to the user as a
+            // cited source; it says nothing about what the resource was, so it cannot be charted as a
+            // kind of tenant content.
+            Assert.AreEqual(CopilotResourceTypeKind.UsageRole, CopilotAccessedResourceTaxonomy.Classify("CITATION"));
+            Assert.AreNotEqual(CopilotResourceTypeKind.TenantContent, CopilotAccessedResourceTaxonomy.Classify("CITATION"));
+        }
+
+        [TestMethod]
+        public void WebSearchQueryIsExternalGrounding()
+        {
+            Assert.AreEqual(CopilotResourceTypeKind.ExternalGrounding, CopilotAccessedResourceTaxonomy.Classify("WebSearchQuery"));
+        }
+
+        [TestMethod]
+        public void ClassificationIsCaseInsensitiveAndIgnoresSurroundingSpace()
+        {
+            Assert.AreEqual(CopilotResourceTypeKind.UsageRole, CopilotAccessedResourceTaxonomy.Classify("citation"));
+            Assert.AreEqual(CopilotResourceTypeKind.TenantContent, CopilotAccessedResourceTaxonomy.Classify("DOCX"));
+            Assert.AreEqual(CopilotResourceTypeKind.ExternalGrounding, CopilotAccessedResourceTaxonomy.Classify(" WebSearchQuery "));
+        }
+
+        [TestMethod]
+        public void AValueMicrosoftHasNotUsedYetIsUnclassified()
+        {
+            // Not a hypothetical: the field is an open Edm.String, and the previous allowlist-based
+            // check treated everything outside its list as "web search only".
+            Assert.AreEqual(CopilotResourceTypeKind.Unclassified,
+                CopilotAccessedResourceTaxonomy.Classify("SomeTypeMicrosoftAddedLater"));
+            Assert.AreEqual(CopilotResourceTypeKind.Unclassified,
+                CopilotAccessedResourceTaxonomy.Classify("http://schema.skype.com/hyperlink"));
+        }
+
+        [TestMethod]
+        public void AMissingTypeIsUnclassified()
+        {
+            Assert.AreEqual(CopilotResourceTypeKind.Unclassified, CopilotAccessedResourceTaxonomy.Classify(null));
+            Assert.AreEqual(CopilotResourceTypeKind.Unclassified, CopilotAccessedResourceTaxonomy.Classify(""));
+            Assert.AreEqual(CopilotResourceTypeKind.Unclassified, CopilotAccessedResourceTaxonomy.Classify("   "));
+
+            // And the label the reporting query substitutes for one, which is not a Microsoft value.
+            Assert.AreEqual(CopilotResourceTypeKind.Unclassified,
+                CopilotAccessedResourceTaxonomy.Classify(CopilotAccessedResourceTaxonomy.UnknownTypeLabel));
+        }
+
+        [TestMethod]
+        public void UnclassifiedIsTheDefaultEnumMember()
+        {
+            // So a row deserialised without a kind, or written by an older component, reads as
+            // "we do not know" rather than as tenant content.
+            Assert.AreEqual(CopilotResourceTypeKind.Unclassified, default(CopilotResourceTypeKind));
+        }
+
+        [TestMethod]
+        public void EveryKindHasItsOwnHeadingAndExplanation()
+        {
+            // The workbook and the portal both label the groups; a kind that fell through to a shared
+            // default would put two different things under one heading.
+            var kinds = new[]
+            {
+                CopilotResourceTypeKind.TenantContent,
+                CopilotResourceTypeKind.UsageRole,
+                CopilotResourceTypeKind.ExternalGrounding,
+                CopilotResourceTypeKind.Unclassified,
+            };
+
+            var labels = new System.Collections.Generic.HashSet<string>();
+            foreach (var kind in kinds)
+            {
+                var label = CopilotAccessedResourceTaxonomy.KindLabel(kind);
+                Assert.IsFalse(string.IsNullOrWhiteSpace(label), kind + " has no heading.");
+                Assert.IsTrue(labels.Add(label), "Two kinds share the heading " + label + ".");
+                Assert.IsFalse(string.IsNullOrWhiteSpace(CopilotAccessedResourceTaxonomy.KindExplanation(kind)),
+                    kind + " has no explanation.");
+            }
+        }
+
+        #region SiteUrl host matching
+
+        [TestMethod]
+        public void CommercialSharePointAndOneDriveUrlsAreTenantContent()
+        {
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso.sharepoint.com/sites/sales/Shared%20Documents/report.docx"));
+
+            // OneDrive for Business lives on the tenant's personal SharePoint host, not on a hostname
+            // containing "onedrive".
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/notes.docx"));
+        }
+
+        [TestMethod]
+        public void TeamsAsyncGatewayFileUrlsAreTenantContent()
+        {
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://eu-prod.asyncgw.teams.microsoft.com/v1/objects/0-eu-d0-0000/views/original/quarterly.xlsx"));
+        }
+
+        [TestMethod]
+        public void SovereignCloudUrlsAreTenantContent()
+        {
+            // The second, independent gap in #469: the old substring list only knew the commercial
+            // cloud, so every SharePoint reference in a GCC High, DoD or 21Vianet tenant failed the
+            // check.
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso.sharepoint.us/sites/ops/doc.docx"), "GCC High");
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso.sharepoint-mil.us/sites/ops/doc.docx"), "DoD");
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso.dps.mil/sites/ops/doc.docx"), "DoD");
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso.sharepoint.cn/sites/ops/doc.docx"), "21Vianet");
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso.sharepoint.de/sites/ops/doc.docx"), "Retired Microsoft Cloud Deutschland");
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://gov.teams.microsoft.us/v1/objects/0-gov-d0-0000/views/original/plan.pptx"), "GCC High Teams");
+        }
+
+        [TestMethod]
+        public void UnicodePathsDoNotBreakHostMatching()
+        {
+            // Tenant content routinely carries non-Latin file names; the check must look at the host.
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso.sharepoint.com/sites/example/Shared Documents/Καλημέρα κόσμε.pdf"));
+        }
+
+        [TestMethod]
+        public void ATrailingRootDotDoesNotDefeatHostMatching()
+        {
+            // .NET keeps the trailing root dot on Uri.Host, so a fully-qualified name would otherwise
+            // miss every suffix and be read as grounding from outside the tenant.
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://contoso.sharepoint.com./sites/sales/doc.docx"));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl(
+                "https://contoso.sharepoint.com./sites/sales/doc.docx"));
+        }
+
+        [TestMethod]
+        public void ANonWebSchemeIsEvidenceOfNothingInEitherDirection()
+        {
+            // Uri populates Host for file: and ftp: too, so without a scheme check a
+            // file://contoso.sharepoint.com/... URL counted as positive tenant evidence. A non-web URL
+            // tells us nothing about a Microsoft 365 tenant, so BOTH predicates must stay silent.
+            var nonWeb = new[]
+            {
+                "file://contoso.sharepoint.com/x",
+                "ftp://contoso.sharepoint.com/x",
+                @"file://server/share/doc.docx",
+            };
+
+            foreach (var url in nonWeb)
+            {
+                Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(url), "tenant: " + url);
+                Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl(url), "external: " + url);
+            }
+        }
+
+        [TestMethod]
+        public void AnAlternativeUnicodeDotSeparatorDoesNotDefeatHostMatching()
+        {
+            // Uri.Host keeps a U+3002 ideographic full stop verbatim while Uri.IdnHost canonicalises
+            // it, so matching on Host alone let a tenant URL be read as external.
+            var ideographicDot = "https://contoso" + (char)0x3002 + "sharepoint.com/sites/sales/doc.docx";
+
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(ideographicDot));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl(ideographicDot));
+        }
+
+        [TestMethod]
+        public void AMicrosoftOperatedHostIsNotClaimedToBeExternal()
+        {
+            // IsExternalWebUrl works by exclusion from a list that cannot be complete - Microsoft can
+            // add a content host at any time. Treating a new Microsoft-operated host as proof of
+            // grounding from OUTSIDE the tenant would recreate the #469 under-estimate by the opposite
+            // route, so the honest answer for one is "cannot tell": false from both predicates.
+            var microsoftOperated = new[]
+            {
+                "https://x.usercontent.microsoft/content/abc",
+                "https://x.usgovcloud-usercontent.microsoft/content/abc",
+                "https://x.sovcloud-usercontent.cn/content/abc",
+            };
+
+            foreach (var url in microsoftOperated)
+            {
+                Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl(url),
+                    "Must not be claimed as external: " + url);
+                Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(url),
+                    "Must not be claimed as tenant content either: " + url);
+            }
+        }
+
+        [TestMethod]
+        public void AHostThatMerelyContainsAMicrosoftDomainIsNotTenantContent()
+        {
+            // The old check was a substring test over the whole URL, so all of these passed it.
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://sharepoint.com.example.invalid/pretend/doc.docx"));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://notsharepoint.com/doc.docx"));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(
+                "https://example.invalid/?redirect=https://contoso.sharepoint.com/doc.docx"));
+        }
+
+        [TestMethod]
+        public void ConsumerAndPublicWebUrlsAreNotTenantContent()
+        {
+            // onedrive.live.com is consumer OneDrive - somebody's personal storage, not the tenant's.
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl("https://onedrive.live.com/view.aspx?id=1"));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl("https://www.example.com/an/article"));
+        }
+
+        [TestMethod]
+        public void AMissingOrUnparseableSiteUrlIsNotEvidence()
+        {
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(null));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(""));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl("   "));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl("not a url"));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsTenantContentUrl("/sites/sales/doc.docx"));
+        }
+
+        [TestMethod]
+        public void AWebUrlOnSomebodyElsesHostIsExternalEvidence()
+        {
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsExternalWebUrl("https://www.example.com/an/article"));
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsExternalWebUrl("http://example.invalid/page"));
+            Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsExternalWebUrl("https://onedrive.live.com/view.aspx?id=1"));
+        }
+
+        [TestMethod]
+        public void ATenantUrlIsNeverAlsoExternalEvidence()
+        {
+            // The two checks must never both be true, or a resource would be both grounded and not.
+            var tenantUrls = new[]
+            {
+                "https://contoso.sharepoint.com/sites/sales/doc.docx",
+                "https://contoso-my.sharepoint.com/personal/user/Documents/notes.docx",
+                "https://eu-prod.asyncgw.teams.microsoft.com/v1/objects/0-eu-d0-0000/views/original/q.xlsx",
+                "https://contoso.sharepoint.us/sites/ops/doc.docx",
+            };
+
+            foreach (var url in tenantUrls)
+            {
+                Assert.IsTrue(CopilotAccessedResourceTaxonomy.IsTenantContentUrl(url), url);
+                Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl(url), url);
+            }
+        }
+
+        [TestMethod]
+        public void NoSiteUrlIsNotExternalEvidenceEither()
+        {
+            // Saying nothing is not the same as saying "somewhere else". Treating the two alike is the
+            // conflation that produced #469, so the absence of a URL must stay silent in BOTH
+            // directions.
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl(null));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl(""));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl("   "));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl("not a url"));
+            Assert.IsFalse(CopilotAccessedResourceTaxonomy.IsExternalWebUrl("/sites/sales/doc.docx"));
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionWorkbookTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionWorkbookTests.cs
@@ -1,3 +1,4 @@
+using Common.Entities.Copilot;
 using Common.Entities.CopilotAdoption;
 using Common.Entities.Xlsx;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -213,6 +214,49 @@ namespace Tests.UnitTests
                 "Non-Latin department names must survive the export verbatim.");
             StringAssert.Contains(text, AmpersandDepartment,
                 "An ampersand and angle brackets must be escaped on write and decode back to the original.");
+        }
+
+        [TestMethod]
+        public void Workbook_SaysWhatEachResourceTypeValueActuallyDescribes()
+        {
+            // Issue #468: the workbook used to introduce these rows as "what Copilot grounded its
+            // answers in", which is false for CITATION - the value that is usually the biggest row.
+            // The exported sheet has to carry the same classification the portal shows, or the two
+            // deliverables tell an admin different things about the same numbers.
+            //
+            // The expected labels are written out literally rather than read back from KindLabel:
+            // deriving them from the same method production uses would make this test pass even if
+            // the two kinds' labels were swapped.
+            var lines = SheetText(CopilotAdoptionWorkbook.Build(SyntheticAnalysis()))
+                .Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(l => l.Trim())
+                .ToList();
+
+            // Scope the search to the resource-type table. Searching the whole flattened workbook
+            // would still pass today, but would silently start checking the wrong cell the moment
+            // another table gained a "Kind" header or a "docx" row.
+            var tableStart = lines.IndexOf("Resource type");
+            Assert.AreNotEqual(-1, tableStart, "The resource-type table is missing from the workbook.");
+            var table = lines.Skip(tableStart).ToList();
+
+            AssertFollowedBy(table, "Resource type", "Kind");
+            AssertFollowedBy(table, "Kind", "References");
+            AssertFollowedBy(table, "CITATION", "How it was used");
+            AssertFollowedBy(table, "docx", "Tenant content");
+        }
+
+        /// <summary>
+        /// Asserts that a cell holding <paramref name="value"/> is immediately followed by one holding
+        /// <paramref name="expectedNext"/>. Cells come back in document order, so this pins the value
+        /// to its own row rather than merely finding both somewhere in the workbook.
+        /// </summary>
+        private static void AssertFollowedBy(List<string> cells, string value, string expectedNext)
+        {
+            var index = cells.IndexOf(value);
+            Assert.AreNotEqual(-1, index, $"'{value}' is missing from the workbook.");
+            Assert.IsTrue(index + 1 < cells.Count, $"'{value}' is the last cell in the workbook.");
+            Assert.AreEqual(expectedNext, cells[index + 1],
+                $"'{value}' should be followed by '{expectedNext}', not '{cells[index + 1]}'.");
         }
 
         [TestMethod]
@@ -552,7 +596,18 @@ namespace Tests.UnitTests
 
             summary.UsageByApp.Add(new AdoptionCategory { Label = "Teams", Value = 1988 });
             summary.UsageByApp.Add(new AdoptionCategory { Label = AmpersandDepartment, Value = 534 });
-            summary.TopResourceTypes.Add(new AdoptionCategory { Label = "docx", Value = 480 });
+            summary.TopResourceTypes.Add(new AdoptionResourceTypeRow
+            {
+                Label = "docx",
+                Value = 480,
+                Kind = CopilotAccessedResourceTaxonomy.Classify("docx"),
+            });
+            summary.TopResourceTypes.Add(new AdoptionResourceTypeRow
+            {
+                Label = "CITATION",
+                Value = 1200,
+                Kind = CopilotAccessedResourceTaxonomy.Classify("CITATION"),
+            });
 
             var users = new AdoptionSeries { Name = "Active licensed users" };
             var volume = new AdoptionSeries { Name = "Licensed interactions" };

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotExtendedDataTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotExtendedDataTests.cs
@@ -53,7 +53,7 @@ namespace Tests.UnitTests
             var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
 
             // Assert
-            // 3 messages ◊ 2 credits = 6 credits
+            // 3 messages ÔøΩ 2 credits = 6 credits
             Assert.AreEqual(6, cost.TotalCredits);
             Assert.AreEqual(3, cost.GenerativeAnswers);
             Assert.AreEqual(0, cost.TenantGraphGroundedAnswers);
@@ -82,13 +82,13 @@ namespace Tests.UnitTests
             var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
 
             // Assert
-            // 3 messages ◊ (2 credits generative + 10 credits tenant graph) = 36 credits
+            // 3 messages ÔøΩ (2 credits generative + 10 credits tenant graph) = 36 credits
             Assert.AreEqual(36, cost.TotalCredits);
             Assert.AreEqual(3, cost.GenerativeAnswers);
             Assert.AreEqual(3, cost.TenantGraphGroundedAnswers);
             Assert.AreEqual(0, cost.DeepReasoningActions);
-            Assert.AreEqual(6, cost.CreditBreakdown["Generative Answers"]); // 3 ◊ 2
-            Assert.AreEqual(30, cost.CreditBreakdown["Tenant Graph Grounding"]); // 3 ◊ 10
+            Assert.AreEqual(6, cost.CreditBreakdown["Generative Answers"]); // 3 ÔøΩ 2
+            Assert.AreEqual(30, cost.CreditBreakdown["Tenant Graph Grounding"]); // 3 ÔøΩ 10
         }
 
         [TestMethod]
@@ -132,8 +132,8 @@ namespace Tests.UnitTests
             var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
 
             // Assert
-            // 3 messages ◊ 2 credits (generative) = 6 credits
-            // 3 messages ◊ 10 credits (tenant graph) = 30 credits
+            // 3 messages ÔøΩ 2 credits (generative) = 6 credits
+            // 3 messages ÔøΩ 10 credits (tenant graph) = 30 credits
             // 1 deep reasoning agent action = 5 credits
             // Total = 41 credits
             Assert.AreEqual(41, cost.TotalCredits);
@@ -166,7 +166,7 @@ namespace Tests.UnitTests
             var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
 
             // Assert
-            // 2 messages ◊ 2 credits (generative) = 4 credits
+            // 2 messages ÔøΩ 2 credits (generative) = 4 credits
             // 1 deep reasoning agent action = 5 credits
             // Total = 9 credits
             Assert.AreEqual(9, cost.TotalCredits);
@@ -194,7 +194,7 @@ namespace Tests.UnitTests
             var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
 
             // Assert
-            // 1 message ◊ (2 + 10) = 12 credits
+            // 1 message ÔøΩ (2 + 10) = 12 credits
             Assert.AreEqual(12, cost.TotalCredits);
             Assert.AreEqual(1, cost.TenantGraphGroundedAnswers);
         }
@@ -240,10 +240,310 @@ namespace Tests.UnitTests
             var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
 
             // Assert
-            // Still just 1 message ◊ (2 + 10) = 12 credits (not multiplied by resource count)
+            // Still just 1 message ÔøΩ (2 + 10) = 12 credits (not multiplied by resource count)
             Assert.AreEqual(12, cost.TotalCredits);
             Assert.AreEqual(4, cost.ResourceTypeBreakdown.Values.Sum()); // 4 resources for reference
         }
+
+        #region Tenant graph grounding - issue #469
+
+        [TestMethod]
+        public void Copilot_CostEstimation_CitationWithNoOtherEvidence_IsStillTenantGrounded()
+        {
+            // The reported defect. CITATION is one of the commonest values Microsoft puts in
+            // AccessedResources[].Type, and it was absent from the old allowlist, so a conversation
+            // grounded on a cited document fell through to "likely web search only" and was estimated
+            // at 2 credits per response instead of 12.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': true },
+                    { 'Id': '2', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    { 'Type': 'CITATION', 'Name': 'Quarterly review' }
+                ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual(1, cost.TenantGraphGroundedAnswers,
+                "A citation with nothing to say it came from outside the tenant must not be waved through.");
+            Assert.AreEqual(12, cost.TotalCredits);
+
+            // And the estimate says out loud that it rests on an assumption rather than on evidence.
+            Assert.AreEqual("UnclassifiedResource", cost.TenantGraphGroundingBasis);
+            Assert.AreEqual(1, cost.UnclassifiedResources);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_CitationOnATenantUrl_IsGroundedOnEvidenceNotAssumption()
+        {
+            // The same value, but this time the record proves where the resource lives. The credits are
+            // identical; what changes is that the estimate is now evidence-based, which is the whole
+            // reason the basis is recorded.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    {
+                        'Type': 'CITATION',
+                        'SiteUrl': 'https://contoso.sharepoint.com/sites/sales/Shared Documents/ŒöŒ±ŒªŒ∑ŒºŒ≠œÅŒ± Œ∫œåœÉŒºŒµ.pdf'
+                    }
+                ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual(1, cost.TenantGraphGroundedAnswers);
+            Assert.AreEqual(12, cost.TotalCredits);
+            Assert.AreEqual("TenantResource", cost.TenantGraphGroundingBasis);
+            Assert.AreEqual(0, cost.UnclassifiedResources);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_CitationWithAListItemId_IsGroundedOnEvidence()
+        {
+            // Microsoft documents listItemUniqueId as the unique identifier for a SharePoint item, so
+            // a real one is positive evidence even when the record carries no SiteUrl at all.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    { 'Type': 'CITATION', 'listItemUniqueId': '11111111-2222-3333-4444-555555555555' }
+                ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual("TenantResource", cost.TenantGraphGroundingBasis);
+            Assert.AreEqual(0, cost.UnclassifiedResources);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_AllZeroIdentifiersAreNotEvidence()
+        {
+            // The payload uses an all-zero GUID as a placeholder where a resource has no such
+            // identifier. Accepting it would make the evidence check true for essentially every
+            // resource, which would be a different way of getting the same answer wrong.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    {
+                        'Type': 'CITATION',
+                        'listItemUniqueId': '00000000-0000-0000-0000-000000000000',
+                        'SensitivityLabelId': '00000000-0000-0000-0000-000000000000'
+                    }
+                ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual("UnclassifiedResource", cost.TenantGraphGroundingBasis,
+                "A placeholder identifier is not evidence that the resource belongs to the tenant.");
+            Assert.AreEqual(1, cost.UnclassifiedResources);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_UnknownFutureType_DoesNotMeanWebSearchOnly()
+        {
+            // AccessedResources[].Type is an open string with no published enumeration, so Microsoft
+            // can add a value at any time. The estimate must not quietly pick the cheaper answer for
+            // one - that is the failure mode that hid #469 for so long.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': false },
+                    { 'Id': '2', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    { 'Type': 'SomeTypeMicrosoftAddedLater' }
+                ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual(2, cost.TenantGraphGroundedAnswers);
+            Assert.AreEqual(24, cost.TotalCredits);
+            Assert.AreNotEqual("ExternalOnly", cost.TenantGraphGroundingBasis,
+                "An unrecognised type is not evidence of web-only grounding.");
+            Assert.AreEqual(1, cost.UnclassifiedResources);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_WebSearchQueryOnly_IsTheOnlyWebOnlyCase()
+        {
+            // The one case the old comment claimed for everything it did not recognise: every resource
+            // is positively identified as grounding from outside the tenant.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    { 'Type': 'WebSearchQuery' },
+                    { 'Type': 'WebSearchQuery' }
+                ],
+                'AISystemPlugin': [{ 'Id': 'BingWebSearch', 'Name': 'BuiltIn' }]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual(0, cost.TenantGraphGroundedAnswers);
+            Assert.AreEqual(2, cost.TotalCredits);
+            Assert.AreEqual("ExternalOnly", cost.TenantGraphGroundingBasis);
+            Assert.AreEqual(0, cost.UnclassifiedResources);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_OneTenantResourceAmongWebResults_IsGrounded()
+        {
+            // Microsoft's own schema example shows a web-search plugin alongside an accessed Microsoft
+            // 365 document, so web grounding never rules tenant grounding out.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    { 'Type': 'WebSearchQuery' },
+                    { 'Type': 'docx', 'SiteUrl': 'https://contoso.sharepoint.com/sites/sales/doc.docx' }
+                ],
+                'AISystemPlugin': [{ 'Id': 'BingWebSearch', 'Name': 'BuiltIn' }]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual(1, cost.TenantGraphGroundedAnswers);
+            Assert.AreEqual("TenantResource", cost.TenantGraphGroundingBasis);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_APlainWebPageIsNotTenantGrounding()
+        {
+            // The counterweight to charging the unknown case: a resource whose SiteUrl resolves to a
+            // host that is not the tenant's is positively OUTSIDE the tenant, and charging it would
+            // swap one systematic error for the opposite one.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': true },
+                    { 'Id': '2', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    { 'Type': 'WebPage', 'SiteUrl': 'https://www.example.com/an/article' }
+                ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual(0, cost.TenantGraphGroundedAnswers);
+            Assert.AreEqual(2, cost.TotalCredits);
+            Assert.AreEqual("ExternalOnly", cost.TenantGraphGroundingBasis);
+            Assert.AreEqual(0, cost.UnclassifiedResources);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_TheSameTypeWithNoUrlStaysUnclassified()
+        {
+            // Same unrecognised type as the test above, minus the one field that placed it. Knowing
+            // where a resource lives and knowing nothing about it must not produce the same answer -
+            // that conflation is what #469 is.
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': true },
+                    { 'Id': '2', 'isPrompt': false }
+                ],
+                'AccessedResources': [
+                    { 'Type': 'WebPage' }
+                ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual("UnclassifiedResource", cost.TenantGraphGroundingBasis);
+            Assert.AreEqual(1, cost.UnclassifiedResources);
+            Assert.AreEqual(1, cost.TenantGraphGroundedAnswers);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_NoAccessedResources_IsNotCharged()
+        {
+            var json = @"{
+                'Messages': [
+                    { 'Id': '1', 'isPrompt': false }
+                ],
+                'AccessedResources': []
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreEqual(0, cost.TenantGraphGroundedAnswers);
+            Assert.AreEqual("NoResources", cost.TenantGraphGroundingBasis);
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_SovereignCloudSharePointIsRecognisedAsTenantEvidence()
+        {
+            // The second, independent gap in #469. The old check matched the substring "sharepoint.com"
+            // only, so every SharePoint reference in a GCC High, DoD or 21Vianet tenant missed. The
+            // basis is what proves the fix: an unrecognised host would also be charged now, so
+            // asserting the credits alone would pass either way.
+            var urls = new[]
+            {
+                "https://contoso.sharepoint.us/sites/ops/doc.docx",
+                "https://contoso.sharepoint-mil.us/sites/ops/doc.docx",
+                "https://contoso.dps.mil/sites/ops/doc.docx",
+                "https://contoso.sharepoint.cn/sites/ops/doc.docx",
+            };
+
+            foreach (var url in urls)
+            {
+                var json = @"{
+                    'Messages': [ { 'Id': '1', 'isPrompt': false } ],
+                    'AccessedResources': [ { 'Type': 'CITATION', 'SiteUrl': '" + url + @"' } ]
+                }";
+
+                var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+                Assert.AreEqual("TenantResource", cost.TenantGraphGroundingBasis, url);
+                Assert.AreEqual(12, cost.TotalCredits, url);
+            }
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_LookalikeHostIsNotTenantEvidence()
+        {
+            // The old check was a substring test over the whole URL, so this host passed it.
+            var json = @"{
+                'Messages': [ { 'Id': '1', 'isPrompt': false } ],
+                'AccessedResources': [
+                    { 'Type': 'CITATION', 'SiteUrl': 'https://sharepoint.com.example.invalid/pretend/doc.docx' }
+                ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: true);
+
+            Assert.AreNotEqual("TenantResource", cost.TenantGraphGroundingBasis,
+                "A host that merely contains a Microsoft domain is not evidence of tenant content.");
+        }
+
+        [TestMethod]
+        public void Copilot_CostEstimation_NonCustomAgent_MakesNoGroundingDecision()
+        {
+            // Standard Microsoft 365 Copilot is not billed in credits, so no grounding decision is
+            // made at all - which is a different statement from "we looked and found nothing".
+            var json = @"{
+                'Messages': [ { 'Id': '1', 'isPrompt': false } ],
+                'AccessedResources': [ { 'Type': 'CITATION' } ]
+            }";
+
+            var cost = CopilotCreditEstimation.Analyze(json, isCustomAgent: false);
+
+            Assert.AreEqual(0, cost.TotalCredits);
+            Assert.AreEqual("NotAssessed", cost.TenantGraphGroundingBasis);
+        }
+
+        #endregion
 
         [TestMethod]
         public void Copilot_CostEstimation_NullOrEmptyInput_ReturnsZero()
@@ -321,7 +621,14 @@ namespace Tests.UnitTests
             Assert.AreEqual(2, cost.ResourceTypeBreakdown["docx"]);
             Assert.AreEqual(1, cost.ResourceTypeBreakdown["xlsx"]);
             Assert.AreEqual(1, cost.ResourceTypeBreakdown["pptx"]);
-            Assert.AreEqual(1, cost.ResourceTypeBreakdown["WebPage"]); // Empty type defaults to WebPage
+
+            // A resource with no type is counted as unknown, NOT as a web page. Microsoft's Type field
+            // is not a content taxonomy, so its absence says nothing about where the resource came
+            // from - and labelling it "WebPage" is the same category error as #468/#469, in the
+            // diagnostic breakdown instead of in the billing.
+            Assert.AreEqual(1, cost.ResourceTypeBreakdown["(unknown)"]);
+            Assert.IsFalse(cost.ResourceTypeBreakdown.ContainsKey("WebPage"),
+                "A missing resource type must not be reported as a web page.");
         }
 
         [TestMethod]
@@ -1076,7 +1383,7 @@ namespace Tests.UnitTests
 
                 // Assert - Verify cost calculation
                 var cost = CopilotCreditEstimation.Analyze(auditLogContent.ParsedAuditEvent, isCustomAgent: true);
-                // 2 messages ◊ (2 generative + 10 tenant graph) + 5 deep reasoning = 29 credits
+                // 2 messages ÔøΩ (2 generative + 10 tenant graph) + 5 deep reasoning = 29 credits
                 Assert.AreEqual(29, cost.TotalCredits);
                 Assert.AreEqual(1, cost.DeepReasoningActions);
                 Assert.IsTrue(cost.ModelsUsed.Contains("DEEP_LEO"));

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -253,6 +253,7 @@
     <Compile Include="CopilotAdoptionTelemetryTests.cs" />
     <Compile Include="CopilotAdoptionTests.cs" />
     <Compile Include="CopilotAdoptionWorkbookTests.cs" />
+    <Compile Include="CopilotAccessedResourceTaxonomyTests.cs" />
     <Compile Include="ReportsAPIControllerTests.cs" />
     <Compile Include="SimplePropsDicTests.cs" />
     <Compile Include="PageUpdateEventListParseTests.cs" />

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/ResourceTypesPanel.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/ResourceTypesPanel.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import { renderWithProvider } from '../../test/renderWithProvider';
+import ResourceTypesPanel from './ResourceTypesPanel';
+import { CopilotResourceTypeKind } from '../../types/copilotAdoption';
+import type { AdoptionResourceTypeRow } from '../../types/copilotAdoption';
+
+/**
+ * The rows the server sends: the raw AccessedResources.Type values from Microsoft's audit log, each
+ * with the kind the shared C# taxonomy assigned it.
+ */
+const ROWS: AdoptionResourceTypeRow[] = [
+  { label: 'CITATION', value: 4200, kind: CopilotResourceTypeKind.UsageRole },
+  { label: 'docx', value: 480, kind: CopilotResourceTypeKind.TenantContent },
+  { label: 'WebSearchQuery', value: 300, kind: CopilotResourceTypeKind.ExternalGrounding },
+  { label: 'xlsx', value: 210, kind: CopilotResourceTypeKind.TenantContent },
+  { label: '(unknown)', value: 90, kind: CopilotResourceTypeKind.Unclassified },
+];
+
+/** The group headings, in the order the panel shows them. */
+const GROUP_TITLES = [
+  'Tenant content',
+  'How it was used',
+  'Grounding from outside the tenant',
+  'Unclassified',
+];
+
+/** The rendered container for one group, or null when the group has no rows. */
+function groupContainer(title: string): HTMLElement | null {
+  const heading = screen.queryByText(title);
+  // <Text> heading -> the heading block -> the group.
+  return (heading?.parentElement?.parentElement as HTMLElement) ?? null;
+}
+
+/** The group heading a label is rendered under, or null if the label is not on screen at all. */
+function groupOf(label: string): string | null {
+  for (const title of GROUP_TITLES) {
+    const group = groupContainer(title);
+    if (group && within(group).queryByText(label)) return title;
+  }
+  return null;
+}
+
+describe('ResourceTypesPanel', () => {
+  it('does not present CITATION as a kind of tenant content', () => {
+    // The defect in issue #468: CITATION describes how the resource was used, not what it is, and it
+    // is usually the largest bucket - so charting it as tenant content made the card's own subtitle
+    // false for most of its ink.
+    renderWithProvider(<ResourceTypesPanel rows={ROWS} />);
+
+    const group = groupOf('CITATION');
+    expect(group).toBe('How it was used');
+    expect(group).not.toBe('Tenant content');
+  });
+
+  it('keeps web grounding out of the tenant content group', () => {
+    renderWithProvider(<ResourceTypesPanel rows={ROWS} />);
+
+    expect(groupOf('WebSearchQuery')).toBe('Grounding from outside the tenant');
+  });
+
+  it('groups file kinds as tenant content', () => {
+    renderWithProvider(<ResourceTypesPanel rows={ROWS} />);
+
+    expect(groupOf('docx')).toBe('Tenant content');
+    expect(groupOf('xlsx')).toBe('Tenant content');
+  });
+
+  it('shows a reference with no type as unclassified rather than as content', () => {
+    renderWithProvider(<ResourceTypesPanel rows={ROWS} />);
+
+    expect(groupOf('(unknown)')).toBe('Unclassified');
+  });
+
+  it('shows a value Microsoft has not used yet as unclassified, and never drops it', () => {
+    // Microsoft publishes no enumeration for this field, so an unrecognised value is expected rather
+    // than exceptional. It must stay visible and visibly unclassified.
+    const future: AdoptionResourceTypeRow[] = [
+      ...ROWS,
+      { label: 'SomeTypeMicrosoftAddedLater', value: 1500, kind: CopilotResourceTypeKind.Unclassified },
+    ];
+    renderWithProvider(<ResourceTypesPanel rows={future} />);
+
+    expect(groupOf('SomeTypeMicrosoftAddedLater')).toBe('Unclassified');
+  });
+
+  it('keeps a row whose kind this build does not know about', () => {
+    // A newer server adding an enum member must not make references disappear from the chart - that
+    // would be a worse version of the silent misclassification this card was reported for.
+    const unknownKind: AdoptionResourceTypeRow[] = [
+      ...ROWS,
+      { label: 'FromANewerServer', value: 75, kind: 99 as CopilotResourceTypeKind },
+    ];
+    renderWithProvider(<ResourceTypesPanel rows={unknownKind} />);
+
+    expect(groupOf('FromANewerServer')).toBe('Unclassified');
+  });
+
+  it('scales bars against the largest value across all groups, not within a group', () => {
+    // Grouping is what makes the different taxonomies readable, but it must not rescale each group to
+    // its own maximum: docx at 480 would then be drawn the same width as CITATION at 4200.
+    const { container } = renderWithProvider(<ResourceTypesPanel rows={ROWS} />);
+
+    const widths = new Map<string, number>();
+    ROWS.forEach((row) => {
+      const cell = screen.getByText(row.label);
+      const bar = cell.parentElement?.querySelector('div > div[style*="width"]') as HTMLElement | null;
+      if (bar) widths.set(row.label, parseFloat(bar.style.width));
+    });
+
+    expect(container).toBeTruthy();
+    expect(widths.get('CITATION')).toBeCloseTo(100, 5);
+    expect(widths.get('docx')).toBeCloseTo((480 / 4200) * 100, 5);
+  });
+
+  it('renders an empty state rather than an empty chart', () => {
+    renderWithProvider(<ResourceTypesPanel rows={[]} />);
+
+    expect(screen.getByText('No data for this period.')).toBeTruthy();
+  });
+
+  it('does not describe the tenant content group without warning that it undercounts', () => {
+    // A cited PDF is typed CITATION, so the file-kind rows are not "how many PDFs Copilot used".
+    // The card is only honest if it says so.
+    renderWithProvider(<ResourceTypesPanel rows={ROWS} />);
+
+    const heading = screen.getByText('Tenant content');
+    const group = heading.parentElement as HTMLElement;
+    expect(within(group).getByText(/Undercounted/)).toBeTruthy();
+  });
+});

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/ResourceTypesPanel.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/copilotAdoption/ResourceTypesPanel.tsx
@@ -1,0 +1,182 @@
+import { makeStyles, tokens, Text } from '@fluentui/react-components';
+import { CopilotResourceTypeKind } from '../../types/copilotAdoption';
+import type { AdoptionResourceTypeRow } from '../../types/copilotAdoption';
+import { formatValue, seriesColor, seriesColorLight } from '../charts/chartCommon';
+
+/**
+ * The groups, in the order they are shown, with the wording the Excel workbook uses for the same
+ * buckets (Common/Entities/Copilot/CopilotAccessedResourceTaxonomy.cs).
+ *
+ * Tenant content first because it is the only group that answers "what content is Copilot working
+ * on"; unclassified last because it is a residue rather than a finding.
+ */
+const GROUPS: { kind: CopilotResourceTypeKind; title: string; explanation: string }[] = [
+  {
+    kind: CopilotResourceTypeKind.TenantContent,
+    title: 'Tenant content',
+    explanation:
+      'Kinds of organisational content - file types and Microsoft Graph entities. Undercounted: a file '
+      + 'Copilot cited is typed CITATION instead of by its file type.',
+  },
+  {
+    kind: CopilotResourceTypeKind.UsageRole,
+    title: 'How it was used',
+    explanation:
+      'How the resource was used, not what it is. A citation can be either tenant content or a web page, '
+      + 'so these references are counted here and nowhere else.',
+  },
+  {
+    kind: CopilotResourceTypeKind.ExternalGrounding,
+    title: 'Grounding from outside the tenant',
+    explanation: 'Grounding from outside the organisation. Not tenant content.',
+  },
+  {
+    kind: CopilotResourceTypeKind.Unclassified,
+    title: 'Unclassified',
+    explanation:
+      'Values this version does not recognise, and references whose type was empty. Microsoft publishes no '
+      + 'list of possible values and can add new ones at any time, so these are shown as-is rather than '
+      + 'counted as content.',
+  },
+];
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '18px',
+    width: '100%',
+    paddingTop: '4px',
+  },
+  group: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  groupHead: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  explanation: {
+    color: tokens.colorNeutralForeground3,
+  },
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(90px, 160px) 1fr auto',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  label: {
+    color: tokens.colorNeutralForeground2,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  track: {
+    position: 'relative',
+    height: '20px',
+    borderRadius: '10px',
+    backgroundColor: tokens.colorNeutralBackground3,
+    overflow: 'hidden',
+  },
+  bar: {
+    height: '100%',
+    borderRadius: '10px',
+    minWidth: '3px',
+  },
+  value: {
+    fontVariantNumeric: 'tabular-nums',
+    textAlign: 'right',
+    minWidth: '48px',
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '24px 0',
+    textAlign: 'center',
+  },
+});
+
+type ResourceTypesPanelProps = {
+  rows: AdoptionResourceTypeRow[];
+};
+
+/**
+ * "What Copilot referenced": the raw `AccessedResources[].Type` values from Microsoft's Copilot audit
+ * log, grouped by what each value actually describes.
+ *
+ * This is not one chart of one taxonomy, and it deliberately does not pretend to be. Microsoft mixes
+ * file kinds, Graph entity names, how the resource was used (`CITATION`) and grounding from outside
+ * the tenant (`WebSearchQuery`) into that single field, so bars from different groups are not
+ * comparable as "kinds of content". Grouping them is what makes that readable - the previous single
+ * chart put `CITATION`, which is usually the largest bucket, next to `pdf` under a subtitle claiming
+ * both were kinds of tenant content. See issue #468.
+ *
+ * Bars are scaled against the largest value ACROSS ALL GROUPS, not within a group, so the visual
+ * lengths stay honest: a group that is a rounding error does not get redrawn as a full-width bar.
+ */
+export default function ResourceTypesPanel({ rows }: ResourceTypesPanelProps) {
+  const styles = useStyles();
+
+  if (rows.length === 0) {
+    return <div className={styles.empty}>No data for this period.</div>;
+  }
+
+  const max = Math.max(...rows.map((r) => r.value), 1);
+  const knownKinds = new Set(GROUPS.map((g) => g.kind));
+
+  // A kind this build does not know about - a newer server adding an enum member - falls into
+  // Unclassified rather than being filtered out of the chart. Dropping the row would be the same
+  // silent loss the raw-Type chart was reported for.
+  const rowsFor = (kind: CopilotResourceTypeKind) =>
+    rows
+      .filter((r) =>
+        kind === CopilotResourceTypeKind.Unclassified ? !knownKinds.has(r.kind) || r.kind === kind : r.kind === kind,
+      )
+      .sort((a, b) => b.value - a.value);
+
+  return (
+    <div className={styles.root}>
+      {GROUPS.map((group, groupIndex) => {
+        const groupRows = rowsFor(group.kind);
+        if (groupRows.length === 0) return null;
+
+        return (
+          <div className={styles.group} key={group.kind}>
+            <div className={styles.groupHead}>
+              <Text size={200} weight="semibold">
+                {group.title}
+              </Text>
+              <Text size={100} className={styles.explanation}>
+                {group.explanation}
+              </Text>
+            </div>
+            {groupRows.map((r) => {
+              const pct = Math.max(1, (r.value / max) * 100);
+
+              return (
+                <div className={styles.row} key={r.label} title={`${r.label}: ${formatValue(r.value)} References`}>
+                  <Text size={200} className={styles.label}>
+                    {r.label}
+                  </Text>
+                  <div className={styles.track}>
+                    <div
+                      className={styles.bar}
+                      style={{
+                        width: `${pct}%`,
+                        backgroundImage: `linear-gradient(90deg, ${seriesColor(groupIndex)} 0%, ${seriesColorLight(groupIndex)} 100%)`,
+                      }}
+                    />
+                  </div>
+                  <Text size={200} weight="semibold" className={styles.value}>
+                    {formatValue(r.value)}
+                  </Text>
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/pages/CopilotAdoptionPage.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/pages/CopilotAdoptionPage.tsx
@@ -49,6 +49,7 @@ import IntensityScatter from '../components/copilotAdoption/IntensityScatter';
 import ActionPlan from '../components/copilotAdoption/ActionPlan';
 import AgentsPanel from '../components/copilotAdoption/AgentsPanel';
 import UnlicensedPanel from '../components/copilotAdoption/UnlicensedPanel';
+import ResourceTypesPanel from '../components/copilotAdoption/ResourceTypesPanel';
 import { ConcentrationBar, CombinedSegmentTable } from '../components/copilotAdoption/CombinedViews';
 import InfoTip from '../components/copilotAdoption/InfoTip';
 import { SegmentTable, BAND_COLOUR_LIST } from '../components/copilotAdoption/adoptionShared';
@@ -968,27 +969,28 @@ function OverviewTab({
           <div className={styles.cardHead}>
             <div>
               <Text weight="semibold" size={400}>
-                What Copilot is working on
+                What Copilot referenced
               </Text>
               <Text size={200} block className={styles.muted}>
-                The kinds of tenant content Copilot grounded its answers in.
+                How Microsoft's audit log typed the resources behind Copilot's answers. The values are not
+                one taxonomy, so they are grouped by what they describe.
               </Text>
             </div>
             <div className={styles.cardTools}>
               <InfoTip
-                title="What Copilot is working on"
+                title="What Copilot referenced"
                 content={{
-                  what: 'The types of organisational content (documents, meetings, chats and so on) that Copilot actually referenced when answering.',
-                  how: `Counted from the resources recorded against each Copilot interaction in the audit log, top ${o.topSegments} types. One interaction can reference several resources, so this counts references rather than interactions.`,
+                  what: `The raw AccessedResources.Type values recorded against each Copilot interaction, top ${o.topSegments} by reference count, grouped by what each value actually describes. One interaction can reference several resources, so this counts references rather than interactions.`,
+                  how: 'Read the groups separately, not as one ranking. Only "Tenant content" answers what Copilot is working on, and it undercounts: a file Copilot cited is typed CITATION rather than by its file type, so those references are counted under "How it was used" instead. "Grounding from outside the tenant" is not your content at all.',
                   source:
-                    'The clearest available evidence that Copilot is doing work on your own data rather than answering generic questions any free chatbot could. A population whose Copilot use never touches tenant content is getting little that a licence pays for.',
+                    'Microsoft publishes no list of possible values for this field - the Purview documentation says it "can contain values like the filetype extension (pptx, docx, etc.) or describe the type of resource (for non-SharePoint resources)" - and can add new ones at any time. Anything this version does not recognise, and any reference whose type was empty, is shown as Unclassified rather than being counted as content.',
                 }}
               />
               {sql?.resourceTypes && <SqlPopover sql={sql.resourceTypes} title="SQL behind this chart" />}
             </div>
           </div>
           <div className={styles.cardBody}>
-            <CategoryBarChart categories={summary.topResourceTypes} valueLabel="References" />
+            <ResourceTypesPanel rows={summary.topResourceTypes} />
           </div>
         </Card>
       )}

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/types/copilotAdoption.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/types/copilotAdoption.ts
@@ -38,6 +38,29 @@ export enum AdoptionBand {
   Champion = 5,
 }
 
+/**
+ * What a Copilot audit record's `AccessedResources[].Type` value actually describes. Numeric values
+ * match the C# CopilotResourceTypeKind enum.
+ *
+ * Microsoft publishes no enumeration for that field - the Purview docs describe it as carrying
+ * "values like the filetype extension (pptx, docx, etc.) or ... the type of resource (for
+ * non-SharePoint resources)" - so a value this version does not recognise is Unclassified rather
+ * than being folded into one of the other buckets. See issue #468.
+ */
+export enum CopilotResourceTypeKind {
+  Unclassified = 0,
+  TenantContent = 1,
+  UsageRole = 2,
+  ExternalGrounding = 3,
+}
+
+/** One row of the "what Copilot referenced" breakdown: a raw audit Type value and what it means. */
+export interface AdoptionResourceTypeRow {
+  label: string;
+  value: number;
+  kind: CopilotResourceTypeKind;
+}
+
 /** Which imports supplied the data, so no headline number is quoted without its caveats. */
 export interface AdoptionDataSources {
   auditAvailable: boolean;
@@ -265,7 +288,7 @@ export interface CopilotAdoptionSummary {
   scoreProfiles: AdoptionScoreProfile[];
   concentration: AdoptionConcentrationBand[];
   combinedByDepartment: AdoptionCombinedSegmentRow[];
-  topResourceTypes: ReportCategory[];
+  topResourceTypes: AdoptionResourceTypeRow[];
   agents: AgentEstateSummary;
   unlicensed: UnlicensedPopulationSummary;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CostEstimate/CopilotCreditEstimation.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CostEstimate/CopilotCreditEstimation.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using Common.Entities.Copilot;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,36 @@ using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation;
 
 namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
 {
+
+    /// <summary>
+    /// How <see cref="CopilotCreditEstimation"/> reached its tenant-graph grounding decision for a
+    /// conversation. Stored as a string on the estimate rather than an enum so an older reader of the
+    /// persisted JSON cannot silently coerce a value it does not know into the first enum member.
+    /// </summary>
+    public static class CopilotTenantGroundingBasis
+    {
+        /// <summary>Not a billable custom agent, or there was nothing to analyse - no decision was made.</summary>
+        public const string NotAssessed = "NotAssessed";
+
+        /// <summary>The conversation listed no accessed resources at all.</summary>
+        public const string NoResources = "NoResources";
+
+        /// <summary>
+        /// Every accessed resource was positively identified as grounding from outside the tenant.
+        /// This is the only case that genuinely means "web search only".
+        /// </summary>
+        public const string ExternalOnly = "ExternalOnly";
+
+        /// <summary>At least one resource carried positive evidence of being a tenant resource.</summary>
+        public const string TenantResource = "TenantResource";
+
+        /// <summary>
+        /// No resource carried positive tenant evidence, but at least one could not be classified
+        /// either way, so the charge was applied on the assumption that it was tenant content. See
+        /// <see cref="CopilotCreditEstimation.UnclassifiedResources"/>.
+        /// </summary>
+        public const string UnclassifiedResource = "UnclassifiedResource";
+    }
 
     /// <summary>
     /// Detailed billing report for a Copilot audit event.
@@ -25,9 +56,18 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
         #region Billing Constants
 
         /// <summary>
-        /// Version of the cost estimation model.
+        /// Version of the cost estimation model. Stamped into every stored estimate, so an estimate
+        /// produced by an older importer can be told apart from a current one.
+        ///
+        /// History:
+        /// 1.0.0.1 - initial model.
+        /// 1.1.0.0 - tenant-graph grounding is decided from positive evidence of a tenant resource
+        ///           rather than from an allowlist of AccessedResources[].Type values, and a resource
+        ///           this product cannot classify no longer silently produces the cheaper answer
+        ///           (#469). Estimates for the same conversation can legitimately differ across this
+        ///           boundary.
         /// </summary>
-        private const string COST_ESTIMATION_VERSION = "1.0.0.1";
+        private const string COST_ESTIMATION_VERSION = "1.1.0.0";
 
         // Based on Microsoft Copilot Studio billing documentation (as of March 2025)
         // https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-messages-management#copilot-credits-and-events-scenarios
@@ -66,6 +106,28 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
         [JsonProperty("TenantGraphGroundedAnswers")]
         public int TenantGraphGroundedAnswers { get; set; }
 
+        /// <summary>
+        /// Why the tenant-graph grounding charge was or was not applied - one of the
+        /// <see cref="CopilotTenantGroundingBasis"/> constants.
+        ///
+        /// Recorded because the decision is an inference, not something the audit log states. An
+        /// estimate that rests on a SharePoint URL is worth more than one that rests on a resource
+        /// type nobody recognises, and without this the two are indistinguishable after the fact.
+        /// </summary>
+        [JsonProperty("TenantGraphGroundingBasis")]
+        public string TenantGraphGroundingBasis { get; set; }
+
+        /// <summary>
+        /// How many accessed resources carried no evidence either way - neither positive evidence of a
+        /// tenant resource nor a recognised marker for grounding from outside the tenant.
+        ///
+        /// These are charged as tenant grounding, because Microsoft documents AccessedResources as the
+        /// resources Copilot accessed to answer and gives no way to tell an unrecognised entry apart.
+        /// The count exists so that assumption is visible rather than buried.
+        /// </summary>
+        [JsonProperty("UnclassifiedResources")]
+        public int UnclassifiedResources { get; set; }
+
         [JsonProperty("DeepReasoningActions")]
         public int DeepReasoningActions { get; set; }
 
@@ -96,6 +158,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
         {
             CostModelVersion = COST_ESTIMATION_VERSION,
             TotalCredits = 0,
+            TenantGraphGroundingBasis = CopilotTenantGroundingBasis.NotAssessed,
             ResourceTypeBreakdown = new Dictionary<string, int>(),
             CreditBreakdown = new Dictionary<string, int>(),
             ModelsUsed = new List<string>()
@@ -117,6 +180,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
                 {
                     CostModelVersion = COST_ESTIMATION_VERSION,
                     TotalCredits = 0,
+                    TenantGraphGroundingBasis = CopilotTenantGroundingBasis.NotAssessed,
                     ResourceTypeBreakdown = new Dictionary<string, int>(),
                     CreditBreakdown = new Dictionary<string, int>(),
                     ModelsUsed = new List<string>()
@@ -171,6 +235,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
                 {
                     CostModelVersion = COST_ESTIMATION_VERSION,
                     TotalCredits = 0,
+                    TenantGraphGroundingBasis = CopilotTenantGroundingBasis.NotAssessed,
                     ResourceTypeBreakdown = new Dictionary<string, int>(),
                     CreditBreakdown = new Dictionary<string, int>(),
                     ModelsUsed = new List<string>()
@@ -180,6 +245,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
             var report = new CopilotCreditEstimation
             {
                 CostModelVersion = COST_ESTIMATION_VERSION,
+                TenantGraphGroundingBasis = CopilotTenantGroundingBasis.NotAssessed,
                 ResourceTypeBreakdown = new Dictionary<string, int>(),
                 CreditBreakdown = new Dictionary<string, int>(),
                 ModelsUsed = new List<string>()
@@ -190,9 +256,7 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
             if (!isCustomAgent)
             {
                 // Build resource breakdown for analytics but don't charge any credits
-                report.ResourceTypeBreakdown = auditEvent.AccessedResources?
-                    .GroupBy(r => string.IsNullOrEmpty(r.Type) ? "WebPage" : r.Type)
-                    .ToDictionary(g => g.Key, g => g.Count()) ?? new Dictionary<string, int>();
+                report.ResourceTypeBreakdown = BuildResourceTypeBreakdown(auditEvent.AccessedResources);
 
                 // Track models used for analytics even if not charging
                 if (HasDeepReasoning(auditEvent.ModelTransparencyDetails))
@@ -207,11 +271,13 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
             int totalCredits = 0;
 
             // STEP 1: Detect tenant graph usage
-            // If any Microsoft Graph resources (SharePoint, OneDrive, Teams files, etc.) were accessed,
-            // this indicates tenant graph grounding was used for the conversation.
             // Per Microsoft docs: "tenant graph grounding for messages" costs 10 credits
-            // PLUS the base generative answer cost of 2 credits = 12 credits total per message
-            bool hasTenantGraphResources = HasTenantGraphResources(auditEvent.AccessedResources);
+            // PLUS the base generative answer cost of 2 credits = 12 credits total per message.
+            // See AssessTenantGrounding for how the decision is reached and what it assumes.
+            var grounding = AssessTenantGrounding(auditEvent.AccessedResources);
+            bool hasTenantGraphResources = grounding.IsTenantGrounded;
+            report.TenantGraphGroundingBasis = grounding.Basis;
+            report.UnclassifiedResources = grounding.UnclassifiedResources;
 
             // STEP 2: Detect deep reasoning usage
             // Deep reasoning is indicated by the DEEP_LEO model in ModelTransparencyDetails.
@@ -267,13 +333,29 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
             // STEP 5: Build resource breakdown (for reference/analytics only)
             // This shows what types of resources were accessed but does NOT affect billing.
             // Resources are billed at the message level, not per resource.
-            report.ResourceTypeBreakdown = auditEvent.AccessedResources?
-                .GroupBy(r => string.IsNullOrEmpty(r.Type) ? "WebPage" : r.Type)
-                .ToDictionary(g => g.Key, g => g.Count()) ?? new Dictionary<string, int>();
+            report.ResourceTypeBreakdown = BuildResourceTypeBreakdown(auditEvent.AccessedResources);
 
             report.TotalCredits = totalCredits;
 
             return report;
+        }
+
+        /// <summary>
+        /// Counts accessed resources by their raw <c>Type</c> value, for reference only.
+        ///
+        /// A resource with no type is counted as <c>(unknown)</c> - the same label the Copilot
+        /// Adoption reporting uses - and deliberately NOT as a web page. Microsoft publishes no list
+        /// of possible values for that field and documents it as carrying either a file extension or
+        /// a description of a non-SharePoint resource, so a missing one says nothing about where the
+        /// resource came from.
+        /// </summary>
+        private static Dictionary<string, int> BuildResourceTypeBreakdown(List<AccessedResource> accessedResources)
+        {
+            if (accessedResources == null) return new Dictionary<string, int>();
+
+            return accessedResources
+                .GroupBy(r => string.IsNullOrWhiteSpace(r?.Type) ? CopilotAccessedResourceTaxonomy.UnknownTypeLabel : r.Type)
+                .ToDictionary(g => g.Key, g => g.Count());
         }
 
         /// <summary>
@@ -296,79 +378,168 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot
         }
 
         /// <summary>
-        /// Determines if the accessed resources indicate tenant graph grounding was used.
-        /// 
-        /// Tenant graph grounding provides RAG over Microsoft Graph data including:
-        /// - SharePoint sites, files, and documents
-        /// - OneDrive files and folders
-        /// - Outlook emails and calendar events
-        /// - Teams messages, channels, and meetings
-        /// - Other Microsoft 365 data synced to Graph
-        /// 
-        /// Detection Logic:
-        /// 1. Check resource Type field for known Microsoft Graph entity types
-        /// 2. Check SiteUrl field for Microsoft 365 service URLs
-        /// 3. Returns true if ANY tenant resource is found (does not count individual resources)
-        /// 
-        /// Important: This is an inference-based approach as current audit logs don't explicitly
-        /// flag tenant graph grounding. Future audit log schema updates may include explicit fields.
+        /// The outcome of the tenant-graph grounding decision for one conversation.
+        /// </summary>
+        private struct TenantGroundingAssessment
+        {
+            public bool IsTenantGrounded { get; set; }
+            public int UnclassifiedResources { get; set; }
+            public string Basis { get; set; }
+        }
+
+        /// <summary>
+        /// Decides whether a conversation should carry the tenant-graph grounding charge, and records
+        /// how that decision was reached.
+        ///
+        /// The question this answers is "did this conversation ground on tenant data?". The audit log
+        /// does not state that, so it has to be inferred - but it is inferred from POSITIVE EVIDENCE
+        /// that a resource belongs to the tenant, not from a list of resource-type names:
+        ///
+        /// 1. A SharePoint list-item id. Microsoft documents ListItemUniqueId as the "unique identifier
+        ///    for a SharePoint item", so a real one only exists for an item in the tenant's own
+        ///    SharePoint or OneDrive.
+        /// 2. A sensitivity label id. Labels are applied by the tenant's own Purview policy; content
+        ///    from the public web does not carry one.
+        /// 3. A SiteUrl on a Microsoft 365 tenant-content host, across the worldwide and sovereign
+        ///    clouds - see CopilotAccessedResourceTaxonomy.IsTenantContentUrl.
+        /// 4. Failing all of those, a Type value that names tenant content.
+        ///
+        /// Why not an allowlist of Type values: Microsoft publishes no enumeration for that field
+        /// (https://learn.microsoft.com/en-us/purview/audit-copilot#common-properties-in-copilot-audit-logs
+        /// describes it as carrying "values like the filetype extension ... or ... the type of resource
+        /// (for non-SharePoint resources)"), and one of the commonest values in practice - CITATION -
+        /// describes how the resource was used rather than what it is. An allowlist therefore silently
+        /// misclassifies whatever Microsoft adds next, which is exactly what happened in #469.
+        ///
+        /// A resource is only dismissed on positive evidence that it came from outside the tenant: a
+        /// type that marks external grounding, or a SiteUrl that resolves to a host which is not the
+        /// tenant's. That is a real finding and is quite different from a resource that says nothing.
+        ///
+        /// An unclassifiable resource - one with neither kind of evidence - is charged rather than
+        /// waved through. Microsoft documents AccessedResources as the resources Copilot accessed in
+        /// order to answer, so an entry with nothing to place it outside the tenant is more likely
+        /// tenant content than not, and the previous behaviour of quietly choosing the cheaper answer
+        /// understated the estimate by 10 credits per response message. The count is reported so the
+        /// assumption is visible: see <see cref="UnclassifiedResources"/> and
+        /// <see cref="TenantGraphGroundingBasis"/>.
+        ///
+        /// Deliberately NOT used: AISystemPlugin.Id == "BingWebSearch". Microsoft documents that as
+        /// the way to tell that Copilot referenced the public web, but their own schema example shows
+        /// it alongside an accessed Microsoft 365 document, so it cannot rule tenant grounding out.
         /// </summary>
         /// <param name="accessedResources">List of resources accessed during the Copilot interaction</param>
-        /// <returns>True if any Microsoft Graph tenant resources were accessed, false for web-only or no resources</returns>
-        private static bool HasTenantGraphResources(List<AccessedResource> accessedResources)
+        private static TenantGroundingAssessment AssessTenantGrounding(List<AccessedResource> accessedResources)
         {
             if (accessedResources == null || accessedResources.Count == 0)
             {
-                return false;
+                return new TenantGroundingAssessment
+                {
+                    IsTenantGrounded = false,
+                    UnclassifiedResources = 0,
+                    Basis = CopilotTenantGroundingBasis.NoResources,
+                };
             }
 
-            // Resource types that indicate tenant graph grounding
-            // These are Microsoft Graph entities that represent tenant data
-            var tenantGraphResourceTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                // SharePoint & OneDrive
-                "Site", "Web", "List", "Folder", "File",
-                "docx", "xlsx", "pptx", "pdf", "txt", "doc", "xls", "ppt",
-                
-                // Email & Calendar
-                "EmailMessage", "Email", "Message", "MailFolder", "Calendar", "Event",
-                
-                // Teams
-                "Team", "Channel", "Chat", "TeamsMessage", "TeamsMeeting",
-                
-                // Other Microsoft Graph entities
-                "User", "Group", "Contact", "Task", "Planner", "OneNote",
-                "Drive", "DriveItem"
-            };
+            var hasTenantResource = false;
+            var unclassified = 0;
 
-            // Check if any accessed resource is a tenant graph resource
             foreach (var resource in accessedResources)
             {
-                // Check resource type field
-                if (!string.IsNullOrEmpty(resource.Type) && tenantGraphResourceTypes.Contains(resource.Type))
+                if (HasTenantResourceEvidence(resource))
                 {
-                    return true;
+                    hasTenantResource = true;
+                    continue;
                 }
 
-                // Check if SiteUrl contains Microsoft 365 service indicators
-                if (!string.IsNullOrEmpty(resource.SiteUrl))
+                // The only things that let a resource be dismissed are positive markers that it came
+                // from outside the tenant: a type that says so, or a SiteUrl that resolves to a host
+                // which is not the tenant's. Everything else is unclassified.
+                if (HasExternalGroundingEvidence(resource))
                 {
-                    var siteUrlLower = resource.SiteUrl.ToLower();
-
-                    // Teams file URLs contain specific patterns
-                    if (siteUrlLower.Contains("sharepoint.com") ||
-                        siteUrlLower.Contains("onedrive.") ||
-                        siteUrlLower.Contains("outlook.office") ||
-                        siteUrlLower.Contains("teams.microsoft.com") ||
-                        siteUrlLower.Contains("asyncgw.teams.microsoft.com"))  // Teams async gateway for file access
-                    {
-                        return true;
-                    }
+                    continue;
                 }
+
+                unclassified++;
             }
 
-            // No tenant resources found - likely web search only
-            return false;
+            if (hasTenantResource)
+            {
+                return new TenantGroundingAssessment
+                {
+                    IsTenantGrounded = true,
+                    UnclassifiedResources = unclassified,
+                    Basis = CopilotTenantGroundingBasis.TenantResource,
+                };
+            }
+
+            if (unclassified > 0)
+            {
+                return new TenantGroundingAssessment
+                {
+                    IsTenantGrounded = true,
+                    UnclassifiedResources = unclassified,
+                    Basis = CopilotTenantGroundingBasis.UnclassifiedResource,
+                };
+            }
+
+            return new TenantGroundingAssessment
+            {
+                IsTenantGrounded = false,
+                UnclassifiedResources = 0,
+                Basis = CopilotTenantGroundingBasis.ExternalOnly,
+            };
+        }
+
+        /// <summary>
+        /// Whether one accessed resource carries positive evidence of belonging to the tenant.
+        ///
+        /// <c>Id</c> and <c>Name</c> are deliberately not treated as evidence: a public web result also
+        /// has an identifier and a human-readable name, so their presence distinguishes nothing.
+        /// </summary>
+        private static bool HasTenantResourceEvidence(AccessedResource resource)
+        {
+            if (resource == null) return false;
+
+            if (IsMeaningfulIdentifier(resource.ListItemUniqueId)) return true;
+            if (IsMeaningfulIdentifier(resource.SensitivityLabelId)) return true;
+            if (CopilotAccessedResourceTaxonomy.IsTenantContentUrl(resource.SiteUrl)) return true;
+
+            return CopilotAccessedResourceTaxonomy.Classify(resource.Type) == CopilotResourceTypeKind.TenantContent;
+        }
+
+        /// <summary>
+        /// Whether one accessed resource carries positive evidence of having come from OUTSIDE the
+        /// tenant - either a type that says so, or a SiteUrl on a host that is not the tenant's.
+        ///
+        /// Only called once tenant evidence has been ruled out, so the two can never both apply.
+        /// "The record says where this lives and it is not in the tenant" is a genuine finding; it is
+        /// not the same as a resource that says nothing at all, which stays unclassified.
+        /// </summary>
+        private static bool HasExternalGroundingEvidence(AccessedResource resource)
+        {
+            if (resource == null) return false;
+
+            if (CopilotAccessedResourceTaxonomy.Classify(resource.Type) == CopilotResourceTypeKind.ExternalGrounding)
+            {
+                return true;
+            }
+
+            return CopilotAccessedResourceTaxonomy.IsExternalWebUrl(resource.SiteUrl);
+        }
+
+        /// <summary>
+        /// Whether an identifier field actually identifies something. The audit payload carries an
+        /// all-zero GUID as a placeholder where a resource has no such identifier, and treating that
+        /// as evidence would make the check true for every resource in the record.
+        /// </summary>
+        private static bool IsMeaningfulIdentifier(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return false;
+
+            Guid parsed;
+            if (Guid.TryParse(value.Trim(), out parsed) && parsed == Guid.Empty) return false;
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Addresses #468
Addresses #469

## Root cause

Microsoft's Copilot audit records carry `AccessedResources[].Type`, stored verbatim (`CopilotAuditLogContent.cs:298` -> `dbo.copilot_event_accessed_resource_types`). Two places read it as a clean taxonomy of content kinds. It is not one.

Microsoft publishes **no enumeration** for the field. The Office 365 Management Activity API schema declares it as an open `Edm.String`, and the Purview docs describe it as *"the type of resource that was accessed. It can contain values like the filetype extension (pptx, docx, etc.) or describe the type of resource (for non-SharePoint resources)"*. In practice one field carries a usage role (`CITATION`), file kinds (`pdf`), Graph entities (`EmailMessage`), grounding markers (`WebSearchQuery`), raw schema URIs and nulls. `CITATION` is one of the commonest values.

Both readings now go through one shared `Common/Entities/Copilot/CopilotAccessedResourceTaxonomy.cs`, so the estimator and the report cannot drift apart again.

## #469 - credit estimation (wrong numbers)

`HasTenantGraphResources` gated the 10-credit tenant-graph charge on a hardcoded type allowlist that omitted `CITATION`, fell back to a `SiteUrl` **substring** test, and otherwise returned `false` with the comment *"No tenant resources found - likely web search only"*. Affected conversations were estimated at 2 credits per response message instead of 12.

`AssessTenantGrounding` replaces it. Per resource:

| Evidence | Outcome |
| --- | --- |
| non-placeholder `ListItemUniqueId` or `SensitivityLabelId`; `SiteUrl` on an M365 tenant-content host; `Type` naming tenant content | tenant |
| `Type` marking external grounding; `SiteUrl` resolving to a host that is not the tenant's | external |
| neither | **unclassified** |

Charged if any resource is tenant **or** unclassified. Only an all-external (or empty) list escapes, so *"web search only"* is now a finding rather than a default. This is the deliberate asymmetry the issue asked for: a resource that says nothing is not evidence of anything, and the previous behaviour silently picked the cheaper answer.

Deliberately **not** used as a negative signal: `AISystemPlugin.Id == "BingWebSearch"`. Microsoft documents it as the way to tell that Copilot referenced the public web, but their own schema example shows it alongside an accessed Microsoft 365 document, so it cannot rule tenant grounding out.

New reported fields make the inference auditable rather than buried:

- `TenantGraphGroundingBasis` - `NotAssessed` / `NoResources` / `ExternalOnly` / `TenantResource` / `UnclassifiedResource`
- `UnclassifiedResources` - count of resources with no evidence either way

Both are additive scalars on the JSON persisted to `copilot_chats.copilot_credit_estimate_json` (`nvarchar(max)`); old rows deserialise with null/0 defaults, and nothing branches on `CostModelVersion`. `COST_ESTIMATION_VERSION` 1.0.0.1 -> 1.1.0.0, because estimates for the same conversation legitimately differ across the boundary. **Historical estimates are not recomputed** - stored rows keep the old numbers until re-imported.

### SiteUrl matching

Substring matching became parsed-host, dot-boundary suffix matching. This closes a second, independent gap: the old list knew only `sharepoint.com`, so every SharePoint reference in a **GCC High, DoD or 21Vianet** tenant missed. Suffixes are taken from Microsoft's published endpoint lists (worldwide/GCC, GCC High, DoD, 21Vianet, plus retired `sharepoint.de` for historical imports).

Also fixed by the same rewrite:

- `https://sharepoint.com.example.invalid/x` no longer counts as tenant evidence.
- `onedrive.` was dropped: OneDrive for Business is served from `*-my.sharepoint.com` (already covered), whereas `onedrive.live.com` is **consumer** OneDrive and is not tenant content.
- `Uri.Host` is populated for `file:`/`ftp:` too, so a scheme gate was added - `file://contoso.sharepoint.com/x` previously counted as tenant evidence.
- `Uri.IdnHost` is used because `Uri.Host` preserves an alternative Unicode dot separator (U+3002), and a trailing DNS root dot is stripped because `Uri` keeps it on both properties. Both were verified against .NET before fixing.
- A Microsoft-operated host that is not tenant-specific (the `.microsoft` brand gTLD, `sovcloud-usercontent.cn`) returns false from **both** predicates. `IsExternalWebUrl` works by exclusion from a list that cannot be complete, so a new Microsoft content host would otherwise read as confident proof of external grounding - reintroducing this bug by the opposite route.

## #468 - the chart (wrong framing)

`TopResourceTypes` rows changed from `AdoptionCategory` to `AdoptionResourceTypeRow` (adds `Kind`; C# enum serialises numerically, matching the TS enum). The new `ResourceTypesPanel` groups bars by what each value actually describes, scaled against the largest value **across all groups** so lengths stay comparable. A `kind` the build does not recognise falls into Unclassified rather than being filtered out.

The card is retitled *"What Copilot referenced"*; the subtitle, InfoTip, Excel workbook (new Kind column) and the model/SQL doc comments now agree - including the point that file-type rows **undercount**, because a file Copilot cited is typed `CITATION` rather than by its file type.

`ResourceTypeBreakdown` now labels a missing type `(unknown)` instead of `WebPage` - the same category error in the diagnostic breakdown.

**No schema change.** The raw `Type` is still stored verbatim; this is about how it is read and presented.

## Tests

Repo-wide search for `CITATION` previously returned zero matches. Added:

- `CopilotAccessedResourceTaxonomyTests` (new) - classification, and host matching for sovereign clouds, lookalike hosts, consumer URLs, non-web schemes, trailing root dot, Unicode dot separator, Microsoft-operated-but-ambiguous hosts, and that the two URL predicates are never both true.
- `CopilotExtendedDataTests` - `CITATION` with and without a matching `SiteUrl`; with a list-item id; with placeholder all-zero GUIDs; an unknown future type pinning that unknown != web-search-only; `WebSearchQuery`-only as the genuine web-only case; a plain web page **not** charged; the same type with no URL still unclassified; sovereign-cloud URLs asserting the **basis** (not just credits, which would pass either way now).
- `ResourceTypesPanel.test.tsx` (new, 9 tests) - `CITATION` is not tenant content, an unrecognised value and an unrecognised `kind` are visibly Unclassified and never dropped, and bars share one scale.

### Verification

- `vstest /TestCaseFilter:"FullyQualifiedName~Copilot"`: **458 passed, 0 failed**.
- Full `Tests.UnitTests`: 13 failed / 1736 passed. 12 are the known local baseline (4 VNet + 8 external-config). The 13th, `FK_Migration_RelaxesNotNullColumn_OnLegacySchema`, is shared-LocalDB pollution, not this change: it runs `ALTER COLUMN operation_id NOT NULL` against a shared table that held 24 pre-existing rows with NULL `operation_id`, and nothing here writes `audit_events`.
- Portal `npm run lint` (`tsc --noEmit`) clean; new panel tests 9/9.
- Reviewed by three models (claude-opus-4.8, gpt-5.6-sol, gemini-3.8-flash) over two rounds; round 1 raised four findings, all verified against the code and fixed, round 2 clean from all three.

## Reviewer hotspots

1. **`AssessTenantGrounding`** - is "unclassified => charge" the right call? It is the deliberate reversal of the reported bug, and the count is reported so the assumption is visible, but it is a judgement about billing.
2. **The host suffix lists** - both the tenant list and the Microsoft-operated-ambiguous list are recognition lists, not specifications.
3. **Known limitation, accepted:** content indexed through a Microsoft Graph connector is tenant grounding but can carry the source system's own URL, so it reads as external. Recognising it needs a signal the audit record does not carry.