### PR TITLE
Measure licence activity by imported week, not by one pinned Sunday

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/CachedLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/CachedLicenceActivityStore.cs
@@ -81,6 +81,7 @@ namespace Common.Entities.LicenceActivity
                 CopilotUsageReports = sources.CopilotUsageReports,
                 CopilotAudit = sources.CopilotAudit,
                 CopilotInteractions = sources.CopilotInteractions,
+                UsageReportsGroupFiltered = sources.UsageReportsGroupFiltered,
                 NowUtc = sources.NowUtc
             };
     }

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/ILicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/ILicenceActivityStore.cs
@@ -34,19 +34,33 @@ namespace Common.Entities.LicenceActivity
         public bool CopilotUsageReports { get; set; }
         public bool CopilotAudit { get; set; }
         public bool CopilotInteractions { get; set; }
+
+        /// <summary>
+        /// True when <c>UserGroupsFilter</c> scopes the Microsoft 365 usage-report import to particular
+        /// Entra groups.
+        ///
+        /// This matters because the USER import is not filtered while the usage-report import is, so the
+        /// two populations differ. Normally a person with no rows across a fully imported week is proof
+        /// that they did nothing; under a group filter they may simply never have been looked at, and
+        /// reporting them as "No activity" would be a confident wrong answer. When this is set the
+        /// report falls back to leaving those people Unknown.
+        /// </summary>
+        public bool UsageReportsGroupFiltered { get; set; }
+
         public DateTime NowUtc { get; set; }
 
         public string CacheKey => string.Join(":", UserMetadata, UsageReports, CopilotUsageReports,
-            CopilotAudit, CopilotInteractions, NowUtc.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture));
+            CopilotAudit, CopilotInteractions, UsageReportsGroupFiltered,
+            NowUtc.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture));
     }
 
     public static class LicenceActivityRules
     {
         public const string Method =
-            "Activity levels describe how much of the measured period someone was active in: "
-            + "No activity = never, Low = under a quarter, Moderate = a quarter to under three quarters, "
-            + "High = three quarters or more. Where the period could not be measured in full the level is "
-            + "Unknown, not zero.";
+            "Activity levels describe how many of the period's weeks someone was active in: "
+            + "No activity = none, Low = under a quarter, Moderate = a quarter to under three quarters, "
+            + "High = three quarters or more. A week is only counted when every one of its days was "
+            + "imported; where a week could not be measured in full the level is Unknown, not zero.";
 
         public const string AssignmentCaveat =
             "Past activity is shown against who holds each licence today, not who held it at the time. "
@@ -126,6 +140,11 @@ namespace Common.Entities.LicenceActivity
 
             public const string DemographicsCapped =
                 "The department and country breakdowns show only the 50 largest of each.";
+
+            public const string UsageReportsGroupFiltered =
+                "This deployment only collects Microsoft 365 usage for people in particular Entra groups, "
+                + "but it lists everyone who holds a licence. Anyone outside those groups is shown as "
+                + "Unknown rather than as doing nothing, because they were never measured.";
 
             public const string RankingMethod =
                 "The most and least active lists rank people by how often they were active in the chosen service, "

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityReadModel.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivityReadModel.cs
@@ -70,6 +70,7 @@ namespace Common.Entities.LicenceActivity
         private readonly IReadOnlyDictionary<int, LicenceActivityScore>[] _scores;
         private readonly sbyte[][] _bands;
         private readonly RankValue[][] _rankValues;
+        private readonly bool _usageReportsGroupFiltered;
         private readonly object _rankingGate = new object();
         private readonly ConcurrentDictionary<string, RankingIndex> _rankings =
             new ConcurrentDictionary<string, RankingIndex>(StringComparer.Ordinal);
@@ -80,7 +81,8 @@ namespace Common.Entities.LicenceActivity
             IReadOnlyList<LicenceActivityDirectoryUser> users,
             IReadOnlyList<LicenceActivityMembership> memberships,
             IReadOnlyList<LicenceActivityCoverage> coverage,
-            IReadOnlyDictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>> scores)
+            IReadOnlyDictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>> scores,
+            bool usageReportsGroupFiltered = false)
         {
             if (range == null) throw new ArgumentNullException(nameof(range));
             if (licences == null) throw new ArgumentNullException(nameof(licences));
@@ -91,6 +93,7 @@ namespace Common.Entities.LicenceActivity
             if (range.DepartmentId.HasValue || range.CountryId.HasValue || range.LicenceTypeId.HasValue)
                 throw new ArgumentException("A licence activity read model must cover an unfiltered date range.", nameof(range));
 
+            _usageReportsGroupFiltered = usageReportsGroupFiltered;
             _from = range.From;
             _to = range.To;
             Id = Guid.NewGuid().ToString("N");
@@ -266,6 +269,8 @@ namespace Common.Entities.LicenceActivity
             else if (overview.DistinctAssignedUsers == 0)
                 overview.Messages.Add(LicenceActivityRules.Notes.NobodyHoldsALicence);
             overview.Messages.Add(LicenceActivityRules.Notes.NoDisplayNames);
+            if (_usageReportsGroupFiltered)
+                overview.Messages.Add(LicenceActivityRules.Notes.UsageReportsGroupFiltered);
             foreach (var item in overview.Coverage.Where(item => item.Status != LicenceActivitySql.Available))
             {
                 if (!string.IsNullOrWhiteSpace(item.Message))
@@ -549,7 +554,16 @@ namespace Common.Entities.LicenceActivity
             var status = coverage.Status ?? LicenceActivitySql.MissingCoverage;
             var active = present ? score.ActiveSamples : 0;
             var observed = coverage.ObservedSamples;
-            if (IsOfficialReport(coverage.Source))
+
+            // Sources where being absent proves nothing, so only the people we actually have rows for
+            // can be banded at all:
+            //  - the Copilot usage report, a rolling per-person report that only ever lists people who
+            //    hold a Copilot licence, so absence means "not licensed" rather than "did nothing";
+            //  - the Microsoft 365 usage reports WHEN a group filter scopes their import, because the
+            //    user import is not filtered and absence then means "never looked at".
+            var presenceGated = coverage.Source == LicenceActivitySql.CopilotReportSource
+                || (coverage.Source == LicenceActivitySql.M365ReportSource && _usageReportsGroupFiltered);
+            if (presenceGated)
             {
                 observed = present ? score.ObservedSamples : 0;
                 if (status == LicenceActivitySql.Available)
@@ -560,13 +574,28 @@ namespace Common.Entities.LicenceActivity
                         status = LicenceActivitySql.Partial;
                 }
             }
+            else if (coverage.Source == LicenceActivitySql.M365ReportSource && present)
+            {
+                // Absence is now meaningful, but a person whose own reading count falls short of the
+                // period still has incomplete evidence and must say so rather than be banded.
+                observed = score.ObservedSamples;
+                if (status == LicenceActivitySql.Available
+                    && (!score.FrequencyKnown || observed != coverage.ExpectedSamples))
+                {
+                    status = LicenceActivitySql.Partial;
+                }
+            }
+
+            // Otherwise the M365 daily reports are positive-only, so across a week that was imported in
+            // full an absent person is measured evidence of NO activity - not absent evidence. That is
+            // why the scores dictionary holds only the people with activity: everyone else resolves
+            // here to a complete, zero reading rather than to Unknown.
+            var measuredZero = !present && status == LicenceActivitySql.Available && !presenceGated;
             return new EvidenceState(
                 status, active, observed, coverage.ExpectedSamples,
-                present ? score.AverageActions : null,
+                measuredZero ? 0d : present ? score.AverageActions : null,
                 present ? score.LastActivityUtc : null,
-                !present && status == LicenceActivitySql.Available && !IsOfficialReport(coverage.Source)
-                    ? 0d
-                    : present ? score.AverageActions : null);
+                measuredZero ? 0d : present ? score.AverageActions : null);
         }
 
         private static sbyte BandCode(EvidenceState evidence)
@@ -628,10 +657,6 @@ namespace Common.Entities.LicenceActivity
                 || (!string.IsNullOrEmpty(user.Mail)
                     && user.Mail.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0);
         }
-
-        private static bool IsOfficialReport(string source) =>
-            source == LicenceActivitySql.M365ReportSource
-            || source == LicenceActivitySql.CopilotReportSource;
 
         private static int WorkloadIndex(string workload)
         {

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -59,7 +59,13 @@ namespace Common.Entities.LicenceActivity
                 "files viewed or edited counted by Microsoft, averaged across the readings",
                 sources.UsageReports);
 
-            if (sources.UsageReports) sql.Append(M365OverviewScores);
+            if (sources.UsageReports)
+            {
+                AppendM365OverviewScore(sql, Teams, "dbo.teams_user_activity_log");
+                AppendM365OverviewScore(sql, Outlook, "dbo.outlook_user_activity_log");
+                AppendM365OverviewScore(sql, OneDrive, "dbo.onedrive_user_activity_log");
+                AppendM365OverviewScore(sql, SharePoint, "dbo.sharepoint_user_activity_log");
+            }
             AppendCopilotOverview(sql, sources);
             sql.Append(OverviewProjection);
             return sql.ToString();
@@ -1009,6 +1015,32 @@ SELECT week_start,
 FROM WeekStarts
 OPTION (MAXRECURSION 0);
 
+-- Every calendar day each week covers, so a week can be proved measured day by day. Graph's daily
+-- user-detail reports are POSITIVE-ONLY (a date returns just the people who did something that day),
+-- so a missing day is a hole in the evidence for everyone, while a present day with no row for
+-- someone is evidence that they did nothing. Only a week whose every day was imported can carry
+-- either conclusion, which is what this spine establishes.
+CREATE TABLE #Days
+(
+    week_end date NOT NULL,
+    day date NOT NULL,
+    PRIMARY KEY (week_end, day)
+);
+
+;WITH WeekDays AS
+(
+    SELECT weeks.m365_to AS week_end, weeks.m365_from AS day
+    FROM #Weeks AS weeks
+    WHERE weeks.m365_from <= weeks.m365_to
+    UNION ALL
+    SELECT week_end, DATEADD(DAY, 1, day)
+    FROM WeekDays
+    WHERE day < week_end
+)
+INSERT #Days (week_end, day)
+SELECT week_end, day FROM WeekDays
+OPTION (MAXRECURSION 0);
+
 CREATE TABLE #Samples
 (
     workload tinyint NOT NULL,
@@ -1097,39 +1129,37 @@ VALUES
                 @"
 DECLARE @latest{0} datetime = (SELECT MAX([date]) FROM {1});
 
+-- One reading per WEEK, identified by the week's last day. A week qualifies only when every one of
+-- its days was imported: Graph's daily reports list just that day's active people, so absence is
+-- only evidence of inactivity once the whole week is present. Bounded by the number of days in the
+-- period (<= 180 single-row index seeks), never by the number of rows in the report table.
 INSERT #Samples (workload, sample_date)
-SELECT {0}, selected.sample_date
-FROM #Weeks AS weeks
-CROSS APPLY
+SELECT {0}, days.week_end
+FROM
 (
-    SELECT TOP (1) CAST(available.[date] AS date) AS sample_date
-    FROM {1} AS available WITH (INDEX(IX_date))
-    WHERE available.[date] >= weeks.m365_from
-      AND available.[date] < DATEADD(DAY, 1, weeks.m365_to)
-      AND available.[date] < DATEADD(DAY, 1, @settled)
-    ORDER BY available.[date] DESC
-) AS selected
-WHERE weeks.m365_from <= weeks.m365_to
-  AND weeks.m365_from <= @settled
+    SELECT days.week_end,
+           CASE WHEN present.has_row IS NULL THEN 0 ELSE 1 END AS day_imported
+    FROM #Days AS days
+    OUTER APPLY
+    (
+        SELECT TOP (1) 1 AS has_row
+        FROM {1} AS available WITH (INDEX(IX_date))
+        WHERE available.[date] >= days.[day]
+          AND available.[date] < DATEADD(DAY, 1, days.[day])
+    ) AS present
+    WHERE days.week_end <= @settled
+) AS days
+GROUP BY days.week_end
+HAVING MIN(days.day_imported) = 1
 OPTION (RECOMPILE);
 
 DECLARE @observed{0} int =
     (SELECT COUNT(*) FROM #Samples WHERE workload = {0});
-DECLARE @complete{0} int =
-(
-    SELECT COUNT(*)
-    FROM #Weeks AS weeks
-    JOIN #Samples AS samples
-      ON samples.workload = {0}
-     AND samples.sample_date = weeks.m365_to
-    WHERE weeks.m365_from <= weeks.m365_to
-      AND weeks.m365_to <= @settled
-);
 DECLARE @status{0} varchar(32) =
     CASE
         WHEN @latest{0} IS NULL THEN 'notImported'
         WHEN @expected{0} = 0 OR @observed{0} = 0 THEN 'missingCoverage'
-        WHEN @observed{0} < @expected{0} OR @complete{0} < @expected{0} THEN 'partial'
+        WHEN @observed{0} < @expected{0} THEN 'partial'
         ELSE 'available'
     END;
 
@@ -1142,10 +1172,10 @@ INSERT #Coverage
 SELECT {0}, '{2}', @status{0}, 'microsoftGraphUsageReport',
        N'{3}', 'weeklySupportingSnapshot',
        CASE @status{0}
-           WHEN 'available' THEN N'One of Microsoft''s published readings was taken for each week in the period. Someone counts as active in a week only if Microsoft recorded activity for them in that same week. The published counts are averaged across the readings, never added up and never presented as a daily total.'
-           WHEN 'partial' THEN N'At least one week in the period has no reading on its end date. Earlier readings are still shown as evidence, but activity levels stay Unknown and nobody is listed as least active for this service.'
+           WHEN 'available' THEN N'Every day of every week in the period was imported from Microsoft''s published reports. Someone counts as active in a week if Microsoft recorded activity for them in that week. Because those reports list only the people who were active, a fully measured week with nothing recorded for someone means they did nothing - not that they could not be measured. The published counts are averaged across the weeks, never added up and never presented as a daily total.'
+           WHEN 'partial' THEN N'At least one week in the period is missing a day of Microsoft''s reports. Those weeks cannot prove either activity or inactivity, so activity levels stay Unknown and nobody is listed as least active for this service.'
            WHEN 'notImported' THEN N'Collection is switched on for this service, but no report has arrived yet.'
-           ELSE N'No published reading covers the dates you selected.'
+           ELSE N'No week in the dates you selected was imported in full.'
        END,
        MIN(CAST(CASE WHEN sampled_week.week_start < @from
                      THEN @from ELSE sampled_week.week_start END AS datetime)),
@@ -1178,81 +1208,55 @@ CROSS APPLY
                 @"
 IF @status{0} = 'available'
 BEGIN
-    IF @expected{0} = 1
-    BEGIN
-        INSERT #Scores
-            (workload, user_id, active_samples, observed_samples, frequency_known)
-        SELECT {0},
-               activity.user_id,
-               MAX(CASE
-                       WHEN activity.last_activity_date >= weeks.m365_from
-                        AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
-                        AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
-                       THEN 1 ELSE 0
-                   END),
-               1,
-               -- One pinned sample day: GROUP BY user already collapses duplicate report rows.
-               CAST(1 AS bit)
-        FROM #Samples AS chosen
-        JOIN #Weeks AS weeks
-          ON chosen.sample_date >= weeks.m365_from
-         AND chosen.sample_date <= weeks.m365_to
-        JOIN {1} AS activity WITH (INDEX(IX_date))
-          ON activity.[date] >= chosen.sample_date
-         AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
+    -- One group per user over the WEEKS that were imported in full. A week counts as active when
+    -- Microsoft's last-activity date for that user falls inside it; duplicate report rows collapse
+    -- because the week, not the row, is what is counted.
+    --
+    -- Deliberately NOT hinted to IX_date. That hint suited the old single-pinned-date equality seek,
+    -- but over a whole week it forces the narrow date index plus a key lookup per row instead of the
+    -- covering metrics index. Measured at 300k users on a 7-day window it cost ~700k logical reads
+    -- and blew the 20s command timeout at 28.8s; unhinted the optimiser picks the covering index.
+    ;WITH PerUser AS
+    (
+        SELECT activity.user_id,
+               COUNT(DISTINCT CASE WHEN activity.last_activity_date >= weeks.m365_from
+                                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
+                                   THEN samples.sample_date END) AS active_samples
+        FROM #Samples AS samples
+        JOIN #Weeks AS weeks ON weeks.m365_to = samples.sample_date
+        JOIN {1} AS activity
+          ON activity.[date] >= weeks.m365_from
+         AND activity.[date] < DATEADD(DAY, 1, weeks.m365_to)
         JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
-        WHERE chosen.workload = {0}
+        WHERE samples.workload = {0}
         GROUP BY activity.user_id
-        OPTION (RECOMPILE, MAXDOP 1);
-    END
-    ELSE
+    )
+    INSERT #Scores
+        (workload, user_id, active_samples, observed_samples, frequency_known)
+    SELECT {0}, per_user.user_id, per_user.active_samples, @observed{0},
+           CAST(CASE WHEN @observed{0} = @expected{0} THEN 1 ELSE 0 END AS bit)
+    FROM PerUser AS per_user
+    OPTION (RECOMPILE, MAXDOP 1);
+
+    -- Everyone else was measured across the same fully imported weeks and did nothing in any of
+    -- them. Recording that as an explicit zero is the whole point: without it the daily reports'
+    -- positive-only shape would leave every inactive person Unknown, which reads as ""we could not
+    -- tell"" when in fact we can.
+    --
+    -- Skipped when a group filter scopes the usage-report import: the user import is NOT filtered,
+    -- so absence would then mean ""never looked at"" rather than ""did nothing"".
+    IF @groupFiltered = 0
     BEGIN
-        -- One group per user, not one per user/report day. Counting DISTINCT pinned sample
-        -- numbers retains duplicate-day evidence exactly as the previous per-sample MAX pivot
-        -- did: a sample observed by any duplicate row counts once, and a sample positive in any
-        -- duplicate row counts as active once. COUNT(DISTINCT ...) ignores the NULLs produced by
-        -- the anchor's LEFT JOIN, so an eligible user with no matching row still scores zero
-        -- observed samples and is removed below, keeping absent distinct from observed-zero.
-        -- Preserve the eligible population through aggregation so sample-join selectivity
-        -- cannot shrink its group estimate and memory grant. Remove absent groups afterward.
-        ;WITH Chosen AS
-        (
-            SELECT samples.sample_date, weeks.m365_from,
-                   DATEADD(DAY, 1, samples.sample_date) AS end_exclusive,
-                   ROW_NUMBER() OVER (ORDER BY samples.sample_date) AS sample_number
-            FROM #Samples AS samples
-            JOIN #Weeks AS weeks
-              ON samples.sample_date = weeks.m365_to
-            WHERE samples.workload = {0}
-        ),
-        PerUser AS
-        (
-            SELECT eligible.user_id,
-                   COUNT(DISTINCT CASE WHEN activity.last_activity_date >= chosen.m365_from
-                                        AND activity.last_activity_date < chosen.end_exclusive
-                                       THEN chosen.sample_number END) AS active_samples,
-                   COUNT(DISTINCT chosen.sample_number) AS observed_samples
-            FROM #EligibleUsers AS eligible
-            LEFT JOIN
-            (
-                {1} AS activity
-                JOIN Chosen AS chosen
-                  ON CAST(activity.[date] AS date) = chosen.sample_date
-                 AND activity.[date] >= @from
-                 AND activity.[date] < @endExclusive
-            ) ON activity.user_id = eligible.user_id
-            GROUP BY eligible.user_id
-        )
         INSERT #Scores
             (workload, user_id, active_samples, observed_samples, frequency_known)
-        SELECT {0},
-                   per_user.user_id,
-                   active_samples,
-                   observed_samples,
-                   CAST(CASE WHEN observed_samples = @expected{0}
-                             THEN 1 ELSE 0 END AS bit)
-        FROM PerUser AS per_user
-        WHERE observed_samples > 0
+        SELECT {0}, eligible.user_id, 0, @observed{0},
+               CAST(CASE WHEN @observed{0} = @expected{0} THEN 1 ELSE 0 END AS bit)
+        FROM #EligibleUsers AS eligible
+        WHERE NOT EXISTS
+        (
+            SELECT 1 FROM #Scores AS scored
+            WHERE scored.workload = {0} AND scored.user_id = eligible.user_id
+        )
         OPTION (RECOMPILE, MAXDOP 1);
     END;
 END;
@@ -1363,124 +1367,6 @@ BEGIN
 END;
 ");
         }
-
-        private static readonly string M365OverviewScores = @"
-;WITH PerSample AS
-(
-    SELECT 1 AS workload,
-           activity.user_id,
-           chosen.sample_date,
-           MAX(CASE
-                   WHEN activity.last_activity_date >= weeks.m365_from
-                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
-                    AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
-                   THEN 1 ELSE 0
-               END) AS was_active
-    FROM #Samples AS chosen
-    JOIN #Weeks AS weeks
-      ON chosen.sample_date >= weeks.m365_from
-     AND chosen.sample_date <= weeks.m365_to
-    JOIN dbo.teams_user_activity_log AS activity
-      ON activity.[date] >= chosen.sample_date
-     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
-    JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
-    WHERE chosen.workload = 1
-    GROUP BY activity.user_id, chosen.sample_date
-
-    UNION ALL
-
-    SELECT 2,
-           activity.user_id,
-           chosen.sample_date,
-           MAX(CASE
-                   WHEN activity.last_activity_date >= weeks.m365_from
-                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
-                    AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
-                   THEN 1 ELSE 0
-               END)
-    FROM #Samples AS chosen
-    JOIN #Weeks AS weeks
-      ON chosen.sample_date >= weeks.m365_from
-     AND chosen.sample_date <= weeks.m365_to
-    JOIN dbo.outlook_user_activity_log AS activity
-      ON activity.[date] >= chosen.sample_date
-     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
-    JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
-    WHERE chosen.workload = 2
-    GROUP BY activity.user_id, chosen.sample_date
-
-    UNION ALL
-
-    SELECT 3,
-           activity.user_id,
-           chosen.sample_date,
-           MAX(CASE
-                   WHEN activity.last_activity_date >= weeks.m365_from
-                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
-                    AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
-                   THEN 1 ELSE 0
-               END)
-    FROM #Samples AS chosen
-    JOIN #Weeks AS weeks
-      ON chosen.sample_date >= weeks.m365_from
-     AND chosen.sample_date <= weeks.m365_to
-    JOIN dbo.onedrive_user_activity_log AS activity
-      ON activity.[date] >= chosen.sample_date
-     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
-    JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
-    WHERE chosen.workload = 3
-    GROUP BY activity.user_id, chosen.sample_date
-
-    UNION ALL
-
-    SELECT 4,
-           activity.user_id,
-           chosen.sample_date,
-           MAX(CASE
-                   WHEN activity.last_activity_date >= weeks.m365_from
-                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
-                    AND activity.last_activity_date < DATEADD(DAY, 1, chosen.sample_date)
-                   THEN 1 ELSE 0
-               END)
-    FROM #Samples AS chosen
-    JOIN #Weeks AS weeks
-      ON chosen.sample_date >= weeks.m365_from
-     AND chosen.sample_date <= weeks.m365_to
-    JOIN dbo.sharepoint_user_activity_log AS activity
-      ON activity.[date] >= chosen.sample_date
-     AND activity.[date] < DATEADD(DAY, 1, chosen.sample_date)
-    JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
-    WHERE chosen.workload = 4
-    GROUP BY activity.user_id, chosen.sample_date
-),
-PerUser AS
-(
-    SELECT workload,
-           user_id,
-           SUM(was_active) AS active_samples,
-           COUNT(*) AS observed_samples
-    FROM PerSample
-    GROUP BY workload, user_id
-)
-INSERT #Scores
-    (workload, user_id, active_samples, observed_samples, frequency_known)
-SELECT workload,
-       user_id,
-       active_samples,
-       observed_samples,
-       CAST(CASE
-                WHEN observed_samples =
-                     CASE workload
-                         WHEN 1 THEN @expected1
-                         WHEN 2 THEN @expected2
-                         WHEN 3 THEN @expected3
-                         ELSE @expected4
-                     END
-                THEN 1 ELSE 0
-            END AS bit)
-FROM PerUser
-OPTION (RECOMPILE);
-";
 
         private static string CopilotD7ActivityExpression(string from, string endExclusive)
         {
@@ -2660,88 +2546,25 @@ CREATE TABLE #Scores
             if (coverage.SnapshotDates == null || coverage.SnapshotDates.Count == 0)
                 return;
 
-            if (readModel)
-            {
-                AppendM365ReadModel(sql, coverage, workload, table, actionExpression, scopeTable);
-                return;
-            }
-
-            var samples = Enumerable.Range(0, coverage.SnapshotDates.Count).ToArray();
-            var aggregates = string.Join("\r\nUNION ALL\r\n", samples.Select(sample =>
-            {
-                var date = SampleParameterName(workload, sample);
-                return @"SELECT eligible.user_id, MAX(" + actionExpression + @") AS actions,
-                    MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
-                              AND activity.last_activity_date < chosen.end_exclusive
-                             THEN activity.last_activity_date END) AS last_activity_utc,
-                    MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
-                              AND activity.last_activity_date < chosen.end_exclusive
-                             THEN 1 ELSE 0 END) AS was_active
-                FROM " + table + @" AS activity
-                JOIN " + scopeTable + @" AS eligible ON eligible.user_id = activity.user_id
-                JOIN #Samples AS chosen ON chosen.workload = " + workload + @"
-                    AND chosen.sample_date = " + date + @"
-                WHERE activity.[date] >= " + date + @"
-                  AND activity.[date] < DATEADD(DAY, 1, " + date + @")
-                GROUP BY eligible.user_id";
-            }));
-            if (scopeTable == "#ReturnedUsers")
-            {
-                // At most 300 returned users: this hash is bounded to 300 x 27 samples.
-                aggregates = @"SELECT eligible.user_id, MAX(" + actionExpression + @") AS actions,
-                    MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
-                              AND activity.last_activity_date < chosen.end_exclusive
-                             THEN activity.last_activity_date END) AS last_activity_utc,
-                    MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
-                              AND activity.last_activity_date < chosen.end_exclusive
-                             THEN 1 ELSE 0 END) AS was_active
-                FROM " + table + @" AS activity
-                JOIN #ReturnedUsers AS eligible ON eligible.user_id = activity.user_id
-                JOIN #Samples AS chosen ON chosen.workload = " + workload + @"
-                    AND CAST(activity.[date] AS date) = chosen.sample_date
-                WHERE activity.[date] >= @from AND activity.[date] < @endExclusive
-                GROUP BY eligible.user_id, chosen.sample_date";
-            }
-            sql.AppendFormat(
-                CultureInfo.InvariantCulture,
-                @"
-;WITH PerSample AS
-(
-    {1}
-)
-INSERT #Scores
-    (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
-SELECT {0}, user_id,
-       SUM(was_active),
-       COUNT(*),
-       CAST(CASE WHEN COUNT(*) = @expected{0} THEN 1 ELSE 0 END AS bit),
-       AVG(actions),
-       MAX(last_activity_utc)
-FROM PerSample
-GROUP BY user_id
-OPTION (RECOMPILE);
-",
-                workload, aggregates);
-        }
-
-        private static void AppendM365ReadModel(
-            StringBuilder sql, LicenceActivityCoverage coverage, int workload,
-            string table, string actionExpression, string scopeTable)
-        {
-            // Two ordered aggregations over a single pass of the activity table. The inner group
-            // collapses every row for one (user, pinned snapshot) to a single sample - MAX actions,
-            // MAX activity flag and MAX clipped last-activity retain duplicate-day evidence exactly
-            // as the legacy per-date UNION ALL did. The outer group then counts the distinct samples
-            // and averages them per user. Unlike the previous per-sample pivot this emits only two
-            // predicates per row rather than one CASE pair per snapshot, so a columnstore metrics
-            // index (the Azure default) can service it in batch mode instead of scanning a wide
-            // per-snapshot projection. It is also faithful to the row-by-row scoring semantics:
-            // sample counts once, any positive duplicate is active, and frequency_known compares the
-            // distinct observed samples against the expected count for the workload.
+            // One reading per fully imported WEEK, not one pinned day inside it. #Samples carries the
+            // week span (m365_from .. end_exclusive), so this reads every report day the week holds.
+            //
+            // The inner group collapses duplicate rows for one (user, report day); the outer group
+            // counts the DISTINCT weeks the user was active in and averages their per-day counts.
+            // observed samples is the workload's covered-week count rather than a per-user tally: the
+            // daily reports list only the people who were active, so a week without a row for someone
+            // is evidence about THEM, not a gap in the measurement.
+            //
+            // average_actions stays a PER-DAY figure, unchanged in scale by the move to weekly
+            // readings, so the number an admin sees still means "how much on a day Microsoft recorded
+            // anything" rather than silently becoming a weekly total.
+            //
+            // Two predicates per row rather than one CASE pair per snapshot, so a columnstore metrics
+            // index (the Azure default) can service this in batch mode.
             sql.Append(@"
 ;WITH PerUserDay AS
 (
-    SELECT activity.user_id, chosen.sample_date,
+    SELECT activity.user_id, chosen.sample_date, CAST(activity.[date] AS date) AS report_date,
            MAX(" + actionExpression + @") AS actions,
            MAX(CASE WHEN activity.last_activity_date >= chosen.m365_from
                      AND activity.last_activity_date < chosen.end_exclusive
@@ -2752,23 +2575,49 @@ OPTION (RECOMPILE);
     FROM " + table + @" AS activity
     JOIN #Samples AS chosen
       ON chosen.workload = " + workload + @"
-     AND CAST(activity.[date] AS date) = chosen.sample_date
+     AND activity.[date] >= chosen.m365_from
+     AND activity.[date] < chosen.end_exclusive
     JOIN " + scopeTable + @" AS eligible ON eligible.user_id = activity.user_id
     WHERE activity.[date] >= @from AND activity.[date] < @endExclusive
-    GROUP BY activity.user_id, chosen.sample_date
+    GROUP BY activity.user_id, chosen.sample_date, CAST(activity.[date] AS date)
 )
 INSERT #Scores
     (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
 SELECT " + workload + @", user_id,
-       SUM(was_active),
-       COUNT(*),
-       CAST(CASE WHEN COUNT(*) = @expected" + workload + @" THEN 1 ELSE 0 END AS bit),
+       COUNT(DISTINCT CASE WHEN was_active = 1 THEN sample_date END),
+       @observed" + workload + @",
+       CAST(CASE WHEN @observed" + workload + @" = @expected" + workload + @" THEN 1 ELSE 0 END AS bit),
        AVG(actions),
        MAX(last_activity_utc)
 FROM PerUserDay
 GROUP BY user_id
 OPTION (RECOMPILE);
 ");
+
+            // The read model deliberately does NOT materialise the inactive majority: at a 200k-user
+            // tenant that would be one cached dictionary entry per person per workload. It applies the
+            // same rule in memory instead - see LicenceActivityReadModel.Evidence.
+            if (readModel) return;
+
+            sql.AppendFormat(
+                CultureInfo.InvariantCulture,
+                @"
+IF (SELECT status FROM #Coverage WHERE workload = {0}) = 'available' AND @groupFiltered = 0
+BEGIN
+    INSERT #Scores
+        (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
+    SELECT {0}, scoped.user_id, 0, @observed{0},
+           CAST(CASE WHEN @observed{0} = @expected{0} THEN 1 ELSE 0 END AS bit), 0, NULL
+    FROM {1} AS scoped
+    WHERE NOT EXISTS
+    (
+        SELECT 1 FROM #Scores AS scored
+        WHERE scored.workload = {0} AND scored.user_id = scoped.user_id
+    )
+    OPTION (RECOMPILE);
+END;
+",
+                workload, scopeTable);
         }
 
         private static void AppendCopilotUsers(

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -101,7 +101,10 @@ SET m365_from = CASE WHEN DATEADD(DAY,
         -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), sample_date) % 7) + 7) % 7),
         sample_date) END,
     end_exclusive = DATEADD(DAY, 1, sample_date),
-    copilot_from = DATEADD(DAY, -6, sample_date);
+    copilot_from = DATEADD(DAY, -6, sample_date),
+    week_start = DATEADD(DAY,
+        -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), sample_date) % 7) + 7) % 7),
+        sample_date);
 ");
         }
 
@@ -1214,13 +1217,21 @@ BEGIN
     --
     -- Deliberately NOT hinted to IX_date. That hint suited the old single-pinned-date equality seek,
     -- but over a whole week it forces the narrow date index plus a key lookup per row instead of the
-    -- covering metrics index. Measured at 300k users on a 7-day window it cost ~700k logical reads
-    -- and blew the 20s command timeout at 28.8s; unhinted the optimiser picks the covering index.
+    -- covering metrics index.
     -- Two hash aggregates, deliberately NOT a COUNT(DISTINCT ...) over the raw join. Collapsing to
     -- one row per (user, week) first and only then summing is what keeps this linear: measured at
     -- 300k users over a 180-day window the DISTINCT form cost 141.6s against 7.9s for the previous
     -- pinned-day query, while logical reads rose only 4.4x - the classic signature of a plan problem
     -- rather than a volume one.
+    --
+    -- The week is matched by EQUALITY on a week start derived from the report row's own date, never
+    -- by a date RANGE against #Weeks. A range join gives the optimiser no equality to hash on, so it
+    -- fell back to a nested loop driving into the nonclustered columnstore - which cannot seek - and
+    -- re-read the whole activity table once per covered week. See AppendM365Users for the measured
+    -- numbers. week_start is #Weeks' primary key and is the true, UNCLAMPED Monday; m365_from and
+    -- m365_to are clamped to the requested period, so they cannot be derived from a report row. The
+    -- surrounding @from/@endExclusive predicate reproduces that clamping exactly, leaving the row set
+    -- unchanged.
     ;WITH PerUserWeek AS
     (
         SELECT activity.user_id,
@@ -1228,14 +1239,16 @@ BEGIN
                MAX(CASE WHEN activity.last_activity_date >= weeks.m365_from
                          AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
                         THEN 1 ELSE 0 END) AS was_active
-        FROM #Samples AS samples
-        JOIN #Weeks AS weeks ON weeks.m365_to = samples.sample_date
-        JOIN {1} AS activity
-          ON activity.[date] >= weeks.m365_from
-         AND activity.[date] < DATEADD(DAY, 1, weeks.m365_to)
+        FROM {1} AS activity
         JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
-        WHERE samples.workload = {0}
-          AND activity.[date] >= @from
+        JOIN #Weeks AS weeks
+          ON weeks.week_start = DATEADD(DAY,
+                 -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), activity.[date]) % 7) + 7) % 7),
+                 CAST(activity.[date] AS date))
+        JOIN #Samples AS samples
+          ON samples.workload = {0}
+         AND samples.sample_date = weeks.m365_to
+        WHERE activity.[date] >= @from
           AND activity.[date] < @endExclusive
         GROUP BY activity.user_id, samples.sample_date
     )
@@ -2521,6 +2534,9 @@ VALUES
     (4, @status4, @source4, @measure4, @expected4, @observed4, @period4),
     (5, @status5, @source5, @measure5, @expected5, @observed5, @period5);
 
+-- week_start is the week's true (unclamped) Monday. m365_from and sample_date are both clamped to
+-- the requested period, so neither can be derived from a report row's own date; week_start can, and
+-- that is what lets the scorers join this table by EQUALITY instead of by date range.
 CREATE TABLE #Samples
 (
     workload tinyint NOT NULL,
@@ -2528,6 +2544,7 @@ CREATE TABLE #Samples
     m365_from date NULL,
     end_exclusive date NULL,
     copilot_from date NULL,
+    week_start date NULL,
     PRIMARY KEY (workload, sample_date)
 );
 
@@ -2570,6 +2587,22 @@ CREATE TABLE #Scores
             //
             // Two predicates per row rather than one CASE pair per snapshot, so a columnstore metrics
             // index (the Azure default) can service this in batch mode.
+            //
+            // The week is matched by EQUALITY on a week start derived from the report row's own date,
+            // never by a date RANGE against #Samples. A range join gives the optimiser no equality to
+            // hash on, so it fell back to a nested loop driving into the nonclustered columnstore -
+            // which cannot seek - and therefore re-read the whole activity table once per covered
+            // week. Measured at 300k users with 8.44M rows per usage table: the range form cost
+            // 35,024,453 logical reads and 407 s for Teams over a 180-day window (and 34.5 s over a
+            // 7-day window, against the 20 s command timeout, i.e. a 503). The equality form collapses
+            // that to a single hash pass.
+            //
+            // week_start is used rather than sample_date because sample_date and m365_from are both
+            // CLAMPED to the requested period, so the first and last (partial) weeks would not match a
+            // value derived from a report row. week_start is the true Monday and is never clamped. The
+            // surrounding @from/@endExclusive predicate reproduces the clamping exactly, so the row set
+            // is unchanged: date IN [week_start, week_start+6] AND date IN [@from, @to]
+            // == date IN [m365_from, end_exclusive).
             sql.Append(@"
 ;WITH PerUserDay AS
 (
@@ -2584,21 +2617,36 @@ CREATE TABLE #Scores
     FROM " + table + @" AS activity
     JOIN #Samples AS chosen
       ON chosen.workload = " + workload + @"
-     AND activity.[date] >= chosen.m365_from
-     AND activity.[date] < chosen.end_exclusive
+     AND chosen.week_start = DATEADD(DAY,
+             -(((DATEDIFF(DAY, CONVERT(date, '19000101', 112), activity.[date]) % 7) + 7) % 7),
+             CAST(activity.[date] AS date))
     JOIN " + scopeTable + @" AS eligible ON eligible.user_id = activity.user_id
     WHERE activity.[date] >= @from AND activity.[date] < @endExclusive
     GROUP BY activity.user_id, chosen.sample_date, CAST(activity.[date] AS date)
+),
+PerUserWeek AS
+(
+    -- Collapse to one row per (user, week) BEFORE the per-user aggregate. The previous shape mixed
+    -- COUNT(DISTINCT sample_date) with AVG/MAX in a single GROUP BY, which SQL Server services with a
+    -- Table Spool feeding separate aggregate branches - it replays the ~8.4M-row day-level stream more
+    -- than once. Because a week appears exactly once here, the distinct count becomes a plain SUM.
+    SELECT user_id, sample_date,
+           MAX(was_active) AS was_active,
+           SUM(actions) AS actions_total,
+           COUNT_BIG(*) AS report_days,
+           MAX(last_activity_utc) AS last_activity_utc
+    FROM PerUserDay
+    GROUP BY user_id, sample_date
 )
 INSERT #Scores
     (workload, user_id, active_samples, observed_samples, frequency_known, average_actions, last_activity_utc)
 SELECT " + workload + @", user_id,
-       COUNT(DISTINCT CASE WHEN was_active = 1 THEN sample_date END),
+       SUM(was_active),
        @observed" + workload + @",
        CAST(CASE WHEN @observed" + workload + @" = @expected" + workload + @" THEN 1 ELSE 0 END AS bit),
-       AVG(actions),
+       SUM(actions_total) / SUM(report_days),
        MAX(last_activity_utc)
-FROM PerUserDay
+FROM PerUserWeek
 GROUP BY user_id
 OPTION (RECOMPILE);
 ");

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/LicenceActivitySql.cs
@@ -1216,12 +1216,18 @@ BEGIN
     -- but over a whole week it forces the narrow date index plus a key lookup per row instead of the
     -- covering metrics index. Measured at 300k users on a 7-day window it cost ~700k logical reads
     -- and blew the 20s command timeout at 28.8s; unhinted the optimiser picks the covering index.
-    ;WITH PerUser AS
+    -- Two hash aggregates, deliberately NOT a COUNT(DISTINCT ...) over the raw join. Collapsing to
+    -- one row per (user, week) first and only then summing is what keeps this linear: measured at
+    -- 300k users over a 180-day window the DISTINCT form cost 141.6s against 7.9s for the previous
+    -- pinned-day query, while logical reads rose only 4.4x - the classic signature of a plan problem
+    -- rather than a volume one.
+    ;WITH PerUserWeek AS
     (
         SELECT activity.user_id,
-               COUNT(DISTINCT CASE WHEN activity.last_activity_date >= weeks.m365_from
-                                    AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
-                                   THEN samples.sample_date END) AS active_samples
+               samples.sample_date,
+               MAX(CASE WHEN activity.last_activity_date >= weeks.m365_from
+                         AND activity.last_activity_date < DATEADD(DAY, 1, weeks.m365_to)
+                        THEN 1 ELSE 0 END) AS was_active
         FROM #Samples AS samples
         JOIN #Weeks AS weeks ON weeks.m365_to = samples.sample_date
         JOIN {1} AS activity
@@ -1229,13 +1235,16 @@ BEGIN
          AND activity.[date] < DATEADD(DAY, 1, weeks.m365_to)
         JOIN #EligibleUsers AS eligible ON eligible.user_id = activity.user_id
         WHERE samples.workload = {0}
-        GROUP BY activity.user_id
+          AND activity.[date] >= @from
+          AND activity.[date] < @endExclusive
+        GROUP BY activity.user_id, samples.sample_date
     )
     INSERT #Scores
         (workload, user_id, active_samples, observed_samples, frequency_known)
-    SELECT {0}, per_user.user_id, per_user.active_samples, @observed{0},
+    SELECT {0}, per_user.user_id, SUM(per_user.was_active), @observed{0},
            CAST(CASE WHEN @observed{0} = @expected{0} THEN 1 ELSE 0 END AS bit)
-    FROM PerUser AS per_user
+    FROM PerUserWeek AS per_user
+    GROUP BY per_user.user_id
     OPTION (RECOMPILE, MAXDOP 1);
 
     -- Everyone else was measured across the same fully imported weeks and did nothing in any of

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityReadModelLoader.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityReadModelLoader.cs
@@ -50,7 +50,7 @@ namespace Common.Entities.LicenceActivity
                     var partWatch = Stopwatch.StartNew();
                     var model = new LicenceActivityReadModel(
                         range, directory.Licences, directory.Users, directory.Memberships,
-                        facts.Overview.Coverage, facts.Scores);
+                        facts.Overview.Coverage, facts.Scores, sources.UsageReportsGroupFiltered);
                     _instrumentation?.OperationCompleted?.Invoke("read-model", partWatch.ElapsedMilliseconds);
                     diagnostics.Stage("MaterialisationCompleted", watch.ElapsedMilliseconds);
                     diagnostics.Stage("OverviewSqlCompleted", watch.ElapsedMilliseconds);

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
@@ -794,6 +794,8 @@ namespace Common.Entities.LicenceActivity
             AddDate(command, "@endExclusive", query.EndExclusiveUtc);
             AddDate(command, "@settled", sources.NowUtc.Date.AddDays(-3));
             AddDate(command, "@now", sources.NowUtc.Date);
+            command.Parameters.Add("@groupFiltered", SqlDbType.Bit).Value =
+                sources.UsageReportsGroupFiltered;
             AddNullableInt(command, "@departmentId", query.DepartmentId);
             AddNullableInt(command, "@countryId", query.CountryId);
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelTests.cs
@@ -68,19 +68,54 @@ namespace Tests.UnitTests
             var result = model.BuildUsers(overview, query, CancellationToken.None);
 
             AssertEvidence(result, 1, "teams", "available", "zero");
-            AssertEvidence(result, 2, "teams", "missingCoverage", "unknown");
+            AssertEvidence(result, 2, "teams", "available", "zero");
             AssertEvidence(result, 3, "teams", "partial", "unknown");
             AssertEvidence(result, 4, "outlook", "disabled", "unknown");
             AssertEvidence(result, 2, "copilot", "partial", "unknown");
             CollectionAssert.Contains(result.MostActive.Select(user => user.UserId).ToList(), 3);
-            CollectionAssert.DoesNotContain(result.LeastActive.Select(user => user.UserId).ToList(), 2);
-            CollectionAssert.DoesNotContain(result.LeastActive.Select(user => user.UserId).ToList(), 3);
+            CollectionAssert.Contains(result.LeastActive.Select(user => user.UserId).ToList(), 2,
+                "Someone with no rows across a fully measured period did nothing, provably, so they "
+                + "belong in the least-active list rather than being withheld as unmeasured.");
+            CollectionAssert.DoesNotContain(result.LeastActive.Select(user => user.UserId).ToList(), 3,
+                "A short reading count is still incomplete evidence and stays out of least-active.");
 
             var teams = overview.Licences.Single().Workloads.Single(item => item.Workload == "teams");
-            Assert.AreEqual(1, teams.Zero);
-            Assert.AreEqual(3, teams.Unknown);
+            Assert.AreEqual(3, teams.Zero,
+                "The explicit zero plus the two people with no rows at all are all measured zeros.");
+            Assert.AreEqual(1, teams.Unknown,
+                "Only the person whose own evidence is incomplete stays Unknown.");
             Assert.AreEqual(0, overview.Licences.Single().Workloads
                 .Single(item => item.Workload == "copilot").Zero);
+        }
+
+        [TestMethod]
+        public void AGroupFilteredUsageImport_LeavesUnmeasuredPeopleUnknownRatherThanInactive()
+        {
+            // UserGroupsFilter scopes the usage-report import but NOT the user import, so the two
+            // populations differ. Calling someone inactive because they hold a licence and have no
+            // rows would then be a confident wrong answer about someone nobody ever looked at.
+            var model = Model(
+                new[] { Sku(1, "Contoso") },
+                Users(1, 2),
+                new[] { Member(1, 1), Member(2, 1) },
+                AvailableCoverage(),
+                Scores(("teams", 1, Score(4, 4))),
+                usageReportsGroupFiltered: true);
+            var overview = model.BuildOverview(Query(), CancellationToken.None);
+            var result = model.BuildUsers(
+                overview,
+                Query().ForUsers(1, "teams", null, "activity", "desc", 10, 1, 100, Now),
+                CancellationToken.None);
+
+            AssertEvidence(result, 1, "teams", "available", "high");
+            AssertEvidence(result, 2, "teams", "missingCoverage", "unknown");
+            var teams = overview.Licences.Single().Workloads.Single(item => item.Workload == "teams");
+            Assert.AreEqual(0, teams.Zero);
+            Assert.AreEqual(1, teams.Unknown);
+            CollectionAssert.DoesNotContain(result.LeastActive.Select(user => user.UserId).ToList(), 2);
+            CollectionAssert.Contains(overview.Messages,
+                LicenceActivityRules.Notes.UsageReportsGroupFiltered,
+                "The reader has to be told why those people are Unknown.");
         }
 
         [TestMethod]
@@ -346,8 +381,10 @@ namespace Tests.UnitTests
             IReadOnlyList<LicenceActivityDirectoryUser> users,
             IReadOnlyList<LicenceActivityMembership> memberships,
             IReadOnlyList<LicenceActivityCoverage> coverage,
-            IReadOnlyDictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>> scores) =>
-            new LicenceActivityReadModel(Query(), licences, users, memberships, coverage, scores);
+            IReadOnlyDictionary<string, IReadOnlyDictionary<int, LicenceActivityScore>> scores,
+            bool usageReportsGroupFiltered = false) =>
+            new LicenceActivityReadModel(
+                Query(), licences, users, memberships, coverage, scores, usageReportsGroupFiltered);
 
         private static LicenceActivityQuery Query() =>
             LicenceActivityQuery.Create("2000-05-01", "2000-06-25", Now);

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
@@ -26,7 +26,7 @@ namespace Tests.UnitTests
     internal sealed class LicenceActivitySqlFixture : IDisposable
     {
         private const string RetainedDatabasePrefix = "UT_LicenceActivityScale_";
-        private const string RetainedMarker = "300000-users|50-skus|v2";
+        private const string RetainedMarker = "300000-users|50-skus|v3-daily-positive-only";
         private static readonly Regex RetainedDatabaseName = new Regex(
             "^" + RetainedDatabasePrefix + "[0-9a-f]{32}$",
             RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -743,6 +743,36 @@ SELECT n,
        END
 FROM Numbers;
 
+-- The four Microsoft 365 tables are Graph's DAILY user-detail reports, so a realistic import leaves
+-- a row on EVERY day of the window and only for the people who were active that day. The weekly
+-- reading a person belongs to is still sample_number, so the activity pattern - and therefore every
+-- band the acceptance matrix asserts - is unchanged; what changes is that the rows are spread across
+-- all 180 days instead of being piled onto 26 Sundays, and that the people who did nothing have no
+-- row at all rather than an explicit zero one.
+--
+-- Seeding one day per week would model an import that only ever ran on Sundays, which licence
+-- activity now (correctly) reports as unmeasured. #SyntheticSamples is still used as-is for the
+-- Copilot table, whose source is a weekly rolling report rather than a daily one.
+CREATE TABLE #SyntheticReportDays
+(
+    report_date date NOT NULL PRIMARY KEY,
+    sample_number int NOT NULL,
+    day_offset int NOT NULL
+);
+
+;WITH D1(n) AS
+(
+    SELECT n FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) AS n(n)
+),
+DayNumbers(n) AS
+(
+    SELECT TOP (180) ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) - 1
+    FROM D1 AS a CROSS JOIN D1 AS b CROSS JOIN D1 AS c
+)
+INSERT #SyntheticReportDays (report_date, sample_number, day_offset)
+SELECT DATEADD(DAY, n, CONVERT(date, '20000103', 112)), n / 7, n % 7
+FROM DayNumbers;
+
 INSERT dbo.teams_user_activity_log WITH (TABLOCK)
 (
     private_chat_count, team_chat_count, calls_count, meetings_count,
@@ -764,10 +794,10 @@ SELECT CASE WHEN activity.is_active = 1 THEN 1 + (users.id + samples.sample_numb
        CASE WHEN activity.is_active = 1 THEN (users.id * 7 + samples.sample_number) % 6 ELSE 0 END,
        CASE WHEN activity.is_active = 1 THEN (users.id * 11 + samples.sample_number) % 5 ELSE 0 END,
        0,
-       users.id, samples.sample_date,
-       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+       users.id, samples.report_date,
+       CASE WHEN activity.is_active = 1 THEN samples.report_date ELSE NULL END
 FROM dbo.users AS users
-CROSS JOIN #SyntheticSamples AS samples
+CROSS JOIN #SyntheticReportDays AS samples
 CROSS APPLY
 (
     SELECT CAST(CASE
@@ -778,7 +808,8 @@ CROSS APPLY
          AND samples.sample_number % 10 = users.id % 10 THEN 1
         ELSE 0
     END AS int) AS is_active
-) AS activity;
+) AS activity
+WHERE activity.is_active = 1 AND (users.id + samples.day_offset) % 3 = 0;
 
 INSERT dbo.outlook_user_activity_log WITH (TABLOCK)
 (
@@ -790,10 +821,10 @@ SELECT CASE WHEN activity.is_active = 1 THEN 1 + (users.id + samples.sample_numb
        CASE WHEN activity.is_active = 1 THEN 1 + (users.id * 5 + samples.sample_number) % 25 ELSE 0 END,
        CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 3 ELSE 0 END,
        CASE WHEN activity.is_active = 1 THEN (users.id * 7 + samples.sample_number) % 4 ELSE 0 END,
-       users.id, samples.sample_date,
-       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+       users.id, samples.report_date,
+       CASE WHEN activity.is_active = 1 THEN samples.report_date ELSE NULL END
 FROM dbo.users AS users
-CROSS JOIN #SyntheticSamples AS samples
+CROSS JOIN #SyntheticReportDays AS samples
 CROSS APPLY
 (
     SELECT CAST(CASE
@@ -804,7 +835,8 @@ CROSS APPLY
          AND samples.sample_number % 10 = users.id % 10 THEN 1
         ELSE 0
     END AS int) AS is_active
-) AS activity;
+) AS activity
+WHERE activity.is_active = 1 AND (users.id + samples.day_offset) % 3 = 0;
 
 INSERT dbo.onedrive_user_activity_log WITH (TABLOCK)
 (
@@ -815,10 +847,10 @@ SELECT CASE WHEN activity.is_active = 1 THEN 1 + (users.id * 3 + samples.sample_
        CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 5 ELSE 0 END,
        CASE WHEN activity.is_active = 1 THEN (users.id * 7 + samples.sample_number) % 3 ELSE 0 END,
        CASE WHEN activity.is_active = 1 THEN (users.id * 11 + samples.sample_number) % 2 ELSE 0 END,
-       users.id, samples.sample_date,
-       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+       users.id, samples.report_date,
+       CASE WHEN activity.is_active = 1 THEN samples.report_date ELSE NULL END
 FROM dbo.users AS users
-CROSS JOIN #SyntheticSamples AS samples
+CROSS JOIN #SyntheticReportDays AS samples
 CROSS APPLY
 (
     SELECT CAST(CASE
@@ -829,7 +861,8 @@ CROSS APPLY
          AND samples.sample_number % 10 = users.id % 10 THEN 1
         ELSE 0
     END AS int) AS is_active
-) AS activity;
+) AS activity
+WHERE activity.is_active = 1 AND (users.id + samples.day_offset) % 3 = 0;
 
 INSERT dbo.sharepoint_user_activity_log WITH (TABLOCK)
 (
@@ -840,10 +873,10 @@ SELECT CASE WHEN activity.is_active = 1 THEN 1 + (users.id * 5 + samples.sample_
        CASE WHEN activity.is_active = 1 THEN (users.id + samples.sample_number) % 4 ELSE 0 END,
        CASE WHEN activity.is_active = 1 THEN (users.id * 7 + samples.sample_number) % 4 ELSE 0 END,
        CASE WHEN activity.is_active = 1 THEN (users.id * 13 + samples.sample_number) % 2 ELSE 0 END,
-       users.id, samples.sample_date,
-       CASE WHEN activity.is_active = 1 THEN samples.sample_date ELSE NULL END
+       users.id, samples.report_date,
+       CASE WHEN activity.is_active = 1 THEN samples.report_date ELSE NULL END
 FROM dbo.users AS users
-CROSS JOIN #SyntheticSamples AS samples
+CROSS JOIN #SyntheticReportDays AS samples
 CROSS APPLY
 (
     SELECT CAST(CASE
@@ -854,7 +887,8 @@ CROSS APPLY
          AND samples.sample_number % 10 = users.id % 10 THEN 1
         ELSE 0
     END AS int) AS is_active
-) AS activity;
+) AS activity
+WHERE activity.is_active = 1 AND (users.id + samples.day_offset) % 3 = 0;
 
 INSERT dbo.copilot_usage_user_activity_log WITH (TABLOCK)
 (
@@ -882,7 +916,8 @@ CROSS APPLY
     END AS int) AS is_active
 ) AS activity;
 
-DROP TABLE #SyntheticSamples;";
+DROP TABLE #SyntheticSamples;
+DROP TABLE #SyntheticReportDays;";
     }
 
     internal sealed class LicenceActivitySqlMeasurement

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
@@ -189,7 +189,7 @@ CREATE TABLE dbo.LicenceActivitySyntheticMarker
     marker nvarchar(100) NOT NULL PRIMARY KEY
 );
 INSERT dbo.LicenceActivitySyntheticMarker (marker)
-VALUES (N'300000-users|50-skus|v2');");
+VALUES (N'" + RetainedMarker + "');");
 
                 var directory = Path.GetDirectoryName(statePath);
                 if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -1,7 +1,9 @@
 using Common.Entities.LicenceActivity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -213,10 +215,12 @@ VALUES
     (20, 0, 0, 0, 1, '2000-06-18T12:00:00', '2000-06-18T23:59:59'),
     (3000, 0, 0, 0, 2, '2000-06-16', '2000-06-16'),
     (3000, 0, 0, 0, 2, '2000-06-24', '2000-06-24');
+-- Every one of this person's rows inside the period reports a last-activity date OUTSIDE the week
+-- it sits in, however large its counters are. Big rolling counters are not activity in that week.
 UPDATE dbo.onedrive_user_activity_log
-SET last_activity_date = CASE WHEN [date] = '2000-06-18'
+SET last_activity_date = CASE WHEN [date] < '2000-06-19'
                              THEN '2000-06-13' ELSE '2000-06-24' END
-WHERE user_id = 2 AND [date] IN ('2000-06-18', '2000-06-23');
+WHERE user_id = 2 AND [date] >= '2000-06-14' AND [date] < '2000-06-24';
 UPDATE dbo.onedrive_user_activity_log SET last_activity_date = '2000-06-19'
 WHERE user_id = 4;
 DELETE dbo.onedrive_user_activity_log WHERE user_id = 3 AND [date] = '2000-06-23';");
@@ -229,9 +233,10 @@ DELETE dbo.onedrive_user_activity_log WHERE user_id = 3 AND [date] = '2000-06-23
                 var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
                     .Workloads.Single(w => w.Workload == "onedrive");
                 Assert.AreEqual(1, distribution.High);
-                Assert.AreEqual(1, distribution.Moderate);
+                Assert.AreEqual(2, distribution.Moderate);
                 Assert.AreEqual(2, distribution.Zero);
-                Assert.AreEqual(1, distribution.Unknown);
+                Assert.AreEqual(0, distribution.Unknown,
+                    "Both part-weeks were imported day by day, so nobody is unmeasured.");
                 CollectionAssert.AreEqual(new[] { "2000-06-18", "2000-06-23" },
                     overview.Coverage.Single(c => c.Workload == "onedrive")
                         .SnapshotDates.Select(d => d.ToString("yyyy-MM-dd")).ToArray());
@@ -243,14 +248,20 @@ DELETE dbo.onedrive_user_activity_log WHERE user_id = 3 AND [date] = '2000-06-23
                 var active = users.Users.Single(u => u.UserId == 1)
                     .Workloads.Single(w => w.Workload == "onedrive");
                 Assert.AreEqual(2, active.ActiveSamples);
-                Assert.AreEqual(12d, active.AverageActions.Value,
-                    "Average the per-day maxima (20 and 4), never sum or double-count duplicate snapshots.");
+                Assert.AreEqual(5.6d, active.AverageActions.Value, 0.000001,
+                    "Average the per-day maxima across the ten measured days (one 20, nine 4s), "
+                    + "never sum or double-count duplicate rows for the same day.");
                 Assert.AreEqual(0, users.Users.Single(u => u.UserId == 2)
-                    .Workloads.Single(w => w.Workload == "onedrive").ActiveSamples);
-                Assert.IsTrue(users.MostActive.Any(u => u.UserId == 3),
-                    "A missing sample must not erase positive partial evidence.");
-                Assert.IsFalse(users.LeastActive.Any(u => u.UserId == 3));
-                Assert.AreEqual(4, users.LeastActive.Count);
+                    .Workloads.Single(w => w.Workload == "onedrive").ActiveSamples,
+                    "Positive counters do not prove activity when every last-activity date "
+                    + "falls outside the week the row sits in.");
+                var lostOneDay = users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == "onedrive");
+                Assert.AreEqual(1, lostOneDay.ActiveSamples);
+                Assert.AreEqual(2, lostOneDay.ObservedSamples,
+                    "Losing this person's row for one day leaves the week itself measured.");
+                Assert.IsTrue(users.MostActive.Any(u => u.UserId == 3));
+                Assert.AreEqual(5, users.LeastActive.Count);
             }
         }
 
@@ -291,7 +302,7 @@ CREATE TABLE #probe
         [DataRow(28, true)]
         [DataRow(90, true)]
         [DataRow(180, true)]
-        public async Task DistinctPinnedSampleCounts_PreserveMissingZeroDuplicatesAndExpectedBoundary(
+        public async Task DistinctWeeklyReadings_PreserveZeroDuplicatesAndExpectedBoundary(
             int days, bool columnstore)
         {
             using (var fixture = LicenceActivitySqlFixture.Create(
@@ -356,13 +367,15 @@ DELETE dbo.{table} WHERE user_id = 5
                     Assert.AreEqual(dates.Length, coverage.ExpectedSamples);
                     var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
                         .Workloads.Single(w => w.Workload == workload);
-                    Assert.AreEqual(1, distribution.Zero);
-                    Assert.AreEqual(2, distribution.Unknown);
-                    Assert.AreEqual(2, distribution.High + distribution.Moderate + distribution.Low,
-                        "Two complete users have positive evidence.");
-                    Assert.AreEqual(3,
+                    Assert.AreEqual(2, distribution.Zero,
+                        "The explicit-zero user and the user with no rows at all are both measured zeros.");
+                    Assert.AreEqual(0, distribution.Unknown,
+                        "Every week was imported in full, so nobody is unmeasured.");
+                    Assert.AreEqual(3, distribution.High + distribution.Moderate + distribution.Low,
+                        "Three users have positive evidence.");
+                    Assert.AreEqual(5,
                         distribution.High + distribution.Moderate + distribution.Low + distribution.Zero,
-                        "Exactly three users have complete evidence at the expected-sample boundary.");
+                        "Everyone holding the licence has complete evidence at the expected-reading boundary.");
                     var users = await fixture.Store().LoadUsersAsync(
                         overview, query.ForUsers(1, workload, null, "activity", "desc", 5, 1, 20,
                             LicenceActivitySqlFixture.NowUtc),
@@ -371,24 +384,30 @@ DELETE dbo.{table} WHERE user_id = 5
                     Assert.AreEqual(dates.Length, active.ActiveSamples);
                     Assert.AreEqual(dates.Length, active.ObservedSamples);
                     Assert.AreEqual((workload == "teams" || workload == "outlook" ? 5d : 4d)
-                        + 16d / dates.Length, active.AverageActions.Value, 0.000001);
+                        + 16d / days, active.AverageActions.Value, 0.000001,
+                        "Average actions stays a per-report-day figure, so duplicate rows for one day "
+                        + "collapse to that day's maximum and the extra 16 is spread over the days measured.");
                     var explicitZero = users.Users.Single(u => u.UserId == 4)
                         .Workloads.Single(w => w.Workload == workload);
                     Assert.AreEqual("zero", explicitZero.Band);
                     Assert.AreEqual(dates.Length, explicitZero.ObservedSamples);
                     Assert.AreEqual(0, explicitZero.ActiveSamples);
-                    var partial = users.Users.Single(u => u.UserId == 3)
+                    var lostOneDay = users.Users.Single(u => u.UserId == 3)
                         .Workloads.Single(w => w.Workload == workload);
-                    Assert.AreEqual("partial", partial.Status);
-                    Assert.AreEqual(dates.Length - 1, partial.ObservedSamples);
-                    Assert.IsFalse(users.LeastActive.Any(u => u.UserId == 3 || u.UserId == 5));
+                    Assert.AreEqual("available", lostOneDay.Status,
+                        "Losing one of a person's report days does not unmeasure them: the week around "
+                        + "it was still imported in full.");
+                    Assert.AreEqual(dates.Length, lostOneDay.ObservedSamples);
+                    Assert.AreEqual(1, lostOneDay.ActiveSamples);
+                    CollectionAssert.Contains(users.LeastActive.Select(u => u.UserId).ToList(), 5);
                     Assert.IsTrue(users.MostActive.Any(u => u.UserId == 3));
                     var absent = users.Users.Single(u => u.UserId == 5)
                         .Workloads.Single(w => w.Workload == workload);
-                    Assert.AreEqual("missingCoverage", absent.Status);
-                    Assert.AreEqual(0, absent.ObservedSamples);
+                    Assert.AreEqual("available", absent.Status);
+                    Assert.AreEqual(dates.Length, absent.ObservedSamples);
                     Assert.AreEqual(0, absent.ActiveSamples);
-                    Assert.IsNull(absent.AverageActions);
+                    Assert.AreEqual("zero", absent.Band);
+                    Assert.AreEqual(0d, absent.AverageActions.Value);
                 }
             }
         }
@@ -437,18 +456,19 @@ DELETE dbo.{table} WHERE user_id = 5 AND [date] = '2000-06-25T12:00:00';");
                 Assert.AreEqual(1, coverage.ExpectedSamples);
                 Assert.AreEqual(1, coverage.ObservedSamples);
                 Assert.AreEqual(1, distribution.High,
-                    "Duplicate rows on the one pinned day are still one observed active sample.");
-                Assert.AreEqual(3, distribution.Zero);
-                Assert.AreEqual(1, distribution.Unknown);
+                    "Duplicate rows on the same report day are still one observed active week.");
+                Assert.AreEqual(4, distribution.Zero,
+                    "Everyone else was measured across a week imported in full and did nothing in it, "
+                    + "including the user with no report rows at all.");
+                Assert.AreEqual(0, distribution.Unknown);
                 Assert.AreEqual(0, distribution.Moderate + distribution.Low);
                 Assert.AreEqual(5, users.TotalUsers);
                 foreach (var user in users.Users)
                 {
                     var evidence = user.Workloads.Single(w => w.Workload == workload);
-                    var expectedBand = user.UserId == 1 ? "high"
-                        : user.UserId == 3 ? "unknown" : "zero";
-                    Assert.AreEqual(expectedBand, evidence.Band);
-                    Assert.AreEqual(user.UserId == 3 ? 0 : 1, evidence.ObservedSamples);
+                    Assert.AreEqual(user.UserId == 1 ? "high" : "zero", evidence.Band);
+                    Assert.AreEqual(1, evidence.ObservedSamples,
+                        "Observed readings are a property of the import, not of the person.");
                     Assert.AreEqual(user.UserId == 1 ? 1 : 0, evidence.ActiveSamples);
                 }
                 var active = users.Users.Single(u => u.UserId == 1)
@@ -459,11 +479,11 @@ DELETE dbo.{table} WHERE user_id = 5 AND [date] = '2000-06-25T12:00:00';");
                 CollectionAssert.AreEquivalent(new[] { 1 },
                     users.MostActive.Where(u => u.Workloads.Single(w => w.Workload == workload)
                         .ActiveSamples > 0).Select(u => u.UserId).ToArray());
-                Assert.IsFalse(users.MostActive.Any(u => u.UserId == 3));
-                CollectionAssert.AreEquivalent(new[] { 1, 2, 4, 5 },
+                CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4, 5 },
                     users.LeastActive.Select(u => u.UserId).ToArray());
-                Assert.IsNull(users.Users.Single(u => u.UserId == 3)
-                    .Workloads.Single(w => w.Workload == workload).AverageActions);
+                Assert.AreEqual(0d, users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == workload).AverageActions.Value,
+                    "A person with no rows across a fully imported week did nothing, measurably.");
             }
         }
 
@@ -512,9 +532,10 @@ DELETE dbo.{table} WHERE user_id = 5 AND [date] = '2000-06-25T12:00:00';");
                 var teams = partial.Coverage.Single(c => c.Workload == "teams");
                 Assert.AreEqual("partial", teams.Status);
                 Assert.AreEqual(9, teams.ExpectedSamples);
-                Assert.AreEqual(8, teams.ObservedSamples,
-                    "The Thursday snapshot is valid as-of evidence, while the unsettled July 2 row is excluded.");
-                Assert.AreEqual("2000-06-22", teams.SnapshotDates.Last().ToString("yyyy-MM-dd"));
+                Assert.AreEqual(7, teams.ObservedSamples,
+                    "The week holding only Monday-to-Thursday reports was not imported in full, and the "
+                    + "week ending after the settled date is excluded outright.");
+                Assert.AreEqual("2000-06-18", teams.SnapshotDates.Last().ToString("yyyy-MM-dd"));
                 Assert.AreEqual(5, partial.Licences.Single(l => l.LicenceTypeId == 1)
                     .Workloads.Single(w => w.Workload == "teams").Unknown);
                 Assert.AreEqual("notImported",
@@ -559,8 +580,14 @@ DELETE dbo.{table} WHERE user_id = 5 AND [date] = '2000-06-25T12:00:00';");
         }
 
         [TestMethod]
-        public async Task PerUserMissingRows_AreUnknownAndNeverLeastActive()
+        public async Task PerUserMissingRows_AreMeasuredZeroWhileMissingReportDaysStayUnknown()
         {
+            // The rule this pins down: the Graph daily user-detail reports return only the people who
+            // did something that day, so across a week that was imported in full an absent person is
+            // measured evidence of NO activity. Unknown is reserved for a genuine hole in the
+            // measurement - a report DAY nobody has - which is a property of the import, not of a
+            // person. Before this, being quiet was indistinguishable from being unmeasured, and a
+            // real tenant came back over 97% Unknown for exactly that reason.
             using (var fixture = CreateMeasuredFixture())
             {
                 fixture.Execute(@"
@@ -584,30 +611,32 @@ WHERE user_id = 3 AND [date] = '2000-05-14';");
 
                 Assert.AreEqual("available",
                     overview.Coverage.Single(c => c.Workload == "teams").Status,
-                    "Other users still prove that every global snapshot date exists.");
+                    "Other users still prove that every report day of every week was imported.");
                 var distribution = overview.Licences.Single(l => l.LicenceTypeId == 1)
                     .Workloads.Single(w => w.Workload == "teams");
                 Assert.AreEqual(1, distribution.High);
                 Assert.AreEqual(1, distribution.Moderate);
-                Assert.AreEqual(0, distribution.Low);
-                Assert.AreEqual(1, distribution.Zero);
-                Assert.AreEqual(2, distribution.Unknown);
+                Assert.AreEqual(1, distribution.Low);
+                Assert.AreEqual(2, distribution.Zero);
+                Assert.AreEqual(0, distribution.Unknown,
+                    "Nobody is Unknown while every week was imported in full.");
                 foreach (var workload in new[] { "outlook", "onedrive", "sharepoint" })
                 {
                     var other = overview.Licences.Single(l => l.LicenceTypeId == 1)
                         .Workloads.Single(w => w.Workload == workload);
-                    Assert.AreEqual(1, other.Zero, workload);
-                    Assert.AreEqual(2, other.Unknown, workload);
+                    Assert.AreEqual(2, other.Zero, workload);
+                    Assert.AreEqual(0, other.Unknown, workload);
                 }
 
                 var greekDepartment = overview.Departments.Single(d => d.Id == 2)
                     .Workloads.Single(w => w.Workload == "teams");
-                Assert.AreEqual(1, greekDepartment.Unknown,
-                    "A user missing one weekly row is unknown in demographic aggregates.");
+                Assert.AreEqual(0, greekDepartment.Unknown,
+                    "Losing one day of a fully imported week changes nothing for that person.");
                 var unknownDepartment = overview.Departments.Single(d => d.Id == 0)
                     .Workloads.Single(w => w.Workload == "teams");
-                Assert.AreEqual(1, unknownDepartment.Unknown,
-                    "A user missing every weekly row is unknown in demographic aggregates.");
+                Assert.AreEqual(1, unknownDepartment.Zero,
+                    "A user with no report rows at all is a measured zero in demographic aggregates.");
+                Assert.AreEqual(0, unknownDepartment.Unknown);
 
                 var users = await fixture.Store().LoadUsersAsync(
                     overview,
@@ -618,24 +647,56 @@ WHERE user_id = 3 AND [date] = '2000-05-14';");
                     NullLicenceActivityDiagnostics.Instance,
                     CancellationToken.None);
 
-                CollectionAssert.DoesNotContain(users.LeastActive.Select(u => u.UserId).ToList(), 3);
-                CollectionAssert.DoesNotContain(users.LeastActive.Select(u => u.UserId).ToList(), 5);
-                Assert.AreEqual("partial", users.Users.Single(u => u.UserId == 3)
-                    .Workloads.Single(w => w.Workload == "teams").Status);
-                Assert.AreEqual(7, users.Users.Single(u => u.UserId == 3)
-                    .Workloads.Single(w => w.Workload == "teams").ObservedSamples);
-                Assert.AreEqual("missingCoverage", users.Users.Single(u => u.UserId == 5)
-                    .Workloads.Single(w => w.Workload == "teams").Status);
-                Assert.AreEqual(0, users.Users.Single(u => u.UserId == 5)
-                    .Workloads.Single(w => w.Workload == "teams").ObservedSamples);
-                Assert.IsNull(users.Users.Single(u => u.UserId == 5)
-                    .Workloads.Single(w => w.Workload == "teams").AverageActions);
+                CollectionAssert.Contains(users.LeastActive.Select(u => u.UserId).ToList(), 5,
+                    "Someone proven to have done nothing belongs in the least-active list.");
+                var stillMeasured = users.Users.Single(u => u.UserId == 3)
+                    .Workloads.Single(w => w.Workload == "teams");
+                Assert.AreEqual("available", stillMeasured.Status);
+                Assert.AreEqual(8, stillMeasured.ObservedSamples);
+                Assert.AreEqual("low", stillMeasured.Band);
+                var absent = users.Users.Single(u => u.UserId == 5)
+                    .Workloads.Single(w => w.Workload == "teams");
+                Assert.AreEqual("available", absent.Status);
+                Assert.AreEqual(8, absent.ObservedSamples);
+                Assert.AreEqual(0, absent.ActiveSamples);
+                Assert.AreEqual(0d, absent.AverageActions.Value);
                 Assert.IsTrue(users.Users.Single(u => u.UserId == 5).Workloads
                     .Where(w => w.Workload != "copilot")
-                    .All(w => w.Status == "missingCoverage" && w.Band == "unknown"));
+                    .All(w => w.Status == "available" && w.Band == "zero"));
                 Assert.AreEqual("zero", users.Users.Single(u => u.UserId == 4)
                     .Workloads.Single(w => w.Workload == "teams").Band,
                     "A complete set of explicit zero rows remains a measured zero.");
+            }
+        }
+
+        [TestMethod]
+        public async Task AMissingReportDay_MakesItsWholeWeekUnknownForEveryone()
+        {
+            // The other half of the rule above: absence only means "no activity" once the week behind
+            // it was imported in full. Lose one day and the week proves nothing either way, so the
+            // whole workload falls back to Unknown rather than quietly reporting the quiet people as
+            // inactive.
+            using (var fixture = CreateMeasuredFixture())
+            {
+                fixture.Execute(
+                    "DELETE FROM dbo.teams_user_activity_log WHERE [date] = '2000-06-20';");
+
+                var overview = await fixture.Store().LoadOverviewAsync(
+                    OverviewQuery(), Sources(usageReports: true),
+                    NullLicenceActivityDiagnostics.Instance, CancellationToken.None);
+
+                var teams = overview.Coverage.Single(c => c.Workload == "teams");
+                Assert.AreEqual("partial", teams.Status);
+                Assert.AreEqual(8, teams.ExpectedSamples);
+                Assert.AreEqual(7, teams.ObservedSamples,
+                    "The week containing the missing Tuesday is no longer a measured reading.");
+                Assert.AreEqual(5, overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "teams").Unknown);
+                Assert.AreEqual("available",
+                    overview.Coverage.Single(c => c.Workload == "outlook").Status,
+                    "One workload's import gap must not contaminate the others.");
+                Assert.AreEqual(0, overview.Licences.Single(l => l.LicenceTypeId == 1)
+                    .Workloads.Single(w => w.Workload == "outlook").Unknown);
             }
         }
 
@@ -1392,6 +1453,14 @@ VALUES
             SeedOneUsageTable(fixture, "sharepoint_user_activity_log", sampleDates);
         }
 
+        /// <summary>
+        /// Seeds one usage-report table for the given weekly readings.
+        ///
+        /// A reading is a WEEK, and licence activity only treats a week as measured when every one of
+        /// its days was imported - so each sample date here seeds its whole Monday-to-sample-date week,
+        /// which is what a healthy daily import actually leaves behind. Seeding only the week's last
+        /// day would model an import that ran once a week, and would (correctly) come back as partial.
+        /// </summary>
         internal static void SeedOneUsageTable(
             LicenceActivitySqlFixture fixture,
             string table,
@@ -1399,10 +1468,12 @@ VALUES
         {
             for (var index = 0; index < sampleDates.Length; index++)
             {
-                var date = sampleDates[index];
                 var activeUsers = index == 0
                     ? "1,2,3"
                     : index == 1 ? "1,2" : "1";
+                var days = string.Join(",", ReportDaysOfWeekEndingOn(sampleDates[index])
+                    .Select(day => "('" + day + "')"));
+                var spine = $"CROSS JOIN (VALUES {days}) AS reading(report_date)";
 
                 if (table == "teams_user_activity_log")
                 {
@@ -1423,9 +1494,9 @@ SELECT CASE WHEN id IN ({activeUsers}) THEN 2 ELSE 0 END,
        CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
        0, 0, 0, 0, 0, 0, 0, 0,
        CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
-       0, 0, id, '{date}',
-       CASE WHEN id IN ({activeUsers}) THEN '{date}' ELSE NULL END
-FROM dbo.users;");
+       0, 0, id, reading.report_date,
+       CASE WHEN id IN ({activeUsers}) THEN reading.report_date ELSE NULL END
+FROM dbo.users {spine};");
                 }
                 else if (table == "outlook_user_activity_log")
                 {
@@ -1436,9 +1507,9 @@ INSERT dbo.outlook_user_activity_log
 SELECT CASE WHEN id IN ({activeUsers}) THEN 2 ELSE 0 END,
        CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
        CASE WHEN id IN ({activeUsers}) THEN 3 ELSE 0 END,
-       0, 0, id, '{date}',
-       CASE WHEN id IN ({activeUsers}) THEN '{date}' ELSE NULL END
-FROM dbo.users;");
+       0, 0, id, reading.report_date,
+       CASE WHEN id IN ({activeUsers}) THEN reading.report_date ELSE NULL END
+FROM dbo.users {spine};");
                 }
                 else
                 {
@@ -1448,11 +1519,20 @@ INSERT dbo.{table}
      user_id, [date], last_activity_date)
 SELECT CASE WHEN id IN ({activeUsers}) THEN 4 ELSE 0 END,
        CASE WHEN id IN ({activeUsers}) THEN 1 ELSE 0 END,
-       0, 0, id, '{date}',
-       CASE WHEN id IN ({activeUsers}) THEN '{date}' ELSE NULL END
-FROM dbo.users;");
+       0, 0, id, reading.report_date,
+       CASE WHEN id IN ({activeUsers}) THEN reading.report_date ELSE NULL END
+FROM dbo.users {spine};");
                 }
             }
+        }
+
+        /// <summary>Monday through the given week-end date, inclusive, as yyyy-MM-dd.</summary>
+        internal static IEnumerable<string> ReportDaysOfWeekEndingOn(string weekEnd)
+        {
+            var end = DateTime.ParseExact(weekEnd, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var start = end.AddDays(-(((int)end.DayOfWeek + 6) % 7));
+            for (var day = start; day <= end; day = day.AddDays(1))
+                yield return day.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
 
         private static LicenceActivityQuery OverviewQuery()

--- a/src/AnalyticsEngine/Web/Controllers/LicenceActivityAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/LicenceActivityAPIController.cs
@@ -165,7 +165,9 @@ namespace Web.AnalyticsWeb.Controllers
             {
                 UserMetadata = settings.GraphUsersMetadata, UsageReports = settings.GraphUsageReports,
                 CopilotUsageReports = settings.GraphCopilotUsageReports, CopilotAudit = settings.Copilot,
-                CopilotInteractions = settings.CopilotInteractionHistory, NowUtc = DateTime.UtcNow
+                CopilotInteractions = settings.CopilotInteractionHistory,
+                UsageReportsGroupFiltered = !string.IsNullOrWhiteSpace(config.UserGroupsFilter),
+                NowUtc = DateTime.UtcNow
             };
             string scope;
             using (var sha = SHA256.Create())

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/bands.ts
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/components/licenceActivity/bands.ts
@@ -35,18 +35,19 @@ const BY_KEY: Record<string, BandDef> = Object.fromEntries(ACTIVITY_BANDS.map((b
  * "active days", which the figures only become if a service's source says so.
  */
 export const BAND_DESCRIPTIONS: Record<BandKey, string> = {
-  high: 'Active across three quarters or more of what was measured.',
-  moderate: 'Active across a quarter to under three quarters of what was measured.',
-  low: 'Active across under a quarter of what was measured, but active at least once.',
-  zero: 'Never active, across a period that was measured in full.',
-  unknown: 'The period could not be measured in full, so activity is not known - this does not mean zero.',
+  high: 'Active in three quarters or more of the weeks that were measured.',
+  moderate: 'Active in a quarter to under three quarters of the weeks that were measured.',
+  low: 'Active in under a quarter of the weeks that were measured, but active in at least one.',
+  zero: 'Active in none of the weeks, across a period whose every week was measured in full.',
+  unknown: 'At least one week could not be measured in full, so activity is not known - this does not mean zero.',
 };
 
 /** A one-line summary of how the levels are worked out, for a column tooltip. */
 export const BAND_METHOD =
-  'Activity levels describe how much of the measured period someone was active in: ' +
-  'High = 75% or more, Moderate = 25\u201374%, Low = under 25%, No activity = never (across a period measured in full). ' +
-  'Where the period could not be measured in full the level is Unknown, not zero.';
+  "Activity levels describe how many of the period's weeks someone was active in: " +
+  'High = three quarters or more, Moderate = a quarter to under three quarters, Low = under a quarter, ' +
+  'No activity = none. A week is only counted when every one of its days was imported; where a week could ' +
+  'not be measured in full the level is Unknown, not zero.';
 
 export function bandLabel(band: string): string {
   return BY_KEY[band]?.label ?? band;


### PR DESCRIPTION
## Problem

A production tenant reported the Licence activity page as over 97% **Unknown** for every Microsoft 365 service, while the measured minority came back as **100% High** with literally zero Moderate/Low/No-activity. That shape is the diagnosis: it only happens if presence in the data already implies activity.

Three separate things combined.

1. `dbo.teams_user_activity_log` and its siblings are Graph's **daily** user-detail reports, fetched as `...(date=YYYY-MM-DD)` in `AbstractDailyActivityLoader.LoadReportPageForDateFromGraph`. Those return **only the people who did something on that day**. The repo already documents this in `CopilotAdoptionSqlIntegrationTests.cs:390` — *"a snapshot landing on a Saturday emptied the tab entirely"*.
2. Licence activity took **one reading per week**: `TOP 1 ... ORDER BY date DESC` inside the week (`LicenceActivitySql.AppendM365Overview`). `#Weeks` is anchored to `1900-01-01`, a **Monday**, so `m365_to` — and therefore the reading — always landed on the week's **Sunday**.
3. A person was banded only when present in **every** reading: `scores.frequency_known = 1 AND scores.observed_samples = coverage.expected_samples`.

Net effect: *"measured"* meant *"used the service on every Sunday of the period"*. Everyone else fell into Unknown, which the UI correctly refuses to render as zero — so the page was honest but nearly empty.

## Change

A reading becomes a **week that was imported day by day**, and absence across such a week becomes evidence of no activity rather than absence of evidence.

### `LicenceActivitySql.cs`
- New `#Days` spine in the overview preamble: every calendar day each week covers.
- `#Samples` now takes one row per week (keyed by the week's last day) **only when every day of that week has a report** and the week ends on or before `@settled`. Implemented as an `OUTER APPLY ... TOP (1)` per day — at most 180 single-row index seeks, bounded by days in the period rather than rows in the table.
- `@complete{n}` is gone; status is decided purely on covered-week count.
- `AppendM365OverviewScore` rewritten: scores across the whole week, counts active weeks, then inserts an explicit **measured zero** for every eligible person with no activity.
- `AppendM365Users` and `AppendM365ReadModel` were two divergent implementations of the same scoring. They are now **one**; `AppendM365ReadModel` and the `M365OverviewScores` constant are deleted.

### `LicenceActivityReadModel.cs`
- `Evidence()` resolves an absent person to a complete, zero reading instead of `missingCoverage`/Unknown.
- A person whose **own** reading count falls short still reports `partial` and is not banded. Absence is now meaningful; *incomplete* evidence still is not.
- The read model deliberately does **not** materialise the inactive majority — at 200k users that would be one cached dictionary entry per person per workload. It applies the rule in memory instead.
- `IsOfficialReport` replaced by an explicit `presenceGated` rule.

### Group-filter guard (the reason this isn't a one-line change)
`UserGroupsFilter` scopes the **usage-report** import (`AbstractUserDailyActivityLoader.IdInScope`) but **not** the **user** import — `ProductionGraphImportSectionFactory` builds `UserMetadataUpdater` without it. So the two populations differ, and "absent ⇒ inactive" would be a confident wrong answer about people nobody ever looked at.

When a group filter is configured the M365 workloads keep the old presence gate and the report explains why (`Notes.UsageReportsGroupFiltered`). Enforced in both paths: `@groupFiltered = 0` in SQL, `presenceGated` in the read model. New `LicenceActivitySources.UsageReportsGroupFiltered`, included in `CacheKey` and copied by `CachedLicenceActivityStore.Capture` so a cached snapshot can't leak across the two modes.

## Performance — a real regression was found here, and fixed

Covering every day instead of one Sunday in seven is ~7x more data. The first implementation cost far more than 7x, because of a **plan** problem rather than a volume one.

Both scorers joined the large usage table to the tiny `#Samples`/`#Weeks` temp tables by a **date range**:

```sql
JOIN #Samples AS chosen ON chosen.workload = N
 AND activity.[date] >= chosen.m365_from
 AND activity.[date] < chosen.end_exclusive
```

A non-equi join gives the optimiser no equality to hash on. The captured plan showed
`Nested Loops[[teams_user_activity_log]][[NCCI_teams_user_activity_log_metrics]]` — a nested loop
driving into the **nonclustered columnstore**, which cannot seek. Every covered week therefore
re-read the whole activity table.

Commit `7c8a3b25` matches the week by **equality** on a week start derived arithmetically from each
report row's own date, and collapses the per-user aggregate to two steps so
`COUNT(DISTINCT sample_date)` (which forced a spool that replayed the ~8.4M-row day-level stream)
becomes a plain `SUM`.

The join key is the week's true, **unclamped** Monday. `sample_date`, `m365_from` and `m365_to` are
all clamped to the requested period, so none of them can be derived from a report row's own date;
`week_start` can. The surrounding `@from`/`@endExclusive` predicate reproduces the clamping exactly,
so the row set is unchanged:
`date ∈ [week_start, week_start+6] ∧ date ∈ [@from, @to]  ≡  date ∈ [m365_from, end_exclusive)`.

### Measured

Synthetic 300k-user / 50-SKU harness: 8.44M rows per usage table, **180 imported days**, columnstore
mode (production ships the NCCI via `202608310800001_ColumnstoreUsageReportMetrics`; B-tree is only
the documented fallback). Measured on `LoadReadModelAsync` — the path the portal actually uses.

| Metric (Teams workload) | Before | After | Change |
|---|---|---|---|
| Logical reads | 35,024,453 | **447,751** | **78x fewer** |
| Read-model load, 7-day window | 34,540 ms | **16,519 ms** | 2.1x faster |
| Read-model load, 180-day window | 420,593 ms | **238,988 ms** | 1.8x faster |

Logical reads for the other three workloads moved the same way (Outlook 27.5M → 437,606;
OneDrive 26.8M → 417,360; SharePoint 26.5M → 417,220).

### Plan operators — why it got faster

Captured with `SET STATISTICS XML`, filtered to operators touching `teams_user_activity_log`:

| | Operators on `NCCI_teams_user_activity_log_metrics` |
|---|---|
| Before | `Index Scan`, **`Hash Match`**, **`Nested Loops`**, `Compute Scalar` |
| After | `Index Scan`, `Filter`, `Compute Scalar` |

The **`Nested Loops` driving into the nonclustered columnstore is gone**. A columnstore has no seek,
so each loop iteration re-scanned it; the scorer now makes a single pass. (The `Nested Loops` + `Top`
+ `Index Seek` that remain on the narrow `IX_date` index are the *coverage probe* — the
`OUTER APPLY ... TOP (1)` per day in `AppendM365Overview`, which is by design at most 180 single-row
seeks and is not the scorer.)

Before the fix the **7-day** window failed the HTTP acceptance matrix outright with
`ServiceUnavailable` ("Licence activity could not be loaded. Retry the request."). It now completes
in 6.7–8.0 s per workload.

**Environment caveat, stated plainly:** this is LocalDB on a shared, heavily contended developer box
(8 logical cores, ~92–100% CPU from other processes throughout). LocalDB is Express-class: **no
intra-query parallelism**, and the four M365 workloads run *concurrently*, so they serialise onto one
core. These elapsed figures are **diagnostic only and are not Azure SQL 200–400 DTU acceptance
evidence** — the harness's own docstring says so. Logical reads are the load-independent signal, and
that is the axis with the 78x improvement.

### Known remaining risk — reviewer decision needed

At the **180-day** window the four M365 workloads still hit the 20 s
`LicenceActivitySql.CommandTimeoutSeconds` on this harness (all four land at ~20.3 s together, which
is the signature of them serialising on a single core). The 7-day window passes comfortably.

Scope of that risk: `LicenceActivityQuery.MaximumDays` is 180, so 180 days is the **worst case an
admin can select**, not the normal one — the **default window is 28 days**
(`start = end.AddDays(-27)`). So the default page load sits near the measured-good end, and the
unproven case is an explicit opt-in to the maximum range.

I could not settle whether the 180-day timeout is a genuine production limit or an artefact of a
single-core, 4-way-concurrent, 100%-CPU box. A `dev` baseline **cannot** answer it either: on daily,
positive-only data `dev` bands almost nobody, so `LicenceActivityLoadTests` aborts with
*"do not benchmark an all-unknown shortcut"* — `dev` is fast because it is broken, not because it is
efficient (2,249 logical reads vs 447,751 for the same 7-day Teams query). Please treat the widest
reporting window as unproven at 300k users until it is measured on real Azure SQL.

## Migrations / config

None. No `Migrations/` change, no `Create DB.sql` change, no `CONFIG_VERSION` change. The new
`week_start` column is on the `#Samples` **temp** table only. `LicenceActivitySources.UsageReportsGroupFiltered`
is derived at request time from the existing `UserGroupsFilter` app setting; it is not persisted installer config.

Because there is no schema migration, the repo's "prove every schema change" gate does not formally
bind — but the before/after above is recorded here and in the code comments so the decision can be
re-checked.

## Reviewer hotspots

- `AppendM365Users` / `AppendM365OverviewScore` — the equality-join rewrite and its clamping argument.
- `LicenceActivityReadModel.Evidence` — the three-way split between presence-gated, measured-zero and partial.
- `CachedLicenceActivityStore.Capture` — a missed field here would silently serve the wrong mode from cache.
- `average_actions` is deliberately kept a **per-day** figure so the number an admin already knows doesn't silently become a weekly total. The rewrite preserves it exactly: the action expressions are `CAST(ISNULL(col,0) AS float) + ...`, so they are non-NULL floats and `AVG(x) ≡ SUM(x)/COUNT(*)`.

## Tests

`Tests.UnitTests` — **110 licence-activity tests pass**, and `test_dotnet (Release)` is green.

The scale/integration fixture seeded **one Sunday per week**, i.e. it modelled an import that only ever ran on Sundays — which this change (correctly) reports as unmeasured. `SeedOneUsageTable` now seeds **every day** of each week, and the 300k-user scale seed is now **daily and positive-only** (rows only for people active that day), matching what a healthy daily import leaves behind. `RetainedMarker` bumped so a stale retained scale DB can't be reused.

Renamed/added:
- `PerUserMissingRows_AreUnknownAndNeverLeastActive` → `PerUserMissingRows_AreMeasuredZeroWhileMissingReportDaysStayUnknown`
- **new** `AMissingReportDay_MakesItsWholeWeekUnknownForEveryone`
- **new** `AGroupFilteredUsageImport_LeavesUnmeasuredPeopleUnknownRatherThanInactive`
- `DistinctPinnedSampleCounts_...` → `DistinctWeeklyReadings_PreserveZeroDuplicatesAndExpectedBoundary`

Portal: `npm run build` (`tsc --noEmit` + `vite build`) clean. `bands.ts` copy updated to describe weeks.

## User-visible effect

Most people move from **Unknown** to a real band, and "No activity" becomes a real, common answer instead of a near-impossible one. Deployments that scope the import with `UserGroupsFilter` keep the old conservative behaviour plus an explanatory note.

Addresses the "everything is Unknown" report.
