### PR TITLE
Use Microsoft Entra ID for Azure SQL when SQL authentication is disabled

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ConfigureAzureComponentsTasks.cs" />
     <Compile Include="InstallerTasks\JobTasks\RunbookCreateOrUpdateTasks.cs" />
     <Compile Include="InstallerTasks\ResourceSecurityInstallJob.cs" />
+    <Compile Include="InstallerTasks\SqlIdentityAccessTask.cs" />
     <Compile Include="InstallerTasks\RunbooksInstallJob.cs" />
     <Compile Include="Models\AzStorageConnectionInfo.cs" />
     <Compile Include="SolutionUninstaller.cs" />
@@ -122,6 +123,7 @@
     <Compile Include="SolutionInstaller.cs" />
     <Compile Include="Models\AzureSubscription.cs" />
     <Compile Include="Models\DatabasePaaSInfo.cs" />
+    <Compile Include="Models\SqlServerAuthDetection.cs" />
     <Compile Include="Models\Exceptions.cs" />
     <Compile Include="Models\Config\InstallerProxyConfig.cs" />
     <Compile Include="Models\Config\InstallTasksConfig.cs" />

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
@@ -1,6 +1,8 @@
 ﻿using App.ControlPanel.Engine.Entities;
 using App.ControlPanel.Engine.Models;
+using Azure.Identity;
 using CloudInstallEngine.Azure;
+using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -21,6 +23,29 @@ namespace App.ControlPanel.Engine
             // Tee everything logged during the install into _installLogEvents so the full log can be
             // registered into sys_configs.messages, while still forwarding to the on-screen logger.
             _logger = new InstallLogCapturingLogger(logger, _installLogEvents);
+
+            RegisterEntraSqlCredential(config);
+        }
+
+        /// <summary>
+        /// Makes the installer's own service principal available for Microsoft Entra ID authentication to
+        /// Azure SQL. Needed because the installer runs on an operator's machine, which has no managed
+        /// identity, and because it is the principal the installer assigns as the SQL server's Entra
+        /// administrator. Harmless when the database still uses SQL authentication: the credential is only
+        /// consulted for a connection string that carries no login. See issue #117.
+        /// </summary>
+        static void RegisterEntraSqlCredential(SolutionInstallConfig config)
+        {
+            var account = config?.InstallerAccount;
+            if (account == null
+                || string.IsNullOrWhiteSpace(account.DirectoryId)
+                || string.IsNullOrWhiteSpace(account.ClientId)
+                || string.IsNullOrWhiteSpace(account.Secret))
+            {
+                return;
+            }
+
+            AzureSqlTokenAuth.SetCredential(new ClientSecretCredential(account.DirectoryId, account.ClientId, account.Secret));
         }
 
         protected List<InstallLogEventArgs> _installLogEvents = new List<InstallLogEventArgs>();
@@ -182,7 +207,23 @@ namespace App.ControlPanel.Engine
         /// <summary>Opens a connection and runs a trivial query. Returns the SqlException rather than logging it.</summary>
         async Task<(bool ok, SqlException error)> TrySqlConnection(string connectionString)
         {
-            using (var conn = new SqlConnection(connectionString))
+            // AzureSqlTokenAuth attaches a Microsoft Entra ID access token when the connection string has
+            // no user id/password - i.e. when the server has SQL authentication disabled. For every
+            // existing SQL-authentication deployment this behaves exactly like new SqlConnection(). See #117.
+            SqlConnection conn;
+            try
+            {
+                conn = AzureSqlTokenAuth.CreateConnection(connectionString);
+            }
+            catch (Exception ex)
+            {
+                // Token acquisition failed, so there is no SqlException to report. Say what actually went
+                // wrong rather than letting an unrelated-looking exception escape to the generic handler.
+                _logger.LogError("Could not authenticate to Azure SQL with Microsoft Entra ID: " + ex.Message);
+                return (false, null);
+            }
+
+            using (conn)
             {
                 try
                 {

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -79,6 +79,7 @@ namespace App.ControlPanel.Engine
             if (sqlReachable && dbInfo.AuthMethod == SqlConnectionAuthMethod.EntraId)
             {
                 await GrantAppServiceDatabaseAccess(webApp, dbInfo);
+                await GrantAutomationAccountDatabaseAccess(automationAccount, dbInfo);
             }
 
             // Find downloaded installer app
@@ -205,6 +206,48 @@ namespace App.ControlPanel.Engine
                 current.Data.Name,
                 principalId.Value,
                 SqlContainedUserScript.AppServiceRoles);
+        }
+
+        /// <summary>
+        /// Grants the Automation account's managed identity access to the analytics database.
+        /// </summary>
+        /// <remarks>
+        /// The Graph usage-report maintenance runbooks connect to the database directly. With SQL
+        /// authentication they use the stored "SQLCredential"; with Microsoft Entra ID there is no
+        /// credential to store, so they authenticate as the Automation account and need a contained user.
+        /// They run Ola Hallengren's IndexOptimize and create/drop objects in the profiling schema, so
+        /// db_owner is the role that actually covers what they do. See issue #117.
+        /// </remarks>
+        private async Task GrantAutomationAccountDatabaseAccess(AutomationAccountResource automationAccount, DatabasePaaSInfo dbInfo)
+        {
+            if (automationAccount == null) return;
+
+            AutomationAccountResource current;
+            try
+            {
+                current = await automationAccount.GetAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not re-read the Automation account to find its managed identity: {ex.Message}");
+                current = automationAccount;
+            }
+
+            var principalId = current?.Data?.Identity?.PrincipalId;
+            if (principalId == null || principalId == Guid.Empty)
+            {
+                _logger.LogWarning(
+                    "The Automation account has no system-assigned managed identity, so the Graph usage-report maintenance " +
+                    "runbooks will not be able to connect to a database that has SQL authentication disabled.");
+                return;
+            }
+
+            var task = new SqlIdentityAccessTask(_logger);
+            await task.GrantDatabaseAccessAsync(
+                dbInfo.ConnectionString,
+                current.Data.Name,
+                principalId.Value,
+                new[] { "db_owner" });
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -72,6 +72,15 @@ namespace App.ControlPanel.Engine
                     "Fix the connectivity problem reported above and re-run the installer.");
             }
 
+            // Give the App Service's managed identity access to the database. Only needed when the database
+            // authenticates with Microsoft Entra ID - a SQL-authentication deployment already has its login
+            // in the connection string, and creating a redundant contained user there would be noise. Done
+            // BEFORE the schema upgrade so the site comes back up with working access. See issue #117.
+            if (sqlReachable && dbInfo.AuthMethod == SqlConnectionAuthMethod.EntraId)
+            {
+                await GrantAppServiceDatabaseAccess(webApp, dbInfo);
+            }
+
             // Find downloaded installer app
             var installerExeFile = GetInstallerExe(solutionSources.GetSolutionComponentLocation(SoftwareComponent.ControlPanel));
 
@@ -152,6 +161,50 @@ namespace App.ControlPanel.Engine
                     _logger.LogInformation("Skipping SharePoint web components (AITracker / SPFx) install because 'Update solution with latest release' is not selected.");
                 }
             }
+        }
+
+        /// <summary>
+        /// Grants the App Service's system-assigned managed identity access to the analytics database.
+        /// </summary>
+        /// <remarks>
+        /// Azure SQL has no ARM role that confers data-plane access, so "give the App Service its own
+        /// permissions" means creating a contained database user for its identity - which is why this is a
+        /// T-SQL step rather than another role assignment in <c>ResourceSecurityInstallJob</c>. Best-effort:
+        /// a failure is reported with the manual remedy but does not abort the install. See issue #117.
+        /// </remarks>
+        private async Task GrantAppServiceDatabaseAccess(WebSiteResource webApp, DatabasePaaSInfo dbInfo)
+        {
+            if (webApp == null) return;
+
+            // Re-read the site: when this run was the one that turned the system-assigned identity on, the
+            // cached ARM payload predates it and its PrincipalId would still be null.
+            WebSiteResource current;
+            try
+            {
+                current = await webApp.GetAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not re-read the App Service to find its managed identity: {ex.Message}");
+                current = webApp;
+            }
+
+            var principalId = current?.Data?.Identity?.PrincipalId;
+            if (principalId == null || principalId == Guid.Empty)
+            {
+                _logger.LogWarning(
+                    "The App Service has no system-assigned managed identity, so it cannot be granted database access. " +
+                    "The web application will not be able to connect to a database that has SQL authentication disabled. " +
+                    "Re-run the installer to create the identity.");
+                return;
+            }
+
+            var task = new SqlIdentityAccessTask(_logger);
+            await task.GrantDatabaseAccessAsync(
+                dbInfo.ConnectionString,
+                current.Data.Name,
+                principalId.Value,
+                SqlContainedUserScript.AppServiceRoles);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -9,11 +9,14 @@ using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Sql;
 using Azure.ResourceManager.Storage;
 using CloudInstallEngine;
+using CloudInstallEngine.Azure;
 using CloudInstallEngine.Azure.InstallTasks;
 using CloudInstallEngine.Models;
 using Common.Entities.Installer;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace App.ControlPanel.Engine.InstallerTasks
 {
@@ -34,6 +37,8 @@ namespace App.ControlPanel.Engine.InstallerTasks
         private readonly SqlServerTask _sqlServerTask;
         private readonly SqlServerFirewallConfigTask _sqlServerFirewallConfigTask;
         private readonly SqlDatabaseTask _sqlDatabaseTask;
+        private TaskConfig _sqlServerConfig;
+        private SqlAuthDecision _sqlAuthDecision;
         private readonly KeyVaultTask _keyVaultTask;
 
         private readonly AppServicePlanTask _appServicePlanTask;
@@ -128,6 +133,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
             var sqlServerConfig = TaskConfig.GetConfigForName(config.SQLServerName)
                 .AddSetting(SqlServerTask.CONFIG_KEY_USERNAME, config.SQLServerAdminUsername)
                 .AddSetting(SqlServerTask.CONFIG_KEY_PASSWORD, config.SQLServerAdminPassword);
+            _sqlServerConfig = sqlServerConfig;
             const string FIREWALL_RULE_NAME = INSTALLER_FIREWALL_RULE_NAME;
 
             _sqlServerTask = new SqlServerTask(sqlServerConfig, logger, Location, tagDic, allowPublicAccess);
@@ -415,6 +421,108 @@ namespace App.ControlPanel.Engine.InstallerTasks
             }
         }
 
+        /// <summary>
+        /// Runs the install, choosing the SQL authentication method around it: the Microsoft Entra
+        /// administrator has to be resolved BEFORE the SQL server is created (it can only be set at
+        /// creation, since an existing server is never reconfigured), and what the server actually
+        /// supports can only be read back AFTER. See issue #117.
+        /// </summary>
+        public override async Task Install(object previousRunResult)
+        {
+            await ConfigureSqlEntraAdministrator();
+
+            await base.Install(previousRunResult);
+
+            await DetectSqlAuthMethod();
+        }
+
+        /// <summary>
+        /// Works out which Microsoft Entra principal should be the new SQL server's administrator and feeds
+        /// it to <see cref="SqlServerTask"/>. No-op unless the operator selected Entra authentication.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to the installer's own service principal. Azure allows exactly one Entra administrator
+        /// per server, and the installer is the identity that has to sign in to the database to run the
+        /// schema upgrade and create the App Service's contained user - so making anything else the
+        /// administrator by default would break the install it is supposed to enable.
+        /// </remarks>
+        async Task ConfigureSqlEntraAdministrator()
+        {
+            if (_config.SqlAuthMode != SqlServerAuthMode.EntraId || _sqlServerConfig == null) return;
+
+            // Re-entrancy guard: TaskConfig.AddSetting throws on a duplicate key, so a second Install()
+            // call on the same job instance must not try to add these again.
+            if (_sqlServerConfig.ContainsKey(SqlServerTask.CONFIG_KEY_ENTRA_ADMIN_OBJECT_ID)) return;
+
+            var objectId = (_config.SQLEntraAdminObjectId ?? string.Empty).Trim();
+            var login = (_config.SQLEntraAdminLogin ?? string.Empty).Trim();
+            var principalType = string.IsNullOrWhiteSpace(_config.SQLEntraAdminPrincipalType) ? "User" : _config.SQLEntraAdminPrincipalType.Trim();
+
+            if (string.IsNullOrWhiteSpace(objectId))
+            {
+                try
+                {
+                    objectId = await ServicePrincipalResolver.GetObjectIdFromClientCredentials(
+                        _config.InstallerAccount.DirectoryId, _config.InstallerAccount.ClientId, _config.InstallerAccount.Secret);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(
+                        "Could not resolve the installer service principal's object ID, so the SQL Server cannot be created with " +
+                        $"Microsoft Entra ID authentication: {ex.Message}. Falling back to SQL Server authentication.");
+                    return;
+                }
+
+                login = string.IsNullOrWhiteSpace(login) ? _config.InstallerAccount.ClientId : login;
+                principalType = "Application";
+
+                Logger.LogInformation(
+                    "No Microsoft Entra administrator was configured for Azure SQL, so the installer's own service principal will be " +
+                    "used. That is the identity which signs in to the database to apply schema upgrades. You can add a human " +
+                    "administrator afterwards in the Azure portal (SQL Server > Microsoft Entra ID).");
+            }
+            else
+            {
+                Logger.LogWarning(
+                    $"A Microsoft Entra administrator ('{login}') is configured for the SQL Server. Azure allows only ONE Entra " +
+                    "administrator per server, so make sure the installer's service principal can also sign in to the database - " +
+                    "typically by making the administrator a security group that contains it. Otherwise the database schema " +
+                    "upgrade will fail with a login error.");
+            }
+
+            _sqlServerConfig
+                .AddSetting(SqlServerTask.CONFIG_KEY_ENTRA_ADMIN_OBJECT_ID, objectId)
+                .AddSetting(SqlServerTask.CONFIG_KEY_ENTRA_ADMIN_LOGIN, login ?? string.Empty)
+                .AddSetting(SqlServerTask.CONFIG_KEY_ENTRA_ADMIN_TENANT_ID, _config.InstallerAccount.DirectoryId ?? string.Empty)
+                .AddSetting(SqlServerTask.CONFIG_KEY_ENTRA_ADMIN_PRINCIPAL_TYPE, principalType)
+
+                // Entra-only (SQL authentication disabled) is only ever applied to a server this run
+                // creates. SqlServerTask ignores it for an existing server.
+                .AddSetting(SqlServerTask.CONFIG_KEY_ENTRA_ONLY_AUTH, "true");
+        }
+
+        /// <summary>
+        /// Reads back what the SQL server actually supports and decides how to connect to it.
+        /// </summary>
+        async Task DetectSqlAuthMethod()
+        {
+            var haveSqlCredentials = !string.IsNullOrWhiteSpace(_config.SQLServerAdminUsername)
+                && !string.IsNullOrWhiteSpace(_config.SQLServerAdminPassword);
+
+            SqlServerAuthState state = null;
+            try
+            {
+                state = await SqlServerAuthReader.ReadAsync(CreatedSqlServer, Logger);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"Could not read the SQL Server's authentication configuration: {ex.Message}");
+            }
+
+            _sqlAuthDecision = SqlServerAuthDetection.Decide(state, haveSqlCredentials, _config.SqlAuthMode);
+            Logger.LogInformation($"SQL authentication: {_sqlAuthDecision.Reason}");
+        }
+
         private void AddPrivateEndpointTask(string peName, string targetResourceId, string groupId, string subnetId, ILogger logger, Dictionary<string, string> tags)
         {
             var peConfig = TaskConfig.GetConfigForName(peName)
@@ -438,7 +546,17 @@ namespace App.ControlPanel.Engine.InstallerTasks
         public SqlServerResource CreatedSqlServer => GetTaskResult<SqlServerResource>(_sqlServerTask);
         public SqlDatabaseResource CreatedSqlDatabase => GetTaskResult<SqlDatabaseResource>(_sqlDatabaseTask);
         public WebSiteResource CreatedWebSiteResource => GetTaskResult<WebSiteResource>(_appServiceWebsiteTask);
-        public DatabasePaaSInfo DatabasePaaSInfo => new DatabasePaaSInfo(CreatedSqlServer, CreatedSqlDatabase, _config);
+
+        /// <summary>
+        /// How the installer decided to authenticate to SQL for this run, and why. Null until the job has
+        /// run. See issue #117.
+        /// </summary>
+        public SqlAuthDecision SqlAuthDecision => _sqlAuthDecision;
+
+        public DatabasePaaSInfo DatabasePaaSInfo => new DatabasePaaSInfo(CreatedSqlServer, CreatedSqlDatabase, _config)
+        {
+            AuthMethod = _sqlAuthDecision != null ? _sqlAuthDecision.Method : SqlConnectionAuthMethod.SqlLogin
+        };
         public RedisInstallResult Redis => GetTaskResult<RedisInstallResult>(_redisTask);
         public StorageAccountResource Storage => GetTaskResult<StorageAccountResource>(_storageAccountInstallTask);
         public AppInsightsInfo AppInsights => GetTaskResult<AppInsightsInfo>(_appInsightsInstallTask);

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -8,6 +8,7 @@ using Azure.ResourceManager.Network;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Sql;
 using Azure.ResourceManager.Storage;
+using Azure;
 using CloudInstallEngine;
 using CloudInstallEngine.Azure;
 using CloudInstallEngine.Azure.InstallTasks;
@@ -38,6 +39,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
         private readonly SqlServerFirewallConfigTask _sqlServerFirewallConfigTask;
         private readonly SqlDatabaseTask _sqlDatabaseTask;
         private TaskConfig _sqlServerConfig;
+        private TaskConfig _automationAccountConfig;
         private SqlAuthDecision _sqlAuthDecision;
         private readonly KeyVaultTask _keyVaultTask;
 
@@ -290,7 +292,10 @@ namespace App.ControlPanel.Engine.InstallerTasks
                     .AddSetting(AutomationAccountTask.CONFIG_PARAM_NAME_SQL_DB, config.SQLServerDatabaseName)
                     .AddSetting(AutomationAccountTask.CONFIG_PARAM_NAME_SQL_USERNAME, config.SQLServerAdminUsername)
                     .AddSetting(AutomationAccountTask.CONFIG_PARAM_NAME_SQL_PASSWORD, config.SQLServerAdminPassword)
+                    .AddSetting(AutomationAccountTask.CONFIG_PARAM_NAME_USE_ENTRA_AUTH,
+                        config.SqlAuthMode == SqlServerAuthMode.EntraId ? "true" : "false")
                     ;
+                _automationAccountConfig = automationAccountConfig;
 
                 _automationAccountTask = new AutomationAccountTask(automationAccountConfig, logger, Location, tagDic, allowPublicAccess);
                 this.AddTask(_automationAccountTask);
@@ -521,6 +526,62 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
             _sqlAuthDecision = SqlServerAuthDetection.Decide(state, haveSqlCredentials, _config.SqlAuthMode);
             Logger.LogInformation($"SQL authentication: {_sqlAuthDecision.Reason}");
+
+            await RepairAutomationSqlCredentialIfNeeded();
+        }
+
+        /// <summary>
+        /// Creates the Automation account's SQL credential when the install turned out to need one after all.
+        /// </summary>
+        /// <remarks>
+        /// The Automation account is provisioned before the SQL server's real capabilities are known, so it
+        /// is told what the operator asked for. When Entra ID was selected but detection fell back to a SQL
+        /// login - an install pointed at an existing SQL-authentication server, which is never reconfigured -
+        /// the credential the runbooks need was skipped. Put it back rather than leaving Graph usage-report
+        /// automation silently broken. See issue #117.
+        /// </remarks>
+        async Task RepairAutomationSqlCredentialIfNeeded()
+        {
+            if (_automationAccountTask == null || _automationAccountConfig == null) return;
+            if (_sqlAuthDecision == null || _sqlAuthDecision.UsesEntraId) return;
+            if (_config.SqlAuthMode != SqlServerAuthMode.EntraId) return;   // credential was already created
+
+            AutomationAccountResource automationAccount;
+            try
+            {
+                automationAccount = CreatedAutomationAccount;
+            }
+            catch (Exception)
+            {
+                return;
+            }
+            if (automationAccount == null) return;
+
+            if (string.IsNullOrWhiteSpace(_config.SQLServerAdminUsername) || string.IsNullOrWhiteSpace(_config.SQLServerAdminPassword))
+            {
+                Logger.LogWarning(
+                    "This install fell back to SQL Server authentication, but no SQL administrator username/password is " +
+                    $"configured, so the Automation account's '{AutomationAccountTask.CRED_SQL_NAME}' credential could not be " +
+                    "created. The Graph usage-report maintenance runbooks will not be able to connect to the database.");
+                return;
+            }
+
+            try
+            {
+                Logger.LogInformation(
+                    $"Creating the Automation account's '{AutomationAccountTask.CRED_SQL_NAME}' credential: this install fell back " +
+                    "to SQL Server authentication, so the runbooks need a SQL login after all.");
+
+                var credential = new Azure.ResourceManager.Automation.Models.AutomationCredentialCreateOrUpdateContent(
+                    AutomationAccountTask.CRED_SQL_NAME, _config.SQLServerAdminUsername, _config.SQLServerAdminPassword);
+
+                await automationAccount.GetAutomationCredentials()
+                    .CreateOrUpdateAsync(WaitUntil.Completed, AutomationAccountTask.CRED_SQL_NAME, credential);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"Could not create the Automation account's SQL credential: {ex.Message}");
+            }
         }
 
         private void AddPrivateEndpointTask(string peName, string targetResourceId, string groupId, string subnetId, ILogger logger, Dictionary<string, string> tags)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
@@ -24,6 +24,15 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
         public const string CONFIG_PARAM_NAME_SQL_USERNAME = "sqlusername";
         public const string CONFIG_PARAM_NAME_SQL_PASSWORD = "sqlpassword";
 
+        /// <summary>
+        /// "true" when the database authenticates with Microsoft Entra ID, in which case there is no SQL
+        /// login to store as an automation credential and the runbooks use the account's managed identity.
+        /// </summary>
+        public const string CONFIG_PARAM_NAME_USE_ENTRA_AUTH = "useEntraAuth";
+
+        /// <summary>Name of the Automation credential holding the (deprecated) SQL login.</summary>
+        public const string CRED_SQL_NAME = "SQLCredential";
+
         private readonly bool _allowPublicAccess;
 
         public AutomationAccountTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
@@ -42,7 +51,13 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
                     Location = base.AzureLocation,
                     Sku = new AutomationSku(AutomationSkuName.Free),
                     Name = _config.ResourceName,
-                    IsPublicNetworkAccessAllowed = _allowPublicAccess
+                    IsPublicNetworkAccessAllowed = _allowPublicAccess,
+
+                    // The runbooks need an identity of their own when the database has SQL authentication
+                    // disabled - there is no credential to store for them. Always enabled so the identity
+                    // exists regardless of how the database is configured later. See issue #117.
+                    Identity = new Azure.ResourceManager.Models.ManagedServiceIdentity(
+                        Azure.ResourceManager.Models.ManagedServiceIdentityType.SystemAssigned)
                 };
                 base.EnsureTagsOnNew(newAutomationAccountInfo.Tags);     // Add configured tags
 
@@ -64,13 +79,30 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
                 _logger.LogInformation($"Using existing Automation account '{automationAccount.Data.Name}'.");
                 await base.EnsureTagsOnExisting(automationAccount.Data.Tags, automationAccount.GetTagResource());
 
-                if (automationAccount.Data.IsPublicNetworkAccessAllowed != _allowPublicAccess)
+                var needsIdentity = automationAccount.Data.Identity == null
+                    || automationAccount.Data.Identity.PrincipalId == null;
+
+                if (automationAccount.Data.IsPublicNetworkAccessAllowed != _allowPublicAccess || needsIdentity)
                 {
-                    _logger.LogInformation($"Updating Automation account '{automationAccount.Data.Name}' public network access to '{(_allowPublicAccess ? "enabled" : "disabled")}'...");
+                    if (needsIdentity)
+                    {
+                        _logger.LogInformation($"Enabling a system-assigned managed identity on Automation account '{automationAccount.Data.Name}'...");
+                    }
+                    if (automationAccount.Data.IsPublicNetworkAccessAllowed != _allowPublicAccess)
+                    {
+                        _logger.LogInformation($"Updating Automation account '{automationAccount.Data.Name}' public network access to '{(_allowPublicAccess ? "enabled" : "disabled")}'...");
+                    }
+
                     var patch = new AutomationAccountPatch
                     {
                         IsPublicNetworkAccessAllowed = _allowPublicAccess
                     };
+                    if (needsIdentity)
+                    {
+                        patch.Identity = new Azure.ResourceManager.Models.ManagedServiceIdentity(
+                            Azure.ResourceManager.Models.ManagedServiceIdentityType.SystemAssigned);
+                    }
+
                     try
                     {
                         var updateReq = await automationAccount.UpdateAsync(patch);
@@ -78,7 +110,7 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
                     }
                     catch (RequestFailedException ex)
                     {
-                        _logger.LogWarning($"Could not update Automation account '{_config.ResourceName}' public access setting: {ex.Message}");
+                        _logger.LogWarning($"Could not update Automation account '{_config.ResourceName}': {ex.Message}");
                     }
                 }
             }
@@ -113,10 +145,23 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
             await CreateVariableIfMissingAsync(variables, CONFIG_PARAM_NAME_WEEKS_TO_KEEP, varWeeksToKeep);
 
             // Creds
-            _logger.LogInformation($"Creating/updating automation credentials for '{_config.ResourceName}'...");
-            const string CRED_SQL_NAME = "SQLCredential";
-            var credSql = new AutomationCredentialCreateOrUpdateContent(CRED_SQL_NAME, _config[CONFIG_PARAM_NAME_SQL_USERNAME], _config[CONFIG_PARAM_NAME_SQL_PASSWORD]);
-            await automationAccount.GetAutomationCredentials().CreateOrUpdateAsync(WaitUntil.Completed, CRED_SQL_NAME, credSql);
+            // With Microsoft Entra ID authentication there is no SQL login to store, and creating an empty
+            // credential would make the runbooks pick the SQL path and fail. They detect the credential's
+            // absence and use this account's managed identity instead. See issue #117.
+            var useEntraAuth = _config.ContainsKey(CONFIG_PARAM_NAME_USE_ENTRA_AUTH)
+                && string.Equals(_config[CONFIG_PARAM_NAME_USE_ENTRA_AUTH], "true", StringComparison.OrdinalIgnoreCase);
+            if (useEntraAuth)
+            {
+                _logger.LogInformation(
+                    $"Skipping the '{CRED_SQL_NAME}' automation credential for '{_config.ResourceName}': the database uses " +
+                    "Microsoft Entra ID authentication, so the runbooks will sign in with the Automation account's managed identity.");
+            }
+            else
+            {
+                _logger.LogInformation($"Creating/updating automation credentials for '{_config.ResourceName}'...");
+                var credSql = new AutomationCredentialCreateOrUpdateContent(CRED_SQL_NAME, _config[CONFIG_PARAM_NAME_SQL_USERNAME], _config[CONFIG_PARAM_NAME_SQL_PASSWORD]);
+                await automationAccount.GetAutomationCredentials().CreateOrUpdateAsync(WaitUntil.Completed, CRED_SQL_NAME, credSql);
+            }
 
             // Schedules
             // Re-running the installer must NOT update existing schedules: doing so would reset

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
@@ -1,0 +1,167 @@
+using App.ControlPanel.Engine.Entities;
+using Azure.ResourceManager.Sql;
+using DataUtils.Sql;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace App.ControlPanel.Engine.InstallerTasks
+{
+    /// <summary>
+    /// Reads an Azure SQL server's authentication configuration back from Azure Resource Manager, so the
+    /// installer can decide whether to talk to it with a SQL login or a Microsoft Entra ID token rather
+    /// than assuming. See issue #117.
+    /// </summary>
+    public static class SqlServerAuthReader
+    {
+        /// <summary>
+        /// Inspects the server. Returns null when there is no server to inspect.
+        /// </summary>
+        public static async Task<SqlServerAuthState> ReadAsync(SqlServerResource sqlServer, ILogger logger)
+        {
+            if (sqlServer == null) return null;
+
+            // The cached ARM payload may predate this run's create/update, so re-read it.
+            var server = await sqlServer.GetAsync();
+            var data = server.Value.Data;
+
+            var state = new SqlServerAuthState
+            {
+                HasSqlAdminLogin = !string.IsNullOrWhiteSpace(data.AdministratorLogin),
+                HasEntraAdmin = data.Administrators != null && data.Administrators.Sid.HasValue,
+                EntraAdminLogin = data.Administrators?.Login,
+                EntraOnlyAuthEnabled = data.Administrators?.IsAzureADOnlyAuthenticationEnabled == true,
+            };
+
+            // The server payload only reports Entra-only auth when the administrator was set through the
+            // server resource. The authoritative source is the azureADOnlyAuthentications child resource,
+            // which is also where a customer's own portal/CLI change shows up.
+            if (!state.EntraOnlyAuthEnabled)
+            {
+                try
+                {
+                    foreach (var onlyAuth in sqlServer.GetSqlServerAzureADOnlyAuthentications())
+                    {
+                        if (onlyAuth.Data != null && onlyAuth.Data.IsAzureADOnlyAuthenticationEnabled == true)
+                        {
+                            state.EntraOnlyAuthEnabled = true;
+                            break;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // A server that has never had it set returns 404/NotFound here. Not an error.
+                    logger?.LogInformation($"Could not read Microsoft Entra-only authentication state for SQL Server '{data.Name}': {ex.Message}");
+                }
+            }
+
+            // Likewise, an administrator assigned separately (portal, CLI, an older install) lives in the
+            // administrators child collection rather than on the server payload.
+            if (!state.HasEntraAdmin)
+            {
+                try
+                {
+                    var admin = sqlServer.GetSqlServerAzureADAdministrators().FirstOrDefault();
+                    if (admin != null && admin.Data != null)
+                    {
+                        state.HasEntraAdmin = true;
+                        state.EntraAdminLogin = admin.Data.Login;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogInformation($"Could not read the Microsoft Entra administrator for SQL Server '{data.Name}': {ex.Message}");
+                }
+            }
+
+            logger?.LogInformation(
+                $"SQL Server '{data.Name}' authentication: Microsoft Entra-only = {state.EntraOnlyAuthEnabled}, " +
+                $"Microsoft Entra administrator = {(state.HasEntraAdmin ? (string.IsNullOrWhiteSpace(state.EntraAdminLogin) ? "yes" : state.EntraAdminLogin) : "none")}, " +
+                $"SQL administrator login = {(state.HasSqlAdminLogin ? "present" : "none")}.");
+
+            return state;
+        }
+    }
+
+    /// <summary>
+    /// Grants an Azure managed identity access to the analytics database by creating a contained user for
+    /// it. This is the database half of "the App Service needs its own RBAC assignment" - Azure SQL has no
+    /// ARM role that grants data-plane access, so it has to be done in T-SQL. See issue #117.
+    /// </summary>
+    public class SqlIdentityAccessTask
+    {
+        private readonly ILogger _logger;
+
+        public SqlIdentityAccessTask(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Creates (or repairs) the contained user for <paramref name="principalName"/> and grants it the
+        /// database roles the runtime needs.
+        /// </summary>
+        /// <remarks>
+        /// Best-effort by design: it returns false rather than throwing, because a failure here does not
+        /// invalidate the rest of the install and the operator can grant access by hand. It is also
+        /// idempotent, so re-running the installer is safe.
+        /// </remarks>
+        public async Task<bool> GrantDatabaseAccessAsync(string connectionString, string principalName, Guid principalObjectId, IEnumerable<string> roles)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentException($"'{nameof(connectionString)}' cannot be null or empty.", nameof(connectionString));
+            }
+
+            if (string.IsNullOrWhiteSpace(principalName) || principalObjectId == Guid.Empty)
+            {
+                _logger.LogWarning(
+                    "Skipping the database permission grant for the App Service: it has no system-assigned managed identity yet. " +
+                    "Re-run the installer once the identity exists.");
+                return false;
+            }
+
+            var roleList = roles == null ? new List<string>() : roles.ToList();
+            var sql = SqlContainedUserScript.CreateUserAndGrantRoles(principalName, principalObjectId, roleList);
+
+            _logger.LogInformation(
+                $"Granting the App Service managed identity '{principalName}' access to the database " +
+                $"({string.Join(", ", roleList)})...");
+
+            try
+            {
+                using (var connection = AzureSqlTokenAuth.CreateConnection(connectionString))
+                {
+                    await connection.OpenAsync();
+                    using (var cmd = connection.CreateCommand())
+                    {
+                        cmd.CommandText = sql;
+                        cmd.CommandTimeout = 120;
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                }
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(
+                    $"Could not grant the App Service managed identity '{principalName}' access to the database: {ex.Message}. " +
+                    "The web application and web-jobs will not be able to connect with their managed identity until this is " +
+                    "fixed. Sign in to the database as its Microsoft Entra administrator and run: " +
+                    $"CREATE USER [{principalName}] FROM EXTERNAL PROVIDER; then add it to {string.Join(", ", roleList)}.");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Could not grant the App Service managed identity access to the database: {ex.Message}");
+                return false;
+            }
+
+            _logger.LogInformation($"App Service managed identity '{principalName}' now has database access.");
+            return true;
+        }
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/Config/SolutionInstallConfig.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/Config/SolutionInstallConfig.cs
@@ -394,20 +394,36 @@ namespace App.ControlPanel.Engine
                     errs.Add("SQL Server names must be lower-case alphanumerics only");
                 }
             }
-            if (string.IsNullOrWhiteSpace(this.SQLServerAdminUsername))
+            if (this.SqlAuthMode == SqlServerAuthMode.EntraId)
             {
-                errs.Add("Provide a Azure SQL administrator username");
-            }
-            if (string.IsNullOrWhiteSpace(this.SQLServerAdminPassword))
-            {
-                errs.Add("Provide an Azure SQL Server password");
+                // Microsoft Entra ID authentication stores no SQL login, so the deprecated username/password
+                // are not required. They are still accepted (and still used) when the installer is pointed at
+                // an existing SQL-authentication server - see SqlServerAuthDetection.
+                if (!string.IsNullOrWhiteSpace(this.SQLEntraAdminObjectId)
+                    && !Guid.TryParse(this.SQLEntraAdminObjectId.Trim(), out _))
+                {
+                    errs.Add("The Microsoft Entra SQL administrator object ID must be a GUID. Leave it blank to use the installer's own service principal.");
+                }
+                if (!string.IsNullOrWhiteSpace(this.SQLEntraAdminObjectId) && string.IsNullOrWhiteSpace(this.SQLEntraAdminLogin))
+                {
+                    errs.Add("Provide the login/display name of the Microsoft Entra SQL administrator alongside its object ID.");
+                }
             }
             else
             {
-                if (this.SQLServerAdminPassword.Contains(";"))
+                if (string.IsNullOrWhiteSpace(this.SQLServerAdminUsername))
                 {
-                    errs.Add("SQL password cannot contain semi-colons (';')");
+                    errs.Add("Provide a Azure SQL administrator username");
                 }
+                if (string.IsNullOrWhiteSpace(this.SQLServerAdminPassword))
+                {
+                    errs.Add("Provide an Azure SQL Server password");
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.SQLServerAdminPassword) && this.SQLServerAdminPassword.Contains(";"))
+            {
+                errs.Add("SQL password cannot contain semi-colons (';')");
             }
 
             // Storage

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabasePaaSInfo.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabasePaaSInfo.cs
@@ -16,12 +16,25 @@ namespace App.ControlPanel.Engine.Entities
         public SqlServerResource Server { get; set; }
         public SolutionInstallConfig Config { get; set; }
 
+        /// <summary>
+        /// How to authenticate to this server. Set from what Azure reports about the server itself
+        /// (see <see cref="SqlServerAuthDetection"/>) rather than assumed, so an existing SQL
+        /// authentication deployment keeps its login and only a server with SQL authentication disabled
+        /// gets a token-based connection string. Defaults to the legacy behaviour. See issue #117.
+        /// </summary>
+        public SqlConnectionAuthMethod AuthMethod { get; set; } = SqlConnectionAuthMethod.SqlLogin;
+
         public string ConnectionString
         {
             get
             {
                 if (Database != null && Server != null && Config != null)
                 {
+                    if (AuthMethod == SqlConnectionAuthMethod.EntraId)
+                    {
+                        return GetEntraIdConnectionString(this.Server.Data.FullyQualifiedDomainName, Database.Data.Name);
+                    }
+
                     var sqlConnectionString = GetConnectionString(this.Server.Data.FullyQualifiedDomainName, Database.Data.Name, this.Server.Data.AdministratorLogin, Config.SQLServerAdminPassword);
 
                     return sqlConnectionString;
@@ -31,6 +44,32 @@ namespace App.ControlPanel.Engine.Entities
                     throw new InvalidOperationException("Server/Database/Config properties not set");
                 }
             }
+        }
+
+        /// <summary>
+        /// Connection string for a server that authenticates with Microsoft Entra ID: deliberately carries
+        /// no <c>user id</c> and no password.
+        /// </summary>
+        /// <remarks>
+        /// The absence of credentials is what signals Entra authentication - both to
+        /// <c>DataUtils.Sql.AzureSqlTokenAuth</c>, which attaches an access token at connection-open time,
+        /// and to anything reading the App Service configuration. Deliberately NOT
+        /// <c>Authentication=Active Directory Managed Identity</c>: that keyword makes SqlClient acquire
+        /// the token itself, which the in-box .NET Framework System.Data.SqlClient provider EF6 requires
+        /// does not support for managed identity.
+        /// </remarks>
+        public static string GetEntraIdConnectionString(string server, string db)
+        {
+            if (string.IsNullOrEmpty(server))
+            {
+                throw new ArgumentException($"'{nameof(server)}' cannot be null or empty.", nameof(server));
+            }
+
+            var catalog = string.IsNullOrEmpty(db) ? string.Empty : $"initial catalog={db};";
+
+            return $"data source={server};{catalog}" +
+                "persist security info=False;" +
+                "MultipleActiveResultSets=True;Encrypt=True;Connection Timeout=120";
         }
 
         public static string GetConnectionString(string server, string db, string username, string password)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabasePaaSInfo.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabasePaaSInfo.cs
@@ -35,6 +35,19 @@ namespace App.ControlPanel.Engine.Entities
                         return GetEntraIdConnectionString(this.Server.Data.FullyQualifiedDomainName, Database.Data.Name);
                     }
 
+                    // Explain the real problem here. Otherwise GetConnectionString throws a bare
+                    // ArgumentException about a parameter name, which surfaces as "FATAL: Unexpected error
+                    // of type 'ArgumentException'" and tells the operator nothing. See issue #117.
+                    if (string.IsNullOrWhiteSpace(this.Server.Data.AdministratorLogin) || string.IsNullOrWhiteSpace(Config.SQLServerAdminPassword))
+                    {
+                        throw new InvalidOperationException(
+                            $"There is no way to authenticate to SQL Server '{this.Server.Data.FullyQualifiedDomainName}'. It has no " +
+                            "Microsoft Entra administrator, so Microsoft Entra ID authentication is not possible, and no SQL " +
+                            "administrator username/password is configured. Either set the SQL administrator credentials in the " +
+                            "installer, or assign a Microsoft Entra administrator to the server in the Azure portal " +
+                            "(SQL Server > Settings > Microsoft Entra ID) and re-run the installer.");
+                    }
+
                     var sqlConnectionString = GetConnectionString(this.Server.Data.FullyQualifiedDomainName, Database.Data.Name, this.Server.Data.AdministratorLogin, Config.SQLServerAdminPassword);
 
                     return sqlConnectionString;

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabasePaaSInfo.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabasePaaSInfo.cs
@@ -38,15 +38,7 @@ namespace App.ControlPanel.Engine.Entities
                     // Explain the real problem here. Otherwise GetConnectionString throws a bare
                     // ArgumentException about a parameter name, which surfaces as "FATAL: Unexpected error
                     // of type 'ArgumentException'" and tells the operator nothing. See issue #117.
-                    if (string.IsNullOrWhiteSpace(this.Server.Data.AdministratorLogin) || string.IsNullOrWhiteSpace(Config.SQLServerAdminPassword))
-                    {
-                        throw new InvalidOperationException(
-                            $"There is no way to authenticate to SQL Server '{this.Server.Data.FullyQualifiedDomainName}'. It has no " +
-                            "Microsoft Entra administrator, so Microsoft Entra ID authentication is not possible, and no SQL " +
-                            "administrator username/password is configured. Either set the SQL administrator credentials in the " +
-                            "installer, or assign a Microsoft Entra administrator to the server in the Azure portal " +
-                            "(SQL Server > Settings > Microsoft Entra ID) and re-run the installer.");
-                    }
+                    EnsureSqlLoginUsable(this.Server.Data.FullyQualifiedDomainName, this.Server.Data.AdministratorLogin, Config.SQLServerAdminPassword);
 
                     var sqlConnectionString = GetConnectionString(this.Server.Data.FullyQualifiedDomainName, Database.Data.Name, this.Server.Data.AdministratorLogin, Config.SQLServerAdminPassword);
 
@@ -57,6 +49,26 @@ namespace App.ControlPanel.Engine.Entities
                     throw new InvalidOperationException("Server/Database/Config properties not set");
                 }
             }
+        }
+
+        /// <summary>
+        /// Throws with an actionable message when there is no way to authenticate to the server: no
+        /// Microsoft Entra administrator to get a token as, and no SQL administrator login configured.
+        /// </summary>
+        /// <remarks>
+        /// Exists as its own method purely so the message is unit testable - the ARM resource types the
+        /// <see cref="ConnectionString"/> getter reads cannot be constructed in a test. See issue #117.
+        /// </remarks>
+        public static void EnsureSqlLoginUsable(string server, string username, string password)
+        {
+            if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password)) return;
+
+            throw new InvalidOperationException(
+                $"There is no way to authenticate to SQL Server '{server}'. It has no Microsoft Entra administrator, so " +
+                "Microsoft Entra ID authentication is not possible, and no SQL administrator username/password is " +
+                "configured. Either set the SQL administrator credentials in the installer, or assign a Microsoft Entra " +
+                "administrator to the server in the Azure portal (SQL Server > Settings > Microsoft Entra ID) and re-run " +
+                "the installer.");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabaseUpgradeInfo.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabaseUpgradeInfo.cs
@@ -14,6 +14,35 @@ namespace App.ControlPanel.Engine.Models
         public List<string> OrgURLs { get; set; }
 
         /// <summary>
+        /// Directory (tenant) ID of the service principal to authenticate to Azure SQL with, when the
+        /// database uses Microsoft Entra ID authentication.
+        /// </summary>
+        /// <remarks>
+        /// The schema upgrade is not run in-process: the installer shells out to the control-panel app it
+        /// downloaded for this release, and that child process has to authenticate for itself. A refreshable
+        /// credential is passed rather than an access token because an upgrade on a large database can run
+        /// for longer than a token's lifetime. Left empty for a SQL-authentication database, where the
+        /// connection string already carries the login. See issue #117.
+        /// </remarks>
+        public string EntraTenantId { get; set; }
+
+        /// <summary>Client ID of the service principal to authenticate to Azure SQL with.</summary>
+        public string EntraClientId { get; set; }
+
+        /// <summary>Client secret of the service principal to authenticate to Azure SQL with.</summary>
+        public string EntraClientSecret { get; set; }
+
+        /// <summary>
+        /// Whether this upgrade needs Microsoft Entra ID authentication, i.e. all three credential
+        /// properties are populated.
+        /// </summary>
+        [Newtonsoft.Json.JsonIgnore]
+        public bool HasEntraCredential =>
+            !string.IsNullOrWhiteSpace(EntraTenantId)
+            && !string.IsNullOrWhiteSpace(EntraClientId)
+            && !string.IsNullOrWhiteSpace(EntraClientSecret);
+
+        /// <summary>
         /// Save the URLs in the database if they're not there already.
         /// </summary>
         public void EnsureOrgURLs(AnalyticsEntitiesContext db)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/InstallStatus.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/InstallStatus.cs
@@ -14,5 +14,28 @@ namespace App.ControlPanel.Engine.Models
 
         public string SetupUserName { get; set; }
 
+        /// <summary>
+        /// Service principal to authenticate to Azure SQL with when <see cref="ConnectionString"/> carries
+        /// no login, i.e. the server has SQL authentication disabled.
+        /// </summary>
+        /// <remarks>
+        /// Config registration runs in the separately downloaded control-panel process, exactly like the
+        /// schema upgrade, and that process has no managed identity of its own to fall back on. Left empty
+        /// for a SQL-authentication database. See issue #117.
+        /// </remarks>
+        public string EntraTenantId { get; set; }
+
+        /// <summary>Client ID of the service principal to authenticate to Azure SQL with.</summary>
+        public string EntraClientId { get; set; }
+
+        /// <summary>Client secret of the service principal to authenticate to Azure SQL with.</summary>
+        public string EntraClientSecret { get; set; }
+
+        /// <summary>Whether all three parts of the Microsoft Entra ID credential are present.</summary>
+        [Newtonsoft.Json.JsonIgnore]
+        public bool HasEntraCredential =>
+            !string.IsNullOrWhiteSpace(EntraTenantId)
+            && !string.IsNullOrWhiteSpace(EntraClientId)
+            && !string.IsNullOrWhiteSpace(EntraClientSecret);
     }
 }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
@@ -1,0 +1,251 @@
+using Common.Entities.Installer;
+using System;
+using System.Collections.Generic;
+
+namespace App.ControlPanel.Engine.Entities
+{
+    /// <summary>
+    /// How the installer should authenticate to an Azure SQL server for this run.
+    /// </summary>
+    public enum SqlConnectionAuthMethod
+    {
+        /// <summary>SQL Server authentication - an admin login and password in the connection string.</summary>
+        SqlLogin,
+
+        /// <summary>Microsoft Entra ID - an access token, no stored secret.</summary>
+        EntraId,
+    }
+
+    /// <summary>
+    /// What we know about an Azure SQL server's authentication configuration, as read back from Azure.
+    /// </summary>
+    public class SqlServerAuthState
+    {
+        /// <summary>
+        /// Server has "Microsoft Entra-only authentication" turned on, so SQL logins are rejected
+        /// outright. Read from the server's <c>azureADOnlyAuthentications/Default</c> child resource.
+        /// </summary>
+        public bool EntraOnlyAuthEnabled { get; set; }
+
+        /// <summary>Server has a Microsoft Entra administrator assigned.</summary>
+        public bool HasEntraAdmin { get; set; }
+
+        /// <summary>Server has a SQL authentication administrator login.</summary>
+        public bool HasSqlAdminLogin { get; set; }
+
+        /// <summary>Login name of the Entra administrator, for logging. Never a secret.</summary>
+        public string EntraAdminLogin { get; set; }
+    }
+
+    /// <summary>
+    /// Chooses between SQL authentication and Microsoft Entra ID for a given Azure SQL server.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Backwards compatibility is the priority. A server the installer did not create is never
+    /// reconfigured; instead we look at what it actually supports and pick the method that works. An
+    /// existing SQL-authentication deployment therefore keeps behaving exactly as it did before this
+    /// change, and only a server that has SQL authentication disabled - whether because a new install
+    /// asked for that, or because the customer turned it on themselves - is driven over Entra ID.
+    /// </para>
+    /// <para>
+    /// Pure rules with no Azure calls, so the decision is unit testable. See issue #117.
+    /// </para>
+    /// </remarks>
+    public static class SqlServerAuthDetection
+    {
+        /// <summary>
+        /// Decides how to authenticate, and explains why in a line safe to write to the install log.
+        /// </summary>
+        /// <param name="serverState">
+        /// What Azure reports about the server, or null when the server could not be inspected (in which
+        /// case we fall back to the legacy behaviour rather than guess).
+        /// </param>
+        /// <param name="haveSqlCredentials">Whether a SQL admin username AND password are configured.</param>
+        /// <param name="configuredMode">What the operator asked for in the installer config.</param>
+        public static SqlAuthDecision Decide(SqlServerAuthState serverState, bool haveSqlCredentials, SqlServerAuthMode configuredMode)
+        {
+            if (serverState == null)
+            {
+                return new SqlAuthDecision(
+                    haveSqlCredentials ? SqlConnectionAuthMethod.SqlLogin : SqlConnectionAuthMethod.EntraId,
+                    "The SQL server could not be inspected, so the configured credentials decide the authentication method.");
+            }
+
+            // Nothing else matters: the server rejects SQL logins, so Entra ID is the only option.
+            if (serverState.EntraOnlyAuthEnabled)
+            {
+                return new SqlAuthDecision(SqlConnectionAuthMethod.EntraId,
+                    "SQL Server has Microsoft Entra-only authentication enabled, so the installer will authenticate with Microsoft Entra ID. " +
+                    "The SQL administrator username/password are ignored.");
+            }
+
+            // The operator asked for Entra and the server can actually do it.
+            if (configuredMode == SqlServerAuthMode.EntraId && serverState.HasEntraAdmin)
+            {
+                return new SqlAuthDecision(SqlConnectionAuthMethod.EntraId,
+                    "Microsoft Entra ID authentication is selected and the SQL Server has a Microsoft Entra administrator, " +
+                    "so the installer will authenticate with Microsoft Entra ID.");
+            }
+
+            // An existing SQL-authentication deployment. Leave it exactly as it is.
+            if (haveSqlCredentials)
+            {
+                var note = configuredMode == SqlServerAuthMode.EntraId && !serverState.HasEntraAdmin
+                    ? "Microsoft Entra ID authentication is selected, but this SQL Server has no Microsoft Entra administrator assigned - " +
+                      "existing servers are deliberately never reconfigured. Falling back to the configured SQL administrator login."
+                    : "Using the configured SQL administrator login (SQL Server authentication).";
+
+                return new SqlAuthDecision(SqlConnectionAuthMethod.SqlLogin, note);
+            }
+
+            if (serverState.HasEntraAdmin)
+            {
+                return new SqlAuthDecision(SqlConnectionAuthMethod.EntraId,
+                    "No SQL administrator password is configured and the SQL Server has a Microsoft Entra administrator, " +
+                    "so the installer will authenticate with Microsoft Entra ID.");
+            }
+
+            return new SqlAuthDecision(SqlConnectionAuthMethod.SqlLogin,
+                "No SQL administrator password is configured and the SQL Server has no Microsoft Entra administrator. " +
+                "There is no usable way to authenticate to this server - set a SQL administrator password, or assign a " +
+                "Microsoft Entra administrator to the server in the Azure portal.");
+        }
+
+        /// <summary>
+        /// Whether the installer should provision this server with Microsoft Entra ID authentication.
+        /// Only ever true for a server the installer is about to create: an existing server's
+        /// authentication configuration is left alone, per the backwards-compatibility rule.
+        /// </summary>
+        public static bool ShouldProvisionWithEntraAuth(bool serverAlreadyExists, SqlServerAuthMode configuredMode)
+        {
+            return !serverAlreadyExists && configuredMode == SqlServerAuthMode.EntraId;
+        }
+    }
+
+    /// <summary>The chosen authentication method plus a human-readable reason for the install log.</summary>
+    public class SqlAuthDecision
+    {
+        public SqlAuthDecision(SqlConnectionAuthMethod method, string reason)
+        {
+            this.Method = method;
+            this.Reason = reason;
+        }
+
+        public SqlConnectionAuthMethod Method { get; }
+        public string Reason { get; }
+
+        public bool UsesEntraId => Method == SqlConnectionAuthMethod.EntraId;
+    }
+
+    /// <summary>
+    /// Builds the T-SQL that gives an Azure managed identity / service principal access to the database.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An Entra principal gets database access through a "contained user" created in the database itself -
+    /// there is no ARM role that grants data-plane access to Azure SQL, which is why this is T-SQL rather
+    /// than another <c>RoleAssignmentTask</c>.
+    /// </para>
+    /// <para>
+    /// The user is created <c>WITH SID = ..., TYPE = E</c> rather than <c>FROM EXTERNAL PROVIDER</c>. Both
+    /// produce the same user, but <c>FROM EXTERNAL PROVIDER</c> makes the SQL server call Microsoft Graph
+    /// to resolve the name, which fails with "Principal '...' could not be found" unless the server's own
+    /// identity has been granted the Directory Readers role - a tenant-wide, Global-Administrator-only
+    /// grant we cannot assume an operator has done. Supplying the object ID as the SID needs no directory
+    /// lookup at all.
+    /// </para>
+    /// <para>Pure string generation, so the emitted script is unit testable. See issue #117.</para>
+    /// </remarks>
+    public static class SqlContainedUserScript
+    {
+        /// <summary>
+        /// Roles granted to the App Service identity.
+        /// <c>db_ddladmin</c> is required, not belt-and-braces: the importers create and drop real
+        /// <c>dbo</c> staging tables at runtime (see <c>InsertBatch</c>), and a DEBUG build can run EF
+        /// migrations on start-up.
+        /// </summary>
+        public static readonly IReadOnlyList<string> AppServiceRoles =
+            new[] { "db_datareader", "db_datawriter", "db_ddladmin" };
+
+        /// <summary>
+        /// Emits an idempotent script that creates the contained user for <paramref name="principalName"/>
+        /// and adds it to <paramref name="roles"/>.
+        /// </summary>
+        /// <param name="principalName">
+        /// The database user name. For a system-assigned managed identity this is the Azure resource name
+        /// (e.g. the App Service name), which is also the identity's display name in Entra ID.
+        /// </param>
+        /// <param name="principalObjectId">The Entra object (principal) ID of the identity.</param>
+        /// <param name="roles">Database roles to add the user to.</param>
+        public static string CreateUserAndGrantRoles(string principalName, Guid principalObjectId, IEnumerable<string> roles)
+        {
+            if (string.IsNullOrWhiteSpace(principalName))
+            {
+                throw new ArgumentException($"'{nameof(principalName)}' cannot be null or empty.", nameof(principalName));
+            }
+            if (principalObjectId == Guid.Empty)
+            {
+                throw new ArgumentException($"'{nameof(principalObjectId)}' cannot be an empty GUID.", nameof(principalObjectId));
+            }
+            if (roles == null) throw new ArgumentNullException(nameof(roles));
+
+            var quotedName = QuoteIdentifier(principalName);
+            var literalName = QuoteLiteral(principalName);
+            var sid = ToSqlSid(principalObjectId);
+
+            var sql = new System.Text.StringBuilder();
+            sql.AppendLine($"IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE [name] = N'{literalName}')");
+            sql.AppendLine("BEGIN");
+            sql.AppendLine($"    CREATE USER {quotedName} WITH SID = {sid}, TYPE = E;");
+            sql.AppendLine("END");
+
+            foreach (var role in roles)
+            {
+                if (string.IsNullOrWhiteSpace(role)) continue;
+
+                var quotedRole = QuoteIdentifier(role);
+                var literalRole = QuoteLiteral(role);
+                sql.AppendLine($"IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm");
+                sql.AppendLine($"    INNER JOIN sys.database_principals r ON r.principal_id = rm.role_principal_id");
+                sql.AppendLine($"    INNER JOIN sys.database_principals m ON m.principal_id = rm.member_principal_id");
+                sql.AppendLine($"    WHERE r.[name] = N'{literalRole}' AND m.[name] = N'{literalName}')");
+                sql.AppendLine("BEGIN");
+                sql.AppendLine($"    ALTER ROLE {quotedRole} ADD MEMBER {quotedName};");
+                sql.AppendLine("END");
+            }
+
+            // db_datareader/db_datawriter cover tables but not EXECUTE, and the solution ships stored
+            // procedures (sp_CreateDimTables and the Power BI refresh procs).
+            sql.AppendLine($"GRANT EXECUTE TO {quotedName};");
+
+            return sql.ToString();
+        }
+
+        /// <summary>
+        /// Converts an Entra object ID to the <c>VARBINARY(16)</c> literal SQL Server expects as a SID for
+        /// an external (type E) principal. This is the GUID's little-endian byte layout - i.e.
+        /// <see cref="Guid.ToByteArray"/> - not the textual GUID.
+        /// </summary>
+        public static string ToSqlSid(Guid principalObjectId)
+        {
+            var bytes = principalObjectId.ToByteArray();
+            var hex = new System.Text.StringBuilder("0x", 2 + (bytes.Length * 2));
+            foreach (var b in bytes)
+            {
+                hex.Append(b.ToString("X2"));
+            }
+            return hex.ToString();
+        }
+
+        static string QuoteIdentifier(string name)
+        {
+            return "[" + name.Replace("]", "]]") + "]";
+        }
+
+        static string QuoteLiteral(string value)
+        {
+            return value.Replace("'", "''");
+        }
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -9,6 +9,7 @@ using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Sql;
 using CloudInstallEngine.Azure;
 using Common.Entities;
+using Common.Entities.Installer;
 using DataUtils;
 using DataUtils.Http;
 using Microsoft.Extensions.Logging;
@@ -130,11 +131,12 @@ namespace App.ControlPanel.Engine
 
         /// <summary>
         /// Return SQL details so connectivity tests can run against an existing server.
-        /// We cannot read back the SQL password, so it must come from config.
+        /// We cannot read back the SQL password, so it must come from config - unless the deployment uses
+        /// Microsoft Entra ID authentication, in which case there is no password at all (issue #117).
         /// </summary>
         public async Task<AutodetectedSqlDetails> GetSqlDetails(string sqlPassword)
         {
-            if (string.IsNullOrEmpty(sqlPassword))
+            if (string.IsNullOrEmpty(sqlPassword) && Config.SqlAuthMode != SqlServerAuthMode.EntraId)
             {
                 throw new ArgumentException($"'{nameof(sqlPassword)}' cannot be null or empty.", nameof(sqlPassword));
             }
@@ -174,11 +176,16 @@ namespace App.ControlPanel.Engine
         {
             if (config == null) return false;
 
+            // A Microsoft Entra ID deployment has no SQL login to supply, so requiring one here would make
+            // autodetection permanently unavailable for it. See issue #117.
+            var haveSqlCredentials = config.SqlAuthMode == SqlServerAuthMode.EntraId
+                || (!string.IsNullOrEmpty(config.SQLServerAdminPassword) && !string.IsNullOrEmpty(config.SQLServerAdminUsername));
+
             var installerAccErrors = config.InstallerAccount?.GetValidationErrors();
             return installerAccErrors != null && installerAccErrors.Count == 0
                 && !string.IsNullOrEmpty(config.ResourceGroupName)
                 && config.Subscription.IsValidSubscription
-                && !string.IsNullOrEmpty(config.SQLServerAdminPassword) && !string.IsNullOrEmpty(config.SQLServerAdminUsername) && !string.IsNullOrEmpty(config.SQLServerName);
+                && haveSqlCredentials && !string.IsNullOrEmpty(config.SQLServerName);
         }
 
         async Task<(ResourceGroupResource, bool)> GetResourceGroupIfValid()

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/DatabaseUpgrader.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/DatabaseUpgrader.cs
@@ -37,8 +37,9 @@ namespace App.ControlPanel.Engine
                 {
                     log?.Invoke(
                         "WARNING: the connection string has no SQL login, so Microsoft Entra ID authentication is required, " +
-                        "but no credential was supplied. This usually means the installer that launched this upgrade is older " +
-                        "than this build. Re-run the upgrade with a matching installer.");
+                        "but no credential was supplied. When the upgrade was launched by the installer, this means the " +
+                        "downloaded 'latest stable' build predates Microsoft Entra ID support. When the connection string was " +
+                        "entered by hand, use one that includes a SQL login, or run the upgrade from the installer.");
                 }
             }
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/DatabaseUpgrader.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/DatabaseUpgrader.cs
@@ -1,6 +1,7 @@
 ﻿using App.ControlPanel.Engine.Models;
 using Common.Entities;
 using DataUtils;
+using DataUtils.Sql;
 using System;
 using System.Linq;
 
@@ -19,6 +20,28 @@ namespace App.ControlPanel.Engine
             var buildLabel = Common.Entities.BuildConstants.BuildLabel;
 
             log?.Invoke($"Build '{buildLabel}' - begin database upgrade.");
+
+            // A connection string with no user id means the server has SQL authentication disabled, so the
+            // upgrade has to authenticate with Microsoft Entra ID. The caller supplies the service principal
+            // to use (see DatabaseUpgradeInfo); registering it here covers both the EF migration pipeline
+            // (via the connection interceptor) and the raw ADO.NET script steps below. See issue #117.
+            if (AzureSqlTokenAuth.NeedsAccessToken(initInfo.ConnectionString))
+            {
+                if (initInfo.HasEntraCredential)
+                {
+                    log?.Invoke("Authenticating to Azure SQL with Microsoft Entra ID (no SQL login in the connection string).");
+                    AzureSqlTokenAuth.SetCredential(new Azure.Identity.ClientSecretCredential(
+                        initInfo.EntraTenantId, initInfo.EntraClientId, initInfo.EntraClientSecret));
+                }
+                else
+                {
+                    log?.Invoke(
+                        "WARNING: the connection string has no SQL login, so Microsoft Entra ID authentication is required, " +
+                        "but no credential was supplied. This usually means the installer that launched this upgrade is older " +
+                        "than this build. Re-run the upgrade with a matching installer.");
+                }
+            }
+
             log?.Invoke($"[{DateTime.Now}]: Connecting to database @ '{StringUtils.RedactSqlConnectionString(initInfo.ConnectionString)}' with Entity Framework context initializer set to 'MigrateDatabaseToLatestVersion'...");
 
             // Update schema with EF migration

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/SqlInstallerTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/SqlInstallerTasks.cs
@@ -115,6 +115,15 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 ConnectionString = _dbInfo.ConnectionString
             };
 
+            // Same reasoning as the schema upgrade: the downloaded control-panel process has to authenticate
+            // for itself, and a token-less connection string means Microsoft Entra ID. See issue #117.
+            if (AzureSqlTokenAuth.NeedsAccessToken(status.ConnectionString))
+            {
+                status.EntraTenantId = _config.InstallerAccount?.DirectoryId;
+                status.EntraClientId = _config.InstallerAccount?.ClientId;
+                status.EntraClientSecret = _config.InstallerAccount?.Secret;
+            }
+
             // Write a temp file to pass to control-panel
             var tempFileName = Path.GetTempFileName();
             File.WriteAllText(tempFileName, status.ToBase64());

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/SqlInstallerTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/SqlInstallerTasks.cs
@@ -1,6 +1,7 @@
 ﻿using App.ControlPanel.Engine.Entities;
 using App.ControlPanel.Engine.Models;
 using DataUtils;
+using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -68,6 +69,23 @@ namespace App.ControlPanel.Engine.InstallerTasks
             var upgradeInfo = new DatabaseUpgradeInfo();
             upgradeInfo.ConnectionString = _dbInfo.ConnectionString;
             upgradeInfo.OrgURLs = targetSites;
+
+            // A connection string with no login means the SQL server has SQL authentication disabled, so
+            // the downloaded app has to authenticate with Microsoft Entra ID. It cannot use a managed
+            // identity - it runs on the operator's machine - so hand it the installer's own service
+            // principal, which is the identity assigned as the server's Entra administrator. See #117.
+            if (AzureSqlTokenAuth.NeedsAccessToken(upgradeInfo.ConnectionString))
+            {
+                upgradeInfo.EntraTenantId = _config.InstallerAccount?.DirectoryId;
+                upgradeInfo.EntraClientId = _config.InstallerAccount?.ClientId;
+                upgradeInfo.EntraClientSecret = _config.InstallerAccount?.Secret;
+
+                _logger.LogInformation(
+                    "The database uses Microsoft Entra ID authentication, so the downloaded control-panel app will sign in with " +
+                    "the installer's service principal. NOTE: this requires the downloaded release to be new enough to support " +
+                    "Microsoft Entra ID authentication - if the upgrade fails with a login error, the downloaded 'latest stable' " +
+                    "build predates that support and you should deploy from a local release override instead.");
+            }
 
             _logger.LogInformation($"Calling downloaded control-panel app to init/update database. This could take a while if the existing schema needs updating.");
 

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
@@ -103,6 +103,7 @@ namespace App.ControlPanel.Frames
                 SQLServerDatabaseName = azureStorageConfigControl1.SQLDb,
                 SQLServerAdminUsername = azureStorageConfigControl1.SQLServerUsername,
                 SQLServerAdminPassword = azureStorageConfigControl1.SQLServerPassword,
+                SqlAuthMode = azureStorageConfigControl1.SqlAuthMode,
                 ServiceBusName = azureStorageConfigControl1.ServiceBusName,
                 ServiceBusEnabled = azureStorageConfigControl1.ServiceBusEnabled,
                 RedisName = azureStorageConfigControl1.RedisName,
@@ -189,6 +190,7 @@ namespace App.ControlPanel.Frames
             azureStorageConfigControl1.SQLServerName = config.SQLServerName;
             azureStorageConfigControl1.SQLServerPassword = config.SQLServerAdminPassword;
             azureStorageConfigControl1.SQLServerUsername = config.SQLServerAdminUsername;
+            azureStorageConfigControl1.SqlAuthMode = config.SqlAuthMode;
             azureStorageConfigControl1.StorageAccount = config.StorageAccountName;
             // Take the region from the picker rather than the raw config: the picker rejects a value that is
             // not a known Azure region (it falls back to its "no region" placeholder), and the preview label

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
@@ -40,6 +40,7 @@
             this.lblGUIAzureServiceBusName = new System.Windows.Forms.Label();
             this.chkServiceBusEnabled = new System.Windows.Forms.CheckBox();
             this.lblGUIAzureHeaderSQL = new System.Windows.Forms.Label();
+            this.chkSqlEntraAuth = new System.Windows.Forms.CheckBox();
             this.txtSQLServerPassword = new System.Windows.Forms.TextBox();
             this.lblGUIAzureSQLPassword = new System.Windows.Forms.Label();
             this.txtSQLServerUsername = new System.Windows.Forms.TextBox();
@@ -171,6 +172,18 @@
             this.lblGUIAzureHeaderSQL.Size = new System.Drawing.Size(102, 19);
             this.lblGUIAzureHeaderSQL.TabIndex = 167;
             this.lblGUIAzureHeaderSQL.Text = "SQL Database";
+            // 
+            // chkSqlEntraAuth
+            // 
+            this.chkSqlEntraAuth.AutoSize = true;
+            this.chkSqlEntraAuth.Location = new System.Drawing.Point(64, 359);
+            this.chkSqlEntraAuth.Name = "chkSqlEntraAuth";
+            this.chkSqlEntraAuth.Size = new System.Drawing.Size(520, 17);
+            this.chkSqlEntraAuth.TabIndex = 178;
+            this.chkSqlEntraAuth.Text = "Use Microsoft Entra ID authentication (recommended) - the SQL login below is depre" +
+    "cated";
+            this.chkSqlEntraAuth.UseVisualStyleBackColor = true;
+            this.chkSqlEntraAuth.CheckedChanged += new System.EventHandler(this.chkSqlEntraAuth_CheckedChanged);
             // 
             // txtSQLServerPassword
             // 
@@ -352,6 +365,7 @@
             this.Controls.Add(this.txtServiceBusName);
             this.Controls.Add(this.lblGUIAzureServiceBusName);
             this.Controls.Add(this.lblGUIAzureHeaderSQL);
+            this.Controls.Add(this.chkSqlEntraAuth);
             this.Controls.Add(this.txtSQLServerPassword);
             this.Controls.Add(this.lblGUIAzureSQLPassword);
             this.Controls.Add(this.txtSQLServerUsername);
@@ -395,6 +409,7 @@
         private System.Windows.Forms.CheckBox chkServiceBusEnabled;
         private System.Windows.Forms.Label lblGUIAzureHeaderSQL;
         private System.Windows.Forms.TextBox txtSQLServerPassword;
+        private System.Windows.Forms.CheckBox chkSqlEntraAuth;
         private System.Windows.Forms.Label lblGUIAzureSQLPassword;
         private System.Windows.Forms.TextBox txtSQLServerUsername;
         private System.Windows.Forms.Label lblGUIAzureSQLUsername;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs
@@ -1,4 +1,5 @@
 ﻿using App.ControlPanel.Engine;
+using Common.Entities.Installer;
 using System;
 using System.Windows.Forms;
 
@@ -17,6 +18,21 @@ namespace App.ControlPanel.Frames.InstallWizard
         public string SQLServerName { get { return txtSQLServerName.Text; } set { txtSQLServerName.Text = value; } }
         public string SQLServerPassword { get { return txtSQLServerPassword.Text; } set { txtSQLServerPassword.Text = value; } }
         public string SQLServerUsername { get { return txtSQLServerUsername.Text; } set { txtSQLServerUsername.Text = value; } }
+
+        /// <summary>
+        /// Whether to authenticate to Azure SQL with Microsoft Entra ID instead of the deprecated SQL
+        /// administrator login. Only applied when the installer CREATES the SQL server - an existing
+        /// server's authentication is detected and left alone. See issue #117.
+        /// </summary>
+        public SqlServerAuthMode SqlAuthMode
+        {
+            get { return chkSqlEntraAuth.Checked ? SqlServerAuthMode.EntraId : SqlServerAuthMode.SqlLogin; }
+            set
+            {
+                chkSqlEntraAuth.Checked = value == SqlServerAuthMode.EntraId;
+                UpdateResponsiveUIControls();
+            }
+        }
         public string StorageAccount { get { return txtStorageAccount.Text; } set { txtStorageAccount.Text = value; } }
         public string RedisName { get { return txtRedisName.Text; } set { txtRedisName.Text = value; } }
         public string ServiceBusName { get { return txtServiceBusName.Text; } set { txtServiceBusName.Text = value; } }
@@ -55,6 +71,20 @@ namespace App.ControlPanel.Frames.InstallWizard
             // Disable SB name fields when Service Bus is disabled
             txtServiceBusName.Enabled = chkServiceBusEnabled.Checked;
             lblServiceBusName.Enabled = chkServiceBusEnabled.Checked;
+
+            // The SQL administrator login is deprecated: grey it out when Microsoft Entra ID authentication
+            // is selected, rather than removing it, because an install pointed at an existing
+            // SQL-authentication server still needs it.
+            var sqlLoginInUse = !chkSqlEntraAuth.Checked;
+            txtSQLServerUsername.Enabled = sqlLoginInUse;
+            txtSQLServerPassword.Enabled = sqlLoginInUse;
+            lblGUIAzureSQLUsername.Enabled = sqlLoginInUse;
+            lblGUIAzureSQLPassword.Enabled = sqlLoginInUse;
+        }
+
+        private void chkSqlEntraAuth_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateResponsiveUIControls();
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/App.ControlPanel/Program.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Program.cs
@@ -120,6 +120,24 @@ namespace App.ControlPanel
         {
             try
             {
+                // A connection string with no login means the server has SQL authentication disabled, so
+                // register the service principal the parent installer supplied before EF opens anything.
+                // See issue #117.
+                if (DataUtils.Sql.AzureSqlTokenAuth.NeedsAccessToken(initInfo.ConnectionString))
+                {
+                    if (initInfo.HasEntraCredential)
+                    {
+                        DataUtils.Sql.AzureSqlTokenAuth.SetCredential(new Azure.Identity.ClientSecretCredential(
+                            initInfo.EntraTenantId, initInfo.EntraClientId, initInfo.EntraClientSecret));
+                    }
+                    else
+                    {
+                        InstallerLogs.AddToWindowsEventLog(
+                            "The connection string has no SQL login, so Microsoft Entra ID authentication is required, but no " +
+                            "credential was supplied. Registering the install configuration will fail.", true);
+                    }
+                }
+
                 using (var db = new AnalyticsEntitiesContext(initInfo.ConnectionString, true, false))
                 {
                     // If we're here, EF has successfully updated/verified the DB. Now register the config and events involved in the install.

--- a/src/AnalyticsEngine/App.ControlPanel/TestSettingsForm.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/TestSettingsForm.cs
@@ -91,6 +91,12 @@ namespace App.ControlPanel
                 {
                     connectionString = DatabasePaaSInfo.GetConnectionString(r.Sql?.SqlFqdn, null, r.Sql?.SqlUsername, r.Sql?.SqlPassword);
                 }
+                else if (!string.IsNullOrEmpty(r.Sql?.SqlFqdn))
+                {
+                    // No SQL login: the server authenticates with Microsoft Entra ID, so the tests connect
+                    // with a token instead of credentials (issue #117).
+                    connectionString = DatabasePaaSInfo.GetEntraIdConnectionString(r.Sql.SqlFqdn, null);
+                }
 
                 this.TestConfiguration = new TestConfiguration
                 {

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerTask.cs
@@ -3,6 +3,7 @@ using Azure.Core;
 using Azure.ResourceManager.Sql;
 using Azure.ResourceManager.Sql.Models;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -12,6 +13,22 @@ namespace CloudInstallEngine.Azure.InstallTasks
     {
         public const string CONFIG_KEY_USERNAME = "username";
         public const string CONFIG_KEY_PASSWORD = "password";
+
+        /// <summary>Display name / UPN of the Microsoft Entra administrator to assign on a NEW server.</summary>
+        public const string CONFIG_KEY_ENTRA_ADMIN_LOGIN = "entraAdminLogin";
+
+        /// <summary>Entra object (principal) ID of the administrator. Azure requires the ID, not the name.</summary>
+        public const string CONFIG_KEY_ENTRA_ADMIN_OBJECT_ID = "entraAdminObjectId";
+
+        /// <summary>Directory (tenant) ID the administrator principal lives in.</summary>
+        public const string CONFIG_KEY_ENTRA_ADMIN_TENANT_ID = "entraAdminTenantId";
+
+        /// <summary>"User", "Group" or "Application".</summary>
+        public const string CONFIG_KEY_ENTRA_ADMIN_PRINCIPAL_TYPE = "entraAdminPrincipalType";
+
+        /// <summary>"true" to create the server with SQL authentication disabled (Entra-only).</summary>
+        public const string CONFIG_KEY_ENTRA_ONLY_AUTH = "entraOnlyAuth";
+
         private readonly bool _allowPublicAccess;
 
         public SqlServerTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags, bool allowPublicAccess = true) : base(config, logger, azureLocation, tags)
@@ -20,6 +37,18 @@ namespace CloudInstallEngine.Azure.InstallTasks
         }
 
         public override string TaskName => "get/create SQL Server";
+
+        /// <summary>
+        /// Whether the server already existed when the task ran. Callers use this to honour the rule that an
+        /// existing server's authentication configuration is never changed - see issue #117.
+        /// </summary>
+        public bool ServerAlreadyExisted { get; private set; }
+
+        /// <summary>
+        /// Whether the task created the server with Microsoft Entra-only authentication (SQL authentication
+        /// disabled). Always false for a pre-existing server.
+        /// </summary>
+        public bool CreatedWithEntraOnlyAuth { get; private set; }
 
         public override async Task<SqlServerResource> ExecuteTaskReturnResult(object contextArg)
         {
@@ -39,15 +68,38 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             if (sqlServer == null)
             {
+                ServerAlreadyExisted = false;
+
+                var entraAdmin = BuildEntraAdministrator();
+                var entraOnly = entraAdmin != null && entraAdmin.IsAzureADOnlyAuthenticationEnabled == true;
+
                 _logger.LogInformation($"Creating new SQL Server '{serverName}' (public access: {(_allowPublicAccess ? "enabled" : "disabled")})...");
 
                 var sqlServerData = new SqlServerData(AzureLocation)
                 {
-                    AdministratorLogin = adminUsername,
-                    AdministratorLoginPassword = adminPassword,
                     MinimalTlsVersion = "1.2",
                     PublicNetworkAccess = desiredAccess
                 };
+
+                if (entraAdmin != null)
+                {
+                    sqlServerData.Administrators = entraAdmin;
+                    _logger.LogInformation(
+                        $"SQL Server '{serverName}' will use Microsoft Entra ID authentication with administrator '{entraAdmin.Login}'" +
+                        (entraOnly
+                            ? " and SQL Server authentication DISABLED. No SQL administrator password is stored anywhere."
+                            : ", alongside SQL Server authentication."));
+                }
+
+                // Azure rejects a SQL admin login without a password, and rejects both when the server is
+                // created Entra-only. Only set them when SQL authentication will actually be available.
+                if (!entraOnly)
+                {
+                    sqlServerData.AdministratorLogin = adminUsername;
+                    sqlServerData.AdministratorLoginPassword = adminPassword;
+                }
+
+                CreatedWithEntraOnlyAuth = entraOnly;
 
                 base.EnsureTagsOnNew(sqlServerData.Tags);
                 var serverCreateResult = await Container.GetSqlServers().CreateOrUpdateAsync(WaitUntil.Completed, serverName, sqlServerData);
@@ -55,6 +107,9 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
             else
             {
+                ServerAlreadyExisted = true;
+                CreatedWithEntraOnlyAuth = false;
+
                 var needsUpdate = false;
                 var updateData = new SqlServerData(AzureLocation);
 
@@ -73,6 +128,10 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     needsUpdate = true;
                 }
 
+                // Deliberately NOT touching Administrators / Entra-only authentication here. An existing
+                // server may well be a long-standing SQL-authentication deployment, and silently flipping
+                // its authentication would lock out the customer's own tooling, Power BI refreshes and any
+                // other consumer of the database. See issue #117.
                 if (needsUpdate)
                 {
                     await Container.GetSqlServers().CreateOrUpdateAsync(WaitUntil.Completed, serverName, updateData);
@@ -82,6 +141,52 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 await base.EnsureTagsOnExisting(sqlServer.Data.Tags, sqlServer.GetTagResource());
             }
             return sqlServer;
+        }
+
+        /// <summary>
+        /// Builds the Microsoft Entra administrator to stamp onto a newly created server, or null when this
+        /// install is not using Entra authentication (the default, and what every existing deployment does).
+        /// </summary>
+        ServerExternalAdministrator BuildEntraAdministrator()
+        {
+            var objectIdRaw = base._config.GetOptionalConfigValue(CONFIG_KEY_ENTRA_ADMIN_OBJECT_ID);
+            var tenantIdRaw = base._config.GetOptionalConfigValue(CONFIG_KEY_ENTRA_ADMIN_TENANT_ID);
+            var login = base._config.GetOptionalConfigValue(CONFIG_KEY_ENTRA_ADMIN_LOGIN);
+
+            if (string.IsNullOrWhiteSpace(objectIdRaw)) return null;
+
+            Guid objectId;
+            if (!Guid.TryParse(objectIdRaw, out objectId) || objectId == Guid.Empty)
+            {
+                _logger.LogWarning(
+                    $"Ignoring the configured Microsoft Entra SQL administrator: '{objectIdRaw}' is not a valid object ID. " +
+                    "The SQL Server will be created with SQL Server authentication only.");
+                return null;
+            }
+
+            Guid tenantId;
+            Guid.TryParse(tenantIdRaw, out tenantId);
+
+            var admin = new ServerExternalAdministrator
+            {
+                AdministratorType = SqlAdministratorType.ActiveDirectory,
+                Login = string.IsNullOrWhiteSpace(login) ? objectId.ToString() : login,
+                Sid = objectId,
+                PrincipalType = ParsePrincipalType(base._config.GetOptionalConfigValue(CONFIG_KEY_ENTRA_ADMIN_PRINCIPAL_TYPE)),
+                IsAzureADOnlyAuthenticationEnabled =
+                    string.Equals(base._config.GetOptionalConfigValue(CONFIG_KEY_ENTRA_ONLY_AUTH), "true", StringComparison.OrdinalIgnoreCase),
+            };
+
+            if (tenantId != Guid.Empty) admin.TenantId = tenantId;
+
+            return admin;
+        }
+
+        static SqlServerPrincipalType ParsePrincipalType(string value)
+        {
+            if (string.Equals(value, "Group", StringComparison.OrdinalIgnoreCase)) return SqlServerPrincipalType.Group;
+            if (string.Equals(value, "Application", StringComparison.OrdinalIgnoreCase)) return SqlServerPrincipalType.Application;
+            return SqlServerPrincipalType.User;
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/TaskConfig.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/TaskConfig.cs
@@ -72,6 +72,15 @@ namespace CloudInstallEngine
                 throw new InstallException($"No configuration by name '{key}'");
             }
         }
+
+        /// <summary>
+        /// Reads a setting that a task can work without, returning null when it is absent. Lets a new
+        /// optional setting be added without breaking every caller that does not supply it.
+        /// </summary>
+        internal string GetOptionalConfigValue(string key)
+        {
+            return base.ContainsKey(key) ? base[key] : null;
+        }
         internal string GetNameConfigValue()
         {
             return GetConfigValue(CONFIG_KEY_NAME);

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/AzureSqlTokenAuth.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/AzureSqlTokenAuth.cs
@@ -1,0 +1,236 @@
+using Azure.Core;
+using Azure.Identity;
+using System;
+using System.Data.SqlClient;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace DataUtils.Sql
+{
+    /// <summary>
+    /// Entra ID (Azure AD) authentication for Azure SQL.
+    /// <para>
+    /// Azure SQL servers can be created with SQL authentication disabled ("Microsoft Entra-only
+    /// authentication"). When that is the case there is no login/password to put in the connection
+    /// string; instead the caller must acquire an Entra access token for the SQL resource and hand
+    /// it to <see cref="SqlConnection.AccessToken"/> before opening the connection.
+    /// </para>
+    /// <para>
+    /// Everything here is opt-in and inferred from the connection string, so existing deployments -
+    /// which still carry <c>user id</c> / <c>password</c> - keep using SQL authentication untouched.
+    /// This mirrors how Redis, Service Bus, Storage and Azure AI Language already prefer RBAC in this
+    /// solution while falling back to key/secret auth. See issue #117.
+    /// </para>
+    /// </summary>
+    public static class AzureSqlTokenAuth
+    {
+        /// <summary>
+        /// Scope for an Azure SQL Database data-plane token. Sovereign clouds use a different audience,
+        /// but the rest of the installer is Azure Public only, so this matches.
+        /// </summary>
+        public const string SqlTokenScope = "https://database.windows.net/.default";
+
+        /// <summary>Host suffix that identifies an Azure SQL Database server (Azure Public cloud).</summary>
+        public const string AzureSqlHostSuffix = ".database.windows.net";
+
+        static TokenCredential _credential;
+
+        /// <summary>
+        /// Registers the credential used to acquire SQL access tokens. Called by the installer (its own
+        /// service principal), by the downloaded control-panel app during a schema upgrade, and by the
+        /// runtime when the App Service has no managed identity available.
+        /// </summary>
+        public static void SetCredential(TokenCredential credential)
+        {
+            Interlocked.Exchange(ref _credential, credential);
+        }
+
+        /// <summary>
+        /// Registers a credential only if one has not already been set. Lets the runtime supply its
+        /// service-principal fallback without overwriting a more specific credential.
+        /// </summary>
+        public static void SetCredentialIfNotSet(TokenCredential credential)
+        {
+            Interlocked.CompareExchange(ref _credential, credential, null);
+        }
+
+        /// <summary>Clears the registered credential. Test hook.</summary>
+        public static void ResetCredential()
+        {
+            Interlocked.Exchange(ref _credential, null);
+        }
+
+        /// <summary>
+        /// The credential to acquire SQL tokens with. Prefers the App Service / VM system-assigned
+        /// managed identity when the host exposes one, because that is the identity the installer
+        /// grants database access to. Otherwise falls back to whatever was registered via
+        /// <see cref="SetCredential"/>.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately NOT <see cref="DefaultAzureCredential"/>: it probes a long chain of sources
+        /// (Visual Studio, Azure CLI, Azure PowerShell, developer tooling) which is slow, unpredictable
+        /// on a server, and can silently authenticate as the wrong identity. The rest of this solution
+        /// has the same rule for Redis/Storage/Service Bus RBAC.
+        /// </remarks>
+        public static TokenCredential Credential
+        {
+            get
+            {
+                var explicitlySet = Volatile.Read(ref _credential);
+                if (explicitlySet != null) return explicitlySet;
+
+                if (HasHostManagedIdentity())
+                {
+                    var managedIdentity = new ManagedIdentityCredential();
+                    Interlocked.CompareExchange(ref _credential, managedIdentity, null);
+                    return Volatile.Read(ref _credential);
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Whether the process is running somewhere that exposes a managed identity endpoint. App Service
+        /// and Azure Functions set IDENTITY_ENDPOINT/IDENTITY_HEADER (older stamps set MSI_ENDPOINT).
+        /// </summary>
+        /// <remarks>
+        /// Checked explicitly rather than letting <see cref="ManagedIdentityCredential"/> probe IMDS,
+        /// which blocks for seconds on a developer machine before failing.
+        /// </remarks>
+        public static bool HasHostManagedIdentity()
+        {
+            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IDENTITY_ENDPOINT"))
+                || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSI_ENDPOINT"));
+        }
+
+        // "Authentication=Active Directory ..." makes SqlClient acquire the token itself, in which case
+        // setting AccessToken as well is an error ("Cannot set the AccessToken property if 'Authentication'
+        // has been specified in the connection string").
+        static readonly Regex _authenticationKeyword =
+            new Regex(@"(^|;)\s*authentication\s*=", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Whether this connection string describes an Azure SQL database that has no credentials of its
+        /// own, and therefore needs an Entra access token.
+        /// </summary>
+        /// <remarks>
+        /// Pure function - no I/O, no token acquisition - so the decision is unit testable. A connection
+        /// string that still carries <c>user id</c> is left alone: that is an existing SQL-authentication
+        /// install, and quietly switching it to Entra would break it.
+        /// </remarks>
+        public static bool NeedsAccessToken(string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString)) return false;
+
+            // SqlClient rejects AccessToken alongside its own Authentication modes, and those modes do
+            // not need our help anyway.
+            if (_authenticationKeyword.IsMatch(connectionString)) return false;
+
+            SqlConnectionStringBuilder builder;
+            try
+            {
+                builder = new SqlConnectionStringBuilder(connectionString);
+            }
+            catch (ArgumentException)
+            {
+                // Not parseable as a SQL connection string - not ours to reason about.
+                return false;
+            }
+
+            // Explicit credentials of any kind mean "leave this connection alone".
+            if (!string.IsNullOrWhiteSpace(builder.UserID)) return false;
+            if (builder.IntegratedSecurity) return false;
+
+            return IsAzureSqlDataSource(builder.DataSource);
+        }
+
+        /// <summary>
+        /// Whether a connection string's data source points at Azure SQL Database. Handles the
+        /// <c>tcp:</c> protocol prefix and an explicit <c>,1433</c> port that Azure's own portal-copied
+        /// connection strings include.
+        /// </summary>
+        public static bool IsAzureSqlDataSource(string dataSource)
+        {
+            if (string.IsNullOrWhiteSpace(dataSource)) return false;
+
+            var host = dataSource.Trim();
+
+            var protocolSeparator = host.IndexOf(':');
+            if (protocolSeparator >= 0) host = host.Substring(protocolSeparator + 1);
+
+            var portSeparator = host.IndexOf(',');
+            if (portSeparator >= 0) host = host.Substring(0, portSeparator);
+
+            return host.Trim().EndsWith(AzureSqlHostSuffix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SqlConnection"/> for the given connection string, attaching an Entra
+        /// access token when the connection string has no credentials of its own. Drop-in replacement
+        /// for <c>new SqlConnection(connectionString)</c>.
+        /// </summary>
+        public static SqlConnection CreateConnection(string connectionString)
+        {
+            var connection = new SqlConnection(connectionString);
+            try
+            {
+                ApplyAccessTokenIfNeeded(connection);
+            }
+            catch
+            {
+                connection.Dispose();
+                throw;
+            }
+            return connection;
+        }
+
+        /// <summary>
+        /// Sets <see cref="SqlConnection.AccessToken"/> when the connection needs one. No-op for
+        /// SQL-authentication and non-Azure connections, so it is safe to call on every connection.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately refreshes the token even when one is already present. A pooled/reused
+        /// <see cref="SqlConnection"/> keeps its <c>AccessToken</c> across close/reopen, so a long-lived
+        /// context (the importer holds contexts for hours) would otherwise reopen with an expired token.
+        /// Re-acquiring is cheap: Azure.Identity credentials cache the token in memory and only call the
+        /// identity provider again when it is close to expiry.
+        /// </remarks>
+        public static void ApplyAccessTokenIfNeeded(SqlConnection connection)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+            if (!NeedsAccessToken(connection.ConnectionString)) return;
+
+            connection.AccessToken = GetAccessToken();
+        }
+
+        /// <summary>
+        /// Acquires an Azure SQL access token from the registered credential. The credential (not the
+        /// token) is cached, so long-running work such as an EF migration keeps getting fresh tokens
+        /// rather than expiring mid-upgrade.
+        /// </summary>
+        public static string GetAccessToken()
+        {
+            var credential = Credential;
+            if (credential == null)
+            {
+                throw new InvalidOperationException(
+                    "This Azure SQL connection string has no user id/password, so it needs Microsoft Entra ID authentication, " +
+                    "but no credential is available. On Azure this means the App Service has no system-assigned managed identity " +
+                    "enabled; elsewhere it means no credential was registered via AzureSqlTokenAuth.SetCredential(). " +
+                    "Re-run the installer to repair the identity and its database permissions.");
+            }
+
+            try
+            {
+                return credential.GetToken(new TokenRequestContext(new[] { SqlTokenScope }), CancellationToken.None).Token;
+            }
+            catch (AuthenticationFailedException ex)
+            {
+                throw new InvalidOperationException(
+                    "Could not acquire a Microsoft Entra ID access token for Azure SQL. The identity this process runs as " +
+                    $"could not authenticate: {ex.Message}", ex);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
@@ -80,7 +80,7 @@ namespace DataUtils.Sql.Inserts
             }
 
             // Do database things
-            using (var opGlobalConnection = new SqlConnection(_connectionString))
+            using (var opGlobalConnection = AzureSqlTokenAuth.CreateConnection(_connectionString))
             {
                 await opGlobalConnection.OpenAsync();
 
@@ -138,7 +138,7 @@ namespace DataUtils.Sql.Inserts
 
         private async Task ProcessChunkAsync(string tempTableName, ILogger logger, List<T> threadListChunk, int chunkIdx)
         {
-            using (var chunkSqlConnection = new SqlConnection(_connectionString))
+            using (var chunkSqlConnection = AzureSqlTokenAuth.CreateConnection(_connectionString))
             {
                 await chunkSqlConnection.OpenAsync();
 

--- a/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
+++ b/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
@@ -536,6 +536,12 @@ namespace Common.Entities
         public SPOInsightsDBConfiguration()
         {
             SetExecutionStrategy("System.Data.SqlClient", () => new System.Data.Entity.SqlServer.SqlAzureExecutionStrategy());
+
+            // Lets EF connect to an Azure SQL server that has SQL authentication disabled, by attaching a
+            // Microsoft Entra ID access token to connections whose connection string carries no
+            // credentials. No-op for every other connection, including the SQL-authentication strings
+            // existing installs still use. See issue #117.
+            AddInterceptor(new Sql.AzureSqlAccessTokenInterceptor());
         }
     }
 }

--- a/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConfig.cs
@@ -27,6 +27,8 @@ namespace Common.Entities.Config
             this.AADInstance = ConfigurationManager.AppSettings.Get("AADInstance");
             this.KeyVaultUrl = ConfigurationManager.AppSettings.Get("KeyVaultUrl");
 
+            RegisterAzureSqlFallbackCredential();
+
             // New: UserGroupsFilter (optional)
             this.UserGroupsFilter = ConfigurationManager.AppSettings.Get("UserGroupsFilter");
 
@@ -265,6 +267,34 @@ namespace Common.Entities.Config
 
             /// <summary>Default daily-gate (hours) for the non-fresh Graph imports. 0 = every cycle (legacy).</summary>
             public int NonFreshGraphIntervalHours { get; set; }
+        }
+
+        /// <summary>
+        /// Makes the runtime service principal available as a fallback identity for Azure SQL, for
+        /// deployments where the database has SQL authentication disabled and the connection string
+        /// therefore carries no login.
+        /// </summary>
+        /// <remarks>
+        /// Only a fallback: <see cref="DataUtils.Sql.AzureSqlTokenAuth"/> prefers the App Service's own
+        /// system-assigned managed identity, which is the identity the installer grants database access
+        /// to. This covers hosts with no managed identity (a hybrid runbook worker, an on-premises job)
+        /// and mirrors how Redis / Storage / Service Bus already fall back to the runtime principal.
+        /// Registered with SetCredentialIfNotSet so it never displaces a credential a caller chose
+        /// deliberately - notably the installer's own principal during a schema upgrade.
+        /// </remarks>
+        private void RegisterAzureSqlFallbackCredential()
+        {
+            if (DataUtils.Sql.AzureSqlTokenAuth.HasHostManagedIdentity()) return;
+
+            if (this.TenantGUID == Guid.Empty
+                || string.IsNullOrEmpty(this.ClientID)
+                || string.IsNullOrEmpty(this.ClientSecret))
+            {
+                return;
+            }
+
+            DataUtils.Sql.AzureSqlTokenAuth.SetCredentialIfNotSet(
+                new Azure.Identity.ClientSecretCredential(this.TenantGUID.ToString(), this.ClientID, this.ClientSecret));
         }
 
         public string BuildLabel { get; set; }

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -443,6 +443,7 @@
     <Compile Include="Redis\ClaimsRedisManager.cs" />
     <Compile Include="Redis\TeamsRedisManager.cs" />
     <Compile Include="AnalyticsEntitiesContext.cs" />
+    <Compile Include="Sql\AzureSqlAccessTokenInterceptor.cs" />
     <Compile Include="IAnalyticsDbContextFactory.cs" />
     <Compile Include="Entities\Url.cs" />
     <Compile Include="Entities\User.cs" />

--- a/src/AnalyticsEngine/Common/Entities/Installer/BaseSolutionInstallConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Installer/BaseSolutionInstallConfig.cs
@@ -23,7 +23,12 @@ namespace Common.Entities.Installer
         //          interaction history import).
         //          2.1.0 -> 2.2.0 added SharePointConfig.AuthClientId / AuthTenantId (optional Entra ID app
         //          registration for the interactive SharePoint sign-in, replacing the old cookie web-login).
-        const string CONFIG_VERSION = "2.2.0";
+        //          2.2.0 -> 2.3.0 added SqlAuthMode + SQLEntraAdminLogin / SQLEntraAdminObjectId /
+        //          SQLEntraAdminPrincipalType (Microsoft Entra ID authentication for Azure SQL). Additive
+        //          and back-compatible: SQLServerAdminUsername / SQLServerAdminPasswordHash are retained
+        //          (deprecated) and an existing config with neither new field keeps using SQL auth exactly
+        //          as before. See issue #117.
+        const string CONFIG_VERSION = "2.3.0";
 
         public BaseSolutionInstallConfig()
         {
@@ -62,7 +67,47 @@ namespace Common.Entities.Installer
 
         public string SQLServerName { get; set; } = string.Empty;
         public string SQLServerDatabaseName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// DEPRECATED. SQL Server authentication admin login for the Azure SQL server.
+        /// </summary>
+        /// <remarks>
+        /// Kept for backwards compatibility: existing deployments were created with SQL authentication and
+        /// must keep working untouched. New deployments should use <see cref="SqlAuthMode"/> =
+        /// <see cref="SqlServerAuthMode.EntraId"/>, which authenticates with Microsoft Entra ID and stores
+        /// no long-lived secret. See issue #117.
+        /// </remarks>
         public string SQLServerAdminUsername { get; set; } = string.Empty;
+
+        /// <summary>
+        /// How the solution authenticates to Azure SQL.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="SqlServerAuthMode.SqlLogin"/> so a config file written by an older
+        /// installer - which has no such property - deserialises to exactly the behaviour it had before.
+        /// Only ever applied when the installer CREATES the SQL server; an existing server's authentication
+        /// configuration is never changed, and the mode actually used at install time is detected from the
+        /// server itself (see <c>SqlServerAuthDetection</c>).
+        /// </remarks>
+        public SqlServerAuthMode SqlAuthMode { get; set; } = SqlServerAuthMode.SqlLogin;
+
+        /// <summary>
+        /// Display name / UPN of the Microsoft Entra ID principal to set as the SQL server's Entra
+        /// administrator. Optional: when blank the installer uses its own service principal, which is the
+        /// identity that has to run the schema upgrade anyway.
+        /// </summary>
+        public string SQLEntraAdminLogin { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Object (principal) ID of <see cref="SQLEntraAdminLogin"/>. Azure requires the object ID, not the
+        /// UPN, to set a server Entra administrator.
+        /// </summary>
+        public string SQLEntraAdminObjectId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Principal type of the configured Entra administrator - "User", "Group" or "Application".
+        /// </summary>
+        public string SQLEntraAdminPrincipalType { get; set; } = "User";
 
         public bool CognitiveServicesEnabled { get; set; } = true;
         public string CognitiveServiceName { get; set; } = string.Empty;
@@ -71,6 +116,14 @@ namespace Common.Entities.Installer
 
         public bool DownloadLatestStable { get; set; } = true;
 
+        /// <summary>
+        /// DEPRECATED. Encrypted SQL Server authentication admin password.
+        /// </summary>
+        /// <remarks>
+        /// Retained so existing config files keep loading and existing SQL-authentication servers keep
+        /// working. Not written when <see cref="SqlAuthMode"/> is <see cref="SqlServerAuthMode.EntraId"/>.
+        /// See issue #117.
+        /// </remarks>
         public string SQLServerAdminPasswordHash { get; set; } = string.Empty;
 
         public string AppInsightsName { get; set; } = string.Empty;
@@ -116,6 +169,30 @@ namespace Common.Entities.Installer
         public List<AzTag> Tags { get; set; } = new List<AzTag>();
 
         public VNetConfig NetworkConfig { get; set; } = new VNetConfig();
+    }
+
+    /// <summary>
+    /// How the solution authenticates to its Azure SQL database.
+    /// </summary>
+    /// <remarks>
+    /// Serialised by name so saved config files stay readable and stay valid if members are ever
+    /// reordered. <see cref="SqlLogin"/> is deliberately the zero/default value so a config file written
+    /// before this property existed loads as "SQL authentication", which is what those deployments use.
+    /// </remarks>
+    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public enum SqlServerAuthMode
+    {
+        /// <summary>
+        /// DEPRECATED for new deployments. SQL Server authentication with an admin login and password
+        /// stored in the connection string. Still fully supported: existing servers are never migrated.
+        /// </summary>
+        SqlLogin = 0,
+
+        /// <summary>
+        /// Microsoft Entra ID authentication. No password is stored anywhere; the App Service uses its
+        /// system-assigned managed identity and the installer uses its own service principal.
+        /// </summary>
+        EntraId = 1,
     }
 
     /// <summary>

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityReadModelLoader.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityReadModelLoader.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DataUtils.Sql;
 
 namespace Common.Entities.LicenceActivity
 {
@@ -105,7 +106,7 @@ namespace Common.Entities.LicenceActivity
             var directory = new ReadModelDirectory();
             try
             {
-                using (var connection = new SqlConnection(_connectionString))
+                using (var connection = AzureSqlTokenAuth.CreateConnection(_connectionString))
                 {
                     await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
                     if (_instrumentation?.ConnectionOpenedForOperation != null)
@@ -200,7 +201,7 @@ namespace Common.Entities.LicenceActivity
             var watch = Stopwatch.StartNew();
             try
             {
-                using (var connection = new SqlConnection(_connectionString))
+                using (var connection = AzureSqlTokenAuth.CreateConnection(_connectionString))
                 {
                     await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
                     if (_instrumentation?.ConnectionOpenedForOperation != null)

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DataUtils.Sql;
 
 namespace Common.Entities.LicenceActivity
 {
@@ -132,7 +133,7 @@ namespace Common.Entities.LicenceActivity
 
             diagnostics = diagnostics ?? NullLicenceActivityDiagnostics.Instance;
 
-            using (var connection = new SqlConnection(_connectionString))
+            using (var connection = AzureSqlTokenAuth.CreateConnection(_connectionString))
             {
                 var connectionWatch = Stopwatch.StartNew();
                 await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
@@ -174,7 +175,7 @@ namespace Common.Entities.LicenceActivity
             ILicenceActivityDiagnostics diagnostics,
             CancellationToken cancellationToken)
         {
-            var connection = new SqlConnection(_connectionString);
+            var connection = AzureSqlTokenAuth.CreateConnection(_connectionString);
             try
             {
                 var watch = Stopwatch.StartNew();
@@ -495,7 +496,7 @@ namespace Common.Entities.LicenceActivity
                     var operationWatch = Stopwatch.StartNew();
                     try
                     {
-                        using (var connection = new SqlConnection(_connectionString))
+                        using (var connection = AzureSqlTokenAuth.CreateConnection(_connectionString))
                         {
                             var connectionWatch = Stopwatch.StartNew();
                             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);

--- a/src/AnalyticsEngine/Common/Entities/Sql/AzureSqlAccessTokenInterceptor.cs
+++ b/src/AnalyticsEngine/Common/Entities/Sql/AzureSqlAccessTokenInterceptor.cs
@@ -1,0 +1,68 @@
+using DataUtils.Sql;
+using System.Data;
+using System.Data.Common;
+using System.Data.Entity.Infrastructure.Interception;
+using System.Data.SqlClient;
+
+namespace Common.Entities.Sql
+{
+    /// <summary>
+    /// Attaches a Microsoft Entra ID access token to every Entity Framework connection that needs one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An Azure SQL server can be created with SQL authentication disabled, in which case the connection
+    /// string has no <c>user id</c> / <c>password</c> and the caller must set
+    /// <see cref="SqlConnection.AccessToken"/> instead. EF6 has no built-in support for that, but it does
+    /// route connection opens through <see cref="DbInterception"/> - including the ones the migration
+    /// pipeline makes for itself, which is the case that matters here, because a schema upgrade opens
+    /// connections EF creates internally rather than the context's own.
+    /// </para>
+    /// <para>
+    /// Deliberately inert unless the connection string genuinely needs a token
+    /// (<see cref="AzureSqlTokenAuth.NeedsAccessToken"/>), so existing SQL-authentication installs and
+    /// LocalDB test databases are completely unaffected. See issue #117.
+    /// </para>
+    /// </remarks>
+    public class AzureSqlAccessTokenInterceptor : IDbConnectionInterceptor
+    {
+        public void Opening(DbConnection connection, DbConnectionInterceptionContext interceptionContext)
+        {
+            var sqlConnection = connection as SqlConnection;
+            if (sqlConnection == null) return;
+
+            AzureSqlTokenAuth.ApplyAccessTokenIfNeeded(sqlConnection);
+        }
+
+        #region Interface members with nothing to do
+
+        // EF6 ships no base class for IDbConnectionInterceptor (unlike DbCommandInterceptor), so every
+        // member has to be implemented even though only Opening does anything.
+
+        public void Opened(DbConnection connection, DbConnectionInterceptionContext interceptionContext) { }
+        public void BeganTransaction(DbConnection connection, BeginTransactionInterceptionContext interceptionContext) { }
+        public void BeginningTransaction(DbConnection connection, BeginTransactionInterceptionContext interceptionContext) { }
+        public void Closed(DbConnection connection, DbConnectionInterceptionContext interceptionContext) { }
+        public void Closing(DbConnection connection, DbConnectionInterceptionContext interceptionContext) { }
+        public void ConnectionStringGetting(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext) { }
+        public void ConnectionStringGot(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext) { }
+        public void ConnectionStringSetting(DbConnection connection, DbConnectionPropertyInterceptionContext<string> interceptionContext) { }
+        public void ConnectionStringSet(DbConnection connection, DbConnectionPropertyInterceptionContext<string> interceptionContext) { }
+        public void ConnectionTimeoutGetting(DbConnection connection, DbConnectionInterceptionContext<int> interceptionContext) { }
+        public void ConnectionTimeoutGot(DbConnection connection, DbConnectionInterceptionContext<int> interceptionContext) { }
+        public void DatabaseGetting(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext) { }
+        public void DatabaseGot(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext) { }
+        public void DataSourceGetting(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext) { }
+        public void DataSourceGot(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext) { }
+        public void Disposing(DbConnection connection, DbConnectionInterceptionContext interceptionContext) { }
+        public void Disposed(DbConnection connection, DbConnectionInterceptionContext interceptionContext) { }
+        public void EnlistingTransaction(DbConnection connection, EnlistTransactionInterceptionContext interceptionContext) { }
+        public void EnlistedTransaction(DbConnection connection, EnlistTransactionInterceptionContext interceptionContext) { }
+        public void ServerVersionGetting(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext) { }
+        public void ServerVersionGot(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext) { }
+        public void StateGetting(DbConnection connection, DbConnectionInterceptionContext<ConnectionState> interceptionContext) { }
+        public void StateGot(DbConnection connection, DbConnectionInterceptionContext<ConnectionState> interceptionContext) { }
+
+        #endregion
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -1,0 +1,479 @@
+using App.ControlPanel.Engine.Entities;
+using App.ControlPanel.Engine.Models;
+using Azure.Core;
+using Common.Entities.Installer;
+using Common.Entities.Sql;
+using DataUtils.Sql;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Data.SqlClient;
+using System.Threading;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Covers Microsoft Entra ID authentication for Azure SQL (issue #117).
+    /// </summary>
+    /// <remarks>
+    /// The rules under test are the ones that decide whether an existing customer deployment keeps using
+    /// its SQL login or is switched to token authentication, so most of these assertions exist to prove
+    /// the backwards-compatible answer, not the new one.
+    /// </remarks>
+    [TestClass]
+    public class AzureSqlEntraAuthTests
+    {
+        // Synthetic throughout - no real server, tenant or identity.
+        const string AzureSqlWithLogin = "data source=contoso-sql.database.windows.net;initial catalog=analytics;persist security info=True;user id=sqladmin;password=Fake123!;MultipleActiveResultSets=True";
+        const string AzureSqlNoLogin = "data source=contoso-sql.database.windows.net;initial catalog=analytics;persist security info=False;MultipleActiveResultSets=True;Encrypt=True";
+        // A deliberately non-palindromic GUID: the SID conversion is endian-sensitive, and a symmetrical
+        // value would let a byte-order bug pass.
+        static readonly Guid AppServiceIdentity = new Guid("0f8fad5b-d9cb-469f-a165-70867728950e");
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // The credential is process-wide ambient state; leaking one would silently change what other
+            // tests exercise.
+            AzureSqlTokenAuth.ResetCredential();
+        }
+
+        #region Connection-string detection
+
+        [TestMethod]
+        public void NeedsAccessToken_AzureSqlWithNoLogin_IsTrue()
+        {
+            Assert.IsTrue(AzureSqlTokenAuth.NeedsAccessToken(AzureSqlNoLogin));
+        }
+
+        /// <summary>
+        /// The single most important assertion here: an existing SQL-authentication deployment must never
+        /// be switched to token authentication behind the operator's back.
+        /// </summary>
+        [TestMethod]
+        public void NeedsAccessToken_AzureSqlWithLogin_IsFalse()
+        {
+            Assert.IsFalse(AzureSqlTokenAuth.NeedsAccessToken(AzureSqlWithLogin));
+        }
+
+        [TestMethod]
+        public void NeedsAccessToken_NonAzureServer_IsFalse()
+        {
+            Assert.IsFalse(AzureSqlTokenAuth.NeedsAccessToken(@"data source=(localdb)\MSSQLLocalDB;initial catalog=UnitTestingAnalytics;integrated security=True"));
+            Assert.IsFalse(AzureSqlTokenAuth.NeedsAccessToken("data source=sql01.contoso.local;initial catalog=analytics"));
+        }
+
+        [TestMethod]
+        public void NeedsAccessToken_IntegratedSecurity_IsFalse()
+        {
+            Assert.IsFalse(AzureSqlTokenAuth.NeedsAccessToken("data source=contoso-sql.database.windows.net;integrated security=True"));
+        }
+
+        /// <summary>
+        /// SqlClient throws if AccessToken is set alongside its own Authentication keyword, so those
+        /// connection strings must be left entirely alone.
+        /// </summary>
+        [TestMethod]
+        public void NeedsAccessToken_SqlClientAuthenticationKeyword_IsFalse()
+        {
+            Assert.IsFalse(AzureSqlTokenAuth.NeedsAccessToken(
+                "data source=contoso-sql.database.windows.net;initial catalog=analytics;Authentication=Active Directory Managed Identity"));
+        }
+
+        [TestMethod]
+        public void NeedsAccessToken_ProtocolPrefixAndPort_IsTrue()
+        {
+            Assert.IsTrue(AzureSqlTokenAuth.NeedsAccessToken("data source=tcp:contoso-sql.database.windows.net,1433;initial catalog=analytics"));
+        }
+
+        [TestMethod]
+        public void NeedsAccessToken_NullEmptyOrUnparseable_IsFalse()
+        {
+            Assert.IsFalse(AzureSqlTokenAuth.NeedsAccessToken(null));
+            Assert.IsFalse(AzureSqlTokenAuth.NeedsAccessToken(string.Empty));
+            Assert.IsFalse(AzureSqlTokenAuth.NeedsAccessToken("this is not a connection string ==== ;;;"));
+        }
+
+        [TestMethod]
+        public void IsAzureSqlDataSource_HandlesCasingAndDecoration()
+        {
+            Assert.IsTrue(AzureSqlTokenAuth.IsAzureSqlDataSource("CONTOSO-SQL.DATABASE.WINDOWS.NET"));
+            Assert.IsTrue(AzureSqlTokenAuth.IsAzureSqlDataSource("tcp:contoso-sql.database.windows.net,1433"));
+            Assert.IsFalse(AzureSqlTokenAuth.IsAzureSqlDataSource("contoso-sql.database.windows.net.evil.example"));
+            Assert.IsFalse(AzureSqlTokenAuth.IsAzureSqlDataSource(null));
+        }
+
+        #endregion
+
+        #region Token application
+
+        [TestMethod]
+        public void ApplyAccessToken_TokenlessAzureConnection_SetsToken()
+        {
+            AzureSqlTokenAuth.SetCredential(new StubTokenCredential("stub-token"));
+
+            using (var connection = AzureSqlTokenAuth.CreateConnection(AzureSqlNoLogin))
+            {
+                Assert.AreEqual("stub-token", connection.AccessToken);
+            }
+        }
+
+        [TestMethod]
+        public void ApplyAccessToken_ConnectionWithLogin_LeavesTokenUnset()
+        {
+            AzureSqlTokenAuth.SetCredential(new StubTokenCredential("stub-token"));
+
+            using (var connection = AzureSqlTokenAuth.CreateConnection(AzureSqlWithLogin))
+            {
+                Assert.IsTrue(string.IsNullOrEmpty(connection.AccessToken));
+            }
+        }
+
+        /// <summary>
+        /// A reused connection keeps its AccessToken across close/reopen, so the token must be replaced on
+        /// every open or a long-running importer would eventually reopen with an expired one.
+        /// </summary>
+        [TestMethod]
+        public void ApplyAccessToken_CalledTwice_RefreshesTheToken()
+        {
+            var credential = new StubTokenCredential("token-1");
+            AzureSqlTokenAuth.SetCredential(credential);
+
+            using (var connection = AzureSqlTokenAuth.CreateConnection(AzureSqlNoLogin))
+            {
+                Assert.AreEqual("token-1", connection.AccessToken);
+
+                credential.NextToken = "token-2";
+                AzureSqlTokenAuth.ApplyAccessTokenIfNeeded(connection);
+
+                Assert.AreEqual("token-2", connection.AccessToken);
+            }
+        }
+
+        [TestMethod]
+        public void ApplyAccessToken_NoCredential_ThrowsExplanatoryError()
+        {
+            AzureSqlTokenAuth.ResetCredential();
+
+            try
+            {
+                AzureSqlTokenAuth.CreateConnection(AzureSqlNoLogin);
+                Assert.Fail("Expected an InvalidOperationException - there is no credential to get a token with.");
+            }
+            catch (InvalidOperationException ex)
+            {
+                StringAssert.Contains(ex.Message, "Microsoft Entra ID authentication");
+            }
+        }
+
+        /// <summary>
+        /// The EF6 interceptor is what tokenises the connections the migration pipeline opens for itself.
+        /// </summary>
+        [TestMethod]
+        public void EfInterceptor_OnlyTokenisesConnectionsThatNeedIt()
+        {
+            AzureSqlTokenAuth.SetCredential(new StubTokenCredential("stub-token"));
+            var interceptor = new AzureSqlAccessTokenInterceptor();
+
+            using (var tokenless = new SqlConnection(AzureSqlNoLogin))
+            using (var withLogin = new SqlConnection(AzureSqlWithLogin))
+            {
+                interceptor.Opening(tokenless, null);
+                interceptor.Opening(withLogin, null);
+
+                Assert.AreEqual("stub-token", tokenless.AccessToken);
+                Assert.IsTrue(string.IsNullOrEmpty(withLogin.AccessToken));
+            }
+        }
+
+        #endregion
+
+        #region Connection string the installer writes
+
+        /// <summary>
+        /// Crosses the boundary that matters: the connection string the installer writes to the App Service
+        /// must be one the runtime recognises as needing a token. If these two ever drift, the web app
+        /// silently fails to authenticate.
+        /// </summary>
+        [TestMethod]
+        public void EntraIdConnectionString_IsRecognisedByTheRuntimeAsNeedingAToken()
+        {
+            var connectionString = DatabasePaaSInfo.GetEntraIdConnectionString("contoso-sql.database.windows.net", "analytics");
+
+            Assert.IsTrue(AzureSqlTokenAuth.NeedsAccessToken(connectionString));
+
+            var builder = new SqlConnectionStringBuilder(connectionString);
+            Assert.AreEqual(string.Empty, builder.UserID);
+            Assert.AreEqual(string.Empty, builder.Password);
+            Assert.AreEqual("analytics", builder.InitialCatalog);
+        }
+
+        [TestMethod]
+        public void EntraIdConnectionString_WithoutDatabase_StillOmitsCredentials()
+        {
+            var connectionString = DatabasePaaSInfo.GetEntraIdConnectionString("contoso-sql.database.windows.net", null);
+
+            Assert.IsTrue(AzureSqlTokenAuth.NeedsAccessToken(connectionString));
+            Assert.AreEqual(string.Empty, new SqlConnectionStringBuilder(connectionString).InitialCatalog);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void EntraIdConnectionString_NoServer_Throws()
+        {
+            DatabasePaaSInfo.GetEntraIdConnectionString(string.Empty, "analytics");
+        }
+
+        #endregion
+
+        #region Per-server auth detection
+
+        /// <summary>
+        /// A server with Entra-only authentication rejects SQL logins outright, so configured credentials
+        /// cannot win here however they are set.
+        /// </summary>
+        [TestMethod]
+        public void Decide_EntraOnlyServer_UsesEntraEvenWithSqlCredentials()
+        {
+            var state = new SqlServerAuthState { EntraOnlyAuthEnabled = true, HasEntraAdmin = true, HasSqlAdminLogin = true };
+
+            Assert.AreEqual(SqlConnectionAuthMethod.EntraId, SqlServerAuthDetection.Decide(state, true, SqlServerAuthMode.SqlLogin).Method);
+            Assert.AreEqual(SqlConnectionAuthMethod.EntraId, SqlServerAuthDetection.Decide(state, false, SqlServerAuthMode.EntraId).Method);
+        }
+
+        /// <summary>The existing-deployment case: nothing about it changes.</summary>
+        [TestMethod]
+        public void Decide_ExistingSqlAuthServer_KeepsSqlLogin()
+        {
+            var state = new SqlServerAuthState { EntraOnlyAuthEnabled = false, HasEntraAdmin = false, HasSqlAdminLogin = true };
+
+            var decision = SqlServerAuthDetection.Decide(state, true, SqlServerAuthMode.SqlLogin);
+
+            Assert.AreEqual(SqlConnectionAuthMethod.SqlLogin, decision.Method);
+            Assert.IsFalse(decision.UsesEntraId);
+        }
+
+        /// <summary>
+        /// Selecting Entra ID must not break an install pointed at an existing SQL-authentication server:
+        /// that server is never reconfigured, so it has no Entra administrator to sign in as.
+        /// </summary>
+        [TestMethod]
+        public void Decide_EntraSelectedButExistingServerHasNoEntraAdmin_FallsBackToSqlLogin()
+        {
+            var state = new SqlServerAuthState { EntraOnlyAuthEnabled = false, HasEntraAdmin = false, HasSqlAdminLogin = true };
+
+            var decision = SqlServerAuthDetection.Decide(state, true, SqlServerAuthMode.EntraId);
+
+            Assert.AreEqual(SqlConnectionAuthMethod.SqlLogin, decision.Method);
+            StringAssert.Contains(decision.Reason, "never reconfigured");
+        }
+
+        [TestMethod]
+        public void Decide_EntraSelectedAndServerHasEntraAdmin_UsesEntra()
+        {
+            var state = new SqlServerAuthState { EntraOnlyAuthEnabled = false, HasEntraAdmin = true, HasSqlAdminLogin = true };
+
+            Assert.AreEqual(SqlConnectionAuthMethod.EntraId, SqlServerAuthDetection.Decide(state, true, SqlServerAuthMode.EntraId).Method);
+        }
+
+        [TestMethod]
+        public void Decide_NoSqlCredentialsButEntraAdminPresent_UsesEntra()
+        {
+            var state = new SqlServerAuthState { EntraOnlyAuthEnabled = false, HasEntraAdmin = true, HasSqlAdminLogin = true };
+
+            Assert.AreEqual(SqlConnectionAuthMethod.EntraId, SqlServerAuthDetection.Decide(state, false, SqlServerAuthMode.SqlLogin).Method);
+        }
+
+        [TestMethod]
+        public void Decide_NothingUsable_ReportsHowToFixIt()
+        {
+            var state = new SqlServerAuthState { EntraOnlyAuthEnabled = false, HasEntraAdmin = false, HasSqlAdminLogin = true };
+
+            var decision = SqlServerAuthDetection.Decide(state, false, SqlServerAuthMode.SqlLogin);
+
+            Assert.AreEqual(SqlConnectionAuthMethod.SqlLogin, decision.Method);
+            StringAssert.Contains(decision.Reason, "no usable way to authenticate");
+        }
+
+        [TestMethod]
+        public void Decide_ServerCouldNotBeInspected_FollowsTheConfiguredCredentials()
+        {
+            Assert.AreEqual(SqlConnectionAuthMethod.SqlLogin, SqlServerAuthDetection.Decide(null, true, SqlServerAuthMode.SqlLogin).Method);
+            Assert.AreEqual(SqlConnectionAuthMethod.EntraId, SqlServerAuthDetection.Decide(null, false, SqlServerAuthMode.EntraId).Method);
+        }
+
+        /// <summary>
+        /// "New SQL: Entra ID enabled. Existing SQL: leave as is." An existing server must never be
+        /// provisioned with Entra-only authentication, whatever the operator selected.
+        /// </summary>
+        [TestMethod]
+        public void ShouldProvisionWithEntraAuth_OnlyForNewServers()
+        {
+            Assert.IsTrue(SqlServerAuthDetection.ShouldProvisionWithEntraAuth(serverAlreadyExists: false, configuredMode: SqlServerAuthMode.EntraId));
+            Assert.IsFalse(SqlServerAuthDetection.ShouldProvisionWithEntraAuth(serverAlreadyExists: true, configuredMode: SqlServerAuthMode.EntraId));
+            Assert.IsFalse(SqlServerAuthDetection.ShouldProvisionWithEntraAuth(serverAlreadyExists: false, configuredMode: SqlServerAuthMode.SqlLogin));
+        }
+
+        #endregion
+
+        #region Contained-user T-SQL
+
+        /// <summary>
+        /// SQL Server wants the object ID's raw little-endian GUID bytes, not the textual GUID. Getting the
+        /// byte order wrong produces a user that exists but can never authenticate.
+        /// </summary>
+        [TestMethod]
+        public void ToSqlSid_IsTheGuidsLittleEndianByteLayout()
+        {
+            var expected = "0x" + BitConverter.ToString(AppServiceIdentity.ToByteArray()).Replace("-", string.Empty);
+
+            Assert.AreEqual(expected, SqlContainedUserScript.ToSqlSid(AppServiceIdentity));
+        }
+
+        [TestMethod]
+        public void CreateUserAndGrantRoles_CreatesExternalUserAndAddsRoles()
+        {
+            var sql = SqlContainedUserScript.CreateUserAndGrantRoles(
+                "contoso-analytics-web", AppServiceIdentity, SqlContainedUserScript.AppServiceRoles);
+
+            StringAssert.Contains(sql, $"CREATE USER [contoso-analytics-web] WITH SID = {SqlContainedUserScript.ToSqlSid(AppServiceIdentity)}, TYPE = E;");
+            StringAssert.Contains(sql, "ALTER ROLE [db_datareader] ADD MEMBER [contoso-analytics-web];");
+            StringAssert.Contains(sql, "ALTER ROLE [db_datawriter] ADD MEMBER [contoso-analytics-web];");
+
+            // The importers create and drop real dbo staging tables, so DDL rights are functional, not
+            // optional - see InsertBatch.
+            StringAssert.Contains(sql, "ALTER ROLE [db_ddladmin] ADD MEMBER [contoso-analytics-web];");
+
+            StringAssert.Contains(sql, "GRANT EXECUTE TO [contoso-analytics-web];");
+
+            // No Microsoft Graph lookup, so the SQL server does not need the Directory Readers role.
+            Assert.IsFalse(sql.Contains("FROM EXTERNAL PROVIDER"));
+        }
+
+        /// <summary>Re-running the installer must not fail on an already-granted identity.</summary>
+        [TestMethod]
+        public void CreateUserAndGrantRoles_IsIdempotent()
+        {
+            var sql = SqlContainedUserScript.CreateUserAndGrantRoles("contoso-analytics-web", AppServiceIdentity, new[] { "db_datareader" });
+
+            StringAssert.Contains(sql, "IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE [name] = N'contoso-analytics-web')");
+            StringAssert.Contains(sql, "sys.database_role_members");
+        }
+
+        [TestMethod]
+        public void CreateUserAndGrantRoles_EscapesIdentifiers()
+        {
+            var sql = SqlContainedUserScript.CreateUserAndGrantRoles("we][rd'name", AppServiceIdentity, new string[0]);
+
+            // T-SQL bracket quoting only doubles the closing bracket; the single quote only matters in the
+            // N'...' literal used by the existence check.
+            StringAssert.Contains(sql, "CREATE USER [we]][rd'name]");
+            StringAssert.Contains(sql, "N'we][rd''name'");
+        }
+
+        [TestMethod]
+        public void ToSqlSid_KnownGuid_MatchesSqlServersExpectedByteOrder()
+        {
+            // 0f8fad5b-d9cb-469f-a165-70867728950e: first three groups are byte-reversed, the last two are not.
+            Assert.AreEqual("0x5BAD8F0FCBD99F46A16570867728950E", SqlContainedUserScript.ToSqlSid(AppServiceIdentity));
+        }
+
+        [TestMethod]
+        public void CreateUserAndGrantRoles_SkipsBlankRoles()
+        {
+            var sql = SqlContainedUserScript.CreateUserAndGrantRoles("contoso-analytics-web", AppServiceIdentity, new[] { "db_datareader", string.Empty, null });
+
+            Assert.AreEqual(1, CountOccurrences(sql, "ALTER ROLE"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateUserAndGrantRoles_EmptyPrincipalName_Throws()
+        {
+            SqlContainedUserScript.CreateUserAndGrantRoles(" ", AppServiceIdentity, new string[0]);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateUserAndGrantRoles_EmptyObjectId_Throws()
+        {
+            SqlContainedUserScript.CreateUserAndGrantRoles("contoso-analytics-web", Guid.Empty, new string[0]);
+        }
+
+        #endregion
+
+        #region Schema-upgrade credential hand-off
+
+        /// <summary>
+        /// The schema upgrade runs in a separately downloaded control-panel process, so it needs its own
+        /// credential. All three parts must be present or it cannot authenticate.
+        /// </summary>
+        [TestMethod]
+        public void DatabaseUpgradeInfo_HasEntraCredential_RequiresAllThreeParts()
+        {
+            Assert.IsFalse(new DatabaseUpgradeInfo().HasEntraCredential);
+            Assert.IsFalse(new DatabaseUpgradeInfo { EntraTenantId = "tenant", EntraClientId = "client" }.HasEntraCredential);
+            Assert.IsTrue(new DatabaseUpgradeInfo { EntraTenantId = "tenant", EntraClientId = "client", EntraClientSecret = "secret" }.HasEntraCredential);
+        }
+
+        #endregion
+
+        #region Config schema back-compatibility
+
+        /// <summary>
+        /// A config file written before this change has no SqlAuthMode property, and must load as SQL
+        /// authentication - the behaviour it was saved with.
+        /// </summary>
+        [TestMethod]
+        public void SqlAuthMode_DefaultsToSqlLoginForOlderConfigs()
+        {
+            var loaded = Newtonsoft.Json.JsonConvert.DeserializeObject<BaseSolutionInstallConfig>(
+                "{ \"SQLServerName\": \"contoso-sql\", \"SQLServerAdminUsername\": \"sqladmin\" }");
+
+            Assert.AreEqual(SqlServerAuthMode.SqlLogin, loaded.SqlAuthMode);
+        }
+
+        [TestMethod]
+        public void SqlAuthMode_SerialisesByName()
+        {
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(new BaseSolutionInstallConfig { SqlAuthMode = SqlServerAuthMode.EntraId });
+
+            StringAssert.Contains(json, "\"SqlAuthMode\":\"EntraId\"");
+        }
+
+        #endregion
+
+        static int CountOccurrences(string haystack, string needle)
+        {
+            var count = 0;
+            var index = 0;
+            while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += needle.Length;
+            }
+            return count;
+        }
+
+        /// <summary>Hands out a fixed token so the tests never touch Entra ID.</summary>
+        private class StubTokenCredential : TokenCredential
+        {
+            public StubTokenCredential(string token)
+            {
+                NextToken = token;
+            }
+
+            public string NextToken { get; set; }
+
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                Assert.AreEqual(AzureSqlTokenAuth.SqlTokenScope, requestContext.Scopes[0]);
+                return new AccessToken(NextToken, DateTimeOffset.UtcNow.AddHours(1));
+            }
+
+            public override System.Threading.Tasks.ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                return new System.Threading.Tasks.ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -223,6 +223,36 @@ namespace Tests.UnitTests
             DatabasePaaSInfo.GetEntraIdConnectionString(string.Empty, "analytics");
         }
 
+        /// <summary>
+        /// The SQL-login path must fail with something an operator can act on. Without this the missing
+        /// password surfaced as a bare ArgumentException naming a parameter, which the installer reports as
+        /// "FATAL: Unexpected error of type 'ArgumentException'".
+        /// </summary>
+        [TestMethod]
+        public void EnsureSqlLoginUsable_MissingCredentials_ExplainsBothWaysToFixIt()
+        {
+            foreach (var missing in new[] { new[] { "sqladmin", "" }, new[] { "", "Fake123!" }, new[] { " ", " " } })
+            {
+                try
+                {
+                    DatabasePaaSInfo.EnsureSqlLoginUsable("contoso-sql.database.windows.net", missing[0], missing[1]);
+                    Assert.Fail("Expected an InvalidOperationException when there is no usable way to authenticate.");
+                }
+                catch (InvalidOperationException ex)
+                {
+                    StringAssert.Contains(ex.Message, "contoso-sql.database.windows.net");
+                    StringAssert.Contains(ex.Message, "SQL administrator credentials");
+                    StringAssert.Contains(ex.Message, "Microsoft Entra");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EnsureSqlLoginUsable_WithCredentials_DoesNotThrow()
+        {
+            DatabasePaaSInfo.EnsureSqlLoginUsable("contoso-sql.database.windows.net", "sqladmin", "Fake123!");
+        }
+
         #endregion
 
         #region Per-server auth detection

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="ActivityImportCacheProviderTests.cs" />
     <Compile Include="ActivityImportCacheWindowTests.cs" />
     <Compile Include="ActivityImporterTests.cs" />
+    <Compile Include="AzureSqlEntraAuthTests.cs" />
     <Compile Include="ActivityReportLoaderTimeoutTests.cs" />
     <Compile Include="ActivityReportSetMinMaxTests.cs" />
     <Compile Include="ActivitySaveConcurrencyPolicyTests.cs" />

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SearchesSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SearchesSaveExtension.cs
@@ -1,4 +1,5 @@
 using Common.Entities;
+using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -60,7 +61,7 @@ namespace WebJob.AppInsightsImporter.Engine.Sql
             var defaultConnectionString = database.Database.Connection.ConnectionString;
 
             // Create our own connection & context to use it
-            using (var con = new SqlConnection(defaultConnectionString))
+            using (var con = AzureSqlTokenAuth.CreateConnection(defaultConnectionString))
             {
                 con.Open();
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -183,7 +183,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                 await _sqlSaveSemaphore.WaitAsync();
                 try
                 {
-                    using (var con = new SqlConnection(_defaultConnectionString))
+                    using (var con = AzureSqlTokenAuth.CreateConnection(_defaultConnectionString))
                     {
                         con.Open();
                         using (var db = new AnalyticsEntitiesContext(con))
@@ -207,7 +207,7 @@ namespace WebJob.Office365ActivityImporter.Engine
                 try
                 {
                     var shardedStagingTable = ActivitySaveConcurrencyPolicy.NewShardedStagingTableName();
-                    using (var con = new SqlConnection(_defaultConnectionString))
+                    using (var con = AzureSqlTokenAuth.CreateConnection(_defaultConnectionString))
                     {
                         con.Open();
                         using (var db = new AnalyticsEntitiesContext(con))

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -1,5 +1,6 @@
 using Common.Entities;
 using DataUtils;
+using DataUtils.Sql;
 using DataUtils.Sql.Inserts;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -544,7 +545,7 @@ namespace ActivityImporter.Engine.ActivityAPI.Copilot
                 var sql = rr.ReadResourceString(
                     "WebJob.Office365ActivityImporter.Engine.ActivityAPI.Copilot.SQL.repair_denormalised_copilot_columns.sql");
 
-                using (var con = new SqlConnection(connectionString))
+                using (var con = AzureSqlTokenAuth.CreateConnection(connectionString))
                 {
                     await con.OpenAsync();
                     using (var cmd = new SqlCommand(sql, con) { CommandTimeout = repairTimeoutSecs })

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserBulkUpdateWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserBulkUpdateWriter.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
+using DataUtils.Sql;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
@@ -37,7 +38,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             if (userUpdates.Rows.Count == 0)
                 return;
 
-            using (var connection = new SqlConnection(_connectionString))
+            using (var connection = AzureSqlTokenAuth.CreateConnection(_connectionString))
             {
                 await connection.OpenAsync();
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Aggregation_Status.ps1
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Aggregation_Status.ps1
@@ -7,11 +7,21 @@ $VerbosePreference = 'SilentlyContinue'
 
 function fd($date) { $date.ToString('yyyy-MM-dd') }
 
-$SqlCredential = Get-AutomationPSCredential -Name "SqlCredential"
+$SqlCredential = Get-AutomationPSCredential -Name "SqlCredential" -ErrorAction SilentlyContinue
 $SqlServer = Get-AutomationVariable -Name "SqlServer"
 $SqlDatabase = Get-AutomationVariable -Name "SqlDatabase"
-$SqlUsername = $SqlCredential.UserName
-$SqlPass = $SqlCredential.GetNetworkCredential().Password
+
+# The "SqlCredential" automation credential only exists while the database uses SQL Server
+# authentication. When the installer configures Microsoft Entra ID authentication there is no login to
+# store, so this Automation account's own managed identity is used instead. See issue #117.
+$UseManagedIdentity = ($null -eq $SqlCredential)
+if ($UseManagedIdentity) {
+    $SqlUsername = ''
+    $SqlPass = ''
+} else {
+    $SqlUsername = $SqlCredential.UserName
+    $SqlPass = $SqlCredential.GetNetworkCredential().Password
+}
 $SqlConnectionString = "`
 data source=$SqlServer;`
 initial catalog=$SqlDatabase;`
@@ -21,7 +31,22 @@ persist security info=True;`
 MultipleActiveResultSets=True;`
 Encrypt=True;`
 Connection Timeout=60"
+if ($UseManagedIdentity) {
+    # No SQL login to put in the connection string: build a credential-free one and attach a Microsoft
+    # Entra ID access token. SqlClient rejects an access token alongside a user id/password.
+    $SqlConnectionString = "data source=$SqlServer;initial catalog=$SqlDatabase;persist security info=False;MultipleActiveResultSets=True;Encrypt=True;Connection Timeout=60"
+}
 $DatabaseConnection = New-Object System.Data.SqlClient.SqlConnection($SqlConnectionString)
+if ($UseManagedIdentity) {
+    Connect-AzAccount -Identity | Out-Null
+    $SqlAccessToken = Get-AzAccessToken -ResourceUrl "https://database.windows.net/"
+    if ($SqlAccessToken.Token -is [System.Security.SecureString]) {
+        # Newer Az modules return the token as a SecureString.
+        $DatabaseConnection.AccessToken = [System.Net.NetworkCredential]::new('', $SqlAccessToken.Token).Password
+    } else {
+        $DatabaseConnection.AccessToken = $SqlAccessToken.Token
+    }
+}
 
 $SqlCmd = @"
 -- Query 1

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Database_Maintenance.ps1
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Database_Maintenance.ps1
@@ -18,11 +18,21 @@ $VerbosePreference = 'SilentlyContinue'
 
 function fd($date) { $date.ToString('yyyy-MM-dd') }
 
-$SqlCredential = Get-AutomationPSCredential -Name "SqlCredential"
+$SqlCredential = Get-AutomationPSCredential -Name "SqlCredential" -ErrorAction SilentlyContinue
 $SqlServer = Get-AutomationVariable -Name "SqlServer"
 $SqlDatabase = Get-AutomationVariable -Name "SqlDatabase"
-$SqlUsername = $SqlCredential.UserName
-$SqlPass = $SqlCredential.GetNetworkCredential().Password
+
+# The "SqlCredential" automation credential only exists while the database uses SQL Server
+# authentication. When the installer configures Microsoft Entra ID authentication there is no login to
+# store, so this Automation account's own managed identity is used instead. See issue #117.
+$UseManagedIdentity = ($null -eq $SqlCredential)
+if ($UseManagedIdentity) {
+    $SqlUsername = ''
+    $SqlPass = ''
+} else {
+    $SqlUsername = $SqlCredential.UserName
+    $SqlPass = $SqlCredential.GetNetworkCredential().Password
+}
 $SqlConnectionString = "`
 data source=$SqlServer;`
 initial catalog=$SqlDatabase;`
@@ -32,7 +42,22 @@ persist security info=True;`
 MultipleActiveResultSets=True;`
 Encrypt=True;`
 Connection Timeout=60"
+if ($UseManagedIdentity) {
+    # No SQL login to put in the connection string: build a credential-free one and attach a Microsoft
+    # Entra ID access token. SqlClient rejects an access token alongside a user id/password.
+    $SqlConnectionString = "data source=$SqlServer;initial catalog=$SqlDatabase;persist security info=False;MultipleActiveResultSets=True;Encrypt=True;Connection Timeout=60"
+}
 $DatabaseConnection = New-Object System.Data.SqlClient.SqlConnection($SqlConnectionString)
+if ($UseManagedIdentity) {
+    Connect-AzAccount -Identity | Out-Null
+    $SqlAccessToken = Get-AzAccessToken -ResourceUrl "https://database.windows.net/"
+    if ($SqlAccessToken.Token -is [System.Security.SecureString]) {
+        # Newer Az modules return the token as a SecureString.
+        $DatabaseConnection.AccessToken = [System.Net.NetworkCredential]::new('', $SqlAccessToken.Token).Password
+    } else {
+        $DatabaseConnection.AccessToken = $SqlAccessToken.Token
+    }
+}
 
 $SqlCmdWeekly = @"
 -- Maintain EVERY index + all statistics across the database. Ola's IndexOptimize

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Weekly.ps1
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Weekly.ps1
@@ -10,11 +10,21 @@ param(
 $ErrorActionPreference = 'Stop'
 $VerbosePreference = 'SilentlyContinue'
 
-$SqlCredential = Get-AutomationPSCredential -Name "SqlCredential"
+$SqlCredential = Get-AutomationPSCredential -Name "SqlCredential" -ErrorAction SilentlyContinue
 $SqlServer = Get-AutomationVariable -Name "SqlServer"
 $SqlDatabase = Get-AutomationVariable -Name "SqlDatabase"
-$SqlUsername = $SqlCredential.UserName
-$SqlPass = $SqlCredential.GetNetworkCredential().Password
+
+# The "SqlCredential" automation credential only exists while the database uses SQL Server
+# authentication. When the installer configures Microsoft Entra ID authentication there is no login to
+# store, so this Automation account's own managed identity is used instead. See issue #117.
+$UseManagedIdentity = ($null -eq $SqlCredential)
+if ($UseManagedIdentity) {
+    $SqlUsername = ''
+    $SqlPass = ''
+} else {
+    $SqlUsername = $SqlCredential.UserName
+    $SqlPass = $SqlCredential.GetNetworkCredential().Password
+}
 $SqlConnectionString = "`
 data source=$SqlServer;`
 initial catalog=$SqlDatabase;`
@@ -24,7 +34,22 @@ persist security info=True;`
 MultipleActiveResultSets=True;`
 Encrypt=True;`
 Connection Timeout=60"
+if ($UseManagedIdentity) {
+    # No SQL login to put in the connection string: build a credential-free one and attach a Microsoft
+    # Entra ID access token. SqlClient rejects an access token alongside a user id/password.
+    $SqlConnectionString = "data source=$SqlServer;initial catalog=$SqlDatabase;persist security info=False;MultipleActiveResultSets=True;Encrypt=True;Connection Timeout=60"
+}
 $DatabaseConnection = New-Object System.Data.SqlClient.SqlConnection($SqlConnectionString)
+if ($UseManagedIdentity) {
+    Connect-AzAccount -Identity | Out-Null
+    $SqlAccessToken = Get-AzAccessToken -ResourceUrl "https://database.windows.net/"
+    if ($SqlAccessToken.Token -is [System.Security.SecureString]) {
+        # Newer Az modules return the token as a SecureString.
+        $DatabaseConnection.AccessToken = [System.Net.NetworkCredential]::new('', $SqlAccessToken.Token).Password
+    } else {
+        $DatabaseConnection.AccessToken = $SqlAccessToken.Token
+    }
+}
 
 $WeeksToKeep = Get-AutomationVariable -Name "WeeksToKeep"
 


### PR DESCRIPTION
## Summary

Adds Microsoft Entra ID authentication for Azure SQL, so the installer can run schema upgrades — and the runtime can connect — against a server that has SQL authentication disabled.

**This is a deliberately scoped, backwards-compatible subset of #117, not the whole issue.** The issue as written removes `SQLServerAdminUsername` / `SQLServerAdminPassword` and flips every server to `AzureADOnlyAuthentication=true`, which is a breaking change for every existing operator. That is *not* what this PR does:

| #117 as written | This PR |
|---|---|
| Remove the SQL admin username/password fields | **Retained**, documented as deprecated, greyed out in the UI when Entra is selected |
| Provision every server with `AzureADOnlyAuthentication=true` | **New servers only.** An existing server's `Administrators` / Entra-only settings are never touched |
| Breaking `CONFIG_VERSION` major bump | **Minor** bump (2.2.0 → 2.3.0) — every new property is additive and defaults to today's behaviour |
| Operators must re-run the installer with an Entra admin | **No action required.** An existing deployment upgrades and keeps its SQL login |

Addresses #117.

## The rule everything follows

The auth method is inferred from the connection string, and the connection string is chosen from what Azure reports about the server — not from a config flag alone.

`AzureSqlTokenAuth.NeedsAccessToken` is a pure function: a connection string needs an Entra token only when it has **no** `User ID`, **no** `Integrated Security`, **no** `Authentication=` keyword, and its data source is `*.database.windows.net`. Every existing deployment's connection string carries a `user id`, so every new code path is inert for them.

## Changes

### Runtime (`Common.DataUtils`, `Common.Entities`)

* **`DataUtils.Sql.AzureSqlTokenAuth`** — the detection rule above, an ambient `TokenCredential`, and a `SqlConnection` factory that attaches the token.
  * Prefers the host's **system-assigned managed identity**, detected via `IDENTITY_ENDPOINT`/`MSI_ENDPOINT` rather than letting `ManagedIdentityCredential` probe IMDS (which blocks for seconds off-Azure).
  * Deliberately **not** `DefaultAzureCredential`, per this repo's existing rule for Redis / Storage / Service Bus RBAC.
* **`Common.Entities.Sql.AzureSqlAccessTokenInterceptor`** — an EF6 `IDbConnectionInterceptor` registered in the existing `SPOInsightsDBConfiguration`. This is what covers the **migration pipeline**, which opens connections EF creates internally rather than the context's own. It refreshes the token on *every* `Opening`: a reused `SqlConnection` keeps its `AccessToken` across close/reopen, so a context held for hours would otherwise reopen with an expired one.
* Production raw-ADO sites now go through the factory: `InsertBatch`, `SqlLicenceActivityStore`, `SqlLicenceActivityReadModelLoader`, `ActivityReportSqlPersistenceManager`, `CopilotAuditEventManager`, `SqlUserBulkUpdateWriter`, `SearchesSaveExtension`.
* `AppConfig` registers the runtime service principal as a **fallback only** — when no managed identity is present, and never displacing a credential already set.

### Provisioning (`CloudInstallEngine`, `App.ControlPanel.Engine`)

* `SqlServerTask` sets a Microsoft Entra administrator and Entra-only authentication **on the create path only**, and then omits the SQL admin login/password entirely (Azure rejects both on an Entra-only server). The existing-server branch gains no auth changes at all.
* `AzurePaaSInstallJob` resolves the Entra administrator *before* provisioning, because it can only be set at creation time. It defaults to **the installer's own service principal**: Azure allows exactly one Entra administrator per server, and the installer is the identity that has to sign in to apply the schema upgrade — so anything else as the default would break the install it exists to enable. An explicitly configured administrator is honoured, with a warning that the installer principal must also be able to sign in (typically via a group).

### Detection

* `SqlServerAuthDetection.Decide` — pure rules, in priority order:
  1. Server has Entra-only auth → **Entra** (SQL logins are rejected outright).
  2. Entra selected *and* the server has an Entra admin → **Entra**.
  3. SQL credentials configured → **SQL login**. *This is the branch that protects existing deployments*, including when Entra was selected but the server is a pre-existing SQL-auth server that we refuse to reconfigure.
  4. Server has an Entra admin → **Entra**.
  5. Otherwise → SQL login, with an explicit "no usable way to authenticate" message naming both fixes.
* `SqlServerAuthReader` reads the state from ARM, including the `azureADOnlyAuthentications` and `administrators` **child resources**, so a customer's own portal/CLI change is picked up rather than only what this installer wrote.

### App Service and Automation permissions

Azure SQL has no ARM role that grants data-plane access, so "the App Service needs its own RBAC assignment" is a **contained database user**, not another `RoleAssignmentTask`.

* `SqlContainedUserScript` generates idempotent T-SQL: `CREATE USER [name] WITH SID = 0x…, TYPE = E`, role membership, `GRANT EXECUTE`.
  * `WITH SID` rather than `FROM EXTERNAL PROVIDER` on purpose: the latter makes the SQL server call Microsoft Graph to resolve the name and fails with *"Principal '…' could not be found"* unless the server's identity has the tenant-wide **Directory Readers** role — a Global-Administrator-only grant we cannot assume.
  * App Service gets `db_datareader`, `db_datawriter`, `db_ddladmin`. **`db_ddladmin` is functional, not defensive**: `InsertBatch` creates and drops real `dbo` staging tables at runtime.
  * Automation account gets `db_owner` — its runbooks run Ola Hallengren's `IndexOptimize` and create objects in the `profiling` schema.
* Granted after SQL connectivity is proven and before the schema upgrade, so the site comes back up with working access. Best-effort: a failure logs the manual `CREATE USER` remedy rather than aborting the install.

### Automation runbooks

* The Automation account now always gets a system-assigned managed identity (create *and* existing paths).
* The `SQLCredential` automation credential is **skipped** on the Entra path — creating an empty one would make the runbooks take the SQL branch and fail. If detection later falls back to a SQL login, the credential is created after the fact rather than leaving usage-report automation silently broken.
* `Aggregation_Status.ps1` / `Database_Maintenance.ps1` / `Weekly.ps1` detect the credential's absence and use `Connect-AzAccount -Identity` + an access token on `SqlConnection`. They build a credential-free connection string for that path because SqlClient rejects an access token alongside a `user id`/`password`, and they unwrap the token when a newer Az module returns a `SecureString`. **The SQL-login path in all three is unchanged.**

### Version skew (the trap called out on the issue)

The schema upgrade does not run in-process — `SqlInstallerTasks` shells out to the *separately downloaded* control-panel app. So a token-less connection string is only usable if that child can authenticate.

* `DatabaseUpgradeInfo` and `InstallStatus` now carry the service principal. A **credential**, not a token: an upgrade on a large database can outlive a token's lifetime.
* `DatabaseUpgrader` and `Program.cs` register it before opening anything. Both warn explicitly when a token-less connection string meets a build with no credential, naming the downloaded-build-is-too-old cause.

### UI and validation

* New **"Use Microsoft Entra ID authentication (recommended) — the SQL login below is deprecated"** checkbox on the SQL page. The username/password fields stay, greyed out when it is ticked.
* `ValidatInputAndGetErrors` only demands the SQL login on the SQL-login path; the Entra path validates the optional admin object ID is a GUID.
* Test Configuration autodetect now works without a SQL password.

## Config schema

`CONFIG_VERSION` 2.2.0 → **2.3.0** (minor). Adds `SqlAuthMode`, `SQLEntraAdminLogin`, `SQLEntraAdminObjectId`, `SQLEntraAdminPrincipalType`. `SqlAuthMode` serialises **by name** and `SqlLogin` is the zero value, so a config file written before this change loads as SQL authentication — the behaviour it was saved with. `SQLServerAdminUsername` / `SQLServerAdminPasswordHash` are retained and documented as deprecated.

## Migrations

**None.** No EF entity, `DbSet`, property or `[Table]` changed; no file added under `Common/Entities/Migrations/`; `Create DB.sql` untouched. No manual SQL upgrade script is required for this PR.

## Tests

35 new tests in `Tests.UnitTests/AzureSqlEntraAuthTests.cs`, weighted towards the backwards-compatible answers:

* Detection in both directions, including everything that must **not** be tokenised: an existing `user id`/`password` string, integrated security, a non-Azure data source, and SqlClient's own `Authentication=` keyword.
* Token refresh on a second `Opening` (the stale-token-on-reuse case).
* The EF6 interceptor tokenises only what needs it.
* **A cross-boundary test that the connection string the installer writes is one the runtime recognises as needing a token.** If those two ever drift, the web app silently fails to authenticate with no useful error — this is the assertion that catches it.
* Every `Decide` branch, plus `ShouldProvisionWithEntraAuth` proving an existing server is never provisioned Entra-only.
* The T-SQL generator: idempotency guards, role membership, identifier escaping, absence of `FROM EXTERNAL PROVIDER`, and an **endian-sensitive** SID conversion checked against a known GUID (a symmetrical GUID would let a byte-order bug pass, and a wrong SID produces a user that exists but can never authenticate).
* Config back-compatibility: no `SqlAuthMode` ⇒ `SqlLogin`; serialises by name.
* The SQL-login path's "no way to authenticate" guard fails with the actionable message rather than a bare `ArgumentException` (extracted to `EnsureSqlLoginUsable` precisely so it is testable — the ARM resource types the `ConnectionString` getter reads cannot be constructed in a test).

## Reviewer hotspots

1. **`SqlServerAuthDetection.Decide` priority order** — this is where "don't break existing installs" is enforced. Branch 3 is load-bearing.
2. **`SqlServerTask`'s existing-server branch** — confirm nothing there touches `Administrators` or Entra-only auth.
3. **Entra admin defaults to the installer service principal.** Reasonable, but it means a human admin is not the server's Entra admin unless configured. They can be added afterwards in the portal.
4. **Runbook diffs** — check the SQL-login path is genuinely untouched and only the `$UseManagedIdentity` branch is new.
5. **`AutomationAccountTask` skip-then-repair** for `SQLCredential`: the account is provisioned before the server's real capabilities are known, so the credential is created after detection if the install fell back to a SQL login.

## Deferred / not in this PR

* **No migration of existing servers to Entra.** By design, per the scope above. An operator wanting it must flip the server in Azure themselves; the installer will then detect it and use tokens.
* **Power BI impact (@jesusfer's question on the issue) is not addressed.** Power BI connects to the database independently of this code. Because no existing server is switched, nothing changes for Power BI today — but a customer who opts a *new* deployment into Entra-only must configure their Power BI dataset for Entra auth. Worth confirming before this is recommended as the default.
* **`GetSqlDetails` still cannot read back a SQL password** (it never could); it now simply tolerates its absence.
* Migration from `System.Data.SqlClient` to `Microsoft.Data.SqlClient` — out of scope on the issue, and the access-token path works on the legacy provider.

## Validation

* `App.ControlPanel.WinForms`, `WebJob.Office365ActivityImporter`, `WebJob.AppInsightsImporter`, `CloudInstallEngine`, `Tests.UnitTests` all rebuild clean.
* All three runbooks parse cleanly via `System.Management.Automation.Language.Parser`.
* **37/37 new tests pass**, and **134/134 pass** across every test class that touches a connection path this PR changed — `CopilotAuditEventManagerStagingTests`, `UserMetadataUpdaterInsertTests`, the `UserLicense*` classes, `PageUpdateManager*`, `InstallEngineTests`, `UrlFullUrlMigrationPipelineTests` — run against a **clean** local database.
* The full `Tests.UnitTests` run is **not** green on this machine, and was not green before these changes either. The remaining failures are environment-dependent, with three distinct causes, none related to this PR:
  * tests needing real Azure credentials — the placeholder tenant `00000000-0000-0000-0000-000000000002` returns `AADSTS90002` (Graph, Teams, Redis RBAC, usage-stats tests);
  * a test needing a reachable Azure AI Language endpoint — DNS failure on the placeholder host (`CommentsCognitiveTests`);
  * `VNetIntegrationTests`, which assert on an operator-supplied `InstallTests/TestConfigs/InstallerTestConfig.json` that is not in the repo.
* **Reproducing locally:** a test database left over from another branch fails ~60 DB-backed tests with `AutomaticDataLossException` *before any of this code runs*. Drop `(localdb)\MSSQLLocalDB::UnitTestingSPOInsights` first, as `.github/copilot-instructions.md` describes — that alone took those ~60 from red to green here, and is worth checking before attributing any DB failure to this PR.
* Not exercised against a real Azure subscription; the Azure-facing paths are covered by the pure rules and generators above.
