### PR TITLE
Fix weekly SharePoint report success cadence

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/ReportCompletionStoreTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ReportCompletionStoreTests.cs
@@ -4,10 +4,12 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Tests.UnitTests.FakeLoaderClasses;
 using UnitTests.FakeLoaderClasses;
 using WebJob.Office365ActivityImporter.Engine;
 using WebJob.Office365ActivityImporter.Engine.Graph;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate;
 
 namespace Tests.UnitTests
 {
@@ -245,6 +247,84 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public async Task WeeklyReportWithNoSundayRefreshGetsShortBackoffButNoDataSuccessStamp()
+        {
+            var store = new InMemoryReportCompletionStore();
+            var clock = new FixedClock(new DateTime(2026, 9, 10, 4, 0, 0, DateTimeKind.Utc));
+            var importer = NewImporter(store, clock: clock);
+            var loader = TestSharePointSitesWeeklyUsageReportLoader.WithSingleReport(
+                new DateTime(2024, 2, 26),
+                "https://contoso.sharepoint.com/sites/non-sunday");
+            var reportKey = GraphImporter.GetReportKey(loader.GetType());
+
+            await importer.RunWeeklyReportIfDueAsync(loader, OneDay);
+
+            Assert.AreEqual(1, loader.LoadCount, "The first due run should download the weekly report.");
+            Assert.AreEqual(1, loader.LastSaveResult.NotRefreshedOnDay,
+                "The loader should expose that it saw data, but not for the required Sunday refresh day.");
+            Assert.IsNull(await store.GetLastSuccessAsync(reportKey),
+                "A non-Sunday Graph refresh date is not a data success and must not feed the 24-hour success stamp.");
+
+            clock.Advance(TimeSpan.FromMinutes(30));
+            await importer.RunWeeklyReportIfDueAsync(loader, OneDay);
+            Assert.AreEqual(1, loader.LoadCount,
+                "The short backoff must prevent a full re-download on every import cycle while Graph has not published Sunday data.");
+
+            clock.Advance(TimeSpan.FromMinutes(31));
+            Assert.IsTrue(await importer.IsReportDueAsync(reportKey, OneDay),
+                "The non-Sunday backoff is deliberately short so the importer can retry the same day.");
+        }
+
+        [TestMethod]
+        public async Task WeeklyReportAlreadyStoredSundayStillGetsFullSuccessCadence()
+        {
+            var store = new InMemoryReportCompletionStore();
+            var clock = new FixedClock(new DateTime(2026, 9, 10, 4, 0, 0, DateTimeKind.Utc));
+            var importer = NewImporter(store, clock: clock);
+            var sunday = new DateTime(2024, 2, 25);
+            var siteUrl = "https://contoso.sharepoint.com/sites/already-current";
+            var loader = TestSharePointSitesWeeklyUsageReportLoader.WithSingleReport(sunday, siteUrl);
+            loader.Store.SeedWeek(loader.Store.SeedSite(siteUrl), sunday);
+            var reportKey = GraphImporter.GetReportKey(loader.GetType());
+
+            await importer.RunWeeklyReportIfDueAsync(loader, OneDay);
+
+            Assert.AreEqual(0, loader.LastSaveResult.ItemsSaved,
+                "The row is already stored, so a naive itemsSaved > 0 success check would fail this case.");
+            Assert.AreEqual(1, loader.LastSaveResult.AlreadyUpToDate);
+            Assert.IsTrue(loader.LastSaveResult.ObservedRefreshDayReport);
+            Assert.IsNotNull(await store.GetLastSuccessAsync(reportKey),
+                "Observing an already-stored Sunday report is still a data success.");
+
+            clock.Advance(TimeSpan.FromHours(23).Add(TimeSpan.FromMinutes(59)));
+            Assert.IsFalse(await importer.IsReportDueAsync(reportKey, OneDay),
+                "A Sunday observation receives the full daily cadence, not the short non-Sunday backoff.");
+        }
+
+        [TestMethod]
+        public async Task WeeklyReportDailyCadenceAnchorsToPreviousDueTimeInsteadOfCompletionTime()
+        {
+            var store = new InMemoryReportCompletionStore();
+            var clock = new FixedClock(new DateTime(2026, 9, 10, 4, 0, 0, DateTimeKind.Utc));
+            var importer = NewImporter(store, clock: clock);
+            var loader = TestSharePointSitesWeeklyUsageReportLoader.WithSingleReport(
+                new DateTime(2024, 2, 25),
+                "https://contoso.sharepoint.com/sites/anti-drift");
+            var reportKey = GraphImporter.GetReportKey(loader.GetType());
+
+            await importer.RunWeeklyReportIfDueAsync(loader, OneDay);
+
+            clock.Advance(OneDay.Add(TimeSpan.FromMinutes(5)));
+            await importer.RunWeeklyReportIfDueAsync(loader, OneDay);
+
+            clock.Advance(OneDay.Subtract(TimeSpan.FromMinutes(4)));
+
+            Assert.IsTrue(await importer.IsReportDueAsync(reportKey, OneDay),
+                "The next due time should remain anchored at the original daily schedule. If completion time " +
+                "were used, this check one minute after the original due time would still be throttled.");
+        }
+
+        [TestMethod]
         public async Task AReportThatSucceededLongerAgoThanTheWindowIsDueAgain()
         {
             var store = new StubCompletionStore { LastSuccess = DateTime.Now.AddDays(-2) };
@@ -295,6 +375,44 @@ namespace Tests.UnitTests
             public Task<DateTime?> GetLastSuccessAsync(string reportKey) => Task.FromResult(LastSuccess);
             public Task SaveSuccessAsync(string reportKey) { LastSuccess = DateTime.Now; return Task.CompletedTask; }
             public Task ClearAsync(string reportKey) { LastSuccess = null; return Task.CompletedTask; }
+        }
+
+        private class TestSharePointSitesWeeklyUsageReportLoader : SharePointSitesWeeklyUsageReportLoader
+        {
+            private readonly SharePointSiteUsageDetail _report;
+
+            private TestSharePointSitesWeeklyUsageReportLoader(InMemorySharePointSiteUsageStore store, SharePointSiteUsageDetail report)
+                : base(store, null, DataUtils.AnalyticsLogger.ConsoleOnlyTracer(), null)
+            {
+                Store = store;
+                _report = report;
+            }
+
+            public InMemorySharePointSiteUsageStore Store { get; }
+            public int LoadCount { get; private set; }
+            public WeeklyUsageReportSaveResult LastSaveResult { get; private set; }
+
+            public static TestSharePointSitesWeeklyUsageReportLoader WithSingleReport(DateTime refreshDate, string siteUrl)
+            {
+                return new TestSharePointSitesWeeklyUsageReportLoader(
+                    new InMemorySharePointSiteUsageStore(),
+                    new SharePointSiteUsageDetail { SiteUrl = siteUrl, ReportRefreshDate = refreshDate, FileCount = 1 });
+            }
+
+            public override Task<AggregateResourceUsageDetail<SharePointSiteUsageDetail>> LoadReportDataForUrl(string requestUrl)
+            {
+                LoadCount++;
+                return Task.FromResult(new AggregateResourceUsageDetail<SharePointSiteUsageDetail>
+                {
+                    Stats = new[] { _report }
+                });
+            }
+
+            public override async Task<WeeklyUsageReportSaveResult> LoadAndSaveLastWeeksReportsIfRefreshOnDayWithResult(DayOfWeek uptoDay)
+            {
+                LastSaveResult = await base.LoadAndSaveLastWeeksReportsIfRefreshOnDayWithResult(uptoDay);
+                return LastSaveResult;
+            }
         }
 
         #endregion

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -39,6 +39,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         private readonly IGraphImportSectionFactory _sectionFactory;
 
         private readonly IClock _clock;
+        internal static readonly TimeSpan WeeklyReportNoSundayBackoff = TimeSpan.FromHours(1);
 
         /// <summary>
         /// Production constructor: builds the <see cref="ProductionGraphImportSectionFactory"/> that holds all
@@ -236,11 +237,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             if (_reportCompletionStore == null) return true;
             if (_settings.ForceUsageReportsImport) return true;
 
+            if (_reportCompletionStore is IReportAttemptScheduleStore scheduleStore)
+            {
+                var nextAttemptUtc = await scheduleStore.GetNextAttemptUtcAsync(reportKey);
+                if (nextAttemptUtc.HasValue)
+                {
+                    return _clock.UtcNow >= nextAttemptUtc.Value.ToUniversalTime();
+                }
+            }
+
             var lastSuccess = await _reportCompletionStore.GetLastSuccessAsync(reportKey);
-            return lastSuccess == null || _clock.UtcNow.Subtract(lastSuccess.Value.ToUniversalTime()) > minWait;
+            return lastSuccess == null || _clock.UtcNow.Subtract(lastSuccess.Value.ToUniversalTime()) >= minWait;
         }
 
-        private async Task RunWeeklyReportIfDueAsync(SharePointSitesWeeklyUsageReportLoader loader, TimeSpan minWait)
+        internal async Task RunWeeklyReportIfDueAsync(SharePointSitesWeeklyUsageReportLoader loader, TimeSpan minWait)
         {
             var reportKey = GetReportKey(loader.GetType());
 
@@ -258,11 +268,55 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 await _reportCompletionStore.ClearAsync(reportKey);
             }
 
-            await loader.LoadAndSaveLastWeeksReportsIfRefreshOnDay(System.DayOfWeek.Sunday);
+            var result = await loader.LoadAndSaveLastWeeksReportsIfRefreshOnDayWithResult(System.DayOfWeek.Sunday);
 
             if (_reportCompletionStore != null)
             {
-                await _reportCompletionStore.SaveSuccessAsync(reportKey);
+                if (result.ObservedRefreshDayReport)
+                {
+                    await _reportCompletionStore.SaveSuccessAsync(reportKey);
+                    await ScheduleNextReportAttemptAsync(reportKey, minWait);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        $"SharePoint sites weekly usage: Graph returned {result.NotRefreshedOnDay} item(s), " +
+                        "but none had a Sunday refresh date. Not recording a data-success stamp; " +
+                        $"retry after {WeeklyReportNoSundayBackoff.TotalMinutes} minutes.");
+                    await ScheduleReportBackoffAsync(reportKey);
+                }
+            }
+        }
+
+        private async Task ScheduleNextReportAttemptAsync(string reportKey, TimeSpan interval)
+        {
+            if (!(_reportCompletionStore is IReportAttemptScheduleStore scheduleStore)) return;
+
+            var now = _clock.UtcNow;
+            var previousDue = await scheduleStore.GetNextAttemptUtcAsync(reportKey);
+            DateTime nextDueUtc;
+            if (previousDue.HasValue && previousDue.Value.ToUniversalTime() <= now)
+            {
+                nextDueUtc = previousDue.Value.ToUniversalTime();
+                do
+                {
+                    nextDueUtc = nextDueUtc.Add(interval);
+                }
+                while (nextDueUtc <= now);
+            }
+            else
+            {
+                nextDueUtc = now.Add(interval);
+            }
+
+            await scheduleStore.SaveNextAttemptUtcAsync(reportKey, DateTime.SpecifyKind(nextDueUtc, DateTimeKind.Utc));
+        }
+
+        private async Task ScheduleReportBackoffAsync(string reportKey)
+        {
+            if (_reportCompletionStore is IReportAttemptScheduleStore scheduleStore)
+            {
+                await scheduleStore.SaveNextAttemptUtcAsync(reportKey, _clock.UtcNow.Add(WeeklyReportNoSundayBackoff));
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractAggregateWeeklyUsageReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/Aggregate/AbstractAggregateWeeklyUsageReportLoader.cs
@@ -75,16 +75,22 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
         public abstract string ReportName { get; }
 
         public async Task<int> LoadAndSaveLastWeeksReportsIfRefreshOnDay(DayOfWeek uptoDay)
+            => (await LoadAndSaveLastWeeksReportsIfRefreshOnDayWithResult(uptoDay)).ItemsSaved;
+
+        public virtual async Task<WeeklyUsageReportSaveResult> LoadAndSaveLastWeeksReportsIfRefreshOnDayWithResult(DayOfWeek uptoDay)
         {
             Telemetry.LogInformation($"Loading {GetType().Name} and saving reports refreshed on a {uptoDay}");
 
             var report = await LoadReportData();
             Telemetry.LogInformation($"Loaded {report.Count()} items for {ReportName} reports");
 
-            return await SaveLoadedReportsIfRefreshOnDay(uptoDay, report);
+            return await SaveLoadedReportsIfRefreshOnDayWithResult(uptoDay, report);
         }
 
         public async Task<int> SaveLoadedReportsIfRefreshOnDay(DayOfWeek uptoDay, IEnumerable<T> data)
+            => (await SaveLoadedReportsIfRefreshOnDayWithResult(uptoDay, data)).ItemsSaved;
+
+        public virtual async Task<WeeklyUsageReportSaveResult> SaveLoadedReportsIfRefreshOnDayWithResult(DayOfWeek uptoDay, IEnumerable<T> data)
         {
             // Materialise once so we can both hand the full set to BeginSaveAsync (for bulk pre-loading)
             // and iterate it below.
@@ -134,7 +140,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
                     Telemetry.LogInformation($"Saving {itemsSaved} items to SQL for {ReportName} reports");
                     await CommitAllChanges();
                 }
-                return itemsSaved;
+                return new WeeklyUsageReportSaveResult(itemsSaved, alreadyUpToDate, notRefreshedOnDay);
             }
             finally
             {
@@ -155,5 +161,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Aggregate
         protected virtual Task EndSaveAsync() => Task.CompletedTask;
 
         public abstract Task<AggregateResourceUsageDetail<T>> LoadReportDataForUrl(string requestUrl);
+    }
+
+    public sealed class WeeklyUsageReportSaveResult
+    {
+        public WeeklyUsageReportSaveResult(int itemsSaved, int alreadyUpToDate, int notRefreshedOnDay)
+        {
+            ItemsSaved = itemsSaved;
+            AlreadyUpToDate = alreadyUpToDate;
+            NotRefreshedOnDay = notRefreshedOnDay;
+        }
+
+        public int ItemsSaved { get; }
+        public int AlreadyUpToDate { get; }
+        public int NotRefreshedOnDay { get; }
+        public bool ObservedRefreshDayReport => ItemsSaved + AlreadyUpToDate > 0;
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ReportCompletionStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ReportCompletionStore.cs
@@ -39,14 +39,23 @@ namespace WebJob.Office365ActivityImporter.Engine
         Task ClearAsync(string reportKey);
     }
 
+    public interface IReportAttemptScheduleStore
+    {
+        Task<DateTime?> GetNextAttemptUtcAsync(string reportKey);
+        Task SaveNextAttemptUtcAsync(string reportKey, DateTime nextAttemptUtc);
+        Task ClearNextAttemptUtcAsync(string reportKey);
+    }
+
     /// <summary>
     /// In-memory fallback used when Redis is not configured; lives only for the life of the WebJob process.
     /// Must be constructed ONCE outside the per-cycle loop, exactly like <see cref="InMemorySingleDateStore"/>.
     /// </summary>
-    public class InMemoryReportCompletionStore : IReportCompletionStore
+    public class InMemoryReportCompletionStore : IReportCompletionStore, IReportAttemptScheduleStore
     {
         // Reports run concurrently under Task.WhenAll, so this must be thread-safe.
         private readonly ConcurrentDictionary<string, DateTime> _lastSuccess =
+            new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, DateTime> _nextAttemptUtc =
             new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
 
         public Task<DateTime?> GetLastSuccessAsync(string reportKey)
@@ -65,6 +74,25 @@ namespace WebJob.Office365ActivityImporter.Engine
             _lastSuccess.TryRemove(reportKey, out _);
             return Task.CompletedTask;
         }
+
+        public Task<DateTime?> GetNextAttemptUtcAsync(string reportKey)
+        {
+            return Task.FromResult(_nextAttemptUtc.TryGetValue(reportKey, out var dt) ? dt : (DateTime?)null);
+        }
+
+        public Task SaveNextAttemptUtcAsync(string reportKey, DateTime nextAttemptUtc)
+        {
+            _nextAttemptUtc[reportKey] = nextAttemptUtc.Kind == DateTimeKind.Utc
+                ? nextAttemptUtc
+                : nextAttemptUtc.ToUniversalTime();
+            return Task.CompletedTask;
+        }
+
+        public Task ClearNextAttemptUtcAsync(string reportKey)
+        {
+            _nextAttemptUtc.TryRemove(reportKey, out _);
+            return Task.CompletedTask;
+        }
     }
 
     /// <summary>
@@ -72,13 +100,14 @@ namespace WebJob.Office365ActivityImporter.Engine
     /// (which is the whole point - an in-memory stamp would be lost on every restart and the skip list would
     /// be empty again).
     /// </summary>
-    public class RedisReportCompletionStore : IReportCompletionStore
+    public class RedisReportCompletionStore : IReportCompletionStore, IReportAttemptScheduleStore
     {
         /// <summary>
         /// Prefix for the per-report keys. Deliberately distinct from the phase-level
         /// <c>UserActivityLastImported</c> key so the two cannot collide.
         /// </summary>
         internal const string KeyPrefix = "UserActivityReportLastImported:";
+        internal const string NextAttemptKeyPrefix = "UserActivityReportNextAttemptUtc:";
 
         private readonly ConcurrentDictionary<string, RedisSingleDateLoader> _loaders =
             new ConcurrentDictionary<string, RedisSingleDateLoader>(StringComparer.OrdinalIgnoreCase);
@@ -102,11 +131,24 @@ namespace WebJob.Office365ActivityImporter.Engine
                 k => new RedisSingleDateLoader(_redisConnectionString, KeyPrefix + k, _tenantId, _clientId, _clientSecret));
         }
 
+        private RedisSingleDateLoader NextAttemptLoaderFor(string reportKey)
+        {
+            return _loaders.GetOrAdd(NextAttemptKeyPrefix + reportKey,
+                k => new RedisSingleDateLoader(_redisConnectionString, k, _tenantId, _clientId, _clientSecret));
+        }
+
         public Task<DateTime?> GetLastSuccessAsync(string reportKey) => LoaderFor(reportKey).GetLastDT();
 
         public Task SaveSuccessAsync(string reportKey) => LoaderFor(reportKey).SaveDT();
 
         public Task ClearAsync(string reportKey) => LoaderFor(reportKey).DeleteDt();
+
+        public Task<DateTime?> GetNextAttemptUtcAsync(string reportKey) => NextAttemptLoaderFor(reportKey).GetLastDT();
+
+        public Task SaveNextAttemptUtcAsync(string reportKey, DateTime nextAttemptUtc)
+            => NextAttemptLoaderFor(reportKey).SaveDT(nextAttemptUtc.Kind == DateTimeKind.Utc ? nextAttemptUtc : nextAttemptUtc.ToUniversalTime());
+
+        public Task ClearNextAttemptUtcAsync(string reportKey) => NextAttemptLoaderFor(reportKey).DeleteDt();
     }
 
     /// <summary>


### PR DESCRIPTION
## Scope
Addresses #452. Fixes the SharePoint sites weekly usage report gate only; the shared activity-report phase throttle is intentionally unchanged.

## Root cause
- `RunWeeklyReportIfDueAsync` cleared the report completion stamp, ran the weekly loader, then saved success unconditionally.
- The weekly loader silently returns zero saves when Graph's current `reportRefreshDate` is not Sunday, so the stamp meant "ran" rather than "obtained the weekly Sunday snapshot".
- The weekly gate also compared `UtcNow - lastSuccess > 1 day` against a completion-time stamp, so each run drifted slightly later and could eventually skip a calendar day.

## Changes
- Added `WeeklyUsageReportSaveResult` and source-compatible `*WithResult` loader methods that expose `itemsSaved`, `alreadyUpToDate`, and `notRefreshedOnDay`; existing `int` methods still return `ItemsSaved` for current call sites.
- Weekly SharePoint sites now records a data-success stamp only when `itemsSaved + alreadyUpToDate > 0`.
- Added a separate per-report next-attempt schedule store for the weekly gate. Successful Sunday observations schedule the next daily attempt from the prior due time when available, preventing completion-time drift. Non-Sunday observations schedule a one-hour retry backoff without writing a data-success stamp.
- The one-hour backoff bounds repeated full SharePoint sites downloads at roughly hourly while Graph has not published Sunday data. At the ~200,000-user/site-scale planning baseline, that avoids hammering Graph on every importer cycle while limiting publication-day latency to about an hour.

## Tests
- `WeeklyReportWithNoSundayRefreshGetsShortBackoffButNoDataSuccessStamp`: proves non-Sunday data does not get a 24-hour data-success stamp and does not re-download every cycle.
- `WeeklyReportAlreadyStoredSundayStillGetsFullSuccessCadence`: proves an already-stored Sunday snapshot (`alreadyUpToDate > 0`, `itemsSaved == 0`) still counts as success.
- `WeeklyReportDailyCadenceAnchorsToPreviousDueTimeInsteadOfCompletionTime`: proves daily due times do not drift forward after late completions.

Validation run:
- `msbuild src\AnalyticsEngine\Tests.UnitTests -t:Restore -p:Configuration=Debug -p:Platform=anycpu -p:ProcessorArchitecture=x86`
- `msbuild src\AnalyticsEngine\Tests.UnitTests -p:Configuration=Debug -p:Platform=anycpu -p:ProcessorArchitecture=x86`
- `vstest.console.exe src\AnalyticsEngine\Tests.UnitTests\bin\Debug\Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~ReportCompletionStoreTests|FullyQualifiedName~SharePointSiteUsageStoreTests|Name=SundayOrNotFakeUsageLoaderTest|Name=MultiPageFakeUsageLoaderTest|Name=SaveLoadedReportsIfRefreshOnDay_CallsEndSaveEvenWhenSaveThrows"`

## Schema/config impact
No SQL schema, EF migration, manual SQL asset, or installer config-schema change is involved.

## Risks and reviewer hotspots
- `ReportCompletionStore.cs`: new Redis/in-memory next-attempt keys are separate from data-success keys so skip-list semantics stay clean.
- `GraphImporter.ScheduleNextReportAttemptAsync`: cadence anchoring intentionally uses the previous due time only when the previous due has been reached.
- Deferred follow-up: the shared phase-level throttle has the same historic drift shape, but changing it would affect the other daily reports and is out of scope for this issue.