### PR TITLE
Diagnose a failed Graph webhook validation callback instead of blaming permissions

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/CallsImportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CallsImportTests.cs
@@ -105,23 +105,133 @@ namespace Tests.UnitTests
         /// reported and re-thrown - but without wrongly telling the admin to grant a permission they
         /// have already granted.
         /// </summary>
+        /// <remarks>
+        /// The example here used to be "Subscription validation request failed." That message is now
+        /// classified and diagnosed specifically (issue #273), so it is no longer an example of the
+        /// generic path. Using a genuinely unrelated Graph failure keeps this test honest.
+        /// </remarks>
         [TestMethod]
         public async Task CreateOrUpdateWebhook_WhenCreateFailsForAnotherReason_ReportsItWithoutBlamingPermissions()
         {
             var logger = new CapturingLogger();
             var subscriptions = new FakeCallRecordSubscriptionManager()
-                .FailingCreateWith(GraphError(400, "Subscription validation request failed."));
+                .FailingCreateWith(GraphError(429, "Too many requests. Please retry later."));
 
             var webhook = new CallWebhook(subscriptions, logger, new FixedClock(Now));
 
             await Assert.ThrowsExceptionAsync<ODataError>(() => webhook.CreateOrUpdateWebhook(WebhookUrl, "the-client-state"));
 
             var critical = logger.Entries.Where(e => e.Level == LogLevel.Critical).Single();
-            StringAssert.Contains(critical.Message, "400 BadRequest");
-            StringAssert.Contains(critical.Message, "Subscription validation request failed.");
+            StringAssert.Contains(critical.Message, "Too many requests. Please retry later.");
             Assert.IsFalse(critical.Message.Contains("CallRecords.Read.All"),
                 "Only a 403 should point the admin at the Graph permission; saying so for every failure sends them down the wrong path.");
+            Assert.IsFalse(critical.Message.Contains("called BACK"),
+                "An unrelated Graph failure must not be diagnosed as a validation-callback problem.");
         }
+
+        #region Validation-callback failure diagnosis (issue #273)
+
+        /// <summary>
+        /// The failure actually observed in production: Graph accepts the request, calls back to our
+        /// notification endpoint to validate it, and something in front of that endpoint refuses the
+        /// call. Graph reports this as a 400 whose message contains the word "Forbidden" - which is what
+        /// OUR endpoint returned to Graph, not the tenant refusing a Graph permission.
+        ///
+        /// Without the diagnosis this produced a generic "couldn't create subscription" critical with no
+        /// next step, and the word "Forbidden" sent admins to re-check the app registration's Graph
+        /// permissions, which is the wrong place entirely.
+        /// </summary>
+        [TestMethod]
+        public async Task CreateOrUpdateWebhook_WhenGraphsValidationCallbackIsRefused_ExplainsItIsOurEndpointNotAPermission()
+        {
+            var logger = new CapturingLogger();
+            var subscriptions = new FakeCallRecordSubscriptionManager()
+                .FailingCreateWith(GraphError(400,
+                    "Subscription validation request failed. HTTP status code is 'Forbidden'. " +
+                    "Notification endpoint must respond with 200 OK to validation request."));
+
+            var webhook = new CallWebhook(subscriptions, logger, new FixedClock(Now));
+
+            await Assert.ThrowsExceptionAsync<ODataError>(() => webhook.CreateOrUpdateWebhook(WebhookUrl, "the-client-state"));
+
+            var critical = logger.Entries.Where(e => e.Level == LogLevel.Critical).Single();
+
+            StringAssert.Contains(critical.Message, "NOT a Graph permission problem",
+                "The whole point is to stop admins re-checking permissions because the word 'Forbidden' appears.");
+            Assert.IsFalse(critical.Message.Contains("CallRecords.Read.All"),
+                "Naming the permission here is exactly the wrong turn this diagnosis exists to prevent.");
+            StringAssert.Contains(critical.Message, WebhookUrl.ToString(),
+                "The admin needs to see which URL Graph tried to call back.");
+            StringAssert.Contains(critical.Message, "ANONYMOUSLY",
+                "An auth layer in front of the endpoint is one of the two most likely causes.");
+            StringAssert.Contains(critical.Message, "access restrictions",
+                "An IP allow-list / private endpoint is the other most likely cause.");
+            StringAssert.Contains(critical.Message, "'Forbidden'",
+                "The status our endpoint gave Graph is the most useful single detail; it must survive into the message.");
+            StringAssert.Contains(critical.Message, "Until this is fixed, NO Teams call records will be imported.",
+                "The impact line must be kept - silent data loss is the reason this is CRITICAL.");
+        }
+
+        /// <summary>
+        /// The other observed variant. A timeout points at cold start, not at a network block, so it
+        /// must NOT tell the admin to go looking at IP restrictions and auth layers.
+        /// </summary>
+        [TestMethod]
+        public async Task CreateOrUpdateWebhook_WhenGraphsValidationCallbackTimesOut_PointsAtColdStartNotAtNetworkBlocks()
+        {
+            var logger = new CapturingLogger();
+            var subscriptions = new FakeCallRecordSubscriptionManager()
+                .WithExistingSubscription("existing-sub-id", Now.AddHours(6))
+                .FailingRenewWith(GraphError(400, "Subscription validation request timed out."));
+
+            var webhook = new CallWebhook(subscriptions, logger, new FixedClock(Now));
+
+            await Assert.ThrowsExceptionAsync<ODataError>(() => webhook.CreateOrUpdateWebhook(WebhookUrl, "the-client-state"));
+
+            var critical = logger.Entries.Where(e => e.Level == LogLevel.Critical).Single();
+
+            StringAssert.Contains(critical.Message, "Always On",
+                "Cold start is the usual cause of the timeout variant, and Always On is the fix.");
+            StringAssert.Contains(critical.Message, "renew subscription 'existing-sub-id'",
+                "The message must still say which operation failed, and on which subscription.");
+            Assert.IsFalse(critical.Message.Contains("access restrictions"),
+                "A timeout is not an IP-restriction symptom; sending the admin there wastes the diagnosis.");
+            Assert.IsFalse(critical.Message.Contains("CallRecords.Read.All"));
+        }
+
+        /// <summary>
+        /// The classifier is a pure rule, so pin its edges directly: both Graph variants, the status
+        /// extraction, and - most importantly - that it does NOT fire on unrelated messages. A
+        /// false positive would replace a correct permission diagnosis with a wrong network one.
+        /// </summary>
+        [TestMethod]
+        public void ClassifyValidationCallbackFailure_RecognisesGraphsVariantsAndNothingElse()
+        {
+            var refused = CallSubscriptionRules.ClassifyValidationCallbackFailure(
+                "Subscription validation request failed. HTTP status code is 'Forbidden'. " +
+                "Notification endpoint must respond with 200 OK to validation request.");
+            Assert.IsTrue(refused.IsValidationCallbackFailure);
+            Assert.IsFalse(refused.TimedOut);
+            Assert.AreEqual("Forbidden", refused.EndpointStatus);
+
+            var timedOut = CallSubscriptionRules.ClassifyValidationCallbackFailure("Subscription validation request timed out.");
+            Assert.IsTrue(timedOut.IsValidationCallbackFailure);
+            Assert.IsTrue(timedOut.TimedOut);
+            Assert.IsNull(timedOut.EndpointStatus, "There is no endpoint status to report when nothing responded.");
+
+            var noStatusNamed = CallSubscriptionRules.ClassifyValidationCallbackFailure(
+                "Subscription validation request failed. Notification endpoint must respond with 200 OK to validation request.");
+            Assert.IsTrue(noStatusNamed.IsValidationCallbackFailure);
+            Assert.IsNull(noStatusNamed.EndpointStatus, "Graph does not always name a status; the diagnosis must cope.");
+
+            Assert.IsFalse(CallSubscriptionRules.ClassifyValidationCallbackFailure(
+                "Insufficient privileges to complete the operation.").IsValidationCallbackFailure,
+                "A real permission failure must keep its own, different diagnosis.");
+            Assert.IsFalse(CallSubscriptionRules.ClassifyValidationCallbackFailure(null).IsValidationCallbackFailure);
+            Assert.IsFalse(CallSubscriptionRules.ClassifyValidationCallbackFailure(string.Empty).IsValidationCallbackFailure);
+        }
+
+        #endregion
 
         /// <summary>
         /// A tenant can hold call-records subscriptions belonging to other applications, and this

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/CallWebhook.cs
@@ -112,8 +112,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         /// <summary>
         /// Emit a single, actionable critical log so operators can immediately tell:
         ///   (a) that the Teams calls import is broken,
-        ///   (b) what Graph returned (status + message), and
-        ///   (c) for the common 403 case, exactly which Graph Application permission to grant.
+        ///   (b) what Graph returned (status + message),
+        ///   (c) for the common 403 case, exactly which Graph Application permission to grant, and
+        ///   (d) for a failed validation callback, that the fault is at OUR endpoint rather than in
+        ///       Graph permissions - see issue #273.
         /// The exception is then re-thrown by the caller so Program.cs's outer catch also runs
         /// TrackException, surfacing it in App Insights' Failures blade.
         /// </summary>
@@ -128,7 +130,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                 : "Graph call failed before a status code was returned.";
             var graphError = ex.Error?.Message ?? ex.Message;
 
-            if (statusCode == (int)HttpStatusCode.Forbidden)
+            var validation = CallSubscriptionRules.ClassifyValidationCallbackFailure(graphError);
+
+            if (validation.IsValidationCallbackFailure)
+            {
+                Telemetry.LogCritical(
+                    $"{LOG_TAG} Couldn't {action} for call-records at '{webAppUrl}'. {statusLine} " +
+                    BuildValidationCallbackDiagnosis(validation, webAppUrl) +
+                    $" Until this is fixed, NO Teams call records will be imported. Graph error: '{graphError}'");
+            }
+            else if (statusCode == (int)HttpStatusCode.Forbidden)
             {
                 Telemetry.LogCritical(
                     $"{LOG_TAG} Couldn't {action} for call-records at '{webAppUrl}'. {statusLine} " +
@@ -146,6 +157,51 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
                     $"{LOG_TAG} Couldn't {action} for call-records at '{webAppUrl}'. {statusLine} " +
                     $"Until this is fixed, NO Teams call records will be imported. Graph error: '{graphError}'");
             }
+        }
+
+        /// <summary>
+        /// The operator-facing explanation of a failed validation callback. Deliberately lists the
+        /// candidate causes rather than asserting one: which it is can only be established against the
+        /// affected deployment, and naming the wrong one sends an admin down a days-long dead end.
+        /// </summary>
+        private static string BuildValidationCallbackDiagnosis(SubscriptionValidationFailure validation, Uri webAppUrl)
+        {
+            // Common to both variants: say plainly which way the failing request travelled, because the
+            // direction is the single most misunderstood thing about this error.
+            var diagnosis =
+                "This is NOT a Graph permission problem. Graph accepted the request and then called BACK to " +
+                $"this deployment's notification endpoint '{webAppUrl}' to validate it, and that callback failed. " +
+                $"The endpoint must be reachable from the public internet (Graph calls from Microsoft's own IP " +
+                $"ranges, not from your network), must accept the request ANONYMOUSLY, and must answer 200 OK " +
+                $"echoing the 'validationToken' query parameter. ";
+
+            if (validation.TimedOut)
+            {
+                diagnosis +=
+                    "Graph gave up waiting for a response, which usually means App Service cold start: the first " +
+                    "request after an idle period or a deploy can take far longer than Graph's validation window. " +
+                    "Check: (1) is 'Always On' enabled on the App Service plan; (2) does the site stay warm between " +
+                    "import cycles; (3) does the endpoint respond quickly when called from outside your network.";
+            }
+            else
+            {
+                var returned = string.IsNullOrEmpty(validation.EndpointStatus)
+                    ? "a non-200 response"
+                    : $"'{validation.EndpointStatus}'";
+
+                diagnosis +=
+                    $"The endpoint returned {returned} to Graph. Check, in order: " +
+                    "(1) App Service access restrictions / IP allow-list, or a private endpoint with public network " +
+                    "access disabled - any of these refuse Graph before the request reaches the app; " +
+                    "(2) an authentication layer in front of the endpoint (App Service Authentication / 'Easy Auth' " +
+                    "with 'require authentication', a WAF, or an App Gateway / Front Door rule) - the validation " +
+                    "handshake is unauthenticated by design and any challenge fails it; " +
+                    "(3) that the notification URL above matches the deployed hostname. " +
+                    "Note that the installer's own webhook warm-up POST proves only that the endpoint answers from " +
+                    "the network the installer ran on - it does not prove Graph can reach it.";
+            }
+
+            return diagnosis;
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/Rules/CallSubscriptionRules.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Calls/Rules/CallSubscriptionRules.cs
@@ -69,6 +69,63 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
         }
 
         /// <summary>
+        /// Classify a Graph subscription error as a failure of Graph's <b>validation callback</b> to our
+        /// notification endpoint, rather than a failure of the Graph call itself. See issue #273.
+        /// </summary>
+        /// <remarks>
+        /// When a subscription is created or renewed, Graph POSTs a validation request to the
+        /// notification URL and expects an anonymous 200 OK echoing the <c>validationToken</c>. If that
+        /// callback fails, Graph rejects the subscription with a <b>400 Bad Request</b> whose message
+        /// describes what happened at <i>our</i> endpoint.
+        ///
+        /// This distinction matters because the message is actively misleading: the common variant reads
+        /// "HTTP status code is 'Forbidden'", where the <c>Forbidden</c> is what our endpoint returned to
+        /// Graph - it is NOT the tenant refusing a Graph permission. An admin who reads the raw message
+        /// goes and re-checks <see cref="CallWebhook.REQUIRED_GRAPH_PERMISSION"/>, which is the wrong
+        /// place: a genuine permission problem surfaces as a 403 from Graph itself, not as a 400 wrapping
+        /// our own status code.
+        /// </remarks>
+        public static SubscriptionValidationFailure ClassifyValidationCallbackFailure(string graphErrorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(graphErrorMessage)) return SubscriptionValidationFailure.NotAValidationFailure;
+
+            // Graph's wording for both variants starts the same way; match on that stem so a later
+            // rewording of the tail does not silently drop us back to the generic message.
+            if (graphErrorMessage.IndexOf("Subscription validation request", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return SubscriptionValidationFailure.NotAValidationFailure;
+            }
+
+            var timedOut = graphErrorMessage.IndexOf("timed out", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            return new SubscriptionValidationFailure
+            {
+                IsValidationCallbackFailure = true,
+                TimedOut = timedOut,
+                EndpointStatus = timedOut ? null : ExtractEndpointStatus(graphErrorMessage),
+            };
+        }
+
+        /// <summary>
+        /// Pull the status our endpoint returned out of Graph's message, e.g. the <c>Forbidden</c> in
+        /// "HTTP status code is 'Forbidden'". Returns null when Graph did not include one.
+        /// </summary>
+        private static string ExtractEndpointStatus(string graphErrorMessage)
+        {
+            const string marker = "HTTP status code is";
+            var markerAt = graphErrorMessage.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (markerAt < 0) return null;
+
+            var openQuote = graphErrorMessage.IndexOf('\'', markerAt + marker.Length);
+            if (openQuote < 0) return null;
+
+            var closeQuote = graphErrorMessage.IndexOf('\'', openQuote + 1);
+            if (closeQuote <= openQuote + 1) return null;
+
+            return graphErrorMessage.Substring(openQuote + 1, closeQuote - openQuote - 1);
+        }
+
+        /// <summary>
         /// Which subscription to report on a status page when several match. The one expiring latest is
         /// the one actually keeping the webhook alive, so that is the one whose expiry an operator
         /// needs to see.
@@ -85,6 +142,26 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Calls
     {
         Create,
         Renew
+    }
+
+    /// <summary>
+    /// The outcome of <see cref="CallSubscriptionRules.ClassifyValidationCallbackFailure"/>. See issue #273.
+    /// </summary>
+    public class SubscriptionValidationFailure
+    {
+        public static readonly SubscriptionValidationFailure NotAValidationFailure = new SubscriptionValidationFailure();
+
+        /// <summary>Graph's validation callback to our notification endpoint is what failed.</summary>
+        public bool IsValidationCallbackFailure { get; set; }
+
+        /// <summary>Graph gave up waiting rather than getting a response it disliked.</summary>
+        public bool TimedOut { get; set; }
+
+        /// <summary>
+        /// The status our endpoint returned to Graph (e.g. "Forbidden"), when Graph reported one.
+        /// Null for the timeout variant, and when Graph did not name a status.
+        /// </summary>
+        public string EndpointStatus { get; set; }
     }
 
     /// <summary>What <see cref="CallSubscriptionRules.Decide"/> decided to do.</summary>


### PR DESCRIPTION
## Scope

Narrow, code-only response to the part of #273 that is actionable **without production access**: acceptance criterion 3 — *"A failure to create or renew a subscription is surfaced clearly (rather than only as an exception), since the symptom is silent data loss."*

This PR **deliberately does not guess at the production root cause** of the `Forbidden` / `timed out` validation failures observed in Application Insights. Which of the candidate causes it is can only be established against the affected deployment. What it fixes is that today the importer gives an operator nothing to act on, and the raw Graph message actively points them at the wrong thing.

## Root cause of the *diagnostic* defect

Graph validates a change-notification subscription by calling **back** to the notification endpoint and requiring an **anonymous** `200 OK` echoing `validationToken`. When that callback fails, Graph rejects the subscription with a **400 Bad Request** whose message describes what happened at *our* endpoint:

```
Subscription validation request failed. HTTP status code is 'Forbidden'.
Notification endpoint must respond with 200 OK to validation request.
```

Two problems followed from that:

1. **It fell into `LogSubscriptionFailure`'s generic `else` branch**, producing `Couldn't create subscription … Graph returned 400 BadRequest. Until this is fixed, NO Teams call records will be imported.` — correct, but with no next step for a failure whose symptom is silent data loss.

2. **The message is misleading in a specific, expensive way.** The `Forbidden` is the status *our* endpoint returned *to Graph*. It is not the tenant refusing a Graph permission. An admin reading it goes and re-checks the app registration's `CallRecords.Read.All` — the wrong place entirely. A genuine permission failure is a **403 from Graph itself** and already has its own, different, correct diagnosis in the same method.

Note that `CallsImportTests` previously used this very message as its example of "a failure that is *not* about permissions", which is how the gap stayed invisible: the test asserted only that we don't *wrongly* blame permissions, never that we say anything useful.

## What changed

**`CallSubscriptionRules.ClassifyValidationCallbackFailure(string)`** — a new pure rule (consistent with #381's convention: a rule, not a dependency), returning `SubscriptionValidationFailure`:
- matches on the stem `"Subscription validation request"` so a reworded tail doesn't silently drop back to the generic message;
- distinguishes the **refused** and **timed out** variants;
- extracts the status our endpoint reported (`HTTP status code is 'Forbidden'` → `Forbidden`), tolerating Graph not naming one.

**`CallWebhook.LogSubscriptionFailure`** — checks the classification *before* the existing 403 branch and emits a targeted message that states the direction of the failing request and lists candidate causes **without asserting one**:

| Variant | What the operator is told |
|---|---|
| Refused | Not a Graph permission problem; Graph called *back* to `<notification URL>` and was refused. Check in order: (1) App Service access restrictions / IP allow-list / private endpoint with public network access disabled; (2) an auth layer in front of an intentionally-unauthenticated handshake (Easy Auth "require authentication", WAF, Front Door / App Gateway rule); (3) notification URL vs deployed hostname. Plus: **the installer's webhook warm-up POST only proves the endpoint answers from the network the installer ran on — it does not prove Graph can reach it.** |
| Timed out | App Service cold start; check Always On, whether the site stays warm between cycles, and response time from outside your network. Explicitly **omits** the network-block checks, which are not timeout symptoms. |

The existing 403 branch, the impact line, and the rethrow-so-`TrackException`-runs behaviour are all unchanged.

## On the rest of #273

- The **installer already captures and reports the warm-up POST status code**, including verifying the controller echoes the validation token (`SolutionInstaller.WarmupCallRecordWebhook`). The "cheap first step" suggested in the issue's triage comment is therefore already implemented — but it runs from the *installer's* network, so it cannot detect a Graph-specific block. This PR says so in the operator message rather than leaving a false sense of proof.
- The **`Forbidden` root cause itself is not addressed here** and #273 should stay open for it.

## Tests

`Tests.UnitTests/CallsImportTests.cs` — 3 added, 1 re-pointed. All 18 tests in the class pass.

- `CreateOrUpdateWebhook_WhenGraphsValidationCallbackIsRefused_ExplainsItIsOurEndpointNotAPermission` — asserts the message says it is **not** a permission problem, does **not** contain `CallRecords.Read.All`, names the callback URL, and covers both leading causes.
- `CreateOrUpdateWebhook_WhenGraphsValidationCallbackTimesOut_PointsAtColdStartNotAtNetworkBlocks` — asserts `Always On` is present and `access restrictions` is **absent**, so the timeout variant doesn't send an admin down the network path.
- `ClassifyValidationCallbackFailure_RecognisesGraphsVariantsAndNothingElse` — pins the pure rule's edges including the **negative** cases: a real permission message, `null` and `string.Empty` must not classify. A false positive here would *replace* a correct permission diagnosis with a wrong network one, which is worse than the bug being fixed.
- `CreateOrUpdateWebhook_WhenCreateFailsForAnotherReason_ReportsItWithoutBlamingPermissions` — its example was `"Subscription validation request failed."`, which is now classified specifically, so it no longer demonstrated the generic path. Re-pointed at an unrelated 429 and additionally asserts the callback diagnosis does **not** fire.

**Both directions:** `ClassifyValidationCallbackFailure` does not exist on `dev`, so the rule test cannot compile against it; the two logging tests assert strings (`NOT a Graph permission problem`, `ANONYMOUSLY`, `called BACK`) that appear nowhere in `dev`'s sources. Over-firing is covered by the two negative assertions above.

## Risk / reviewer hotspots

- **String matching on a Graph error message is inherently brittle.** Mitigated by matching the stem only, and by the fallback being the *existing* generic message — a match failure degrades to today's behaviour, it does not lose the error. Worth a reviewer's eye on whether the stem is the right anchor.
- **Ordering in `LogSubscriptionFailure`:** the validation check runs before the 403 check. That is intentional (the validation failure is a 400, so they cannot both match today), but if Graph ever returned a 403 carrying validation-callback text, the callback diagnosis would win. That is the desired precedence.
- Operator message wording — it is long by design, because it is the only thing an admin gets. Reviewers may want to trim.

## Non-applicable release gates

No SQL schema change, no migration, no `CONFIG_VERSION` change, no config-schema change. The migration / benchmark / manual-SQL release gates do not apply.

Addresses #273
