### PR TITLE
Bound Graph user imports and delta recovery

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserMetadataLoader.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/FakeLoaderClasses/FakeUserMetadataLoader.cs
@@ -2,6 +2,7 @@ using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.Graph;
 
@@ -29,6 +30,7 @@ namespace Tests.UnitTests.FakeLoaderClasses
         /// committed vs uncommitted import without extra setup.
         /// </summary>
         public string SimulatedNewDeltaToken { get; set; } = "fake-new-delta";
+        public bool ThrowOnCommitDeltaToken { get; set; }
 
         /// <summary>
         /// When non-null AND the delta provider already has a token (i.e. this is
@@ -135,6 +137,11 @@ namespace Tests.UnitTests.FakeLoaderClasses
         {
             if (_hasPendingDeltaToken)
             {
+                if (ThrowOnCommitDeltaToken)
+                {
+                    throw new InvalidOperationException("simulated delta persistence failure");
+                }
+
                 await _deltaProvider.SetDeltaToken(_pendingDeltaToken);
                 _pendingDeltaToken = null;
                 _hasPendingDeltaToken = false;
@@ -149,19 +156,22 @@ namespace Tests.UnitTests.FakeLoaderClasses
     {
         private string _deltaToken;
 
-        public Task ClearDeltaToken()
+        public Task ClearDeltaToken(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             _deltaToken = null;
             return Task.CompletedTask;
         }
 
-        public Task<string> GetDeltaToken()
+        public Task<string> GetDeltaToken(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(_deltaToken);
         }
 
-        public Task SetDeltaToken(string deltaToken)
+        public Task SetDeltaToken(string deltaToken, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             _deltaToken = deltaToken;
             return Task.CompletedTask;
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphBoundedRequestAndDeltaTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphBoundedRequestAndDeltaTests.cs
@@ -60,6 +60,20 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public async Task BoundedGraphRequestHandler_NonGetRequest_IsDeadlineBoundedButNotRetried()
+        {
+            var terminal = new SequenceHttpHandler(
+                async ct => { await Task.Delay(TimeSpan.FromSeconds(5), ct); return new HttpResponseMessage(HttpStatusCode.OK); });
+            var client = BuildBoundedClient(terminal, timeoutRetryCount: 3, perRequestMs: 25, totalBudgetMs: 500);
+
+            await Assert.ThrowsExceptionAsync<TimeoutException>(() => client.PostAsync(
+                "https://graph.microsoft.com/v1.0/teams",
+                new StringContent("{}")));
+
+            Assert.AreEqual(1, terminal.Attempts, "Non-GET SDK calls must keep a request deadline but must not be retried by the local timeout policy.");
+        }
+
+        [TestMethod]
         public async Task RedisDeltaProvider_ReadUnavailableWithCommittedToken_UsesSafeFallbackOnlyAfterCommit()
         {
             var store = new FakeStringValueStore();
@@ -136,6 +150,24 @@ namespace Tests.UnitTests
             Assert.IsNull(await second.GetDeltaToken(), "A token committed for one synthetic tenant/configuration scope must not be reused for another.");
         }
 
+        [TestMethod]
+        public async Task RedisDeltaProvider_CancellationDuringBackoff_StopsWithoutFurtherAttempts()
+        {
+            var store = new FakeStringValueStore { ThrowOnGet = true };
+            var provider = new RedisProcessDeltaValueProvider(
+                BuildConfig(8),
+                AnalyticsLogger.ConsoleOnlyTracer(),
+                store,
+                new DeltaTokenStoreRetryOptions(3, TimeSpan.FromSeconds(5)));
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(25)))
+            {
+                await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => provider.GetDeltaToken(cts.Token));
+            }
+
+            Assert.AreEqual(1, store.GetAttempts, "Cancellation during Redis retry backoff must stop promptly instead of waiting for the bounded delay.");
+        }
+
         private static HttpClient BuildBoundedClient(SequenceHttpHandler terminal, int timeoutRetryCount, int perRequestMs, int totalBudgetMs)
         {
             var handler = new BoundedGraphRequestHandler(
@@ -156,16 +188,18 @@ namespace Tests.UnitTests
         }
 
         private static RedisProcessDeltaValueProvider BuildDeltaProvider(FakeStringValueStore store, int tenantSeed)
+            => new RedisProcessDeltaValueProvider(
+                BuildConfig(tenantSeed),
+                AnalyticsLogger.ConsoleOnlyTracer(),
+                store,
+                new DeltaTokenStoreRetryOptions(3, TimeSpan.Zero));
+
+        private static AppConfig BuildConfig(int tenantSeed)
         {
             var config = (AppConfig)FormatterServices.GetUninitializedObject(typeof(AppConfig));
             config.TenantGUID = Guid.Parse($"00000000-0000-0000-0000-00000000000{tenantSeed}");
             config.ConnectionStrings = new AppConnectionStrings();
-
-            return new RedisProcessDeltaValueProvider(
-                config,
-                AnalyticsLogger.ConsoleOnlyTracer(),
-                store,
-                new DeltaTokenStoreRetryOptions(3, TimeSpan.Zero));
+            return config;
         }
 
         private sealed class SequenceHttpHandler : HttpMessageHandler
@@ -216,4 +250,3 @@ namespace Tests.UnitTests
         }
     }
 }
-

--- a/src/AnalyticsEngine/Tests.UnitTests/GraphBoundedRequestAndDeltaTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/GraphBoundedRequestAndDeltaTests.cs
@@ -1,0 +1,219 @@
+using Common.Entities.Config;
+using DataUtils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.Serialization;
+using WebJob.Office365ActivityImporter.Engine.Graph;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    public class GraphBoundedRequestAndDeltaTests
+    {
+        [TestMethod]
+        public async Task BoundedGraphRequestHandler_RequestTimeoutThenHealthyResponse_RetriesSamePageOnly()
+        {
+            var terminal = new SequenceHttpHandler(
+                async ct => { await Task.Delay(TimeSpan.FromSeconds(5), ct); return new HttpResponseMessage(HttpStatusCode.OK); },
+                ct => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+            var client = BuildBoundedClient(terminal, timeoutRetryCount: 1, perRequestMs: 25, totalBudgetMs: 500);
+
+            var response = await client.GetAsync("https://graph.microsoft.com/v1.0/users");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(2, terminal.Attempts, "Only the timed-out page request should be retried; the tenant crawl is not restarted by this handler.");
+        }
+
+        [TestMethod]
+        public async Task BoundedGraphRequestHandler_RepeatedTimeouts_StopsInsideExplicitBudget()
+        {
+            var terminal = new SequenceHttpHandler(
+                async ct => { await Task.Delay(TimeSpan.FromSeconds(5), ct); return new HttpResponseMessage(HttpStatusCode.OK); },
+                async ct => { await Task.Delay(TimeSpan.FromSeconds(5), ct); return new HttpResponseMessage(HttpStatusCode.OK); });
+            var client = BuildBoundedClient(terminal, timeoutRetryCount: 1, perRequestMs: 25, totalBudgetMs: 200);
+            var sw = Stopwatch.StartNew();
+
+            await Assert.ThrowsExceptionAsync<TimeoutException>(() => client.GetAsync("https://graph.microsoft.com/v1.0/users"));
+
+            Assert.AreEqual(2, terminal.Attempts);
+            Assert.IsTrue(sw.Elapsed < TimeSpan.FromSeconds(2), "The test timeout budget should bound elapsed time deterministically.");
+        }
+
+        [TestMethod]
+        public async Task BoundedGraphRequestHandler_CallerCancellation_IsNotRetriedAsTransientTimeout()
+        {
+            var terminal = new SequenceHttpHandler(
+                async ct => { await Task.Delay(TimeSpan.FromSeconds(5), ct); return new HttpResponseMessage(HttpStatusCode.OK); });
+            var client = BuildBoundedClient(terminal, timeoutRetryCount: 3, perRequestMs: 5000, totalBudgetMs: 6000);
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(25)))
+            {
+                await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => client.GetAsync("https://graph.microsoft.com/v1.0/users", cts.Token));
+            }
+
+            Assert.AreEqual(1, terminal.Attempts, "Shutdown/caller cancellation must stop promptly and must not consume timeout retry attempts.");
+        }
+
+        [TestMethod]
+        public async Task RedisDeltaProvider_ReadUnavailableWithCommittedToken_UsesSafeFallbackOnlyAfterCommit()
+        {
+            var store = new FakeStringValueStore();
+            var provider = BuildDeltaProvider(store, tenantSeed: 1);
+            await provider.SetDeltaToken("committed-token");
+            store.ThrowOnGet = true;
+
+            var token = await provider.GetDeltaToken();
+
+            Assert.AreEqual("committed-token", token);
+            Assert.AreEqual(3, store.GetAttempts, "The unavailable read is bounded before the last committed in-process checkpoint is used.");
+        }
+
+        [TestMethod]
+        public async Task RedisDeltaProvider_ReadUnavailableWithNoSafeFallback_DefersInsteadOfInventingMiss()
+        {
+            var store = new FakeStringValueStore { ThrowOnGet = true };
+            var provider = BuildDeltaProvider(store, tenantSeed: 2);
+
+            await Assert.ThrowsExceptionAsync<DeltaTokenUnavailableException>(() => provider.GetDeltaToken());
+
+            Assert.AreEqual(3, store.GetAttempts);
+        }
+
+        [TestMethod]
+        public async Task RedisDeltaProvider_ConfirmedMissingKey_ReturnsNullForExplicitFullEnumerationPath()
+        {
+            var store = new FakeStringValueStore();
+            var provider = BuildDeltaProvider(store, tenantSeed: 3);
+
+            var token = await provider.GetDeltaToken();
+
+            Assert.IsNull(token, "A successful Redis read with no value remains the deliberate first-run/full-load path.");
+        }
+
+        [TestMethod]
+        public async Task RedisDeltaProvider_WriteFailureSurfacesAndDoesNotCreateFallbackCheckpoint()
+        {
+            var store = new FakeStringValueStore { ThrowOnSet = true };
+            var provider = BuildDeltaProvider(store, tenantSeed: 4);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => provider.SetDeltaToken("pending-token"));
+            store.ThrowOnSet = false;
+            store.ThrowOnGet = true;
+
+            await Assert.ThrowsExceptionAsync<DeltaTokenUnavailableException>(() => provider.GetDeltaToken());
+        }
+
+        [TestMethod]
+        public async Task RedisDeltaProvider_StoreRecovers_ResumesPersistedCheckpointWithoutOperatorAction()
+        {
+            var store = new FakeStringValueStore();
+            var provider = BuildDeltaProvider(store, tenantSeed: 5);
+            await provider.SetDeltaToken("first-committed-token");
+            store.ThrowOnGet = true;
+            Assert.AreEqual("first-committed-token", await provider.GetDeltaToken());
+
+            store.ThrowOnGet = false;
+            await provider.SetDeltaToken("second-committed-token");
+
+            Assert.AreEqual("second-committed-token", await provider.GetDeltaToken());
+        }
+
+        [TestMethod]
+        public async Task RedisDeltaProvider_MultipleSyntheticScopes_DoNotReuseCheckpoints()
+        {
+            var store = new FakeStringValueStore();
+            var first = BuildDeltaProvider(store, tenantSeed: 6);
+            var second = BuildDeltaProvider(store, tenantSeed: 7);
+
+            await first.SetDeltaToken("contoso-scope-a-token");
+
+            Assert.AreEqual("contoso-scope-a-token", await first.GetDeltaToken());
+            Assert.IsNull(await second.GetDeltaToken(), "A token committed for one synthetic tenant/configuration scope must not be reused for another.");
+        }
+
+        private static HttpClient BuildBoundedClient(SequenceHttpHandler terminal, int timeoutRetryCount, int perRequestMs, int totalBudgetMs)
+        {
+            var handler = new BoundedGraphRequestHandler(
+                new GraphRequestBudgetOptions(
+                    TimeSpan.FromMilliseconds(perRequestMs),
+                    timeoutRetryCount,
+                    TimeSpan.FromMilliseconds(1),
+                    TimeSpan.FromMilliseconds(totalBudgetMs),
+                    0,
+                    0,
+                    TimeSpan.FromMilliseconds(totalBudgetMs)),
+                AnalyticsLogger.ConsoleOnlyTracer())
+            {
+                InnerHandler = terminal
+            };
+
+            return new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan };
+        }
+
+        private static RedisProcessDeltaValueProvider BuildDeltaProvider(FakeStringValueStore store, int tenantSeed)
+        {
+            var config = (AppConfig)FormatterServices.GetUninitializedObject(typeof(AppConfig));
+            config.TenantGUID = Guid.Parse($"00000000-0000-0000-0000-00000000000{tenantSeed}");
+            config.ConnectionStrings = new AppConnectionStrings();
+
+            return new RedisProcessDeltaValueProvider(
+                config,
+                AnalyticsLogger.ConsoleOnlyTracer(),
+                store,
+                new DeltaTokenStoreRetryOptions(3, TimeSpan.Zero));
+        }
+
+        private sealed class SequenceHttpHandler : HttpMessageHandler
+        {
+            private readonly Queue<Func<CancellationToken, Task<HttpResponseMessage>>> _responses;
+            public int Attempts { get; private set; }
+
+            public SequenceHttpHandler(params Func<CancellationToken, Task<HttpResponseMessage>>[] responses)
+            {
+                _responses = new Queue<Func<CancellationToken, Task<HttpResponseMessage>>>(responses);
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Attempts++;
+                return _responses.Count == 0
+                    ? Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK))
+                    : _responses.Dequeue()(cancellationToken);
+            }
+        }
+
+        private sealed class FakeStringValueStore : IStringValueStore
+        {
+            private readonly Dictionary<string, string> _values = new Dictionary<string, string>(StringComparer.Ordinal);
+            public bool ThrowOnGet { get; set; }
+            public bool ThrowOnSet { get; set; }
+            public int GetAttempts { get; private set; }
+
+            public Task<string> GetString(string key)
+            {
+                GetAttempts++;
+                if (ThrowOnGet) throw new InvalidOperationException("synthetic Redis outage");
+                return Task.FromResult(_values.TryGetValue(key, out var value) ? value : null);
+            }
+
+            public Task SetString(string key, string value)
+            {
+                if (ThrowOnSet) throw new InvalidOperationException("synthetic Redis write outage");
+                _values[key] = value;
+                return Task.CompletedTask;
+            }
+
+            public Task DeleteString(string key)
+            {
+                _values.Remove(key);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}
+

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -215,6 +215,7 @@
     <Compile Include="FakeLoaderClasses\FakeOrgUrlStore.cs" />
     <Compile Include="FakeLoaderClasses\FakeCallsPorts.cs" />
     <Compile Include="FakeLoaderClasses\FakeGraphImportSections.cs" />
+    <Compile Include="GraphBoundedRequestAndDeltaTests.cs" />
     <Compile Include="GraphImportOrchestrationTests.cs" />
     <Compile Include="GraphImportSectionCompositionTests.cs" />
     <Compile Include="ImportRuntimeOptionsTests.cs" />
@@ -535,3 +536,5 @@
     <TransformXml Source="App.Template.config" Transform="App.$(Configuration).config" Destination="App.config" />
   </Target>
 </Project>
+
+

--- a/src/AnalyticsEngine/Tests.UnitTests/UserLicenseRefreshTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserLicenseRefreshTests.cs
@@ -643,6 +643,78 @@ namespace Tests.UnitTests
             }
         }
 
+        [TestMethod]
+        public async Task UserLicenseRefresh_FailureAfterOneSkuPage_DoesNotReconcilePartialInventory()
+        {
+            var tick = DateTime.Now.Ticks;
+            var userAUpn = $"licencepartialA{tick}@test.com";
+            var userBUpn = $"licencepartialB{tick}@test.com";
+            await RemoveTestUsers(userAUpn, userBUpn);
+
+            var skuAId = Guid.NewGuid();
+            var skuBId = Guid.NewGuid();
+            var initialSkus = new List<SubscribedSku>
+            {
+                new SubscribedSku { SkuId = skuAId, SkuPartNumber = "ENTERPRISEPACK" },
+                new SubscribedSku { SkuId = skuBId, SkuPartNumber = "ENTERPRISEPREMIUM" }
+            };
+
+            try
+            {
+                using (var db = new AnalyticsEntitiesContext())
+                {
+                    var userA = await InsertUser(db, userAUpn);
+                    var userB = await InsertUser(db, userBUpn);
+                    var users = new List<Common.Entities.User> { userA, userB };
+
+                    var setupLoader = new FakeUserMetadataLoader(null, initialSkus,
+                        new Dictionary<Guid, List<SkuUser>>
+                        {
+                            { skuAId, new List<SkuUser> { new SkuUser { UserPrincipalName = userAUpn } } },
+                            { skuBId, new List<SkuUser> { new SkuUser { UserPrincipalName = userBUpn } } }
+                        });
+
+                    await new UserLicenseProcessor(AnalyticsLogger.ConsoleOnlyTracer(), setupLoader, new UserMetadataCache(db))
+                        .ProcessSKUsForAllUsers(initialSkus, users, db);
+                    Assert.AreEqual(1, await CountLookups(db, userA.ID));
+                    Assert.AreEqual(1, await CountLookups(db, userB.ID));
+
+                    var partialLoader = new FakeUserMetadataLoader(null, initialSkus,
+                        new Dictionary<Guid, List<SkuUser>>
+                        {
+                            { skuAId, new List<SkuUser> { new SkuUser { UserPrincipalName = userAUpn } } },
+                            { skuBId, new List<SkuUser> { new SkuUser { UserPrincipalName = userBUpn } } }
+                        });
+                    var loadedSkuAPage = false;
+                    partialLoader.OnLoadUsersBySku = skuId =>
+                    {
+                        if (skuId == skuAId)
+                        {
+                            loadedSkuAPage = true;
+                            return Task.CompletedTask;
+                        }
+
+                        throw new InvalidOperationException("simulated failure after a partial SKU-holder inventory");
+                    };
+                    var recorder = new RecordingUserLicenseStore(new SqlUserLicenseStore(db, AnalyticsLogger.ConsoleOnlyTracer()));
+
+                    await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                        new UserLicenseProcessor(AnalyticsLogger.ConsoleOnlyTracer(), partialLoader, new UserMetadataCache(db), _ => recorder)
+                            .ProcessSKUsForAllUsers(initialSkus, users, db));
+
+                    Assert.IsTrue(loadedSkuAPage, "The failure must occur after at least one SKU-holder page has been read.");
+                    Assert.AreEqual(0, recorder.Operations.Count,
+                        "A partial SKU-holder inventory must not be reconciled as complete; writes happen only after every SKU has been read.");
+                    Assert.AreEqual(1, await CountLookups(db, userA.ID));
+                    Assert.AreEqual(1, await CountLookups(db, userB.ID));
+                }
+            }
+            finally
+            {
+                await RemoveTestUsers(userAUpn, userBUpn);
+            }
+        }
+
         #endregion
 
         #region Helpers

--- a/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterLicenseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UserMetadataUpdaterLicenseTests.cs
@@ -707,6 +707,61 @@ namespace Tests.UnitTests
         }
 
         [TestMethod]
+        public async Task UserMetadataUpdater_DeltaPersistenceFailsAfterDatabaseSave_ReplayIsIdempotent()
+        {
+            var logger = AnalyticsLogger.ConsoleOnlyTracer();
+            var config = new AppConfig();
+
+            var userId = Guid.NewGuid().ToString();
+            var userUpn = $"deltawritefail{DateTime.Now.Ticks}@test.com";
+
+            using (var cleanupDb = new AnalyticsEntitiesContext())
+            {
+                var existingTestUser = await cleanupDb.users
+                    .Include(u => u.LicenseLookups)
+                    .Where(u => u.UserPrincipalName == userUpn)
+                    .FirstOrDefaultAsync();
+                if (existingTestUser != null)
+                {
+                    cleanupDb.UserLicenseTypeLookups.RemoveRange(existingTestUser.LicenseLookups);
+                    cleanupDb.users.Remove(existingTestUser);
+                    await cleanupDb.SaveChangesAsync();
+                }
+            }
+
+            var graphUser = new GraphUser { UserPrincipalName = userUpn, Id = userId, AccountEnabled = true, Mail = userUpn };
+            var fakeLoader = new FakeUserMetadataLoader(new List<GraphUser> { graphUser });
+            fakeLoader.SimulatedNewDeltaToken = "delta-write-that-fails";
+            fakeLoader.ThrowOnCommitDeltaToken = true;
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                async () => await new UserMetadataUpdater(logger, config, fakeLoader).InsertAndUpdateDatabaseFromExternalUsers(),
+                "A delta persistence failure after DB work must remain visible to the caller.");
+
+            Assert.IsNull(await fakeLoader.DeltaValueProvider.GetDeltaToken(),
+                "The pending delta token must not become a recovery checkpoint when persistence fails.");
+
+            using (var verifyDb = new AnalyticsEntitiesContext())
+            {
+                Assert.AreEqual(1, await verifyDb.users.CountAsync(u => u.UserPrincipalName == userUpn),
+                    "The database save already succeeded before the delta write failed; replay must therefore be idempotent rather than assuming rollback.");
+            }
+
+            fakeLoader.ThrowOnCommitDeltaToken = false;
+            fakeLoader.SimulatedNewDeltaToken = "delta-after-idempotent-replay";
+
+            await new UserMetadataUpdater(logger, config, fakeLoader).InsertAndUpdateDatabaseFromExternalUsers();
+
+            using (var verifyDb = new AnalyticsEntitiesContext())
+            {
+                Assert.AreEqual(1, await verifyDb.users.CountAsync(u => u.UserPrincipalName == userUpn),
+                    "Replaying after an uncommitted delta write must update the same user, not insert a duplicate.");
+            }
+
+            Assert.AreEqual("delta-after-idempotent-replay", await fakeLoader.DeltaValueProvider.GetDeltaToken());
+        }
+
+        [TestMethod]
         public async Task UserMetadataUpdater_LicenceRefreshSpansEntireDb_NotJustDeltaUsers()
         {
             // Regression test for the licence-count drift bug seen against tenants

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/BoundedGraphRequestHandler.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/BoundedGraphRequestHandler.cs
@@ -8,7 +8,8 @@ using System.Threading.Tasks;
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
     /// <summary>
-    /// Retries idempotent SDK HTTP reads only when this process' request deadline expires.
+    /// Applies a deadline to every SDK HTTP request and retries idempotent reads only when
+    /// this process' request deadline expires.
     /// Kiota's RetryHandler still owns Graph-directed HTTP retries such as 429/503/504 and
     /// Retry-After. Caller cancellation is never treated as a transient timeout.
     /// </summary>
@@ -25,15 +26,11 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (!IsRetryableRead(request))
-            {
-                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            }
-
             var started = Stopwatch.StartNew();
             TaskCanceledException lastTimeout = null;
+            var maxAttempts = IsRetryableRead(request) ? _options.MaxAttempts : 1;
 
-            for (var attempt = 1; attempt <= _options.MaxAttempts; attempt++)
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -53,16 +50,16 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                         var response = await base.SendAsync(requestForAttempt, requestDeadline.Token).ConfigureAwait(false);
                         if (attempt > 1)
                         {
-                            _logger?.LogInformation($"Graph user import request succeeded on timeout attempt {attempt:N0} after {started.ElapsedMilliseconds:N0} ms.");
+                            _logger?.LogInformation($"Graph import SDK request succeeded on timeout attempt {attempt:N0} after {started.ElapsedMilliseconds:N0} ms.");
                         }
                         return response;
                     }
                     catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested && requestDeadline.IsCancellationRequested)
                     {
                         lastTimeout = ex;
-                        _logger?.LogWarning($"Graph user import request attempt {attempt:N0}/{_options.MaxAttempts:N0} exceeded its {timeout.TotalSeconds:N0}s deadline after {started.ElapsedMilliseconds:N0} ms.");
+                        _logger?.LogWarning($"Graph import SDK request attempt {attempt:N0}/{maxAttempts:N0} exceeded its {timeout.TotalSeconds:N0}s deadline after {started.ElapsedMilliseconds:N0} ms.");
 
-                        if (attempt >= _options.MaxAttempts || started.Elapsed >= _options.TotalTimeoutRetryBudget)
+                        if (attempt >= maxAttempts || started.Elapsed >= _options.TotalTimeoutRetryBudget)
                         {
                             throw new TimeoutException(BuildExhaustedMessage(attempt, started.Elapsed), ex);
                         }
@@ -77,15 +74,15 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                 }
             }
 
-            throw new TimeoutException(BuildExhaustedMessage(_options.MaxAttempts, started.Elapsed), lastTimeout);
+            throw new TimeoutException(BuildExhaustedMessage(maxAttempts, started.Elapsed), lastTimeout);
         }
 
         private static bool IsRetryableRead(HttpRequestMessage request)
             => request.Method == HttpMethod.Get || request.Method == HttpMethod.Head;
 
         private string BuildExhaustedMessage(int attempts, TimeSpan elapsed)
-            => $"Graph user import request deadline exhausted after {attempts:N0} attempt(s) and {elapsed.TotalSeconds:N1}s. " +
-               "The user/licence import is deferred; the previous committed delta checkpoint remains in force.";
+            => $"Graph import SDK request deadline exhausted after {attempts:N0} attempt(s) and {elapsed.TotalSeconds:N1}s. " +
+               "The affected Graph import section is deferred; any previous committed checkpoint remains in force.";
 
         private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request)
         {

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/BoundedGraphRequestHandler.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/BoundedGraphRequestHandler.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Retries idempotent SDK HTTP reads only when this process' request deadline expires.
+    /// Kiota's RetryHandler still owns Graph-directed HTTP retries such as 429/503/504 and
+    /// Retry-After. Caller cancellation is never treated as a transient timeout.
+    /// </summary>
+    internal sealed class BoundedGraphRequestHandler : DelegatingHandler
+    {
+        private readonly GraphRequestBudgetOptions _options;
+        private readonly ILogger _logger;
+
+        public BoundedGraphRequestHandler(GraphRequestBudgetOptions options, ILogger logger)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (!IsRetryableRead(request))
+            {
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+
+            var started = Stopwatch.StartNew();
+            TaskCanceledException lastTimeout = null;
+
+            for (var attempt = 1; attempt <= _options.MaxAttempts; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var remaining = _options.TotalTimeoutRetryBudget - started.Elapsed;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    throw new TimeoutException(BuildExhaustedMessage(attempt - 1, started.Elapsed), lastTimeout);
+                }
+
+                var timeout = remaining < _options.PerRequestTimeout ? remaining : _options.PerRequestTimeout;
+                using (var requestDeadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                {
+                    requestDeadline.CancelAfter(timeout);
+                    var requestForAttempt = attempt == 1 ? request : await CloneRequestAsync(request).ConfigureAwait(false);
+                    try
+                    {
+                        var response = await base.SendAsync(requestForAttempt, requestDeadline.Token).ConfigureAwait(false);
+                        if (attempt > 1)
+                        {
+                            _logger?.LogInformation($"Graph user import request succeeded on timeout attempt {attempt:N0} after {started.ElapsedMilliseconds:N0} ms.");
+                        }
+                        return response;
+                    }
+                    catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested && requestDeadline.IsCancellationRequested)
+                    {
+                        lastTimeout = ex;
+                        _logger?.LogWarning($"Graph user import request attempt {attempt:N0}/{_options.MaxAttempts:N0} exceeded its {timeout.TotalSeconds:N0}s deadline after {started.ElapsedMilliseconds:N0} ms.");
+
+                        if (attempt >= _options.MaxAttempts || started.Elapsed >= _options.TotalTimeoutRetryBudget)
+                        {
+                            throw new TimeoutException(BuildExhaustedMessage(attempt, started.Elapsed), ex);
+                        }
+                    }
+                }
+
+                var delayRemaining = _options.TotalTimeoutRetryBudget - started.Elapsed;
+                if (_options.TimeoutRetryDelay > TimeSpan.Zero && delayRemaining > TimeSpan.Zero)
+                {
+                    var delay = delayRemaining < _options.TimeoutRetryDelay ? delayRemaining : _options.TimeoutRetryDelay;
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            throw new TimeoutException(BuildExhaustedMessage(_options.MaxAttempts, started.Elapsed), lastTimeout);
+        }
+
+        private static bool IsRetryableRead(HttpRequestMessage request)
+            => request.Method == HttpMethod.Get || request.Method == HttpMethod.Head;
+
+        private string BuildExhaustedMessage(int attempts, TimeSpan elapsed)
+            => $"Graph user import request deadline exhausted after {attempts:N0} attempt(s) and {elapsed.TotalSeconds:N1}s. " +
+               "The user/licence import is deferred; the previous committed delta checkpoint remains in force.";
+
+        private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Version = request.Version
+            };
+
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            foreach (var property in request.Properties)
+            {
+                clone.Properties[property.Key] = property.Value;
+            }
+
+            if (request.Content != null)
+            {
+                var bytes = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                clone.Content = new ByteArrayContent(bytes);
+                foreach (var header in request.Content.Headers)
+                {
+                    clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            return clone;
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/DeltaValueProvider.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/DeltaValueProvider.cs
@@ -2,15 +2,20 @@ using Common.Entities.Config;
 using Common.Entities.Redis;
 using DataUtils;
 using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
+    /// <summary>
+    /// Interface for delta token provider
+    /// </summary>
     public interface IDeltaValueProvider
     {
-        Task<string> GetDeltaToken();
-        Task SetDeltaToken(string deltaToken);
-        Task ClearDeltaToken();
+        Task<string> GetDeltaToken(CancellationToken cancellationToken = default);
+        Task SetDeltaToken(string deltaToken, CancellationToken cancellationToken = default);
+        Task ClearDeltaToken(CancellationToken cancellationToken = default);
     }
 
     public sealed class DeltaTokenUnavailableException : Exception
@@ -55,6 +60,9 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         public TimeSpan Delay { get; }
     }
 
+    /// <summary>
+    /// In-process delta token provider. Used when no Redis connection string is provided.
+    /// </summary>
     public class InProcessDeltaValueProvider : IDeltaValueProvider
     {
         private readonly AnalyticsLogger _logger;
@@ -64,15 +72,17 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             _logger = logger;
         }
 
-        public Task ClearDeltaToken()
+        public Task ClearDeltaToken(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             _deltaToken = null;
             _logger.LogWarning($"Cleared in-memory delta token for tenant.");
             return Task.CompletedTask;
         }
 
-        public Task<string> GetDeltaToken()
+        public Task<string> GetDeltaToken(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (string.IsNullOrEmpty(_deltaToken))
             {
                 _logger.LogWarning($"No in-memory delta token found.");
@@ -84,14 +94,18 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             return Task.FromResult(_deltaToken);
         }
 
-        public Task SetDeltaToken(string deltaToken)
+        public Task SetDeltaToken(string deltaToken, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             _logger.LogInformation($"Setting in-memory delta token.");
             _deltaToken = deltaToken;
             return Task.CompletedTask;
         }
     }
 
+    /// <summary>
+    /// Redis-based delta token provider. Used when Redis connection string is provided.
+    /// </summary>
     public class RedisProcessDeltaValueProvider : IDeltaValueProvider
     {
         private readonly IStringValueStore _store;
@@ -113,20 +127,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             _retryOptions = retryOptions ?? DeltaTokenStoreRetryOptions.Default;
         }
 
-        public async Task ClearDeltaToken()
+        public async Task ClearDeltaToken(CancellationToken cancellationToken = default)
         {
             var key = GetRedisUserDeltaCacheKey();
-            await ExecuteWithRetry(() => _store.DeleteString(key), "delete");
+            await ExecuteWithRetry(() => _store.DeleteString(key), "delete", cancellationToken);
             _lastKnownCommittedDeltaToken = null;
             _logger.LogWarning($"Cleared persisted user delta token.");
         }
 
-        public async Task<string> GetDeltaToken()
+        public async Task<string> GetDeltaToken(CancellationToken cancellationToken = default)
         {
             var key = GetRedisUserDeltaCacheKey();
             try
             {
-                var usersQueryDelta = await ExecuteWithRetry(() => _store.GetString(key), "read");
+                var usersQueryDelta = await ExecuteWithRetry(() => _store.GetString(key), "read", cancellationToken);
                 if (string.IsNullOrEmpty(usersQueryDelta))
                 {
                     _logger.LogWarning($"No persisted user delta token found; a confirmed first-run/full-enumeration path will be used.");
@@ -151,19 +165,20 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
         }
 
-        public async Task SetDeltaToken(string deltaToken)
+        public async Task SetDeltaToken(string deltaToken, CancellationToken cancellationToken = default)
         {
             var key = GetRedisUserDeltaCacheKey();
             _logger.LogInformation($"Setting persisted user delta token.");
-            await ExecuteWithRetry(() => _store.SetString(key, deltaToken), "write");
+            await ExecuteWithRetry(() => _store.SetString(key, deltaToken), "write", cancellationToken);
             _lastKnownCommittedDeltaToken = deltaToken;
         }
 
-        private async Task<T> ExecuteWithRetry<T>(Func<Task<T>> action, string operation)
+        private async Task<T> ExecuteWithRetry<T>(Func<Task<T>> action, string operation, CancellationToken cancellationToken)
         {
             Exception last = null;
             for (var attempt = 1; attempt <= _retryOptions.MaxAttempts; attempt++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
                     return await action();
@@ -183,21 +198,22 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
                     _logger?.LogWarning($"User delta token store {operation} attempt {attempt:N0}/{_retryOptions.MaxAttempts:N0} failed ({ex.GetType().Name}); retrying.");
                     if (_retryOptions.Delay > TimeSpan.Zero)
                     {
-                        await Task.Delay(_retryOptions.Delay);
+                        await Task.Delay(_retryOptions.Delay, cancellationToken);
                     }
                 }
             }
 
-            throw last;
+            ExceptionDispatchInfo.Capture(last).Throw();
+            throw new InvalidOperationException("Unreachable retry state.");
         }
 
-        private async Task ExecuteWithRetry(Func<Task> action, string operation)
+        private async Task ExecuteWithRetry(Func<Task> action, string operation, CancellationToken cancellationToken)
         {
             await ExecuteWithRetry(async () =>
             {
                 await action();
                 return true;
-            }, operation);
+            }, operation, cancellationToken);
         }
 
         string GetRedisUserDeltaCacheKey()
@@ -206,5 +222,4 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         }
     }
 }
-
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/DeltaValueProvider.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/DeltaValueProvider.cs
@@ -1,13 +1,11 @@
 using Common.Entities.Config;
 using Common.Entities.Redis;
 using DataUtils;
+using System;
 using System.Threading.Tasks;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
-    /// <summary>
-    /// Interface for delta token provider
-    /// </summary>
     public interface IDeltaValueProvider
     {
         Task<string> GetDeltaToken();
@@ -15,9 +13,48 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         Task ClearDeltaToken();
     }
 
-    /// <summary>
-    /// In-process delta token provider. Used when no Redis connection string is provided.
-    /// </summary>
+    public sealed class DeltaTokenUnavailableException : Exception
+    {
+        public DeltaTokenUnavailableException(string message, Exception innerException) : base(message, innerException) { }
+    }
+
+    internal interface IStringValueStore
+    {
+        Task<string> GetString(string key);
+        Task SetString(string key, string value);
+        Task DeleteString(string key);
+    }
+
+    internal sealed class CacheConnectionStringValueStore : IStringValueStore
+    {
+        private readonly CacheConnectionManager _cache;
+
+        public CacheConnectionStringValueStore(CacheConnectionManager cache)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        }
+
+        public Task<string> GetString(string key) => _cache.GetString(key);
+        public Task SetString(string key, string value) => _cache.SetString(key, value);
+        public Task DeleteString(string key) => _cache.DeleteString(key);
+    }
+
+    internal sealed class DeltaTokenStoreRetryOptions
+    {
+        public static readonly DeltaTokenStoreRetryOptions Default = new DeltaTokenStoreRetryOptions(3, TimeSpan.FromSeconds(2));
+
+        public DeltaTokenStoreRetryOptions(int maxAttempts, TimeSpan delay)
+        {
+            if (maxAttempts < 1) throw new ArgumentOutOfRangeException(nameof(maxAttempts));
+            if (delay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
+            MaxAttempts = maxAttempts;
+            Delay = delay;
+        }
+
+        public int MaxAttempts { get; }
+        public TimeSpan Delay { get; }
+    }
+
     public class InProcessDeltaValueProvider : IDeltaValueProvider
     {
         private readonly AnalyticsLogger _logger;
@@ -55,55 +92,119 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         }
     }
 
-    /// <summary>
-    /// Redis-based delta token provider. Used when Redis connection string is provided.
-    /// </summary>
     public class RedisProcessDeltaValueProvider : IDeltaValueProvider
     {
-        private readonly CacheConnectionManager _cacheConnectionManager;
+        private readonly IStringValueStore _store;
         private readonly AppConfig _appConfig;
         private readonly AnalyticsLogger _logger;
+        private readonly DeltaTokenStoreRetryOptions _retryOptions;
+        private string _lastKnownCommittedDeltaToken;
 
         public RedisProcessDeltaValueProvider(AppConfig appConfig, DataUtils.AnalyticsLogger logger)
+            : this(appConfig, logger, new CacheConnectionStringValueStore(CacheConnectionManager.GetConnectionManager(appConfig.ConnectionStrings.RedisConnectionString, tenantId: appConfig.TenantGUID.ToString(), clientId: appConfig.ClientID, clientSecret: appConfig.ClientSecret)), DeltaTokenStoreRetryOptions.Default)
         {
-            _cacheConnectionManager = CacheConnectionManager.GetConnectionManager(appConfig.ConnectionStrings.RedisConnectionString, tenantId: appConfig.TenantGUID.ToString(), clientId: appConfig.ClientID, clientSecret: appConfig.ClientSecret);
-            _appConfig = appConfig;
+        }
+
+        internal RedisProcessDeltaValueProvider(AppConfig appConfig, DataUtils.AnalyticsLogger logger, IStringValueStore store, DeltaTokenStoreRetryOptions retryOptions)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _appConfig = appConfig ?? throw new ArgumentNullException(nameof(appConfig));
             _logger = logger;
+            _retryOptions = retryOptions ?? DeltaTokenStoreRetryOptions.Default;
         }
 
         public async Task ClearDeltaToken()
         {
-            var REDIS_USER_DELTA_KEY = GetRedisUserDeltaCacheKey();
-            await _cacheConnectionManager.DeleteString(REDIS_USER_DELTA_KEY);
-            _logger.LogWarning($"Cleared delta token for tenant {_appConfig.TenantGUID}.");
+            var key = GetRedisUserDeltaCacheKey();
+            await ExecuteWithRetry(() => _store.DeleteString(key), "delete");
+            _lastKnownCommittedDeltaToken = null;
+            _logger.LogWarning($"Cleared persisted user delta token.");
         }
 
         public async Task<string> GetDeltaToken()
         {
-            var REDIS_USER_DELTA_KEY = GetRedisUserDeltaCacheKey();
-            var usersQueryDelta = await _cacheConnectionManager.GetString(REDIS_USER_DELTA_KEY);
-            if (string.IsNullOrEmpty(usersQueryDelta))
+            var key = GetRedisUserDeltaCacheKey();
+            try
             {
-                _logger.LogWarning($"No delta token found for tenant {_appConfig.TenantGUID}.");
+                var usersQueryDelta = await ExecuteWithRetry(() => _store.GetString(key), "read");
+                if (string.IsNullOrEmpty(usersQueryDelta))
+                {
+                    _logger.LogWarning($"No persisted user delta token found; a confirmed first-run/full-enumeration path will be used.");
+                    return null;
+                }
+
+                _lastKnownCommittedDeltaToken = usersQueryDelta;
+                _logger.LogInformation($"Persisted user delta token found.");
+                return usersQueryDelta;
             }
-            else
+            catch (Exception ex) when (!(ex is DeltaTokenUnavailableException) && !(ex is OperationCanceledException))
             {
-                _logger.LogInformation($"Delta token found for tenant {_appConfig.TenantGUID}.");
+                if (!string.IsNullOrEmpty(_lastKnownCommittedDeltaToken))
+                {
+                    _logger.LogWarning($"User delta token store read failed after {_retryOptions.MaxAttempts:N0} attempt(s); using the last committed in-process checkpoint for this WebJob process. The next successful Redis read will resume normal persisted checkpoint use.");
+                    return _lastKnownCommittedDeltaToken;
+                }
+
+                throw new DeltaTokenUnavailableException(
+                    "User delta token store is unavailable and this process has no last committed checkpoint. Deferring user metadata/licence import rather than treating the outage as a cache miss and starting a full tenant crawl.",
+                    ex);
             }
-            return usersQueryDelta;
         }
 
         public async Task SetDeltaToken(string deltaToken)
         {
-            var REDIS_USER_DELTA_KEY = GetRedisUserDeltaCacheKey();
-            _logger.LogInformation($"Setting delta token for tenant {_appConfig.TenantGUID}.");
-            await _cacheConnectionManager.SetString(REDIS_USER_DELTA_KEY, deltaToken);
+            var key = GetRedisUserDeltaCacheKey();
+            _logger.LogInformation($"Setting persisted user delta token.");
+            await ExecuteWithRetry(() => _store.SetString(key, deltaToken), "write");
+            _lastKnownCommittedDeltaToken = deltaToken;
+        }
+
+        private async Task<T> ExecuteWithRetry<T>(Func<Task<T>> action, string operation)
+        {
+            Exception last = null;
+            for (var attempt = 1; attempt <= _retryOptions.MaxAttempts; attempt++)
+            {
+                try
+                {
+                    return await action();
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    last = ex;
+                    if (attempt >= _retryOptions.MaxAttempts)
+                    {
+                        break;
+                    }
+
+                    _logger?.LogWarning($"User delta token store {operation} attempt {attempt:N0}/{_retryOptions.MaxAttempts:N0} failed ({ex.GetType().Name}); retrying.");
+                    if (_retryOptions.Delay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(_retryOptions.Delay);
+                    }
+                }
+            }
+
+            throw last;
+        }
+
+        private async Task ExecuteWithRetry(Func<Task> action, string operation)
+        {
+            await ExecuteWithRetry(async () =>
+            {
+                await action();
+                return true;
+            }, operation);
         }
 
         string GetRedisUserDeltaCacheKey()
         {
-            var REDIS_USER_DELTA_KEY = $"UserDeltaCode-{_appConfig.TenantGUID}";
-            return REDIS_USER_DELTA_KEY;
+            return $"UserDeltaCode-{_appConfig.TenantGUID}";
         }
     }
 }
+
+

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphRequestBudgetOptions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphRequestBudgetOptions.cs
@@ -4,7 +4,7 @@ using System;
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
     /// <summary>
-    /// Bounded request/retry settings for SDK-backed Graph user and licence reads.
+    /// Bounded request/retry settings for SDK-backed Graph import reads.
     /// The installed Microsoft.Graph 6.5.0 pipeline already includes Kiota's RetryHandler
     /// (3 retries by default, respecting Retry-After for transient HTTP responses). These
     /// values keep that service-directed retry path, but cap the per HTTP request deadline
@@ -13,7 +13,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
     /// </summary>
     public sealed class GraphRequestBudgetOptions
     {
-        public static readonly GraphRequestBudgetOptions UserImportDefault = new GraphRequestBudgetOptions(
+        public static readonly GraphRequestBudgetOptions GraphImportDefault = new GraphRequestBudgetOptions(
             perRequestTimeout: TimeSpan.FromMinutes(2),
             timeoutRetryCount: 2,
             timeoutRetryDelay: TimeSpan.FromSeconds(5),
@@ -60,7 +60,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         public void Log(ILogger logger)
         {
             logger?.LogInformation(
-                $"Graph user import request budget: per-request timeout {PerRequestTimeout.TotalSeconds:N0}s, " +
+                $"Graph import SDK request budget: per-request timeout {PerRequestTimeout.TotalSeconds:N0}s, " +
                 $"timeout retries {TimeoutRetryCount:N0} with {TimeoutRetryDelay.TotalSeconds:N0}s delay, " +
                 $"timeout-retry budget {TotalTimeoutRetryBudget.TotalSeconds:N0}s; Kiota RetryHandler remains enabled " +
                 $"for transient HTTP responses with max retry {SdkRetryCount:N0}, initial delay {SdkRetryDelaySeconds:N0}s, " +

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphRequestBudgetOptions.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphRequestBudgetOptions.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace WebJob.Office365ActivityImporter.Engine.Graph
+{
+    /// <summary>
+    /// Bounded request/retry settings for SDK-backed Graph user and licence reads.
+    /// The installed Microsoft.Graph 6.5.0 pipeline already includes Kiota's RetryHandler
+    /// (3 retries by default, respecting Retry-After for transient HTTP responses). These
+    /// values keep that service-directed retry path, but cap the per HTTP request deadline
+    /// and the total time spent on timeout retries so one stalled page cannot monopolise the
+    /// whole Graph phase.
+    /// </summary>
+    public sealed class GraphRequestBudgetOptions
+    {
+        public static readonly GraphRequestBudgetOptions UserImportDefault = new GraphRequestBudgetOptions(
+            perRequestTimeout: TimeSpan.FromMinutes(2),
+            timeoutRetryCount: 2,
+            timeoutRetryDelay: TimeSpan.FromSeconds(5),
+            totalTimeoutRetryBudget: TimeSpan.FromMinutes(6),
+            sdkRetryCount: 3,
+            sdkRetryDelaySeconds: 3,
+            sdkRetryTimeLimit: TimeSpan.FromMinutes(4));
+
+        public GraphRequestBudgetOptions(
+            TimeSpan perRequestTimeout,
+            int timeoutRetryCount,
+            TimeSpan timeoutRetryDelay,
+            TimeSpan totalTimeoutRetryBudget,
+            int sdkRetryCount,
+            int sdkRetryDelaySeconds,
+            TimeSpan sdkRetryTimeLimit)
+        {
+            if (perRequestTimeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(perRequestTimeout));
+            if (timeoutRetryCount < 0) throw new ArgumentOutOfRangeException(nameof(timeoutRetryCount));
+            if (timeoutRetryDelay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeoutRetryDelay));
+            if (totalTimeoutRetryBudget < perRequestTimeout) throw new ArgumentOutOfRangeException(nameof(totalTimeoutRetryBudget));
+            if (sdkRetryCount < 0) throw new ArgumentOutOfRangeException(nameof(sdkRetryCount));
+            if (sdkRetryDelaySeconds < 0) throw new ArgumentOutOfRangeException(nameof(sdkRetryDelaySeconds));
+            if (sdkRetryTimeLimit <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(sdkRetryTimeLimit));
+
+            PerRequestTimeout = perRequestTimeout;
+            TimeoutRetryCount = timeoutRetryCount;
+            TimeoutRetryDelay = timeoutRetryDelay;
+            TotalTimeoutRetryBudget = totalTimeoutRetryBudget;
+            SdkRetryCount = sdkRetryCount;
+            SdkRetryDelaySeconds = sdkRetryDelaySeconds;
+            SdkRetryTimeLimit = sdkRetryTimeLimit;
+        }
+
+        public TimeSpan PerRequestTimeout { get; }
+        public int TimeoutRetryCount { get; }
+        public TimeSpan TimeoutRetryDelay { get; }
+        public TimeSpan TotalTimeoutRetryBudget { get; }
+        public int SdkRetryCount { get; }
+        public int SdkRetryDelaySeconds { get; }
+        public TimeSpan SdkRetryTimeLimit { get; }
+        public int MaxAttempts => TimeoutRetryCount + 1;
+
+        public void Log(ILogger logger)
+        {
+            logger?.LogInformation(
+                $"Graph user import request budget: per-request timeout {PerRequestTimeout.TotalSeconds:N0}s, " +
+                $"timeout retries {TimeoutRetryCount:N0} with {TimeoutRetryDelay.TotalSeconds:N0}s delay, " +
+                $"timeout-retry budget {TotalTimeoutRetryBudget.TotalSeconds:N0}s; Kiota RetryHandler remains enabled " +
+                $"for transient HTTP responses with max retry {SdkRetryCount:N0}, initial delay {SdkRetryDelaySeconds:N0}s, " +
+                $"time limit {SdkRetryTimeLimit.TotalSeconds:N0}s.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphServiceClientFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphServiceClientFactory.cs
@@ -21,15 +21,19 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         private static readonly string[] DefaultScopes = new[] { "https://graph.microsoft.com/.default" };
 
         /// <summary>
-        /// Create the SDK-backed Graph client used by user metadata and licence imports.
+        /// Create the SDK-backed Graph client used by the Graph importer.
         /// Microsoft.Graph 6.5.0 installs Kiota's RetryHandler in the default pipeline; we
-        /// keep it for service-directed transient HTTP retries and add only a bounded wrapper
-        /// for local request-deadline timeouts.
+        /// keep it for service-directed transient HTTP retries and add a bounded wrapper for
+        /// local request-deadline timeouts. The deadline applies to every method; only idempotent
+        /// reads get local timeout retries.
         /// </summary>
-        public static GraphServiceClient CreateForUserImport(TokenCredential credential, ILogger logger = null)
-            => CreateForUserImport(credential, GraphRequestBudgetOptions.UserImportDefault, logger);
+        public static GraphServiceClient CreateForGraphImport(TokenCredential credential, ILogger logger = null)
+            => CreateForGraphImport(credential, GraphRequestBudgetOptions.GraphImportDefault, logger);
 
-        internal static GraphServiceClient CreateForUserImport(TokenCredential credential, GraphRequestBudgetOptions budget, ILogger logger, HttpMessageHandler finalHandler = null)
+        public static GraphServiceClient CreateForUserImport(TokenCredential credential, ILogger logger = null)
+            => CreateForGraphImport(credential, logger);
+
+        internal static GraphServiceClient CreateForGraphImport(TokenCredential credential, GraphRequestBudgetOptions budget, ILogger logger, HttpMessageHandler finalHandler = null)
         {
             if (credential == null) throw new ArgumentNullException(nameof(credential));
             var authProvider = new AzureIdentityAuthenticationProvider(credential, scopes: DefaultScopes);
@@ -67,7 +71,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
 
         /// <summary>
         /// Legacy helper kept for callers outside the user import path. Prefer
-        /// <see cref="CreateForUserImport"/> for SDK-backed user/licence enumeration.
+        /// <see cref="CreateForGraphImport"/> for SDK-backed importer work.
         /// </summary>
         public static GraphServiceClient CreateWithTimeout(TokenCredential credential, TimeSpan timeout)
         {
@@ -78,4 +82,3 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         }
     }
 }
-

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphServiceClientFactory.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/GraphServiceClientFactory.cs
@@ -1,24 +1,73 @@
 using Azure.Core;
+using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
 using Microsoft.Kiota.Authentication.Azure;
+using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
+using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 using System;
+using System.Linq;
 using System.Net.Http;
+using System.Threading;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph
 {
     /// <summary>
     /// Factory helpers for <see cref="GraphServiceClient"/> v5+. The v4 client exposed
     /// <c>HttpProvider.OverallTimeout</c> directly; in v5+ that property is gone, so we
-    /// build a custom <see cref="HttpClient"/> with the desired timeout and pass it to
-    /// <see cref="GraphServiceClient(HttpClient, Microsoft.Kiota.Abstractions.Authentication.IAuthenticationProvider, string)"/>.
+    /// build a custom <see cref="HttpClient"/> with bounded request and retry budgets.
     /// </summary>
     public static class GraphServiceClientFactory
     {
         private static readonly string[] DefaultScopes = new[] { "https://graph.microsoft.com/.default" };
 
         /// <summary>
-        /// Create a client with a per-request HTTP timeout. Use for long-running enumeration
-        /// (e.g. /users/delta or large tenant scans) where the default 100s would fire mid-page.
+        /// Create the SDK-backed Graph client used by user metadata and licence imports.
+        /// Microsoft.Graph 6.5.0 installs Kiota's RetryHandler in the default pipeline; we
+        /// keep it for service-directed transient HTTP retries and add only a bounded wrapper
+        /// for local request-deadline timeouts.
+        /// </summary>
+        public static GraphServiceClient CreateForUserImport(TokenCredential credential, ILogger logger = null)
+            => CreateForUserImport(credential, GraphRequestBudgetOptions.UserImportDefault, logger);
+
+        internal static GraphServiceClient CreateForUserImport(TokenCredential credential, GraphRequestBudgetOptions budget, ILogger logger, HttpMessageHandler finalHandler = null)
+        {
+            if (credential == null) throw new ArgumentNullException(nameof(credential));
+            var authProvider = new AzureIdentityAuthenticationProvider(credential, scopes: DefaultScopes);
+            var httpClient = CreateHttpClient(authProvider, budget, logger, finalHandler);
+            return new GraphServiceClient(httpClient, authProvider);
+        }
+
+        internal static HttpClient CreateHttpClient(AzureIdentityAuthenticationProvider authProvider, GraphRequestBudgetOptions budget, ILogger logger, HttpMessageHandler finalHandler = null)
+        {
+            if (authProvider == null) throw new ArgumentNullException(nameof(authProvider));
+            if (budget == null) throw new ArgumentNullException(nameof(budget));
+
+            var graphOptions = new GraphClientOptions();
+            var handlers = GraphClientFactory.CreateDefaultHandlers(graphOptions).ToList();
+
+            for (var i = 0; i < handlers.Count; i++)
+            {
+                if (handlers[i] is RetryHandler)
+                {
+                    handlers[i] = new RetryHandler(new RetryHandlerOption
+                    {
+                        MaxRetry = budget.SdkRetryCount,
+                        Delay = budget.SdkRetryDelaySeconds,
+                        RetriesTimeLimit = budget.SdkRetryTimeLimit
+                    });
+                }
+            }
+
+            handlers.Insert(0, new BoundedGraphRequestHandler(budget, logger));
+            var httpClient = GraphClientFactory.Create(authProvider, handlers, finalHandler: finalHandler);
+            httpClient.Timeout = Timeout.InfiniteTimeSpan;
+            budget.Log(logger);
+            return httpClient;
+        }
+
+        /// <summary>
+        /// Legacy helper kept for callers outside the user import path. Prefer
+        /// <see cref="CreateForUserImport"/> for SDK-backed user/licence enumeration.
         /// </summary>
         public static GraphServiceClient CreateWithTimeout(TokenCredential credential, TimeSpan timeout)
         {
@@ -29,3 +78,4 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
         }
     }
 }
+

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -43,9 +43,10 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             }
 
             // v4 used graphClient.HttpProvider.OverallTimeout = 1h directly. HttpProvider is gone
-            // in v5+, so we build a HttpClient with the desired timeout and inject it into the
-            // GraphServiceClient. /users/delta over a 200k-tenant can comfortably exceed the
-            // default 100s timeout - the explicit 1h timeout is load-bearing.
+            // in v5+, so we build a HttpClient that keeps Kiota's service-directed Retry-After
+            // handling but caps any single stalled HTTP request. /users/delta over a 200k-user
+            // tenant can legitimately take longer than the framework default 100s across all pages;
+            // the budget is therefore per request, not per full tenant traversal.
             var graphServiceClient = GraphServiceClientFactory.CreateForUserImport(creds, _logger);
 
             _userLoader = new GraphUserLoader(manualGraphCallClient, deltaProvider, _logger, graphServiceClient);

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserMetadataUpdater.cs
@@ -46,7 +46,7 @@ namespace WebJob.Office365ActivityImporter.Engine.Graph
             // in v5+, so we build a HttpClient with the desired timeout and inject it into the
             // GraphServiceClient. /users/delta over a 200k-tenant can comfortably exceed the
             // default 100s timeout - the explicit 1h timeout is load-bearing.
-            var graphServiceClient = GraphServiceClientFactory.CreateWithTimeout(creds, TimeSpan.FromHours(1));
+            var graphServiceClient = GraphServiceClientFactory.CreateForUserImport(creds, _logger);
 
             _userLoader = new GraphUserLoader(manualGraphCallClient, deltaProvider, _logger, graphServiceClient);
             _contextFactory = DefaultAnalyticsDbContextFactory.Instance;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Entities\MessageCognitiveStats.cs" />
     <Compile Include="Entities\WebActivityReportSet.cs" />
     <Compile Include="ExceptionHandler.cs" />
+    <Compile Include="Graph\BoundedGraphRequestHandler.cs" />
     <Compile Include="Graph\DeltaValueProvider.cs" />
     <Compile Include="Graph\Copilot\InteractionHistory\AiInteractionModels.cs" />
     <Compile Include="Graph\Copilot\InteractionHistory\CopilotInteractionHistoryImporter.cs" />
@@ -221,6 +222,7 @@
     <Compile Include="Graph\Teams\Extensions\ItemBodyExtensions.cs" />
     <Compile Include="Graph\Teams\GraphReadExceptions.cs" />
     <Compile Include="Graph\BearerTokenAuthenticationProvider.cs" />
+    <Compile Include="Graph\GraphRequestBudgetOptions.cs" />
     <Compile Include="Graph\GraphServiceClientFactory.cs" />
     <Compile Include="Graph\ManualGraphCallClient.cs" />
     <Compile Include="Graph\Teams\O365Team.cs" />
@@ -395,3 +397,4 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
+

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -112,7 +112,7 @@ namespace WebJob.Office365ActivityImporter
                 return;
             }
             await _graphAppIndentityOAuthContext.InitClientCredential();
-            _graphClient = GraphServiceClientFactory.CreateForUserImport(_graphAppIndentityOAuthContext.Creds, _logger);
+            _graphClient = GraphServiceClientFactory.CreateForGraphImport(_graphAppIndentityOAuthContext.Creds, _logger);
             _manualGraphCallClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _logger);
             _graphUserGroupsCache = new GraphUserGroupsCache(_manualGraphCallClient, _logger);
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/ProgramTasks.cs
@@ -112,7 +112,7 @@ namespace WebJob.Office365ActivityImporter
                 return;
             }
             await _graphAppIndentityOAuthContext.InitClientCredential();
-            _graphClient = GraphServiceClientFactory.CreateWithTimeout(_graphAppIndentityOAuthContext.Creds, TimeSpan.FromHours(1));
+            _graphClient = GraphServiceClientFactory.CreateForUserImport(_graphAppIndentityOAuthContext.Creds, _logger);
             _manualGraphCallClient = new ManualGraphCallClient(_graphAppIndentityOAuthContext, _logger);
             _graphUserGroupsCache = new GraphUserGroupsCache(_manualGraphCallClient, _logger);
 


### PR DESCRIPTION
## Summary
Addresses #493
Addresses #494

This PR bounds the SDK-backed Graph import path and makes Redis delta-token state explicit instead of treating store outages like cache misses.

## Behaviour changes
- Replaces the old one-hour SDK Graph client timeout with explicit budgets:
  - per SDK HTTP request deadline: 2 minutes
  - local timeout retries: 2 retries, 5 seconds between attempts, GET/HEAD only
  - total local timeout-retry budget: 6 minutes per SDK request
  - Kiota RetryHandler remains enabled for service-directed transient HTTP responses: max retry 3, initial delay 3 seconds, retry time limit 4 minutes
- The deadline applies to every SDK method, including non-GET calls. Non-idempotent methods are deadline-bounded but are not retried by the local timeout policy.
- This intentionally covers the shared `GraphImporter` SDK client (`ProgramTasks.InitAuth`) as well as the user metadata loader's SDK client. That means Teams and the SharePoint site cache get the same per-request stall protection. The 2-minute deadline is per HTTP request, not per crawl/report/user-delta traversal; long imports still progress through many bounded requests, while service-directed 429/503/504 backoff remains Kiota-owned.
- Leaves strict SKU-holder paging intact: an abandoned page still throws, partial holder sets are never reconciled as complete, and the delta token is committed only after the existing final user-import commit gate succeeds.
- Redis-backed user delta reads now distinguish:
  - committed token read successfully: resume from it
  - confirmed missing key: deliberate first-run/full-enumeration path
  - unavailable store with last committed in-process token: bounded retry then safe fallback
  - unavailable store without safe checkpoint: throw a clear defer/failure instead of inventing a miss
- Redis delta writes are retried and still surface failures, preserving the original exception stack, so DB work followed by checkpoint persistence failure does not become a false success/cadence stamp.
- Redis retry backoff now accepts cancellation through the delta-provider boundary.
- Delta logs were made privacy-safe: no tenant identifiers, Redis endpoints, keys, delta links, UPNs, URLs, or payloads are logged.

## Code changes
- Added `GraphRequestBudgetOptions` and `BoundedGraphRequestHandler` for the Graph SDK HTTP boundary.
- Updated `GraphServiceClientFactory`, `ProgramTasks.InitAuth`, and `UserMetadataUpdater` to use the bounded Graph-import client.
- Added retry/fallback semantics and `DeltaTokenUnavailableException` to `RedisProcessDeltaValueProvider` without changing `CacheConnectionManager` globally.
- Added deterministic fakes/tests for timeout retry, caller cancellation, non-GET deadline/no-retry behaviour, Redis missing vs unavailable state, write failure, store recovery, cancellation-aware Redis backoff, synthetic tenant scope isolation, partial SKU inventory failure, and delta-write failure after DB save.

## SDK retry finding
The project uses `Microsoft.Graph` 6.5.0 (`Microsoft.Graph.Core` 4.0.1 / Kiota HTTP pipeline). `GraphClientFactory.CreateDefaultHandlers` includes Kiota `RetryHandler`. Its defaults include max retry 3, initial delay 3 seconds and service-directed `Retry-After` handling; upstream defaults also allow a longer retry time limit than we want for this import path. This PR does not add a second HTTP-status retry policy; it caps the Kiota retry time and adds a separate local timeout retry only for local request-deadline cancellations on idempotent reads.

## Test/issue matrix coverage
- Request timeout then healthy response: `GraphBoundedRequestAndDeltaTests.BoundedGraphRequestHandler_RequestTimeoutThenHealthyResponse_RetriesSamePageOnly`
- Repeated timeouts: `GraphBoundedRequestAndDeltaTests.BoundedGraphRequestHandler_RepeatedTimeouts_StopsInsideExplicitBudget`
- Caller cancellation during request/backoff: `BoundedGraphRequestHandler_CallerCancellation_IsNotRetriedAsTransientTimeout`, `RedisDeltaProvider_CancellationDuringBackoff_StopsWithoutFurtherAttempts`
- Non-GET deadline without retry: `BoundedGraphRequestHandler_NonGetRequest_IsDeadlineBoundedButNotRetried`
- Failure after one or more SKU-holder pages: `UserLicenseRefresh_FailureAfterOneSkuPage_DoesNotReconcilePartialInventory`
- Successful DB save followed by failed delta persistence: `UserMetadataUpdater_DeltaPersistenceFailsAfterDatabaseSave_ReplayIsIdempotent`
- Users outside current metadata delta still included in licence reconciliation: existing `UserMetadataUpdater_LicenceRefreshSpansEntireDb_NotJustDeltaUsers`
- Genuinely empty valid response remains distinct from failure: existing `UserLicenseRefresh_EmptyTenantSkuList_LeavesLicencesUntouched` and `UserLicenseRefresh_SkuClaimsConsumedSeatsButReportsNoHolders_RemovalsHeldBack`
- Healthy paged responses: existing `MultiPageFakeUsageLoaderTest`; SKU/user SDK paging still uses the existing `PageIterator` strict-completion checks from #392/#285 and is covered by the new timeout-boundary tests rather than a live Graph call.
- Redis state model: `RedisDeltaProvider_ReadUnavailableWithCommittedToken_UsesSafeFallbackOnlyAfterCommit`, `RedisDeltaProvider_ReadUnavailableWithNoSafeFallback_DefersInsteadOfInventingMiss`, `RedisDeltaProvider_ConfirmedMissingKey_ReturnsNullForExplicitFullEnumerationPath`, `RedisDeltaProvider_WriteFailureSurfacesAndDoesNotCreateFallbackCheckpoint`, `RedisDeltaProvider_StoreRecovers_ResumesPersistedCheckpointWithoutOperatorAction`, `RedisDeltaProvider_MultipleSyntheticScopes_DoNotReuseCheckpoints`

## Tests
Passed with VS Enterprise MSBuild/TestPlatform from `C:\Users\sambetts\source\repos\wt-graph`:
- `MSBuild.exe src\AnalyticsEngine\Tests.UnitTests\Tests.UnitTests.csproj -t:Restore -p:Configuration=Release -p:Platform=anycpu -p:ProcessorArchitecture=x86`
- `MSBuild.exe src\AnalyticsEngine\Tests.UnitTests\Tests.UnitTests.csproj -p:Configuration=Release -p:Platform=anycpu -p:ProcessorArchitecture=x86` — build succeeded, 0 warnings, 0 errors
- `Patch-LocalTestConfig.ps1 -WorktreeRoot C:\Users\sambetts\source\repos\wt-graph -Configuration Release`
- Focused new/regression filter: 13/13 passed
- Baseline filter plus new tests: total 195, passed 194, failed 1. The only failure is the expected baseline `GraphUsageReportImportTests.SharePointSitesUsageLoaderTest`, which calls Entra using the synthetic zeroed app ID and fails with `AADSTS700038`.

## Risks / reviewer hotspots
- Review the ordering of `BoundedGraphRequestHandler` relative to Kiota middleware: the intent is local deadline enforcement around the SDK pipeline, while Kiota remains responsible for HTTP status retries and `Retry-After`.
- The Redis fallback is intentionally process-local and only populated by successful reads/writes of committed tokens; it is not a durable replacement for Redis.
- `CacheConnectionManager` is deliberately untouched; there is no global swallow-and-return-null behaviour.
- No schema migration and no installer persisted setting changes.

## Deferred
No synthetic 200k-user latency/volume benchmark numbers are fabricated here. The deterministic tests prove bounded retry and checkpoint behaviour; large-scale request-volume measurement remains a follow-up performance exercise if needed.
