### PR TITLE
Withhold Teams delta token when paging caps truncate reads

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/TeamsCrawlTests.cs
@@ -247,6 +247,100 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
+        /// Regression for #451: a channel delta token is unsafe when any reply iterator stopped at the
+        /// cap. Graph has no reply-level checkpoint, so the channel token must be withheld and the
+        /// stored token left alone for a later re-read, even though additive Teams stats may be counted
+        /// again.
+        /// </summary>
+        [TestMethod]
+        public async Task ChannelMessagesLoader_WithholdsDeltaTokenWhenReplyPageHitsCap()
+        {
+            var channel = Channel("channel-1");
+            var rootMessage = Msg("root-1", AfterToken);
+            var pageReader = new FakeChannelMessagesPageReader()
+                .ReturningRootMessages(channel.Id, DeltaLink("delta-after-partial-replies"), completed: true, rootMessage)
+                .ReturningReplies(rootMessage.Id, completed: false, Msg("reply-kept", AfterToken));
+            var store = new InMemoryTeamChannelDeltaTokenStore();
+            await store.SetDeltaToken("team-1", channel.Id, new TeamsRedisManager.TeamChannelDeltaTokenInfo
+            {
+                Token = "previous-delta",
+                LastUpdated = DeltaTokenWrittenAt
+            });
+
+            var crawler = new TeamsChannelCrawler(new DelegatingChannelMessagesSourceLoader(
+                (ch, teamId) => new ChannelMessagesLoader(pageReader, store, AnalyticsLogger.ConsoleOnlyTracer())
+                    .LoadTeamMessagesAndReplies(ch, teamId)));
+
+            var pendingTokens = await crawler.PopulateNewMessagesAndReactions(new List<ChannelWithReactions> { channel }, "team-1");
+            await TeamChannelDeltaTokenCommitter.CommitPendingTokens(store, "team-1", pendingTokens);
+
+            Assert.AreEqual(0, pendingTokens.Count,
+                "A partial reply page must not queue the channel delta token for commit.");
+            Assert.AreEqual("previous-delta", (await store.GetDeltaToken("team-1", channel.Id))?.Token,
+                "Withholding the token must leave the old checkpoint untouched rather than deleting it.");
+            CollectionAssert.AreEqual(new[] { "root-1", "reply-kept" }, channel.Messages.Select(m => m.Id).ToArray(),
+                "The partial data is still returned for persistence; only the checkpoint is withheld.");
+        }
+
+        /// <summary>
+        /// The opposite #451 guard: if the root-message and reply iterators both complete, the channel
+        /// delta token is still queued and committed. This prevents an over-fix that would make every
+        /// Teams channel re-read forever.
+        /// </summary>
+        [TestMethod]
+        public async Task ChannelMessagesLoader_CommitsDeltaTokenWhenAllMessageAndReplyPagesComplete()
+        {
+            var channel = Channel("channel-1");
+            var rootMessage = Msg("root-1", AfterToken);
+            var pageReader = new FakeChannelMessagesPageReader()
+                .ReturningRootMessages(channel.Id, DeltaLink("delta-after-complete-read"), completed: true, rootMessage)
+                .ReturningReplies(rootMessage.Id, completed: true, Msg("reply-1", AfterToken));
+            var store = new InMemoryTeamChannelDeltaTokenStore();
+
+            var crawler = new TeamsChannelCrawler(new DelegatingChannelMessagesSourceLoader(
+                (ch, teamId) => new ChannelMessagesLoader(pageReader, store, AnalyticsLogger.ConsoleOnlyTracer())
+                    .LoadTeamMessagesAndReplies(ch, teamId)));
+
+            var pendingTokens = await crawler.PopulateNewMessagesAndReactions(new List<ChannelWithReactions> { channel }, "team-1");
+            await TeamChannelDeltaTokenCommitter.CommitPendingTokens(store, "team-1", pendingTokens);
+
+            Assert.AreEqual(1, pendingTokens.Count,
+                "A complete channel read must still queue its delta token.");
+            Assert.AreEqual("delta-after-complete-read", (await store.GetDeltaToken("team-1", channel.Id))?.Token);
+            CollectionAssert.AreEqual(new[] { "root-1", "reply-1" }, channel.Messages.Select(m => m.Id).ToArray());
+        }
+
+        /// <summary>
+        /// The root-message cap has the same checkpoint risk if the page iterator is paused while a
+        /// delta link is present: the loader must treat any paused channel-level iterator as incomplete,
+        /// regardless of whether Graph supplied a token.
+        /// </summary>
+        [TestMethod]
+        public async Task ChannelMessagesLoader_WithholdsDeltaTokenWhenRootMessagePageHitsCap()
+        {
+            var channel = Channel("channel-1");
+            var pageReader = new FakeChannelMessagesPageReader()
+                .ReturningRootMessages(channel.Id, DeltaLink("delta-after-partial-roots"), completed: false, Msg("root-1", AfterToken));
+            var store = new InMemoryTeamChannelDeltaTokenStore();
+            await store.SetDeltaToken("team-1", channel.Id, new TeamsRedisManager.TeamChannelDeltaTokenInfo
+            {
+                Token = "previous-delta",
+                LastUpdated = DeltaTokenWrittenAt
+            });
+
+            var crawler = new TeamsChannelCrawler(new DelegatingChannelMessagesSourceLoader(
+                (ch, teamId) => new ChannelMessagesLoader(pageReader, store, AnalyticsLogger.ConsoleOnlyTracer())
+                    .LoadTeamMessagesAndReplies(ch, teamId)));
+
+            var pendingTokens = await crawler.PopulateNewMessagesAndReactions(new List<ChannelWithReactions> { channel }, "team-1");
+            await TeamChannelDeltaTokenCommitter.CommitPendingTokens(store, "team-1", pendingTokens);
+
+            Assert.AreEqual(0, pendingTokens.Count,
+                "A paused root-message iterator must not queue a channel delta token even if one is present.");
+            Assert.AreEqual("previous-delta", (await store.GetDeltaToken("team-1", channel.Id))?.Token);
+        }
+
+        /// <summary>
         /// An expired user-delegated token aborts the whole team's crawl, but tokens returned by
         /// earlier channels stay pending so they can be committed if those earlier channels are still
         /// persisted successfully.
@@ -392,6 +486,78 @@ namespace Tests.UnitTests
 
             public Task RemoveDeltaToken(string teamId, string channelId)
                 => _inner.RemoveDeltaToken(teamId, channelId);
+        }
+
+        private static string DeltaLink(string token)
+            => $"https://graph.microsoft.com/v1.0/teams/team-1/channels/channel-1/messages/delta?$deltatoken={token}";
+
+        private class DelegatingChannelMessagesSourceLoader : IChannelMessagesSourceLoader
+        {
+            private readonly Func<ChannelWithReactions, string, Task<TeamsRedisManager.TeamChannelDeltaTokenInfo>> _load;
+
+            public DelegatingChannelMessagesSourceLoader(Func<ChannelWithReactions, string, Task<TeamsRedisManager.TeamChannelDeltaTokenInfo>> load)
+            {
+                _load = load;
+            }
+
+            public Task<TeamsRedisManager.TeamChannelDeltaTokenInfo> LoadMessagesAndReactions(ChannelWithReactions channel, string teamId)
+                => _load(channel, teamId);
+        }
+
+        private class FakeChannelMessagesPageReader : IChannelMessagesPageReader
+        {
+            private readonly Dictionary<string, ChannelRootMessagesPageResult> _rootMessagesByChannelId
+                = new Dictionary<string, ChannelRootMessagesPageResult>(StringComparer.Ordinal);
+
+            private readonly Dictionary<string, ChannelRepliesPageResult> _repliesByMessageId
+                = new Dictionary<string, ChannelRepliesPageResult>(StringComparer.Ordinal);
+
+            public FakeChannelMessagesPageReader ReturningRootMessages(
+                string channelId,
+                string deltaLink,
+                bool completed,
+                params ChatMessage[] messages)
+            {
+                _rootMessagesByChannelId[channelId] = new ChannelRootMessagesPageResult
+                {
+                    Messages = messages.ToList(),
+                    Deltalink = deltaLink,
+                    Completed = completed
+                };
+                return this;
+            }
+
+            public FakeChannelMessagesPageReader ReturningReplies(
+                string messageId,
+                bool completed,
+                params ChatMessage[] replies)
+            {
+                _repliesByMessageId[messageId] = new ChannelRepliesPageResult
+                {
+                    Replies = replies.ToList(),
+                    Completed = completed
+                };
+                return this;
+            }
+
+            public Task<ChannelRootMessagesPageResult> LoadRootMessages(
+                string teamId,
+                string channelId,
+                TeamsRedisManager.TeamChannelDeltaTokenInfo channelDeltaInfo)
+            {
+                _rootMessagesByChannelId.TryGetValue(channelId, out var result);
+                return Task.FromResult(result);
+            }
+
+            public Task<ChannelRepliesPageResult> LoadReplies(string teamId, string channelId, string messageId)
+            {
+                if (_repliesByMessageId.TryGetValue(messageId, out var result))
+                {
+                    return Task.FromResult(result);
+                }
+
+                return Task.FromResult(new ChannelRepliesPageResult { Completed = true });
+            }
         }
 
         #endregion

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelMessagesLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/ChannelMessagesLoader.cs
@@ -17,7 +17,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
     /// </summary>
     public class ChannelMessagesLoader
     {
-        private readonly GraphServiceClient _client;
+        private readonly IChannelMessagesPageReader _pageReader;
         private readonly ITeamChannelDeltaTokenStore _deltaTokenStore;
         private readonly ILogger _logger;
 
@@ -32,8 +32,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// without Redis. See issue #377.
         /// </summary>
         public ChannelMessagesLoader(GraphServiceClient client, ITeamChannelDeltaTokenStore deltaTokenStore, ILogger logger)
+            : this(new GraphChannelMessagesPageReader(client), deltaTokenStore, logger) { }
+
+        internal ChannelMessagesLoader(IChannelMessagesPageReader pageReader, ITeamChannelDeltaTokenStore deltaTokenStore, ILogger logger)
         {
-            this._client = client;
+            this._pageReader = pageReader ?? throw new ArgumentNullException(nameof(pageReader));
             this._deltaTokenStore = deltaTokenStore ?? throw new ArgumentNullException(nameof(deltaTokenStore));
             this._logger = logger;
         }
@@ -47,23 +50,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             var channelDeltaInfo = await _deltaTokenStore.GetDeltaToken(teamId, channel.Id);
 
-            // v5+ removed QueryOption / $deltatoken support on the typed Delta request builder. To
-            // keep using the SDK serialiser for ChatMessage we construct the full URL ourselves
-            // (with $deltatoken appended when we have one) and instantiate a DeltaRequestBuilder
-            // against the existing RequestAdapter, then walk pages via PageIterator.
-            var baseUrl = $"{_client.RequestAdapter.BaseUrl}/teams/{teamId}/channels/{channel.Id}/messages/delta";
-            var initialUrl = channelDeltaInfo != null
-                ? $"{baseUrl}?$deltatoken={channelDeltaInfo.Token}"
-                : baseUrl;
-            var deltaBuilder = new DeltaRequestBuilder(initialUrl, _client.RequestAdapter);
-
             var rootMsgs = new List<ChatMessage>();
             TeamsRedisManager.TeamChannelDeltaTokenInfo newDelta = null;
+            var channelReadComplete = true;
 
-            DeltaGetResponse firstPage = null;
+            ChannelRootMessagesPageResult rootMessagesResult = null;
             try
             {
-                firstPage = await deltaBuilder.GetAsDeltaGetResponseAsync();
+                rootMessagesResult = await _pageReader.LoadRootMessages(teamId, channel.Id, channelDeltaInfo);
             }
             catch (ODataError ex)
             {
@@ -75,29 +69,21 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
                 else throw;
             }
 
-            if (firstPage != null)
+            if (rootMessagesResult != null)
             {
-                int loaded = 0;
-                var iterator = PageIterator<ChatMessage, DeltaGetResponse>
-                    .CreatePageIterator(_client, firstPage, msg =>
-                    {
-                        rootMsgs.Add(msg);
-                        loaded++;
-                        return TeamsCrawlPagingPolicy.ShouldContinuePaging(loaded, TeamsCrawlPagingPolicy.MaxMessagesPerChannel);
-                    });
+                rootMsgs = rootMessagesResult.Messages;
+                channelReadComplete = rootMessagesResult.Completed;
 
-                await iterator.IterateAsync();
-
-                if (iterator.State == PagingState.Paused)
+                if (!rootMessagesResult.Completed)
                 {
                     _logger.LogWarning($"Channel '{channel.DisplayName}' on Team '{teamId}': hit MAX_MESSAGES_PER_CHANNEL ({TeamsCrawlPagingPolicy.MaxMessagesPerChannel:N0}). Returning partial set of {rootMsgs.Count:N0} root messages.");
                 }
 
-                if (!string.IsNullOrEmpty(iterator.Deltalink))
+                if (!string.IsNullOrEmpty(rootMessagesResult.Deltalink))
                 {
                     newDelta = new TeamsRedisManager.TeamChannelDeltaTokenInfo
                     {
-                        Token = StringUtils.ExtractCodeFromGraphUrl(iterator.Deltalink),
+                        Token = StringUtils.ExtractCodeFromGraphUrl(rootMessagesResult.Deltalink),
                         LastUpdated = DateTime.Now
                     };
                 }
@@ -106,9 +92,23 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
             // Load all replies for each root message
             foreach (var rootMsg in rootMsgs)
             {
-                rootMsg.Replies = await LoadAllRepliesForMessage(teamId, channel.Id, rootMsg.Id);
+                var repliesResult = await LoadAllRepliesForMessage(teamId, channel.Id, rootMsg.Id);
+                rootMsg.Replies = repliesResult.Replies;
+
+                if (!repliesResult.Completed)
+                {
+                    channelReadComplete = false;
+                }
             }
 
+            if (!channelReadComplete && newDelta != null)
+            {
+                // Deliberately leave the stored token untouched when a cap stopped paging. The next
+                // cycle re-reads from the previous token and may double-count additive Teams stats, but
+                // a visible duplicate is safer than silently losing messages or replies.
+                _logger.LogWarning($"Withholding Teams channel delta token for Team '{teamId}', channel '{channel.Id}' because at least one message or reply page hit a paging cap. The next import cycle will re-read from the previous token; additive Teams stats may be double-counted.");
+                newDelta = null;
+            }
 
             if (channelDeltaInfo != null)
             {
@@ -128,12 +128,108 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
         /// <summary>
         /// Walk all reply pages for a single message via <see cref="PageIterator{TEntity, TCollectionPage}"/>.
         /// </summary>
-        internal async Task<List<ChatMessage>> LoadAllRepliesForMessage(string teamId, string channelId, string messageId)
+        internal async Task<ChannelRepliesPageResult> LoadAllRepliesForMessage(string teamId, string channelId, string messageId)
+        {
+            var repliesResult = await _pageReader.LoadReplies(teamId, channelId, messageId);
+            if (!repliesResult.Completed)
+            {
+                _logger.LogWarning($"Channel {channelId} msg {messageId}: hit MAX_REPLIES_PER_MESSAGE ({TeamsCrawlPagingPolicy.MaxRepliesPerMessage:N0}). Returning partial reply list of {repliesResult.Replies.Count:N0}.");
+            }
+
+            return repliesResult;
+        }
+
+        public class ChannelChatInfo
+        {
+            public List<ChatMessage> NewMessages { get; set; }
+            public List<ChatMessageReaction> NewReactions { get; set; }
+
+            public TeamsRedisManager.TeamChannelDeltaTokenInfo DeltaInfo { get; set; }
+        }
+    }
+
+    internal interface IChannelMessagesPageReader
+    {
+        Task<ChannelRootMessagesPageResult> LoadRootMessages(
+            string teamId,
+            string channelId,
+            TeamsRedisManager.TeamChannelDeltaTokenInfo channelDeltaInfo);
+
+        Task<ChannelRepliesPageResult> LoadReplies(string teamId, string channelId, string messageId);
+    }
+
+    internal class ChannelRootMessagesPageResult
+    {
+        public List<ChatMessage> Messages { get; set; } = new List<ChatMessage>();
+
+        public string Deltalink { get; set; }
+
+        public bool Completed { get; set; }
+    }
+
+    internal class ChannelRepliesPageResult
+    {
+        public List<ChatMessage> Replies { get; set; } = new List<ChatMessage>();
+
+        public bool Completed { get; set; }
+    }
+
+    internal class GraphChannelMessagesPageReader : IChannelMessagesPageReader
+    {
+        private readonly GraphServiceClient _client;
+
+        public GraphChannelMessagesPageReader(GraphServiceClient client)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public async Task<ChannelRootMessagesPageResult> LoadRootMessages(
+            string teamId,
+            string channelId,
+            TeamsRedisManager.TeamChannelDeltaTokenInfo channelDeltaInfo)
+        {
+            // v5+ removed QueryOption / $deltatoken support on the typed Delta request builder. To
+            // keep using the SDK serialiser for ChatMessage we construct the full URL ourselves
+            // (with $deltatoken appended when we have one) and instantiate a DeltaRequestBuilder
+            // against the existing RequestAdapter, then walk pages via PageIterator.
+            var baseUrl = $"{_client.RequestAdapter.BaseUrl}/teams/{teamId}/channels/{channelId}/messages/delta";
+            var initialUrl = channelDeltaInfo != null
+                ? $"{baseUrl}?$deltatoken={channelDeltaInfo.Token}"
+                : baseUrl;
+            var deltaBuilder = new DeltaRequestBuilder(initialUrl, _client.RequestAdapter);
+
+            var firstPage = await deltaBuilder.GetAsDeltaGetResponseAsync();
+            if (firstPage == null) return null;
+
+            var rootMsgs = new List<ChatMessage>();
+            int loaded = 0;
+            var iterator = PageIterator<ChatMessage, DeltaGetResponse>
+                .CreatePageIterator(_client, firstPage, msg =>
+                {
+                    rootMsgs.Add(msg);
+                    loaded++;
+                    return TeamsCrawlPagingPolicy.ShouldContinuePaging(loaded, TeamsCrawlPagingPolicy.MaxMessagesPerChannel);
+                });
+
+            await iterator.IterateAsync();
+
+            return new ChannelRootMessagesPageResult
+            {
+                Messages = rootMsgs,
+                Deltalink = iterator.Deltalink,
+                Completed = iterator.State != PagingState.Paused
+            };
+        }
+
+        public async Task<ChannelRepliesPageResult> LoadReplies(string teamId, string channelId, string messageId)
         {
             var allReplies = new List<ChatMessage>();
 
             var firstPage = await _client.Teams[teamId].Channels[channelId].Messages[messageId].Replies.GetAsync();
-            if (firstPage == null) return allReplies;
+            if (firstPage == null)
+            {
+                return new ChannelRepliesPageResult { Replies = allReplies, Completed = true };
+            }
 
             int loaded = 0;
             var iterator = PageIterator<ChatMessage, ChatMessageCollectionResponse>
@@ -146,20 +242,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams
 
             await iterator.IterateAsync();
 
-            if (iterator.State == PagingState.Paused)
+            return new ChannelRepliesPageResult
             {
-                _logger.LogWarning($"Channel {channelId} msg {messageId}: hit MAX_REPLIES_PER_MESSAGE ({TeamsCrawlPagingPolicy.MaxRepliesPerMessage:N0}). Returning partial reply list of {allReplies.Count:N0}.");
-            }
-
-            return allReplies;
-        }
-
-        public class ChannelChatInfo
-        {
-            public List<ChatMessage> NewMessages { get; set; }
-            public List<ChatMessageReaction> NewReactions { get; set; }
-
-            public TeamsRedisManager.TeamChannelDeltaTokenInfo DeltaInfo { get; set; }
+                Replies = allReplies,
+                Completed = iterator.State != PagingState.Paused
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses #451.

This fixes the Teams channel checkpoint decision when Graph paging is deliberately stopped by the crawl caps. `ChannelMessagesLoader` now treats the channel read as incomplete if either the root-message iterator or any reply iterator ends in `PagingState.Paused`, and returns `null` instead of the new channel delta token in that case. `TeamsChannelCrawler` already interprets `null` as "leave the stored token alone", so no port contract change was needed.

## Root cause

The loader extracted `iterator.Deltalink` from the root-message delta iterator before loading replies. If a reply thread hit `TeamsCrawlPagingPolicy.MaxRepliesPerMessage`, `LoadAllRepliesForMessage` logged and returned the partial reply list, but the caller still returned the channel delta token. After SQL persistence, `O365Team.SaveToSQL` committed that token, advancing past replies for which there is no reply-level continuation token.

The same risk exists for the root-message cap if the root iterator is paused while `iterator.Deltalink` is non-empty: the old code checked `iterator.State == PagingState.Paused` and `!string.IsNullOrEmpty(iterator.Deltalink)` independently, so a paused root iterator with a delta link would still commit the token. The fix therefore withholds the token for any paused root or reply paging result.

## What changed

- Added a small page-reader seam inside `ChannelMessagesLoader` so tests can exercise the real loader/token decision without Graph or Redis.
- Propagated root/reply paging completeness to `LoadTeamMessagesAndReplies`.
- Withheld the returned channel delta token whenever any message or reply page hit a configured cap.
- Logged an explicit warning when the token is withheld, including the deliberate trade-off: the next import cycle re-reads from the previous token, and additive Teams stats may be double-counted, but that is preferred over silent data loss.

## Tests

- `ChannelMessagesLoader_WithholdsDeltaTokenWhenReplyPageHitsCap`: proves a partial reply page queues no delta-token commit and leaves the previous stored token untouched.
- `ChannelMessagesLoader_CommitsDeltaTokenWhenAllMessageAndReplyPagesComplete`: proves fully-read channels still commit their token, preventing over-withholding.
- `ChannelMessagesLoader_WithholdsDeltaTokenWhenRootMessagePageHitsCap`: proves a paused root-message iterator with a delta link is also treated as incomplete.

Validation run from the dedicated worktree:

```text
msbuild src\AnalyticsEngine\Tests.UnitTests -t:Restore -p:Configuration=Debug -p:Platform=anycpu -p:ProcessorArchitecture=x86
msbuild src\AnalyticsEngine\Tests.UnitTests -p:Configuration=Debug -p:Platform=anycpu -p:ProcessorArchitecture=x86
vstest.console.exe src\AnalyticsEngine\Tests.UnitTests\bin\Debug\Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~TeamsCrawlTests"
```

The Teams crawl test filter passed: 16/16 tests.

## Schema/config impact

No SQL schema, EF migration, manual SQL, benchmark, installer config schema, or `CONFIG_VERSION` change is involved.

## Risk and reviewer hotspots

- Hotspot: `ChannelMessagesLoader` now gates token return on completeness after replies are loaded.
- Hotspot: the new internal page-reader seam should preserve the existing Graph request/`PageIterator` behaviour while making the checkpoint decision testable.
- Expected consequence: channels that hit the caps keep re-reading from the old token until a complete read occurs. Additive Teams stat persistence can double-count during those retries; this is the accepted trade-off for avoiding silently dropped messages/replies.