### PR TITLE
Instrument usage report save diagnostics

### DIFF
--- a/src/AnalyticsEngine/Benchmarks/UsageReportSaveSyntheticBenchmark.sql
+++ b/src/AnalyticsEngine/Benchmarks/UsageReportSaveSyntheticBenchmark.sql
@@ -1,0 +1,130 @@
+/*
+Synthetic daily usage-report save benchmark harness for issue #495.
+
+Run only against an empty throwaway SQL Server database. This script creates synthetic tables with the
+same relevant production column types and current query shapes used by AbstractDailyActivityLoader:
+  - dbo.users.user_name is varchar(250), matching production Entra UPN storage.
+  - dbo.outlook_user_activity_log uses int identity id, datetime date/last_activity_date, int user_id,
+    bigint report counters, FK to users and the current IX_date shape from IndexUsageReportSnapshots.
+  - lookup path: users WHERE user_name = @Upn ORDER BY id.
+  - existing-row load path: outlook_user_activity_log WHERE [date] = @ReportDate, then client-side key by user_id.
+
+Do not paste production names, row counts, plans or data into this file or into PR/release text. Vary the
+parameters below for small/intermediate/200k-user synthetic runs, narrow/wide reporting windows and cold/warm
+cache runs, then record medians externally with SET STATISTICS IO/TIME and actual execution plans enabled.
+*/
+SET NOCOUNT ON;
+
+IF CONVERT(sysname, DATABASEPROPERTYEX(DB_NAME(), 'Collation')) <> N'Latin1_General_CI_AS'
+BEGIN
+    RAISERROR('Create the throwaway benchmark database with Latin1_General_CI_AS to match the production EF database collation.', 16, 1);
+    RETURN;
+END
+
+DECLARE @SyntheticUsers int = 200000;
+DECLARE @SyntheticDays int = 28;
+DECLARE @ReportDate date = DATEADD(day, -1, CONVERT(date, SYSUTCDATETIME()));
+
+IF OBJECT_ID(N'dbo.outlook_user_activity_log', N'U') IS NOT NULL DROP TABLE dbo.outlook_user_activity_log;
+IF OBJECT_ID(N'dbo.users', N'U') IS NOT NULL DROP TABLE dbo.users;
+
+CREATE TABLE dbo.users
+(
+    id int IDENTITY(1,1) NOT NULL CONSTRAINT PK_users PRIMARY KEY CLUSTERED,
+    user_name varchar(250) NOT NULL,
+    mail varchar(max) NULL,
+    last_updated datetime NULL,
+    azure_ad_id varchar(max) NULL,
+    account_enabled bit NULL,
+    postalcode nvarchar(50) NULL,
+    org_id int NULL,
+    company_name_id int NULL,
+    state_or_province_id int NULL,
+    manager_id int NULL,
+    country_or_region_id int NULL,
+    office_location_id int NULL,
+    usage_location_id int NULL,
+    department_id int NULL,
+    job_title_id int NULL
+);
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_users_user_name ON dbo.users(user_name);
+
+CREATE TABLE dbo.outlook_user_activity_log
+(
+    id int IDENTITY(1,1) NOT NULL CONSTRAINT PK_outlook_user_activity_log PRIMARY KEY CLUSTERED,
+    [date] datetime NOT NULL,
+    last_activity_date datetime NULL,
+    user_id int NOT NULL,
+    email_send_count bigint NOT NULL CONSTRAINT DF_outlook_send DEFAULT (0),
+    email_receive_count bigint NOT NULL CONSTRAINT DF_outlook_receive DEFAULT (0),
+    email_read_count bigint NOT NULL CONSTRAINT DF_outlook_read DEFAULT (0),
+    meeting_created_count bigint NOT NULL CONSTRAINT DF_outlook_meeting_created DEFAULT (0),
+    meeting_interacted_count bigint NOT NULL CONSTRAINT DF_outlook_meeting_interacted DEFAULT (0),
+    CONSTRAINT FK_outlook_user_activity_log_users FOREIGN KEY(user_id) REFERENCES dbo.users(id)
+);
+
+CREATE NONCLUSTERED INDEX IX_date ON dbo.outlook_user_activity_log([date], last_activity_date) INCLUDE(user_id);
+CREATE NONCLUSTERED INDEX IX_outlook_user_activity_log_user_date ON dbo.outlook_user_activity_log(user_id, [date]);
+
+;WITH n AS
+(
+    SELECT TOP (@SyntheticUsers) ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS rn
+    FROM sys.all_objects a CROSS JOIN sys.all_objects b
+)
+INSERT dbo.users(user_name, mail, azure_ad_id, account_enabled, postalcode)
+SELECT CONCAT('user', rn, '@contoso.com'), CONCAT('user', rn, '@contoso.com'),
+       '00000000-0000-0000-0000-000000000000', 1, N'00000'
+FROM n
+ORDER BY rn;
+
+;WITH d AS
+(
+    SELECT TOP (@SyntheticDays) ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) - 1 AS day_offset
+    FROM sys.all_objects
+)
+INSERT dbo.outlook_user_activity_log([date], last_activity_date, user_id, email_send_count, email_receive_count,
+                                     email_read_count, meeting_created_count, meeting_interacted_count)
+SELECT DATEADD(day, -d.day_offset, @ReportDate), DATEADD(day, -d.day_offset, @ReportDate), u.id,
+       u.id % 17, u.id % 19, u.id % 23, u.id % 3, u.id % 5
+FROM dbo.users AS u
+CROSS JOIN d;
+
+CHECKPOINT;
+
+-- Existing-row materialisation query used once per report date by SqlUsageReportStore.GetRowsForDateAsync.
+DBCC FREEPROCCACHE WITH NO_INFOMSGS;
+SET STATISTICS IO, TIME ON;
+SELECT id, [date], last_activity_date, user_id, email_send_count, email_receive_count,
+       email_read_count, meeting_created_count, meeting_interacted_count
+FROM dbo.outlook_user_activity_log
+WHERE [date] = CONVERT(datetime, @ReportDate)
+OPTION (RECOMPILE);
+SET STATISTICS IO, TIME OFF;
+
+-- Cold lookup path used by UserCache.Load before an uncached row can be inserted or linked.
+DECLARE @LookupUpn varchar(250) = 'user1000@contoso.com';
+DBCC FREEPROCCACHE WITH NO_INFOMSGS;
+SET STATISTICS IO, TIME ON;
+SELECT TOP (1) id, user_name, mail, last_updated, azure_ad_id, account_enabled, postalcode,
+       org_id, company_name_id, state_or_province_id, manager_id, country_or_region_id,
+       office_location_id, usage_location_id, department_id, job_title_id
+FROM dbo.users
+WHERE user_name = @LookupUpn
+ORDER BY id
+OPTION (RECOMPILE);
+SET STATISTICS IO, TIME OFF;
+
+-- Dirty-check/update shape for a changed existing row. Execute with a small and large changed-row set.
+DECLARE @ChangedRows int = 1000;
+;WITH c AS
+(
+    SELECT TOP (@ChangedRows) id
+    FROM dbo.outlook_user_activity_log
+    WHERE [date] = CONVERT(datetime, @ReportDate)
+    ORDER BY id
+)
+UPDATE l
+SET email_read_count = email_read_count + 1
+FROM dbo.outlook_user_activity_log AS l
+JOIN c ON c.id = l.id;

--- a/src/AnalyticsEngine/Common/DataUtils/AnalyticsLogger.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/AnalyticsLogger.cs
@@ -378,7 +378,8 @@ namespace DataUtils
             ImporterHeartbeat,
             CopilotAdoptionAnalysis,
             CopilotAdoptionLifecycle,
-            LicenceActivityLifecycle
+            LicenceActivityLifecycle,
+            UsageReportSaveStage
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
@@ -3,11 +3,14 @@ using DataUtils;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Common.Entities;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Tests.UnitTests.FakeLoaderClasses;
 using UnitTests.FakeLoaderClasses;
+using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports;
 
 namespace Tests.UnitTests
 {
@@ -369,6 +372,214 @@ namespace Tests.UnitTests
             CollectionAssert.AreEqual(new[] { storedInWindow }, skip.ToArray(),
                 "A stored date inside the 3-day mutability window can still change in Graph and must be re-imported.");
         }
+
+
+
+        [TestMethod]
+        public async Task DailyActivityLoader_InstrumentationCountsColdWarmMissingScopeAndRowOutcomes()
+        {
+            var instrumentation = new RecordingUsageReportSaveInstrumentation();
+            var lookupCalls = new ConcurrentDictionary<string, int>();
+            CountingUserActivityDetail.ResolveAsync = upn =>
+            {
+                lookupCalls.AddOrUpdate(upn, 1, (_, old) => old + 1);
+                return Task.FromResult(upn == UserA ? UserAId : UserBId);
+            };
+
+            var loader = new InMemoryDailyActivityLoader(NullLogger.Instance)
+            {
+                SaveInstrumentation = instrumentation,
+                InScopeRule = upn => upn != "outofscope@contoso.com",
+            };
+            loader.LoadedReportPages[Day1] = new List<FakeUserActivityDetail>
+            {
+                new CountingUserActivityDetail(UserA, 10),       // changed existing
+                new CountingUserActivityDetail(UserB, 20),       // new
+                new CountingUserActivityDetail(null, 30),        // intentionally missing lookup
+                new CountingUserActivityDetail("outofscope@contoso.com", 40),
+            };
+            loader.LoadedReportPages[Day2] = new List<FakeUserActivityDetail>
+            {
+                new CountingUserActivityDetail(UserA, 10),       // repeated user, cache hit after day 1
+            };
+            var store = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(StoredRow(Day1, UserAId, thingCount: 5));
+            loader.ReportStore = store;
+            var cache = new ConcurrentLookupDbIdsCache();
+
+            await loader.SaveLoadedReportsToSql(cache, new UserCache(null));
+
+            Assert.AreEqual(1, lookupCalls[UserA], "Cold lookup should hit the backing lookup once; the repeated row is a cache hit.");
+            Assert.AreEqual(1, lookupCalls[UserB]);
+            Assert.AreEqual(3, store.Stored.Count);
+            Assert.AreEqual(2, loader.LastSaveDbWriteCount);
+
+            var completed = instrumentation.Single(UsageReportSaveStageIds.SaveCompleted);
+            AssertMetric(completed, "LookupDatabaseCallCount", 2);
+            AssertMetric(completed, "LookupCacheMissCount", 2);
+            AssertMetric(completed, "LookupCacheHitCount", 1);
+            AssertMetric(completed, "MissingLookupValueRowCount", 1);
+            AssertMetric(completed, "OutOfScopeRowCount", 1);
+            AssertMetric(completed, "AddedRowCount", 2);
+            AssertMetric(completed, "ChangedRowCount", 1);
+
+            instrumentation.Events.Clear();
+            lookupCalls.Clear();
+            await loader.SaveLoadedReportsToSql(cache, new UserCache(null));
+
+            var warm = instrumentation.Single(UsageReportSaveStageIds.SaveCompleted);
+            Assert.AreEqual(0, lookupCalls.Count, "Warm lookup-cache run must not call the backing lookup store.");
+            AssertMetric(warm, "LookupDatabaseCallCount", 0);
+            AssertMetric(warm, "LookupCacheHitCount", 3);
+            AssertMetric(warm, "UnchangedRowCount", 3);
+            Assert.AreEqual(0, loader.LastSaveDbWriteCount);
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_InstrumentationCountsDuplicateConcurrentMissesAcrossLoaders()
+        {
+            var instrumentation = new RecordingUsageReportSaveInstrumentation();
+            var lookupCalls = new ConcurrentDictionary<string, int>();
+            var ids = new Dictionary<string, int>
+            {
+                { UserA, UserAId },
+                { "loader1only@contoso.com", 101 },
+                { "loader2only@contoso.com", 202 },
+            };
+            CountingUserActivityDetail.ResolveAsync = async upn =>
+            {
+                lookupCalls.AddOrUpdate(upn, 1, (_, old) => old + 1);
+                await Task.Delay(50);
+                return ids[upn];
+            };
+
+            var cache = new ConcurrentLookupDbIdsCache();
+            var loader1 = new InMemoryDailyActivityLoader(NullLogger.Instance) { SaveInstrumentation = instrumentation };
+            var loader2 = new InMemoryDailyActivityLoader(NullLogger.Instance) { SaveInstrumentation = instrumentation };
+            loader1.ReportStore = new InMemoryUsageReportStore<FakeUserUsageActivityLog>();
+            loader2.ReportStore = new InMemoryUsageReportStore<FakeUserUsageActivityLog>();
+            loader1.LoadedReportPages[Day1] = new List<FakeUserActivityDetail>
+            {
+                new CountingUserActivityDetail(UserA, 1),
+                new CountingUserActivityDetail("loader1only@contoso.com", 10),
+            };
+            loader2.LoadedReportPages[Day1] = new List<FakeUserActivityDetail>
+            {
+                new CountingUserActivityDetail(UserA, 2),
+                new CountingUserActivityDetail("loader2only@contoso.com", 20),
+            };
+
+            await Task.WhenAll(
+                loader1.SaveLoadedReportsToSql(cache, new UserCache(null)),
+                loader2.SaveLoadedReportsToSql(cache, new UserCache(null)));
+
+            Assert.AreEqual(2, lookupCalls[UserA], "Both loaders intentionally miss before either can populate the shared cache.");
+            Assert.AreEqual(1, lookupCalls["loader1only@contoso.com"], "Non-overlapping users still resolve independently.");
+            Assert.AreEqual(1, lookupCalls["loader2only@contoso.com"], "Non-overlapping users still resolve independently.");
+            Assert.AreEqual(1d, instrumentation.Events.Where(e => e.Stage == UsageReportSaveStageIds.SaveCompleted).Sum(e => Metric(e, "DuplicateConcurrentMissCount")),
+                "The second resolver must record that another loader populated the cache while it awaited the lookup.");
+        }
+
+        [TestMethod]
+        public async Task DailyActivityLoader_RetryAfterIntermediateBatchFailure_IsIdempotentAndStampedByHealthyRun()
+        {
+            CountingUserActivityDetail.ResolveAsync = upn => Task.FromResult(int.Parse(upn.Substring(4, 1)));
+            var failingInstrumentation = new RecordingUsageReportSaveInstrumentation();
+            var failingLoader = new InMemoryDailyActivityLoader(NullLogger.Instance) { SaveBatchSize = 2, SaveInstrumentation = failingInstrumentation };
+            var rows = Enumerable.Range(1, 5)
+                .Select(i => new CountingUserActivityDetail($"user{i}@contoso.com", i))
+                .Cast<FakeUserActivityDetail>()
+                .ToList();
+            failingLoader.LoadedReportPages[Day1] = rows;
+            var failingStore = new FailOnSaveNumberUsageReportStore(2);
+            failingLoader.ReportStore = failingStore;
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => failingLoader.SaveLoadedReportsToSql(new ConcurrentLookupDbIdsCache(), new UserCache(null)));
+            Assert.IsTrue(failingInstrumentation.Events.Any(e => e.Stage == UsageReportSaveStageIds.SaveFailed));
+            Assert.AreEqual(2, failingStore.Stored.Count, "Only the first healthy batch should remain committed after the injected failure.");
+
+            var retryInstrumentation = new RecordingUsageReportSaveInstrumentation();
+            var retryLoader = new InMemoryDailyActivityLoader(NullLogger.Instance) { SaveBatchSize = 2, SaveInstrumentation = retryInstrumentation };
+            retryLoader.LoadedReportPages[Day1] = rows;
+            var retryStore = new InMemoryUsageReportStore<FakeUserUsageActivityLog>()
+                .Seed(failingStore.Stored.Select(CloneRow).ToArray());
+            retryLoader.ReportStore = retryStore;
+
+            await retryLoader.SaveLoadedReportsToSql(new ConcurrentLookupDbIdsCache(), new UserCache(null));
+
+            Assert.AreEqual(5, retryStore.Stored.Count);
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5 }, retryStore.Stored.OrderBy(r => r.UserID).Select(r => r.UserID).ToArray());
+            Assert.AreEqual(3, retryLoader.LastSaveDbWriteCount, "The retry must not rewrite the two rows already committed by the failed attempt.");
+            Assert.IsTrue(retryInstrumentation.Events.Any(e => e.Stage == UsageReportSaveStageIds.SaveCompleted));
+            Assert.IsFalse(retryInstrumentation.Events.Any(e => e.Stage == UsageReportSaveStageIds.SaveFailed));
+        }
+
+
+
+        private static FakeUserUsageActivityLog CloneRow(FakeUserUsageActivityLog row)
+            => new FakeUserUsageActivityLog
+            {
+                ID = row.ID,
+                Date = row.Date,
+                UserID = row.UserID,
+                ThingCount = row.ThingCount,
+                LastActivityDate = row.LastActivityDate,
+            };
+
+        private static void AssertMetric(UsageReportSaveTelemetryPoint point, string name, double expected)
+            => Assert.AreEqual(expected, Metric(point, name), $"Metric {name}");
+
+        private static double Metric(UsageReportSaveTelemetryPoint point, string name)
+            => point.Metrics.TryGetValue(name, out var value) ? value : 0;
+
+        private sealed class CountingUserActivityDetail : FakeUserActivityDetail
+        {
+            public static Func<string, Task<int>> ResolveAsync { get; set; }
+
+            public CountingUserActivityDetail(string upn, int thingCount)
+            {
+                UserPrincipalName = upn;
+                ThingCount = thingCount;
+            }
+
+            public override async Task<AbstractEFEntity> GetOrCreateLookup(DBLookupCache<User> lookupCache)
+                => new User { ID = await ResolveAsync(UserPrincipalName), UserPrincipalName = UserPrincipalName };
+        }
+
+        private sealed class RecordingUsageReportSaveInstrumentation : IUsageReportSaveInstrumentation
+        {
+            private readonly object _lock = new object();
+            public bool IsEnabled => true;
+            public List<UsageReportSaveTelemetryPoint> Events { get; } = new List<UsageReportSaveTelemetryPoint>();
+            public void Track(UsageReportSaveTelemetryPoint point)
+            {
+                lock (_lock)
+                {
+                    Events.Add(point);
+                }
+            }
+            public UsageReportSaveTelemetryPoint Single(string stage) => Events.Single(e => e.Stage == stage);
+        }
+
+        private sealed class FailOnSaveNumberUsageReportStore : InMemoryUsageReportStore<FakeUserUsageActivityLog>
+        {
+            private readonly int _saveNumberToFail;
+            private int _saveCalls;
+
+            public FailOnSaveNumberUsageReportStore(int saveNumberToFail) => _saveNumberToFail = saveNumberToFail;
+
+            public override async Task SaveChangesAsync()
+            {
+                _saveCalls++;
+                if (_saveCalls == _saveNumberToFail)
+                {
+                    throw new InvalidOperationException("Synthetic intermediate batch failure.");
+                }
+                await base.SaveChangesAsync();
+            }
+        }
+
 
         /// <summary>
         /// Store whose flush always fails, for the "the bulk-write scope is left even on failure" case.

--- a/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DailyActivityLoaderTests.cs
@@ -412,7 +412,7 @@ namespace Tests.UnitTests
             Assert.AreEqual(1, lookupCalls[UserA], "Cold lookup should hit the backing lookup once; the repeated row is a cache hit.");
             Assert.AreEqual(1, lookupCalls[UserB]);
             Assert.AreEqual(3, store.Stored.Count);
-            Assert.AreEqual(2, loader.LastSaveDbWriteCount);
+            Assert.AreEqual(3, loader.LastSaveDbWriteCount);
 
             var completed = instrumentation.Single(UsageReportSaveStageIds.SaveCompleted);
             AssertMetric(completed, "LookupDatabaseCallCount", 2);

--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryUsageReportStore.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/InMemoryUsageReportStore.cs
@@ -1,4 +1,4 @@
-using Common.Entities.ActivityReports;
+﻿using Common.Entities.ActivityReports;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -78,6 +78,8 @@ namespace Tests.UnitTests.FakeLoaderClasses
         public bool AllWritesInsideBulkScope { get; private set; } = true;
 
         private int _openScopes;
+
+        public int TrackedEntityCount => _snapshots.Count + _pendingInserts.Count;
 
         /// <summary>Pre-populate a committed row (no snapshot: it has not been handed out yet).</summary>
         public InMemoryUsageReportStore<TReportDbType> Seed(params TReportDbType[] rows)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -503,15 +503,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
             var instrumentation = abstractActivityLoader.SaveInstrumentation ?? NullUsageReportSaveInstrumentation.Instance;
             var instrumentationEnabled = instrumentation.IsEnabled;
-            var activeLoaderCount = 0;
+            var activeLoaderCountAtStart = 0;
             var phaseWatch = instrumentationEnabled ? Stopwatch.StartNew() : null;
             var reportId = abstractActivityLoader.GetType().Name;
             if (instrumentationEnabled)
             {
-                activeLoaderCount = UsageReportSaveInstrumentationRuntime.IncrementActiveDailyLoaders();
+                activeLoaderCountAtStart = UsageReportSaveInstrumentationRuntime.IncrementActiveDailyLoaders();
                 TrackDailyReportPhaseStage(instrumentation, UsageReportSaveStageIds.ReportPhaseStarted, reportId, thingWeAreImporting, "Started", m =>
                 {
-                    m["ActiveLoaderCount"] = activeLoaderCount;
+                    m["ActiveLoaderCount"] = activeLoaderCountAtStart;
                     m["DaysBackMax"] = daysBackMax;
                     UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
                 });
@@ -519,84 +519,85 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
             try
             {
-            var reportKey = GetReportKey(abstractActivityLoader.GetType());
-            var lastSuccessfulImport = await ResolveReportSkipListInputAsync(reportKey, lastSuccessfulPhaseImport);
+                var reportKey = GetReportKey(abstractActivityLoader.GetType());
+                var lastSuccessfulImport = await ResolveReportSkipListInputAsync(reportKey, lastSuccessfulPhaseImport);
 
-            if (_reportCompletionStore != null)
-            {
-                // Clear before any writes, for the same reason the phase marker is cleared: if this report
-                // fails part-way through its save, the next cycle must re-import rather than trust a stamp
-                // that claims a window it only partly wrote.
-                await _reportCompletionStore.ClearAsync(reportKey);
-            }
+                if (_reportCompletionStore != null)
+                {
+                    // Clear before any writes, for the same reason the phase marker is cleared: if this report
+                    // fails part-way through its save, the next cycle must re-import rather than trust a stamp
+                    // that claims a window it only partly wrote.
+                    await _reportCompletionStore.ClearAsync(reportKey);
+                }
 
-            // Graph usage data is stable once finalized (~2-3 day latency), so days we already hold and that can no
-            // longer change don't need re-downloading or re-writing. Skip them unless a forced full re-import is set.
-            ISet<DateTime> datesToSkip = null;
-            if (!_settings.ForceUsageReportsImport)
-            {
+                // Graph usage data is stable once finalized (~2-3 day latency), so days we already hold and that can no
+                // longer change don't need re-downloading or re-writing. Skip them unless a forced full re-import is set.
+                ISet<DateTime> datesToSkip = null;
+                if (!_settings.ForceUsageReportsImport)
+                {
+                    using (var db = new AnalyticsEntitiesContext())
+                    {
+                        datesToSkip = await abstractActivityLoader.GetFinalizedStoredDatesToSkipAsync(
+                            db,
+                            daysBackMax,
+                            lastSuccessfulImport);
+                    }
+                    if (datesToSkip.Count > 0)
+                    {
+                        logger.LogInformation($"{thingWeAreImporting}: skipping {datesToSkip.Count} already-stored finalized day(s); " +
+                            $"only re-importing the most recent {abstractActivityLoader.RefreshableRecentDays} day(s) that can still change in Graph.");
+                    }
+                }
+
+                await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax, datesToSkip);
+
                 using (var db = new AnalyticsEntitiesContext())
                 {
-                    datesToSkip = await abstractActivityLoader.GetFinalizedStoredDatesToSkipAsync(
-                        db,
-                        daysBackMax,
-                        lastSuccessfulImport);
+                    _logger.LogInformation($"{this.GetType().Name} read {abstractActivityLoader.LoadedReportPages.SelectMany(p => p.Value).Count().ToString("N0")} {thingWeAreImporting} records from Graph API");
+                    await abstractActivityLoader.SaveLoadedReportsToSql(userEmailToDbIdCache, DBLookupCache<TLookupType>.Create<CACHETYPE>(db));
+
+                    // Keep the columnstore index (ColumnstoreUsageReportMetrics) compacted. The upserts above
+                    // land in the rowstore delta store, which is scanned uncompressed, so without this the
+                    // licence-opportunity report gets slower every cycle. A no-op where no columnstore exists.
+                    // Never allowed to fail the import: this is maintenance, not data.
+                    try
+                    {
+                        await abstractActivityLoader.CompactColumnstoreAsync(db);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning($"{thingWeAreImporting}: could not compact the columnstore index "
+                            + $"({ex.Message}). The import succeeded; the licence-opportunity report may be "
+                            + "slower until this is compacted.");
+                    }
                 }
-                if (datesToSkip.Count > 0)
+
+                var total = abstractActivityLoader.LoadedReportPages.SelectMany(r => r.Value).Count();
+                logger.LogInformation($"Imported {total.ToString("N0")} {thingWeAreImporting} reports.");
+
+                // Only reached when the download AND the save both completed - anything else threw and is caught
+                // by RunReportSafely, leaving this report's stamp cleared so its window is retried next cycle.
+                if (_reportCompletionStore != null)
                 {
-                    logger.LogInformation($"{thingWeAreImporting}: skipping {datesToSkip.Count} already-stored finalized day(s); " +
-                        $"only re-importing the most recent {abstractActivityLoader.RefreshableRecentDays} day(s) that can still change in Graph.");
+                    await _reportCompletionStore.SaveSuccessAsync(reportKey);
                 }
-            }
 
-            await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax, datesToSkip);
-
-            using (var db = new AnalyticsEntitiesContext())
-            {
-                _logger.LogInformation($"{this.GetType().Name} read {abstractActivityLoader.LoadedReportPages.SelectMany(p => p.Value).Count().ToString("N0")} {thingWeAreImporting} records from Graph API");
-                await abstractActivityLoader.SaveLoadedReportsToSql(userEmailToDbIdCache, DBLookupCache<TLookupType>.Create<CACHETYPE>(db));
-
-                // Keep the columnstore index (ColumnstoreUsageReportMetrics) compacted. The upserts above
-                // land in the rowstore delta store, which is scanned uncompressed, so without this the
-                // licence-opportunity report gets slower every cycle. A no-op where no columnstore exists.
-                // Never allowed to fail the import: this is maintenance, not data.
-                try
+                if (instrumentationEnabled)
                 {
-                    await abstractActivityLoader.CompactColumnstoreAsync(db);
+                    phaseWatch.Stop();
+                    TrackDailyReportPhaseStage(instrumentation, UsageReportSaveStageIds.ReportPhaseCompleted, reportId, thingWeAreImporting, "Completed", m =>
+                    {
+                        m["DurationMs"] = phaseWatch.ElapsedMilliseconds;
+                        m["GraphRowCount"] = total;
+                        m["DbWriteCount"] = abstractActivityLoader.LastSaveDbWriteCount;
+                        // The completed event repeats the concurrency observed when this loader started, not
+                        // a racy post-completion snapshot that depends on which sibling reports finish first.
+                        m["ActiveLoaderCount"] = activeLoaderCountAtStart;
+                        UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
+                    });
                 }
-                catch (Exception ex)
-                {
-                    logger.LogWarning($"{thingWeAreImporting}: could not compact the columnstore index "
-                        + $"({ex.Message}). The import succeeded; the licence-opportunity report may be "
-                        + "slower until this is compacted.");
-                }
-            }
 
-            var total = abstractActivityLoader.LoadedReportPages.SelectMany(r => r.Value).Count();
-            logger.LogInformation($"Imported {total.ToString("N0")} {thingWeAreImporting} reports.");
-
-            // Only reached when the download AND the save both completed - anything else threw and is caught
-            // by RunReportSafely, leaving this report's stamp cleared so its window is retried next cycle.
-            if (_reportCompletionStore != null)
-            {
-                await _reportCompletionStore.SaveSuccessAsync(reportKey);
-            }
-
-            if (instrumentationEnabled)
-            {
-                phaseWatch.Stop();
-                TrackDailyReportPhaseStage(instrumentation, UsageReportSaveStageIds.ReportPhaseCompleted, reportId, thingWeAreImporting, "Completed", m =>
-                {
-                    m["DurationMs"] = phaseWatch.ElapsedMilliseconds;
-                    m["GraphRowCount"] = total;
-                    m["DbWriteCount"] = abstractActivityLoader.LastSaveDbWriteCount;
-                    m["ActiveLoaderCount"] = activeLoaderCount;
-                    UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
-                });
-                UsageReportSaveInstrumentationRuntime.DecrementActiveDailyLoaders();
-            }
-
-            return total;
+                return total;
             }
             catch (Exception ex)
             {
@@ -606,12 +607,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     TrackDailyReportPhaseStage(instrumentation, UsageReportSaveStageIds.ReportPhaseFailed, reportId, thingWeAreImporting, "Failed", m =>
                     {
                         m["DurationMs"] = phaseWatch.ElapsedMilliseconds;
-                        m["ActiveLoaderCount"] = activeLoaderCount;
+                        m["ActiveLoaderCount"] = activeLoaderCountAtStart;
                         UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
                     }, ex.GetType().Name);
-                    UsageReportSaveInstrumentationRuntime.DecrementActiveDailyLoaders();
                 }
                 throw;
+            }
+            finally
+            {
+                if (instrumentationEnabled)
+                {
+                    UsageReportSaveInstrumentationRuntime.DecrementActiveDailyLoaders();
+                }
             }
         }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph.Email;
@@ -500,6 +501,24 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         {
             logger.LogInformation($"Importing {thingWeAreImporting} reports...");
 
+            var instrumentation = abstractActivityLoader.SaveInstrumentation ?? NullUsageReportSaveInstrumentation.Instance;
+            var instrumentationEnabled = instrumentation.IsEnabled;
+            var activeLoaderCount = 0;
+            var phaseWatch = instrumentationEnabled ? Stopwatch.StartNew() : null;
+            var reportId = abstractActivityLoader.GetType().Name;
+            if (instrumentationEnabled)
+            {
+                activeLoaderCount = UsageReportSaveInstrumentationRuntime.IncrementActiveDailyLoaders();
+                TrackDailyReportPhaseStage(instrumentation, UsageReportSaveStageIds.ReportPhaseStarted, reportId, thingWeAreImporting, "Started", m =>
+                {
+                    m["ActiveLoaderCount"] = activeLoaderCount;
+                    m["DaysBackMax"] = daysBackMax;
+                    UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
+                });
+            }
+
+            try
+            {
             var reportKey = GetReportKey(abstractActivityLoader.GetType());
             var lastSuccessfulImport = await ResolveReportSkipListInputAsync(reportKey, lastSuccessfulPhaseImport);
 
@@ -563,7 +582,59 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 await _reportCompletionStore.SaveSuccessAsync(reportKey);
             }
 
+            if (instrumentationEnabled)
+            {
+                phaseWatch.Stop();
+                TrackDailyReportPhaseStage(instrumentation, UsageReportSaveStageIds.ReportPhaseCompleted, reportId, thingWeAreImporting, "Completed", m =>
+                {
+                    m["DurationMs"] = phaseWatch.ElapsedMilliseconds;
+                    m["GraphRowCount"] = total;
+                    m["DbWriteCount"] = abstractActivityLoader.LastSaveDbWriteCount;
+                    m["ActiveLoaderCount"] = activeLoaderCount;
+                    UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
+                });
+                UsageReportSaveInstrumentationRuntime.DecrementActiveDailyLoaders();
+            }
+
             return total;
+            }
+            catch (Exception ex)
+            {
+                if (instrumentationEnabled)
+                {
+                    phaseWatch.Stop();
+                    TrackDailyReportPhaseStage(instrumentation, UsageReportSaveStageIds.ReportPhaseFailed, reportId, thingWeAreImporting, "Failed", m =>
+                    {
+                        m["DurationMs"] = phaseWatch.ElapsedMilliseconds;
+                        m["ActiveLoaderCount"] = activeLoaderCount;
+                        UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
+                    }, ex.GetType().Name);
+                    UsageReportSaveInstrumentationRuntime.DecrementActiveDailyLoaders();
+                }
+                throw;
+            }
+        }
+
+        private static void TrackDailyReportPhaseStage(
+            IUsageReportSaveInstrumentation instrumentation,
+            string stage,
+            string reportId,
+            string reportName,
+            string outcome,
+            Action<Dictionary<string, double>> populateMetrics,
+            string exceptionType = null)
+        {
+            var point = new UsageReportSaveTelemetryPoint
+            {
+                Stage = stage,
+                ReportId = reportId,
+                LoaderType = reportId,
+                ReportTable = reportName,
+                Outcome = outcome,
+                ExceptionType = exceptionType,
+            };
+            populateMetrics?.Invoke(point.Metrics);
+            instrumentation.Track(point);
         }
     }
 }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -5,7 +5,9 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Entities.Serialisation.UsageReports;
 using WebJob.Office365ActivityImporter.Engine.Graph.UsageReports.Rules;
@@ -27,6 +29,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         internal AbstractDailyActivityLoader(ManualGraphCallClient client, ILogger logger) : base(logger)
         {
             _client = client;
+            SaveInstrumentation = AnalyticsUsageReportSaveInstrumentation.ForLogger(logger);
         }
 
         public abstract DbSet<TReportDbType> GetTable(AnalyticsEntitiesContext context);
@@ -89,6 +92,13 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         /// read when the two straddle UTC midnight.
         /// </summary>
         public IClock Clock { get; set; } = SystemClock.Instance;
+
+        /// <summary>
+        /// Opt-in, privacy-safe stage diagnostics for the daily usage-report save path. The default is a
+        /// no-op unless <c>AI_USAGE_REPORT_SAVE_DIAGNOSTICS</c> is enabled and the logger can emit App
+        /// Insights events, so the hot path keeps the pre-existing cost when diagnostics are disabled.
+        /// </summary>
+        public IUsageReportSaveInstrumentation SaveInstrumentation { get; set; }
 
         /// <summary>
         /// The set of dates within the [now-daysBackMax, now) import window that are already stored in SQL, old
@@ -230,164 +240,444 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         {
             int i = 0; int dbWrites = 0; var enUS = new System.Globalization.CultureInfo("en-US");
             var db = lookupCache.DB;
+            var instrumentation = SaveInstrumentation ?? NullUsageReportSaveInstrumentation.Instance;
+            var instrumentationEnabled = instrumentation.IsEnabled;
+            var loaderType = this.GetType().Name;
+            var reportTable = instrumentationEnabled ? (UsageReportTableName.TryResolve(typeof(TReportDbType)) ?? typeof(TReportDbType).Name) : null;
+            var saveWatch = instrumentationEnabled ? Stopwatch.StartNew() : null;
+            var totals = instrumentationEnabled ? new SaveLoopMetrics() : null;
 
-            Telemetry.LogInformation($"Saving {this.GetType().Name} for {LoadedReportPages.Keys.Count} dates");
+            Telemetry.LogInformation($"Saving {loaderType} for {LoadedReportPages.Keys.Count} dates");
 
-            // Compute total once. The previous "LoadedReportPages.SelectMany(r => r.Value).Count()"
-            // call ran on every 1000-row progress print, making progress O(n^2).
             var totalReports = LoadedReportPages.Sum(kv => kv.Value.Count);
-
-            // Persist one day at a time, committing in fixed-size batches. Previously every row across every date
-            // was added to a single context and committed in ONE SaveChangesAsync, and every existing row across
-            // the whole date range was pre-loaded and tracked. At ~200k users x up to 28 days EF6 builds an
-            // insert/update command tree for every pending row at once and throws OutOfMemoryException on a small
-            // App Service (observed on a 7GB P2v2). Reading only one day at a time and flushing in batches keeps
-            // the command-tree build bounded; auto change-detection is turned off so adding a day's rows stays
-            // O(n) instead of O(n^2). AssociatedLookupId is [NotMapped] (it maps to UserID / YammerGroupID per
-            // subclass), so existing rows can only be filtered in SQL by the mapped Date column - we key them by
-            // lookup id in memory.
-            var store = StoreFor(db);
-            using (store.BeginBulkWrite())
+            if (instrumentationEnabled)
             {
-                foreach (var dateTime in LoadedReportPages.Keys)
+                TrackSaveStage(instrumentation, UsageReportSaveStageIds.SaveStarted, loaderType, reportTable, "Started", m =>
                 {
-                    // This day's existing rows, tracked (so updates go through the identity map without attach
-                    // conflicts), keyed in memory by the [NotMapped] AssociatedLookupId.
-                    var existingByLookupId = new Dictionary<int, TReportDbType>();
-                    foreach (var existingRow in await store.GetRowsForDateAsync(dateTime.Date))
+                    m["DateCount"] = LoadedReportPages.Keys.Count;
+                    m["InputRowCount"] = totalReports;
+                    m["SaveBatchSize"] = SaveBatchSize;
+                    UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
+                });
+            }
+
+            var store = StoreFor(db);
+            try
+            {
+                using (store.BeginBulkWrite())
+                {
+                    var dateIndex = 0;
+                    foreach (var dateTime in LoadedReportPages.Keys)
                     {
-                        // Graph returns one row per lookup per date; last wins if the DB somehow has duplicates.
-                        existingByLookupId[existingRow.AssociatedLookupId] = existingRow;
-                    }
+                        var existingLoadWatch = instrumentationEnabled ? Stopwatch.StartNew() : null;
+                        var existingRows = await store.GetRowsForDateAsync(dateTime.Date);
+                        existingLoadWatch?.Stop();
 
-                    var pendingChanges = 0;
-                    foreach (var reportPage in LoadedReportPages[dateTime])
-                    {
-                        // A usage-report row with no user/group identifier (e.g. a Graph row with a null
-                        // userPrincipalName when report anonymisation is enabled on the tenant) can't be matched
-                        // to a DB lookup. Skip it rather than NRE / ArgumentNullException deeper in the loop.
-                        if (string.IsNullOrWhiteSpace(reportPage.LookupFieldValue))
+                        var existingByLookupId = new Dictionary<int, TReportDbType>();
+                        foreach (var existingRow in existingRows)
                         {
-                            Telemetry.LogWarning($"Skipping a {typeof(TReportDbType).Name} report row with no lookup identifier (null/empty user or group name).");
-                            continue;
+                            existingByLookupId[existingRow.AssociatedLookupId] = existingRow;
                         }
 
-                        // Usually an Entra ID group-membership check for a group filter.
-                        if (!await IdInScope(reportPage.LookupFieldValue))
+                        if (instrumentationEnabled)
                         {
-                            Telemetry.LogInformation($"Skipping {reportPage.LookupFieldValue} as not in scope");
-                            continue;
-                        }
-
-                        var lookupId = await ResolveLookupIdAsync(reportPage, userEmailToDbIdCache, lookupCache);
-
-                        // Output progress every 1000 imports
-                        if (i > 0 && i % 1000 == 0)
-                        {
-                            Console.WriteLine($"{this.GetType().Name}: Saved {i} / {totalReports}");
-                        }
-
-                        // Upsert: reuse the existing row for this (date, lookup) if we have one, else insert.
-                        var isNewLog = !existingByLookupId.TryGetValue(lookupId, out var dateRequestedLog);
-                        if (isNewLog)
-                        {
-                            dateRequestedLog = new TReportDbType() { AssociatedLookupId = lookupId };
-                            existingByLookupId[lookupId] = dateRequestedLog;
-                        }
-
-                        // Set log stats
-                        dateRequestedLog.Date = dateTime.Date;
-
-                        // Example: "2017-08-30"
-                        var activityDate = DateTime.MinValue;
-                        if (!string.IsNullOrEmpty(reportPage.LastActivityDateString))
-                        {
-                            if (DateTime.TryParseExact(reportPage.LastActivityDateString, "yyyy-MM-dd", enUS, System.Globalization.DateTimeStyles.None, out activityDate))
+                            totals.ExistingRowLoadMs += existingLoadWatch.ElapsedMilliseconds;
+                            TrackSaveStage(instrumentation, UsageReportSaveStageIds.ExistingRowsLoaded, loaderType, reportTable, "Completed", m =>
                             {
-                                dateRequestedLog.LastActivityDate = activityDate;
+                                m["DateIndex"] = dateIndex;
+                                m["DurationMs"] = existingLoadWatch.ElapsedMilliseconds;
+                                m["ExistingRowCount"] = existingRows.Count;
+                                m["MaterializedLookupCount"] = existingByLookupId.Count;
+                                m["TrackedEntityCount"] = store.TrackedEntityCount;
+                            });
+                        }
+
+                        var pendingChanges = 0;
+                        var pendingBatchRows = 0;
+                        var dateMetrics = instrumentationEnabled ? new SaveLoopMetrics() : null;
+                        foreach (var reportPage in LoadedReportPages[dateTime])
+                        {
+                            dateMetrics?.RecordInputRow();
+                            totals?.RecordInputRow();
+
+                            if (string.IsNullOrWhiteSpace(reportPage.LookupFieldValue))
+                            {
+                                dateMetrics?.RecordMissingLookupValue();
+                                totals?.RecordMissingLookupValue();
+                                Telemetry.LogWarning($"Skipping a {typeof(TReportDbType).Name} report row with no lookup identifier (null/empty user or group name).");
+                                continue;
+                            }
+
+                            var scopeTicks = instrumentationEnabled ? Stopwatch.GetTimestamp() : 0;
+                            var inScope = await IdInScope(reportPage.LookupFieldValue);
+                            if (instrumentationEnabled)
+                            {
+                                var elapsed = ElapsedMillisecondsSince(scopeTicks);
+                                dateMetrics.ScopeFilterMs += elapsed;
+                                totals.ScopeFilterMs += elapsed;
+                            }
+                            if (!inScope)
+                            {
+                                dateMetrics?.RecordOutOfScope();
+                                totals?.RecordOutOfScope();
+                                Telemetry.LogInformation($"Skipping {reportPage.LookupFieldValue} as not in scope");
+                                continue;
+                            }
+
+                            var lookupStats = instrumentationEnabled ? new LookupResolutionStats() : null;
+                            var lookupTicks = instrumentationEnabled ? Stopwatch.GetTimestamp() : 0;
+                            var lookupId = await ResolveLookupIdAsync(reportPage, userEmailToDbIdCache, lookupCache, lookupStats);
+                            if (instrumentationEnabled)
+                            {
+                                var elapsed = ElapsedMillisecondsSince(lookupTicks);
+                                dateMetrics.LookupResolveMs += elapsed;
+                                totals.LookupResolveMs += elapsed;
+                                dateMetrics.Add(lookupStats);
+                                totals.Add(lookupStats);
+                            }
+
+                            if (i > 0 && i % 1000 == 0)
+                            {
+                                Console.WriteLine($"{loaderType}: Saved {i} / {totalReports}");
+                            }
+
+                            var isNewLog = !existingByLookupId.TryGetValue(lookupId, out var dateRequestedLog);
+                            if (isNewLog)
+                            {
+                                dateRequestedLog = new TReportDbType() { AssociatedLookupId = lookupId };
+                                existingByLookupId[lookupId] = dateRequestedLog;
+                            }
+
+                            dateRequestedLog.Date = dateTime.Date;
+
+                            var parseTicks = instrumentationEnabled ? Stopwatch.GetTimestamp() : 0;
+                            var activityDate = DateTime.MinValue;
+                            if (!string.IsNullOrEmpty(reportPage.LastActivityDateString))
+                            {
+                                if (DateTime.TryParseExact(reportPage.LastActivityDateString, "yyyy-MM-dd", enUS, System.Globalization.DateTimeStyles.None, out activityDate))
+                                {
+                                    dateRequestedLog.LastActivityDate = activityDate;
+                                }
+                                else
+                                {
+                                    Telemetry.LogInformation($"Invalid LastActivity value: '{reportPage.LastActivityDateString}'");
+                                    dateRequestedLog.LastActivityDate = null;
+                                }
+                            }
+                            if (instrumentationEnabled)
+                            {
+                                var elapsed = ElapsedMillisecondsSince(parseTicks);
+                                dateMetrics.DateParseMs += elapsed;
+                                totals.DateParseMs += elapsed;
+                            }
+
+                            var projectionTicks = instrumentationEnabled ? Stopwatch.GetTimestamp() : 0;
+                            PopulateReportSpecificMetadata(dateRequestedLog, reportPage);
+                            if (instrumentationEnabled)
+                            {
+                                var elapsed = ElapsedMillisecondsSince(projectionTicks);
+                                dateMetrics.ProjectionMs += elapsed;
+                                totals.ProjectionMs += elapsed;
+                            }
+
+                            bool willWrite;
+                            var dirtyTicks = instrumentationEnabled ? Stopwatch.GetTimestamp() : 0;
+                            if (isNewLog)
+                            {
+                                store.AddRow(dateRequestedLog);
+                                willWrite = true;
+                                dateMetrics?.RecordAdded();
+                                totals?.RecordAdded();
                             }
                             else
                             {
-                                Telemetry.LogInformation($"Invalid LastActivity value: '{reportPage.LastActivityDateString}'");
-                                dateRequestedLog.LastActivityDate = null;
+                                willWrite = store.MarkUpdatedIfChanged(dateRequestedLog);
+                                if (willWrite)
+                                {
+                                    dateMetrics?.RecordChanged();
+                                    totals?.RecordChanged();
+                                }
+                                else
+                                {
+                                    dateMetrics?.RecordUnchanged();
+                                    totals?.RecordUnchanged();
+                                }
                             }
-                        }
-                        PopulateReportSpecificMetadata(dateRequestedLog, reportPage);
-
-                        // Auto-detect is off, so state the change explicitly. Only write when something actually
-                        // changed: existing rows for finalized days re-fetched by the recent-window rule are almost
-                        // always identical to what's stored, so dirty-checking skips the vast majority of UPDATEs -
-                        // the dominant cost of this import at large-tenant scale.
-                        bool willWrite;
-                        if (isNewLog)
-                        {
-                            store.AddRow(dateRequestedLog);
-                            willWrite = true;
-                        }
-                        else
-                        {
-                            willWrite = store.MarkUpdatedIfChanged(dateRequestedLog);
-                        }
-
-                        i++;
-                        if (willWrite)
-                        {
-                            dbWrites++;
-                            pendingChanges++;
-                            if (pendingChanges >= SaveBatchSize)
+                            if (instrumentationEnabled)
                             {
-                                await store.SaveChangesAsync();
-                                pendingChanges = 0;
+                                var elapsed = ElapsedMillisecondsSince(dirtyTicks);
+                                dateMetrics.DirtyCheckMs += elapsed;
+                                totals.DirtyCheckMs += elapsed;
+                            }
+
+                            i++;
+                            if (willWrite)
+                            {
+                                dbWrites++;
+                                pendingChanges++;
+                                pendingBatchRows++;
+                                if (pendingChanges >= SaveBatchSize)
+                                {
+                                    await SavePendingBatchAsync(store, instrumentation, loaderType, reportTable, pendingBatchRows);
+                                    pendingChanges = 0;
+                                    pendingBatchRows = 0;
+                                }
                             }
                         }
-                    }
 
-                    if (pendingChanges > 0)
+                        if (pendingChanges > 0)
+                        {
+                            await SavePendingBatchAsync(store, instrumentation, loaderType, reportTable, pendingBatchRows);
+                        }
+
+                        if (instrumentationEnabled)
+                        {
+                            TrackSaveStage(instrumentation, UsageReportSaveStageIds.RowsProcessed, loaderType, reportTable, "Completed", m => dateMetrics.WriteTo(m, dateIndex));
+                        }
+
+                        var releaseTicks = instrumentationEnabled ? Stopwatch.GetTimestamp() : 0;
+                        var trackedBeforeRelease = instrumentationEnabled ? store.TrackedEntityCount : 0;
+                        store.ReleaseSavedRows();
+                        if (instrumentationEnabled)
+                        {
+                            TrackSaveStage(instrumentation, UsageReportSaveStageIds.RowsReleased, loaderType, reportTable, "Completed", m =>
+                            {
+                                m["DateIndex"] = dateIndex;
+                                m["DurationMs"] = ElapsedMillisecondsSince(releaseTicks);
+                                m["TrackedEntityCountBeforeRelease"] = trackedBeforeRelease;
+                                m["TrackedEntityCountAfterRelease"] = store.TrackedEntityCount;
+                            });
+                        }
+                        dateIndex++;
+                    }
+                }
+
+                LastSaveDbWriteCount = dbWrites;
+                if (instrumentationEnabled)
+                {
+                    saveWatch.Stop();
+                    TrackSaveStage(instrumentation, UsageReportSaveStageIds.SaveCompleted, loaderType, reportTable, "Completed", m =>
                     {
-                        await store.SaveChangesAsync();
-                    }
-
-                    // Release this day's tracked rows before moving to the next day.
-                    store.ReleaseSavedRows();
+                        totals.WriteTo(m, null);
+                        m["DurationMs"] = saveWatch.ElapsedMilliseconds;
+                        m["InputRowCount"] = totalReports;
+                        m["DbWriteCount"] = dbWrites;
+                        UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
+                    });
                 }
             }
+            catch (Exception ex)
+            {
+                if (instrumentationEnabled)
+                {
+                    saveWatch.Stop();
+                    TrackSaveStage(instrumentation, UsageReportSaveStageIds.SaveFailed, loaderType, reportTable, "Failed", m =>
+                    {
+                        m["DurationMs"] = saveWatch.ElapsedMilliseconds;
+                        m["InputRowCount"] = totalReports;
+                        m["DbWriteCount"] = dbWrites;
+                        UsageReportSaveInstrumentationRuntime.AddRuntimeMetrics(m);
+                    }, ex.GetType().Name);
+                }
+                throw;
+            }
+        }
 
-            LastSaveDbWriteCount = dbWrites;
+        private async Task SavePendingBatchAsync(
+            IUsageReportStore<TReportDbType> store,
+            IUsageReportSaveInstrumentation instrumentation,
+            string loaderType,
+            string reportTable,
+            int batchRows)
+        {
+            if (instrumentation == null || !instrumentation.IsEnabled)
+            {
+                await store.SaveChangesAsync();
+                return;
+            }
+
+            var trackedBeforeSave = store.TrackedEntityCount;
+            var saveWatch = Stopwatch.StartNew();
+            await store.SaveChangesAsync();
+            saveWatch.Stop();
+            TrackSaveStage(instrumentation, UsageReportSaveStageIds.SaveBatch, loaderType, reportTable, "Completed", m =>
+            {
+                m["DurationMs"] = saveWatch.ElapsedMilliseconds;
+                m["BatchRowCount"] = batchRows;
+                m["TrackedEntityCountBeforeSave"] = trackedBeforeSave;
+                m["TrackedEntityCountAfterSave"] = store.TrackedEntityCount;
+            });
         }
 
         // Resolve the DB id for a report row's user/group lookup, using the shared cross-thread id cache and
         // only hitting the DB (via GetOrCreateLookup) on a cache miss. Resolution happens OUTSIDE the cache lock:
         // the previous .Result-inside-lock pattern held a shared mutex through a full DB round-trip, starving all
         // parallel import threads on the same cache.
-        private async Task<int> ResolveLookupIdAsync(TUserActivityUserDetail reportPage, ConcurrentLookupDbIdsCache userEmailToDbIdCache, CACHETYPE lookupCache)
+        private async Task<int> ResolveLookupIdAsync(
+            TUserActivityUserDetail reportPage,
+            ConcurrentLookupDbIdsCache userEmailToDbIdCache,
+            CACHETYPE lookupCache,
+            LookupResolutionStats stats = null)
         {
             int? lookupId;
-            lock (userEmailToDbIdCache)
+            var lockStart = stats == null ? 0 : Stopwatch.GetTimestamp();
+            Monitor.Enter(userEmailToDbIdCache);
+            try
             {
+                stats?.AddSynchronizationWait(ElapsedMillisecondsSince(lockStart));
                 lookupId = userEmailToDbIdCache.GetCachedIdForName<TReportDbType>(reportPage.LookupFieldValue);
+            }
+            finally
+            {
+                Monitor.Exit(userEmailToDbIdCache);
             }
             if (lookupId != null)
             {
+                stats?.RecordHit();
                 return lookupId.Value;
             }
 
+            stats?.RecordMiss();
+            var dbCallStart = stats == null ? 0 : Stopwatch.GetTimestamp();
             var lookup = await reportPage.GetOrCreateLookup(lookupCache);
+            stats?.RecordDatabaseCall(ElapsedMillisecondsSince(dbCallStart));
             if (!lookup.IsSavedToDB)
             {
                 throw new InvalidOperationException("Cannot use unsaved lookups for activity records");
             }
 
-            lock (userEmailToDbIdCache)
+            lockStart = stats == null ? 0 : Stopwatch.GetTimestamp();
+            Monitor.Enter(userEmailToDbIdCache);
+            try
             {
-                // Re-check in case another thread populated it while we were resolving.
+                stats?.AddSynchronizationWait(ElapsedMillisecondsSince(lockStart));
                 lookupId = userEmailToDbIdCache.GetCachedIdForName<TReportDbType>(reportPage.LookupFieldValue);
                 if (lookupId == null)
                 {
                     lookupId = lookup.ID;
                     userEmailToDbIdCache.AddOrUpdateForName<TReportDbType>(reportPage.LookupFieldValue, lookupId.Value);
                 }
+                else
+                {
+                    stats?.RecordDuplicateConcurrentMiss();
+                }
+            }
+            finally
+            {
+                Monitor.Exit(userEmailToDbIdCache);
             }
             return lookupId.Value;
+        }
+
+        private static long ElapsedMillisecondsSince(long startTimestamp)
+        {
+            if (startTimestamp == 0) return 0;
+            return (long)((Stopwatch.GetTimestamp() - startTimestamp) * 1000.0 / Stopwatch.Frequency);
+        }
+
+        private static void TrackSaveStage(
+            IUsageReportSaveInstrumentation instrumentation,
+            string stage,
+            string loaderType,
+            string reportTable,
+            string outcome,
+            Action<Dictionary<string, double>> populateMetrics,
+            string exceptionType = null)
+        {
+            var point = new UsageReportSaveTelemetryPoint
+            {
+                Stage = stage,
+                ReportId = loaderType,
+                LoaderType = loaderType,
+                ReportTable = reportTable,
+                Outcome = outcome,
+                ExceptionType = exceptionType,
+            };
+            populateMetrics?.Invoke(point.Metrics);
+            instrumentation.Track(point);
+        }
+
+        private sealed class LookupResolutionStats
+        {
+            public long CacheHits;
+            public long CacheMisses;
+            public long DatabaseCalls;
+            public long DuplicateConcurrentMisses;
+            public long SynchronizationWaitMs;
+            public long DatabaseCallMs;
+
+            public void RecordHit() => CacheHits++;
+            public void RecordMiss() => CacheMisses++;
+            public void RecordDuplicateConcurrentMiss() => DuplicateConcurrentMisses++;
+            public void AddSynchronizationWait(long milliseconds) => SynchronizationWaitMs += milliseconds;
+            public void RecordDatabaseCall(long milliseconds)
+            {
+                DatabaseCalls++;
+                DatabaseCallMs += milliseconds;
+            }
+        }
+
+        private sealed class SaveLoopMetrics
+        {
+            public long InputRows;
+            public long MissingLookupValueRows;
+            public long OutOfScopeRows;
+            public long AddedRows;
+            public long ChangedRows;
+            public long UnchangedRows;
+            public long ExistingRowLoadMs;
+            public long ScopeFilterMs;
+            public long LookupResolveMs;
+            public long DateParseMs;
+            public long ProjectionMs;
+            public long DirtyCheckMs;
+            public long LookupCacheHits;
+            public long LookupCacheMisses;
+            public long LookupDatabaseCalls;
+            public long DuplicateConcurrentMisses;
+            public long LookupSynchronizationWaitMs;
+            public long LookupDatabaseCallMs;
+
+            public void RecordInputRow() => InputRows++;
+            public void RecordMissingLookupValue() => MissingLookupValueRows++;
+            public void RecordOutOfScope() => OutOfScopeRows++;
+            public void RecordAdded() => AddedRows++;
+            public void RecordChanged() => ChangedRows++;
+            public void RecordUnchanged() => UnchangedRows++;
+
+            public void Add(LookupResolutionStats stats)
+            {
+                if (stats == null) return;
+                LookupCacheHits += stats.CacheHits;
+                LookupCacheMisses += stats.CacheMisses;
+                LookupDatabaseCalls += stats.DatabaseCalls;
+                DuplicateConcurrentMisses += stats.DuplicateConcurrentMisses;
+                LookupSynchronizationWaitMs += stats.SynchronizationWaitMs;
+                LookupDatabaseCallMs += stats.DatabaseCallMs;
+            }
+
+            public void WriteTo(Dictionary<string, double> metrics, int? dateIndex)
+            {
+                if (dateIndex.HasValue) metrics["DateIndex"] = dateIndex.Value;
+                metrics["InputRowCount"] = InputRows;
+                metrics["MissingLookupValueRowCount"] = MissingLookupValueRows;
+                metrics["OutOfScopeRowCount"] = OutOfScopeRows;
+                metrics["AddedRowCount"] = AddedRows;
+                metrics["ChangedRowCount"] = ChangedRows;
+                metrics["UnchangedRowCount"] = UnchangedRows;
+                metrics["ExistingRowLoadMs"] = ExistingRowLoadMs;
+                metrics["ScopeFilterMs"] = ScopeFilterMs;
+                metrics["LookupResolveMs"] = LookupResolveMs;
+                metrics["DateParseMs"] = DateParseMs;
+                metrics["ProjectionMs"] = ProjectionMs;
+                metrics["DirtyCheckMs"] = DirtyCheckMs;
+                metrics["LookupCacheHitCount"] = LookupCacheHits;
+                metrics["LookupCacheMissCount"] = LookupCacheMisses;
+                metrics["LookupDatabaseCallCount"] = LookupDatabaseCalls;
+                metrics["DuplicateConcurrentMissCount"] = DuplicateConcurrentMisses;
+                metrics["LookupSynchronizationWaitMs"] = LookupSynchronizationWaitMs;
+                metrics["LookupDatabaseCallMs"] = LookupDatabaseCallMs;
+            }
         }
 
         protected virtual Task<bool> IdInScope(string lookupId)

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/AbstractDailyActivityLoader.cs
@@ -249,6 +249,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
 
             Telemetry.LogInformation($"Saving {loaderType} for {LoadedReportPages.Keys.Count} dates");
 
+            // Compute total once. The previous "LoadedReportPages.SelectMany(r => r.Value).Count()"
+            // call ran on every 1000-row progress print, making progress O(n^2).
             var totalReports = LoadedReportPages.Sum(kv => kv.Value.Count);
             if (instrumentationEnabled)
             {
@@ -261,6 +263,14 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                 });
             }
 
+            // Persist one day at a time, committing in fixed-size batches. Previously every row across every date
+            // was added to a single context and committed in ONE SaveChangesAsync, and every existing row across
+            // the whole date range was pre-loaded and tracked. At ~200k users x up to 28 days EF6 builds an
+            // insert/update command tree for every pending row at once and throws OutOfMemoryException on a small
+            // App Service. Reading only one day at a time and flushing in batches keeps the command-tree build
+            // bounded; auto change-detection is turned off so adding a day's rows stays O(n) instead of O(n^2).
+            // AssociatedLookupId is [NotMapped] (it maps to UserID / YammerGroupID per subclass), so existing
+            // rows can only be filtered in SQL by the mapped Date column - we key them by lookup id in memory.
             var store = StoreFor(db);
             try
             {
@@ -274,6 +284,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                         existingLoadWatch?.Stop();
 
                         var existingByLookupId = new Dictionary<int, TReportDbType>();
+                        // Graph returns one row per lookup per date; last wins if the DB somehow has duplicates.
                         foreach (var existingRow in existingRows)
                         {
                             existingByLookupId[existingRow.AssociatedLookupId] = existingRow;
@@ -300,6 +311,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                             dateMetrics?.RecordInputRow();
                             totals?.RecordInputRow();
 
+                            // A usage-report row with no user/group identifier (e.g. a Graph row with a null
+                            // userPrincipalName when report anonymisation is enabled on the tenant) can't be matched
+                            // to a DB lookup. Skip it rather than NRE / ArgumentNullException deeper in the loop.
                             if (string.IsNullOrWhiteSpace(reportPage.LookupFieldValue))
                             {
                                 dateMetrics?.RecordMissingLookupValue();
@@ -308,6 +322,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                                 continue;
                             }
 
+                            // Usually an Entra ID group-membership check for a group filter.
                             var scopeTicks = instrumentationEnabled ? Stopwatch.GetTimestamp() : 0;
                             var inScope = await IdInScope(reportPage.LookupFieldValue);
                             if (instrumentationEnabled)
@@ -380,6 +395,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
                                 totals.ProjectionMs += elapsed;
                             }
 
+                            // Auto-detect is off, so state the change explicitly. Only write when something actually
+                            // changed: existing rows for finalized days re-fetched by the recent-window rule are almost
+                            // always identical to what's stored, so dirty-checking skips the vast majority of UPDATEs -
+                            // the dominant cost of this import at large-tenant scale.
                             bool willWrite;
                             var dirtyTicks = instrumentationEnabled ? Stopwatch.GetTimestamp() : 0;
                             if (isNewLog)
@@ -551,6 +570,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
             try
             {
                 stats?.AddSynchronizationWait(ElapsedMillisecondsSince(lockStart));
+                // Re-check in case another thread populated it while we were resolving.
                 lookupId = userEmailToDbIdCache.GetCachedIdForName<TReportDbType>(reportPage.LookupFieldValue);
                 if (lookupId == null)
                 {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs
@@ -72,15 +72,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         /// </summary>
         void ReleaseSavedRows();
 
+        /// <summary>Current tracked usage-report entity count, for save-stage diagnostics.</summary>
+        int TrackedEntityCount { get; }
+
         /// <summary>
         /// Enter a bulk-write scope, restoring whatever was changed when disposed. For the SQL adapter
         /// that means turning EF6 change auto-detection off, without which adding a day's rows is
         /// O(n^2) - and restoring the PREVIOUS value, not a hard-coded "on", because the context may
         /// have been handed in with it already off.
         /// </summary>
-        /// <summary>Current tracked usage-report entity count, for save-stage diagnostics.</summary>
-        int TrackedEntityCount { get; }
-
         IDisposable BeginBulkWrite();
     }
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs
@@ -72,7 +72,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         /// </summary>
         void ReleaseSavedRows();
 
-        /// <summary>Current tracked usage-report entity count, for save-stage diagnostics.</summary>
+        /// <summary>
+        /// Current tracked usage-report entity count, for save-stage diagnostics only. Implementations may need
+        /// to enumerate the change tracker to answer this, so callers must keep it behind the opt-in diagnostics
+        /// gate and never call it on the normal hot path when diagnostics are disabled.
+        /// </summary>
         int TrackedEntityCount { get; }
 
         /// <summary>
@@ -95,7 +99,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         private readonly AnalyticsEntitiesContext _db;
         private readonly DbSet<TReportDbType> _table;
 
-        public int TrackedEntityCount => _db.ChangeTracker.Entries<AbstractUsageActivityLog>().Count();
+        public int TrackedEntityCount
+        {
+            get
+            {
+                // EF6 ChangeTracker.Entries<T>() reaches InternalContext.GetStateEntries<T>(), which calls
+                // DetectChanges(), but InternalContext.DetectChanges() is a no-op when AutoDetectChangesEnabled
+                // is false. The save loop reads this only inside BeginBulkWrite(), where this adapter disables
+                // auto-detect, so diagnostics do not reintroduce the O(n^2) change-detection cost that batching
+                // avoids. It still enumerates tracked entries, so keep this diagnostics-only and gated off the
+                // normal hot path.
+                return _db.ChangeTracker.Entries<AbstractUsageActivityLog>().Count();
+            }
+        }
 
         public SqlUsageReportStore(AnalyticsEntitiesContext db, DbSet<TReportDbType> table)
         {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStore.cs
@@ -78,6 +78,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
         /// O(n^2) - and restoring the PREVIOUS value, not a hard-coded "on", because the context may
         /// have been handed in with it already off.
         /// </summary>
+        /// <summary>Current tracked usage-report entity count, for save-stage diagnostics.</summary>
+        int TrackedEntityCount { get; }
+
         IDisposable BeginBulkWrite();
     }
 
@@ -91,6 +94,8 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
     {
         private readonly AnalyticsEntitiesContext _db;
         private readonly DbSet<TReportDbType> _table;
+
+        public int TrackedEntityCount => _db.ChangeTracker.Entries<AbstractUsageActivityLog>().Count();
 
         public SqlUsageReportStore(AnalyticsEntitiesContext db, DbSet<TReportDbType> table)
         {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/UsageReportSaveInstrumentation.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/UsageReportSaveInstrumentation.cs
@@ -1,0 +1,129 @@
+using DataUtils;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph.UsageReports
+{
+    public static class UsageReportSaveStageIds
+    {
+        public const string ReportPhaseStarted = "ReportPhaseStarted";
+        public const string ReportPhaseCompleted = "ReportPhaseCompleted";
+        public const string ReportPhaseFailed = "ReportPhaseFailed";
+        public const string SaveStarted = "SaveStarted";
+        public const string ExistingRowsLoaded = "ExistingRowsLoaded";
+        public const string RowsProcessed = "RowsProcessed";
+        public const string SaveBatch = "SaveBatch";
+        public const string RowsReleased = "RowsReleased";
+        public const string SaveCompleted = "SaveCompleted";
+        public const string SaveFailed = "SaveFailed";
+    }
+
+    public interface IUsageReportSaveInstrumentation
+    {
+        bool IsEnabled { get; }
+        void Track(UsageReportSaveTelemetryPoint point);
+    }
+
+    public sealed class UsageReportSaveTelemetryPoint
+    {
+        public string Stage { get; set; }
+        public string ReportId { get; set; }
+        public string LoaderType { get; set; }
+        public string ReportTable { get; set; }
+        public string Outcome { get; set; }
+        public string ExceptionType { get; set; }
+        public Dictionary<string, double> Metrics { get; } = new Dictionary<string, double>();
+    }
+
+    public sealed class NullUsageReportSaveInstrumentation : IUsageReportSaveInstrumentation
+    {
+        public static readonly NullUsageReportSaveInstrumentation Instance = new NullUsageReportSaveInstrumentation();
+        private NullUsageReportSaveInstrumentation() { }
+        public bool IsEnabled => false;
+        public void Track(UsageReportSaveTelemetryPoint point) { }
+    }
+
+    public sealed class AnalyticsUsageReportSaveInstrumentation : IUsageReportSaveInstrumentation
+    {
+        public const string EnableEnvironmentVariable = "AI_USAGE_REPORT_SAVE_DIAGNOSTICS";
+        private readonly AnalyticsLogger _logger;
+        private readonly string _runId;
+
+        private AnalyticsUsageReportSaveInstrumentation(AnalyticsLogger logger)
+        {
+            _logger = logger;
+            _runId = Guid.NewGuid().ToString("N");
+        }
+
+        public bool IsEnabled => true;
+
+        public static IUsageReportSaveInstrumentation ForLogger(ILogger logger)
+        {
+            var enabled = Environment.GetEnvironmentVariable(EnableEnvironmentVariable);
+            if (!IsTruthy(enabled))
+            {
+                return NullUsageReportSaveInstrumentation.Instance;
+            }
+
+            var analyticsLogger = logger as AnalyticsLogger;
+            return analyticsLogger == null
+                ? (IUsageReportSaveInstrumentation)NullUsageReportSaveInstrumentation.Instance
+                : new AnalyticsUsageReportSaveInstrumentation(analyticsLogger);
+        }
+
+        public void Track(UsageReportSaveTelemetryPoint point)
+        {
+            if (point == null) return;
+
+            var dimensions = new Dictionary<string, string>
+            {
+                { "RunId", _runId },
+                { "Stage", point.Stage ?? string.Empty },
+                { "ReportId", point.ReportId ?? string.Empty },
+                { "LoaderType", point.LoaderType ?? string.Empty },
+                { "ReportTable", point.ReportTable ?? string.Empty },
+                { "Outcome", point.Outcome ?? string.Empty },
+            };
+            if (!string.IsNullOrEmpty(point.ExceptionType))
+            {
+                dimensions["ExceptionType"] = point.ExceptionType;
+            }
+
+            _logger.TrackEvent(AnalyticsLogger.AnalyticsEvent.UsageReportSaveStage, dimensions, point.Metrics);
+        }
+
+        private static bool IsTruthy(string value)
+        {
+            return string.Equals(value, "1", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    internal static class UsageReportSaveInstrumentationRuntime
+    {
+        private static int _activeDailyLoaders;
+
+        public static int IncrementActiveDailyLoaders() => Interlocked.Increment(ref _activeDailyLoaders);
+        public static int DecrementActiveDailyLoaders() => Interlocked.Decrement(ref _activeDailyLoaders);
+
+        public static void AddRuntimeMetrics(Dictionary<string, double> metrics)
+        {
+            if (metrics == null) return;
+
+            metrics["ManagedHeapBytes"] = GC.GetTotalMemory(false);
+            metrics["Gen0Collections"] = GC.CollectionCount(0);
+            metrics["Gen1Collections"] = GC.CollectionCount(1);
+            metrics["Gen2Collections"] = GC.CollectionCount(2);
+            using (var process = Process.GetCurrentProcess())
+            {
+                metrics["WorkingSetBytes"] = process.WorkingSet64;
+            }
+        }
+    }
+}
+
+

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -203,6 +203,7 @@
     <Compile Include="Graph\UsageReports\AbstractDailyActivityLoader.cs" />
     <Compile Include="Graph\UsageReports\IUsageReportStorageInspector.cs" />
     <Compile Include="Graph\UsageReports\IUsageReportStore.cs" />
+    <Compile Include="Graph\UsageReports\UsageReportSaveInstrumentation.cs" />
     <Compile Include="Graph\UsageReports\Rules\UsageReportRefreshPolicy.cs" />
     <Compile Include="Graph\Calls\CallQueueProcessor.cs" />
     <Compile Include="Graph\Calls\CallRecordAdapters.cs" />


### PR DESCRIPTION
## Summary Addresses #495.  Adds opt-in, privacy-safe daily usage-report save diagnostics without changing lookup, dirty-checking, batching, EF persistence, schema, indexes or query hints. Diagnostics are disabled by default and turn into App Insights `UsageReportSaveStage` custom events only when `AI_USAGE_REPORT_SAVE_DIAGNOSTICS` is `1`, `true` or `yes` and the runtime logger is `AnalyticsLogger`.  ## Implementation scope - Extends the existing #375 `IUsageReportStore<T>` seam with `TrackedEntityCount` so batch/release telemetry can report EF tracking pressure without parallel persistence logic. - Instruments `AbstractDailyActivityLoader.SaveLoadedReportsToSql` around existing-row materialisation, scope checks, lookup resolution, date parsing, projection, dirty checking, EF save batches, row release and whole-save completion/failure. - Instruments the daily-loader composition boundary in `GraphImporter.LoadAndSaveDailyImportReport` for whole report-loader phase duration and active daily-loader concurrency. This is the only `GraphImporter.cs` edit. - Adds deterministic in-memory call-shape tests for cold/warm lookup cache, repeated users, missing lookup identifiers, out-of-scope rows, partial overlap across concurrent loaders, duplicate concurrent misses, mixed new/changed/unchanged rows, and a mid-batch save failure followed by a healthy idempotent retry. - Adds `src/AnalyticsEngine/Benchmarks/UsageReportSaveSyntheticBenchmark.sql`, an isolated SQL Server harness that recreates the relevant production column types/collation guard/index/query shapes with synthetic `Contoso` data only.  ## Stage identifiers and key metrics App Insights event name: `UsageReportSaveStage`.  Stable `customDimensions.Stage` values: - `ReportPhaseStarted` - `ReportPhaseCompleted` - `ReportPhaseFailed` - `SaveStarted` - `ExistingRowsLoaded` - `RowsProcessed` - `SaveBatch` - `RowsReleased` - `SaveCompleted` - `SaveFailed`  Stable report identifiers are code-defined loader type names in `customDimensions.ReportId`/`LoaderType`; no user identifiers, URLs, rows, DB names or tenant values are emitted.  Selected `customMeasurements`: `DurationMs`, `InputRowCount`, `ExistingRowCount`, `MaterializedLookupCount`, `LookupCacheHitCount`, `LookupCacheMissCount`, `LookupDatabaseCallCount`, `DuplicateConcurrentMissCount`, `LookupSynchronizationWaitMs`, `LookupDatabaseCallMs`, `ScopeFilterMs`, `DateParseMs`, `ProjectionMs`, `DirtyCheckMs`, `AddedRowCount`, `ChangedRowCount`, `UnchangedRowCount`, `BatchRowCount`, `TrackedEntityCountBeforeSave`, `TrackedEntityCountAfterSave`, `TrackedEntityCountBeforeRelease`, `TrackedEntityCountAfterRelease`, `ActiveLoaderCount`, `ManagedHeapBytes`, `WorkingSetBytes`, `Gen0Collections`, `Gen1Collections`, `Gen2Collections`.  Example operator query: ```kusto customEvents | where name == "UsageReportSaveStage" | extend Stage=tostring(customDimensions.Stage), ReportId=tostring(customDimensions.ReportId) | project timestamp, ReportId, Stage,           DurationMs=todouble(customMeasurements.DurationMs),           LookupDbCalls=tolong(customMeasurements.LookupDatabaseCallCount),           DuplicateMisses=tolong(customMeasurements.DuplicateConcurrentMissCount),           Added=tolong(customMeasurements.AddedRowCount),           Changed=tolong(customMeasurements.ChangedRowCount),           Unchanged=tolong(customMeasurements.UnchangedRowCount),           ActiveLoaders=tolong(customMeasurements.ActiveLoaderCount) | order by timestamp asc ```  ## Validation - `MSBuild Tests.UnitTests.csproj -t:Restore -p:Configuration=Release -p:Platform=anycpu -p:ProcessorArchitecture=x86` succeeded. - `dotnet build Common\DataUtils\DataUtils.csproj -c Release --no-restore` succeeded. - Changed-file check with `dotnet build WebJob.Office365ActivityImporter.Engine.csproj -c Release --no-restore` found no errors in changed files, but the full build cannot complete in this environment because SDK/package resolution differs from the requested VS build environment. - Requested full `MSBuild Tests.UnitTests.csproj` failed before compiling tests: `Microsoft.WebApplication.targets` is missing under the installed VS 18 BuildTools path. - Requested `vstest.console.exe ... /TestCaseFilter:"FullyQualifiedName~DailyActivityLoaderTests"` could not run because the failed build did not produce `Tests.UnitTests.dll`.  ## Acceptance criteria met - Privacy-safe aggregate diagnostics at the daily save boundary and daily report-loader phase boundary. - Lookup hit/miss/DB-call/duplicate-miss/synchronisation metrics without serialising unrelated lookup I/O. - Per-batch save, tracked entity and release/detach metrics. - No EF SQL/parameter logging; no tenant/customer values in events or tests. - Deterministic fake-store tests for the required call shapes and retry/idempotency behavior. - Synthetic benchmark harness for later SQL logical-read/elapsed-time/plan-operator measurement.  ## Deferred intentionally - The 200k-user SQL measurement run, logical reads, elapsed time medians, CPU and actual plan operators: this environment has no throwaway SQL Server benchmark database populated for that run. - Any lookup preload/batching change, query hint, index or migration: #495 and repo release rules require measured before/after evidence first, and this PR deliberately does not fabricate benchmark numbers.  ## Reviewer hotspots - `AbstractDailyActivityLoader.SaveLoadedReportsToSql` instrumentation placement around existing behavior. - `ResolveLookupIdAsync` lock-wait and duplicate concurrent miss accounting. - `GraphImporter.LoadAndSaveDailyImportReport` active-loader phase events. - `UsageReportSaveSyntheticBenchmark.sql` production-shape assumptions.   
