### PR TITLE
Fix HTTP retry deadlines and gateway GET retries

### DIFF
--- a/src/AnalyticsEngine/Common/DataUtils/Http/AutoThrottleHttpClient.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/AutoThrottleHttpClient.cs
@@ -1,94 +1,111 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace DataUtils.Http
 {
+    public interface IAutoThrottleHttpClientClock
+    {
+        DateTimeOffset UtcNow { get; }
+        Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);
+    }
+
+    public sealed class SystemAutoThrottleHttpClientClock : IAutoThrottleHttpClientClock
+    {
+        public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            return Task.Delay(delay, cancellationToken);
+        }
+    }
+
     public class AutoThrottleHttpClient : HttpClient
     {
         #region Constructor, Props, and Privates
 
         const string THROTTLE_ERROR = "Throttle error";
+        private static readonly TimeSpan MinimumRetryDelay = TimeSpan.FromSeconds(1);
 
         private readonly bool ignoreRetryHeader;
+        private readonly IAutoThrottleHttpClientClock _clock;
         protected readonly ILogger _logger;
-        private DateTime? _nextCallEarliestTime = null;
+        private DateTimeOffset? _nextCallEarliestTime = null;
         private int _concurrentCalls = 0, _throttledCalls = 0, _completedCalls = 0;
         private int _maxRetries = 10;
-        private int _maxRetryAfterWaitSeconds = 180;
+        private int _maxRetryAfterWaitSeconds = 3600;
         private object _concurrentCallsObj = new object(), _throttledCallsObject = new object(), _completedCallsObject = new object(), _maxRetriesObj = new object();
 
 
-        public AutoThrottleHttpClient(bool ignoreRetryHeader, ILogger logger)
+        public AutoThrottleHttpClient(bool ignoreRetryHeader, ILogger logger, IAutoThrottleHttpClientClock clock = null)
         {
             Timeout = TimeSpan.FromHours(1);
             this.ignoreRetryHeader = ignoreRetryHeader;
             _logger = logger;
+            _clock = clock ?? new SystemAutoThrottleHttpClientClock();
         }
-        public AutoThrottleHttpClient(bool ignoreRetryHeader, ILogger logger, DelegatingHandler handler) : base(handler)
+        public AutoThrottleHttpClient(bool ignoreRetryHeader, ILogger logger, DelegatingHandler handler, IAutoThrottleHttpClientClock clock = null) : base(handler)
         {
             Timeout = TimeSpan.FromHours(1);
             this.ignoreRetryHeader = ignoreRetryHeader;
             _logger = logger;
+            _clock = clock ?? new SystemAutoThrottleHttpClientClock();
         }
 
-        public AutoThrottleHttpClient(HttpMessageHandler handler, ILogger logger) : base(handler)
+        public AutoThrottleHttpClient(HttpMessageHandler handler, ILogger logger, IAutoThrottleHttpClientClock clock = null) : base(handler)
         {
+            Timeout = TimeSpan.FromHours(1);
             _logger = logger;
+            _clock = clock ?? new SystemAutoThrottleHttpClientClock();
         }
 
 
         #endregion
 
         /// <summary>
-        /// Execute a method that returns a HttpResponseMessage, with throttling retry logic
+        /// Execute a method that returns a HttpResponseMessage, with throttling retry logic.
         /// </summary>
-        public async Task<HttpResponseMessage> ExecuteHttpCallWithThrottleRetries(Func<Task<HttpResponseMessage>> httpAction, string url)
+        public Task<HttpResponseMessage> ExecuteHttpCallWithThrottleRetries(Func<Task<HttpResponseMessage>> httpAction, string url, bool isReplayableIdempotentGet = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            HttpResponseMessage response = null;
-            int retries = 0, secondsToWait = 0;
-            bool retryDownload = true;
-            while (retryDownload)
+            if (httpAction is null)
             {
+                throw new ArgumentNullException(nameof(httpAction));
+            }
+
+            return ExecuteHttpCallWithThrottleRetries(ct => httpAction(), url, isReplayableIdempotentGet, cancellationToken);
+        }
+
+        /// <summary>
+        /// Execute a method that returns a HttpResponseMessage, with throttling retry logic.
+        /// </summary>
+        public async Task<HttpResponseMessage> ExecuteHttpCallWithThrottleRetries(Func<CancellationToken, Task<HttpResponseMessage>> httpAction, string url, bool isReplayableIdempotentGet = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (httpAction is null)
+            {
+                throw new ArgumentNullException(nameof(httpAction));
+            }
+
+            var startedUtc = _clock.UtcNow;
+            var attempt = 0;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await WaitForSharedRetryDeadline(startedUtc, url, cancellationToken);
+
                 lock (_concurrentCallsObj)
                 {
                     _concurrentCalls++;
                 }
 
-                // Figure out if we need to wait. Sleep thread outside lock
-                TimeSpan? sleepTimeNeeded = null;
-                lock (this)
-                {
-                    if (_nextCallEarliestTime != null && _nextCallEarliestTime > DateTime.Now)
-                    {
-                        sleepTimeNeeded = _nextCallEarliestTime.Value.Subtract(DateTime.Now);
-                    }
-                }
-                if (sleepTimeNeeded.HasValue)
-                {
-                    lock (this)
-                    {
-                        _throttledCalls++;
-                    }
-                    Thread.Sleep(sleepTimeNeeded.Value);
-                    lock (this)
-                    {
-                        _nextCallEarliestTime = null;
-                    }
-                }
-
-                // Get response but don't buffer full content (which will buffer overlflow for large files).
-                // A client-side timeout (HttpClient.Timeout elapsed) surfaces as a TaskCanceledException, and a
-                // transient socket/DNS blip as an HttpRequestException thrown from the call itself (before any
-                // response is received). Neither is an HTTP 429, so the status-code retry logic below would
-                // never see them - they'd propagate and, in the importers, abort a whole import section (or in
-                // DEBUG crash the process). Retry them here with a linear back-off, sharing the MaxRetries
-                // budget, then rethrow so a genuinely dead endpoint still surfaces to the caller's own handling.
+                HttpResponseMessage response = null;
                 try
                 {
-                    response = await httpAction();
+                    attempt++;
+                    response = await httpAction(cancellationToken);
                 }
                 catch (Exception ex) when (IsTransientException(ex))
                 {
@@ -97,16 +114,15 @@ namespace DataUtils.Http
                         _concurrentCalls--;
                     }
 
-                    retries++;
-                    if (retries >= MaxRetries)
+                    if (attempt >= MaxRetries)
                     {
                         _logger.LogError(ex, $"Transient error calling {url}: '{ex.Message}'. Giving up after {MaxRetries} attempts.");
                         throw;
                     }
 
-                    secondsToWait = retries * 2;
-                    _logger.LogWarning($"Transient error calling {url}: '{ex.Message}'. Waiting {secondsToWait}s before retry (attempt #{retries} of {MaxRetries})...");
-                    Thread.Sleep(TimeSpan.FromSeconds(secondsToWait));
+                    var delay = GetFallbackDelay(attempt);
+                    _logger.LogWarning($"Transient error calling {url}: '{ex.Message}'. Waiting {FormatDelay(delay)} before retry (attempt #{attempt} of {MaxRetries})...");
+                    await DelayWithinRetryBudget(delay, startedUtc, url, null, cancellationToken);
                     continue;
                 }
 
@@ -115,91 +131,228 @@ namespace DataUtils.Http
                     _concurrentCalls--;
                 }
 
-                if (!response.IsSuccessStatusCode && (int)response.StatusCode == 429)
+                if (!IsRetryableResponse(response, isReplayableIdempotentGet))
                 {
-                    retries++;
-                    lock (this)
-                    {
-                        _throttledCalls++;
-                    }
-
-                    // Enforce the retry budget on EVERY 429, not just the ones without a 'retry-after'
-                    // header. Graph almost always sends that header, so the previous shape only counted
-                    // retries and never stopped: a persistently throttled endpoint looped forever, blocking
-                    // the calling import section indefinitely (which no exception handler can recover from).
-                    if (retries >= MaxRetries)
-                    {
-                        _logger.LogError($"{THROTTLE_ERROR}. Maximum retry attempts {MaxRetries} reached for {url}; giving up.");
-                        try
-                        {
-                            // Throws the usual HttpRequestException so callers handle it as a failed call.
-                            response.EnsureSuccessStatusCode();
-                        }
-                        finally
-                        {
-                            response.Dispose();
-                        }
-                    }
-
-                    // Do we have a "retry-after" header & should we use it?
-                    var waitValue = response.GetRetryAfterHeaderSeconds();
-                    if (!ignoreRetryHeader && waitValue.HasValue)
-                    {
-                        // Honour 'retry-after', but cap it: a single very large (or buggy) value would otherwise
-                        // block this thread for that entire duration (we saw multi-minute stalls in usage-report
-                        // paging). Capping breaks one huge sleep into shorter, observable waits + retries.
-                        var cap = MaxRetryAfterWaitSeconds;
-                        secondsToWait = Math.Min(waitValue.Value, cap);
-                        if (waitValue.Value > cap)
-                        {
-                            _logger.LogWarning($"{THROTTLE_ERROR} for {url}. 'retry-after' header asked for {waitValue.Value}s; capping wait at {cap}s for attempt #{retries}.");
-                        }
-                        else
-                        {
-                            _logger.LogInformation($"{THROTTLE_ERROR} for {url}. Waiting to retry for attempt #{retries}, {secondsToWait} seconds (from 'retry-after' header)...");
-                        }
-                    }
-                    else
-                    {
-                        // We have to guess how much to back-off. Loop with ever-increasing wait.
-                        // (The retry budget itself is enforced above, for both header and no-header paths.)
-                        _logger.LogInformation($"{THROTTLE_ERROR} downloading from REST. Waiting {retries} seconds to try again...");
-
-                        secondsToWait = retries * 2;
-                    }
-
-                    // Wait before trying again
-                    lock (this)
-                    {
-                        _nextCallEarliestTime = DateTime.Now.AddSeconds(secondsToWait);
-                    }
-
-                    // This response is being discarded, so release it before looping. It matters for callers
-                    // that request HttpCompletionOption.ResponseHeadersRead (the Copilot CSV report
-                    // downloads): the body is still unread, so without this each retry leaks a connection.
-                    response.Dispose();
-                    response = null;
-                }
-                else
-                {
-                    // Not HTTP 429. Don't bother retrying & let caller handle any error
-                    retryDownload = false;
-
                     lock (_completedCallsObject)
                     {
                         _completedCalls++;
                     }
+
+                    return response;
+                }
+
+                lock (_throttledCallsObject)
+                {
+                    _throttledCalls++;
+                }
+
+                if (attempt >= MaxRetries)
+                {
+                    _logger.LogError($"Retryable HTTP {(int)response.StatusCode} from {url}. Maximum retry attempts {MaxRetries} reached; giving up.");
+                    try
+                    {
+                        response.EnsureSuccessStatusCode();
+                    }
+                    finally
+                    {
+                        response.Dispose();
+                    }
+                }
+
+                var delayNeeded = GetRetryDelay(response, attempt, url);
+                await DelayWithinRetryBudget(delayNeeded, startedUtc, url, response, cancellationToken);
+                response.Dispose();
+            }
+        }
+
+        private async Task WaitForSharedRetryDeadline(DateTimeOffset startedUtc, string url, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                DateTimeOffset? earliest;
+                lock (this)
+                {
+                    earliest = _nextCallEarliestTime;
+                    if (earliest.HasValue && earliest.Value <= _clock.UtcNow)
+                    {
+                        _nextCallEarliestTime = null;
+                        earliest = null;
+                    }
+                }
+
+                if (!earliest.HasValue)
+                {
+                    return;
+                }
+
+                var delay = earliest.Value - _clock.UtcNow;
+                if (delay < MinimumRetryDelay)
+                {
+                    delay = MinimumRetryDelay;
+                }
+
+                lock (_throttledCallsObject)
+                {
+                    _throttledCalls++;
+                }
+
+                await DelayWithinRetryBudget(delay, startedUtc, url, null, cancellationToken);
+            }
+        }
+
+        private TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt, string url)
+        {
+            int? retryAfterSeconds = null;
+            if (!ignoreRetryHeader)
+            {
+                retryAfterSeconds = response.GetRetryAfterHeaderSeconds(_clock.UtcNow);
+            }
+
+            if (retryAfterSeconds.HasValue)
+            {
+                var delay = TimeSpan.FromSeconds(retryAfterSeconds.Value);
+                if (delay < MinimumRetryDelay)
+                {
+                    _logger.LogInformation($"Retryable HTTP {(int)response.StatusCode} from {url}. 'retry-after' was due now/past; using {FormatDelay(MinimumRetryDelay)} minimum retry delay for attempt #{attempt}.");
+                    return MinimumRetryDelay;
+                }
+
+                _logger.LogInformation($"Retryable HTTP {(int)response.StatusCode} from {url}. Waiting full 'retry-after' delay of {FormatDelay(delay)} for attempt #{attempt}.");
+                return delay;
+            }
+
+            var fallback = GetFallbackDelay(attempt);
+            _logger.LogInformation($"Retryable HTTP {(int)response.StatusCode} from {url} without a usable 'retry-after'. Waiting {FormatDelay(fallback)} before attempt #{attempt + 1}...");
+            return fallback;
+        }
+
+        private static TimeSpan GetFallbackDelay(int attempt)
+        {
+            var seconds = Math.Max(1, attempt * 2);
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        private async Task DelayWithinRetryBudget(TimeSpan delay, DateTimeOffset startedUtc, string url, HttpResponseMessage responseToFail, CancellationToken cancellationToken)
+        {
+            if (delay < MinimumRetryDelay)
+            {
+                delay = MinimumRetryDelay;
+            }
+
+            var now = _clock.UtcNow;
+            var elapsed = now - startedUtc;
+            var budget = TimeSpan.FromSeconds(Math.Max(0, MaxRetryAfterWaitSeconds));
+            var remaining = budget - elapsed;
+
+            if (remaining < TimeSpan.Zero || delay > remaining)
+            {
+                _logger.LogError($"Retry deadline for {url} is {FormatDelay(delay)} away, exceeding the remaining retry budget of {FormatDelay(remaining)}. Not retrying before the server's not-before time.");
+                if (responseToFail != null)
+                {
+                    try
+                    {
+                        responseToFail.EnsureSuccessStatusCode();
+                    }
+                    finally
+                    {
+                        responseToFail.Dispose();
+                    }
+                }
+
+                throw new HttpRequestException($"Retry deadline for {url} exceeds the remaining retry budget; not retrying before the server's not-before time.");
+            }
+
+            DateTimeOffset deadline;
+            if (!TryAdd(now, delay, out deadline))
+            {
+                _logger.LogError($"Retry deadline for {url} is too large to represent. Not retrying before the server's not-before time.");
+                if (responseToFail != null)
+                {
+                    responseToFail.Dispose();
+                }
+                throw new HttpRequestException($"Retry deadline for {url} is too large to represent.");
+            }
+
+            lock (this)
+            {
+                if (!_nextCallEarliestTime.HasValue || _nextCallEarliestTime.Value < deadline)
+                {
+                    _nextCallEarliestTime = deadline;
                 }
             }
 
-            return response;
+            try
+            {
+                await _clock.DelayAsync(delay, cancellationToken);
+            }
+            finally
+            {
+                lock (this)
+                {
+                    if (_nextCallEarliestTime.HasValue && _nextCallEarliestTime.Value <= _clock.UtcNow)
+                    {
+                        _nextCallEarliestTime = null;
+                    }
+                }
+            }
+        }
+
+        private static bool TryAdd(DateTimeOffset value, TimeSpan delay, out DateTimeOffset result)
+        {
+            try
+            {
+                result = value.Add(delay);
+                return true;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                result = DateTimeOffset.MaxValue;
+                return false;
+            }
+        }
+
+        private static bool IsRetryableResponse(HttpResponseMessage response, bool isReplayableIdempotentGet)
+        {
+            if (response == null)
+            {
+                return false;
+            }
+
+            if ((int)response.StatusCode == 429)
+            {
+                return true;
+            }
+
+            if (!isReplayableIdempotentGet)
+            {
+                return false;
+            }
+
+            return response.StatusCode == HttpStatusCode.BadGateway
+                || response.StatusCode == HttpStatusCode.ServiceUnavailable
+                || response.StatusCode == HttpStatusCode.GatewayTimeout;
+        }
+
+        private static string FormatDelay(TimeSpan delay)
+        {
+            if (delay < TimeSpan.Zero)
+            {
+                delay = TimeSpan.Zero;
+            }
+
+            if (delay.TotalSeconds >= 1)
+            {
+                return $"{delay.TotalSeconds:N0}s";
+            }
+
+            return $"{delay.TotalMilliseconds:N0}ms";
         }
 
         /// <summary>
         /// Transient failures worth retrying at the HTTP layer: a client-side timeout (HttpClient.Timeout
         /// elapsed) surfaces as a <see cref="TaskCanceledException"/>, and a transient socket/DNS failure as an
-        /// <see cref="HttpRequestException"/> thrown from the send itself. HTTP 429 is handled separately via the
-        /// response status code, so it is deliberately not included here.
+        /// <see cref="HttpRequestException"/> thrown from the send itself. HTTP status codes are handled
+        /// separately via the response status code.
         /// </summary>
         private static bool IsTransientException(Exception ex)
         {
@@ -226,8 +379,9 @@ namespace DataUtils.Http
         }
 
         /// <summary>
-        /// Upper bound (seconds) on how long a single 'retry-after' back-off will sleep. A very large or buggy
-        /// header value would otherwise stall the calling thread for its whole duration.
+        /// Total retry/back-off execution budget, in seconds. Retry-After is never clipped to this value: when a
+        /// server not-before deadline would exceed the remaining budget, the call fails visibly instead of
+        /// retrying early.
         /// </summary>
         public int MaxRetryAfterWaitSeconds
         {

--- a/src/AnalyticsEngine/Common/DataUtils/Http/AutoThrottleHttpClient.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/AutoThrottleHttpClient.cs
@@ -36,7 +36,7 @@ namespace DataUtils.Http
         private DateTimeOffset? _nextCallEarliestTime = null;
         private int _concurrentCalls = 0, _throttledCalls = 0, _completedCalls = 0;
         private int _maxRetries = 10;
-        private int _maxRetryAfterWaitSeconds = 3600;
+        private int _maxTotalRetryBudgetSeconds = 3600;
         private object _concurrentCallsObj = new object(), _throttledCallsObject = new object(), _completedCallsObject = new object(), _maxRetriesObj = new object();
 
 
@@ -104,10 +104,11 @@ namespace DataUtils.Http
                 HttpResponseMessage response = null;
                 try
                 {
+                    // Get response but don't buffer full content (which will buffer overflow for large files).
                     attempt++;
                     response = await httpAction(cancellationToken);
                 }
-                catch (Exception ex) when (IsTransientException(ex))
+                catch (Exception ex) when (IsTransientException(ex) && !cancellationToken.IsCancellationRequested)
                 {
                     lock (_concurrentCallsObj)
                     {
@@ -120,9 +121,13 @@ namespace DataUtils.Http
                         throw;
                     }
 
+                    // A client-side HTTP timeout (HttpClient.Timeout elapsed) surfaces as TaskCanceledException,
+                    // and a transient socket/DNS blip as HttpRequestException thrown from the send itself before
+                    // any response is received. Neither is an HTTP 429, so response-status retry logic never sees
+                    // them; without retrying here they would abort a whole import section (or crash in DEBUG).
                     var delay = GetFallbackDelay(attempt);
                     _logger.LogWarning($"Transient error calling {url}: '{ex.Message}'. Waiting {FormatDelay(delay)} before retry (attempt #{attempt} of {MaxRetries})...");
-                    await DelayWithinRetryBudget(delay, startedUtc, url, null, cancellationToken);
+                    await DelayWithinRetryBudget(delay, startedUtc, url, publishSharedDeadline: false, cancellationToken: cancellationToken);
                     continue;
                 }
 
@@ -146,6 +151,10 @@ namespace DataUtils.Http
                     _throttledCalls++;
                 }
 
+                // Enforce the retry budget on EVERY 429, not just the ones without a 'retry-after'
+                // header. Graph almost always sends that header, so the previous shape only counted
+                // retries and never stopped: a persistently throttled endpoint looped forever, blocking
+                // the calling import section indefinitely.
                 if (attempt >= MaxRetries)
                 {
                     _logger.LogError($"Retryable HTTP {(int)response.StatusCode} from {url}. Maximum retry attempts {MaxRetries} reached; giving up.");
@@ -160,8 +169,18 @@ namespace DataUtils.Http
                 }
 
                 var delayNeeded = GetRetryDelay(response, attempt, url);
-                await DelayWithinRetryBudget(delayNeeded, startedUtc, url, response, cancellationToken);
-                response.Dispose();
+                try
+                {
+                    await DelayWithinRetryBudget(delayNeeded.Delay, startedUtc, url, delayNeeded.PublishSharedDeadline, cancellationToken);
+                }
+                finally
+                {
+                    // This response is being discarded, so release it before looping or when cancellation stops
+                    // the loop. It matters for callers that request HttpCompletionOption.ResponseHeadersRead
+                    // (the Copilot CSV report downloads): the body is still unread, so without this each retry
+                    // leaks a connection.
+                    response.Dispose();
+                }
             }
         }
 
@@ -196,11 +215,11 @@ namespace DataUtils.Http
                     _throttledCalls++;
                 }
 
-                await DelayWithinRetryBudget(delay, startedUtc, url, null, cancellationToken);
+                await DelayWithinRetryBudget(delay, startedUtc, url, publishSharedDeadline: false, cancellationToken: cancellationToken);
             }
         }
 
-        private TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt, string url)
+        private RetryDelayDecision GetRetryDelay(HttpResponseMessage response, int attempt, string url)
         {
             int? retryAfterSeconds = null;
             if (!ignoreRetryHeader)
@@ -214,16 +233,16 @@ namespace DataUtils.Http
                 if (delay < MinimumRetryDelay)
                 {
                     _logger.LogInformation($"Retryable HTTP {(int)response.StatusCode} from {url}. 'retry-after' was due now/past; using {FormatDelay(MinimumRetryDelay)} minimum retry delay for attempt #{attempt}.");
-                    return MinimumRetryDelay;
+                    return new RetryDelayDecision(MinimumRetryDelay, ShouldPublishSharedDeadline(response, hasRetryAfterHeader: true));
                 }
 
                 _logger.LogInformation($"Retryable HTTP {(int)response.StatusCode} from {url}. Waiting full 'retry-after' delay of {FormatDelay(delay)} for attempt #{attempt}.");
-                return delay;
+                return new RetryDelayDecision(delay, ShouldPublishSharedDeadline(response, hasRetryAfterHeader: true));
             }
 
             var fallback = GetFallbackDelay(attempt);
             _logger.LogInformation($"Retryable HTTP {(int)response.StatusCode} from {url} without a usable 'retry-after'. Waiting {FormatDelay(fallback)} before attempt #{attempt + 1}...");
-            return fallback;
+            return new RetryDelayDecision(fallback, ShouldPublishSharedDeadline(response, hasRetryAfterHeader: false));
         }
 
         private static TimeSpan GetFallbackDelay(int attempt)
@@ -232,7 +251,7 @@ namespace DataUtils.Http
             return TimeSpan.FromSeconds(seconds);
         }
 
-        private async Task DelayWithinRetryBudget(TimeSpan delay, DateTimeOffset startedUtc, string url, HttpResponseMessage responseToFail, CancellationToken cancellationToken)
+        private async Task DelayWithinRetryBudget(TimeSpan delay, DateTimeOffset startedUtc, string url, bool publishSharedDeadline, CancellationToken cancellationToken)
         {
             if (delay < MinimumRetryDelay)
             {
@@ -241,24 +260,12 @@ namespace DataUtils.Http
 
             var now = _clock.UtcNow;
             var elapsed = now - startedUtc;
-            var budget = TimeSpan.FromSeconds(Math.Max(0, MaxRetryAfterWaitSeconds));
+            var budget = TimeSpan.FromSeconds(Math.Max(0, MaxTotalRetryBudgetSeconds));
             var remaining = budget - elapsed;
 
             if (remaining < TimeSpan.Zero || delay > remaining)
             {
                 _logger.LogError($"Retry deadline for {url} is {FormatDelay(delay)} away, exceeding the remaining retry budget of {FormatDelay(remaining)}. Not retrying before the server's not-before time.");
-                if (responseToFail != null)
-                {
-                    try
-                    {
-                        responseToFail.EnsureSuccessStatusCode();
-                    }
-                    finally
-                    {
-                        responseToFail.Dispose();
-                    }
-                }
-
                 throw new HttpRequestException($"Retry deadline for {url} exceeds the remaining retry budget; not retrying before the server's not-before time.");
             }
 
@@ -266,18 +273,17 @@ namespace DataUtils.Http
             if (!TryAdd(now, delay, out deadline))
             {
                 _logger.LogError($"Retry deadline for {url} is too large to represent. Not retrying before the server's not-before time.");
-                if (responseToFail != null)
-                {
-                    responseToFail.Dispose();
-                }
                 throw new HttpRequestException($"Retry deadline for {url} is too large to represent.");
             }
 
-            lock (this)
+            if (publishSharedDeadline)
             {
-                if (!_nextCallEarliestTime.HasValue || _nextCallEarliestTime.Value < deadline)
+                lock (this)
                 {
-                    _nextCallEarliestTime = deadline;
+                    if (!_nextCallEarliestTime.HasValue || _nextCallEarliestTime.Value < deadline)
+                    {
+                        _nextCallEarliestTime = deadline;
+                    }
                 }
             }
 
@@ -287,11 +293,14 @@ namespace DataUtils.Http
             }
             finally
             {
-                lock (this)
+                if (publishSharedDeadline)
                 {
-                    if (_nextCallEarliestTime.HasValue && _nextCallEarliestTime.Value <= _clock.UtcNow)
+                    lock (this)
                     {
-                        _nextCallEarliestTime = null;
+                        if (_nextCallEarliestTime.HasValue && _nextCallEarliestTime.Value <= _clock.UtcNow)
+                        {
+                            _nextCallEarliestTime = null;
+                        }
                     }
                 }
             }
@@ -333,6 +342,31 @@ namespace DataUtils.Http
                 || response.StatusCode == HttpStatusCode.GatewayTimeout;
         }
 
+        private static bool ShouldPublishSharedDeadline(HttpResponseMessage response, bool hasRetryAfterHeader)
+        {
+            if ((int)response.StatusCode == 429)
+            {
+                return true;
+            }
+
+            // A 503 Retry-After is an explicit service not-before signal, so share it across the client. Guessed
+            // fallback delays for 502/503/504 are scoped only to the replayed GET: one flaky endpoint should not
+            // stall unrelated requests on the same ManualGraphCallClient.
+            return response.StatusCode == HttpStatusCode.ServiceUnavailable && hasRetryAfterHeader;
+        }
+
+        private struct RetryDelayDecision
+        {
+            public RetryDelayDecision(TimeSpan delay, bool publishSharedDeadline)
+            {
+                Delay = delay;
+                PublishSharedDeadline = publishSharedDeadline;
+            }
+
+            public TimeSpan Delay { get; }
+            public bool PublishSharedDeadline { get; }
+        }
+
         private static string FormatDelay(TimeSpan delay)
         {
             if (delay < TimeSpan.Zero)
@@ -352,7 +386,9 @@ namespace DataUtils.Http
         /// Transient failures worth retrying at the HTTP layer: a client-side timeout (HttpClient.Timeout
         /// elapsed) surfaces as a <see cref="TaskCanceledException"/>, and a transient socket/DNS failure as an
         /// <see cref="HttpRequestException"/> thrown from the send itself. HTTP status codes are handled
-        /// separately via the response status code.
+        /// separately via the response status code. A caller-requested cancellation also surfaces as
+        /// <see cref="TaskCanceledException"/>, so callers must check their own token before treating this as
+        /// transient; caller cancellation propagates immediately and does not consume another retry.
         /// </summary>
         private static bool IsTransientException(Exception ex)
         {
@@ -381,24 +417,32 @@ namespace DataUtils.Http
         /// <summary>
         /// Total retry/back-off execution budget, in seconds. Retry-After is never clipped to this value: when a
         /// server not-before deadline would exceed the remaining budget, the call fails visibly instead of
-        /// retrying early.
+        /// retrying early. Defaults to 3600 seconds, so the worst-case retry back-off is bounded by this budget
+        /// per retryable response cycle and by MaxRetries for total attempts.
         /// </summary>
-        public int MaxRetryAfterWaitSeconds
+        public int MaxTotalRetryBudgetSeconds
         {
             get
             {
                 lock (_maxRetriesObj)
                 {
-                    return _maxRetryAfterWaitSeconds;
+                    return _maxTotalRetryBudgetSeconds;
                 }
             }
             set
             {
                 lock (_maxRetriesObj)
                 {
-                    _maxRetryAfterWaitSeconds = value;
+                    _maxTotalRetryBudgetSeconds = value;
                 }
             }
+        }
+
+        [Obsolete("Use MaxTotalRetryBudgetSeconds. Retry-After values are no longer clipped to this property; it now forwards to the total retry budget.")]
+        public int MaxRetryAfterWaitSeconds
+        {
+            get { return MaxTotalRetryBudgetSeconds; }
+            set { MaxTotalRetryBudgetSeconds = value; }
         }
         public int ConcurrentCalls
         {

--- a/src/AnalyticsEngine/Common/DataUtils/Http/ConfidentialClientApplicationThrottledHttpClient.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/ConfidentialClientApplicationThrottledHttpClient.cs
@@ -13,12 +13,12 @@ namespace DataUtils.Http
     /// </summary>
     public class ConfidentialClientApplicationThrottledHttpClient : AutoThrottleHttpClient
     {
-        public ConfidentialClientApplicationThrottledHttpClient(HttpMessageHandler server, ILogger logger) : base(server, logger)
+        public ConfidentialClientApplicationThrottledHttpClient(HttpMessageHandler server, ILogger logger, IAutoThrottleHttpClientClock clock = null) : base(server, logger, clock)
         {
         }
 
-        public ConfidentialClientApplicationThrottledHttpClient(ImportAppIndentityOAuthContext appIndentity, bool ignoreRetryHeader, ILogger logger)
-            : base(ignoreRetryHeader, logger, new ConfidentialClientApplicationHttpHandler(appIndentity))
+        public ConfidentialClientApplicationThrottledHttpClient(ImportAppIndentityOAuthContext appIndentity, bool ignoreRetryHeader, ILogger logger, IAutoThrottleHttpClientClock clock = null)
+            : base(ignoreRetryHeader, logger, new ConfidentialClientApplicationHttpHandler(appIndentity), clock)
         {
         }
     }

--- a/src/AnalyticsEngine/Common/DataUtils/Http/HttpClientExtensions.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Http/HttpClientExtensions.cs
@@ -1,19 +1,21 @@
 using Microsoft.Extensions.Logging;
 using System;
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DataUtils.Http
 {
     public static class HttpClientExtensions
     {
-        public static async Task<HttpResponseMessage> GetAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, ILogger logger)
+        public static async Task<HttpResponseMessage> GetAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, ILogger logger, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Default to return when full content is read
-            return await httpClient.GetAsyncWithThrottleRetries(url, HttpCompletionOption.ResponseContentRead, logger);
+            return await httpClient.GetAsyncWithThrottleRetries(url, HttpCompletionOption.ResponseContentRead, logger, cancellationToken);
         }
-        public static async Task<HttpResponseMessage> GetAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, HttpCompletionOption completionOption, ILogger logger)
+        public static async Task<HttpResponseMessage> GetAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, HttpCompletionOption completionOption, ILogger logger, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (httpClient is null)
             {
@@ -30,13 +32,16 @@ namespace DataUtils.Http
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            var response = await httpClient.ExecuteHttpCallWithThrottleRetries(async () => await httpClient.GetAsync(url, completionOption), url);
-
+            var response = await httpClient.ExecuteHttpCallWithThrottleRetries(
+                ct => httpClient.GetAsync(url, completionOption, ct),
+                url,
+                isReplayableIdempotentGet: true,
+                cancellationToken: cancellationToken);
 
             return response;
         }
 
-        public static async Task<HttpResponseMessage> PostAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, object body, ILogger logger)
+        public static async Task<HttpResponseMessage> PostAsyncWithThrottleRetries(this AutoThrottleHttpClient httpClient, string url, object body, ILogger logger, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (httpClient is null)
             {
@@ -54,15 +59,16 @@ namespace DataUtils.Http
             }
 
             var payload = Newtonsoft.Json.JsonConvert.SerializeObject(body);
-            var httpContent = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");
-
-            var response = await httpClient.ExecuteHttpCallWithThrottleRetries(async () => await httpClient.PostAsync(url, httpContent), url);
+            var response = await httpClient.ExecuteHttpCallWithThrottleRetries(
+                ct => httpClient.PostAsync(url, new StringContent(payload, System.Text.Encoding.UTF8, "application/json"), ct),
+                url,
+                cancellationToken: cancellationToken);
 
             return response;
         }
 
 
-        public static async Task<HttpResponseMessage> PostAsyncWithThrottleRetries(this ConfidentialClientApplicationThrottledHttpClient httpClient, string url, string bodyContent, string mimeType, string boundary, ILogger logger)
+        public static async Task<HttpResponseMessage> PostAsyncWithThrottleRetries(this ConfidentialClientApplicationThrottledHttpClient httpClient, string url, string bodyContent, string mimeType, string boundary, ILogger logger, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (httpClient is null)
             {
@@ -79,29 +85,59 @@ namespace DataUtils.Http
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            var body = new StringContent(bodyContent);
-            var header = new MediaTypeHeaderValue(mimeType);
-            header.Parameters.Add(new NameValueHeaderValue("boundary", boundary));
-            body.Headers.ContentType = header;
-
-            var response = await httpClient.ExecuteHttpCallWithThrottleRetries(async () => await httpClient.PostAsync(url, body), url);
+            var response = await httpClient.ExecuteHttpCallWithThrottleRetries(
+                ct =>
+                {
+                    var body = new StringContent(bodyContent);
+                    var header = new MediaTypeHeaderValue(mimeType);
+                    header.Parameters.Add(new NameValueHeaderValue("boundary", boundary));
+                    body.Headers.ContentType = header;
+                    return httpClient.PostAsync(url, body, ct);
+                },
+                url,
+                cancellationToken: cancellationToken);
 
             return response;
         }
 
-        public static int? GetRetryAfterHeaderSeconds(this HttpResponseMessage response)
+        public static int? GetRetryAfterHeaderSeconds(this HttpResponseMessage response, DateTimeOffset? nowUtc = null)
         {
-            int responseWaitVal = 0;
-            response.Headers.TryGetValues("Retry-After", out var r);
+            if (response == null)
+            {
+                return null;
+            }
 
-            if (r != null)
-                foreach (var retryAfterHeaderVal in r)
+            response.Headers.TryGetValues("Retry-After", out var retryAfterHeaderValues);
+
+            if (retryAfterHeaderValues == null)
+            {
+                return null;
+            }
+
+            foreach (var retryAfterHeaderVal in retryAfterHeaderValues)
+            {
+                if (long.TryParse(retryAfterHeaderVal, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds))
                 {
-                    if (int.TryParse(retryAfterHeaderVal, out responseWaitVal))
+                    if (seconds <= 0)
                     {
-                        return responseWaitVal;
+                        return 0;
                     }
+
+                    return seconds > int.MaxValue ? int.MaxValue : (int)seconds;
                 }
+
+                if (DateTimeOffset.TryParse(retryAfterHeaderVal, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var retryAfterDateUtc))
+                {
+                    var now = nowUtc ?? DateTimeOffset.UtcNow;
+                    var delta = retryAfterDateUtc - now.ToUniversalTime();
+                    if (delta <= TimeSpan.Zero)
+                    {
+                        return 0;
+                    }
+
+                    return delta.TotalSeconds >= int.MaxValue ? int.MaxValue : (int)Math.Ceiling(delta.TotalSeconds);
+                }
+            }
 
             return null;
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityReportLoaderTimeoutTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityReportLoaderTimeoutTests.cs
@@ -1,8 +1,13 @@
+using Common.Entities.Config;
 using DataUtils;
 using DataUtils.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI;
@@ -12,20 +17,169 @@ namespace Tests.UnitTests
 {
     /// <summary>
     /// Regression tests for the audit-log download loaders and HTTP timeouts.
-    ///
-    /// A single report/metadata download that timed out threw a <see cref="TaskCanceledException"/> that was
-    /// not caught by the loaders (they only handled <see cref="HttpRequestException"/>), so it propagated all
-    /// the way up through the parallel processor and crashed the whole Office 365 Activity import WebJob.
-    /// These tests assert that a timeout is now handled gracefully - logged, counted, and skipped - so the
-    /// import keeps going and the item is retried on the next cycle.
     /// </summary>
     [TestClass]
     public class ActivityReportLoaderTimeoutTests
     {
-        /// <summary>
-        /// Handler that mimics how <see cref="HttpClient"/> surfaces a timeout on .NET Framework: the request
-        /// completes as a cancelled task (<see cref="TaskCanceledException"/>).
-        /// </summary>
+        [TestMethod]
+        public async Task ActivityReportWebLoader_HttpTimeout_DoesNotCrash_AndCountsError()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+
+            using (var httpClient = new AutoThrottleHttpClient(new TimeoutHttpMessageHandler(), logger))
+            {
+                httpClient.MaxRetries = 1;
+
+                var loader = new ActivityReportWebLoader(httpClient, logger, Guid.Empty.ToString());
+                var metadata = new ActivityReportInfo { ContentUri = new Uri("https://contoso.example/audit/content") };
+
+                var result = await loader.Load(metadata);
+
+                Assert.IsNotNull(result, "A timed-out download should return an (empty) report set, not throw.");
+                Assert.AreEqual(0, result.Count, "A timed-out download should yield no reports.");
+                Assert.AreEqual(1, loader.ReportDownloadErrorCount, "A timed-out download should be counted as a report download error so it is visible and retried next cycle.");
+                Assert.IsFalse(result.DownloadComplete, "Timed-out report downloads must not be checkpointed as complete.");
+            }
+        }
+
+        [TestMethod]
+        public async Task ActivityReportWebLoader_GatewayTimeoutThenOk_RetriesAndKeepsEmptySuccessDistinctFromFailure()
+        {
+            var clock = NewClock();
+            var handler = new SequencedContentHandler(clock, new[]
+            {
+                Response(HttpStatusCode.GatewayTimeout, string.Empty),
+                Response(HttpStatusCode.OK, "[]")
+            });
+
+            using (var httpClient = NewAutoClient(handler, clock))
+            {
+                var loader = new ActivityReportWebLoader(httpClient, AnalyticsLogger.ConsoleOnlyTracer(), Guid.Empty.ToString());
+                var result = await loader.Load(new ActivityReportInfo { ContentUri = new Uri("https://contoso.example/audit/content") });
+
+                Assert.AreEqual(0, result.Count, "A valid empty JSON array is genuine emptiness, not a download failure.");
+                Assert.IsTrue(result.DownloadComplete, "The successful retry should leave the report eligible for checkpointing.");
+                Assert.AreEqual(0, loader.ReportDownloadErrorCount, "The superseded 504 should not be counted once the same report succeeds.");
+            }
+
+            CollectionAssert.AreEqual(new[] { 0, 2 }, AttemptOffsets(clock, handler));
+        }
+
+        [TestMethod]
+        public async Task ActivityReportWebLoader_PermanentHttpError_IsIncompleteNotSuccessfulEmptyData()
+        {
+            var clock = NewClock();
+            var handler = new SequencedContentHandler(clock, new[] { Response(HttpStatusCode.NotFound, "[]") });
+
+            using (var httpClient = NewAutoClient(handler, clock))
+            {
+                var loader = new ActivityReportWebLoader(httpClient, AnalyticsLogger.ConsoleOnlyTracer(), Guid.Empty.ToString());
+                var result = await loader.Load(new ActivityReportInfo { ContentUri = new Uri("https://contoso.example/audit/missing") });
+
+                Assert.AreEqual(0, result.Count);
+                Assert.IsFalse(result.DownloadComplete, "401/403/404 responses must not be converted into successful empty reports.");
+                Assert.AreEqual(1, loader.ReportDownloadErrorCount, "The failed download remains visible in loader error accounting.");
+            }
+
+            CollectionAssert.AreEqual(new[] { 0 }, AttemptOffsets(clock, handler));
+        }
+
+        [TestMethod]
+        public async Task WebContentMetaDataLoader_GetBadGatewayThenOk_RetriesSameMetadataPage()
+        {
+            var clock = NewClock();
+            var handler = new SequencedContentHandler(clock, new[]
+            {
+                Response(HttpStatusCode.BadGateway, string.Empty),
+                Response(HttpStatusCode.OK, MetadataJson("page-1"))
+            });
+
+            using (var httpClient = NewConfidentialClient(handler, clock))
+            {
+                var loader = new WebContentMetaDataLoader(AnalyticsLogger.ConsoleOnlyTracer(), httpClient, NewConfig());
+                var result = await loader.DownloadMetadata("https://contoso.example/metadata?page=1", batchId: 42);
+
+                Assert.AreEqual(1, result.Count);
+                Assert.AreEqual("page-1", result[0].ContentId);
+                Assert.AreEqual(42, result[0].BatchID);
+                Assert.AreEqual(0, loader.MetadataDownloadErrorCount);
+            }
+
+            CollectionAssert.AreEqual(new[] { "https://contoso.example/metadata?page=1", "https://contoso.example/metadata?page=1" }, handler.RequestUris.ToArray());
+            CollectionAssert.AreEqual(new[] { 0, 2 }, AttemptOffsets(clock, handler));
+        }
+
+        [TestMethod]
+        public async Task WebContentMetaDataLoader_ServiceUnavailableRetryAfterThenOk_WaitsFullDeadline()
+        {
+            var clock = NewClock();
+            var handler = new SequencedContentHandler(clock, new[]
+            {
+                Response(HttpStatusCode.ServiceUnavailable, string.Empty, "Retry-After", "45"),
+                Response(HttpStatusCode.OK, MetadataJson("page-1"))
+            });
+
+            using (var httpClient = NewConfidentialClient(handler, clock, budgetSeconds: 90))
+            {
+                var loader = new WebContentMetaDataLoader(AnalyticsLogger.ConsoleOnlyTracer(), httpClient, NewConfig());
+                var result = await loader.DownloadMetadata("https://contoso.example/metadata?page=1", batchId: 42);
+
+                Assert.AreEqual(1, result.Count);
+                Assert.AreEqual(0, loader.MetadataDownloadErrorCount);
+            }
+
+            CollectionAssert.AreEqual(new[] { 0, 45 }, AttemptOffsets(clock, handler));
+        }
+
+        [TestMethod]
+        public async Task WebContentMetaDataLoader_RepeatedGatewayFailures_StopPagingAndCountVisibleFailure()
+        {
+            var clock = NewClock();
+            var handler = new SequencedContentHandler(clock, new[]
+            {
+                Response(HttpStatusCode.BadGateway, string.Empty),
+                Response(HttpStatusCode.BadGateway, string.Empty)
+            });
+
+            using (var httpClient = NewConfidentialClient(handler, clock, maxRetries: 2))
+            {
+                var loader = new WebContentMetaDataLoader(AnalyticsLogger.ConsoleOnlyTracer(), httpClient, NewConfig());
+                var result = await loader.DownloadMetadata("https://contoso.example/metadata?page=1", batchId: 42);
+
+                Assert.AreEqual(0, result.Count, "A failed metadata page must not be reported as a complete empty listing.");
+                Assert.AreEqual(1, loader.MetadataDownloadErrorCount, "Exhausted gateway retries must use the existing visible metadata error accounting.");
+            }
+
+            CollectionAssert.AreEqual(new[] { 0, 2 }, AttemptOffsets(clock, handler));
+        }
+
+        [TestMethod]
+        public async Task WebContentMetaDataLoader_TransientFailureOnLaterPage_RetriesSamePageAndPreservesOrder()
+        {
+            var clock = NewClock();
+            var page2 = "https://contoso.example/metadata?page=2";
+            var handler = new SequencedContentHandler(clock, new[]
+            {
+                Response(HttpStatusCode.OK, MetadataJson("page-1"), "NextPageUri", page2),
+                Response(HttpStatusCode.BadGateway, string.Empty),
+                Response(HttpStatusCode.OK, MetadataJson("page-2"))
+            });
+
+            using (var httpClient = NewConfidentialClient(handler, clock))
+            {
+                var loader = new WebContentMetaDataLoader(AnalyticsLogger.ConsoleOnlyTracer(), httpClient, NewConfig());
+                var result = await loader.DownloadMetadata("https://contoso.example/metadata?page=1", batchId: 42);
+
+                CollectionAssert.AreEqual(new[] { "page-1", "page-2" }, result.Select(r => r.ContentId).ToArray(), "Retrying a later page must not skip the failed page or reorder the suffix.");
+                Assert.AreEqual(0, loader.MetadataDownloadErrorCount);
+            }
+
+            Assert.AreEqual("https://contoso.example/metadata?page=1", handler.RequestUris[0]);
+            Assert.IsTrue(handler.RequestUris[1].StartsWith(page2, StringComparison.Ordinal));
+            Assert.IsTrue(handler.RequestUris[2].StartsWith(page2, StringComparison.Ordinal), "The retry must request the same next-page URI, not skip forward.");
+            CollectionAssert.AreEqual(new[] { 0, 0, 2 }, AttemptOffsets(clock, handler));
+        }
+
         private sealed class TimeoutHttpMessageHandler : HttpMessageHandler
         {
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -34,27 +188,83 @@ namespace Tests.UnitTests
             }
         }
 
-        [TestMethod]
-        public async Task ActivityReportWebLoader_HttpTimeout_DoesNotCrash_AndCountsError()
+        private static AutoThrottleHttpClientTests.FakeRetryClock NewClock()
         {
-            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            return new AutoThrottleHttpClientTests.FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        }
 
-            using (var httpClient = new AutoThrottleHttpClient(new TimeoutHttpMessageHandler(), logger))
+        private static AutoThrottleHttpClient NewAutoClient(HttpMessageHandler handler, AutoThrottleHttpClientTests.FakeRetryClock clock, int budgetSeconds = 60, int maxRetries = 10)
+        {
+            return new AutoThrottleHttpClient(handler, AnalyticsLogger.ConsoleOnlyTracer(), clock)
             {
-                // Don't retry - we're testing the loader's handling of a download that ultimately times out,
-                // not the AutoThrottleHttpClient retry loop (covered by AutoThrottleHttpClientTests). Retrying
-                // 10x with back-off would make this test take ~90s.
-                httpClient.MaxRetries = 1;
+                MaxRetryAfterWaitSeconds = budgetSeconds,
+                MaxRetries = maxRetries
+            };
+        }
 
-                var loader = new ActivityReportWebLoader(httpClient, logger, Guid.Empty.ToString());
-                var metadata = new ActivityReportInfo { ContentUri = new Uri("https://contoso.example/audit/content") };
+        private static ConfidentialClientApplicationThrottledHttpClient NewConfidentialClient(HttpMessageHandler handler, AutoThrottleHttpClientTests.FakeRetryClock clock, int budgetSeconds = 60, int maxRetries = 10)
+        {
+            return new ConfidentialClientApplicationThrottledHttpClient(handler, AnalyticsLogger.ConsoleOnlyTracer(), clock)
+            {
+                MaxRetryAfterWaitSeconds = budgetSeconds,
+                MaxRetries = maxRetries
+            };
+        }
 
-                // Before the fix this threw TaskCanceledException and crashed the import.
-                var result = await loader.Load(metadata);
+        private static AppConfig NewConfig()
+        {
+            var config = (AppConfig)FormatterServices.GetUninitializedObject(typeof(AppConfig));
+            config.TenantGUID = Guid.Empty;
+            return config;
+        }
 
-                Assert.IsNotNull(result, "A timed-out download should return an (empty) report set, not throw.");
-                Assert.AreEqual(0, result.Count, "A timed-out download should yield no reports.");
-                Assert.AreEqual(1, loader.ReportDownloadErrorCount, "A timed-out download should be counted as a report download error so it is visible and retried next cycle.");
+        private static Func<HttpResponseMessage> Response(HttpStatusCode status, string content, string headerName = null, string headerValue = null)
+        {
+            return () =>
+            {
+                var response = new HttpResponseMessage(status) { Content = new StringContent(content ?? string.Empty) };
+                if (!string.IsNullOrEmpty(headerName))
+                {
+                    response.Headers.TryAddWithoutValidation(headerName, headerValue);
+                }
+                return response;
+            };
+        }
+
+        private static string MetadataJson(string contentId)
+        {
+            return "[{\"contentType\":\"Audit.SharePoint\",\"contentId\":\"" + contentId + "\",\"contentUri\":\"https://contoso.example/audit/" + contentId + "\",\"contentCreated\":\"2026-01-01T00:00:00Z\"}]";
+        }
+
+        private static int[] AttemptOffsets(AutoThrottleHttpClientTests.FakeRetryClock clock, SequencedContentHandler handler)
+        {
+            return handler.AttemptTimes.Select(t => (int)(t - clock.StartUtc).TotalSeconds).ToArray();
+        }
+
+        private sealed class SequencedContentHandler : HttpMessageHandler
+        {
+            private readonly AutoThrottleHttpClientTests.FakeRetryClock _clock;
+            private readonly Queue<Func<HttpResponseMessage>> _responses;
+
+            public SequencedContentHandler(AutoThrottleHttpClientTests.FakeRetryClock clock, IEnumerable<Func<HttpResponseMessage>> responses)
+            {
+                _clock = clock;
+                _responses = new Queue<Func<HttpResponseMessage>>(responses);
+            }
+
+            public List<DateTimeOffset> AttemptTimes { get; } = new List<DateTimeOffset>();
+            public List<string> RequestUris { get; } = new List<string>();
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                AttemptTimes.Add(_clock.UtcNow);
+                RequestUris.Add(request.RequestUri.ToString());
+                if (_responses.Count == 0)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[]") });
+                }
+
+                return Task.FromResult(_responses.Dequeue()());
             }
         }
     }

--- a/src/AnalyticsEngine/Tests.UnitTests/ActivityReportLoaderTimeoutTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ActivityReportLoaderTimeoutTests.cs
@@ -119,7 +119,7 @@ namespace Tests.UnitTests
                 Response(HttpStatusCode.OK, MetadataJson("page-1"))
             });
 
-            using (var httpClient = NewConfidentialClient(handler, clock, budgetSeconds: 90))
+            using (var httpClient = NewConfidentialClient(handler, clock, retryBudgetSeconds: 90))
             {
                 var loader = new WebContentMetaDataLoader(AnalyticsLogger.ConsoleOnlyTracer(), httpClient, NewConfig());
                 var result = await loader.DownloadMetadata("https://contoso.example/metadata?page=1", batchId: 42);
@@ -193,20 +193,20 @@ namespace Tests.UnitTests
             return new AutoThrottleHttpClientTests.FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
         }
 
-        private static AutoThrottleHttpClient NewAutoClient(HttpMessageHandler handler, AutoThrottleHttpClientTests.FakeRetryClock clock, int budgetSeconds = 60, int maxRetries = 10)
+        private static AutoThrottleHttpClient NewAutoClient(HttpMessageHandler handler, AutoThrottleHttpClientTests.FakeRetryClock clock, int retryBudgetSeconds = 60, int maxRetries = 10)
         {
             return new AutoThrottleHttpClient(handler, AnalyticsLogger.ConsoleOnlyTracer(), clock)
             {
-                MaxRetryAfterWaitSeconds = budgetSeconds,
+                MaxTotalRetryBudgetSeconds = retryBudgetSeconds,
                 MaxRetries = maxRetries
             };
         }
 
-        private static ConfidentialClientApplicationThrottledHttpClient NewConfidentialClient(HttpMessageHandler handler, AutoThrottleHttpClientTests.FakeRetryClock clock, int budgetSeconds = 60, int maxRetries = 10)
+        private static ConfidentialClientApplicationThrottledHttpClient NewConfidentialClient(HttpMessageHandler handler, AutoThrottleHttpClientTests.FakeRetryClock clock, int retryBudgetSeconds = 60, int maxRetries = 10)
         {
             return new ConfidentialClientApplicationThrottledHttpClient(handler, AnalyticsLogger.ConsoleOnlyTracer(), clock)
             {
-                MaxRetryAfterWaitSeconds = budgetSeconds,
+                MaxTotalRetryBudgetSeconds = retryBudgetSeconds,
                 MaxRetries = maxRetries
             };
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/AutoThrottleHttpClientTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AutoThrottleHttpClientTests.cs
@@ -3,6 +3,7 @@ using DataUtils.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -20,7 +21,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "600"), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 900))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 900))
             using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -35,7 +36,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "30"), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 120))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 120))
             using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -52,7 +53,7 @@ namespace Tests.UnitTests
             var retryAt = start.AddSeconds(120).UtcDateTime.ToString("r");
             var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", retryAt), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 300))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 300))
             using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -67,7 +68,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "600"), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 180))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 180))
             {
                 await AssertThrowsAsync<HttpRequestException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()));
             }
@@ -85,7 +86,7 @@ namespace Tests.UnitTests
                 HeaderStatus((HttpStatusCode)429, "Retry-After", "20"),
                 Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 60))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 60))
             using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -107,7 +108,7 @@ namespace Tests.UnitTests
                 HeaderStatus((HttpStatusCode)429, "Retry-After", past),
                 Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 60))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 60))
             using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -122,7 +123,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "999999999999"), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 3600))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 3600))
             {
                 await AssertThrowsAsync<HttpRequestException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()));
             }
@@ -139,7 +140,7 @@ namespace Tests.UnitTests
             {
                 clock.BeforeDelay = (delay, token) => cts.Cancel();
 
-                using (var client = NewClient(handler, clock, budgetSeconds: 900))
+                using (var client = NewClient(handler, clock, retryBudgetSeconds: 900))
                 {
                     await AssertThrowsAsync<OperationCanceledException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer(), cts.Token));
                 }
@@ -149,12 +150,60 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_CancellationDuringBackoffDisposesHeadersReadResponse()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var content = new DisposalTrackingContent();
+            var handler = SequencedHandler.FromStatuses(clock, () =>
+            {
+                var response = new HttpResponseMessage((HttpStatusCode)429) { Content = content };
+                response.Headers.TryAddWithoutValidation("Retry-After", "600");
+                return response;
+            }, Status(HttpStatusCode.OK));
+
+            using (var cts = new CancellationTokenSource())
+            {
+                clock.BeforeDelay = (delay, token) => cts.Cancel();
+
+                using (var client = NewClient(handler, clock, retryBudgetSeconds: 900))
+                {
+                    await AssertThrowsAsync<OperationCanceledException>(() => client.GetAsyncWithThrottleRetries(
+                        "https://contoso.example/throttled",
+                        HttpCompletionOption.ResponseHeadersRead,
+                        AnalyticsLogger.ConsoleOnlyTracer(),
+                        cts.Token));
+                }
+            }
+
+            AssertAttemptOffsets(clock, handler, 0);
+            Assert.IsTrue(content.Disposed, "The discarded 429 response content must be disposed even when cancellation interrupts the backoff.");
+        }
+
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_CallerCancellationDuringRequestPropagatesWithoutRetry()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            using (var cts = new CancellationTokenSource())
+            {
+                var handler = new CallerCanceledHandler(clock, cts);
+
+                using (var client = NewClient(handler, clock, retryBudgetSeconds: 30))
+                {
+                    await AssertThrowsAsync<TaskCanceledException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/cancelled", AnalyticsLogger.ConsoleOnlyTracer(), cts.Token));
+                }
+
+                AssertAttemptOffsets(clock, handler, 0);
+                Assert.AreEqual(TimeSpan.Zero, clock.Elapsed, "Caller cancellation during the request must not consume a retry/backoff attempt.");
+            }
+        }
+
+        [TestMethod]
         public async Task GetAsyncWithThrottleRetries_RetriesGatewayResponsesForIdempotentGet()
         {
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = SequencedHandler.FromStatuses(clock, Status(HttpStatusCode.BadGateway), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 30))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 30))
             using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/gateway", AnalyticsLogger.ConsoleOnlyTracer()))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -170,7 +219,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = SequencedHandler.FromStatuses(clock, HeaderStatus(HttpStatusCode.ServiceUnavailable, "Retry-After", "45"), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 90))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 90))
             using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/gateway", AnalyticsLogger.ConsoleOnlyTracer()))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -185,7 +234,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = SequencedHandler.FromStatuses(clock, Status(HttpStatusCode.GatewayTimeout), Status(HttpStatusCode.GatewayTimeout), Status(HttpStatusCode.GatewayTimeout), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 30, maxRetries: 3))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 30, maxRetries: 3))
             {
                 await AssertThrowsAsync<HttpRequestException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/gateway", AnalyticsLogger.ConsoleOnlyTracer()));
             }
@@ -201,7 +250,7 @@ namespace Tests.UnitTests
                 var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
                 var handler = SequencedHandler.FromStatuses(clock, Status(status), Status(HttpStatusCode.OK));
 
-                using (var client = NewClient(handler, clock, budgetSeconds: 30))
+                using (var client = NewClient(handler, clock, retryBudgetSeconds: 30))
                 using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/client-error", AnalyticsLogger.ConsoleOnlyTracer()))
                 {
                     Assert.AreEqual(status, response.StatusCode);
@@ -217,7 +266,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = SequencedHandler.FromStatuses(clock, Status(HttpStatusCode.BadGateway), Status(HttpStatusCode.OK));
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 30))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 30))
             using (var response = await client.PostAsyncWithThrottleRetries("https://contoso.example/post", new { value = "synthetic" }, AnalyticsLogger.ConsoleOnlyTracer()))
             {
                 Assert.AreEqual(HttpStatusCode.BadGateway, response.StatusCode);
@@ -233,7 +282,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = new TimeoutThenOkHandler(clock, timeoutsBeforeSuccess: 1);
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 30))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 30))
             using (var response = await client.ExecuteHttpCallWithThrottleRetries(ct => client.GetAsync("https://contoso.example/timeout", ct), "https://contoso.example/timeout", isReplayableIdempotentGet: true))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "A transient timeout should be retried and then succeed.");
@@ -248,7 +297,7 @@ namespace Tests.UnitTests
             var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
             var handler = new TimeoutThenOkHandler(clock, timeoutsBeforeSuccess: int.MaxValue);
 
-            using (var client = NewClient(handler, clock, budgetSeconds: 30, maxRetries: 2))
+            using (var client = NewClient(handler, clock, retryBudgetSeconds: 30, maxRetries: 2))
             {
                 await AssertThrowsAsync<TaskCanceledException>(() => client.ExecuteHttpCallWithThrottleRetries(ct => client.GetAsync("https://contoso.example/timeout", ct), "https://contoso.example/timeout", isReplayableIdempotentGet: true));
             }
@@ -256,11 +305,11 @@ namespace Tests.UnitTests
             AssertAttemptOffsets(clock, handler, 0, 2);
         }
 
-        private static AutoThrottleHttpClient NewClient(HttpMessageHandler handler, FakeRetryClock clock, int budgetSeconds, int maxRetries = 10)
+        private static AutoThrottleHttpClient NewClient(HttpMessageHandler handler, FakeRetryClock clock, int retryBudgetSeconds, int maxRetries = 10)
         {
             return new AutoThrottleHttpClient(handler, AnalyticsLogger.ConsoleOnlyTracer(), clock)
             {
-                MaxRetryAfterWaitSeconds = budgetSeconds,
+                MaxTotalRetryBudgetSeconds = retryBudgetSeconds,
                 MaxRetries = maxRetries
             };
         }
@@ -395,6 +444,48 @@ namespace Tests.UnitTests
                 }
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+
+        private sealed class CallerCanceledHandler : RecordingHandler
+        {
+            private readonly CancellationTokenSource _cts;
+
+            public CallerCanceledHandler(FakeRetryClock clock, CancellationTokenSource cts) : base(clock)
+            {
+                _cts = cts;
+            }
+
+            protected override Task<HttpResponseMessage> SendRecordedAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _cts.Cancel();
+                return Task.FromCanceled<HttpResponseMessage>(cancellationToken);
+            }
+        }
+
+        private sealed class DisposalTrackingContent : HttpContent
+        {
+            public bool Disposed { get; private set; }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                return Task.FromResult(0);
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = 0;
+                return true;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Disposed = true;
+                }
+
+                base.Dispose(disposing);
             }
         }
     }

--- a/src/AnalyticsEngine/Tests.UnitTests/AutoThrottleHttpClientTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AutoThrottleHttpClientTests.cs
@@ -2,7 +2,8 @@ using DataUtils;
 using DataUtils.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -13,133 +14,386 @@ namespace Tests.UnitTests
     [TestClass]
     public class AutoThrottleHttpClientTests
     {
-        /// <summary>
-        /// A very large 'retry-after' value must be capped at MaxRetryAfterWaitSeconds rather than sleeping the
-        /// calling thread for the whole duration - the fix that prevents a single throttling response from
-        /// stalling an import for minutes/hours.
-        /// </summary>
         [TestMethod]
-        public async Task ExecuteHttpCallWithThrottleRetries_CapsLargeRetryAfter()
+        public async Task ExecuteHttpCallWithThrottleRetries_HonoursFullRetryAfterWithoutClipping()
         {
-            var logger = AnalyticsLogger.ConsoleOnlyTracer();
-            var handler = new SequencedThrottleHandler(retryAfterSeconds: 3600); // server asks for a full hour
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "600"), Status(HttpStatusCode.OK));
 
-            using (var client = new AutoThrottleHttpClient(handler, logger))
+            using (var client = NewClient(handler, clock, budgetSeconds: 900))
+            using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
             {
-                client.MaxRetryAfterWaitSeconds = 1; // cap low so the test is fast
-
-                var sw = Stopwatch.StartNew();
-                var response = await client.ExecuteHttpCallWithThrottleRetries(
-                    () => client.GetAsync("https://example.test/throttled"),
-                    "https://example.test/throttled");
-                sw.Stop();
-
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-                Assert.AreEqual(2, handler.CallCount, "Should have retried exactly once after the capped wait");
-                Assert.IsTrue(sw.Elapsed.TotalSeconds < 30,
-                    $"Back-off should be capped near 1s (not the 3600s the header asked for) - was {sw.Elapsed.TotalSeconds:F1}s");
+            }
+
+            AssertAttemptOffsets(clock, handler, 0, 600);
+        }
+
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_DelayShorterThanBudgetStillWaitsFullDelay()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "30"), Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 120))
+            using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+
+            AssertAttemptOffsets(clock, handler, 0, 30);
+        }
+
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_HonoursHttpDateRetryAfter()
+        {
+            var start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var clock = new FakeRetryClock(start);
+            var retryAt = start.AddSeconds(120).UtcDateTime.ToString("r");
+            var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", retryAt), Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 300))
+            using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+
+            AssertAttemptOffsets(clock, handler, 0, 120);
+        }
+
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_DelayBeyondBudgetFailsWithoutEarlyRetry()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "600"), Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 180))
+            {
+                await AssertThrowsAsync<HttpRequestException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()));
+            }
+
+            AssertAttemptOffsets(clock, handler, 0);
+            Assert.AreEqual(TimeSpan.Zero, clock.Elapsed, "The client must not shorten the server's deadline to fit the local budget.");
+        }
+
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_RepeatedRetryAfterHintsEachSetANewDeadline()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock,
+                HeaderStatus((HttpStatusCode)429, "Retry-After", "10"),
+                HeaderStatus((HttpStatusCode)429, "Retry-After", "20"),
+                Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 60))
+            using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+
+            AssertAttemptOffsets(clock, handler, 0, 10, 30);
+        }
+
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_MissingMalformedZeroAndPastRetryAfterUseBoundedFallbacks()
+        {
+            var start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var clock = new FakeRetryClock(start);
+            var past = start.AddSeconds(-10).UtcDateTime.ToString("r");
+            var handler = SequencedHandler.FromStatuses(clock,
+                Status((HttpStatusCode)429),
+                HeaderStatus((HttpStatusCode)429, "Retry-After", "not-a-date"),
+                HeaderStatus((HttpStatusCode)429, "Retry-After", "0"),
+                HeaderStatus((HttpStatusCode)429, "Retry-After", past),
+                Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 60))
+            using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+
+            AssertAttemptOffsets(clock, handler, 0, 2, 6, 7, 8);
+        }
+
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_VeryLargeRetryAfterFailsSafelyWithoutOverflowOrBusyLoop()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "999999999999"), Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 3600))
+            {
+                await AssertThrowsAsync<HttpRequestException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer()));
+            }
+
+            AssertAttemptOffsets(clock, handler, 0);
+        }
+
+        [TestMethod]
+        public async Task ExecuteHttpCallWithThrottleRetries_CancellationDuringBackoffStopsBeforeNextAttempt()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, HeaderStatus((HttpStatusCode)429, "Retry-After", "600"), Status(HttpStatusCode.OK));
+            using (var cts = new CancellationTokenSource())
+            {
+                clock.BeforeDelay = (delay, token) => cts.Cancel();
+
+                using (var client = NewClient(handler, clock, budgetSeconds: 900))
+                {
+                    await AssertThrowsAsync<OperationCanceledException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/throttled", AnalyticsLogger.ConsoleOnlyTracer(), cts.Token));
+                }
+            }
+
+            AssertAttemptOffsets(clock, handler, 0);
+        }
+
+        [TestMethod]
+        public async Task GetAsyncWithThrottleRetries_RetriesGatewayResponsesForIdempotentGet()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, Status(HttpStatusCode.BadGateway), Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 30))
+            using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/gateway", AnalyticsLogger.ConsoleOnlyTracer()))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+
+            AssertAttemptOffsets(clock, handler, 0, 2);
+            CollectionAssert.AreEqual(new[] { HttpMethod.Get, HttpMethod.Get }, handler.Requests.Select(r => r.Method).ToArray());
+        }
+
+        [TestMethod]
+        public async Task GetAsyncWithThrottleRetries_ServiceUnavailableHonoursRetryAfter()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, HeaderStatus(HttpStatusCode.ServiceUnavailable, "Retry-After", "45"), Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 90))
+            using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/gateway", AnalyticsLogger.ConsoleOnlyTracer()))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+
+            AssertAttemptOffsets(clock, handler, 0, 45);
+        }
+
+        [TestMethod]
+        public async Task GetAsyncWithThrottleRetries_RepeatedGatewayFailuresRespectAttemptLimitAndRemainVisible()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, Status(HttpStatusCode.GatewayTimeout), Status(HttpStatusCode.GatewayTimeout), Status(HttpStatusCode.GatewayTimeout), Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 30, maxRetries: 3))
+            {
+                await AssertThrowsAsync<HttpRequestException>(() => client.GetAsyncWithThrottleRetries("https://contoso.example/gateway", AnalyticsLogger.ConsoleOnlyTracer()));
+            }
+
+            AssertAttemptOffsets(clock, handler, 0, 2, 6);
+        }
+
+        [TestMethod]
+        public async Task GetAsyncWithThrottleRetries_DoesNotRetryPermanentClientErrors()
+        {
+            foreach (var status in new[] { HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden, HttpStatusCode.NotFound })
+            {
+                var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+                var handler = SequencedHandler.FromStatuses(clock, Status(status), Status(HttpStatusCode.OK));
+
+                using (var client = NewClient(handler, clock, budgetSeconds: 30))
+                using (var response = await client.GetAsyncWithThrottleRetries("https://contoso.example/client-error", AnalyticsLogger.ConsoleOnlyTracer()))
+                {
+                    Assert.AreEqual(status, response.StatusCode);
+                }
+
+                AssertAttemptOffsets(clock, handler, 0);
             }
         }
 
-        /// <summary>
-        /// A client-side HTTP timeout surfaces as a TaskCanceledException. It is not an HTTP 429, so it must be
-        /// retried by the transient-error path (previously it propagated and aborted the whole import).
-        /// </summary>
+        [TestMethod]
+        public async Task PostAsyncWithThrottleRetries_DoesNotUseIdempotentGatewayRetryPolicy()
+        {
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = SequencedHandler.FromStatuses(clock, Status(HttpStatusCode.BadGateway), Status(HttpStatusCode.OK));
+
+            using (var client = NewClient(handler, clock, budgetSeconds: 30))
+            using (var response = await client.PostAsyncWithThrottleRetries("https://contoso.example/post", new { value = "synthetic" }, AnalyticsLogger.ConsoleOnlyTracer()))
+            {
+                Assert.AreEqual(HttpStatusCode.BadGateway, response.StatusCode);
+            }
+
+            AssertAttemptOffsets(clock, handler, 0);
+            Assert.AreEqual(HttpMethod.Post, handler.Requests[0].Method);
+        }
+
         [TestMethod]
         public async Task ExecuteHttpCallWithThrottleRetries_RetriesTransientTimeout_ThenSucceeds()
         {
-            var logger = AnalyticsLogger.ConsoleOnlyTracer();
-            var handler = new TimeoutThenOkHandler(timeoutsBeforeSuccess: 1); // one timeout, then 200 OK
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = new TimeoutThenOkHandler(clock, timeoutsBeforeSuccess: 1);
 
-            using (var client = new AutoThrottleHttpClient(handler, logger))
+            using (var client = NewClient(handler, clock, budgetSeconds: 30))
+            using (var response = await client.ExecuteHttpCallWithThrottleRetries(ct => client.GetAsync("https://contoso.example/timeout", ct), "https://contoso.example/timeout", isReplayableIdempotentGet: true))
             {
-                var response = await client.ExecuteHttpCallWithThrottleRetries(
-                    () => client.GetAsync("https://example.test/timeout"),
-                    "https://example.test/timeout");
-
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "A transient timeout should be retried and then succeed.");
-                Assert.AreEqual(2, handler.CallCount, "Should have retried exactly once after the timeout.");
             }
+
+            AssertAttemptOffsets(clock, handler, 0, 2);
         }
 
-        /// <summary>
-        /// A genuinely dead endpoint (every call times out) must still surface to the caller after MaxRetries -
-        /// the retry loop must give up and rethrow rather than spin forever.
-        /// </summary>
         [TestMethod]
         public async Task ExecuteHttpCallWithThrottleRetries_GivesUpAndRethrows_OnPersistentTimeout()
         {
-            var logger = AnalyticsLogger.ConsoleOnlyTracer();
-            var handler = new TimeoutThenOkHandler(timeoutsBeforeSuccess: int.MaxValue); // always times out
+            var clock = new FakeRetryClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var handler = new TimeoutThenOkHandler(clock, timeoutsBeforeSuccess: int.MaxValue);
 
-            using (var client = new AutoThrottleHttpClient(handler, logger))
+            using (var client = NewClient(handler, clock, budgetSeconds: 30, maxRetries: 2))
             {
-                client.MaxRetries = 2; // keep the test fast
+                await AssertThrowsAsync<TaskCanceledException>(() => client.ExecuteHttpCallWithThrottleRetries(ct => client.GetAsync("https://contoso.example/timeout", ct), "https://contoso.example/timeout", isReplayableIdempotentGet: true));
+            }
 
-                TaskCanceledException caught = null;
-                try
-                {
-                    await client.ExecuteHttpCallWithThrottleRetries(
-                        () => client.GetAsync("https://example.test/timeout"),
-                        "https://example.test/timeout");
-                }
-                catch (TaskCanceledException ex)
-                {
-                    caught = ex;
-                }
+            AssertAttemptOffsets(clock, handler, 0, 2);
+        }
 
-                Assert.IsNotNull(caught, "A persistent timeout must be rethrown to the caller after MaxRetries.");
-                Assert.AreEqual(2, handler.CallCount, "Should have attempted exactly MaxRetries times before giving up.");
+        private static AutoThrottleHttpClient NewClient(HttpMessageHandler handler, FakeRetryClock clock, int budgetSeconds, int maxRetries = 10)
+        {
+            return new AutoThrottleHttpClient(handler, AnalyticsLogger.ConsoleOnlyTracer(), clock)
+            {
+                MaxRetryAfterWaitSeconds = budgetSeconds,
+                MaxRetries = maxRetries
+            };
+        }
+
+        private static Func<HttpResponseMessage> Status(HttpStatusCode status)
+        {
+            return () => new HttpResponseMessage(status) { Content = new StringContent(string.Empty) };
+        }
+
+        private static Func<HttpResponseMessage> HeaderStatus(HttpStatusCode status, string headerName, string headerValue)
+        {
+            return () =>
+            {
+                var response = new HttpResponseMessage(status) { Content = new StringContent(string.Empty) };
+                response.Headers.TryAddWithoutValidation(headerName, headerValue);
+                return response;
+            };
+        }
+
+        private static void AssertAttemptOffsets(FakeRetryClock clock, RecordingHandler handler, params int[] expectedSeconds)
+        {
+            CollectionAssert.AreEqual(expectedSeconds, handler.Requests.Select(r => (int)(r.TimestampUtc - clock.StartUtc).TotalSeconds).ToArray());
+        }
+
+        private static async Task<TException> AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
+        {
+            try
+            {
+                await action();
+            }
+            catch (TException ex)
+            {
+                return ex;
+            }
+
+            Assert.Fail($"Expected {typeof(TException).Name}.");
+            return null;
+        }
+
+        public sealed class FakeRetryClock : IAutoThrottleHttpClientClock
+        {
+            public FakeRetryClock(DateTimeOffset startUtc)
+            {
+                StartUtc = startUtc;
+                UtcNow = startUtc;
+            }
+
+            public DateTimeOffset StartUtc { get; }
+            public DateTimeOffset UtcNow { get; private set; }
+            public TimeSpan Elapsed => UtcNow - StartUtc;
+            public Action<TimeSpan, CancellationToken> BeforeDelay { get; set; }
+
+            public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+            {
+                BeforeDelay?.Invoke(delay, cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+                UtcNow = UtcNow.Add(delay);
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(0);
             }
         }
 
-        /// <summary>Returns 429 with a Retry-After header on the first call, then 200 OK.</summary>
-        private class SequencedThrottleHandler : HttpMessageHandler
+        private sealed class RequestRecord
         {
-            private int _callCount;
-            private readonly int _retryAfterSeconds;
-            public int CallCount => _callCount;
+            public DateTimeOffset TimestampUtc { get; set; }
+            public HttpMethod Method { get; set; }
+            public Uri RequestUri { get; set; }
+        }
 
-            public SequencedThrottleHandler(int retryAfterSeconds)
+        private abstract class RecordingHandler : HttpMessageHandler
+        {
+            private readonly FakeRetryClock _clock;
+            private readonly List<RequestRecord> _requests = new List<RequestRecord>();
+
+            protected RecordingHandler(FakeRetryClock clock)
             {
-                _retryAfterSeconds = retryAfterSeconds;
+                _clock = clock;
             }
+
+            public List<RequestRecord> Requests => _requests;
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                var call = Interlocked.Increment(ref _callCount);
-                if (call == 1)
+                _requests.Add(new RequestRecord { TimestampUtc = _clock.UtcNow, Method = request.Method, RequestUri = request.RequestUri });
+                return SendRecordedAsync(request, cancellationToken);
+            }
+
+            protected abstract Task<HttpResponseMessage> SendRecordedAsync(HttpRequestMessage request, CancellationToken cancellationToken);
+        }
+
+        private sealed class SequencedHandler : RecordingHandler
+        {
+            private readonly Queue<Func<HttpResponseMessage>> _responses;
+
+            private SequencedHandler(FakeRetryClock clock, IEnumerable<Func<HttpResponseMessage>> responses) : base(clock)
+            {
+                _responses = new Queue<Func<HttpResponseMessage>>(responses);
+            }
+
+            public static SequencedHandler FromStatuses(FakeRetryClock clock, params Func<HttpResponseMessage>[] responses)
+            {
+                return new SequencedHandler(clock, responses);
+            }
+
+            protected override Task<HttpResponseMessage> SendRecordedAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (_responses.Count == 0)
                 {
-                    var throttled = new HttpResponseMessage((HttpStatusCode)429);
-                    throttled.Headers.TryAddWithoutValidation("Retry-After", _retryAfterSeconds.ToString());
-                    return Task.FromResult(throttled);
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
                 }
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+
+                return Task.FromResult(_responses.Dequeue()());
             }
         }
 
-        /// <summary>
-        /// Faults with a TaskCanceledException (how a client-side HTTP timeout surfaces) for the first N calls,
-        /// then returns 200 OK. Set <paramref name="timeoutsBeforeSuccess"/> to int.MaxValue to always time out.
-        /// </summary>
-        private class TimeoutThenOkHandler : HttpMessageHandler
+        private sealed class TimeoutThenOkHandler : RecordingHandler
         {
             private int _callCount;
             private readonly int _timeoutsBeforeSuccess;
-            public int CallCount => _callCount;
 
-            public TimeoutThenOkHandler(int timeoutsBeforeSuccess)
+            public TimeoutThenOkHandler(FakeRetryClock clock, int timeoutsBeforeSuccess) : base(clock)
             {
                 _timeoutsBeforeSuccess = timeoutsBeforeSuccess;
             }
 
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            protected override Task<HttpResponseMessage> SendRecordedAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                var call = Interlocked.Increment(ref _callCount);
-                if (call <= _timeoutsBeforeSuccess)
+                _callCount++;
+                if (_callCount <= _timeoutsBeforeSuccess)
                 {
                     return Task.FromException<HttpResponseMessage>(new TaskCanceledException("Simulated HTTP timeout."));
                 }
+
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             }
         }

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Loaders/ActivityReportLoader.cs
@@ -76,6 +76,17 @@ namespace WebJob.Office365ActivityImporter.Engine.ActivityAPI.Loaders
             {
                 var logs = new WebActivityReportSet();
 
+                try
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+                catch (HttpRequestException ex)
+                {
+                    Interlocked.Increment(ref _reportDownloadErrors);
+                    _logger.LogError(ex, $"Got HTTP error '{ex.Message}' downloading {metadata.ContentUri}. Will try again on next cycle.");
+                    return new WebActivityReportSet { DownloadComplete = false };
+                }
+
                 // Stream one JSON object at a time from the response, so the entire array is never materialised
                 // in memory at once. Each JObject is processed and dropped before the next is read.
                 try


### PR DESCRIPTION
## Summary
- Addresses #496 by replacing blocking `Thread.Sleep`/`DateTime.Now` retry waits with an injectable UTC clock and cancellable async delay.
- Honors `Retry-After` seconds and HTTP-date values as full not-before deadlines; `MaxTotalRetryBudgetSeconds` is now the total retry/backoff budget, so over-budget deadlines fail visibly instead of retrying early.
- Addresses #497 by retrying HTTP 502/503/504 only for replayable idempotent GET calls; POST and permanent 401/403/404 responses are not opted into the gateway retry policy.

## Code changes
- Added optional `CancellationToken` and replayable-GET metadata to HTTP retry APIs without breaking existing call sites.
- Added safe handling for missing, malformed, zero, past-dated, and oversized `Retry-After` headers.
- Disposes superseded retry responses before another attempt, including when caller cancellation interrupts a `ResponseHeadersRead` backoff.
- Propagates caller cancellation during request execution immediately; `TaskCanceledException` is retried only when the caller token was not cancelled, preserving HTTP-timeout retry behavior without converting caller cancellation into a transient retry.
- Keeps metadata/report failures visible and incomplete after retry exhaustion; report downloads now `EnsureSuccessStatusCode()` before parsing so permanent HTTP errors cannot become successful empty arrays.

## Retry budget and not-before scope
- Renamed the budget property to `MaxTotalRetryBudgetSeconds`; the old `MaxRetryAfterWaitSeconds` name remains as an `[Obsolete]` forwarding alias for compatibility.
- New default retry budget is 3600 seconds, replacing the previous 180-second single-sleep cap. With default `MaxRetries = 10`, the conservative operator-visible ceiling to reason about is budget x attempts = 3600s x 10, although the implementation applies one total wall-clock retry budget per call so it never clips a server `Retry-After` to fit an individual attempt.
- 429 deadlines remain client-wide because they represent throttling for the shared service/client. 503 with an explicit `Retry-After` is also shared because it is a service not-before signal. Guessed fallback delays for 502/503/504 are scoped only to the current replayed GET so one flaky endpoint does not stall unrelated requests sharing the same client.

## Test contract change
- Rewrote the old `ExecuteHttpCallWithThrottleRetries_CapsLargeRetryAfter` contract because that test asserted the #496 bug: clipping a server `Retry-After: 3600` to a shorter local cap. The replacement tests assert the new contract instead: a retry never happens before the full server not-before deadline, and if that deadline exceeds the remaining retry budget the call fails visibly without making an early network attempt.

## Tests added/expanded
- Expanded `AutoThrottleHttpClientTests` with virtual-time assertions for Retry-After deadlines, budget exhaustion, repeated hints, malformed/zero/past/huge headers, cancellation during request and backoff, `ResponseHeadersRead` disposal during cancelled backoff, GET gateway retries, and POST/client-error non-retry behavior.
- Expanded `ActivityReportLoaderTimeoutTests` for same-page metadata retries, later-page pagination order, retry exhaustion accounting, 504 report retry success, and permanent HTTP error incompleteness.

## Validation
- `MSBuild.exe src\AnalyticsEngine\Tests.UnitTests\Tests.UnitTests.csproj -t:Restore -p:Configuration=Release -p:Platform=anycpu -p:ProcessorArchitecture=x86` using VS 18 Enterprise — passed.
- `MSBuild.exe src\AnalyticsEngine\Tests.UnitTests\Tests.UnitTests.csproj -p:Configuration=Release -p:Platform=anycpu -p:ProcessorArchitecture=x86` using VS 18 Enterprise — passed.
- Targeted tests after patching generated local test config: `vstest.console.exe ... /TestCaseFilter:"FullyQualifiedName~AutoThrottleHttpClientTests|FullyQualifiedName~ActivityReportLoaderTimeoutTests"` — passed, 24/24.
- Broad local baseline filter after `Patch-LocalTestConfig.ps1` — total 202, passed 201, failed 1. The only failure was the expected credential-dependent `GraphUsageReportImportTests.SharePointSitesUsageLoaderTest` (`AADSTS700038` for the synthetic zeroed app id), matching the known local baseline behavior.

## Reviewer hotspots
- `MaxTotalRetryBudgetSeconds` semantic repurpose from the old per-sleep `MaxRetryAfterWaitSeconds` cap to total execution/retry budget.
- `isReplayableIdempotentGet` default remains false; only `GetAsyncWithThrottleRetries` opts into 502/503/504 replay.
- `ActivityReportWebLoader` now treats non-success HTTP responses as incomplete downloads before JSON parsing.