### PR TITLE
Stop manual upgrade scripts applying schema when run out of order

### DIFF
--- a/src/AnalyticsEngine/Common/Entities/Migrations/202609090519337_AgentCostTables.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202609090519337_AgentCostTables.manual.sql
@@ -64,6 +64,33 @@ SET NOCOUNT ON;
 SET QUOTED_IDENTIFIER ON;
 GO
 
+/* =====================================================================================================
+   PRE-FLIGHT - runs BEFORE anything is created.
+
+   sqlcmd and SSMS do NOT stop at a severity-16 error: they abandon the failing batch and carry on with
+   the next one. So a RAISERROR alone does not prevent an out-of-order run - it just prints a message and
+   then creates the tables anyway. The database would end up carrying this migration's schema WITHOUT a
+   __MigrationHistory row, and the next installer run would then fail in EF's own CreateTable with
+   "There is already an object named 'copilot_studio_credit_daily'", stranding the upgrade.
+
+   SET NOEXEC ON is what makes the failure real: every following batch is compiled but not executed, and
+   the SET NOEXEC OFF at the very end of the script restores the session. This is the same mechanism the
+   later scripts in this release use.
+   ===================================================================================================== */
+IF OBJECT_ID(N'dbo.__MigrationHistory', N'U') IS NULL
+BEGIN
+    RAISERROR('AgentCostTables: dbo.__MigrationHistory does not exist - this does not look like an Analytics database. Nothing has been changed.', 16, 1) WITH NOWAIT;
+    SET NOEXEC ON;
+END
+
+IF NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202608310800001_ColumnstoreUsageReportMetrics')
+   AND NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202609090519337_AgentCostTables')
+BEGIN
+    RAISERROR('AgentCostTables: prerequisite migration 202608310800001_ColumnstoreUsageReportMetrics is not stamped in __MigrationHistory. Run the manual scripts in migration-id order. Nothing has been changed.', 16, 1) WITH NOWAIT;
+    SET NOEXEC ON;
+END
+GO
+
 DECLARE @migration nvarchar(200) = N'202609090519337_AgentCostTables';
 DECLARE @msg nvarchar(500);
 DECLARE @start datetime2 = SYSUTCDATETIME();
@@ -254,4 +281,9 @@ BEGIN
 END
 ELSE
     RAISERROR('AgentCostTables: already recorded in __MigrationHistory, nothing to do.', 0, 1) WITH NOWAIT;
+GO
+
+-- Restore the session. SET statements still execute under NOEXEC, so this is reached even when the
+-- pre-flight above turned NOEXEC on and skipped everything in between.
+SET NOEXEC OFF;
 GO

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202609090647151_AgentCostUserCredits.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202609090647151_AgentCostUserCredits.manual.sql
@@ -71,6 +71,27 @@ SET NOCOUNT ON;
 SET QUOTED_IDENTIFIER ON;
 GO
 
+/* =====================================================================================================
+   PRE-FLIGHT - runs BEFORE anything is created. See the note in
+   202609090519337_AgentCostTables.manual.sql: a severity-16 RAISERROR does not stop sqlcmd, so without
+   SET NOEXEC ON an out-of-order run would create this migration's schema and leave it unstamped, and the
+   next installer run would then fail inside EF's own CreateTable. SET NOEXEC OFF at the end of the
+   script restores the session.
+   ===================================================================================================== */
+IF OBJECT_ID(N'dbo.__MigrationHistory', N'U') IS NULL
+BEGIN
+    RAISERROR('AgentCostUserCredits: dbo.__MigrationHistory does not exist - this does not look like an Analytics database. Nothing has been changed.', 16, 1) WITH NOWAIT;
+    SET NOEXEC ON;
+END
+
+IF NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202609090519337_AgentCostTables')
+   AND NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202609090647151_AgentCostUserCredits')
+BEGIN
+    RAISERROR('AgentCostUserCredits: prerequisite migration 202609090519337_AgentCostTables is not stamped in __MigrationHistory. Run the manual scripts in migration-id order. Nothing has been changed.', 16, 1) WITH NOWAIT;
+    SET NOEXEC ON;
+END
+GO
+
 DECLARE @migration nvarchar(200) = N'202609090647151_AgentCostUserCredits';
 DECLARE @msg nvarchar(500);
 
@@ -203,4 +224,9 @@ BEGIN
 END
 ELSE
     RAISERROR('AgentCostUserCredits: already recorded in __MigrationHistory, nothing to do.', 0, 1) WITH NOWAIT;
+GO
+
+-- Restore the session. SET statements still execute under NOEXEC, so this is reached even when the
+-- pre-flight above turned NOEXEC on and skipped everything in between.
+SET NOEXEC OFF;
 GO

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202609100900001_DlpCopilotImpact.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202609100900001_DlpCopilotImpact.manual.sql
@@ -32,9 +32,22 @@ GO
 
 DECLARE @prev nvarchar(255) = N'202609090647151_AgentCostUserCredits';
 
-IF NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = @prev)
+/* A severity-16 RAISERROR does NOT stop sqlcmd or SSMS - they abandon the failing batch and continue
+   with the next one. Without SET NOEXEC ON this "pre-flight" printed a message and then created every
+   DLP table anyway, leaving the schema applied but unstamped; the next installer run would then fail in
+   EF's own CreateTable with "There is already an object named 'dlp_policies'" and strand the upgrade.
+   SET NOEXEC OFF at the end of the script restores the session. */
+IF OBJECT_ID(N'dbo.__MigrationHistory', N'U') IS NULL
 BEGIN
-    RAISERROR('PREREQUISITE MISSING: migration %s is not stamped in __MigrationHistory. Run the manual scripts in migration-id order.', 16, 1, @prev);
+    RAISERROR('DlpCopilotImpact: dbo.__MigrationHistory does not exist - this does not look like an Analytics database. Nothing has been changed.', 16, 1) WITH NOWAIT;
+    SET NOEXEC ON;
+END
+
+IF NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = @prev)
+   AND NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202609100900001_DlpCopilotImpact')
+BEGIN
+    RAISERROR('PREREQUISITE MISSING: migration %s is not stamped in __MigrationHistory. Run the manual scripts in migration-id order. Nothing has been changed.', 16, 1, @prev);
+    SET NOEXEC ON;
 END
 GO
 
@@ -335,4 +348,9 @@ SET @b64 = @b64 + 's6U12Ee15HLEeKVRs3E3Inq/n5y5SvoiRpb4TaeaXGXTpHBhmkiSnVBFrpgeG
         RAISERROR('Already stamped - nothing to do.', 0, 1) WITH NOWAIT;
     END
 END
+GO
+
+-- Restore the session. SET statements still execute under NOEXEC, so this is reached even when the
+-- pre-flight above turned NOEXEC on and skipped everything in between.
+SET NOEXEC OFF;
 GO

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202609101000001_RetireUnusedAuditYammerStreamTables.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202609101000001_RetireUnusedAuditYammerStreamTables.manual.sql
@@ -128,6 +128,29 @@ SET NOCOUNT ON;
 SET QUOTED_IDENTIFIER ON;
 GO
 
+/* =====================================================================================================
+   PRE-FLIGHT - runs BEFORE anything is dropped.
+
+   This script DROPS TABLES, and a drop is not reversible. A severity-16 RAISERROR does not stop sqlcmd
+   or SSMS - they abandon the failing batch and continue - so the predecessor check that used to live
+   next to the __MigrationHistory stamp at the end of this script came far too late: by then the tables
+   were already gone. SET NOEXEC ON turns the check into a real stop; SET NOEXEC OFF at the very end of
+   the script restores the session.
+   ===================================================================================================== */
+IF OBJECT_ID(N'dbo.__MigrationHistory', N'U') IS NULL
+BEGIN
+    RAISERROR('RetireUnusedAuditYammerStreamTables: dbo.__MigrationHistory does not exist - this does not look like an Analytics database. Nothing has been changed.', 16, 1) WITH NOWAIT;
+    SET NOEXEC ON;
+END
+
+IF NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202609100900001_DlpCopilotImpact')
+   AND NOT EXISTS (SELECT 1 FROM dbo.__MigrationHistory WHERE MigrationId = N'202609101000001_RetireUnusedAuditYammerStreamTables')
+BEGIN
+    RAISERROR('RetireUnusedAuditYammerStreamTables: prerequisite migration 202609100900001_DlpCopilotImpact is not stamped in __MigrationHistory. Run the manual scripts in migration-id order. Nothing has been changed.', 16, 1) WITH NOWAIT;
+    SET NOEXEC ON;
+END
+GO
+
 SET NOCOUNT ON;
 
 DECLARE @migration nvarchar(100) = N'RetireUnusedAuditYammerStreamTables';
@@ -531,4 +554,9 @@ SET @model = @model + 0x4C84105F15074628EA5F476AB3590FF9C042B387B25FB9DA484D7C15
 END
 ELSE
     RAISERROR('RetireUnusedAuditYammerStreamTables: already recorded in __MigrationHistory.', 0, 1) WITH NOWAIT;
+GO
+
+-- Restore the session. SET statements still execute under NOEXEC, so this is reached even when the
+-- pre-flight above turned NOEXEC on and skipped everything in between.
+SET NOEXEC OFF;
 GO

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202609101100001_UniqueUrlsFullUrlIndex.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202609101100001_UniqueUrlsFullUrlIndex.cs
@@ -111,18 +111,43 @@ DECLARE @sql nvarchar(max);
 DECLARE @rows bigint;
 DECLARE @total bigint = 0;
 
+/* Is there any work to do at all? Deliberately computed BEFORE the concurrency gate below, and using
+   exactly the predicate the ""already applied"" branch further down uses, so the two can never disagree.
+
+   An already-applied database needs no mutation, so a live writer is no reason to refuse: there is
+   nothing for it to race. Gating the check on this is what keeps the migration a genuine no-op on
+   re-run. It matters most on the MANUAL path, where the gate's abort is a RETURN in the same batch as
+   the __MigrationHistory stamp - so aborting on a database whose schema work had already completed
+   would leave it complete but UNSTAMPED, and an unstamped migration blocks every later script in the
+   chain. Refusing to stamp a database that is already in the target state is the same class of mistake
+   as DenormaliseCopilotChatUserAndTime's data-state guard, and this is what prevents it. */
+DECLARE @workRequired bit =
+    CASE
+        WHEN OBJECT_ID(N'dbo.urls', N'U') IS NULL THEN 0
+        WHEN NOT EXISTS (SELECT 1 FROM sys.columns
+                         WHERE object_id = OBJECT_ID(N'dbo.urls') AND name = N'full_url') THEN 0
+        WHEN EXISTS (SELECT 1 FROM sys.indexes
+                     WHERE object_id = OBJECT_ID(N'dbo.urls') AND name = @ix
+                       AND is_unique = 1 AND ignore_dup_key = 1) THEN 0
+        ELSE 1
+    END;
+
 SET @msg = @migration + N': EngineEdition=' + CAST(@edition AS nvarchar(10)) + N'; ONLINE index build '
     + CASE WHEN @canOnline = 1 THEN N'will be attempted (with offline fallback).'
            ELSE N'is not supported on this edition - the rebuild also locks dbo.urls for its duration.' END;
 RAISERROR(@msg, 0, 1) WITH NOWAIT;
 
--- Unconditional, and deliberately NOT softened on ONLINE-capable editions. ONLINE affects only the index
--- BUILD; the de-duplication that precedes it repoints references and deletes rows across several separately
--- committed statements, so a writer that inserts a reference to a duplicate URL after that table has been
--- repointed but before the URL row is deleted can have its row cascade-deleted (file_metadata_property_values,
--- page_comments, page_likes and copilot_event_files all cascade from urls) or left orphaned (the legacy
--- event_meta_sharepoint reference has no FK at all).
-RAISERROR('UniqueUrlsFullUrlIndex: STOP THE IMPORTER before running this. It de-duplicates dbo.urls by repointing references and deleting rows across several committed statements, which is not safe against concurrent writers - an ONLINE index build does not change that.', 0, 1) WITH NOWAIT;
+-- Unconditional on ONLINE-capable editions, but NOT on an already-applied database: ONLINE affects only
+-- the index BUILD; the de-duplication that precedes it repoints references and deletes rows across
+-- several separately committed statements, so a writer that inserts a reference to a duplicate URL after
+-- that table has been repointed but before the URL row is deleted can have its row cascade-deleted
+-- (file_metadata_property_values, page_comments, page_likes and copilot_event_files all cascade from
+-- urls) or left orphaned (the legacy event_meta_sharepoint reference has no FK at all). None of that can
+-- happen when there is nothing to de-duplicate, so the warning is suppressed on a re-run.
+IF @workRequired = 1
+    RAISERROR('UniqueUrlsFullUrlIndex: STOP THE IMPORTER before running this. It de-duplicates dbo.urls by repointing references and deleting rows across several committed statements, which is not safe against concurrent writers - an ONLINE index build does not change that.', 0, 1) WITH NOWAIT;
+ELSE
+    RAISERROR('UniqueUrlsFullUrlIndex: dbo.urls is already in the target state, so there is nothing to de-duplicate and no concurrency risk; the writer check below is skipped.', 0, 1) WITH NOWAIT;
 
 /* -------------------------------------------------------------------------------------------------
    Concurrency check. The warning above used to be the only protection; this turns it into an actual
@@ -159,7 +184,7 @@ DECLARE @skipConcurrencyCheck bit =
 DECLARE @recentImports bigint = 0;
 DECLARE @activeWriters bigint = 0;
 
-IF @skipConcurrencyCheck = 0
+IF @workRequired = 1 AND @skipConcurrencyCheck = 0
 BEGIN
     -- The tables a concurrent writer could actually corrupt: dbo.urls, everything with a foreign key to
     -- it, and the legacy non-FK reference. Built from the catalogue rather than hard-coded, so it stays
@@ -241,7 +266,10 @@ BEGIN
             + N'statements, so running it against a live writer can cascade-delete or orphan that writer''s '
             + N'rows. Stop the Office365ActivityImporter / AppInsightsImporter web-jobs, wait for the current '
             + N'cycle to finish, then re-run. Nothing has been changed. '
-            + N'(To override once you have confirmed the importer is stopped, set @skipConcurrencyCheck = 1 at the top of this script.)';
+            + N'This gate is reached only when there is de-duplication work left to do, so an already-migrated '
+            + N'database is never blocked by it. To override once you have confirmed the importer is stopped, '
+            + N'run  EXEC sp_set_session_context N''UniqueUrlsFullUrlIndex_SkipConcurrencyCheck'', 1;  on the same '
+            + N'session first - this works for the installer / DatabaseUpgrader path as well as for sqlcmd.';
         RAISERROR(@msg, 16, 1) WITH NOWAIT;
         RETURN;
     END

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202609101100001_UniqueUrlsFullUrlIndex.manual.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202609101100001_UniqueUrlsFullUrlIndex.manual.sql
@@ -112,18 +112,43 @@ DECLARE @sql nvarchar(max);
 DECLARE @rows bigint;
 DECLARE @total bigint = 0;
 
+/* Is there any work to do at all? Deliberately computed BEFORE the concurrency gate below, and using
+   exactly the predicate the "already applied" branch further down uses, so the two can never disagree.
+
+   An already-applied database needs no mutation, so a live writer is no reason to refuse: there is
+   nothing for it to race. Gating the check on this is what keeps the migration a genuine no-op on
+   re-run. It matters most on the MANUAL path, where the gate's abort is a RETURN in the same batch as
+   the __MigrationHistory stamp - so aborting on a database whose schema work had already completed
+   would leave it complete but UNSTAMPED, and an unstamped migration blocks every later script in the
+   chain. Refusing to stamp a database that is already in the target state is the same class of mistake
+   as DenormaliseCopilotChatUserAndTime's data-state guard, and this is what prevents it. */
+DECLARE @workRequired bit =
+    CASE
+        WHEN OBJECT_ID(N'dbo.urls', N'U') IS NULL THEN 0
+        WHEN NOT EXISTS (SELECT 1 FROM sys.columns
+                         WHERE object_id = OBJECT_ID(N'dbo.urls') AND name = N'full_url') THEN 0
+        WHEN EXISTS (SELECT 1 FROM sys.indexes
+                     WHERE object_id = OBJECT_ID(N'dbo.urls') AND name = @ix
+                       AND is_unique = 1 AND ignore_dup_key = 1) THEN 0
+        ELSE 1
+    END;
+
 SET @msg = @migration + N': EngineEdition=' + CAST(@edition AS nvarchar(10)) + N'; ONLINE index build '
     + CASE WHEN @canOnline = 1 THEN N'will be attempted (with offline fallback).'
            ELSE N'is not supported on this edition - the rebuild also locks dbo.urls for its duration.' END;
 RAISERROR(@msg, 0, 1) WITH NOWAIT;
 
--- Unconditional, and deliberately NOT softened on ONLINE-capable editions. ONLINE affects only the index
--- BUILD; the de-duplication that precedes it repoints references and deletes rows across several separately
--- committed statements, so a writer that inserts a reference to a duplicate URL after that table has been
--- repointed but before the URL row is deleted can have its row cascade-deleted (file_metadata_property_values,
--- page_comments, page_likes and copilot_event_files all cascade from urls) or left orphaned (the legacy
--- event_meta_sharepoint reference has no FK at all).
-RAISERROR('UniqueUrlsFullUrlIndex: STOP THE IMPORTER before running this. It de-duplicates dbo.urls by repointing references and deleting rows across several committed statements, which is not safe against concurrent writers - an ONLINE index build does not change that.', 0, 1) WITH NOWAIT;
+-- Unconditional on ONLINE-capable editions, but NOT on an already-applied database: ONLINE affects only
+-- the index BUILD; the de-duplication that precedes it repoints references and deletes rows across
+-- several separately committed statements, so a writer that inserts a reference to a duplicate URL after
+-- that table has been repointed but before the URL row is deleted can have its row cascade-deleted
+-- (file_metadata_property_values, page_comments, page_likes and copilot_event_files all cascade from
+-- urls) or left orphaned (the legacy event_meta_sharepoint reference has no FK at all). None of that can
+-- happen when there is nothing to de-duplicate, so the warning is suppressed on a re-run.
+IF @workRequired = 1
+    RAISERROR('UniqueUrlsFullUrlIndex: STOP THE IMPORTER before running this. It de-duplicates dbo.urls by repointing references and deleting rows across several committed statements, which is not safe against concurrent writers - an ONLINE index build does not change that.', 0, 1) WITH NOWAIT;
+ELSE
+    RAISERROR('UniqueUrlsFullUrlIndex: dbo.urls is already in the target state, so there is nothing to de-duplicate and no concurrency risk; the writer check below is skipped.', 0, 1) WITH NOWAIT;
 
 /* -------------------------------------------------------------------------------------------------
    Concurrency check. The warning above used to be the only protection; this turns it into an actual
@@ -160,7 +185,7 @@ DECLARE @skipConcurrencyCheck bit =
 DECLARE @recentImports bigint = 0;
 DECLARE @activeWriters bigint = 0;
 
-IF @skipConcurrencyCheck = 0
+IF @workRequired = 1 AND @skipConcurrencyCheck = 0
 BEGIN
     -- The tables a concurrent writer could actually corrupt: dbo.urls, everything with a foreign key to
     -- it, and the legacy non-FK reference. Built from the catalogue rather than hard-coded, so it stays
@@ -242,7 +267,10 @@ BEGIN
             + N'statements, so running it against a live writer can cascade-delete or orphan that writer''s '
             + N'rows. Stop the Office365ActivityImporter / AppInsightsImporter web-jobs, wait for the current '
             + N'cycle to finish, then re-run. Nothing has been changed. '
-            + N'(To override once you have confirmed the importer is stopped, set @skipConcurrencyCheck = 1 at the top of this script.)';
+            + N'This gate is reached only when there is de-duplication work left to do, so an already-migrated '
+            + N'database is never blocked by it. To override once you have confirmed the importer is stopped, '
+            + N'run  EXEC sp_set_session_context N''UniqueUrlsFullUrlIndex_SkipConcurrencyCheck'', 1;  on the same '
+            + N'session first - this works for the installer / DatabaseUpgrader path as well as for sqlcmd.';
         RAISERROR(@msg, 16, 1) WITH NOWAIT;
         RETURN;
     END

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202609101100001_UniqueUrlsFullUrlIndex.sizing.sql
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202609101100001_UniqueUrlsFullUrlIndex.sizing.sql
@@ -126,15 +126,30 @@ BEGIN
     ;WITH canon AS (
         SELECT id, MIN(id) OVER (PARTITION BY full_url) AS canonical_id
         FROM dbo.urls
+    ), dup_groups AS (
+        SELECT DISTINCT canonical_id FROM canon WHERE id <> canonical_id
+    ), mapped AS (
+        -- Every row landing in a group that HAS duplicates, INCLUDING rows already pointing at the
+        -- canonical url. Those must be counted: the migration ranks the whole post-remap partition
+        -- together (see the ranked CTE in the migration's Up_Sql), so a canonical-side row and a
+        -- repointed row with the same field_id collide and one of them is deleted. Counting only the
+        -- repointed side - as this query used to - reports 0 pruned rows for the commonest collision
+        -- there is: one property row on the canonical url and one on its duplicate.
+        SELECT cn.canonical_id, f.field_id,
+               CASE WHEN cn.id = cn.canonical_id THEN 0 ELSE 1 END AS is_repointed
+        FROM dbo.file_metadata_property_values f
+        JOIN canon cn ON cn.id = f.url_id
+        JOIN dup_groups g ON g.canonical_id = cn.canonical_id
     )
     SELECT
         child_table       = 'dbo.file_metadata_property_values',
-        rows_to_repoint   = COUNT_BIG(*),
-        rows_pruned       = COUNT_BIG(*) - COUNT(DISTINCT CAST(cn.canonical_id AS varchar(20))
-                                                 + ':' + CAST(f.field_id AS varchar(20)))
-    FROM dbo.file_metadata_property_values f
-    JOIN canon cn ON cn.id = f.url_id
-    WHERE cn.id <> cn.canonical_id;
+        rows_to_repoint   = (SELECT COUNT_BIG(*) FROM mapped WHERE is_repointed = 1),
+        -- total - distinct post-remap keys = rows the unique index cannot hold, i.e. rows deleted.
+        -- ISNULL because a UNIQUE index treats NULLs as equal but COUNT(DISTINCT) discards them.
+        rows_pruned       = (SELECT COUNT_BIG(*)
+                                    - COUNT(DISTINCT CAST(canonical_id AS varchar(20))
+                                            + ':' + ISNULL(CAST(field_id AS varchar(20)), '<null>'))
+                             FROM mapped);
 END
 
 IF OBJECT_ID(N'dbo.hits_clicked_elements') IS NOT NULL
@@ -142,16 +157,24 @@ BEGIN
     ;WITH canon AS (
         SELECT id, MIN(id) OVER (PARTITION BY full_url) AS canonical_id
         FROM dbo.urls
+    ), dup_groups AS (
+        SELECT DISTINCT canonical_id FROM canon WHERE id <> canonical_id
+    ), mapped AS (
+        -- See the note above: canonical-side rows take part in the collision and must be counted.
+        SELECT cn.canonical_id, h.hit_id, h.[timestamp],
+               CASE WHEN cn.id = cn.canonical_id THEN 0 ELSE 1 END AS is_repointed
+        FROM dbo.hits_clicked_elements h
+        JOIN canon cn ON cn.id = h.url_id
+        JOIN dup_groups g ON g.canonical_id = cn.canonical_id
     )
     SELECT
         child_table       = 'dbo.hits_clicked_elements',
-        rows_to_repoint   = COUNT_BIG(*),
-        rows_pruned       = COUNT_BIG(*) - COUNT(DISTINCT CAST(cn.canonical_id AS varchar(20))
-                                                 + ':' + CAST(h.hit_id AS varchar(20))
-                                                 + ':' + CONVERT(varchar(30), h.[timestamp], 126))
-    FROM dbo.hits_clicked_elements h
-    JOIN canon cn ON cn.id = h.url_id
-    WHERE cn.id <> cn.canonical_id;
+        rows_to_repoint   = (SELECT COUNT_BIG(*) FROM mapped WHERE is_repointed = 1),
+        rows_pruned       = (SELECT COUNT_BIG(*)
+                                    - COUNT(DISTINCT CAST(canonical_id AS varchar(20))
+                                            + ':' + ISNULL(CAST(hit_id AS varchar(20)), '<null>')
+                                            + ':' + ISNULL(CONVERT(varchar(30), [timestamp], 126), '<null>'))
+                             FROM mapped);
 END
 
 /* --------------------------------------------------------------------------------------------

--- a/src/AnalyticsEngine/Common/Entities/Migrations/202609101200001_RetireImportDbHacks.cs
+++ b/src/AnalyticsEngine/Common/Entities/Migrations/202609101200001_RetireImportDbHacks.cs
@@ -38,6 +38,22 @@ namespace Common.Entities.Migrations
     /// so there is no before/after query to benchmark. The performance win is the removal of the
     /// per-startup and per-batch work from the importer, which is a code change, not a schema one.
     ///
+    /// UPGRADE COST
+    ///   * Normal case - the App Insights importer has run at some point, so both indexes and the
+    ///     collation are already correct: METADATA ONLY. Every guard is a sys.indexes / sys.columns
+    ///     lookup and neither dbo.hits nor dbo.sessions is touched. Measured at milliseconds, and
+    ///     independent of table size. This is what essentially every upgrading customer gets.
+    ///   * Fresh install, or a deployment that never ran that importer: dbo.hits and dbo.sessions are
+    ///     empty or tiny, so the index builds are instant.
+    ///   * The only slow case is a database that HAS a populated dbo.hits but has lost
+    ///     IX_PageRequestID (a DBA dropped it, or a restore lost it). Then the de-duplication runs, and
+    ///     it re-evaluates ROW_NUMBER() over the whole of dbo.hits once per 20,000-row batch - so its
+    ///     cost is one full pass of dbo.hits per batch of duplicates removed. With no duplicates it is
+    ///     a single pass and nothing is deleted. If you are in that state with a large dbo.hits AND
+    ///     many duplicates, expect this to be the long pole of the upgrade and run it in a maintenance
+    ///     window; the subsequent UNIQUE index build on dbo.hits is ONLINE only on Enterprise / Azure
+    ///     SQL DB / Azure SQL MI and offline (table-locking) everywhere else.
+    ///
     /// IX_ai_session_id IS DELIBERATELY NOT UNIQUE. <c>sessions.ai_session_id</c> can legitimately
     /// duplicate, and the hits merge depends on tolerating that - see the ROW_NUMBER() fan-out defence in
     /// "Migrate Hits Import into Hits.sql" and issue #165. The hack actively rebuilt this index as

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -27,7 +27,7 @@ namespace Tests.UnitTests
         const string AzureSqlNoLogin = "data source=contoso-sql.database.windows.net;initial catalog=analytics;persist security info=False;MultipleActiveResultSets=True;Encrypt=True";
         // A deliberately non-palindromic GUID: the SID conversion is endian-sensitive, and a symmetrical
         // value would let a byte-order bug pass.
-        static readonly Guid AppServiceIdentity = new Guid("0f8fad5b-d9cb-469f-a165-70867728950e");
+        static readonly Guid AppServiceIdentity = new Guid("0a1b2c3d-4e5f-6789-abcd-ef0123456789");
 
         [TestCleanup]
         public void Cleanup()
@@ -403,8 +403,8 @@ namespace Tests.UnitTests
         [TestMethod]
         public void ToSqlSid_KnownGuid_MatchesSqlServersExpectedByteOrder()
         {
-            // 0f8fad5b-d9cb-469f-a165-70867728950e: first three groups are byte-reversed, the last two are not.
-            Assert.AreEqual("0x5BAD8F0FCBD99F46A16570867728950E", SqlContainedUserScript.ToSqlSid(AppServiceIdentity));
+            // 0a1b2c3d-4e5f-6789-abcd-ef0123456789: first three groups are byte-reversed, the last two are not.
+            Assert.AreEqual("0x3D2C1B0A5F4E8967ABCDEF0123456789", SqlContainedUserScript.ToSqlSid(AppServiceIdentity));
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/UniqueUrlsFullUrlIndexMigrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UniqueUrlsFullUrlIndexMigrationTests.cs
@@ -453,6 +453,60 @@ CREATE NONCLUSTERED INDEX [{IndexName}] ON [dbo].[urls] ([full_url]);");
         }
 
         [TestMethod]
+        public async Task Migration_DoesNotAbort_WhenTheWorkIsAlreadyDone_EvenWithAConcurrentWriter()
+        {
+            // The POSITIVE direction of the gate covered by
+            // Migration_Aborts_WhenAnotherSessionHoldsWriteLocks. A guard tested only against the state it
+            // was written to catch looks perfect and blocks every healthy upgrade, so this asserts the
+            // other half: on a database that is ALREADY in the target state there is nothing to
+            // de-duplicate, therefore nothing a writer can race, therefore no reason to refuse.
+            //
+            // This is not cosmetic. In the manual upgrade script the gate's abort is a RETURN in the same
+            // batch as the __MigrationHistory stamp, so aborting here would leave a database whose schema
+            // work had completed recorded as NOT migrated - and because the manual scripts form a
+            // prerequisite chain, that unstamped migration would block every later script in the release.
+            // That is precisely the DenormaliseCopilotChatUserAndTime failure mode.
+            using (var db = new AnalyticsEntitiesContext())
+            {
+                await EnsureSchemaAsync(db);
+
+                // Fully migrated starting point (RestoreSharedSchema leaves the suite here anyway, but
+                // this test must not depend on execution order).
+                await RunMigrationAsync(db);
+                Assert.IsTrue(await IndexIsUniqueAsync(db), "Pre-condition: the migration is already applied.");
+                Assert.IsTrue(await IndexIgnoresDuplicateKeysAsync(db), "Pre-condition: IGNORE_DUP_KEY is on.");
+
+                var cs = db.Database.Connection.ConnectionString;
+                using (var blocker = new SqlConnection(cs))
+                {
+                    await blocker.OpenAsync();
+                    using (var tx = blocker.BeginTransaction())
+                    {
+                        using (var cmd = blocker.CreateCommand())
+                        {
+                            cmd.Transaction = tx;
+                            cmd.CommandText =
+                                "INSERT INTO dbo.urls (full_url) VALUES (N'https://contoso.sharepoint.com/sites/example/Writer.docx');";
+                            await cmd.ExecuteNonQueryAsync();
+                        }
+
+                        // Deliberately WITHOUT the skip flag that RunMigrationAsync sets - the gate is
+                        // live, and a live writer is present. LOCK_TIMEOUT so a regression that made this
+                        // block on the writer fails in seconds instead of hanging CI.
+                        await ExecAsync(db, "SET LOCK_TIMEOUT 15000;\r\n" + UniqueUrlsFullUrlIndex.Up_Sql);
+
+                        tx.Rollback();
+                    }
+                }
+
+                Assert.IsTrue(await IndexIsUniqueAsync(db),
+                    "The no-op run must leave the unique index in place.");
+                Assert.IsTrue(await IndexIgnoresDuplicateKeysAsync(db),
+                    "The no-op run must leave IGNORE_DUP_KEY in place.");
+            }
+        }
+
+        [TestMethod]
         public void ManualScriptUsesTheSameSqlAsTheMigration()
         {
             // Rule 7 of the migration conventions: the manual upgrade script must contain the migration's


### PR DESCRIPTION
Fixes the blocker found by the release critique on #489, plus four related defects. All ten files are migration scripts or their tests; no product code changes.

**Addresses review findings on #489.** Uses `Addresses`, not `Closes` — the issue-closing keyword belongs on the `dev`→`main` release PR, since `main` is the default branch.

## The blocker

Manual scripts 1–4 checked that their predecessor migration was stamped only at the **end** of the script, after all their DDL had run, and relied on `RAISERROR(…, 16, 1)` to stop. **sqlcmd and SSMS do not stop at severity 16** — they abandon the failing batch and continue with the next one. So the guard printed a message and then let the schema work happen anyway.

Reproduced against a database restored to one release too old (`202608190622001_CopilotDroppedAuditFields`):

```
dlp_tables_created_out_of_order     4
legacy_tables_DROPPED_out_of_order  8      <-- irreversible
stamped                             0
```

Eight legacy tables dropped and four created, with **nothing** in `__MigrationHistory`. The drop is irreversible, and the now-unstamped database fails the next installer run inside EF's own unguarded `CreateTable` with `There is already an object named 'dlp_policies'` — stranding the upgrade on top of the data loss.

### Fix

A first-batch pre-flight in each of the four scripts — `__MigrationHistory` existence, then `IF NOT EXISTS(predecessor) AND NOT EXISTS(self)` — that raises and then `SET NOEXEC ON`, followed by `GO`, with a matching `SET NOEXEC OFF` at the very end. `SET NOEXEC ON` compiles but does not execute every later batch, which is what turns the check into a real stop; `SET` statements still execute under `NOEXEC`, so the restore is always reached.

**Migrations 5 and 6 already used exactly this mechanism** — scripts 1–4 were the inconsistent ones. The earlier review round only ever saw four scripts, so it had no counter-example to compare them against.

The pre-flight is inserted *before* the verbatim `Up_Sql` copy region begins and the restore *after* the stamp, so both upgrade paths still run identical DDL and the `ManualScript…Verbatim…` parity tests still pass.

## The other four fixes

| | What | Why it matters |
|---|---|---|
| **F2** | `UniqueUrlsFullUrlIndex` aborted when the work was already done | The concurrency gate ran *before* the "index is already UNIQUE with `IGNORE_DUP_KEY`, nothing to do" branch, and its `RAISERROR`/`RETURN` exits the same batch that holds the post-flight check **and** the stamp. A database whose schema work had completed but which was not yet stamped was refused for no reason and left **complete-but-unstamped**, blocking every later script in the chain. That is the `DenormaliseCopilotChatUserAndTime` failure mode with a different trigger. Now conditioned on a `@workRequired` flag computed from exactly the predicate the already-applied branch uses. |
| **F2b** | The gate's override named a variable the installer path cannot reach | It told operators to edit `@skipConcurrencyCheck` in a script `DatabaseUpgrader` never runs. Now names an `sp_set_session_context` flag that works on **both** the installer and sqlcmd paths. |
| **F9** | The sizing script under-reported rows the migration deletes | Its collision query excluded rows already pointing at the canonical URL, but the migration ranks the whole post-remap partition, so a canonical-side row and a repointed row sharing a key collide and one is deleted. Measured on a seeded pair: **old query `0`, new query `1`, migration actually pruned `1`.** Also adds `ISNULL` — a UNIQUE index treats NULLs as equal, `COUNT(DISTINCT)` discards them. |
| **F10** | `RetireImportDbHacks` had no upgrade-time estimate | Required for every migration. Metadata-only for essentially every upgrading customer, with the caveat that the one slow path — a populated `dbo.hits` that has *lost* `IX_PageRequestID` — re-evaluates `ROW_NUMBER()` over the whole table once per 20,000-row batch. |
| **F12** | A published sample GUID in a public repo | `AzureSqlEntraAuthTests.cs` used the only non-placeholder GUID in the release diff. Replaced with a synthetic one and the hard-coded SID recomputed; still non-palindromic, so the little-endian byte-order assertion continues to bite. |

## Verification

Proven in **both** directions, which is where self-inflicted guard bugs get caught:

- **Negative** — predecessor missing: all six scripts stamp nothing and create or drop nothing.
- **Positive** — predecessor stamped: the full six-script chain runs under **sqlcmd at `QUOTED_IDENTIFIER OFF`** (the real operator path) with zero errors, all six stamped, 5 agent-cost + 5 DLP tables created, 8 legacy tables dropped, `IX_urls_full_url` unique + `IGNORE_DUP_KEY`, `IX_PageRequestID` unique, `IX_ai_session_id` non-unique, `ai_session_id` case-sensitive.
- **Convergence** — re-running the whole chain on the migrated database: 0 errors, every no-op path taken, state unchanged.
- **`__MigrationHistory` absent entirely** — checked that the guard's own `SELECT` cannot raise Msg 208 before `SET NOEXEC ON` runs and leak DDL. Deferred name resolution defers it to execution, so `NOEXEC` wins: 0 objects created.

`Migration_DoesNotAbort_WhenTheWorkIsAlreadyDone_EvenWithAConcurrentWriter` is new — it pins F2's positive direction against a **live uncommitted writer** on a second connection, with `LOCK_TIMEOUT` set so a regression fails fast rather than hanging CI. `Migration_Aborts_WhenAnotherSessionHoldsWriteLocks` still passes, so the negative direction is intact.

### Local test run

61 tests across the directly affected suites pass: `UniqueUrlsFullUrlIndexMigrationTests`, `RetireImportDbHacksMigrationTests`, `RetireUnusedAuditYammerStreamTablesMigrationTests`, `UrlFullUrlMigrationPipelineTests`, `AzureSqlEntraAuthTests`. Wider filter: 100 passed, 2 failed — both failures are `AppConfig..ctor()` throwing `FormatException` on a placeholder `TenantGUID` in the local `App.config`, in `HealthServiceTests` and `CopilotEventManagerAccessedResourcesTests`, neither of which this PR touches. `test_dotnet (Release)` passes these in CI.

## Reviewer hotspots

- The pre-flight must sit **outside** the verbatim `Up_Sql` region in all four scripts, or the parity tests break. Same placement rule as the earlier `SET QUOTED_IDENTIFIER ON` fix.
- `@workRequired` must match the already-applied branch's predicate **exactly**. If they ever drift, the gate either returns to blocking healthy upgrades or stops protecting real ones.
- `SET NOEXEC OFF` must be the last statement in each script and must be in its own batch after the stamp.

## Not addressed here

Recorded on #489 for a deliberate decision rather than fixed unilaterally: the TOCTOU inherent in the `sys.dm_tran_locks` snapshot; that a **schema-only** upgrade does not stop the App Service (`ConfigureAzureComponentsTasks.cs:94` gates it on `InstallLatestSolutionContent`), so the gate will abort it; content-only upgrades deploying the new importer without migration 6; the two different meanings of "Last 7 days" across the DLP and agent-cost pages; and `AutoThrottleHttpClient` logging full URLs, which is pre-existing on `main`.
