### PR TITLE
Handle App Service plans without Always On support

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -40,14 +40,14 @@ namespace App.ControlPanel.Engine
         /// <summary>
         /// Install configure & software on App Service, update target DB. 
         /// </summary>
-        public async Task RunPostCreatePaaSTasks(WebSiteResource webApp, DatabasePaaSInfo dbInfo, StorageAccountResource storage, AutomationAccountResource automationAccount,
+        public async Task RunPostCreatePaaSTasks(WebSiteResource webApp, AppServicePlanResource appServicePlan, DatabasePaaSInfo dbInfo, StorageAccountResource storage, AutomationAccountResource automationAccount,
             AppInsightsInfo appInsights,
             RedisInstallResult redis, CognitiveServicesInfo cognitiveServicesInfo,
             KeyVaultResource keyVault, string serviceBusConnectionString, SubscriptionResource subscription,
             SqlServerResource sqlServer = null)
         {
             // Configure app-service connection-strings, etc
-            await ConfigureWebApp(webApp, dbInfo, storage, redis, cognitiveServicesInfo, appInsights, serviceBusConnectionString, keyVault);
+            await ConfigureWebApp(webApp, appServicePlan, dbInfo, storage, redis, cognitiveServicesInfo, appInsights, serviceBusConnectionString, keyVault);
 
             // Download/extract the release while the App Service is still available. Kudu/SCM
             // rejects deployments while the site resource is stopped.
@@ -292,7 +292,7 @@ namespace App.ControlPanel.Engine
             await installJob.Install();
         }
 
-        async Task ConfigureWebApp(WebSiteResource webApp, DatabasePaaSInfo backendInfo,
+        async Task ConfigureWebApp(WebSiteResource webApp, AppServicePlanResource appServicePlan, DatabasePaaSInfo backendInfo,
             StorageAccountResource storage,
             RedisInstallResult redis,
             CognitiveServicesInfo cognitiveServicesInfo,
@@ -389,12 +389,38 @@ namespace App.ControlPanel.Engine
             }
             connectionStrings.Properties.Add("Redis", new ConnStringValueTypePair(redisConnectionString, ConnectionStringType.Custom));
 
-            await webApp.UpdateAsync(new SitePatchInfo { SiteConfig = new SiteConfigProperties { Use32BitWorkerProcess = false, IsAlwaysOn = true } });
+            var siteConfig = BuildPostCreateSiteConfig(appServicePlan?.Data?.Sku);
+            try
+            {
+                await webApp.UpdateAsync(new SitePatchInfo { SiteConfig = siteConfig });
+            }
+            catch (RequestFailedException ex) when (AppServicePlanCapabilities.IsPlanCapabilityConflict(ex))
+            {
+                _logger.LogWarning(AppServicePlanCapabilities.BuildAlwaysOnUnsupportedWarning(appServicePlan?.Data?.Name ?? Config.AppServicePlanName, appServicePlan?.Data?.Sku));
+                await webApp.UpdateAsync(new SitePatchInfo { SiteConfig = BuildPostCreateSiteConfig(appServicePlan?.Data?.Sku, includePlanSensitiveSettings: false) });
+            }
             await PreserveUnmanagedAppSettingsAsync(webApp, appSettings);
             await webApp.UpdateApplicationSettingsAsync(appSettings);
             await webApp.UpdateConnectionStringsAsync(connectionStrings);
 
             _logger.LogInformation("App Service connection-strings & app-settings configured");
+        }
+
+        public static SiteConfigProperties BuildPostCreateSiteConfig(AppServiceSkuDescription appServicePlanSku, bool includePlanSensitiveSettings = true)
+        {
+            var siteConfig = new SiteConfigProperties();
+
+            if (includePlanSensitiveSettings && AppServicePlanCapabilities.SupportsAlwaysOn(appServicePlanSku))
+            {
+                siteConfig.IsAlwaysOn = true;
+            }
+
+            if (includePlanSensitiveSettings && AppServicePlanCapabilities.Supports64BitWorkerProcess(appServicePlanSku))
+            {
+                siteConfig.Use32BitWorkerProcess = false;
+            }
+
+            return siteConfig;
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -437,6 +437,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
         public SqlServerResource CreatedSqlServer => GetTaskResult<SqlServerResource>(_sqlServerTask);
         public SqlDatabaseResource CreatedSqlDatabase => GetTaskResult<SqlDatabaseResource>(_sqlDatabaseTask);
+        public AppServicePlanResource CreatedAppServicePlan => GetTaskResult<AppServicePlanResource>(_appServicePlanTask);
         public WebSiteResource CreatedWebSiteResource => GetTaskResult<WebSiteResource>(_appServiceWebsiteTask);
         public DatabasePaaSInfo DatabasePaaSInfo => new DatabasePaaSInfo(CreatedSqlServer, CreatedSqlDatabase, _config);
         public RedisInstallResult Redis => GetTaskResult<RedisInstallResult>(_redisTask);

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -5,9 +5,10 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.KeyVault;
 using Azure.ResourceManager.Redis;
 using Azure.ResourceManager.RedisEnterprise;
+using Azure.ResourceManager.AppService;
+using CloudInstallEngine.Azure;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Sql;
-using CloudInstallEngine.Azure;
 using Common.Entities;
 using DataUtils;
 using DataUtils.Http;
@@ -82,6 +83,9 @@ namespace App.ControlPanel.Engine
                     _logger.LogInformation($"Resource-group found with name {Config.ResourceGroupName}.");
                 }
             }
+
+            // Verify the existing App Service plan supports solution runtime features.
+            await VerifyAppServicePlanCapabilities(testRg);
 
             // Verify the installer account can create RBAC role assignments
             // (Microsoft.Authorization/roleAssignments/write). Lacking this permission is the cause of
@@ -209,6 +213,51 @@ namespace App.ControlPanel.Engine
                 }
             }
             return (null, false);
+        }
+
+        /// <summary>
+        /// Warn when an existing App Service plan cannot run Always On / 64-bit workers so Test Configuration
+        /// catches under-provisioned plans before the install writes App Service settings. Logs only; never throws.
+        /// </summary>
+        Task VerifyAppServicePlanCapabilities(ResourceGroupResource testRg)
+        {
+            if (testRg == null)
+            {
+                _logger.LogInformation("Skipping App Service plan capability check - resource group is not available.");
+                return Task.CompletedTask;
+            }
+
+            var planName = string.IsNullOrWhiteSpace(Config.AppServicePlanName) ? Config.AppServiceWebAppName : Config.AppServicePlanName;
+            if (string.IsNullOrWhiteSpace(planName))
+            {
+                _logger.LogInformation("Skipping App Service plan capability check - no App Service plan name is configured.");
+                return Task.CompletedTask;
+            }
+
+            try
+            {
+                var plan = testRg.GetAppServicePlans().Where(p => p.Data.Name == planName).SingleOrDefault();
+                if (plan == null)
+                {
+                    _logger.LogInformation($"App Service plan '{planName}' not found yet; skipping capability check (it will be created during install).");
+                    return Task.CompletedTask;
+                }
+
+                if (!AppServicePlanCapabilities.SupportsAlwaysOn(plan.Data.Sku))
+                {
+                    _logger.LogWarning(AppServicePlanCapabilities.BuildAlwaysOnUnsupportedWarning(plan.Data.Name, plan.Data.Sku));
+                }
+                else
+                {
+                    _logger.LogInformation($"App Service plan '{plan.Data.Name}' tier '{AppServicePlanCapabilities.GetDisplayTier(plan.Data.Sku)}' supports Always On and 64-bit workers.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Could not check App Service plan '{planName}' capabilities: {ex.Message}");
+            }
+
+            return Task.CompletedTask;
         }
 
         #region Configuration & Key Vault checks

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
@@ -84,6 +84,7 @@ namespace App.ControlPanel.Engine
                 var tasks = new ConfigureAzureComponentsTasks(Config, log, _proxyConfig, InstalledByUsername, _softwareConfig, _configPassword);
                 await tasks.RunPostCreatePaaSTasks(
                     azureBackeEndCreationJob.CreatedWebSiteResource,
+                    azureBackeEndCreationJob.CreatedAppServicePlan,
                     azureBackeEndCreationJob.DatabasePaaSInfo,
                     azureBackeEndCreationJob.Storage,
                     azureBackeEndCreationJob.CreatedAutomationAccount,

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/AppServicePlanCapabilities.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/AppServicePlanCapabilities.cs
@@ -1,0 +1,64 @@
+using Azure;
+using Azure.ResourceManager.AppService.Models;
+using System;
+
+namespace CloudInstallEngine.Azure
+{
+    public static class AppServicePlanCapabilities
+    {
+        public static bool SupportsAlwaysOn(AppServiceSkuDescription sku)
+        {
+            return !IsFreeOrShared(sku);
+        }
+
+        public static bool Supports64BitWorkerProcess(AppServiceSkuDescription sku)
+        {
+            return !IsFreeOrShared(sku);
+        }
+
+        public static bool IsFreeOrShared(AppServiceSkuDescription sku)
+        {
+            if (sku == null) return false;
+
+            if (IsTierKnownUnsupported(sku.Tier)) return true;
+
+            // ARM normally supplies Tier ("Free"/"Shared"), which is the stable capability boundary.
+            // Some partially populated test/ARM objects only carry Name or Size, so fall back to exact F1/D1.
+            return IsFreeOrSharedName(sku.Name) || IsFreeOrSharedName(sku.Size);
+        }
+
+        public static string GetDisplayTier(AppServiceSkuDescription sku)
+        {
+            if (sku == null) return "unknown";
+
+            var tier = string.IsNullOrWhiteSpace(sku.Tier) ? "unknown" : sku.Tier.Trim();
+            var name = string.IsNullOrWhiteSpace(sku.Name) ? sku.Size : sku.Name;
+            return string.IsNullOrWhiteSpace(name) ? tier : $"{tier} ({name.Trim()})";
+        }
+
+        public static string BuildAlwaysOnUnsupportedWarning(string planName, AppServiceSkuDescription sku)
+        {
+            var safePlanName = string.IsNullOrWhiteSpace(planName) ? "<unknown>" : planName.Trim();
+            return $"App Service plan '{safePlanName}' is tier '{GetDisplayTier(sku)}', which does not support Always On or 64-bit workers. " +
+                "The site will be unloaded when idle and the web-jobs will not run reliably. " +
+                "Scale the plan to B1 or higher and re-run the installer.";
+        }
+
+        public static bool IsPlanCapabilityConflict(RequestFailedException ex)
+        {
+            return ex != null && ex.Status == 409;
+        }
+
+        private static bool IsTierKnownUnsupported(string tier)
+        {
+            return string.Equals(tier, "Free", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(tier, "Shared", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsFreeOrSharedName(string nameOrSize)
+        {
+            return string.Equals(nameOrSize, "F1", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(nameOrSize, "D1", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServicePlanTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServicePlanTask.cs
@@ -2,6 +2,7 @@
 using Azure.Core;
 using Azure.ResourceManager.AppService;
 using Azure.ResourceManager.AppService.Models;
+using CloudInstallEngine.Azure;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
@@ -51,6 +52,10 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 await base.EnsureTagsOnExisting(plan.Data.Tags, plan.GetTagResource());     // Add configured tags
 
                 _logger.LogInformation($"Using existing App Service plan '{_config.ResourceName}'.");
+                if (!AppServicePlanCapabilities.SupportsAlwaysOn(plan.Data.Sku))
+                {
+                    _logger.LogWarning(AppServicePlanCapabilities.BuildAlwaysOnUnsupportedWarning(plan.Data.Name, plan.Data.Sku));
+                }
             }
 
             return plan;

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -3,6 +3,7 @@ using Azure.Core;
 using Azure.ResourceManager.AppService;
 using Azure.ResourceManager.AppService.Models;
 using Azure.ResourceManager.Models;
+using CloudInstallEngine.Azure;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,29 +33,32 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
             var appServicePlan = (AppServicePlanResource)contextArg;
             var desiredAccess = _allowPublicAccess ? "Enabled" : "Disabled";
+            var appServicePlanSku = appServicePlan.Data.Sku;
+            var supportsAlwaysOn = AppServicePlanCapabilities.SupportsAlwaysOn(appServicePlanSku);
 
             // Get/create app-service with plan
             var webApp = Container.GetWebSites().Where(s => s.Data.Name == _config.ResourceName).SingleOrDefault();
             if (webApp == null)
             {
-                var newWebAppInfo = new WebSiteData(base.AzureLocation)
-                {
-                    AppServicePlanId = appServicePlan.Id,
-                    IsHttpsOnly = true,
-                    PublicNetworkAccess = desiredAccess,
-                    SiteConfig = new SiteConfigProperties
-                    {
-                        IsAlwaysOn = true,
-                        FtpsState = AppServiceFtpsState.Disabled,
-                        MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2
-                    },
-                    Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.SystemAssigned)
-                };
+                var newWebAppInfo = BuildNewWebSiteData(base.AzureLocation, appServicePlan.Id, appServicePlanSku, _allowPublicAccess);
 
                 base.EnsureTagsOnNew(newWebAppInfo.Tags);     // Add configured tags
+                if (!supportsAlwaysOn)
+                    _logger.LogWarning(AppServicePlanCapabilities.BuildAlwaysOnUnsupportedWarning(appServicePlan.Data.Name, appServicePlanSku));
+
                 _logger.LogInformation($"Creating App Service '{_config.ResourceName}' on plan '{appServicePlan.Data.Name}' (public access: {(_allowPublicAccess ? "enabled" : "disabled")})...");
-                var newWebAppReq = await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newWebAppInfo);
-                webApp = newWebAppReq.Value;
+                try
+                {
+                    var newWebAppReq = await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newWebAppInfo);
+                    webApp = newWebAppReq.Value;
+                }
+                catch (RequestFailedException ex) when (AppServicePlanCapabilities.IsPlanCapabilityConflict(ex))
+                {
+                    _logger.LogWarning(AppServicePlanCapabilities.BuildAlwaysOnUnsupportedWarning(appServicePlan.Data.Name, appServicePlanSku));
+                    newWebAppInfo.SiteConfig = BuildSecureSiteConfig(appServicePlanSku, includeAlwaysOn: false);
+                    var newWebAppReq = await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, newWebAppInfo);
+                    webApp = newWebAppReq.Value;
+                }
             }
             else
             {
@@ -69,21 +73,16 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     needsUpdate = true;
                 }
 
-                // Ensure minimum TLS version is 1.2 and Always On is enabled
+                // Ensure minimum TLS version is 1.2 and enable Always On when the plan supports it.
                 var siteConfig = (await webApp.GetWebSiteConfig().GetAsync()).Value.Data;
                 var needsTlsUpdate = siteConfig.MinTlsVersion == null || !siteConfig.MinTlsVersion.Value.ToString().Equals(AppServiceSupportedTlsVersion.Tls1_2.ToString());
-                var needsAlwaysOnUpdate = siteConfig.IsAlwaysOn != true;
+                var needsAlwaysOnUpdate = supportsAlwaysOn && siteConfig.IsAlwaysOn != true;
                 var needsFtpsDisable = siteConfig.FtpsState != AppServiceFtpsState.Disabled;
                 var needsPublicAccessUpdate = !string.Equals(webApp.Data.PublicNetworkAccess, desiredAccess, System.StringComparison.OrdinalIgnoreCase);
                 if (needsTlsUpdate || needsAlwaysOnUpdate || needsFtpsDisable || needsPublicAccessUpdate)
                 {
                     webAppUpdateInfo.PublicNetworkAccess = desiredAccess;
-                    webAppUpdateInfo.SiteConfig = new SiteConfigProperties
-                    {
-                        MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2,
-                        IsAlwaysOn = true,
-                        FtpsState = AppServiceFtpsState.Disabled
-                    };
+                    webAppUpdateInfo.SiteConfig = BuildSecureSiteConfig(appServicePlanSku, supportsAlwaysOn);
                     if (needsTlsUpdate)
                         _logger.LogInformation($"Updating App Service '{_config.ResourceName}' to enforce TLS 1.2...");
                     if (needsAlwaysOnUpdate)
@@ -98,7 +97,17 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 if (needsUpdate)
                 {
                     base.EnsureTagsOnNew(webAppUpdateInfo.Tags);
-                    await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, webAppUpdateInfo);
+                    try
+                    {
+                        await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, webAppUpdateInfo);
+                    }
+                    catch (RequestFailedException ex) when (AppServicePlanCapabilities.IsPlanCapabilityConflict(ex))
+                    {
+                        _logger.LogWarning(AppServicePlanCapabilities.BuildAlwaysOnUnsupportedWarning(appServicePlan.Data.Name, appServicePlanSku));
+                        if (webAppUpdateInfo.SiteConfig != null)
+                            webAppUpdateInfo.SiteConfig.IsAlwaysOn = null;
+                        await Container.GetWebSites().CreateOrUpdateAsync(WaitUntil.Completed, _config.ResourceName, webAppUpdateInfo);
+                    }
                 }
 
                 await base.EnsureTagsOnExisting(webApp.Data.Tags, webApp.GetTagResource());     // Add configured tags
@@ -164,6 +173,34 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
             return webApp;
 
+        }
+
+        public static WebSiteData BuildNewWebSiteData(AzureLocation azureLocation, ResourceIdentifier appServicePlanId, AppServiceSkuDescription appServicePlanSku, bool allowPublicAccess)
+        {
+            return new WebSiteData(azureLocation)
+            {
+                AppServicePlanId = appServicePlanId,
+                IsHttpsOnly = true,
+                PublicNetworkAccess = allowPublicAccess ? "Enabled" : "Disabled",
+                SiteConfig = BuildSecureSiteConfig(appServicePlanSku),
+                Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.SystemAssigned)
+            };
+        }
+
+        public static SiteConfigProperties BuildSecureSiteConfig(AppServiceSkuDescription appServicePlanSku, bool includeAlwaysOn = true)
+        {
+            var siteConfig = new SiteConfigProperties
+            {
+                MinTlsVersion = AppServiceSupportedTlsVersion.Tls1_2,
+                FtpsState = AppServiceFtpsState.Disabled
+            };
+
+            if (includeAlwaysOn && AppServicePlanCapabilities.SupportsAlwaysOn(appServicePlanSku))
+            {
+                siteConfig.IsAlwaysOn = true;
+            }
+
+            return siteConfig;
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/AppServicePlanCapabilitiesTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/AppServicePlanCapabilitiesTests.cs
@@ -1,0 +1,119 @@
+using App.ControlPanel.Engine;
+using Azure;
+using Azure.Core;
+using Azure.ResourceManager.AppService.Models;
+using ManagedServiceIdentityType = Azure.ResourceManager.Models.ManagedServiceIdentityType;
+using CloudInstallEngine.Azure;
+using CloudInstallEngine.Azure.InstallTasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Tests.UnitTests.InstallTests
+{
+    [TestClass]
+    public class AppServicePlanCapabilitiesTests
+    {
+        [DataTestMethod]
+        [DataRow("Free", "F1", false)]
+        [DataRow("Shared", "D1", false)]
+        [DataRow("Basic", "B1", true)]
+        [DataRow("Standard", "S1", true)]
+        [DataRow("PremiumV3", "P1V3", true)]
+        public void SupportsAlwaysOn_UsesTierCapabilityBoundary(string tier, string name, bool expected)
+        {
+            Assert.AreEqual(expected, AppServicePlanCapabilities.SupportsAlwaysOn(Sku(tier, name)));
+        }
+
+        [TestMethod]
+        public void SupportsAlwaysOn_NullEmptyAndUnknown_DefaultsToSupported()
+        {
+            Assert.IsTrue(AppServicePlanCapabilities.SupportsAlwaysOn(null));
+            Assert.IsTrue(AppServicePlanCapabilities.SupportsAlwaysOn(Sku(null, null)));
+            Assert.IsTrue(AppServicePlanCapabilities.SupportsAlwaysOn(Sku("ElasticPremium", "EP1")));
+        }
+
+        [TestMethod]
+        public void SupportsAlwaysOn_FallsBackToNameWhenTierIsMissing()
+        {
+            Assert.IsFalse(AppServicePlanCapabilities.SupportsAlwaysOn(Sku(null, "F1")));
+            Assert.IsFalse(AppServicePlanCapabilities.SupportsAlwaysOn(Sku(null, "D1")));
+        }
+
+        [TestMethod]
+        public void BuildSecureSiteConfig_FreePlanSkipsAlwaysOnButKeepsSecurityHardening()
+        {
+            var config = AppServiceWebsiteTask.BuildSecureSiteConfig(Sku("Free", "F1"));
+
+            Assert.IsNull(config.IsAlwaysOn, "Always On must not be sent to Free/Shared plans.");
+            Assert.AreEqual(AppServiceFtpsState.Disabled, config.FtpsState, "FTPS hardening must still be applied.");
+            Assert.AreEqual(AppServiceSupportedTlsVersion.Tls1_2, config.MinTlsVersion, "TLS 1.2 hardening must still be applied.");
+        }
+
+        [TestMethod]
+        public void BuildSecureSiteConfig_BasicPlanEnablesAlwaysOnAndSecurityHardening()
+        {
+            var config = AppServiceWebsiteTask.BuildSecureSiteConfig(Sku("Basic", "B1"));
+
+            Assert.AreEqual(true, config.IsAlwaysOn, "Always On must still be enabled on B1+ plans.");
+            Assert.AreEqual(AppServiceFtpsState.Disabled, config.FtpsState);
+            Assert.AreEqual(AppServiceSupportedTlsVersion.Tls1_2, config.MinTlsVersion);
+        }
+
+
+        [TestMethod]
+        public void BuildNewWebSiteData_FreePlanSkipsAlwaysOnButKeepsPublicAccessAndIdentityHardening()
+        {
+            var data = AppServiceWebsiteTask.BuildNewWebSiteData(
+                AzureLocation.WestEurope,
+                new ResourceIdentifier("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-rg/providers/Microsoft.Web/serverfarms/contoso-plan"),
+                Sku("Free", "F1"),
+                allowPublicAccess: false);
+
+            Assert.AreEqual("Disabled", data.PublicNetworkAccess, "Public network access hardening must still be applied.");
+            Assert.IsNotNull(data.Identity, "System-assigned managed identity must still be requested.");
+            Assert.AreEqual(ManagedServiceIdentityType.SystemAssigned, data.Identity.ManagedServiceIdentityType);
+            Assert.IsNull(data.SiteConfig.IsAlwaysOn, "Always On must not be sent to Free/Shared plans.");
+            Assert.AreEqual(AppServiceFtpsState.Disabled, data.SiteConfig.FtpsState);
+            Assert.AreEqual(AppServiceSupportedTlsVersion.Tls1_2, data.SiteConfig.MinTlsVersion);
+        }
+
+        [TestMethod]
+        public void BuildPostCreateSiteConfig_FreePlanSkipsAlwaysOnAnd64BitWorkerSetting()
+        {
+            var config = ConfigureAzureComponentsTasks.BuildPostCreateSiteConfig(Sku("Shared", "D1"));
+
+            Assert.IsNull(config.IsAlwaysOn, "Always On must not be sent to Free/Shared plans.");
+            Assert.IsNull(config.Use32BitWorkerProcess, "64-bit worker setting must not be sent to Free/Shared plans.");
+        }
+
+        [TestMethod]
+        public void BuildPostCreateSiteConfig_BasicPlanEnablesAlwaysOnAnd64BitWorkers()
+        {
+            var config = ConfigureAzureComponentsTasks.BuildPostCreateSiteConfig(Sku("Basic", "B1"));
+
+            Assert.AreEqual(true, config.IsAlwaysOn, "Always On must still be enabled on B1+ plans.");
+            Assert.AreEqual(false, config.Use32BitWorkerProcess, "B1+ plans should still be set to 64-bit workers.");
+        }
+
+        [TestMethod]
+        public void UnsupportedWarning_NamesPlanTierConsequenceAndRemedy()
+        {
+            var warning = AppServicePlanCapabilities.BuildAlwaysOnUnsupportedWarning("contoso-plan", Sku("Free", "F1"));
+
+            StringAssert.Contains(warning, "contoso-plan");
+            StringAssert.Contains(warning, "Free");
+            StringAssert.Contains(warning, "site will be unloaded when idle");
+            StringAssert.Contains(warning, "web-jobs will not run reliably");
+            StringAssert.Contains(warning, "Scale the plan to B1 or higher and re-run the installer");
+        }
+
+        private static AppServiceSkuDescription Sku(string tier, string name)
+        {
+            return new AppServiceSkuDescription
+            {
+                Tier = tier,
+                Name = name,
+                Size = name
+            };
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="SentEmailMailboxSkipListTests.cs" />
     <Compile Include="InstallTests\VNetIntegrationTests.cs" />
     <Compile Include="InstallTests\AppInsightsArmTemplateTests.cs" />
+    <Compile Include="InstallTests\AppServicePlanCapabilitiesTests.cs" />
     <Compile Include="UserImportCaseSensitivityTests.cs" />
     <Compile Include="UserLicenseRefreshTests.cs" />
     <Compile Include="FakeLoaderClasses\FakeUserPipelinePorts.cs" />


### PR DESCRIPTION
## Summary
Addresses #463.

This fixes the installer path that treated an App Service plan capability conflict as a critical App Service creation/update failure. Free (`F1`) and Shared (`D1`) App Service plans do not support Always On, and also reject the 64-bit worker-process setting used later by the post-create configuration step.

## Root cause
The issue had four contributing causes:

1. `AppServiceWebsiteTask` unconditionally sent `IsAlwaysOn = true` when creating a site and when hardening an existing site, even though the task already receives the `AppServicePlanResource` and can read `plan.Data.Sku`.
2. `AppServicePlanTask` reused existing plans without checking or warning about unsupported Free/Shared SKUs, so the admin only saw the failure two stages later.
3. `AppServiceWebsiteTask` is critical, so a non-essential Always On 409 escaped as a fatal install error and blocked the entire deployment.
4. `ConfigureAzureComponentsTasks` later sent both `IsAlwaysOn = true` and `Use32BitWorkerProcess = false`; Free/Shared plans can reject either property, so fixing only the first task would still leave a second 409 path.

## Changes
- Added pure `AppServicePlanCapabilities` helper:
  - `SupportsAlwaysOn(...)` and `Supports64BitWorkerProcess(...)` return `false` for Free/Shared plans and `true` otherwise.
  - The decision keys primarily on `Sku.Tier` (`Free` / `Shared`) because tier is the Azure capability boundary; it falls back to exact `Name` / `Size` values (`F1` / `D1`) only for partially populated SDK objects.
  - Unknown or missing SKU data defaults to supported. That preserves the existing behaviour for future tiers or incomplete ARM payloads; the 409 retry below is the safety net if Azure later rejects the write.
- Updated `AppServiceWebsiteTask`:
  - New-site creation builds the site data through a tested helper, omitting `IsAlwaysOn` only when the plan is known unsupported while still setting HTTPS-only, TLS 1.2, FTPS disabled, public-network-access, and system-assigned managed identity.
  - Existing-site hardening only requests Always On when the plan supports it, but still applies TLS 1.2, FTPS disabled, public-network-access, and identity updates on Free/Shared plans.
  - Wraps the ARM site create/update in a 409 fallback that logs the actionable warning and retries without `IsAlwaysOn`.
- Updated `ConfigureAzureComponentsTasks`:
  - Carries the `AppServicePlanResource` from `AzurePaaSInstallJob` into post-create configuration.
  - Gates both `IsAlwaysOn` and 64-bit worker settings on the same capability helper.
  - Wraps the site-config patch in the same 409 fallback and retries without plan-sensitive settings.
- Updated `AppServicePlanTask` and Test Configuration:
  - Existing plans now emit an early warning naming the plan, tier, consequence, and remedy: the site unloads when idle, web-jobs are unreliable, and admins should scale to B1 or higher then re-run the installer.
  - `SolutionInstallVerifier` reports the same warning during read-only Test Configuration when the existing plan can be found.

I did not add automatic plan scale-up. Scaling a customer's App Service plan changes their Azure bill, so this PR only warns and leaves the action explicit.

## Tests
- `MSBuild.exe src\AnalyticsEngine\Tests.UnitTests -t:Restore -p:Configuration=Debug -p:Platform=anycpu -p:ProcessorArchitecture=x86 -v:m -nologo` ✅
- `MSBuild.exe src\AnalyticsEngine\Tests.UnitTests -p:Configuration=Debug -p:Platform=anycpu -p:ProcessorArchitecture=x86 -v:m -nologo` ✅
- `vstest.console.exe src\AnalyticsEngine\Tests.UnitTests\bin\Debug\Tests.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~AppServicePlanCapabilitiesTests"` ✅ 13 passed

The unit tests cover Free, Shared, Basic, Standard, Premium, null/empty, and unknown SKUs; they also prove the Free/Shared path omits Always On/64-bit settings while retaining security hardening, and that B1+ still enables Always On and 64-bit workers.

## Not covered by unit tests
The actual Azure `CreateOrUpdateAsync` / `UpdateAsync` retry path is intentionally a thin ARM wrapper and is not faked with a large Azure mocking framework. The decision logic and data/patch objects are covered by pure unit tests; live ARM rejection handling still depends on Azure SDK behaviour.

## Schema / config impact
No database schema changes, migrations, benchmark gate, or manual SQL assets are involved. No persisted installer config properties were added, removed, or renamed, so `CONFIG_VERSION` is unchanged.

## Risk and reviewer hotspots
- Review the 409 catch scope: it retries only the same site-config write without Always On / plan-sensitive settings so security hardening and later app settings still run.
- Review the SKU default: unknown tiers remain treated as capable by design, with the 409 retry as the belt-and-braces fallback.
- Review the post-create method signature change that passes `CreatedAppServicePlan` into `ConfigureAzureComponentsTasks`.