### PR TITLE
Fix Copilot adoption failure telemetry dedup

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionTelemetryTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionTelemetryTests.cs
@@ -426,29 +426,25 @@ namespace Tests.UnitTests
         [TestMethod]
         public async Task AnalysisFailure_AcceptedByTheSink_IsStillVisibleToAWaitingRequest()
         {
-            // Deliberate trade-off, pinned so it is not "tidied" into silence later.
-            //
-            // Acceptance is not delivery: QueueFailure returning true means the failure was added to an
-            // in-memory queue whose worker can drop it. Marking the exception reported on acceptance
-            // would suppress reporting by waiting requests without anything having confirmed the failure
-            // was reported.
-            //
-            // So an accepted failure stays unmarked and a waiting request can still report it. That can
-            // duplicate the sink's own report, which is noise; removing the duplicate needs delivery
-            // acknowledgement from the sink - see issue #454.
+            // Delivery, not acceptance, is the dedup boundary. Once the sink writer has actually
+            // reported the exception, waiting requests must stand down: exactly one exception
+            // telemetry item is the invariant, not "one from the sink plus one from a waiter".
             var channel = new RecordingTelemetryChannel();
             var configuration = new TelemetryConfiguration
             {
                 TelemetryChannel = channel,
                 ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000001",
             };
-            var logger = new AnalyticsLogger(new TelemetryClient(configuration), "WebApiTest");
+            var sinkLogger = new AnalyticsLogger(new TelemetryClient(configuration), "CopilotAdoptionTest");
+            var waiterLogger = new AnalyticsLogger(new TelemetryClient(configuration), "WebApiTest");
+            var sink = new AdoptionQueuedSink(() => new AppInsightsAdoptionWriter(sinkLogger));
+            var heartbeat = new ManualHeartbeatFactory();
 
             var boom = new InvalidOperationException("analysis failed");
             var coordinator = new AdoptionCoordinator(
                 new SequencedRunner(Task.FromException<CopilotAdoptionAnalysis>(boom)),
                 new InMemoryAnalysisCache(),
-                (window, hasOverride) => new AcceptingTelemetry(),
+                (window, hasOverride) => NewTelemetry(sink, heartbeat, window, hasOverride),
                 TimeSpan.FromMinutes(10));
 
             Exception observed = null;
@@ -463,15 +459,112 @@ namespace Tests.UnitTests
             }
 
             Assert.AreSame(boom, observed, "every waiter observes the one shared instance");
+            Assert.IsTrue(
+                SpinWait.SpinUntil(
+                    () => channel.Sent.OfType<ExceptionTelemetry>().Any(),
+                    TimeSpan.FromSeconds(2)),
+                "the queued sink should report the accepted failure");
 
             // Exactly what a request awaiting the shared run does next.
-            WebExceptionTelemetry.Report(observed, "WebApi /api/copilotadoption", _ => logger);
-            WebExceptionTelemetry.Report(observed, "WebApi /api/copilotadoption", _ => logger);
+            WebExceptionTelemetry.Report(observed, "WebApi /api/copilotadoption", _ => waiterLogger);
+            WebExceptionTelemetry.Report(observed, "WebApi /api/copilotadoption", _ => waiterLogger);
 
             Assert.AreEqual(
                 1,
                 channel.Sent.OfType<ExceptionTelemetry>().Count(),
-                "An accepted failure must remain visible to a waiting request - once, not zero and not per waiter.");
+                "A delivered sink failure must be reported exactly once, not once per waiting request.");
+
+            sink.Shutdown(TimeSpan.FromSeconds(2));
+        }
+
+        [TestMethod]
+        public void QueuedSink_AcceptedFailureDroppedByWorker_IsReportedByFallback()
+        {
+            var boom = new InvalidOperationException("analysis failed");
+            var reported = new ConcurrentQueue<Tuple<Exception, string>>();
+            var sink = new AdoptionQueuedSink(
+                () => new ThrowingFailureWriter(),
+                (ex, context) => reported.Enqueue(Tuple.Create(ex, context)));
+            var failure = new AdoptionFailure
+            {
+                RunId = "00000000000000000000000000000005",
+                WindowDays = 28,
+                Exception = boom,
+            };
+
+            Assert.IsTrue(
+                sink.TrackFailure(
+                    failure,
+                    LifecycleEvent(CopilotAdoptionTelemetryStages.Failed, failure.RunId)),
+                "the queue must accept the failure before the worker drops it");
+
+            Assert.IsTrue(
+                SpinWait.SpinUntil(() => reported.Count == 1, TimeSpan.FromSeconds(2)),
+                "a failure dropped after queue acceptance must be redeemed by fallback reporting");
+            Assert.AreSame(boom, reported.Single().Item1);
+            Assert.AreEqual(1, sink.DroppedEvents);
+
+            sink.Shutdown(TimeSpan.FromSeconds(2));
+        }
+
+        [TestMethod]
+        public void ConcurrentWaitingRequests_ReportSharedFailureOnce()
+        {
+            for (var iteration = 0; iteration < 20; iteration++)
+            {
+                var channel = new BlockingExceptionTelemetryChannel();
+                var configuration = new TelemetryConfiguration
+                {
+                    TelemetryChannel = channel,
+                    ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000001",
+                };
+                var logger = new AnalyticsLogger(new TelemetryClient(configuration), "WebApiTest");
+                var boom = new InvalidOperationException("analysis failed " + iteration);
+
+                var first = Task.Run(
+                    () => WebExceptionTelemetry.Report(
+                        boom,
+                        "WebApi /api/copilotadoption",
+                        _ => logger));
+                Assert.IsTrue(
+                    channel.FirstExceptionSendEntered.Wait(TimeSpan.FromSeconds(2)),
+                    "the first waiter should reach the telemetry send and pause before marking reported");
+
+                var second = Task.Run(
+                    () => WebExceptionTelemetry.Report(
+                        boom,
+                        "WebApi /api/copilotadoption",
+                        _ => logger));
+
+                channel.ReleaseFirstExceptionSend.Set();
+                Assert.IsTrue(Task.WaitAll(new[] { first, second }, TimeSpan.FromSeconds(2)));
+                Assert.AreEqual(
+                    1,
+                    channel.Sent.OfType<ExceptionTelemetry>().Count(),
+                    "two concurrent waiters must share one atomic report claim");
+            }
+        }
+
+        [TestMethod]
+        public async Task FailureTelemetryFallbackFailure_DoesNotReplaceAnalysisFailure()
+        {
+            var boom = new InvalidOperationException("analysis failed");
+            var coordinator = new AdoptionCoordinator(
+                new SequencedRunner(Task.FromException<CopilotAdoptionAnalysis>(boom)),
+                new InMemoryAnalysisCache(),
+                (window, hasOverride) => new RejectingTelemetry(),
+                TimeSpan.FromMinutes(10),
+                (ex, context) => throw new ApplicationException("telemetry failed"));
+
+            try
+            {
+                await coordinator.GetAsync(28, new List<int>());
+                Assert.Fail("the fake analysis should fail");
+            }
+            catch (InvalidOperationException ex)
+            {
+                Assert.AreSame(boom, ex, "telemetry failure must not replace the analysis exception");
+            }
         }
 
         private class RejectingTelemetry : StubAnalysisTelemetry
@@ -753,9 +846,19 @@ namespace Tests.UnitTests
 
         private sealed class RecordingTelemetryChannel : ITelemetryChannel
         {
+            private readonly object _gate = new object();
             private readonly List<ITelemetry> _sent = new List<ITelemetry>();
 
-            public IList<ITelemetry> Sent => _sent;
+            public IList<ITelemetry> Sent
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        return _sent.ToList();
+                    }
+                }
+            }
 
             public bool? DeveloperMode { get; set; }
 
@@ -763,7 +866,60 @@ namespace Tests.UnitTests
 
             public void Send(ITelemetry item)
             {
-                _sent.Add(item);
+                lock (_gate)
+                {
+                    _sent.Add(item);
+                }
+            }
+
+            public void Flush()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private sealed class BlockingExceptionTelemetryChannel : ITelemetryChannel
+        {
+            private readonly object _gate = new object();
+            private readonly List<ITelemetry> _sent = new List<ITelemetry>();
+            private int _blockedFirstException;
+
+            public ManualResetEventSlim FirstExceptionSendEntered { get; } =
+                new ManualResetEventSlim(false);
+            public ManualResetEventSlim ReleaseFirstExceptionSend { get; } =
+                new ManualResetEventSlim(false);
+
+            public IList<ITelemetry> Sent
+            {
+                get
+                {
+                    lock (_gate)
+                    {
+                        return _sent.ToList();
+                    }
+                }
+            }
+
+            public bool? DeveloperMode { get; set; }
+
+            public string EndpointAddress { get; set; }
+
+            public void Send(ITelemetry item)
+            {
+                if (item is ExceptionTelemetry
+                    && Interlocked.CompareExchange(ref _blockedFirstException, 1, 0) == 0)
+                {
+                    FirstExceptionSendEntered.Set();
+                    ReleaseFirstExceptionSend.Wait(TimeSpan.FromSeconds(2));
+                }
+
+                lock (_gate)
+                {
+                    _sent.Add(item);
+                }
             }
 
             public void Flush()
@@ -928,6 +1084,26 @@ namespace Tests.UnitTests
 
             public void WriteFailure(AdoptionFailure failure)
             {
+            }
+
+            public void Flush()
+            {
+            }
+        }
+
+        private sealed class ThrowingFailureWriter : AdoptionWriter
+        {
+            public void Write(AdoptionEvent telemetryEvent)
+            {
+            }
+
+            public void WriteCompletion(AdoptionCompletion completion)
+            {
+            }
+
+            public void WriteFailure(AdoptionFailure failure)
+            {
+                throw new InvalidOperationException("synthetic telemetry failure");
             }
 
             public void Flush()

--- a/src/AnalyticsEngine/Web/App_Start/WebExceptionTelemetry.cs
+++ b/src/AnalyticsEngine/Web/App_Start/WebExceptionTelemetry.cs
@@ -1,6 +1,8 @@
 ﻿using Common.Entities.Config;
 using DataUtils;
 using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Web.Http.ExceptionHandling;
 using Web.AnalyticsWeb.Models.CopilotAdoption;
 
@@ -22,14 +24,15 @@ namespace Web.AnalyticsWeb
     /// </summary>
     public static class WebExceptionTelemetry
     {
-        /// <summary>
-        /// Marker written into <see cref="Exception.Data"/> once an exception has been reported.
-        /// </summary>
-        private const string ReportedKey = "AnalyticsWeb.TelemetryReported";
+        private const int Unreported = 0;
+        private const int Reporting = 1;
+        private const int Reported = 2;
+        private static readonly ConditionalWeakTable<Exception, StrongBox<int>> ReportStates =
+            new ConditionalWeakTable<Exception, StrongBox<int>>();
 
         /// <summary>
-        /// Records that this exception has already been sent to Application Insights, so the Web API
-        /// exception logger does not report it a second time.
+        /// Records that this exception has already been sent to Application Insights, so another
+        /// telemetry path does not report it a second time.
         /// </summary>
         /// <remarks>
         /// The Copilot adoption analysis is SHARED: one background run can have many HTTP requests
@@ -44,23 +47,63 @@ namespace Web.AnalyticsWeb
 
             try
             {
-                ex.Data[ReportedKey] = true;
+                Interlocked.Exchange(ref ReportState(ex).Value, Reported);
             }
             catch (Exception)
             {
-                // Some exception types expose a fixed IDictionary. Not worth failing over.
+                // Telemetry bookkeeping must not make the original failure worse.
             }
         }
 
-        private static bool AlreadyReported(Exception ex)
+        internal static bool TryClaim(Exception ex)
+        {
+            if (ex == null) return false;
+
+            try
+            {
+                if (AnyClaimedOrReported(ex)) return false;
+                return Interlocked.CompareExchange(
+                           ref ReportState(ex).Value,
+                           Reporting,
+                           Unreported)
+                       == Unreported;
+            }
+            catch (Exception)
+            {
+                // If the dedup marker itself fails, prefer a possible duplicate over silent loss.
+                return true;
+            }
+        }
+
+        internal static void ReleaseClaim(Exception ex)
+        {
+            if (ex == null) return;
+
+            try
+            {
+                Interlocked.CompareExchange(
+                    ref ReportState(ex).Value,
+                    Unreported,
+                    Reporting);
+            }
+            catch (Exception)
+            {
+                // Best effort only.
+            }
+        }
+
+        private static bool AnyClaimedOrReported(Exception ex)
         {
             for (var current = ex; current != null; current = current.InnerException)
             {
-                if (current.Data != null && current.Data.Contains(ReportedKey)) return true;
+                if (Volatile.Read(ref ReportState(current).Value) != Unreported) return true;
             }
 
             return false;
         }
+
+        private static StrongBox<int> ReportState(Exception ex) =>
+            ReportStates.GetValue(ex, _ => new StrongBox<int>(Unreported));
 
         /// <summary>
         /// Reports an unhandled exception. Never throws: telemetry must not turn one failure into two,
@@ -85,7 +128,7 @@ namespace Web.AnalyticsWeb
             string context,
             Func<string, AnalyticsLogger> loggerFactory)
         {
-            if (ex == null || AlreadyReported(ex)) return;
+            if (!TryClaim(ex)) return;
 
             try
             {
@@ -109,6 +152,7 @@ namespace Web.AnalyticsWeb
             }
             catch (Exception)
             {
+                ReleaseClaim(ex);
                 // Deliberately swallowed - see above.
             }
         }

--- a/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionAnalysisCoordinator.cs
+++ b/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionAnalysisCoordinator.cs
@@ -264,11 +264,17 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
                 // the event has only been added to an in-memory queue whose worker can drop it. Marking
                 // here would suppress reporting by waiting requests without anything having confirmed
                 // the failure was reported. An accepted failure may therefore be reported by a waiting
-                // request as well as by the sink; removing that duplicate needs delivery acknowledgement
-                // from the sink - see issue #454.
+                // request if it wins the atomic report claim before the sink worker writes it.
                 if (!telemetry.QueueFailure(ex))
                 {
-                    _reportUnqueuedFailure(ex, "CopilotAdoption background analysis");
+                    try
+                    {
+                        _reportUnqueuedFailure(ex, "CopilotAdoption background analysis");
+                    }
+                    catch (Exception)
+                    {
+                        // Failure telemetry is best-effort and must never replace the analysis fault.
+                    }
                 }
 
                 throw;

--- a/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionTelemetry.cs
+++ b/src/AnalyticsEngine/Web/Models/CopilotAdoption/CopilotAdoptionTelemetry.cs
@@ -266,13 +266,17 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
         private readonly BlockingCollection<SinkItem> _queue =
             new BlockingCollection<SinkItem>(new ConcurrentQueue<SinkItem>(), Capacity);
         private readonly Func<ICopilotAdoptionTelemetryWriter> _writerFactory;
+        private readonly Action<Exception, string> _reportDroppedFailure;
         private readonly Thread _worker;
         private int _droppedEvents;
         private int _stopping;
 
-        public QueuedCopilotAdoptionEventSink(Func<ICopilotAdoptionTelemetryWriter> writerFactory)
+        public QueuedCopilotAdoptionEventSink(
+            Func<ICopilotAdoptionTelemetryWriter> writerFactory,
+            Action<Exception, string> reportDroppedFailure = null)
         {
             _writerFactory = writerFactory ?? throw new ArgumentNullException(nameof(writerFactory));
+            _reportDroppedFailure = reportDroppedFailure ?? WebExceptionTelemetry.Report;
             _worker = new Thread(Drain)
             {
                 IsBackground = true,
@@ -351,6 +355,7 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
                             Interlocked.Increment(ref _droppedEvents);
                             Console.WriteLine(
                                 $"Copilot adoption telemetry writer could not start ({ex.GetBaseException().GetType().Name}).");
+                            item.ReportDroppedFailure(_reportDroppedFailure);
                             continue;
                         }
                     }
@@ -364,6 +369,7 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
                         Interlocked.Increment(ref _droppedEvents);
                         Console.WriteLine(
                             $"Copilot adoption telemetry write failed ({ex.GetBaseException().GetType().Name}).");
+                        item.ReportDroppedFailure(_reportDroppedFailure);
                     }
                 }
             }
@@ -392,6 +398,7 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
             private readonly CopilotAdoptionCompletionEvent _completion;
             private readonly CopilotAdoptionFailureEvent _failure;
             private readonly CopilotAdoptionLifecycleEvent _submitted;
+            private int _failureClaimed;
 
             private SinkItem(
                 CopilotAdoptionLifecycleEvent lifecycle,
@@ -433,8 +440,52 @@ namespace Web.AnalyticsWeb.Models.CopilotAdoption
                 }
                 if (_failure != null)
                 {
-                    writer.WriteFailure(_failure);
-                    writer.Flush();
+                    if (WebExceptionTelemetry.TryClaim(_failure.Exception))
+                    {
+                        Interlocked.Exchange(ref _failureClaimed, 1);
+                        try
+                        {
+                            writer.WriteFailure(_failure);
+                            writer.Flush();
+                            WebExceptionTelemetry.MarkReported(_failure.Exception);
+                            Interlocked.Exchange(ref _failureClaimed, 0);
+                        }
+                        catch (Exception)
+                        {
+                            ReleaseFailureClaim();
+                            throw;
+                        }
+                    }
+                    else
+                    {
+                        writer.Flush();
+                    }
+                }
+            }
+
+            public void ReportDroppedFailure(Action<Exception, string> reporter)
+            {
+                if (_failure?.Exception == null || reporter == null) return;
+
+                ReleaseFailureClaim();
+
+                try
+                {
+                    reporter(
+                        _failure.Exception,
+                        "CopilotAdoption background analysis telemetry sink");
+                }
+                catch (Exception)
+                {
+                    // The telemetry worker must keep draining even when fallback telemetry fails.
+                }
+            }
+
+            private void ReleaseFailureClaim()
+            {
+                if (Interlocked.Exchange(ref _failureClaimed, 0) == 1)
+                {
+                    WebExceptionTelemetry.ReleaseClaim(_failure.Exception);
                 }
             }
         }


### PR DESCRIPTION
## Scope
Addresses #454. Fixes Copilot Adoption failure telemetry de-duplication between the queued lifecycle sink and HTTP requests waiting on the shared analysis task.

## Root cause
`QueueFailure(true)` only meant the failure was accepted into the in-memory sink queue, not that Application Insights received it. The shared analysis task rethrows the same exception instance to every waiter, while the previous `Exception.Data` marker was a non-atomic check-then-act written only by `WebExceptionTelemetry.Report`. That allowed both duplicates and a concurrent two-waiter race; marking at queue-acceptance was intentionally avoided because a later worker drop could make the failure silent.

## Design
- Replaced the `Exception.Data` de-dup marker with a `ConditionalWeakTable<Exception, StrongBox<int>>` state and `Interlocked.CompareExchange`, giving one atomic claim point per exception instance without leaking exception references.
- `WebExceptionTelemetry.Report` now claims before reporting, marks delivered only after `TrackException`/trace logging succeeds, and releases the claim if its own telemetry path throws.
- The queued Copilot Adoption sink writes the lifecycle failure event, then claims the exception only when the worker is ready to call `WriteFailure`; it marks reported only after `WriteFailure` and `Flush` complete.
- If a waiter claimed/reported the shared exception first, the sink skips exception telemetry and flushes the lifecycle event instead.
- If the worker later drops a failure item (writer construction failure or write failure), it releases any sink-owned claim and invokes the fallback reporter in a swallowed best-effort path, so accepted failures are redeemed instead of becoming silent.
- The coordinator now also swallows fallback-reporter failures so telemetry bookkeeping cannot replace the analysis exception.

## Spec coverage
1. Delivery acknowledgement: sink marks reported only after `WriteFailure` + `Flush` complete on the worker thread.
2. Waiter/worker race: both use the same atomic claim; the loser stands down.
3. Worker drop: failure items are redeemed through the fallback reporter, with any sink claim released first.
4. Analysis safety: queueing remains non-blocking, fallback/report exceptions are swallowed, and failure de-dup no longer writes `Exception.Data` concurrently.

## Tests
- Updated `AnalysisFailure_AcceptedByTheSink_IsStillVisibleToAWaitingRequest` to pin the new invariant: a delivered sink failure produces exactly one exception telemetry item even when waiting requests also report.
- Added `QueuedSink_AcceptedFailureDroppedByWorker_IsReportedByFallback` to prove accepted-but-dropped failures are never zero.
- Added `ConcurrentWaitingRequests_ReportSharedFailureOnce`; it deterministically pauses the first waiter inside telemetry send before delivery marking, then starts a second waiter and repeats the race.
- Added `FailureTelemetryFallbackFailure_DoesNotReplaceAnalysisFailure` to prove telemetry fallback failure does not fault the analysis path.

## Validation
- `msbuild src\AnalyticsEngine\Tests.UnitTests -t:Restore -p:Configuration=Debug -p:Platform=anycpu -p:ProcessorArchitecture=x86`
- `msbuild src\AnalyticsEngine\Tests.UnitTests\Tests.UnitTests.csproj -p:Configuration=Debug -p:Platform=anycpu -p:ProcessorArchitecture=x86 -m:1 -nr:false -v:minimal -clp:Summary`
- `vstest.console.exe src\AnalyticsEngine\Tests.UnitTests\bin\Debug\Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~CopilotAdoptionTelemetryTests"` (15/15 passed)
- Re-ran `ConcurrentWaitingRequests_ReportSharedFailureOnce` three additional times; all passed.

## Schema/config impact
No SQL schema change, migrations, manual SQL assets, performance benchmark gate, or installer config-schema change is involved.

## Risk and reviewer hotspots
The main review area is the `WebExceptionTelemetry` claim/release lifecycle and the queued sink's drop redemption path. A rare telemetry-path failure may still prefer a visible duplicate over silence, but successful delivery now de-dups worker and waiter reports atomically.