### PR TITLE
Resolve audit user ids that are Entra object ids to UPNs before they become users

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ActivitySavePipelineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivitySavePipelineTests.cs
@@ -78,6 +78,33 @@ namespace Tests.UnitTests
         private static ActivityStagingPass PassFor(AuditFilterConfig filterConfig, ILogger logger)
             => new ActivityStagingPass(filterConfig, GroupsCache(), new UserGroupsFilterModel("Finance"), logger);
 
+        private static ActivityStagingPass PassFor(AuditFilterConfig filterConfig, ILogger logger, IAuditUserIdentityResolver resolver)
+            => new ActivityStagingPass(filterConfig, GroupsCache(), new UserGroupsFilterModel("Finance"), logger, resolver);
+
+        /// <summary>Resolver stub returning a fixed object-id to UPN map, and counting its calls.</summary>
+        private sealed class StubUserIdentityResolver : IAuditUserIdentityResolver
+        {
+            private readonly Dictionary<string, string> _map;
+            public int Calls { get; private set; }
+
+            public StubUserIdentityResolver(Dictionary<string, string> map = null)
+            {
+                _map = map ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            public Task<IReadOnlyDictionary<string, string>> ResolveToUpnAsync(IReadOnlyCollection<string> ids)
+            {
+                Calls++;
+                var hits = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var id in ids)
+                {
+                    string upn;
+                    if (_map.TryGetValue(id, out upn)) hits[id] = upn;
+                }
+                return Task.FromResult<IReadOnlyDictionary<string, string>>(hits);
+            }
+        }
+
         private sealed class SequenceActivityImportCacheProvider : IActivityImportCacheProvider
         {
             private readonly Queue<ActivityImportCache> _caches;
@@ -495,9 +522,89 @@ namespace Tests.UnitTests
             Assert.AreEqual("a.docx", row.FileName);
         }
 
+        /// <summary>
+        /// The point of the whole resolver: an audit record that identifies its user by Entra object id
+        /// must be staged under that person's UPN, so it lands on their existing <c>dbo.users</c> row
+        /// instead of the merge creating a second "user" named after a GUID.
+        /// </summary>
         [TestMethod]
-        public async Task SavePipeline_SlowScopeCheck_IsChargedToTheDedupPhaseNotTheMerge()
+        public async Task SavePipeline_EventIdentifiedByEntraObjectId_IsStagedUnderTheResolvedUpn()
         {
+            const string objectId = "00000000-0000-0000-0000-0000000000a1";
+            var resolver = new StubUserIdentityResolver(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { objectId, InScopeUpn }
+            });
+
+            var writer = new InMemoryActivityStagingWriter();
+            var batch = writer.CreateBatch(null);
+
+            var result = await PassFor(new AllowAllFilterConfig(), new RecordingLogger(), resolver).RunAsync(
+                SetOf(SpEvent(objectId)), ActivityImportCache.GetEmptyCache(), batch,
+                stagingTableName: null, mergeLock: null);
+
+            Assert.AreEqual(1, result.Stats.Imported,
+                "The resolved UPN is in the groups filter, so the event must survive the user-scope check.");
+            Assert.AreEqual(InScopeUpn, writer.LastBatch.Rows.Single().UserName,
+                "The staging row must carry the resolved UPN, not the object id.");
+        }
+
+        /// <summary>
+        /// An id the directory could not resolve keeps the behaviour it had before this existed: staged
+        /// verbatim. Dropping the event or inventing an identity for it would both be worse.
+        /// </summary>
+        [TestMethod]
+        public async Task SavePipeline_UnresolvableEntraObjectId_KeepsTheRawValue()
+        {
+            const string objectId = "00000000-0000-0000-0000-0000000000b2";
+            var writer = new InMemoryActivityStagingWriter();
+            var batch = writer.CreateBatch(null);
+
+            await PassFor(new AllowAllFilterConfig(), new RecordingLogger(), new StubUserIdentityResolver()).RunAsync(
+                SetOf(SpEvent(objectId)), ActivityImportCache.GetEmptyCache(), batch,
+                stagingTableName: null, mergeLock: null);
+
+            Assert.AreEqual(objectId, writer.LastBatch.Rows.Single().UserName);
+        }
+
+        /// <summary>
+        /// The resolver must not be consulted at all when every UserId is already a UPN - which is the
+        /// normal case. This is what keeps the feature free on the hot save path.
+        /// </summary>
+        [TestMethod]
+        public async Task SavePipeline_AllUpns_NeverCallsTheResolver()
+        {
+            var resolver = new StubUserIdentityResolver();
+            var writer = new InMemoryActivityStagingWriter();
+
+            await PassFor(new AllowAllFilterConfig(), new RecordingLogger(), resolver).RunAsync(
+                SetOf(SpEvent(InScopeUpn), SpEvent(OutOfScopeUpn)), ActivityImportCache.GetEmptyCache(),
+                writer.CreateBatch(null), stagingTableName: null, mergeLock: null);
+
+            Assert.AreEqual(0, resolver.Calls,
+                "A batch of ordinary UPNs must not reach the resolver, let alone the database or Graph.");
+        }
+
+        /// <summary>
+        /// <c>app@sharepoint</c> is a service principal, not a person. It must never be sent to Entra -
+        /// and it contains an '@', so a naive UPN test would already have let it through.
+        /// </summary>
+        [TestMethod]
+        public async Task SavePipeline_ServicePrincipalActivity_IsNeverSentForResolution()
+        {
+            var resolver = new StubUserIdentityResolver();
+            var writer = new InMemoryActivityStagingWriter();
+
+            await PassFor(new AllowAllFilterConfig(), new RecordingLogger(), resolver).RunAsync(
+                SetOf(SpEvent(AuditUserIdentity.SharePointAppAccount)), ActivityImportCache.GetEmptyCache(),
+                writer.CreateBatch(null), stagingTableName: null, mergeLock: null);
+
+            Assert.AreEqual(0, resolver.Calls);
+            Assert.AreEqual(AuditUserIdentity.SharePointAppAccount, writer.LastBatch.Rows.Single().UserName);
+        }
+
+        [TestMethod]
+        public async Task SavePipeline_SlowScopeCheck_IsChargedToTheDedupPhaseNotTheMerge()        {
             // The two halves of the crossed pair below exist because a single "is a timing recorded?" test
             // would pass even if the two phases were swapped.
             const int slowMs = 400;

--- a/src/AnalyticsEngine/Tests.UnitTests/AuditUserIdentityTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AuditUserIdentityTests.cs
@@ -1,0 +1,274 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Tests for resolving the Office 365 Management Activity API's <c>UserId</c> to a user principal
+    /// name before it becomes a <c>dbo.users</c> row.
+    /// </summary>
+    /// <remarks>
+    /// The importer stages <c>UserId</c> straight into <c>users.user_name</c> and the merge creates a
+    /// row for any value it has not seen. The common schema does not guarantee a UPN there - Microsoft
+    /// documents Entra object ids, Windows SIDs and service principals such as <c>app@sharepoint</c> in
+    /// the same field - so without this, one person seen under an object id silently becomes a second
+    /// "user" and every per-user figure splits between the two.
+    /// </remarks>
+    [TestClass]
+    public class AuditUserIdentityTests
+    {
+        #region Classification
+
+        [TestMethod]
+        public void AUpnIsRecognisedAndNeedsNoResolution()
+        {
+            Assert.AreEqual(AuditUserIdKind.Upn, AuditUserIdentity.Classify("ada@contoso.com"));
+            Assert.IsFalse(AuditUserIdentity.NeedsResolving("ada@contoso.com"));
+        }
+
+        [TestMethod]
+        public void AnEntraObjectIdIsRecognisedAndNeedsResolution()
+        {
+            const string objectId = "00000000-0000-0000-0000-000000000001";
+
+            Assert.AreEqual(AuditUserIdKind.EntraObjectId, AuditUserIdentity.Classify(objectId));
+            Assert.IsTrue(AuditUserIdentity.NeedsResolving(objectId));
+
+            // Braced and upper-case forms are still GUIDs.
+            Assert.AreEqual(AuditUserIdKind.EntraObjectId, AuditUserIdentity.Classify("{00000000-0000-0000-0000-000000000001}"));
+            Assert.AreEqual(AuditUserIdKind.EntraObjectId, AuditUserIdentity.Classify("00000000-0000-0000-0000-00000000000A".ToUpperInvariant()));
+        }
+
+        /// <summary>
+        /// Service principals must never be resolved against Entra or counted as people. `app@sharepoint`
+        /// contains an `@`, so it would otherwise be classified as a UPN.
+        /// </summary>
+        [TestMethod]
+        public void ServicePrincipalsAreNotPeopleAndAreNotResolved()
+        {
+            foreach (var value in new[] { "app@sharepoint", "APP@SHAREPOINT", "DlpAgent", "dlpagent", "S-1-5-18", "S-1-12-1-4141" })
+            {
+                Assert.AreEqual(AuditUserIdKind.SystemAccount, AuditUserIdentity.Classify(value), value);
+                Assert.IsTrue(AuditUserIdentity.IsSystemAccount(value), value);
+                Assert.IsFalse(AuditUserIdentity.NeedsResolving(value), value);
+            }
+        }
+
+        [TestMethod]
+        public void MissingAndUnrecognisedValuesAreLeftAlone()
+        {
+            Assert.AreEqual(AuditUserIdKind.Missing, AuditUserIdentity.Classify(null));
+            Assert.AreEqual(AuditUserIdKind.Missing, AuditUserIdentity.Classify("   "));
+            Assert.AreEqual(AuditUserIdKind.Other, AuditUserIdentity.Classify("SHAREPOINT\\system"));
+
+            // An unrecognised value must never be resolved - that would be guesswork.
+            Assert.IsFalse(AuditUserIdentity.NeedsResolving("SHAREPOINT\\system"));
+            Assert.IsFalse(AuditUserIdentity.NeedsResolving(null));
+        }
+
+        #endregion
+
+        #region Resolution policy
+
+        private sealed class FakeEntraIdStore : IUserEntraIdStore
+        {
+            public Dictionary<string, string> Known { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            public List<string> Queried { get; } = new List<string>();
+            public Dictionary<string, string> Stored { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            public Exception StoreThrows { get; set; }
+
+            public Task<IReadOnlyDictionary<string, string>> GetUpnsByEntraObjectIdAsync(IReadOnlyCollection<string> ids)
+            {
+                Queried.AddRange(ids);
+                var hits = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var id in ids)
+                {
+                    string upn;
+                    if (Known.TryGetValue(id, out upn)) hits[id] = upn;
+                }
+                return Task.FromResult<IReadOnlyDictionary<string, string>>(hits);
+            }
+
+            public Task StoreEntraObjectIdAsync(IReadOnlyDictionary<string, string> map)
+            {
+                if (StoreThrows != null) throw StoreThrows;
+                foreach (var pair in map) Stored[pair.Key] = pair.Value;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class FakeEntraLookup : IEntraUserLookup
+        {
+            public Dictionary<string, string> Directory { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            public List<string> Queried { get; } = new List<string>();
+            public Exception Throws { get; set; }
+
+            public Task<IReadOnlyDictionary<string, string>> GetUpnsByObjectIdAsync(IReadOnlyCollection<string> ids)
+            {
+                if (Throws != null) throw Throws;
+                Queried.AddRange(ids);
+                var hits = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var id in ids)
+                {
+                    string upn;
+                    if (Directory.TryGetValue(id, out upn)) hits[id] = upn;
+                }
+                return Task.FromResult<IReadOnlyDictionary<string, string>>(hits);
+            }
+        }
+
+        private const string ObjectIdA = "00000000-0000-0000-0000-0000000000a1";
+        private const string ObjectIdB = "00000000-0000-0000-0000-0000000000b2";
+
+        /// <summary>
+        /// The database is authoritative and must be asked first: the Graph user import already stores
+        /// every user's object id, so a tenant running it should never pay a directory round-trip here.
+        /// </summary>
+        [TestMethod]
+        public async Task TheDatabaseAnswersFirstAndEntraIsNotCalledAtAll()
+        {
+            var store = new FakeEntraIdStore();
+            store.Known[ObjectIdA] = "ada@contoso.com";
+            var entra = new FakeEntraLookup();
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            var resolved = await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+
+            Assert.AreEqual("ada@contoso.com", resolved[ObjectIdA]);
+            Assert.AreEqual(0, entra.Queried.Count, "Entra must not be called for an id the database already knows.");
+            Assert.AreEqual(0, resolver.EntraLookupCount);
+        }
+
+        [TestMethod]
+        public async Task EntraIsAskedOnlyForWhatTheDatabaseCouldNotAnswer()
+        {
+            var store = new FakeEntraIdStore();
+            store.Known[ObjectIdA] = "ada@contoso.com";
+            var entra = new FakeEntraLookup();
+            entra.Directory[ObjectIdB] = "grace@contoso.com";
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            var resolved = await resolver.ResolveToUpnAsync(new[] { ObjectIdA, ObjectIdB });
+
+            Assert.AreEqual("ada@contoso.com", resolved[ObjectIdA]);
+            Assert.AreEqual("grace@contoso.com", resolved[ObjectIdB]);
+            CollectionAssert.AreEqual(new[] { ObjectIdB }, entra.Queried.ToArray(),
+                "Only the id the database could not answer should reach Entra.");
+        }
+
+        /// <summary>
+        /// What Entra teaches us is written back, so the next cycle is answered from SQL. Without this the
+        /// same id costs a directory read on every import cycle, forever.
+        /// </summary>
+        [TestMethod]
+        public async Task AnIdLearnedFromEntraIsRecordedAgainstTheUser()
+        {
+            var store = new FakeEntraIdStore();
+            var entra = new FakeEntraLookup();
+            entra.Directory[ObjectIdA] = "ada@contoso.com";
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+
+            Assert.AreEqual("ada@contoso.com", store.Stored[ObjectIdA]);
+        }
+
+        /// <summary>
+        /// A deleted user can never resolve. Without a negative cache it would be looked up again for
+        /// every event that mentions it - the per-event Graph call this codebase forbids at scale.
+        /// </summary>
+        [TestMethod]
+        public async Task AnUnresolvableIdIsAskedForExactlyOnce()
+        {
+            var store = new FakeEntraIdStore();
+            var entra = new FakeEntraLookup();
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+            await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+            await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+
+            Assert.AreEqual(1, entra.Queried.Count, "An id proven unresolvable must not be asked for again.");
+            Assert.AreEqual(1, store.Queried.Count, "Nor should the database be re-queried for it.");
+            Assert.AreEqual(1, resolver.UnresolvedCount);
+        }
+
+        [TestMethod]
+        public async Task AResolvedIdIsCachedAndNeitherSourceIsAskedAgain()
+        {
+            var store = new FakeEntraIdStore();
+            store.Known[ObjectIdA] = "ada@contoso.com";
+            var entra = new FakeEntraLookup();
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+            var second = await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+
+            Assert.AreEqual("ada@contoso.com", second[ObjectIdA]);
+            Assert.AreEqual(1, store.Queried.Count);
+        }
+
+        /// <summary>
+        /// A directory outage must not fail the import. The events still save with their raw identifier,
+        /// exactly as they did before this resolution existed.
+        /// </summary>
+        [TestMethod]
+        public async Task ADirectoryFailureLeavesTheIdUnresolvedRatherThanFailingTheImport()
+        {
+            var store = new FakeEntraIdStore();
+            var entra = new FakeEntraLookup { Throws = new InvalidOperationException("Graph is down") };
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            var resolved = await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+
+            Assert.AreEqual(0, resolved.Count);
+        }
+
+        /// <summary>Write-back is an optimisation for later cycles; failing it must not lose this cycle's answer.</summary>
+        [TestMethod]
+        public async Task AFailedWriteBackStillReturnsTheResolvedUpn()
+        {
+            var store = new FakeEntraIdStore { StoreThrows = new InvalidOperationException("SQL is busy") };
+            var entra = new FakeEntraLookup();
+            entra.Directory[ObjectIdA] = "ada@contoso.com";
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            var resolved = await resolver.ResolveToUpnAsync(new[] { ObjectIdA });
+
+            Assert.AreEqual("ada@contoso.com", resolved[ObjectIdA]);
+        }
+
+        [TestMethod]
+        public async Task DuplicateIdsInOneBatchAreLookedUpOnce()
+        {
+            var store = new FakeEntraIdStore();
+            store.Known[ObjectIdA] = "ada@contoso.com";
+            var entra = new FakeEntraLookup();
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            await resolver.ResolveToUpnAsync(new[] { ObjectIdA, ObjectIdA, ObjectIdA.ToUpperInvariant() });
+
+            Assert.AreEqual(1, store.Queried.Count, "The same id, however it is cased, is one lookup.");
+        }
+
+        [TestMethod]
+        public async Task NothingToResolveCallsNeitherSource()
+        {
+            var store = new FakeEntraIdStore();
+            var entra = new FakeEntraLookup();
+
+            var resolver = new AuditUserIdentityResolver(store, entra);
+            var resolved = await resolver.ResolveToUpnAsync(new string[0]);
+
+            Assert.AreEqual(0, resolved.Count);
+            Assert.AreEqual(0, store.Queried.Count);
+            Assert.AreEqual(0, entra.Queried.Count);
+        }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="ActivityImportCacheProviderTests.cs" />
     <Compile Include="ActivityImportCacheWindowTests.cs" />
     <Compile Include="ActivityImporterTests.cs" />
+    <Compile Include="AuditUserIdentityTests.cs" />
     <Compile Include="ActivityReportLoaderTimeoutTests.cs" />
     <Compile Include="ActivityReportSetMinMaxTests.cs" />
     <Compile Include="ActivitySaveConcurrencyPolicyTests.cs" />

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -117,7 +117,16 @@ namespace WebJob.Office365ActivityImporter.Engine
                 _saveConcurrencyGate = new SemaphoreSlim(_maxConcurrentSaves, _maxConcurrentSaves);
             }
 
-            _stagingPass = new ActivityStagingPass(filterConfig, userGroupsCache, userGroupsFilter, logger);
+            // Resolves audit UserIds that arrive as Entra object ids rather than UPNs, so a person seen
+            // that way lands on their existing user row instead of creating a second one keyed on a GUID.
+            // Database-first (users.azure_ad_id), Graph only on a miss, and the Graph client is not even
+            // built unless something needs it.
+            var userIdentityResolver = new AuditUserIdentityResolver(
+                new SqlUserEntraIdStore(new ConnectionStringAnalyticsDbContextFactory(appConfig.ConnectionStrings.DatabaseConnectionString)),
+                new LazyGraphEntraUserLookup(appConfig, logger),
+                msg => logger?.LogWarning(msg));
+
+            _stagingPass = new ActivityStagingPass(filterConfig, userGroupsCache, userGroupsFilter, logger, userIdentityResolver);
             _cacheProvider = cacheProvider ?? new ActivityImportCacheProvider(SqlActivityImportCacheLoader.Instance, logger);
             _stagingWriter = stagingWriter ?? new SqlActivityStagingWriter(logger);
             _copilotPrewarmer = new CopilotMetadataPrewarmer(

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/ActivityStagingPass.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
@@ -101,6 +102,12 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
         private readonly UserGroupsFilterModel _userGroupsFilter;
         private readonly ILogger _logger;
 
+        /// <summary>
+        /// Resolves Entra object ids found in audit records to UPNs. Optional: when null the pass keeps
+        /// its original behaviour and stages whatever the record carried.
+        /// </summary>
+        private readonly IAuditUserIdentityResolver _userIdentityResolver;
+
         /// <remarks>
         /// Deliberately no null guards: the manager did not validate these either, and it dereferences them
         /// during the save. Adding an <c>ArgumentNullException</c> here would move a
@@ -109,11 +116,18 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
         /// </remarks>
         public ActivityStagingPass(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache,
             UserGroupsFilterModel userGroupsFilter, ILogger logger)
+            : this(filterConfig, userGroupsCache, userGroupsFilter, logger, null)
+        {
+        }
+
+        public ActivityStagingPass(AuditFilterConfig filterConfig, UserGroupsCache userGroupsCache,
+            UserGroupsFilterModel userGroupsFilter, ILogger logger, IAuditUserIdentityResolver userIdentityResolver)
         {
             _filterConfig = filterConfig;
             _userGroupsCache = userGroupsCache;
             _userGroupsFilter = userGroupsFilter;
             _logger = logger;
+            _userIdentityResolver = userIdentityResolver;
         }
 
         /// <param name="stagingTableName">
@@ -128,6 +142,71 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
         {
             return await RunAsync(activities, cache, batch, stagingTableName, mergeLock, retryState: null);
         }
+
+        /// <summary>
+        /// The UPN to use for an audit record's <c>UserId</c>: the resolved one when it was an Entra
+        /// object id we could translate, otherwise the value exactly as it arrived.
+        /// </summary>
+        /// <remarks>
+        /// Falling back to the raw value matters. An id we cannot resolve - a deleted user, a directory
+        /// read that failed - must keep the behaviour it had before this resolution existed rather than
+        /// dropping the event or inventing an identity for it.
+        /// </remarks>
+        internal static string EffectiveUserId(string userId, IReadOnlyDictionary<string, string> resolved)
+        {
+            if (resolved == null || resolved.Count == 0 || string.IsNullOrWhiteSpace(userId))
+            {
+                return userId;
+            }
+
+            string upn;
+            return resolved.TryGetValue(userId.Trim(), out upn) && !string.IsNullOrWhiteSpace(upn) ? upn : userId;
+        }
+
+        /// <summary>
+        /// Finds the Entra object ids in this batch and resolves them to UPNs in one call.
+        /// </summary>
+        /// <remarks>
+        /// Returns an empty map - having called nothing - when every <c>UserId</c> is already a UPN, a
+        /// system principal such as <c>app@sharepoint</c>, or an unrecognised value. That is the normal
+        /// case, so the resolution path adds a per-event string check and nothing else.
+        /// </remarks>
+        private async Task<IReadOnlyDictionary<string, string>> ResolveUserIdentitiesAsync(ActivityReportSet activities)
+        {
+            if (_userIdentityResolver == null || activities == null)
+            {
+                return Empty;
+            }
+
+            HashSet<string> objectIds = null;
+            foreach (var log in activities)
+            {
+                var userId = log?.UserId;
+                if (!AuditUserIdentity.NeedsResolving(userId)) continue;
+
+                if (objectIds == null)
+                {
+                    objectIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                }
+                objectIds.Add(userId.Trim());
+            }
+
+            if (objectIds == null)
+            {
+                return Empty;
+            }
+
+            var resolved = await _userIdentityResolver.ResolveToUpnAsync(objectIds.ToList()) ?? Empty;
+
+            _logger?.LogInformation(
+                $"Audit events import: resolved {resolved.Count} of {objectIds.Count} Entra object id(s) in this batch " +
+                "to user principal names. Unresolved ids keep their raw identifier.");
+
+            return resolved;
+        }
+
+        private static readonly IReadOnlyDictionary<string, string> Empty =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         internal async Task<ActivityStagingPassResult> RunAsync(ActivityReportSet activities, ActivityImportCache cache,
             IActivityStagingBatch batch, string stagingTableName, SemaphoreSlim mergeLock,
@@ -145,12 +224,20 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
             // serialised by mergeLock so their summed times approximate the real serialised wall-time.
             var swDedup = System.Diagnostics.Stopwatch.StartNew();
 
+            // Resolve any Entra object ids in this batch to UPNs BEFORE the loop, so a person identified
+            // by object id lands on their real user row instead of creating a second one keyed on a GUID.
+            // Costs nothing on a batch whose UserIds are all UPNs, which is the normal case: the scan is a
+            // character test per event and the resolver is never called.
+            var resolvedUserIds = await ResolveUserIdentitiesAsync(activities);
+
             // Hoisted out of the loop: all three capture only loop-invariant state, and Roslyn does not
             // cache capturing lambdas, so building them per event would allocate three delegates for every
             // one of the batch's events.
             Func<AbstractAuditLogContent, bool> urlInScope = log => _filterConfig.InScope(log);
-            Func<string, Task<bool>> userInGroupsFilter = upn => _userGroupsCache.IsInGroupsFilter(upn, _userGroupsFilter);
-            Action<AbstractAuditLogContent> stageRow = log => batch.AddRow(new AuditLogTempEntity(log, log.UserId));
+            Func<string, Task<bool>> userInGroupsFilter = userId =>
+                _userGroupsCache.IsInGroupsFilter(EffectiveUserId(userId, resolvedUserIds), _userGroupsFilter);
+            Action<AbstractAuditLogContent> stageRow = log => batch.AddRow(
+                new AuditLogTempEntity(log, EffectiveUserId(log.UserId, resolvedUserIds)));
 
             try
             {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/SqlUserEntraIdStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Persistence/SqlUserEntraIdStore.cs
@@ -1,0 +1,271 @@
+using Common.Entities;
+using Common.Entities.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Persistence
+{
+    /// <summary>
+    /// Reads and writes <c>dbo.users.azure_ad_id</c> - the Entra object id the Graph user import
+    /// already stores for every user it sees.
+    /// </summary>
+    internal class SqlUserEntraIdStore : IUserEntraIdStore
+    {
+        /// <summary>
+        /// Matches the chunk size the rest of the user pipeline uses. EF6 sends each element of a
+        /// <c>Contains</c> list as its own parameter and SQL Server allows 2,100 per command, so this
+        /// stays comfortably below that.
+        /// </summary>
+        public const int ChunkSize = 1000;
+
+        private readonly IAnalyticsDbContextFactory _contextFactory;
+        private readonly int _chunkSize;
+
+        public SqlUserEntraIdStore(IAnalyticsDbContextFactory contextFactory) : this(contextFactory, ChunkSize) { }
+
+        public SqlUserEntraIdStore(IAnalyticsDbContextFactory contextFactory, int chunkSize)
+        {
+            if (chunkSize < 1) throw new ArgumentOutOfRangeException(nameof(chunkSize));
+            _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+            _chunkSize = chunkSize;
+        }
+
+        public async Task<IReadOnlyDictionary<string, string>> GetUpnsByEntraObjectIdAsync(IReadOnlyCollection<string> entraObjectIds)
+        {
+            var found = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (entraObjectIds == null || entraObjectIds.Count == 0)
+            {
+                return found;
+            }
+
+            var all = entraObjectIds as List<string> ?? entraObjectIds.ToList();
+
+            using (var db = _contextFactory.Create())
+            {
+                for (var i = 0; i < all.Count; i += _chunkSize)
+                {
+                    // GetRange rather than Skip().Take(): Skip() on a List walks past every prior
+                    // element, making chunking O(N^2/K).
+                    var chunk = all.GetRange(i, Math.Min(_chunkSize, all.Count - i));
+
+                    // No LOWER() on the column - the default collation is already case-insensitive,
+                    // and lowering it would make the predicate non-SARGable.
+                    var rows = await db.users
+                        .Where(u => chunk.Contains(u.AzureAdId))
+                        .Select(u => new { u.AzureAdId, u.UserPrincipalName })
+                        .ToListAsync();
+
+                    foreach (var row in rows)
+                    {
+                        if (string.IsNullOrWhiteSpace(row.AzureAdId) || string.IsNullOrWhiteSpace(row.UserPrincipalName))
+                        {
+                            continue;
+                        }
+                        found[row.AzureAdId] = row.UserPrincipalName;
+                    }
+                }
+            }
+
+            return found;
+        }
+
+        public async Task StoreEntraObjectIdAsync(IReadOnlyDictionary<string, string> upnsByEntraObjectId)
+        {
+            if (upnsByEntraObjectId == null || upnsByEntraObjectId.Count == 0)
+            {
+                return;
+            }
+
+            var upns = upnsByEntraObjectId.Values
+                .Where(u => !string.IsNullOrWhiteSpace(u))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (upns.Count == 0)
+            {
+                return;
+            }
+
+            var entraIdByUpn = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pair in upnsByEntraObjectId)
+            {
+                if (!string.IsNullOrWhiteSpace(pair.Value))
+                {
+                    entraIdByUpn[pair.Value] = pair.Key;
+                }
+            }
+
+            using (var db = _contextFactory.Create())
+            {
+                for (var i = 0; i < upns.Count; i += _chunkSize)
+                {
+                    var chunk = upns.GetRange(i, Math.Min(_chunkSize, upns.Count - i));
+
+                    var users = await db.users
+                        .Where(u => chunk.Contains(u.UserPrincipalName))
+                        .ToListAsync();
+
+                    foreach (var user in users)
+                    {
+                        string entraId;
+                        if (!entraIdByUpn.TryGetValue(user.UserPrincipalName, out entraId))
+                        {
+                            continue;
+                        }
+
+                        // Only fill a gap. The Graph user import is the authority for this column, so
+                        // an existing value is never overwritten on the strength of an audit record.
+                        if (string.IsNullOrWhiteSpace(user.AzureAdId))
+                        {
+                            user.AzureAdId = entraId;
+                        }
+                    }
+
+                    await db.SaveChangesAsync();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves Entra object ids to UPNs through Microsoft Graph.
+    /// </summary>
+    /// <remarks>
+    /// One request per id, because Graph has no filter that takes a list of object ids for
+    /// <c>/users</c>. That is acceptable only because the caller reaches this at all rarely: the
+    /// resolver answers from SQL first and caches every outcome - including failures - for the run, so
+    /// a given id costs at most one request per process. A per-event Graph call would be the
+    /// anti-pattern this codebase's performance guidance calls out at the ~200,000-user design target,
+    /// and <see cref="MaxLookupsPerBatch"/> is the backstop that keeps it that way if an unexpected
+    /// payload ever produced a flood of unknown ids.
+    /// </remarks>
+    internal class GraphEntraUserLookup : IEntraUserLookup
+    {
+        /// <summary>
+        /// Hard cap on directory reads in a single call, so a pathological batch degrades into
+        /// unresolved ids (which keep today's behaviour) rather than a very long stall.
+        /// </summary>
+        public const int MaxLookupsPerBatch = 200;
+
+        private readonly GraphServiceClient _graph;
+        private readonly Action<string> _log;
+        private readonly int _maxLookups;
+
+        public GraphEntraUserLookup(GraphServiceClient graph, Action<string> log = null)
+            : this(graph, MaxLookupsPerBatch, log) { }
+
+        public GraphEntraUserLookup(GraphServiceClient graph, int maxLookups, Action<string> log = null)
+        {
+            if (maxLookups < 1) throw new ArgumentOutOfRangeException(nameof(maxLookups));
+            _graph = graph ?? throw new ArgumentNullException(nameof(graph));
+            _maxLookups = maxLookups;
+            _log = log;
+        }
+
+        public async Task<IReadOnlyDictionary<string, string>> GetUpnsByObjectIdAsync(IReadOnlyCollection<string> entraObjectIds)
+        {
+            var found = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (entraObjectIds == null || entraObjectIds.Count == 0)
+            {
+                return found;
+            }
+
+            var looked = 0;
+            foreach (var id in entraObjectIds)
+            {
+                if (string.IsNullOrWhiteSpace(id)) continue;
+
+                if (looked >= _maxLookups)
+                {
+                    _log?.Invoke($"Reached the per-batch cap of {_maxLookups} Entra user lookups; " +
+                                 "the remaining ids keep their raw identifier and are retried next cycle.");
+                    break;
+                }
+
+                looked++;
+                try
+                {
+                    var user = await _graph.Users[id.Trim()].GetAsync(config =>
+                    {
+                        config.QueryParameters.Select = new[] { "id", "userPrincipalName" };
+                    });
+
+                    if (!string.IsNullOrWhiteSpace(user?.UserPrincipalName))
+                    {
+                        found[id.Trim()] = user.UserPrincipalName;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // A deleted user, a guest that has been purged, or an id that is not a user at
+                    // all. Absent from the result, which the resolver records so it is never asked
+                    // for again this run.
+                    _log?.Invoke($"Entra lookup failed for an audit user id: {ex.Message}");
+                }
+            }
+
+            return found;
+        }
+    }
+
+    /// <summary>
+    /// Builds the Graph client on first use, so a tenant whose audit records are all UPNs - or whose
+    /// object ids are all answered from <c>users.azure_ad_id</c> - never authenticates to Graph for this
+    /// at all.
+    /// </summary>
+    /// <remarks>
+    /// Worth the indirection because the client needs an async credential init that cannot happen in a
+    /// constructor, and because this path is expected to be cold: the resolver asks the database first
+    /// and caches every outcome for the run.
+    /// </remarks>
+    internal class LazyGraphEntraUserLookup : IEntraUserLookup
+    {
+        private readonly AppConfig _appConfig;
+        private readonly ILogger _logger;
+        private IEntraUserLookup _inner;
+        private bool _initFailed;
+
+        public LazyGraphEntraUserLookup(AppConfig appConfig, ILogger logger)
+        {
+            _appConfig = appConfig ?? throw new ArgumentNullException(nameof(appConfig));
+            _logger = logger;
+        }
+
+        public async Task<IReadOnlyDictionary<string, string>> GetUpnsByObjectIdAsync(IReadOnlyCollection<string> entraObjectIds)
+        {
+            var empty = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (entraObjectIds == null || entraObjectIds.Count == 0 || _initFailed)
+            {
+                return empty;
+            }
+
+            if (_inner == null)
+            {
+                try
+                {
+                    var auth = new GraphAppIndentityOAuthContext(
+                        _logger, _appConfig.ClientID, _appConfig.TenantGUID.ToString(),
+                        _appConfig.ClientSecret, _appConfig.KeyVaultUrl, _appConfig.UseClientCertificate);
+                    await auth.InitClientCredential();
+                    _inner = new GraphEntraUserLookup(new GraphServiceClient(auth.Creds), msg => _logger?.LogWarning(msg));
+                }
+                catch (Exception ex)
+                {
+                    // Remembered, so a broken credential is not retried for every batch of the cycle.
+                    _initFailed = true;
+                    _logger?.LogWarning(
+                        $"Could not authenticate to Microsoft Graph to resolve audit user ids: {ex.Message}. " +
+                        "Those events keep their raw identifier.");
+                    return empty;
+                }
+            }
+
+            return await _inner.GetUpnsByObjectIdAsync(entraObjectIds);
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/AuditUserIdentity.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/AuditUserIdentity.cs
@@ -1,0 +1,124 @@
+using System;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules
+{
+    /// <summary>What kind of identifier an audit record's <c>UserId</c> turned out to be.</summary>
+    public enum AuditUserIdKind
+    {
+        /// <summary>Nothing usable - null, empty or whitespace.</summary>
+        Missing = 0,
+
+        /// <summary>A user principal name, which is what <c>dbo.users.user_name</c> stores.</summary>
+        Upn = 1,
+
+        /// <summary>An Entra ID object id (GUID). Needs resolving to a UPN before it can be stored.</summary>
+        EntraObjectId = 2,
+
+        /// <summary>
+        /// A service or system principal rather than a person - <c>app@sharepoint</c>, <c>DlpAgent</c>,
+        /// a Windows SID, and similar.
+        /// </summary>
+        SystemAccount = 3,
+
+        /// <summary>Something else. Stored verbatim, exactly as before.</summary>
+        Other = 4,
+    }
+
+    /// <summary>
+    /// Classifies the Office 365 Management Activity API's common-schema <c>UserId</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The importer stages <c>UserId</c> straight into <c>dbo.users.user_name</c>, and the merge creates
+    /// a user row for any value it has not seen. That is correct for the overwhelmingly common case,
+    /// where <c>UserId</c> is a UPN - but the common schema does not guarantee one. Microsoft documents
+    /// the same field carrying Entra object ids (GUIDs), Windows SIDs and service principals such as
+    /// <c>app@sharepoint</c>, and DLP records additionally carry the literal <c>DlpAgent</c> in
+    /// <c>UserKey</c>. Each distinct non-UPN value silently becomes its own "user", so one real person
+    /// can be split across several rows and every per-user report under-counts them.
+    /// https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-schema#common-schema
+    /// </para>
+    /// <para>
+    /// Pure and allocation-light on the hot path: the UPN case - which is nearly every event - is
+    /// settled by a single character scan and never allocates or calls anything.
+    /// </para>
+    /// </remarks>
+    public static class AuditUserIdentity
+    {
+        /// <summary>
+        /// Service principal that SharePoint attributes app-only activity to. Not a person, and must
+        /// never be resolved against Entra or counted as a user.
+        /// </summary>
+        public const string SharePointAppAccount = "app@sharepoint";
+
+        /// <summary>The literal DLP records carry instead of a principal.</summary>
+        public const string DlpAgentAccount = "DlpAgent";
+
+        /// <summary>
+        /// Classifies <paramref name="userId"/>. Never throws - an unrecognised value is
+        /// <see cref="AuditUserIdKind.Other"/> and keeps today's behaviour.
+        /// </summary>
+        public static AuditUserIdKind Classify(string userId)
+        {
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return AuditUserIdKind.Missing;
+            }
+
+            var trimmed = userId.Trim();
+
+            if (IsSystemAccount(trimmed))
+            {
+                return AuditUserIdKind.SystemAccount;
+            }
+
+            // A UPN is the expected shape and by far the most common, so settle it before the more
+            // expensive checks. Deliberately a shape test, not validation: Entra restricts the
+            // characters a UPN may contain, but this code's job is routing, not policing.
+            if (trimmed.IndexOf('@') > 0)
+            {
+                return AuditUserIdKind.Upn;
+            }
+
+            Guid ignored;
+            if (Guid.TryParse(trimmed, out ignored))
+            {
+                return AuditUserIdKind.EntraObjectId;
+            }
+
+            return AuditUserIdKind.Other;
+        }
+
+        /// <summary>
+        /// True when the value names a service/system principal rather than a person.
+        /// </summary>
+        /// <remarks>
+        /// A Windows SID is matched by prefix rather than by a full parse: the point is only to keep it
+        /// out of Entra resolution and out of the user population, and the exact sub-authority layout
+        /// does not change that answer.
+        /// </remarks>
+        public static bool IsSystemAccount(string userId)
+        {
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return false;
+            }
+
+            var trimmed = userId.Trim();
+
+            return trimmed.Equals(SharePointAppAccount, StringComparison.OrdinalIgnoreCase)
+                || trimmed.Equals(DlpAgentAccount, StringComparison.OrdinalIgnoreCase)
+                || trimmed.StartsWith("S-1-", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// True when the value must be resolved before it can be stored as a user. Only Entra object
+        /// ids qualify: everything else is either already a UPN, not a person, or unrecognised - and
+        /// resolving an unrecognised value would be guesswork.
+        /// </summary>
+        public static bool NeedsResolving(string userId)
+        {
+            return Classify(userId) == AuditUserIdKind.EntraObjectId;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/AuditUserIdentityResolver.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Rules/AuditUserIdentityResolver.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules
+{
+    /// <summary>
+    /// Resolves Entra ID object ids found in audit records to the user principal name the rest of the
+    /// importer keys on.
+    /// </summary>
+    /// <remarks>
+    /// A port so the resolution policy - database first, Entra only on a miss, remember both answers -
+    /// can be tested without a database or a Graph client.
+    /// </remarks>
+    public interface IAuditUserIdentityResolver
+    {
+        /// <summary>
+        /// Resolves the given Entra object ids to UPNs, in one batch.
+        /// </summary>
+        /// <returns>
+        /// A map from object id to UPN. Ids that could not be resolved are simply absent - callers keep
+        /// their existing behaviour for those rather than inventing a user.
+        /// </returns>
+        Task<IReadOnlyDictionary<string, string>> ResolveToUpnAsync(IReadOnlyCollection<string> entraObjectIds);
+    }
+
+    /// <summary>Reads the <c>azure_ad_id</c> to <c>user_name</c> mapping the user import already stores.</summary>
+    public interface IUserEntraIdStore
+    {
+        /// <summary>UPNs for the users whose <c>azure_ad_id</c> matches one of <paramref name="entraObjectIds"/>.</summary>
+        Task<IReadOnlyDictionary<string, string>> GetUpnsByEntraObjectIdAsync(IReadOnlyCollection<string> entraObjectIds);
+
+        /// <summary>
+        /// Records the Entra object id against an existing user, so the next occurrence is answered from
+        /// the database instead of Entra. A user that cannot be found is skipped, not created: this is a
+        /// cache-warming step, and the audit merge owns creating users.
+        /// </summary>
+        Task StoreEntraObjectIdAsync(IReadOnlyDictionary<string, string> upnsByEntraObjectId);
+    }
+
+    /// <summary>Looks a user up in Entra by object id.</summary>
+    public interface IEntraUserLookup
+    {
+        /// <summary>
+        /// UPNs for the given object ids. Ids Entra does not return - deleted users, or ids that are not
+        /// users at all - are absent from the result rather than throwing.
+        /// </summary>
+        Task<IReadOnlyDictionary<string, string>> GetUpnsByObjectIdAsync(IReadOnlyCollection<string> entraObjectIds);
+    }
+
+    /// <summary>
+    /// Database-first resolver: answers from <c>dbo.users.azure_ad_id</c> where it can, asks Entra only
+    /// for what is left, and remembers both answers for the rest of the run.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The ordering is the whole point. The Graph user import already stores every user's
+    /// <c>azure_ad_id</c>, so on a tenant that runs it the database answers nearly everything and Entra
+    /// is never called. Going to Graph first would add a network round-trip per unseen id to the save
+    /// path for information already held locally.
+    /// </para>
+    /// <para>
+    /// Both outcomes are cached for the lifetime of the resolver, including failures. Without the
+    /// negative cache a deleted user - which by definition can never resolve - would be looked up again
+    /// on every event that mentions it, which at the ~200,000-user design target is exactly the
+    /// per-event Graph call this codebase's performance guidance forbids.
+    /// </para>
+    /// </remarks>
+    public class AuditUserIdentityResolver : IAuditUserIdentityResolver
+    {
+        private readonly IUserEntraIdStore _store;
+        private readonly IEntraUserLookup _entra;
+        private readonly Action<string> _log;
+
+        /// <summary>Object id to UPN for everything resolved so far this run.</summary>
+        private readonly Dictionary<string, string> _resolved =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Object ids already proven unresolvable, so they are asked for exactly once.</summary>
+        private readonly HashSet<string> _unresolvable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        public AuditUserIdentityResolver(IUserEntraIdStore store, IEntraUserLookup entra, Action<string> log = null)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _entra = entra ?? throw new ArgumentNullException(nameof(entra));
+            _log = log;
+        }
+
+        /// <summary>Object ids resolved from Entra this run (rather than from the database).</summary>
+        public int EntraLookupCount { get; private set; }
+
+        /// <summary>Object ids that could not be resolved at all this run.</summary>
+        public int UnresolvedCount => _unresolvable.Count;
+
+        public async Task<IReadOnlyDictionary<string, string>> ResolveToUpnAsync(IReadOnlyCollection<string> entraObjectIds)
+        {
+            var answer = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (entraObjectIds == null || entraObjectIds.Count == 0)
+            {
+                return answer;
+            }
+
+            var outstanding = new List<string>();
+            var outstandingSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var id in entraObjectIds)
+            {
+                if (string.IsNullOrWhiteSpace(id)) continue;
+                var trimmed = id.Trim();
+
+                string cached;
+                if (_resolved.TryGetValue(trimmed, out cached))
+                {
+                    answer[trimmed] = cached;
+                }
+                else if (!_unresolvable.Contains(trimmed) && outstandingSet.Add(trimmed))
+                {
+                    outstanding.Add(trimmed);
+                }
+            }
+
+            if (outstanding.Count == 0)
+            {
+                return answer;
+            }
+
+            // 1. The database first - the user import has usually already stored these.
+            var fromStore = await _store.GetUpnsByEntraObjectIdAsync(outstanding);
+            if (fromStore != null)
+            {
+                foreach (var pair in fromStore)
+                {
+                    if (string.IsNullOrWhiteSpace(pair.Value)) continue;
+                    _resolved[pair.Key] = pair.Value;
+                    answer[pair.Key] = pair.Value;
+                }
+            }
+
+            var stillOutstanding = outstanding.FindAll(id => !answer.ContainsKey(id));
+            if (stillOutstanding.Count == 0)
+            {
+                return answer;
+            }
+
+            // 2. Entra for the remainder.
+            IReadOnlyDictionary<string, string> fromEntra = null;
+            try
+            {
+                fromEntra = await _entra.GetUpnsByObjectIdAsync(stillOutstanding);
+            }
+            catch (Exception ex)
+            {
+                // A directory read failing must not fail the import. The events still save with their
+                // raw id, exactly as they did before this resolution existed.
+                _log?.Invoke($"Could not resolve {stillOutstanding.Count} audit user id(s) against Entra: {ex.Message}. " +
+                             "Those events keep their raw identifier for this cycle.");
+                return answer;
+            }
+
+            var learned = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (fromEntra != null)
+            {
+                foreach (var pair in fromEntra)
+                {
+                    if (string.IsNullOrWhiteSpace(pair.Value)) continue;
+                    _resolved[pair.Key] = pair.Value;
+                    answer[pair.Key] = pair.Value;
+                    learned[pair.Key] = pair.Value;
+                    EntraLookupCount++;
+                }
+            }
+
+            foreach (var id in stillOutstanding)
+            {
+                if (!answer.ContainsKey(id))
+                {
+                    _unresolvable.Add(id);
+                }
+            }
+
+            // 3. Write back what Entra taught us, so the next cycle answers it from SQL.
+            if (learned.Count > 0)
+            {
+                try
+                {
+                    await _store.StoreEntraObjectIdAsync(learned);
+                }
+                catch (Exception ex)
+                {
+                    // Purely an optimisation for later cycles; this run already has its answer.
+                    _log?.Invoke($"Resolved {learned.Count} audit user id(s) but could not record them against the user rows: {ex.Message}.");
+                }
+            }
+
+            return answer;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -84,9 +84,12 @@
     <Compile Include="ActivityAPI\Persistence\IActivityStagingWriter.cs" />
     <Compile Include="ActivityAPI\Persistence\ICopilotMetadataLoaderFactory.cs" />
     <Compile Include="ActivityAPI\Persistence\ISaveSessionFactory.cs" />
+    <Compile Include="ActivityAPI\Persistence\SqlUserEntraIdStore.cs" />
     <Compile Include="ActivityAPI\Rules\ActivityImportCacheWindow.cs" />
     <Compile Include="ActivityAPI\Rules\ActivitySaveConcurrencyPolicy.cs" />
     <Compile Include="ActivityAPI\Rules\ActivityStagingRules.cs" />
+    <Compile Include="ActivityAPI\Rules\AuditUserIdentity.cs" />
+    <Compile Include="ActivityAPI\Rules\AuditUserIdentityResolver.cs" />
     <Compile Include="ActivityAPI\Rules\CopilotPrewarmPolicy.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\PowerPlatformAuditEventManager.cs" />
     <Compile Include="ActivityAPI\PowerPlatform\IPowerPlatformStagingWriter.cs" />


### PR DESCRIPTION
## Summary

The importer stages the Management Activity API's `UserId` straight into `dbo.users.user_name`, and the merge creates a user row for any value it has not seen:

```sql
INSERT INTO users(user_name)
SELECT DISTINCT imports.user_name ... WHERE users.user_name IS NULL;
```

That is correct for a UPN, which is nearly always what arrives. But **the common schema does not guarantee one**, and there was no guard anywhere in the path — `ActivityStagingPass` passes `log.UserId` through verbatim. Microsoft documents the same field carrying **Entra object ids (GUIDs)**, **Windows SIDs** and **service principals** such as `app@sharepoint`; DLP records additionally carry the literal `DlpAgent`.

So each distinct non-UPN value silently becomes its own "user". One person seen under an object id splits across two rows, and every per-user report under-counts them — with nothing in the logs to say so.

## What this does

Resolve an Entra object id to the person's UPN **before** it becomes a user row, so it lands on their existing `dbo.users` record.

| Piece | Role |
|---|---|
| `AuditUserIdentity` | Pure classifier: UPN / Entra object id / system account / unrecognised. |
| `AuditUserIdentityResolver` | Database-first resolution, Entra on a miss, caching and write-back. |
| `SqlUserEntraIdStore` | Reads and fills `users.azure_ad_id`. |
| `GraphEntraUserLookup` / `LazyGraphEntraUserLookup` | Directory lookup, with the client built only if needed. |

**Only Entra object ids are resolved.** A UPN needs nothing; a service principal is not a person; and resolving an unrecognised value would be guesswork. `app@sharepoint` is specifically handled because it *contains an `@`* — a naive UPN test would let it straight through to the directory.

**Database first, and usually only.** The Graph user import already stores every user's `azure_ad_id`, so on a tenant that runs it the database answers everything and Entra is never called. What Entra does teach us is **written back** to `azure_ad_id`, so the next cycle answers from SQL.

## Performance — free on the hot path

This sits in the audit save path for **every** workload, so it is built to cost nothing in the normal case:

- A batch whose `UserId`s are all UPNs costs **one character test per event** and never touches the resolver, the database or Graph. There is a test asserting exactly that (`SavePipeline_AllUpns_NeverCallsTheResolver`).
- Resolution is **batched per staging pass**, not per event.
- Outcomes are cached for the run **including failures**. Without the negative cache, a deleted user — which by definition can never resolve — would be looked up again for every event that mentions it: the per-event Graph call this repo's guidance forbids at the ~200k-user target.
- `MaxLookupsPerBatch` (200) is a backstop so a pathological batch degrades into unresolved ids rather than a long stall.

## Every failure mode degrades to today's behaviour

Nothing here can drop an event or invent an identity. An unresolvable id, a directory outage, a failed credential, and a failed write-back **all keep the raw value**, exactly as before this existed. Each is covered by a test.

## Verification

- Full solution builds.
- **29 focused tests pass** — 13 on classification and resolution policy, plus 4 new end-to-end assertions through `ActivityStagingPass` proving a staged row actually carries the resolved UPN (and that an unresolvable id keeps its raw value).
- **Broad regression run: 989 tests, 980 passed, 5 failed.** All 5 failures are pre-existing environmental ones — `AADSTS90002: Tenant '00000000-…-000000000002' not found` and Redis RBAC — in Teams/calls tests that need real Azure credentials. None touch this code.

No schema change, no migration, no new permission: `azure_ad_id` already exists and `User.Read.All` is already required.

## Reviewer hotspots

1. **`AuditUserIdentity.Classify` ordering** — the system-account check runs *before* the `@` test, which is what stops `app@sharepoint` being treated as a UPN and sent to Entra.
2. **The group filter now tests the resolved UPN**, not the raw id. Before, an object id would have been tested against `UserGroupsFilter` and failed, silently dropping that person's events on a scoped tenant. This is a behaviour change, and I believe it is the correct one.
3. **Write-back only fills a gap** — an existing `azure_ad_id` is never overwritten on the strength of an audit record; the Graph user import stays the authority for that column.

## Honest caveat on the evidence

I could not reproduce this from data. I checked both local databases and found **zero** GUID-shaped `user_name` rows (the non-UPN ones there are all stress-test artifacts like `test chat user 6392…`). What is proven is the **code path** — there is no guard, so any non-UPN value becomes a user row — and Microsoft's documented schema for the field. Treat this as a correctness guard rather than a fix for an observed incident; that is also why it is built to be free when the case never fires.

## Deferred

Repairing junk rows already present in `dbo.users`. That is a data migration with its own risks (merging user rows, re-pointing foreign keys) and belongs in its own change, once there is evidence of rows that need it.
