### PR TITLE
Installer: don't crash when the Automation account was never provisioned

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -602,7 +602,19 @@ namespace App.ControlPanel.Engine.InstallerTasks
         }
 
         // Task results, typed
-        public AutomationAccountResource CreatedAutomationAccount => GetTaskResult<AutomationAccountResource>(_automationAccountTask);
+
+        /// <summary>
+        /// The Automation account, or null when this install did not create one.
+        /// </summary>
+        /// <remarks>
+        /// The Automation account task is only registered when the Graph usage-reports import is enabled,
+        /// and that setting defaults to off - so on most installs there is no task to read a result from.
+        /// Every consumer already treats null as "no Automation account" (RunPostCreatePaaSTasks skips the
+        /// contained-user grant, and AppServiceContentInstallJob skips the runbook install), so this returns
+        /// null to match, exactly as CognitiveServicesInfo / SBQueueWithConnectionString / VNet do.
+        /// </remarks>
+        public AutomationAccountResource CreatedAutomationAccount =>
+            _automationAccountTask != null ? GetTaskResult<AutomationAccountResource>(_automationAccountTask) : null;
 
         public SqlServerResource CreatedSqlServer => GetTaskResult<SqlServerResource>(_sqlServerTask);
         public SqlDatabaseResource CreatedSqlDatabase => GetTaskResult<SqlDatabaseResource>(_sqlDatabaseTask);

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/InstallJobInContainer.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/InstallJobInContainer.cs
@@ -151,6 +151,17 @@ namespace CloudInstallEngine
                 throw new InstallException("Installer hasn't run - can't return results");
             }
 
+            // A null task means the caller asked for the result of a task that was never registered,
+            // because the feature that creates it is switched off in the install configuration. Say so.
+            // Without this the lookup below hits Dictionary.ContainsKey(null) and the install dies with a
+            // bare "Value cannot be null. Parameter name: key", which names neither the task nor the setting.
+            if (task == null)
+            {
+                throw new InstallException($"No results for a task of type '{typeof(T).Name}' because the task was never " +
+                    "registered for this install - the feature that creates it is disabled in the installer configuration. " +
+                    "Optional resources must be read through a null-checked property.");
+            }
+
             if (TaskResults.ContainsKey(task))
             {
                 return (T)TaskResults[task];

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/FakeInstallClasses.cs
@@ -185,4 +185,31 @@ namespace Tests.UnitTests.InstallTests
             return Task.FromResult<object>(new object());
         }
     }
+
+    /// <summary>
+    /// Mirrors the optional-resource shape in AzurePaaSInstallJob: a task that is only registered when a
+    /// feature is switched on in the install config, exposed through both the unguarded getter shape that
+    /// caused issue #490 and the null-safe shape every optional resource must use.
+    /// </summary>
+    public class FakeOptionalTaskJob : InstallJobInContainerJob<DummyContainerHost>
+    {
+        private readonly FakeChildInstallTask1 _optionalTask;
+
+        public FakeOptionalTaskJob(ILogger logger, bool featureEnabled)
+            : base(logger, new FakeResourceContainerLoader(TaskConfig.NoConfig, logger))
+        {
+            if (featureEnabled)
+            {
+                _optionalTask = new FakeChildInstallTask1(TaskConfig.NoConfig, logger);
+                AddTask(_optionalTask);
+            }
+        }
+
+        /// <summary>The shape that produced "Value cannot be null. Parameter name: key" when the feature was off.</summary>
+        public FakeCloudResourceType1 OptionalResultUnguarded => GetTaskResult<FakeCloudResourceType1>(_optionalTask);
+
+        /// <summary>The shape used by CognitiveServicesInfo / SBQueueWithConnectionString / VNet / CreatedAutomationAccount.</summary>
+        public FakeCloudResourceType1 OptionalResultNullSafe =>
+            _optionalTask != null ? GetTaskResult<FakeCloudResourceType1>(_optionalTask) : null;
+    }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallEngineTests.cs
@@ -705,6 +705,43 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
+        /// Reading the result of a task that was never registered - because the feature that creates it is
+        /// disabled - must fail with a diagnosable InstallException, not ArgumentNullException. Regression
+        /// test for issue #490: CreatedAutomationAccount read _automationAccountTask unconditionally, so
+        /// GetTaskResult hit Dictionary.ContainsKey(null) and the install died with a bare
+        /// "Value cannot be null. Parameter name: key" that named neither the task nor the setting.
+        /// </summary>
+        [TestMethod]
+        public async Task DisabledOptionalTaskResultIsNullAndNeverArgumentNullException()
+        {
+            var job = new FakeOptionalTaskJob(_logger, featureEnabled: false);
+            await job.Install();
+
+            var ex = Assert.ThrowsException<InstallException>(() => { var ignored = job.OptionalResultUnguarded; },
+                "An unregistered task must raise InstallException, not the ArgumentNullException from Dictionary.ContainsKey(null).");
+            StringAssert.Contains(ex.Message, nameof(FakeCloudResourceType1),
+                "The error must name the resource type that could not be resolved.");
+
+            Assert.IsNull(job.OptionalResultNullSafe,
+                "An optional resource that was never provisioned must read as null so callers can skip it.");
+        }
+
+        /// <summary>
+        /// The other direction: when the feature IS enabled the null-safe getter must still return the real
+        /// result, so the fix cannot silently disable an optional resource that was actually provisioned.
+        /// </summary>
+        [TestMethod]
+        public async Task EnabledOptionalTaskStillReturnsItsResult()
+        {
+            var job = new FakeOptionalTaskJob(_logger, featureEnabled: true);
+            await job.Install();
+
+            Assert.IsNotNull(job.OptionalResultNullSafe, "An optional resource that WAS provisioned must not read as null.");
+            Assert.AreSame(job.OptionalResultUnguarded, job.OptionalResultNullSafe,
+                "The null-safe getter must return the same result as reading the task result directly.");
+        }
+
+        /// <summary>
         /// Needs an account with owner rights to the sub.
         /// The sub should have all the solution pre-reqs applied (resource providers, etc)
         /// </summary>


### PR DESCRIPTION
Addresses #490.

## Problem

`AzurePaaSInstallJob` registers the Automation account task only when the Graph usage-reports import is enabled:

```csharp
if (config.SolutionConfig.ImportTaskSettings.GraphUsageReports)
{
    _automationAccountTask = new AutomationAccountTask(...);
    this.AddTask(_automationAccountTask);
}
```

`ImportTaskSettings.GraphUsageReports` defaults to `false`, so on a typical install `_automationAccountTask` is `null`.

`SolutionInstaller.InstallOrUpdate` reads the result unconditionally while building the argument list for `RunPostCreatePaaSTasks` (5th argument), and the getter was not null-safe:

```csharp
public AutomationAccountResource CreatedAutomationAccount
    => GetTaskResult<AutomationAccountResource>(_automationAccountTask);
```

`GetTaskResult` starts with `TaskResults.ContainsKey(task)` on a `Dictionary<BaseInstallTask, object>`. `Dictionary.ContainsKey(null)` throws `ArgumentNullException` with `ParamName = "key"`, producing:

```
=== Phase: App Service configuration & content deploy ===
ERROR  FATAL: Unexpected error of type 'ArgumentNullException': [ArgumentNullException] Value cannot be null.
Parameter name: key
```

The throw happens during *argument evaluation*, before the first statement of `RunPostCreatePaaSTasks`, which is why the log shows the phase banner followed by nothing. The message names neither the task nor the setting, so there is nothing actionable in it.

## Changes

**`AzurePaaSInstallJob.CreatedAutomationAccount`** — now null-safe, matching the shape already used by the three other optionally-registered resources (`CognitiveServicesInfo`, `SBQueueWithConnectionString`, `VNet`):

```csharp
public AutomationAccountResource CreatedAutomationAccount =>
    _automationAccountTask != null ? GetTaskResult<AutomationAccountResource>(_automationAccountTask) : null;
```

**`InstallJobInContainerJob.GetTaskResult<T>`** — a `null` task now throws an `InstallException` naming the requested type and stating that the task was never registered because the feature is disabled. This is defence-in-depth: the next time someone adds a conditional task and forgets the null-check, the installer says so instead of emitting `Value cannot be null. Parameter name: key`.

## Why returning null is correct, not a papered-over NRE

`null` is already the contract every consumer is written against — this getter was simply the one place that could not express it:

| Consumer | Existing handling |
|---|---|
| `ConfigureAzureComponentsTasks.GrantAutomationAccountDatabaseAccess` | `if (automationAccount == null) return;` |
| `AppServiceContentInstallJob` ctor | `if (automationAccount != null)` before constructing `RunbooksInstallJob`; logs and skips otherwise |
| `AzurePaaSInstallJob.RepairAutomationSqlCredentialIfNeeded` | already checks `_automationAccountTask == null` *before* touching the getter |

I specifically checked the two paths that run **after** `webApp.StopAsync()` — `InstallSolutionContent` and `GetSolutionFromSource` — because a null-deref there would be strictly worse than the current early crash: it would leave the customer's App Service stopped. Both route into the `AppServiceContentInstallJob` constructor, whose runbook block is guarded twice (`GraphUsageReports` *and* `automationAccount != null`). `RunbooksInstallJob`, the only thing that dereferences `automationAccount.Data.Name`, is unreachable with a null value.

## Scope check

I audited every task field against its getter. Only `CreatedAutomationAccount` was wrong:

- Conditionally registered, **guarded**: `_cognitiveServicesInstallTask`, `_serviceBusQueueWithPolicyInstallTask`, `_vnetInstallTask`
- Conditionally registered, **unguarded**: `_automationAccountTask` — fixed here
- Unconditionally registered (safe): `_sqlServerTask`, `_sqlDatabaseTask`, `_appServicePlanTask`, `_appServiceWebsiteTask`, `_redisTask`, `_storageAccountInstallTask`, `_appInsightsInstallTask`, `_keyVaultTask`
- No public getter: `_rgCreateTask`, `_sqlServerFirewallConfigTask`, `_logAnalyticsInstallTask`, `_serviceBusNamespaceInstallTask`, `_hybridWorkerGroupTask` (exposed only as the `_hybridWorkerGroupName` string)

## Impact / risk

- **Behavioural change is limited to the failing path.** With Graph usage reports *enabled* nothing changes: the task exists and the getter returns the same result as before.
- No schema migrations, no config-schema change, so no `CONFIG_VERSION` bump.
- Not a data-loss or outage fix: the old crash happened before the App Service was stopped, so an existing deployment kept running on its previous content. The install simply never applied App Service settings, the database upgrade or the solution content.

## Testing

Added `FakeOptionalTaskJob` to the existing install-engine fake harness. It mirrors `AzurePaaSInstallJob`'s optional-resource shape — a task registered only when a feature flag is on, exposed through both the unguarded getter that caused this bug and the null-safe one — plus two tests:

| Test | Asserts |
|---|---|
| `DisabledOptionalTaskResultIsNullAndNeverArgumentNullException` | reading an unregistered task's result raises `InstallException` naming the type, **not** `ArgumentNullException`; and the null-safe getter reads as `null` |
| `EnabledOptionalTaskStillReturnsItsResult` | with the feature on, the null-safe getter still returns the same real result — so the fix cannot silently disable a resource that *was* provisioned |

**Verified in both directions.** With the `GetTaskResult` null guard temporarily removed, the first test fails with exactly the reported error:

```
Assert.ThrowsException failed. Expected exception type:<CloudInstallEngine.Models.InstallException>.
Actual exception type:<System.ArgumentNullException>.
```

With the guard restored, all 9 install-engine tests pass (the 2 new ones plus the 7 pre-existing task-loop tests, which are unaffected). `App.ControlPanel.Engine`, `CloudInstallEngine` and `Tests.UnitTests` all build clean in Debug.

**Not covered:** I did not run a live Azure install against a `GraphUsageReports = false` config — that needs a real subscription. The runtime path is covered by reasoning plus the exhaustive call-site audit above rather than by execution, so that is the thing worth a second reviewer's eye.

## Workaround for anyone hitting this before the fix ships

Enable **Graph usage reports** in the installer's import settings and re-run. That registers the Automation account task so the getter has a result to return. It provisions a Free-tier Automation account and the maintenance runbooks as a side effect.
