### PR TITLE
Expand synthetic demo coverage with per-area new and existing database generation

### DIFF
--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoAreas.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoAreas.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tests.FakeDataGen.Demo
+{
+    [Flags]
+    internal enum DemoArea
+    {
+        Directory = 1,
+        Copilot = 2,
+        CopilotHistory = 4,
+        Teams = 8,
+        Outlook = 16,
+        SentEmail = 32,
+        SharePoint = 64,
+        Web = 128,
+        OneDrive = 256,
+        Engage = 512,
+        Office = 1024,
+        PowerApps = 2048,
+        PowerAutomate = 4096,
+        PowerBI = 8192,
+        CopilotStudio = 16384,
+        Dlp = 32768,
+        All = 65535
+    }
+
+    internal sealed class DemoAreaDescription
+    {
+        public DemoArea Area { get; }
+        public string Key { get; }
+        public string Title { get; }
+
+        public DemoAreaDescription(DemoArea area, string key, string title)
+        {
+            Area = area; Key = key; Title = title;
+        }
+    }
+
+    internal static class DemoAreas
+    {
+        public const DemoArea DailyWorkloads = DemoArea.Teams | DemoArea.Outlook | DemoArea.SharePoint
+            | DemoArea.OneDrive | DemoArea.Engage | DemoArea.Office;
+
+        public static readonly IReadOnlyList<DemoAreaDescription> Catalogue = new[]
+        {
+            new DemoAreaDescription(DemoArea.Directory, "directory", "Directory, demographics and current licences"),
+            new DemoAreaDescription(DemoArea.Copilot, "copilot", "Copilot audit activity and official usage reports"),
+            new DemoAreaDescription(DemoArea.CopilotHistory, "copilot-history", "Copilot interaction history (metadata only)"),
+            new DemoAreaDescription(DemoArea.Teams, "teams", "Teams usage, calls and channel activity"),
+            new DemoAreaDescription(DemoArea.Outlook, "outlook", "Outlook daily usage"),
+            new DemoAreaDescription(DemoArea.SentEmail, "sent-email", "Sent email and synthetic sentiment"),
+            new DemoAreaDescription(DemoArea.SharePoint, "sharepoint", "SharePoint audit and daily usage"),
+            new DemoAreaDescription(DemoArea.Web, "web", "Web traffic, pages, comments, clicks and search"),
+            new DemoAreaDescription(DemoArea.OneDrive, "onedrive", "OneDrive daily usage and storage"),
+            new DemoAreaDescription(DemoArea.Engage, "engage", "Viva Engage user/group activity and devices"),
+            new DemoAreaDescription(DemoArea.Office, "office", "Office application and device usage"),
+            new DemoAreaDescription(DemoArea.PowerApps, "powerapps", "Power Apps usage, sharing and connectors"),
+            new DemoAreaDescription(DemoArea.PowerAutomate, "powerautomate", "Power Automate activity, sharing and connectors"),
+            new DemoAreaDescription(DemoArea.PowerBI, "powerbi", "Power BI report usage"),
+            new DemoAreaDescription(DemoArea.CopilotStudio, "copilot-studio", "Copilot Studio bot activity"),
+            new DemoAreaDescription(DemoArea.Dlp, "dlp", "DLP policy matches and Copilot impact")
+        };
+
+        public static DemoArea Parse(string value)
+        {
+            if (string.Equals(value, "all", StringComparison.OrdinalIgnoreCase)) return DemoArea.All;
+            var selected = (DemoArea)0;
+            foreach (var key in value.Split(','))
+            {
+                var area = Catalogue.SingleOrDefault(a => a.Key.Equals(key.Trim(), StringComparison.OrdinalIgnoreCase));
+                if (area == null || (selected & area.Area) != 0)
+                    throw new ArgumentException("Unknown or duplicate activity area: " + key
+                        + ". Use all or " + string.Join(",", Catalogue.Select(a => a.Key)) + ".");
+                selected |= area.Area;
+            }
+            return selected;
+        }
+
+        public static string Format(DemoArea areas) => areas == DemoArea.All ? "all"
+            : string.Join(",", Catalogue.Where(a => (areas & a.Area) != 0).Select(a => a.Key));
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoCollaborationGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoCollaborationGenerator.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Generic;
+using Tests.FakeDataGen.Seeding;
+
+namespace Tests.FakeDataGen.Demo
+{
+    /// <summary>
+    /// Representative detail follows the common timeline. Channel/group summaries retain only
+    /// O(departments * days) counters; call partners use a bounded sample, not all users' timelines.
+    /// </summary>
+    internal sealed class DemoCollaborationGenerator
+    {
+        private static readonly string[] KeywordNames =
+            { "Contoso planning", "Contoso customer success", "Contoso onboarding", "Contoso research", "Συνεργασία" };
+        private static readonly string[] LanguageNames = { "English", "French", "Greek" };
+        private static readonly string[] Subjects =
+        {
+            "Contoso project update", "Contoso customer workshop follow-up", "Contoso budget review",
+            "Contoso onboarding next steps", "Contoso research – Καλημέρα κόσμε"
+        };
+        private static readonly string[] CommentTexts =
+        {
+            "Thanks, the Contoso guidance resolved my question.",
+            "Can we clarify the next steps for the Contoso project?",
+            "The Contoso instructions need another example.",
+            "Καλημέρα κόσμε – ευχαριστούμε για τη συνεργασία!"
+        };
+        private static readonly string[] Ratings = { "good", "poor", "fair", "excellent" };
+        private readonly DemoOptions _options;
+        private readonly DemoPopulation _population;
+        private readonly DemoCalendar _calendar;
+        private readonly IDemoSink _sink;
+        private readonly int[,] _channelMessages, _groupReads, _groupPosts, _groupLikes;
+        private readonly int[] _members;
+        private readonly List<int>[] _callPartners;
+        private int _calls, _sessions, _emails, _comments, _lastUser, _likedPages;
+        private bool _dimensionsWritten, _summariesWritten;
+
+        public DemoCollaborationGenerator(DemoOptions options, DemoPopulation population, DemoCalendar calendar, IDemoSink sink)
+        {
+            _options = options;
+            _population = population;
+            _calendar = calendar;
+            _sink = sink;
+            int departments = SeedDataCatalogue.Departments.Length;
+            _members = new int[departments];
+            if (options.Includes(DemoArea.Teams))
+            {
+                _channelMessages = new int[departments * 2, options.Days];
+                _callPartners = new List<int>[options.Days];
+                for (int day = 0; day < options.Days; day++) _callPartners[day] = new List<int>();
+            }
+            if (options.Includes(DemoArea.Engage))
+            {
+                _groupReads = new int[departments, options.Days];
+                _groupPosts = new int[departments, options.Days];
+                _groupLikes = new int[departments, options.Days];
+            }
+        }
+
+        public void WriteDimensions()
+        {
+            if (_dimensionsWritten) throw new InvalidOperationException("Collaboration dimensions already written.");
+            _dimensionsWritten = true;
+            if (_options.Includes(DemoArea.Teams)) WriteTeamDimensions();
+            if (_options.Includes(DemoArea.Teams | DemoArea.Web | DemoArea.CopilotHistory))
+                WriteNames(DemoTables.Languages, LanguageNames);
+            if (_options.Includes(DemoArea.Teams | DemoArea.CopilotHistory)) WriteNames(DemoTables.Keywords, KeywordNames);
+            // Page metadata/comments/likes arrive as AppInsights custom events under WebTraffic,
+            // not through the SharePoint management audit or Graph usage-report import.
+            if (_options.Includes(DemoArea.Web)) WritePageDimensions();
+            if (_options.Includes(DemoArea.Web))
+            {
+                WriteNames(DemoTables.ClickTitles, new[] { "Contoso guidance", "Contoso project workspace", "Contoso learning" });
+                WriteNames(DemoTables.ClickClasses, new[] { "contoso-navigation-link", "contoso-quick-link", "contoso-learning-card" });
+                WriteNames(DemoTables.SearchTerms, new[]
+                {
+                    "Contoso travel policy", "Contoso onboarding", "Contoso project planning",
+                    "Contoso customer workshop", "Καλημέρα κόσμε"
+                });
+            }
+            if (_options.Includes(DemoArea.Engage))
+                for (int department = 0; department < _members.Length; department++)
+                    _sink.Write(DemoTables.EngageGroups, department + 1,
+                        "Contoso " + SeedDataCatalogue.Departments[department] + " Community");
+
+            if (_options.Includes(DemoArea.Teams | DemoArea.SentEmail | DemoArea.Engage))
+            {
+                var owners = new bool[_members.Length];
+                for (int id = 1; id <= _options.Users; id++)
+                {
+                    var user = _population.User(id);
+                    _members[user.Department]++;
+                    if (_options.Includes(DemoArea.SentEmail))
+                        _sink.Write(DemoTables.EmailAddresses, id, user.Upn);
+                    if (!_options.Includes(DemoArea.Teams)) continue;
+                    int team = user.Department + 1;
+                    _sink.Write(DemoTables.TeamMemberships, id, _options.Start, team);
+                    _sink.Write(DemoTables.TeamMemberships, id, _options.ReportEnd, team);
+                    if (!owners[user.Department])
+                    {
+                        _sink.Write(DemoTables.TeamOwners, id, _options.Start, team);
+                        owners[user.Department] = true;
+                    }
+                }
+            }
+            if (_options.Includes(DemoArea.SentEmail))
+            {
+                _sink.Write(DemoTables.EmailAddresses, _options.Users + 1, "contoso.workshops@contoso.example");
+                _sink.Write(DemoTables.EmailAddresses, _options.Users + 2, "contoso.partners@contoso.example");
+            }
+            if (_options.Includes(DemoArea.Teams)) PrepareCallPartners();
+        }
+
+        private void WriteTeamDimensions()
+        {
+            WriteNames(DemoTables.CallTypes, new[] { "peerToPeer", "groupCall" });
+            WriteNames(DemoTables.CallModalities, new[] { "audio", "video", "screenSharing" });
+            WriteNames(DemoTables.ReactionTypes, new[] { "like", "heart", "laugh", "surprised" });
+            for (int department = 0; department < _members.Length; department++)
+            {
+                int team = department + 1;
+                _sink.Write(DemoTables.TeamDefinitions, team, _options.Start, false, null,
+                    DemoRandom.Id(_options.Seed, 1000, team).ToString(),
+                    "Contoso " + SeedDataCatalogue.Departments[department]);
+                for (int channel = 0; channel < 2; channel++)
+                {
+                    int id = department * 2 + channel + 1;
+                    _sink.Write(DemoTables.TeamChannels, id, DemoRandom.Id(_options.Seed, 1001, id).ToString(),
+                        channel == 0 ? "Contoso General" : "Contoso Projects", team);
+                    _sink.Write(DemoTables.TeamTabs, id,
+                        "https://contoso.sharepoint.com/sites/demo-" + team.ToString("D2")
+                            + "/SitePages/Contoso-demo-page-" + (channel + 1) + ".aspx",
+                        DemoRandom.Id(_options.Seed, 1002, id).ToString(),
+                        channel == 0 ? "Contoso Knowledge" : "Contoso Delivery Plan");
+                    _sink.Write(DemoTables.TeamTabLogs, id, _options.Start, id);
+                    _sink.Write(DemoTables.TeamTabLogs, id, _options.ReportEnd, id);
+                }
+            }
+        }
+
+        private void WritePageDimensions()
+        {
+            WriteNames(DemoTables.PageFields, new[] { "Title", "ContosoDepartment", "ContosoTopic", "ContentType" });
+            for (int department = 0; department < _members.Length; department++)
+                for (int page = 0; page < 3; page++)
+                {
+                    int url = department * 3 + page + 1;
+                    _sink.Write(DemoTables.PageMetadata, url, 1,
+                        page == 2 ? "Καλημέρα κόσμε" : page == 0 ? "Welcome" : "Working together", null, _options.Start);
+                    _sink.Write(DemoTables.PageMetadata, url, 2, SeedDataCatalogue.Departments[department], null, _options.Start);
+                    _sink.Write(DemoTables.PageMetadata, url, 3, KeywordNames[(department + page) % KeywordNames.Length],
+                        DemoRandom.Id(_options.Seed, 1003, (department + page) % KeywordNames.Length + 1), _options.Start);
+                    _sink.Write(DemoTables.PageMetadata, url, 4, "Site Page", null, _options.Start);
+                }
+        }
+
+        private void PrepareCallPartners()
+        {
+            // Avoid either O(users * days) retained timelines or a fresh full timeline per call.
+            int count = Math.Min(64, _options.Users);
+            for (int sample = 0; sample < count; sample++)
+            {
+                int id = 1 + (int)((long)sample * _options.Users / count);
+                var user = _population.User(id);
+                if (user.Cohort == DemoCohort.Zero) continue;
+                var timeline = new DemoTimeline(_options, user);
+                for (int day = 0; day < _options.Days; day++)
+                    if (timeline.Day(day).Meetings > 0) _callPartners[day].Add(id);
+            }
+        }
+
+        public void WriteDay(DemoUser user, int day, DemoDay activity)
+        {
+            if (!_dimensionsWritten || _summariesWritten) throw new InvalidOperationException("Invalid collaboration generation order.");
+            if (user.Cohort == DemoCohort.Zero || !activity.HasWorkloadActivity) return;
+            if (!DemoCalendar.IsWorkingDate(_options.Start.AddDays(day)) || DemoTimeline.IsOnLeave(user.Id, day)
+                || (user.Cohort == DemoCohort.Inactive && _options.Days - day <= 60)) return;
+            if (_lastUser != user.Id) { _lastUser = user.Id; _likedPages = 0; }
+            if (_options.Includes(DemoArea.Teams))
+            {
+                if (activity.Meetings > 0) WriteCall(user, day);
+                if (activity.Messages > 0) WriteChannelActivity(user, day, activity);
+            }
+            if (_options.Includes(DemoArea.SentEmail) && activity.Sent > 0) WriteEmail(user, day, activity);
+            if (_options.Includes(DemoArea.Web) && activity.SharePointFiles > 0) WritePageActivity(user, day, activity);
+            if (_options.Includes(DemoArea.Web) && activity.SharePointFiles > 0) WriteWebActivity(user, day, activity);
+            var date = _options.Start.AddDays(day);
+            if (date > _options.ReportEnd) return;
+            if (_options.Includes(DemoArea.OneDrive) && activity.OneDriveFiles > 0)
+            {
+                long files = 120 + user.Id % 500 + day * 2;
+                _sink.Write(DemoTables.OneDriveStorage, user.Id, date, date,
+                    files * (250000L + user.Id % 100 * 10000L), (long)activity.OneDriveFiles, files);
+            }
+            if (_options.Includes(DemoArea.Engage) && activity.EngageRead > 0)
+            {
+                _groupReads[user.Department, day] += activity.EngageRead;
+                _groupPosts[user.Department, day] += activity.EngageRead / 3;
+                _groupLikes[user.Department, day] += activity.EngageRead / 2;
+            }
+        }
+
+        private void WriteCall(DemoUser user, int day)
+        {
+            var partners = _callPartners[day];
+            int wanted = 1 + (int)(Random(user, day, 1010) % 3);
+            var participants = new List<int>(3);
+            int offset = partners.Count == 0 ? 0 : (int)(Random(user, day, 1011) % (uint)partners.Count);
+            for (int i = 0; i < partners.Count && participants.Count < wanted; i++)
+            {
+                int id = partners[(offset + i) % partners.Count];
+                if (id != user.Id) participants.Add(id);
+            }
+            int call = ++_calls;
+            var start = Timestamp(user, day, 1012);
+            // Bound the interval at UTC midnight even for late North American office hours.
+            var end = start.AddMinutes(10 + Random(user, day, 1013) % 36);
+            var last = _options.Start.AddDays(day + 1).AddSeconds(-1);
+            if (end > last) end = last;
+            _sink.Write(DemoTables.CallRecords, call, user.Id, participants.Count == 1 ? 1 : 2,
+                DemoRandom.Id(_options.Seed, 1014, user.Id, day).ToString(), start, end);
+            for (int i = 0; i < participants.Count; i++)
+            {
+                int session = ++_sessions;
+                _sink.Write(DemoTables.CallSessions, session, participants[i],
+                    start.AddSeconds(i * 5), end.AddSeconds(-i * 5), call);
+                _sink.Write(DemoTables.CallSessionModalities, 1, session);
+                if ((user.Id + day + i) % 3 != 0) _sink.Write(DemoTables.CallSessionModalities, 2, session);
+                if (i == 0 && (user.Id + day) % 2 == 0) _sink.Write(DemoTables.CallSessionModalities, 3, session);
+                if (i == 0 && Random(user, day, 1015) % 3 == 0)
+                {
+                    int rating = (int)(Random(user, day, 1016) % (uint)Ratings.Length);
+                    _sink.Write(DemoTables.CallFeedback, Ratings[rating],
+                        rating == 1 ? "Contoso demo: intermittent audio." : "Contoso demo: meeting feedback.",
+                        participants[i], call);
+                }
+            }
+            if (participants.Count > 0 && Random(user, day, 1017) % 13 == 0)
+                _sink.Write(DemoTables.CallFailures, "mediaConnectivityFailure", "midCall", call);
+        }
+
+        private void WriteChannelActivity(DemoUser user, int day, DemoDay activity)
+        {
+            int channel = user.Department * 2 + (int)(Random(user, day, 1020) % 2);
+            _channelMessages[channel, day] += Math.Max(1, activity.Messages / 4);
+            if (Random(user, day, 1021) % 3 == 0)
+                _sink.Write(DemoTables.ChannelReactions, 1 + (int)(Random(user, day, 1022) % 4),
+                    user.Id, channel + 1, Timestamp(user, day, 1023));
+        }
+
+        private void WriteEmail(DemoUser user, int day, DemoDay activity)
+        {
+            int count = Math.Min(2, activity.Sent);
+            for (int slot = 0; slot < count; slot++)
+            {
+                int id = ++_emails;
+                uint draw = Random(user, day, 1030 + slot);
+                _sink.Write(DemoTables.SentEmails, id, Subjects[draw % (uint)Subjects.Length],
+                    _calendar.Timestamp(user.Zone, day, Random(user, day, 1032), slot),
+                    "ContosoDemo-" + DemoRandom.Id(_options.Seed, 1033, user.Id, day, slot).ToString("N"),
+                    Sentiment(draw), user.Id, user.Id);
+                // Receiving an email is not evidence of a recipient action: inactive colleagues may receive mail.
+                int recipient = _options.Users == 1 ? _options.Users + 1 : user.Id % _options.Users + 1;
+                _sink.Write(DemoTables.EmailRecipients, id, recipient);
+                if (draw % 2 == 0)
+                    _sink.Write(DemoTables.EmailRecipients, id, _options.Users + 2);
+            }
+        }
+
+        private void WritePageActivity(DemoUser user, int day, DemoDay activity)
+        {
+            int page = day % Math.Min(3, activity.SharePointFiles);
+            int url = user.Department * 3 + page + 1;
+            var time = Timestamp(user, day, 1040);
+            if ((_likedPages & (1 << page)) == 0)
+            {
+                _sink.Write(DemoTables.PageLikes, user.Id, url, time, user.Id);
+                _likedPages |= 1 << page;
+            }
+            uint draw = Random(user, day, 1041);
+            if (draw % 5 != 0) return;
+            int comment = ++_comments, text = (int)(draw % (uint)CommentTexts.Length);
+            _sink.Write(DemoTables.PageComments, comment, CommentTexts[text],
+                draw % 7 == 0 ? (object)null : text == 3 ? 3 : 1, Sentiment(Random(user, day, 1042)), null,
+                user.Id, url, time, comment);
+            if (draw % 4 == 0)
+            {
+                int reply = ++_comments;
+                _sink.Write(DemoTables.PageComments, reply, "Contoso follow-up: adding a worked example.",
+                    1, 0.8, comment, user.Id, url, time.AddSeconds(20), reply);
+            }
+        }
+
+        private void WriteWebActivity(DemoUser user, int day, DemoDay activity)
+        {
+            int session = (user.Id - 1) * _options.Days + day + 1;
+            // Reuse the base navigation path and timestamp, not an unrelated second set of sessions/hits.
+            var start = _calendar.Timestamp(user.Zone, day, DemoRandom.Value(_options.Seed, user.Id, day, 90));
+            int element = 1 + (int)(Random(user, day, 1052) % 3);
+            _sink.Write(DemoTables.Clicks, user.Department * 3 + 2, element, element,
+                checked((session - 1) * 3 + 1), start.AddSeconds(5));
+            if (Random(user, day, 1050) % 3 == 0)
+                _sink.Write(DemoTables.Searches, session, 1 + (int)(Random(user, day, 1051) % 5), start.AddSeconds(7));
+        }
+
+        public void WriteSummaries()
+        {
+            if (!_dimensionsWritten || _summariesWritten) throw new InvalidOperationException("Invalid collaboration summary order.");
+            _summariesWritten = true;
+            if (_options.Includes(DemoArea.Teams))
+                for (int channel = 0; channel < _members.Length * 2; channel++)
+                    for (int day = 0; day < _options.Days; day++)
+                    {
+                        int messages = _channelMessages[channel, day];
+                        if (messages == 0) continue;
+                        int id = channel * _options.Days + day + 1;
+                        uint draw = DemoRandom.Value(_options.Seed, channel + 1, day, 1060);
+                        var sentiment = Sentiment(draw);
+                        _sink.Write(DemoTables.ChannelStats, id, messages, sentiment, _options.Start.AddDays(day), channel + 1);
+                        if (sentiment == null) continue;
+                        int keyword = (int)(draw % (uint)KeywordNames.Length);
+                        _sink.Write(DemoTables.ChannelKeywords, keyword + 1, id, Math.Max(1, messages / 3));
+                        _sink.Write(DemoTables.ChannelKeywords, (keyword + 1) % KeywordNames.Length + 1, id, Math.Max(1, messages / 5));
+                        _sink.Write(DemoTables.ChannelLanguages, 1, id);
+                        if (draw % 4 == 0) _sink.Write(DemoTables.ChannelLanguages, 2 + (int)(draw / 4 % 2), id);
+                    }
+            if (_options.Includes(DemoArea.Engage))
+                for (int group = 0; group < _members.Length; group++)
+                    for (int day = 0; day < _options.Days; day++)
+                    {
+                        if (_groupReads[group, day] == 0) continue;
+                        var date = _options.Start.AddDays(day);
+                        _sink.Write(DemoTables.EngageGroupActivity, _groupPosts[group, day], _groupReads[group, day],
+                            _groupLikes[group, day], _members[group], group + 1, date, date);
+                    }
+        }
+
+        private void WriteNames(DemoTable table, string[] names)
+        {
+            for (int i = 0; i < names.Length; i++) _sink.Write(table, i + 1, names[i]);
+        }
+
+        private uint Random(DemoUser user, int day, int salt) => DemoRandom.Value(_options.Seed, user.Id, day, salt);
+        private DateTime Timestamp(DemoUser user, int day, int salt) => _calendar.Timestamp(user.Zone, day, Random(user, day, salt));
+        private static object Sentiment(uint draw) => draw % 5 == 0 ? null : (object)(0.15 + draw % 8 * 0.1);
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoCollaborationTables.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoCollaborationTables.cs
@@ -1,0 +1,65 @@
+namespace Tests.FakeDataGen.Demo
+{
+    internal static partial class DemoTables
+    {
+        // Mappings follow the production entities and their explicit migrations, not DbSet names.
+        public static readonly DemoTable CallTypes = Named("call_types");
+        public static readonly DemoTable CallModalities = Named("call_modalities");
+        public static readonly DemoTable CallRecords = T("call_records", true, I("id"), I("organizer_id"),
+            I("call_type_id"), N("graph_id"), D("start"), D("end"));
+        public static readonly DemoTable CallSessions = T("call_sessions", true, I("id"), I("attendee_user_id"),
+            D("start"), D("end"), I("call_record_id"));
+        public static readonly DemoTable CallSessionModalities = T("call_session_call_modalities", false,
+            I("call_modality_id"), I("call_session_id"));
+        public static readonly DemoTable CallFeedback = T("call_feedback", false, N("rating", -1), N("text", -1),
+            I("user_id"), I("call_id"));
+        public static readonly DemoTable CallFailures = T("call_failures", false, N("reason", -1), N("stage", -1), I("call_id"));
+
+        public static readonly DemoTable TeamDefinitions = T("teams", true, I("id"), D("discovered"),
+            B("has_refresh_token"), D("last_refresh"), N("graph_id"), N("name"));
+        public static readonly DemoTable TeamChannels = T("teams_channels", true,
+            I("id"), N("graph_id"), N("name"), I("team_id"));
+        public static readonly DemoTable TeamMemberships = T("team_membership_log", false, I("user_id"), D("date"), I("team_id"));
+        public static readonly DemoTable TeamOwners = T("team_owners", false, I("owner_id"), D("discovered"), I("team_id"));
+        public static readonly DemoTable TeamTabs = T("teams_tabs", true, I("id"), N("url", -1), N("graph_id"), N("name"));
+        public static readonly DemoTable TeamTabLogs = T("teams_channel_tabs_log", false, I("tab_id"), D("date"), I("channel_id"));
+        public static readonly DemoTable ChannelStats = T("teams_channel_stats_log", true, I("id"),
+            I("chats_count"), F("sentiment_score"), D("date"), I("channel_id"));
+        public static readonly DemoTable ChannelKeywords = T("teams_channel_stats_log_keywords", false,
+            I("keyword_id"), I("channel_stats_log_id"), I("keyword_count"));
+        public static readonly DemoTable ChannelLanguages = T("teams_channel_stats_log_langs", false,
+            I("language_id"), I("channel_stats_log_id"));
+        public static readonly DemoTable ReactionTypes = Named("teams_reaction_types");
+        public static readonly DemoTable ChannelReactions = T("teams_user_channel_reactions", false,
+            I("reaction_id"), I("user_id"), I("channel_id"), D("date"));
+
+        public static readonly DemoTable EmailAddresses = T("email_addresses", true, I("id"), N("address", 450));
+        public static readonly DemoTable SentEmails = T("sent_emails", true, I("id"), N("subject", 1000),
+            D("sent_date"), N("graph_message_id", 450), F("cognitive_score"), I("from_address_id"), I("user_id"));
+        public static readonly DemoTable EmailRecipients = T("sent_email_recipients", false,
+            I("sent_email_id"), I("recipient_address_id"));
+
+        public static readonly DemoTable PageFields = Named("file_field_definitions");
+        public static readonly DemoTable PageMetadata = T("file_metadata_property_values", false,
+            I("url_id"), I("field_id"), N("field_value", -1), G("tag_guid"), D("updated"));
+        public static readonly DemoTable PageComments = T("page_comments", true, I("id"), N("comment", -1),
+            I("language_id"), F("sentiment_score"), I("parent_id"), I("user_id"), I("url_id"), D("created"), I("sp_id"));
+        public static readonly DemoTable PageLikes = T("page_likes", false,
+            I("user_id"), I("url_id"), D("created"), I("sp_id"));
+
+        public static readonly DemoTable ClickTitles = Named("hits_clicked_element_titles");
+        public static readonly DemoTable ClickClasses = T("hits_clicked_element_class_names", true,
+            I("id"), N("class_names", 2000));
+        public static readonly DemoTable Clicks = T("hits_clicked_elements", false, I("url_id"), I("element_title_id"),
+            I("class_names_id"), I("hit_id"), D("timestamp"));
+        public static readonly DemoTable SearchTerms = T("search_terms", true, I("id"), N("search_term", 250));
+        public static readonly DemoTable Searches = T("searches", false, I("session_id"), I("search_term_id"), D("date_time"));
+
+        public static readonly DemoTable OneDriveStorage = Daily("onedrive_usage_activity_log",
+            L("storage_used_bytes"), L("active_file_count"), L("file_count"));
+        public static readonly DemoTable EngageGroups = Named("yammer_groups");
+        public static readonly DemoTable EngageGroupActivity = T("yammer_group_activity_log", false,
+            I("posted_count"), I("read_count"), I("liked_count"), I("member_count"),
+            I("yammer_group_id"), D("date"), D("last_activity_date"));
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoCommand.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoCommand.cs
@@ -9,13 +9,26 @@ namespace Tests.FakeDataGen.Demo
 {
     internal static class DemoCommand
     {
-        public static int Run(string[] args)
+        public static int Run(string[] args) => RunCore(args, null);
+
+        public static int RunExisting(string[] args, string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString)
+                || args.Count(a => a == "--confirm-existing") != 1)
+            {
+                Console.Error.WriteLine("Appending synthetic activity requires a TEST database connection string and --confirm-existing.");
+                return 2;
+            }
+            return RunCore(args.Where(a => a != "--confirm-existing").ToArray(), connectionString);
+        }
+
+        private static int RunCore(string[] args, string existingConnectionString)
         {
             FileStream summaryFile = null;
             string portalConnectionString = null;
             try
             {
-                var options = DemoOptions.Parse(args, DateTime.UtcNow);
+                var options = DemoOptions.Parse(args, DateTime.UtcNow, existingConnectionString != null);
                 if (options.Help) { Console.WriteLine(DemoOptions.HelpText); return 0; }
                 if (options.Output != null)
                     summaryFile = new FileStream(options.Output, FileMode.CreateNew, FileAccess.Write, FileShare.None);
@@ -28,12 +41,24 @@ namespace Tests.FakeDataGen.Demo
                     try
                     {
                         Console.WriteLine($"Synthetic demo: {options.Users:N0} users, {options.Skus} SKUs, {options.Days} days, seed {options.Seed}, as-of {options.AsOf:yyyy-MM-dd}.");
+                        Console.WriteLine("Activity areas: " + DemoAreas.Format(options.Areas));
                         Console.WriteLine("Current assignments only: no historical seat ownership or purchased capacity is inferred.");
                         if (options.Preview)
                         {
                             using (var sink = new CountingDemoSink(summary))
                                 new DemoGenerator(options, cancellation.Token).Generate(sink, summary, Console.WriteLine);
                             summary.Status = "Preview";
+                        }
+                        else if (existingConnectionString != null)
+                        {
+                            using (var database = new SqlExistingDemoDatabase(existingConnectionString, options, cancellation.Token))
+                            {
+                                database.Open(Console.WriteLine);
+                                using (var sink = new CountingDemoSink(summary, database.CreateSink()))
+                                    new DemoGenerator(options, cancellation.Token).Generate(sink, summary, Console.WriteLine);
+                                database.Complete(summary, Console.WriteLine);
+                                summary.Status = "Appended";
+                            }
                         }
                         else
                         {
@@ -67,7 +92,7 @@ namespace Tests.FakeDataGen.Demo
                     // Deliberately the real clock, not the demo's as-of: this reports what a portal opened
                     // now would be able to measure, which is different when a historical --as-of was used.
                     DemoPortalReadiness.PrintMeasuredCoverage(portalConnectionString, DateTime.UtcNow, Console.WriteLine);
-                    DemoPortalReadiness.PrintPortalSetup(options.Database, Console.WriteLine);
+                    DemoPortalReadiness.PrintPortalSetup(options.Database, Console.WriteLine, options.Areas);
                 }
                 if (summaryFile != null)
                 {
@@ -78,8 +103,10 @@ namespace Tests.FakeDataGen.Demo
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine("Demo generation FAILED: " + ex.Message);
-                Console.Error.WriteLine("Targets are never reset automatically. Incomplete or changed targets are refused; an already completed target remains a read-only no-op.");
+                Console.Error.WriteLine("Demo generation FAILED: " + ex.GetBaseException().Message);
+                Console.Error.WriteLine(existingConnectionString == null
+                    ? "Targets are never reset automatically. Incomplete or changed targets are refused; an already completed target remains a read-only no-op."
+                    : "Append failed. Previously committed synthetic batches may remain. Existing rows are not reset or cleaned up automatically.");
                 if (summaryFile != null) Console.Error.WriteLine("No successful JSON summary was produced; the reserved output file may be empty or incomplete.");
                 return ex is ArgumentException ? 2 : ex is OperationCanceledException ? 130 : 1;
             }
@@ -89,7 +116,8 @@ namespace Tests.FakeDataGen.Demo
         internal static DemoSummary NewSummary(DemoOptions options) => new DemoSummary
         {
             Fingerprint = options.Fingerprint, Users = options.Users, Skus = options.Skus, Seed = options.Seed,
-            AsOf = options.AsOf, FirstActivityDate = options.Start, LastReportDate = options.ReportEnd
+            AsOf = options.AsOf, FirstActivityDate = options.Start, LastReportDate = options.ReportEnd,
+            Areas = DemoAreas.Format(options.Areas)
         };
     }
 }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoGenerator.cs
@@ -12,6 +12,7 @@ namespace Tests.FakeDataGen.Demo
         public string FormatVersion { get; set; } = DemoOptions.FormatVersion;
         public string Fingerprint { get; set; }
         public string Status { get; set; }
+        public string Areas { get; set; }
         public int Users { get; set; }
         public int Skus { get; set; }
         public int Seed { get; set; }
@@ -56,6 +57,8 @@ namespace Tests.FakeDataGen.Demo
         private readonly CancellationToken _cancellation;
         private IDemoSink _sink;
         private DemoSummary _summary;
+        private DemoCollaborationGenerator _collaboration;
+        private DemoPowerPlatformGenerator _powerPlatform;
 
         public DemoGenerator(DemoOptions options, CancellationToken cancellation = default(CancellationToken))
         {
@@ -96,9 +99,14 @@ namespace Tests.FakeDataGen.Demo
             }
             foreach (var sku in _population.Skus) summary.CurrentSkuMembers.Add(sku.PartNumber, sku.Members);
             _sink.Flush();
+            _collaboration = new DemoCollaborationGenerator(_options, _population, _calendar, _sink);
+            _collaboration.WriteDimensions();
+            _powerPlatform = new DemoPowerPlatformGenerator(_options, _calendar, _sink);
+            _powerPlatform.WriteDimensions();
+            _sink.Flush();
 
             int progressEvery = Math.Max(1, _options.Users / 20);
-            for (int id = 1; id <= _options.Users; id++)
+            for (int id = 1; id <= _options.Users && _options.Areas != DemoArea.Directory; id++)
             {
                 _cancellation.ThrowIfCancellationRequested();
                 var user = _population.User(id);
@@ -107,7 +115,8 @@ namespace Tests.FakeDataGen.Demo
                 if (id % progressEvery == 0 || id == _options.Users)
                     progress?.Invoke($"Activity: {id:N0}/{_options.Users:N0} users; {summary.TotalRows:N0} source rows.");
             }
-            WriteCopilotCounts();
+            _collaboration.WriteSummaries();
+            if (_options.Includes(DemoArea.Copilot)) WriteCopilotCounts();
             _sink.Flush();
             return summary;
         }
@@ -181,7 +190,20 @@ namespace Tests.FakeDataGen.Demo
                 _sink.Write(DemoTables.InteractionApps, i + 1, "IPM.SkypeTeams.Message.Copilot." + DemoTimeline.Hosts[i]);
             _sink.Write(DemoTables.ConversationTypes, 1, "bizchat");
             _sink.Write(DemoTables.ConversationTypes, 2, "appchat");
-            WriteDlpDimensions();
+            if (_options.Includes(DemoArea.Copilot | DemoArea.Dlp))
+            {
+                _sink.Write(DemoTables.CopilotModels, 1, "Contoso demo language model", "Synthetic provider", "1.0");
+                _sink.Write(DemoTables.CopilotModels, 2, "Contoso demo reasoning model", "Synthetic provider", "2.0");
+                _sink.Write(DemoTables.CopilotPlugins, 1, DemoRandom.Id(_options.Seed, 2100, 1).ToString(),
+                    "Contoso knowledge retrieval", "1.0");
+                _sink.Write(DemoTables.CopilotPlugins, 2, DemoRandom.Id(_options.Seed, 2100, 2).ToString(),
+                    "Contoso calendar assistant", "1.0");
+                for (int department = 0; department < SeedDataCatalogue.Departments.Length; department++)
+                    _sink.Write(DemoTables.CopilotMeetings, department + 1, _options.Start,
+                        DemoRandom.Id(_options.Seed, 2101, department + 1).ToString(),
+                        "Contoso " + SeedDataCatalogue.Departments[department] + " weekly sync");
+            }
+            if (_options.Includes(DemoArea.Dlp)) WriteDlpDimensions();
         }
 
         /// <summary>
@@ -276,7 +298,8 @@ namespace Tests.FakeDataGen.Demo
                         if (timeline.Agent(d, slot) > 0) { appDays[bucket, 8] = 1; lastApps[8] = date; }
                         if (reported && d >= _options.Days - 28) hosts.Add(host);
                     }
-                    if (reported) WriteCopilotEvents(user, timeline, d);
+                    if (reported && _options.Includes(DemoArea.Copilot | DemoArea.CopilotHistory | DemoArea.Dlp))
+                        WriteCopilotEvents(user, timeline, d);
                 }
                 windowTurns += turnWindow[bucket];
                 windowChat += chatWindow[bucket];
@@ -295,17 +318,20 @@ namespace Tests.FakeDataGen.Demo
                     _rollingPrompts[d] += windowTurns;
                 }
                 if (!reported) continue;
-                if (day.SharePointFiles > 0) WriteWebEvents(user, d, day);
+                if (day.SharePointFiles > 0 && _options.Includes(DemoArea.SharePoint | DemoArea.Web))
+                    WriteWebEvents(user, d, day);
+                _collaboration.WriteDay(user, d, day);
+                _powerPlatform.WriteDay(user, d, day);
                 if (date > _options.ReportEnd) continue;
                 int appMask = 0;
                 for (int app = 1; app <= 7; app++) if (appDays[bucket, app] > 0) appMask |= 1 << app;
                 WriteWorkloadRows(user, d, day, lastWorkload, appMask, ref lastOffice, ref lastTeamsDevice);
-                if (user.CopilotLicensed)
+                if (user.CopilotLicensed && _options.Includes(DemoArea.Copilot))
                     _sink.Write(DemoTables.CopilotUsage, user.Id, date, lastApps[0], 28, windowTurns, windowChat, 0,
                         appWindow[0], lastApps[1], lastApps[2], lastApps[3], lastApps[4], lastApps[5], lastApps[6],
                         lastApps[7], lastApps[1], lastApps[8], false);
             }
-            if (user.CopilotLicensed)
+            if (user.CopilotLicensed && _options.Includes(DemoArea.Copilot))
             {
                 var scored = CopilotAdoptionScoring.Score(new LicensedUserUsageRow
                 {
@@ -324,25 +350,25 @@ namespace Tests.FakeDataGen.Demo
             for (int i = 0; i < last.Length; i++) if (totals[i] > 0) last[i] = date;
             int privateChats = day.Messages / 2, posts = day.Messages / 8, replies = day.Messages / 4;
             int organised = day.Meetings / 3, attended = day.Meetings - organised;
-            _sink.Write(DemoTables.Teams, user.Id, date, last[0],
+            if (_options.Includes(DemoArea.Teams)) _sink.Write(DemoTables.Teams, user.Id, date, last[0],
                 privateChats, day.Messages - privateChats - posts - replies, posts, replies, day.Messages / 30,
                 day.Messages / 40, day.Meetings, attended / 3, organised / 3, attended, organised,
                 attended / 3, organised / 3, attended - 2 * (attended / 3), organised - 2 * (organised / 3),
                 day.Meetings * 1500 + day.Messages / 40 * 480, day.Meetings * 900, day.Meetings * 300);
-            _sink.Write(DemoTables.Outlook, user.Id, date, last[1], day.Sent, day.Received, day.Read,
+            if (_options.Includes(DemoArea.Outlook)) _sink.Write(DemoTables.Outlook, user.Id, date, last[1], day.Sent, day.Received, day.Read,
                 day.Sent > 0 ? organised : 0, day.Sent > 0 ? day.Meetings : 0);
-            _sink.Write(DemoTables.SharePoint, user.Id, date, last[2], day.SharePointFiles, day.SharePointFiles / 5,
+            if (_options.Includes(DemoArea.SharePoint)) _sink.Write(DemoTables.SharePoint, user.Id, date, last[2], day.SharePointFiles, day.SharePointFiles / 5,
                 day.SharePointFiles / 6, day.SharePointFiles / 30);
-            _sink.Write(DemoTables.OneDrive, user.Id, date, last[3], day.OneDriveFiles, day.OneDriveFiles / 3,
+            if (_options.Includes(DemoArea.OneDrive)) _sink.Write(DemoTables.OneDrive, user.Id, date, last[3], day.OneDriveFiles, day.OneDriveFiles / 3,
                 day.OneDriveFiles / 8, day.OneDriveFiles / 30);
-            _sink.Write(DemoTables.Engage, user.Id, date, last[4], day.EngageRead / 8, day.EngageRead, day.EngageRead / 4);
+            if (_options.Includes(DemoArea.Engage)) _sink.Write(DemoTables.Engage, user.Id, date, last[4], day.EngageRead / 8, day.EngageRead, day.EngageRead / 4);
 
             bool teams = totals[0] > 0 || (copilotApps & (1 << 2)) != 0;
             bool engage = day.EngageRead > 0, mac = user.Id % 5 == 0, mobile = user.Id % 3 == 0;
             if (teams) lastTeamsDevice = date;
-            _sink.Write(DemoTables.TeamsDevices, user.Id, date, lastTeamsDevice,
+            if (_options.Includes(DemoArea.Teams)) _sink.Write(DemoTables.TeamsDevices, user.Id, date, lastTeamsDevice,
                 teams, false, false, false, teams && mobile && mac, teams && mobile && !mac, teams && mac, teams && !mac);
-            _sink.Write(DemoTables.EngageDevices, user.Id, date, last[4], engage, false,
+            if (_options.Includes(DemoArea.Engage)) _sink.Write(DemoTables.EngageDevices, user.Id, date, last[4], engage, false,
                 engage && mobile && !mac, false, engage && mobile && mac, false);
             bool files = day.SharePointFiles + day.OneDriveFiles > 0;
             bool[] apps =
@@ -361,7 +387,7 @@ namespace Tests.FakeDataGen.Demo
             values.AddRange(apps.Cast<object>());
             foreach (bool device in new[] { !mac, mac, mobile, true })
                 values.AddRange(apps.Select(a => (object)(a && device)));
-            _sink.Write(DemoTables.Platforms, values.ToArray());
+            if (_options.Includes(DemoArea.Office)) _sink.Write(DemoTables.Platforms, values.ToArray());
         }
 
         private void WriteCopilotEvents(DemoUser user, DemoTimeline timeline, int dayIndex)
@@ -369,28 +395,45 @@ namespace Tests.FakeDataGen.Demo
             var day = timeline.Day(dayIndex);
             int sessionId = (user.Id - 1) * _options.Days + dayIndex + 1;
             string thread = "contoso-demo-" + DemoRandom.Id(_options.Seed, 3, user.Id, dayIndex).ToString("N");
-            if (user.CopilotLicensed) _sink.Write(DemoTables.InteractionSessions, sessionId, thread, user.Id);
+            if (user.CopilotLicensed && _options.Includes(DemoArea.CopilotHistory))
+                _sink.Write(DemoTables.InteractionSessions, sessionId, thread, user.Id);
             for (int slot = 0; slot < day.CopilotTurns; slot++)
             {
                 var id = DemoRandom.Id(_options.Seed, 4, user.Id, dayIndex, slot);
                 int host = timeline.HostIndex(dayIndex, slot), agent = timeline.Agent(dayIndex, slot);
                 var time = _calendar.Timestamp(user.Zone, dayIndex, DemoRandom.Value(_options.Seed, user.Id, dayIndex, 50), slot);
-                _sink.Write(DemoTables.Audit, id, user.Id, 1, time);
-                _sink.Write(DemoTables.Chats, id, DemoTimeline.Hosts[host], agent == 0 ? (object)null : agent,
-                    thread, user.Profile.UsageLocation, DemoOptions.FormatVersion, user.Id, time);
-                if (agent > 0 && agent != 5 && slot == 0)
-                    _sink.Write(DemoTables.Resources, id, 1, 1, 1);
-                WriteDlpEvent(user, dayIndex, slot, id, agent, time);
+                if (_options.Includes(DemoArea.Copilot | DemoArea.Dlp))
+                {
+                    _sink.Write(DemoTables.Audit, id, user.Id, 1, time);
+                    _sink.Write(DemoTables.Chats, id, DemoTimeline.Hosts[host], agent == 0 ? (object)null : agent,
+                        thread, user.Profile.UsageLocation, DemoOptions.FormatVersion, user.Id, time);
+                    if (agent > 0 && agent != 5 && slot == 0)
+                        _sink.Write(DemoTables.Resources, id, 1, 1, 1);
+                    if (slot == 0 && user.Id % 3 != 0)
+                        _sink.Write(DemoTables.CopilotEventModels, id, 1 + user.Id % 2);
+                    if (slot == 0 && agent > 0 && user.Id % 2 == 0)
+                        _sink.Write(DemoTables.CopilotEventPlugins, id, 1 + user.Id / 2 % 2);
+                    if (slot == 0 && host == 0 && user.Id % 2 != 0)
+                        _sink.Write(DemoTables.CopilotFileContexts, id, 1, 1, user.Department * 3 + 1, user.Department + 1);
+                    if (slot == 0 && host == 1)
+                        _sink.Write(DemoTables.CopilotMeetingContexts, id, user.Department + 1);
+                    if (_options.Includes(DemoArea.Dlp))
+                        WriteDlpEvent(user, dayIndex, slot, id, agent, time);
+                }
                 // Graph interaction history requires a Copilot licence. Free Chat demand is
                 // visible in the audit source, but must not be invented in that Graph feed.
-                if (!user.CopilotLicensed) continue;
+                if (!user.CopilotLicensed || !_options.Includes(DemoArea.CopilotHistory)) continue;
                 int words = 8 + (int)(DemoRandom.Value(_options.Seed, user.Id, dayIndex, 51 + slot) % 50);
                 int latency = 800 + (int)(DemoRandom.Value(_options.Seed, user.Id, dayIndex, 71 + slot) % 15000);
                 string request = id.ToString("N");
+                object language = user.Id % 3 == 0 ? null : (object)1;
+                object sentiment = language == null ? null : (object)((1 + (user.Id + slot) % 9) / 10.0);
                 _sink.Write(DemoTables.Interactions, request + "-prompt", sessionId, user.Id, request, 1,
-                    host + 1, host == 0 ? 1 : 2, time, words * 6, words, 0, 0, 0, agent > 0 ? 1 : 0, null);
+                    host + 1, host == 0 ? 1 : 2, time, words * 6, words, 0, 0, 0, agent > 0 ? 1 : 0, null,
+                    language, sentiment);
                 _sink.Write(DemoTables.Interactions, request + "-response", sessionId, user.Id, request, 2,
-                    host + 1, host == 0 ? 1 : 2, time.AddMilliseconds(latency), words * 24, words * 4, 0, agent > 0 ? 1 : 0, 0, 0, latency);
+                    host + 1, host == 0 ? 1 : 2, time.AddMilliseconds(latency), words * 24, words * 4, 0, agent > 0 ? 1 : 0, 0, 0, latency,
+                    language, sentiment);
             }
         }
 
@@ -424,9 +467,11 @@ namespace Tests.FakeDataGen.Demo
             _sink.Write(DemoTables.DlpRuleMatches, id, policy + 1, policy + 1, blocked ? 1 : 2, blocked);
         }
 
-        private void WriteWebEvents(DemoUser user, int day, DemoDay activity)        {
+        private void WriteWebEvents(DemoUser user, int day, DemoDay activity)
+        {
             int session = (user.Id - 1) * _options.Days + day + 1, site = user.Department + 1;
-            _sink.Write(DemoTables.Sessions, session, DemoRandom.Id(_options.Seed, 5, user.Id, day).ToString("N"), user.Id);
+            if (_options.Includes(DemoArea.Web))
+                _sink.Write(DemoTables.Sessions, session, DemoRandom.Id(_options.Seed, 5, user.Id, day).ToString("N"), user.Id);
             var start = _calendar.Timestamp(user.Zone, day, DemoRandom.Value(_options.Seed, user.Id, day, 90));
             // A small representative navigation path, not a second copy of every Graph file count.
             for (int page = 0; page < Math.Min(3, activity.SharePointFiles); page++)
@@ -434,13 +479,17 @@ namespace Tests.FakeDataGen.Demo
                 int url = (site - 1) * 3 + page + 1;
                 var stamp = start.AddSeconds(page * 12);
                 var eventId = DemoRandom.Id(_options.Seed, 6, user.Id, day, page);
-                _sink.Write(DemoTables.Audit, eventId, user.Id, page == 2 ? 3 : 2, stamp);
-                _sink.Write(DemoTables.SharePointAudit, eventId, url, 1, page + 1, site, 1);
+                if (_options.Includes(DemoArea.SharePoint))
+                {
+                    _sink.Write(DemoTables.Audit, eventId, user.Id, page == 2 ? 3 : 2, stamp);
+                    _sink.Write(DemoTables.SharePointAudit, eventId, url, 1, page + 1, site, 1);
+                }
                 bool mac = user.Id % 5 == 0, mobile = user.Id % 3 == 0;
-                _sink.Write(DemoTables.Hits, url, stamp, session, page + 1, site, mac ? 3 : 1 + user.Id % 2,
+                if (_options.Includes(DemoArea.Web)) _sink.Write(DemoTables.Hits, url, stamp, session, page + 1, site, mac ? 3 : 1 + user.Id % 2,
                     mobile ? 2 : 1, mobile ? (mac ? 3 : 4) : mac ? 2 : 1, 10.0 + page, 350.0 + user.Id % 500,
                     DemoRandom.Id(_options.Seed, 7, user.Id, day, page),
-                    Lookup(DemoTables.WebCountries, user.Profile.Country), Lookup(DemoTables.WebCities, WebCity(user.Profile.City)));
+                    Lookup(DemoTables.WebCountries, user.Profile.Country), Lookup(DemoTables.WebCities, WebCity(user.Profile.City)),
+                    checked((session - 1) * 3 + page + 1));
             }
         }
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoInteractive.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoInteractive.cs
@@ -50,6 +50,21 @@ namespace Tests.FakeDataGen.Demo
             }
         }
 
+        public static void RunArea(DemoAreaDescription area, string connectionString)
+        {
+            var prompt = new ConsoleDemoPrompt();
+            prompt.Write(area.Title);
+            bool existing = AskYesNo(prompt, "Append to the existing TEST database supplied at startup (otherwise create a new LocalDB database)?", false);
+            if (existing && string.IsNullOrWhiteSpace(connectionString))
+                throw new InvalidOperationException("No existing database connection was supplied. Restart with a TEST database connection string, or choose a new database.");
+            var args = BuildArgs(prompt, DateTime.UtcNow, area.Area, existing);
+            if (args == null) { prompt.Write("Cancelled. Nothing was changed."); return; }
+            int code = existing
+                ? DemoCommand.RunExisting(args.Concat(new[] { "--confirm-existing" }).ToArray(), connectionString)
+                : DemoCommand.Run(args);
+            if (code != 0) prompt.Write($"Activity generation FAILED (exit code {code}).");
+        }
+
         /// <summary>
         /// Asks for the options, then runs the demo generator. Returns the same exit code the
         /// <c>demo</c> command line returns, or 0 when the user chose not to start.
@@ -73,25 +88,35 @@ namespace Tests.FakeDataGen.Demo
         /// otherwise defaults to the clock: without it the printed line would name a different window when
         /// it is read on a later day.
         /// </summary>
-        internal static string[] BuildArgs(IDemoPrompt prompt, DateTime utcNow)
+        internal static string[] BuildArgs(IDemoPrompt prompt, DateTime utcNow,
+            DemoArea areas = DemoArea.All, bool existing = false)
         {
             var defaults = new DemoOptions();
 
             prompt.Write(string.Empty);
             prompt.Write("Generates the same rounded, entirely synthetic Contoso data set as");
             prompt.Write("'Tests.FakeDataGen.exe demo': licences, daily workload activity, Copilot adoption");
-            prompt.Write("and D28 snapshots, metadata-only interactions, SharePoint facts and weekly Power BI");
-            prompt.Write("profiles. No prompt or response text is generated.");
+            prompt.Write("and D28 snapshots, Teams detail, sent email, SharePoint/web and Power Platform");
+            prompt.Write("activity. No real message, prompt or response text is generated.");
+            prompt.Write("Selected areas: " + DemoAreas.Format(areas) + ". Shared synthetic users/licences are included.");
             prompt.Write(string.Empty);
-            prompt.Write(@"It only ever creates a NEW database on (localdb)\MSSQLLocalDB. It ignores the");
-            prompt.Write("connection string this tool was started with, never writes to an existing database,");
-            prompt.Write("and has no reset option - re-running a completed target is a read-only no-op.");
+            if (existing)
+            {
+                prompt.Write("WARNING: use only a TEST/demo database. This appends a NEW synthetic population.");
+                prompt.Write("Existing users are not changed; no schema upgrade, global profiles or tenant totals.");
+                prompt.Write("Committed batches remain after failure. No automatic cleanup or reset is performed.");
+            }
+            else
+            {
+                prompt.Write(@"It only creates a NEW database on (localdb)\MSSQLLocalDB and ignores the startup");
+                prompt.Write("connection string. There is no reset - an exact completed rerun is a read-only no-op.");
+            }
             prompt.Write(string.Empty);
 
             bool preview = AskYesNo(prompt, "Preview only (count the rows, write no SQL at all)?", false);
 
             string database = null;
-            if (!preview)
+            if (!preview && !existing)
             {
                 database = AskDatabaseName(prompt, DefaultDatabaseName(utcNow));
             }
@@ -104,7 +129,7 @@ namespace Tests.FakeDataGen.Demo
             int copilotPercent = defaults.CopilotPercent;
             int batchSize = defaults.BatchSize;
             string mix = string.Join(",", defaults.Mix);
-            bool compileProfiles = defaults.CompileProfiles;
+            bool compileProfiles = defaults.CompileProfiles && !existing;
             string output = null;
 
             prompt.Write(string.Empty);
@@ -122,9 +147,10 @@ namespace Tests.FakeDataGen.Demo
 
                 if (!preview)
                 {
-                    compileProfiles = AskYesNo(prompt,
-                        "Compile the weekly Power BI profiles afterwards (slower, but the reports need them)?",
-                        compileProfiles);
+                    if (!existing)
+                        compileProfiles = AskYesNo(prompt,
+                            "Compile the weekly Power BI profiles afterwards (slower, but the reports need them)?",
+                            compileProfiles);
                     batchSize = AskInt(prompt, "SQL insert batch size", batchSize,
                         DemoOptions.MinBatchSize, DemoOptions.MaxBatchSize);
                 }
@@ -137,10 +163,15 @@ namespace Tests.FakeDataGen.Demo
             {
                 args.Add("--preview");
             }
-            else
+            else if (!existing)
             {
                 args.Add("--database");
                 args.Add(database);
+            }
+            if (areas != DemoArea.All)
+            {
+                args.Add("--areas");
+                args.Add(DemoAreas.Format(areas));
             }
             args.Add("--as-of");
             args.Add(asOf.ToString(DemoOptions.DateFormat, CultureInfo.InvariantCulture));
@@ -166,6 +197,7 @@ namespace Tests.FakeDataGen.Demo
             prompt.Write("About to generate:");
             prompt.Write("  Target             " + (preview
                 ? "preview only - no database, no rows, no weekly profiles"
+                : existing ? "existing TEST database supplied at startup (additive)"
                 : database + @" (new database on (localdb)\MSSQLLocalDB)"));
             prompt.Write($"  Users / SKUs       {users:N0} / {skus:N0}");
             prompt.Write($"  History            {days:N0} days ending {asOf.ToString(DemoOptions.DateFormat, CultureInfo.InvariantCulture)} (exclusive)");
@@ -178,12 +210,14 @@ namespace Tests.FakeDataGen.Demo
             }
             prompt.Write("  JSON summary       " + (string.IsNullOrEmpty(output) ? "(none)" : output));
             prompt.Write(string.Empty);
-            prompt.Write("Equivalent command line: Tests.FakeDataGen.exe demo " + CommandLine(args));
+            prompt.Write("Equivalent command line: Tests.FakeDataGen.exe " + (existing
+                ? "append \"<test-database-connection-string>\" --confirm-existing "
+                : "demo ") + CommandLine(args));
             prompt.Write(string.Empty);
             prompt.Write("Large populations or long histories can exceed LocalDB's storage limit; preview first if unsure.");
             prompt.Write(string.Empty);
 
-            return AskYesNo(prompt, "Start generating now?", true) ? args.ToArray() : null;
+            return AskYesNo(prompt, "Start generating now?", !existing) ? args.ToArray() : null;
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoOptions.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoOptions.cs
@@ -12,7 +12,8 @@ namespace Tests.FakeDataGen.Demo
     {
         // Bump when generation rules change: completed targets must not silently reuse an older shape.
         // History: contoso-demo-v2 - Copilot report rows now cover the whole window (28-day warm-up).
-        public const string FormatVersion = "contoso-demo-v2";
+        // History: contoso-demo-v3 - selectable imported workloads and detailed activity.
+        public const string FormatVersion = "contoso-demo-v3";
 
         // Accepted ranges, shared with the interactive menu (DemoInteractive) so the two entry points
         // cannot drift apart and offer a value the other refuses.
@@ -39,11 +40,14 @@ namespace Tests.FakeDataGen.Demo
         public bool Preview { get; private set; }
         public bool Help { get; private set; }
         public bool CompileProfiles { get; private set; } = true;
+        public DemoArea Areas { get; private set; } = DemoArea.All;
+        public bool Includes(DemoArea area) => (Areas & area) != 0;
+        public bool HasAllDailyWorkloads => (Areas & DemoAreas.DailyWorkloads) == DemoAreas.DailyWorkloads;
         public int[] Mix { get; private set; } = new[] { 30, 35, 20, 8, 7 };
         public DateTime Start => AsOf.AddDays(-Days);
         public DateTime ReportEnd => AsOf.AddDays(-3);
 
-        public static DemoOptions Parse(string[] args, DateTime utcToday)
+        public static DemoOptions Parse(string[] args, DateTime utcToday, bool existingTarget = false)
         {
             var result = new DemoOptions { AsOf = DateTime.SpecifyKind(utcToday.Date, DateTimeKind.Utc) };
             var seen = new HashSet<string>(StringComparer.Ordinal);
@@ -60,6 +64,7 @@ namespace Tests.FakeDataGen.Demo
                 switch (key)
                 {
                     case "--database": result.Database = value; break;
+                    case "--areas": result.Areas = DemoAreas.Parse(value); break;
                     case "--output": result.Output = value; break;
                     case "--users": result.Users = Integer(key, value, MinUsers, MaxUsers); break;
                     case "--skus": result.Skus = Integer(key, value, MinSkus, MaxSkus); break;
@@ -81,10 +86,14 @@ namespace Tests.FakeDataGen.Demo
                     default: throw new ArgumentException("Unknown demo option: " + key + ". Use demo --help.");
                 }
             }
-            if (!result.Help && !result.Preview && string.IsNullOrWhiteSpace(result.Database))
+            if (!result.Help && !result.Preview && !existingTarget && string.IsNullOrWhiteSpace(result.Database))
                 throw new ArgumentException("Use --database ContosoDemo_<name> for a NEW local demo database, or --preview for no SQL.");
+            if (existingTarget && result.Database != null)
+                throw new ArgumentException("An existing target cannot also specify --database. Use demo for a new LocalDB target.");
             if (result.Database != null && !IsValidDatabaseName(result.Database))
                 throw new ArgumentException("--database must start with ContosoDemo_ and contain only ASCII letters, digits and underscores.");
+            if (result.Includes(DemoArea.Web) && (long)result.Users * result.Days * 3 > int.MaxValue)
+                throw new ArgumentException("Web activity requires 3 * users * days to fit SQL integer hit IDs. Reduce --users or --days.");
             return result;
         }
 
@@ -109,7 +118,7 @@ namespace Tests.FakeDataGen.Demo
             {
                 // Destination, progress and SQL batch size do not change the generated data.
                 var shape = FormattableString.Invariant(
-                    $"{FormatVersion}|{Users}|{Skus}|{Days}|{Seed}|{AsOf:yyyy-MM-dd}|{CopilotPercent}|{string.Join(",", Mix)}|{CompileProfiles}");
+                    $"{FormatVersion}|{Users}|{Skus}|{Days}|{Seed}|{AsOf:yyyy-MM-dd}|{CopilotPercent}|{string.Join(",", Mix)}|{CompileProfiles}|{DemoAreas.Format(Areas)}");
                 using (var hash = SHA256.Create())
                     return BitConverter.ToString(hash.ComputeHash(Encoding.UTF8.GetBytes(shape))).Replace("-", "").ToLowerInvariant();
             }
@@ -119,12 +128,19 @@ namespace Tests.FakeDataGen.Demo
   Tests.FakeDataGen.exe demo --database ContosoDemo_Example
   Tests.FakeDataGen.exe demo --preview --users 300000 --skus 50 --days 31
   Tests.FakeDataGen.exe demo --database ContosoDemo_Repeatable --as-of 2026-09-01 --seed 42
+  Tests.FakeDataGen.exe demo --database ContosoDemo_Teams --areas teams
+  Tests.FakeDataGen.exe append ""<test-database-connection-string>"" --areas powerapps,powerbi --confirm-existing
 
 Or run Tests.FakeDataGen.exe with no arguments and pick the demo option from the menu: it
 asks for the same values, prints the equivalent command line, and runs this same generator.
 
   --database NAME          NEW database on (localdb)\MSSQLLocalDB only. Required unless preview.
   --preview                Stream the same rows to counters; no SQL, config or external services.
+  --areas LIST             all (default), or comma-separated area keys:
+                           directory,copilot,copilot-history,teams,outlook,sent-email,
+                           sharepoint,web,onedrive,engage,office,powerapps,powerautomate,
+                           powerbi,copilot-studio,dlp. Shared users/licences are prerequisites.
+                           dlp includes the Copilot audit interactions its policy matches need.
   --users N                1..1000000 (default 1000).
   --skus N                 10..1000 (default 50); current assignments, not purchased capacity.
   --days N                 31..730 preceding calendar days (default 180).
@@ -145,13 +161,19 @@ asks for the same values, prints the equivalent command line, and runs this same
 Includes demographics, overlapping/rare SKUs, explicit zero daily workload rows, weekday
 office-hour activity with time zones/leave, Copilot adoption personas/agents/Cowork,
 licensed-only D28 v2 snapshots, paired metadata-only interactions, SharePoint/web facts,
-and complete-week Power BI activity/device profiles. No prompt or response text.
+Teams call/channel detail, sent email, Power Platform audit events and complete-week
+Power BI activity/device profiles. Power BI report views are separate from these profiles.
+No real message, prompt or response text. All text/sentiment is synthetic.
 No schema/config changes; existing schema is applied through DatabaseUpgrader on the NEW DB.
 Exact completed reruns are read-only no-ops. Unmarked, changed or incomplete targets fail;
 choose a new name after a failure. There is deliberately no reset or production-connection option.
+The separate append command requires --confirm-existing and an existing, current-schema
+TEST database. It adds a fresh synthetic population without modifying existing users.
+It never creates/upgrades the target, compiles global profiles or invents tenant-wide
+Copilot totals. Completed batches remain after failure; there is no automatic cleanup.
 Large populations/histories can exceed LocalDB's storage limit: preview the row counts first.
-Not generated: Teams call/channel detail, sent-email sentiment, Power Platform audit events,
-tenant capacity/history, installation/health success logs or cognitive enrichment.
+Not generated: tenant capacity/licence history, installation/health success logs or
+live cognitive enrichment. Demo activity is representative, not an importer load test.
 Full guide: https://github.com/pnp/Microsoft365-Analytics-Insights/wiki/Synthetic-demo-data";
     }
 }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoOptions.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoOptions.cs
@@ -173,7 +173,8 @@ choose a new name after a failure. There is deliberately no reset or production-
 The separate append command requires --confirm-existing and an existing, current-schema
 TEST database. It adds a fresh synthetic population without modifying existing users.
 It never creates/upgrades the target, compiles global profiles or invents tenant-wide
-Copilot totals. Completed batches remain after failure; there is no automatic cleanup.
+Copilot totals, Copilot Studio credits, capacity or Azure agent spend.
+Completed batches remain after failure; there is no automatic cleanup.
 Large populations/histories can exceed LocalDB's storage limit: preview the row counts first.
 Agent costs follow the generated agent traffic, so a population that never uses an agent gets
 no Copilot Studio credits; Azure's fixed meters are still billed because the resources exist.

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoPortalReadiness.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoPortalReadiness.cs
@@ -24,23 +24,49 @@ namespace Tests.FakeDataGen.Demo
         /// The import toggles whose tables this generator actually fills. Deliberately not "everything":
         /// a flag listed here but not generated would send an operator looking for data that is absent.
         /// </summary>
-        internal const string RequiredImportJobSettings =
-            "GraphUsersMetadata=True;GraphUsageReports=True;GraphCopilotUsageReports=True;"
-            + "Copilot=True;CopilotInteractionHistory=True;ActivityLog=True;WebTraffic=True;ImportDlp=True";
+        internal static string RequiredImportJobSettings => ImportSettings(DemoArea.All);
 
-        internal static void PrintPortalSetup(string database, Action<string> write)
+        internal static void PrintPortalSetup(string database, Action<string> write, DemoArea areas = DemoArea.All)
         {
             if (write == null) return;
             write(string.Empty);
             write("To view this data, point a web application at it with:");
             write($"  connectionStrings   SPOInsightsEntities = Server=(localdb)\\MSSQLLocalDB;Database={database};Integrated Security=True");
-            write("  appSettings         ImportJobSettings = " + RequiredImportJobSettings);
+            write("  appSettings         ImportJobSettings = " + ImportSettings(areas));
             write(string.Empty);
             write("Those toggles are how the portal decides which sources exist; they are all opt-in and");
-            write("default to false. In particular, WITHOUT GraphCopilotUsageReports=True the Licence");
-            write("assignments report shows Copilot as \"Not measured\" for every user even though this");
-            write("database is full of Copilot activity: the audit and interaction sources are positive");
-            write("evidence only and never produce activity bands.");
+            write("default to false.");
+            if ((areas & (DemoArea.Copilot | DemoArea.CopilotHistory)) != 0)
+            {
+                write("Without official usage-report data and GraphCopilotUsageReports=True, the Licence");
+                write("assignments report cannot measure Copilot activity bands. Audit and interaction");
+                write("history are positive evidence only; they do not replace the official usage feed.");
+            }
+            write("Use these flags on the demo portal, not on live import jobs connected to the synthetic database.");
+        }
+
+        internal static string ImportSettings(DemoArea areas)
+        {
+            var flags = new List<string> { "GraphUsersMetadata=True" };
+            if ((areas & DemoAreas.DailyWorkloads) != 0) flags.Add("GraphUsageReports=True");
+            if ((areas & DemoArea.Copilot) != 0)
+            {
+                flags.Add("GraphCopilotUsageReports=True");
+            }
+            if ((areas & (DemoArea.Copilot | DemoArea.Dlp)) != 0) flags.Add("Copilot=True");
+            if ((areas & DemoArea.CopilotHistory) != 0) flags.Add("CopilotInteractionHistory=True");
+            if ((areas & DemoArea.SharePoint) != 0) flags.Add("ActivityLog=True");
+            if ((areas & DemoArea.Web) != 0) flags.Add("WebTraffic=True");
+            if ((areas & DemoArea.Teams) != 0)
+            {
+                flags.Add("Calls=True");
+                flags.Add("GraphTeams=True");
+            }
+            if ((areas & DemoArea.SentEmail) != 0) flags.Add("SentEmails=True");
+            if ((areas & (DemoArea.PowerApps | DemoArea.PowerAutomate | DemoArea.PowerBI | DemoArea.CopilotStudio)) != 0)
+                flags.Add("ImportPowerPlatform=True");
+            if ((areas & DemoArea.Dlp) != 0) flags.Add("ImportDlp=True");
+            return string.Join(";", flags);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoPowerPlatformGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoPowerPlatformGenerator.cs
@@ -1,0 +1,144 @@
+using System;
+using Tests.FakeDataGen.Seeding;
+
+namespace Tests.FakeDataGen.Demo
+{
+    internal sealed class DemoPowerPlatformGenerator
+    {
+        private readonly DemoOptions _options;
+        private readonly DemoCalendar _calendar;
+        private readonly IDemoSink _sink;
+        private static readonly string[] Operations =
+        {
+            "LaunchPowerApp", "EditPowerApp", "PublishPowerApp", "SharePowerApp",
+            "CreateFlow", "EditFlow", "PutPermissions", "DeletePermissions",
+            "ViewReport", "BotUpdateOperation-BotPublish", "BotUpdateOperation-BotNameUpdate"
+        };
+        private static readonly string[] Connectors =
+        {
+            "shared_sharepointonline", "shared_office365", "shared_teams", "shared_sql"
+        };
+
+        public DemoPowerPlatformGenerator(DemoOptions options, DemoCalendar calendar, IDemoSink sink)
+        {
+            _options = options; _calendar = calendar; _sink = sink;
+        }
+
+        public void WriteDimensions()
+        {
+            var platform = DemoArea.PowerApps | DemoArea.PowerAutomate | DemoArea.PowerBI | DemoArea.CopilotStudio;
+            if (!_options.Includes(platform)) return;
+            for (int i = 0; i < Operations.Length; i++) _sink.Write(DemoTables.Operations, 100 + i, Operations[i]);
+            if (_options.Includes(DemoArea.PowerApps | DemoArea.PowerAutomate | DemoArea.CopilotStudio))
+                for (int i = 1; i <= 3; i++)
+                    _sink.Write(DemoTables.PowerEnvironments, i, Id(2000, i),
+                        "Contoso " + new[] { "Production", "Sandbox", "Development" }[i - 1]);
+            if (_options.Includes(DemoArea.PowerApps))
+                for (int i = 1; i <= 4; i++)
+                    _sink.Write(DemoTables.PowerClients, i, new[] { "Web", "Mobile", "Teams", "Desktop" }[i - 1]);
+            if (_options.Includes(DemoArea.PowerApps | DemoArea.PowerAutomate))
+                for (int i = 1; i <= Connectors.Length; i++)
+                    _sink.Write(DemoTables.PowerConnectors, i, Connectors[i - 1], "Microsoft", i == 4);
+
+            for (int department = 0; department < SeedDataCatalogue.Departments.Length; department++)
+            {
+                string name = "Contoso " + SeedDataCatalogue.Departments[department];
+                int workspace = department + 1;
+                if (_options.Includes(DemoArea.PowerBI))
+                {
+                    _sink.Write(DemoTables.PowerWorkspaces, workspace, Id(2001, workspace), name);
+                    _sink.Write(DemoTables.PowerDashboards, workspace, Id(2002, workspace),
+                        name + " Overview", workspace, _options.Start);
+                }
+                for (int variant = 0; variant < 2; variant++)
+                {
+                    int id = department * 2 + variant + 1;
+                    int environment = variant == 0 ? 1 : 2 + department % 2;
+                    if (_options.Includes(DemoArea.PowerApps))
+                    {
+                        _sink.Write(DemoTables.PowerApps, id, Id(2003, id),
+                            name + (variant == 0 ? " Requests" : " Approvals"), environment, _options.Start);
+                        _sink.Write(DemoTables.PowerAppConnectors, id, 1);
+                        _sink.Write(DemoTables.PowerAppConnectors, id, 2 + department % 3);
+                    }
+                    if (_options.Includes(DemoArea.PowerAutomate))
+                    {
+                        _sink.Write(DemoTables.PowerFlows, id, Id(2004, id),
+                            name + (variant == 0 ? " Approval routing" : " Daily digest"), environment, _options.Start);
+                        _sink.Write(DemoTables.PowerFlowConnectors, id, 2);
+                        _sink.Write(DemoTables.PowerFlowConnectors, id, department % 2 == 0 ? 3 : 4);
+                    }
+                    if (_options.Includes(DemoArea.PowerBI))
+                        _sink.Write(DemoTables.PowerReports, id, Id(2005, id),
+                            name + (variant == 0 ? " Performance" : " Monthly detail"),
+                            variant == 0 ? "PowerBIReport" : "PaginatedReport", workspace, _options.Start);
+                }
+            }
+            if (_options.Includes(DemoArea.CopilotStudio))
+            {
+                string[] bots = { "Knowledge Assistant", "Sales Coach", "Expenses Bot", "Onboarding Guide" };
+                for (int i = 1; i <= bots.Length; i++)
+                    _sink.Write(DemoTables.StudioBots, i, Id(2006, i), "Contoso " + bots[i - 1],
+                        i == 4 ? 2 : 1, _options.Start);
+            }
+        }
+
+        public void WriteDay(DemoUser user, int day, DemoDay activity)
+        {
+            if (!activity.HasWorkloadActivity) return;
+            int objectId = user.Department * 2 + 1 + user.Id % 2;
+            uint sample = DemoRandom.Value(_options.Seed, user.Id, day, 2010);
+            if (_options.Includes(DemoArea.PowerApps) && sample % 100 < 55)
+            {
+                // Most usage is launches; a smaller maker cohort edits, publishes and shares.
+                int operation = user.Id % 5 == 0 && sample % 10 < 3 ? 1 + (int)(sample % 3) : 0;
+                var id = Audit(user, day, 2011, operation);
+                _sink.Write(DemoTables.PowerAppEvents, id, objectId, Id(2012, user.Id, day),
+                    1 + user.Id % 4);
+                if (operation == 3)
+                    _sink.Write(DemoTables.PowerAppShares, id, objectId, Recipient(user.Id),
+                        user.Id % 2 == 0 ? "CanEdit" : "CanView");
+            }
+            if (_options.Includes(DemoArea.PowerAutomate) && sample / 101 % 100 < 25)
+            {
+                // The audit importer observes flow administration, not successful flow executions.
+                int operation = 4 + (int)(sample / 1009 % 4);
+                var id = Audit(user, day, 2013, operation);
+                _sink.Write(DemoTables.PowerFlowEvents, id, objectId, null);
+                if (operation >= 6)
+                    _sink.Write(DemoTables.PowerFlowShares, id, objectId, Recipient(user.Id),
+                        operation == 6 ? "CanEdit" : "CanView");
+            }
+            if (_options.Includes(DemoArea.PowerBI) && sample / 10007 % 100 < 65)
+            {
+                int views = user.Cohort == DemoCohort.High ? 3 : user.Cohort == DemoCohort.Moderate ? 2 : 1;
+                for (int slot = 0; slot < views; slot++)
+                {
+                    int department = slot == 0 ? user.Department
+                        : (user.Department + slot) % SeedDataCatalogue.Departments.Length;
+                    int report = department * 2 + 1 + (user.Id + slot) % 2;
+                    var id = Audit(user, day, 2014, 8, slot);
+                    _sink.Write(DemoTables.PowerBIEvents, id, department + 1, report,
+                        slot == 0 && user.Id % 4 == 0 ? (object)(department + 1) : null);
+                }
+            }
+            if (_options.Includes(DemoArea.CopilotStudio) && sample / 100003 % 100 < 15)
+            {
+                int operation = user.Id % 3 == 0 ? 10 : 9;
+                var id = Audit(user, day, 2015, operation);
+                _sink.Write(DemoTables.StudioEvents, id, 1 + (user.Id + day / 7) % 4);
+            }
+        }
+
+        private Guid Audit(DemoUser user, int day, short salt, int operation, int slot = 0)
+        {
+            var id = DemoRandom.Id(_options.Seed, salt, user.Id, day, slot);
+            var time = _calendar.Timestamp(user.Zone, day, DemoRandom.Value(_options.Seed, user.Id, day, salt), slot);
+            _sink.Write(DemoTables.Audit, id, user.Id, 100 + operation, time);
+            return id;
+        }
+
+        private int Recipient(int user) => user % _options.Users + 1;
+        private string Id(short salt, int item, int day = 0) => DemoRandom.Id(_options.Seed, salt, item, day).ToString();
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoPowerPlatformTables.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoPowerPlatformTables.cs
@@ -1,0 +1,39 @@
+namespace Tests.FakeDataGen.Demo
+{
+    internal static partial class DemoTables
+    {
+        public static readonly DemoTable PowerEnvironments = T("power_app_environments", true,
+            I("id"), N("environment_id", 200), N("name", 255));
+        public static readonly DemoTable PowerClients = Named("power_platform_client_types");
+        public static readonly DemoTable PowerConnectors = T("power_platform_connectors", true,
+            I("id"), N("name", 255), N("publisher", 255), B("is_premium"));
+        public static readonly DemoTable PowerApps = T("power_apps", true, I("id"), N("app_id", 200),
+            N("name", 255), I("environment_id"), D("first_seen_at"));
+        public static readonly DemoTable PowerFlows = T("power_automate_flows", true, I("id"), N("flow_id", 200),
+            N("name", 255), I("environment_id"), D("first_seen_at"));
+        public static readonly DemoTable PowerWorkspaces = T("power_bi_workspaces", true,
+            I("id"), N("workspace_id", 200), N("name", 255));
+        public static readonly DemoTable PowerReports = T("power_bi_reports", true, I("id"), N("report_id", 200),
+            N("name", 255), N("report_type"), I("workspace_id"), D("first_seen_at"));
+        public static readonly DemoTable PowerDashboards = T("power_bi_dashboards", true, I("id"), N("dashboard_id", 200),
+            N("name", 255), I("workspace_id"), D("first_seen_at"));
+        public static readonly DemoTable StudioBots = T("copilot_studio_bots", true, I("id"), N("bot_id", 200),
+            N("name", 255), I("environment_id"), D("first_seen_at"));
+        public static readonly DemoTable PowerAppConnectors = T("power_app_connectors", false,
+            I("power_app_id"), I("connector_id"));
+        public static readonly DemoTable PowerFlowConnectors = T("power_automate_flow_connectors", false,
+            I("flow_id"), I("connector_id"));
+        public static readonly DemoTable PowerAppEvents = T("event_meta_power_app", false,
+            G("event_id"), I("power_app_id"), N("app_session_id", 200), I("client_type_id"));
+        public static readonly DemoTable PowerAppShares = T("event_meta_power_app_share", false,
+            G("event_id"), I("power_app_id"), I("shared_with_user_id"), N("role_name"));
+        public static readonly DemoTable PowerFlowEvents = T("event_meta_power_automate_flow", false,
+            G("event_id"), I("flow_id"), N("run_id", 200));
+        public static readonly DemoTable PowerFlowShares = T("event_meta_power_automate_flow_share", false,
+            G("event_id"), I("flow_id"), I("shared_with_user_id"), N("role_name"));
+        public static readonly DemoTable PowerBIEvents = T("event_meta_power_bi", false,
+            G("event_id"), I("workspace_id"), I("report_id"), I("dashboard_id"));
+        public static readonly DemoTable StudioEvents = T("event_meta_copilot_studio", false,
+            G("event_id"), I("bot_id"));
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoTables.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/DemoTables.cs
@@ -47,10 +47,11 @@ namespace Tests.FakeDataGen.Demo
         void Flush();
     }
 
-    internal static class DemoTables
+    internal static partial class DemoTables
     {
         // Dependency order is also the SQL buffer-flush order.
-        private static readonly List<DemoTable> Tables = new List<DemoTable>();
+        private static List<DemoTable> _tables;
+        private static List<DemoTable> Tables => _tables ?? (_tables = new List<DemoTable>());
         public static IReadOnlyList<DemoTable> All => Tables;
         private static DemoColumn I(string name) => new DemoColumn(name, SqlDbType.Int);
         private static DemoColumn L(string name) => new DemoColumn(name, SqlDbType.BigInt);
@@ -98,6 +99,8 @@ namespace Tests.FakeDataGen.Demo
         public static readonly DemoTable InteractionTypes = Named("copilot_interaction_types");
         public static readonly DemoTable InteractionApps = Named("copilot_interaction_app_classes");
         public static readonly DemoTable ConversationTypes = Named("copilot_interaction_conversation_types");
+        public static readonly DemoTable Keywords = Named("keywords");
+        public static readonly DemoTable Languages = Named("languages");
         public static readonly DemoTable Users = T("users", true, I("id"), A("user_name", 250), N("mail", 400),
             N("azure_ad_id", 400), B("account_enabled"), D("last_updated"), N("postalcode", 50), I("department_id"),
             I("company_name_id"), I("job_title_id"), I("state_or_province_id"), I("country_or_region_id"),
@@ -125,14 +128,14 @@ namespace Tests.FakeDataGen.Demo
             G("event_id"), I("dlp_policy_id"), I("dlp_rule_id"), I("dlp_action_id"), B("is_blocked"));
         public static readonly DemoTable SharePointAudit = T("event_meta_sharepoint", false, G("event_id"), I("url_id"),
             I("file_extension_id"), I("file_name_id"), I("related_web_id"), I("item_type_id"));
-        public static readonly DemoTable Hits = T("hits", false, I("url_id"), D("hit_timestamp"), I("session_id"),
+        public static readonly DemoTable Hits = T("hits", true, I("url_id"), D("hit_timestamp"), I("session_id"),
             I("page_title_id"), I("web_id"), I("agent_id"), I("device_id"), I("os_id"),
-            F("seconds_on_page"), F("page_load_time"), G("page_request_id"), I("country_id"), I("city_id"));
+            F("seconds_on_page"), F("page_load_time"), G("page_request_id"), I("country_id"), I("city_id"), I("id"));
         public static readonly DemoTable Interactions = T("copilot_interactions", false,
             N("graph_interaction_id", 200), I("session_id"), I("user_id"), N("request_id", 200),
             I("interaction_type_id"), I("app_class_id"), I("conversation_type_id"), D("created_utc"),
             I("body_char_count"), I("body_word_count"), I("attachment_count"), I("link_count"),
-            I("mention_count"), I("context_count"), I("response_latency_ms"));
+            I("mention_count"), I("context_count"), I("response_latency_ms"), I("language_id"), F("sentiment_score"));
         public static readonly DemoTable Teams = Daily("teams_user_activity_log", L("private_chat_count"), L("team_chat_count"),
             L("post_messages"), L("reply_messages"), L("urgent_messages"), L("calls_count"), L("meetings_count"),
             L("adhoc_meetings_attended_count"), L("adhoc_meetings_organized_count"), L("meetings_attended_count"),
@@ -165,5 +168,19 @@ namespace Tests.FakeDataGen.Demo
         public static readonly DemoTable CopilotCounts = T("copilot_user_count_log", false,
             D("report_refresh_date"), D("report_date"), N("report_type", 20), I("report_period_days"), N("app_name"),
             I("enabled_users"), I("active_users"), L("prompts_submitted"), F("average_prompts_submitted"));
+        public static readonly DemoTable CopilotModels = T("copilot_ai_models", true,
+            I("id"), N("name"), N("provider_name"), N("version"));
+        public static readonly DemoTable CopilotPlugins = T("copilot_ai_system_plugins", true,
+            I("id"), N("plugin_id", 255), N("name", 255), N("version", 50));
+        public static readonly DemoTable CopilotEventModels = T("copilot_event_ai_models", false,
+            G("copilot_chat_id"), I("model_id"));
+        public static readonly DemoTable CopilotEventPlugins = T("copilot_event_ai_system_plugins", false,
+            G("copilot_chat_id"), I("ai_system_plugin_id"));
+        public static readonly DemoTable CopilotMeetings = T("online_meetings", true,
+            I("id"), D("created"), N("meeting_id", 200), N("name"));
+        public static readonly DemoTable CopilotFileContexts = T("copilot_event_files", false,
+            G("copilot_chat_id"), I("file_name_id"), I("file_extension_id"), I("url_id"), I("site_id"));
+        public static readonly DemoTable CopilotMeetingContexts = T("copilot_event_meetings", false,
+            G("copilot_chat_id"), I("meeting_id"));
     }
 }

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlDemoDatabase.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlDemoDatabase.cs
@@ -141,7 +141,9 @@ FROM sys.columns AS c WHERE c.object_id = OBJECT_ID(@table);";
                 if (Convert.ToInt64(Scalar(_connection, "SELECT COUNT_BIG(*) FROM dbo.[" + table.Name + "];")) != expected)
                     throw new InvalidOperationException("Persisted row count differs from the generated stream for " + table.Name);
             }
-            if (_options.CompileProfiles)
+            if (_options.CompileProfiles && !_options.HasAllDailyWorkloads)
+                progress?.Invoke("Weekly cross-workload profiles skipped: select all six daily M365 workloads to compile complete profiles.");
+            if (_options.CompileProfiles && _options.HasAllDailyWorkloads)
             {
                 var monday = _options.Start;
                 while (monday.DayOfWeek != DayOfWeek.Monday) monday = monday.AddDays(1);

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlExistingDemoDatabase.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlExistingDemoDatabase.cs
@@ -26,6 +26,23 @@ namespace Tests.FakeDataGen.Demo
         private ExistingSink _sink;
         private bool _opened, _ready, _failed, _disposed, _markerInvalidated;
 
+        /// <summary>
+        /// Tables describing the TENANT rather than the appended population, so they are counted and then
+        /// dropped instead of inserted. An append adds a fresh synthetic population to someone else's
+        /// database; it cannot restate that tenant's Copilot totals, its Copilot Credits entitlement, its
+        /// Azure bill or the fact that an import ran. Agent costs also key on (usage_date, dimension_hash),
+        /// which is UNIQUE on copilot_studio_credit_user_daily: a second population regenerates the same
+        /// agent/environment dimensions for the same dates, so appending them is a duplicate-key failure
+        /// rather than more data.
+        /// </summary>
+        private static readonly DemoTable[] TenantWideTables =
+        {
+            DemoTables.CopilotCounts, DemoTables.StudioCredits, DemoTables.StudioUserCredits,
+            DemoTables.StudioCapacity, DemoTables.AzureCosts, DemoTables.AgentCostImports,
+        };
+
+        private static bool IsTenantWide(DemoTable table) => Array.IndexOf(TenantWideTables, table) >= 0;
+
         public SqlExistingDemoDatabase(string connectionString, DemoOptions options, CancellationToken cancellation)
         {
             if (options == null || options.Preview || options.Help)
@@ -76,7 +93,7 @@ namespace Tests.FakeDataGen.Demo
                     Execute(command, command.ExecuteNonQuery);
                 _ready = true;
                 progress?.Invoke("Existing-target append: fresh synthetic users; existing users and activities are never updated.");
-                progress?.Invoke("Tenant-wide Copilot count snapshots will be skipped: this population does not represent the existing tenant.");
+                progress?.Invoke("Tenant-wide Copilot count snapshots, Copilot Studio credits, capacity and Azure agent spend will be skipped: this population does not represent the existing tenant.");
                 if (_options.CompileProfiles)
                     progress?.Invoke("Global weekly profiling is skipped for existing targets; existing profiles are not recomputed.");
                 progress?.Invoke("Batches commit independently." + FailureAdvice);
@@ -117,7 +134,7 @@ namespace Tests.FakeDataGen.Demo
                 var reused = _plans.Values.Sum(p => p.Reused);
                 var skipped = _plans.Values.Sum(p => p.Skipped);
                 progress?.Invoke($"Append verified from committed batches: {inserted:N0} inserted rows; {reused:N0} reused dimension rows.");
-                progress?.Invoke($"Skipped {skipped:N0} tenant-wide Copilot count snapshots; no global profiling or new-demo completion marker was written.");
+                progress?.Invoke($"Skipped {skipped:N0} tenant-wide Copilot count snapshot and agent-cost rows; no global profiling or new-demo completion marker was written.");
                 summary.Rows.Clear();
                 foreach (var plan in _plans.Values.Where(p => p.Received > 0))
                     summary.Rows.Add(plan.Table.Name, plan.Inserted);
@@ -254,7 +271,7 @@ WHERE f.parent_object_id=OBJECT_ID(@table);"))
                     var fk = keys[0];
                     var target = _plans.Values.SingleOrDefault(p => p.Table.Name == fk.Table);
                     if (keys.Length != 1 || fk.Width != 1 || fk.Disabled || fk.Schema != "dbo" || target == null
-                        || target.Order > plan.Order || target.Table == DemoTables.CopilotCounts)
+                        || target.Order > plan.Order || IsTenantWide(target.Table))
                         throw SchemaError(plan.Table, "unsupported foreign-key mapping for " + supplied.Name);
                     int targetIndex = target.Table.Columns.ToList().FindIndex(c => c.Name == fk.TargetColumn);
                     if (targetIndex < 0 || target.Table.Columns[targetIndex].Type != supplied.Type)
@@ -593,7 +610,7 @@ END;", transaction))
                     if (plan.IdentityIndex >= 0 && (!(row[plan.IdentityIndex] is int key) || key <= 0))
                         throw new InvalidOperationException("A positive logical integer identity is required.");
                     plan.Received++;
-                    if (table == DemoTables.CopilotCounts) { plan.Skipped++; return; }
+                    if (IsTenantWide(table)) { plan.Skipped++; return; }
                     if (!Buffers.TryGetValue(table, out var rows))
                         Buffers.Add(table, rows = new List<object[]>(table.BatchLimit(_owner._options.BatchSize)));
                     rows.Add(row);

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlExistingDemoDatabase.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlExistingDemoDatabase.cs
@@ -1,0 +1,643 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace Tests.FakeDataGen.Demo
+{
+    internal sealed class SqlExistingDemoDatabase : IDisposable
+    {
+        private const string FailureAdvice = " Previously batch-committed synthetic rows may persist; no automatic cleanup is performed.";
+        private static readonly Regex GuidToken = new Regex(
+            @"(?<![0-9a-fA-F])(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32})(?![0-9a-fA-F])",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex Email = new Regex(@"^[^@\s:/?#]+@[^@\s:/?#]+$", RegexOptions.CultureInvariant);
+        private readonly SqlConnection _connection;
+        private readonly DemoOptions _options;
+        private readonly CancellationToken _cancellation;
+        private readonly byte[] _runNamespace = Guid.NewGuid().ToByteArray();
+        private readonly Dictionary<DemoTable, TablePlan> _plans = new Dictionary<DemoTable, TablePlan>();
+        private SHA256 _emailHash;
+        private ExistingSink _sink;
+        private bool _opened, _ready, _failed, _disposed, _markerInvalidated;
+
+        public SqlExistingDemoDatabase(string connectionString, DemoOptions options, CancellationToken cancellation)
+        {
+            if (options == null || options.Preview || options.Help)
+                throw new ArgumentException("Parsed, writable demo options are required.", nameof(options));
+            if (string.IsNullOrWhiteSpace(connectionString))
+                throw new ArgumentException("An explicit existing TEST database connection string is required.", nameof(connectionString));
+            var builder = new SqlConnectionStringBuilder(connectionString);
+            if (string.IsNullOrWhiteSpace(builder.InitialCatalog) || IsSystemDatabase(builder.InitialCatalog)
+                || !string.IsNullOrEmpty(builder.AttachDBFilename) || builder.UserInstance)
+                throw new ArgumentException("Specify an existing non-system TEST catalog; attaching database files is not supported.", nameof(connectionString));
+            builder.Pooling = false;
+            builder.ApplicationName = "Contoso synthetic append generator";
+            _connection = new SqlConnection(builder.ConnectionString);
+            _options = options;
+            _cancellation = cancellation;
+        }
+
+        public void Open(Action<string> progress)
+        {
+            if (_opened || _disposed) throw new InvalidOperationException("This existing target cannot be reopened.");
+            _opened = true;
+            try
+            {
+                _cancellation.ThrowIfCancellationRequested();
+                _connection.OpenAsync(_cancellation).GetAwaiter().GetResult();
+                using (var command = Command(@"SELECT DB_NAME(), DATABASEPROPERTYEX(DB_NAME(), 'Updateability');"))
+                {
+                    Execute(command, () =>
+                    {
+                        using (var reader = command.ExecuteReader())
+                        {
+                            if (!reader.Read() || IsSystemDatabase(reader.GetString(0))
+                                || !string.Equals(reader.GetString(0), _connection.Database, StringComparison.OrdinalIgnoreCase)
+                                || !string.Equals(Convert.ToString(reader.GetValue(1)), "READ_WRITE", StringComparison.OrdinalIgnoreCase))
+                                throw new InvalidOperationException("The target must be an existing writable non-system TEST database.");
+                        }
+                        return 0;
+                    });
+                }
+                progress?.Invoke("Checking existing schema without creating, upgrading or reshaping application tables...");
+                ReadSchema();
+                ConfigureMappings();
+                // These are connection-local tempdb maps, not application schema. Session/user
+                // populations never accumulate in a client dictionary.
+                using (var command = Command(string.Join(Environment.NewLine, _plans.Values
+                    .Where(p => p.IdentityIndex >= 0).Select(p => "CREATE TABLE " + p.MapName
+                        + " (logical_id int NOT NULL PRIMARY KEY, actual_id int NOT NULL);"))))
+                    Execute(command, command.ExecuteNonQuery);
+                _ready = true;
+                progress?.Invoke("Existing-target append: fresh synthetic users; existing users and activities are never updated.");
+                progress?.Invoke("Tenant-wide Copilot count snapshots will be skipped: this population does not represent the existing tenant.");
+                if (_options.CompileProfiles)
+                    progress?.Invoke("Global weekly profiling is skipped for existing targets; existing profiles are not recomputed.");
+                progress?.Invoke("Batches commit independently." + FailureAdvice);
+            }
+            catch
+            {
+                _failed = true;
+                throw;
+            }
+        }
+
+        public IDemoSink CreateSink()
+        {
+            EnsureReady();
+            if (_sink != null) throw new InvalidOperationException("Only one append stream can be created for this run.");
+            return _sink = new ExistingSink(this);
+        }
+
+        public void Complete(DemoSummary summary, Action<string> progress)
+        {
+            EnsureReady();
+            try
+            {
+                _cancellation.ThrowIfCancellationRequested();
+                if (summary == null || _sink == null || _sink.PendingRows != 0 || _sink.DiscardedRows)
+                    throw new InvalidOperationException("Only an explicitly flushed, successful append stream can be completed.");
+                foreach (var plan in _plans.Values.OrderBy(p => p.Order))
+                {
+                    summary.Rows.TryGetValue(plan.Table.Name, out long expected);
+                    if (expected != plan.Received || plan.Received != plan.Inserted + plan.Reused + plan.Skipped)
+                        throw new InvalidOperationException("Append stream accounting differs for " + plan.Table.Name + ".");
+                }
+                if (_plans[DemoTables.Users].Inserted != _options.Users
+                    || summary.Rows.Keys.Any(n => !_plans.Keys.Any(t => t.Name == n)))
+                    throw new InvalidOperationException("The requested synthetic population did not complete.");
+
+                var inserted = _plans.Values.Sum(p => p.Inserted);
+                var reused = _plans.Values.Sum(p => p.Reused);
+                var skipped = _plans.Values.Sum(p => p.Skipped);
+                progress?.Invoke($"Append verified from committed batches: {inserted:N0} inserted rows; {reused:N0} reused dimension rows.");
+                progress?.Invoke($"Skipped {skipped:N0} tenant-wide Copilot count snapshots; no global profiling or new-demo completion marker was written.");
+                summary.Rows.Clear();
+                foreach (var plan in _plans.Values.Where(p => p.Received > 0))
+                    summary.Rows.Add(plan.Table.Name, plan.Inserted);
+                summary.CompletedProfileWeeks = 0;
+                _ready = false;
+            }
+            catch
+            {
+                _failed = true;
+                throw;
+            }
+        }
+
+        private static bool IsSystemDatabase(string name) =>
+            new[] { "master", "model", "msdb", "tempdb", "mssqlsystemresource", "distribution" }
+                .Contains(name.Trim(), StringComparer.OrdinalIgnoreCase);
+
+        private void ReadSchema()
+        {
+            foreach (var table in DemoTables.All)
+            {
+                _cancellation.ThrowIfCancellationRequested();
+                var plan = new TablePlan(table, _plans.Count);
+                _plans.Add(table, plan);
+                using (var command = Command(@"SELECT c.name, TYPE_NAME(c.system_type_id), c.max_length,
+c.is_nullable, c.is_identity, c.is_computed, c.default_object_id, c.generated_always_type,
+CASE WHEN EXISTS (SELECT 1 FROM sys.indexes i JOIN sys.index_columns ic
+ ON ic.object_id=i.object_id AND ic.index_id=i.index_id
+ WHERE i.object_id=c.object_id AND i.is_primary_key=1 AND ic.column_id=c.column_id AND ic.key_ordinal>0) THEN 1 ELSE 0 END
+FROM sys.columns c JOIN sys.tables t ON t.object_id=c.object_id
+WHERE t.object_id=OBJECT_ID(@table, 'U') AND t.is_ms_shipped=0;"))
+                {
+                    command.Parameters.Add("@table", SqlDbType.NVarChar, 256).Value = "dbo." + table.Name;
+                    Execute(command, () =>
+                    {
+                        using (var reader = command.ExecuteReader())
+                            while (reader.Read())
+                                plan.Columns.Add(reader.GetString(0), new SqlColumn
+                                {
+                                    Type = reader.GetString(1), Length = reader.GetInt16(2),
+                                    Nullable = reader.GetBoolean(3), Identity = reader.GetBoolean(4),
+                                    Computed = reader.GetBoolean(5), HasDefault = reader.GetInt32(6) != 0,
+                                    Generated = reader.GetByte(7) != 0, PrimaryKey = reader.GetInt32(8) != 0
+                                });
+                        return 0;
+                    });
+                }
+                if (plan.Columns.Count == 0) throw SchemaError(table, "missing table or unavailable column metadata");
+                for (int i = 0; i < table.Columns.Count; i++)
+                {
+                    var supplied = table.Columns[i];
+                    if (!plan.Columns.TryGetValue(supplied.Name, out var actual) || !Compatible(supplied, actual)
+                        || actual.Computed || actual.Generated)
+                        throw SchemaError(table, "missing or incompatible supplied column " + supplied.Name);
+                    if (actual.Identity)
+                    {
+                        if (!table.SupplyIdentity || supplied.Type != SqlDbType.Int || !actual.PrimaryKey
+                            || plan.Columns.Values.Count(c => c.PrimaryKey) != 1 || plan.IdentityIndex >= 0)
+                            throw SchemaError(table, "unsupported supplied identity/primary key");
+                        plan.IdentityIndex = i;
+                    }
+                }
+                if (table.SupplyIdentity && plan.IdentityIndex < 0)
+                    throw SchemaError(table, "the logical integer key is not a SQL identity primary key");
+                foreach (var column in plan.Columns)
+                    if (!column.Value.Nullable && !column.Value.Identity && !column.Value.Computed && !column.Value.Generated
+                        && !column.Value.HasDefault && column.Value.Type != "timestamp" && !table.Columns.Any(c => c.Name == column.Key))
+                        throw SchemaError(table, "generator does not supply required column " + column.Key);
+
+                using (var command = Command(@"SELECT f.object_id, pc.name, rs.name, rt.name, rc.name, f.is_disabled,
+ (SELECT COUNT(*) FROM sys.foreign_key_columns x WHERE x.constraint_object_id=f.object_id)
+FROM sys.foreign_keys f JOIN sys.foreign_key_columns fc ON fc.constraint_object_id=f.object_id
+JOIN sys.columns pc ON pc.object_id=fc.parent_object_id AND pc.column_id=fc.parent_column_id
+JOIN sys.tables rt ON rt.object_id=fc.referenced_object_id
+JOIN sys.schemas rs ON rs.schema_id=rt.schema_id
+JOIN sys.columns rc ON rc.object_id=fc.referenced_object_id AND rc.column_id=fc.referenced_column_id
+WHERE f.parent_object_id=OBJECT_ID(@table);"))
+                {
+                    command.Parameters.Add("@table", SqlDbType.NVarChar, 256).Value = "dbo." + table.Name;
+                    Execute(command, () =>
+                    {
+                        using (var reader = command.ExecuteReader())
+                            while (reader.Read())
+                                plan.ForeignKeys.Add(new ForeignKey
+                                {
+                                    Column = reader.GetString(1), Schema = reader.GetString(2),
+                                    Table = reader.GetString(3), TargetColumn = reader.GetString(4),
+                                    Disabled = reader.GetBoolean(5), Width = reader.GetInt32(6)
+                                });
+                        return 0;
+                    });
+                }
+                using (var command = Command(@"SELECT CASE WHEN EXISTS (SELECT 1 FROM sys.triggers
+ WHERE parent_id=OBJECT_ID(@table) AND is_disabled=0) THEN 1 ELSE 0 END;"))
+                {
+                    command.Parameters.Add("@table", SqlDbType.NVarChar, 256).Value = "dbo." + table.Name;
+                    if (Convert.ToInt32(Execute(command, command.ExecuteScalar)) != 0)
+                        throw SchemaError(table, "enabled triggers could modify existing rows");
+                }
+            }
+        }
+
+        private void ConfigureMappings()
+        {
+            foreach (var plan in _plans.Values)
+                plan.ReuseKey = NaturalKey(plan);
+            foreach (var plan in _plans.Values.OrderBy(p => p.Order))
+            {
+                // An unused nullable relationship must not inherit a non-NULL schema default.
+                plan.NullColumns = plan.ForeignKeys.Select(f => f.Column).Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Where(name => !plan.Table.Columns.Any(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                        && plan.Columns[name].Nullable && !plan.Columns[name].Computed
+                        && !plan.Columns[name].Generated && !plan.Columns[name].Identity).ToArray();
+                for (int i = 0; i < plan.Table.Columns.Count; i++)
+                {
+                    var supplied = plan.Table.Columns[i];
+                    var keys = plan.ForeignKeys.Where(f => f.Column == supplied.Name).ToArray();
+                    if (keys.Length == 0)
+                    {
+                        // Do not silently attach a logical ID to an existing row when a
+                        // required constraint is missing. SharePoint sp_id is a remote handle.
+                        if (i != plan.IdentityIndex && supplied.Type == SqlDbType.Int)
+                        {
+                            var inherited = InheritedIdentityReference(plan, supplied.Name);
+                            if (inherited != null)
+                                plan.IdentityReferences.Add(i, inherited);
+                            else if (supplied.Name.EndsWith("_id", StringComparison.Ordinal)
+                                && !(supplied.Name == "sp_id"
+                                    && (plan.Table == DemoTables.PageComments || plan.Table == DemoTables.PageLikes)))
+                                throw SchemaError(plan.Table, "missing foreign-key metadata for " + supplied.Name);
+                        }
+                        continue;
+                    }
+                    var fk = keys[0];
+                    var target = _plans.Values.SingleOrDefault(p => p.Table.Name == fk.Table);
+                    if (keys.Length != 1 || fk.Width != 1 || fk.Disabled || fk.Schema != "dbo" || target == null
+                        || target.Order > plan.Order || target.Table == DemoTables.CopilotCounts)
+                        throw SchemaError(plan.Table, "unsupported foreign-key mapping for " + supplied.Name);
+                    int targetIndex = target.Table.Columns.ToList().FindIndex(c => c.Name == fk.TargetColumn);
+                    if (targetIndex < 0 || target.Table.Columns[targetIndex].Type != supplied.Type)
+                        throw SchemaError(plan.Table, "foreign key does not reference a supplied compatible key: " + supplied.Name);
+                    if (supplied.Type == SqlDbType.Int)
+                    {
+                        if (targetIndex != target.IdentityIndex)
+                            throw SchemaError(plan.Table, "integer foreign key does not reference a mapped identity: " + supplied.Name);
+                        plan.IdentityReferences.Add(i, target);
+                    }
+                    else if ((supplied.Type != SqlDbType.UniqueIdentifier && !IsText(supplied.Type))
+                        || (target.ReuseKey.Length != 0 && !target.ReuseKey.Contains(targetIndex)))
+                        throw SchemaError(plan.Table, "unsupported non-identity foreign-key mapping for " + supplied.Name);
+                }
+            }
+        }
+
+        private TablePlan InheritedIdentityReference(TablePlan plan, string column)
+        {
+            // The legacy audit table has no physical user FK, even after current migrations.
+            if (plan.Table == DemoTables.Audit && column == "user_id")
+                return _plans[DemoTables.Users];
+            if (plan.Table == DemoTables.SharePointAudit)
+            {
+                switch (column)
+                {
+                    case "url_id": return _plans[DemoTables.Urls];
+                    case "file_extension_id": return _plans[DemoTables.Extensions];
+                    case "file_name_id": return _plans[DemoTables.FileNames];
+                    case "related_web_id": return _plans[DemoTables.Webs];
+                    case "item_type_id": return _plans[DemoTables.ItemTypes];
+                }
+            }
+            if (plan.Table != DemoTables.Chats || column != "user_id") return null;
+            // The chat's denormalised user follows its shared-primary-key audit parent.
+            var candidates = new HashSet<TablePlan>();
+            if (plan.Columns.Values.Count(c => c.PrimaryKey) != 1) return null;
+            foreach (var key in plan.ForeignKeys.Where(f => f.Width == 1 && !f.Disabled && f.Schema == "dbo"
+                && plan.Columns[f.Column].PrimaryKey))
+            {
+                var parent = _plans.Values.SingleOrDefault(p => p.Table.Name == key.Table && p.Order < plan.Order);
+                if (parent == null || !parent.Columns[key.TargetColumn].PrimaryKey) continue;
+                int index = parent.Table.Columns.ToList().FindIndex(c => c.Name == column);
+                if (index >= 0 && parent.IdentityReferences.TryGetValue(index, out var target))
+                    candidates.Add(target);
+            }
+            return candidates.Count == 1 ? candidates.Single() : null;
+        }
+
+        private static int[] NaturalKey(TablePlan plan)
+        {
+            if (plan.IdentityIndex < 0 || plan.Table == DemoTables.Users
+                || plan.ForeignKeys.Any(f => f.Table == "users" && plan.Table.Columns.Any(c => c.Name == f.Column)))
+                return new int[0];
+            string column = null;
+            switch (plan.Table.Name)
+            {
+                case "copilot_ai_models":
+                    return new[] { "name", "provider_name", "version" }
+                        .Select(name => plan.Table.Columns.ToList().FindIndex(c => c.Name == name)).ToArray();
+                case "license_types": column = "sku_id"; break;
+                case "copilot_agents": column = "agent_id"; break;
+                case "power_platform_connectors": column = "name"; break;
+                case "sites":
+                case "webs": column = "url_base"; break;
+            }
+            if (column != null)
+                return new[] { plan.Table.Columns.ToList().FindIndex(c => c.Name == column) };
+            var values = Enumerable.Range(0, plan.Table.Columns.Count).Where(i => i != plan.IdentityIndex).ToArray();
+            return values.Length == 1 && IsText(plan.Table.Columns[values[0]].Type) ? values : new int[0];
+        }
+
+        private static bool IsText(SqlDbType type) => type == SqlDbType.NVarChar || type == SqlDbType.VarChar;
+
+        private static bool Compatible(DemoColumn supplied, SqlColumn actual) =>
+            Compatible(supplied, actual.Type, actual.Length);
+
+        internal static bool Compatible(DemoColumn supplied, string actualType, int maxLengthBytes)
+        {
+            string expected = supplied.Type.ToString().ToLowerInvariant();
+            bool typeMatches = actualType == expected
+                || (supplied.Type == SqlDbType.VarChar && actualType == "nvarchar")
+                || (supplied.Type == SqlDbType.DateTime && (actualType == "datetime2"
+                    || (actualType == "date" && (supplied.Name == "date" || supplied.Name.EndsWith("_date", StringComparison.Ordinal)))));
+            if (!typeMatches) return false;
+            if (!IsText(supplied.Type)) return true;
+            if (maxLengthBytes == -1) return true;
+            // SQL reports bytes. ASCII varchar input can widen to Unicode, but the target's
+            // character capacity must still cover the descriptor; the reverse conversion is unsafe.
+            int width = maxLengthBytes / (actualType == "nvarchar" ? 2 : 1);
+            return supplied.Size > 0 && supplied.Size <= width;
+        }
+
+        private static InvalidOperationException SchemaError(DemoTable table, string reason) =>
+            new InvalidOperationException("Existing schema preflight refused dbo." + table.Name + ": " + reason
+                + ". No application rows were written.");
+
+        private Guid NamespaceGuid(Guid value)
+        {
+            var bytes = value.ToByteArray();
+            for (int i = 0; i < bytes.Length; i++) bytes[i] ^= _runNamespace[i];
+            return new Guid(bytes);
+        }
+
+        private object NamespaceValue(object value)
+        {
+            if (value is Guid guid) return NamespaceGuid(guid);
+            if (!(value is string text)) return value;
+            if (Email.IsMatch(text))
+            {
+                if (_emailHash == null) _emailHash = SHA256.Create();
+                var bytes = _emailHash.ComputeHash(Encoding.UTF8.GetBytes(text.ToUpperInvariant()));
+                return "demo-" + NamespaceGuid(new Guid(bytes.Take(16).ToArray())).ToString("N") + "@contoso.example";
+            }
+            var namespaced = GuidToken.Replace(text, match => NamespaceGuid(Guid.Parse(match.Value))
+                .ToString(match.Value.Length == 32 ? "N" : "D"));
+            if (Uri.TryCreate(namespaced, UriKind.Absolute, out var uri)
+                && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            {
+                // Keep the original Unicode/escaping rather than expanding it through AbsoluteUri.
+                // Row validation rejects an over-width result before SQL; identifiers are never truncated.
+                int authorityEnd = namespaced.IndexOfAny(new[] { '/', '?', '#' },
+                    namespaced.IndexOf("://", StringComparison.Ordinal) + 3);
+                if (authorityEnd < 0) authorityEnd = namespaced.Length;
+                string path = namespaced.Substring(authorityEnd);
+                return namespaced.Substring(0, authorityEnd) + "/contoso-demo-" + new Guid(_runNamespace).ToString("N")
+                    + (path.StartsWith("/", StringComparison.Ordinal) ? path : "/" + path);
+            }
+            return namespaced;
+        }
+
+        private void Flush(ExistingSink sink)
+        {
+            EnsureReady();
+            _cancellation.ThrowIfCancellationRequested();
+            if (sink.PendingRows == 0) return;
+            try
+            {
+                var insertedCounts = new Dictionary<TablePlan, long>();
+                using (var transaction = _connection.BeginTransaction())
+                {
+                    if (!_markerInvalidated) InvalidateMarker(transaction);
+                    foreach (var plan in _plans.Values.OrderBy(p => p.Order))
+                    {
+                        if (!sink.Buffers.TryGetValue(plan.Table, out var rows) || rows.Count == 0) continue;
+                        using (var command = InsertCommand(plan, rows, transaction))
+                            insertedCounts.Add(plan, Convert.ToInt64(Execute(command, command.ExecuteScalar)));
+                    }
+                    _cancellation.ThrowIfCancellationRequested();
+                    transaction.Commit();
+                }
+                _markerInvalidated = true;
+                foreach (var entry in insertedCounts)
+                {
+                    entry.Key.Inserted += entry.Value;
+                    entry.Key.Reused += sink.Buffers[entry.Key.Table].Count - entry.Value;
+                }
+                sink.ClearBuffers();
+            }
+            catch (Exception ex)
+            {
+                _failed = true;
+                sink.ClearBuffers();
+                if (_cancellation.IsCancellationRequested)
+                    throw new OperationCanceledException("Synthetic append cancelled." + FailureAdvice, ex, _cancellation);
+                throw new InvalidOperationException("Synthetic append batch failed." + FailureAdvice, ex);
+            }
+        }
+
+        private SqlCommand InsertCommand(TablePlan plan, List<object[]> rows, SqlTransaction transaction)
+        {
+            var command = Command("", transaction);
+            var sql = new StringBuilder("SET NOCOUNT ON; DECLARE @inserted bigint=0, @actual int;");
+            int parameterIndex = 0;
+            foreach (var row in rows)
+            {
+                var parameters = new string[row.Length];
+                for (int i = 0; i < row.Length; i++)
+                {
+                    string name = "@p" + parameterIndex++;
+                    parameters[i] = name;
+                    var column = plan.Table.Columns[i];
+                    var parameter = column.Size == 0 ? command.Parameters.Add(name, column.Type)
+                        : command.Parameters.Add(name, column.Type, column.Size);
+                    parameter.Value = row[i] ?? DBNull.Value;
+                }
+                var expressions = (string[])parameters.Clone();
+                foreach (var reference in plan.IdentityReferences)
+                {
+                    string parameter = parameters[reference.Key], map = reference.Value.MapName;
+                    sql.Append("IF ").Append(parameter).Append(" IS NOT NULL AND NOT EXISTS (SELECT 1 FROM ")
+                        .Append(map).Append(" WHERE logical_id=").Append(parameter)
+                        .Append(") THROW 51000, 'A synthetic logical foreign key has not been mapped.', 1;");
+                    expressions[reference.Key] = "(SELECT actual_id FROM " + map + " WHERE logical_id=" + parameter + ")";
+                }
+                if (plan.ReuseKey.Length > 0)
+                {
+                    sql.Append("SET @actual=NULL; SELECT TOP (1) @actual=").Append(Quote(plan.IdentityColumn))
+                        .Append(" FROM ").Append(plan.SqlName).Append(" WITH (UPDLOCK,HOLDLOCK) WHERE ")
+                        .Append(string.Join(" AND ", plan.ReuseKey.Select(i => "(" + Quote(plan.Table.Columns[i].Name)
+                            + "=" + expressions[i] + " OR (" + Quote(plan.Table.Columns[i].Name) + " IS NULL AND "
+                            + expressions[i] + " IS NULL))")))
+                        .Append(" ORDER BY ").Append(Quote(plan.IdentityColumn)).Append("; IF @actual IS NULL BEGIN ");
+                }
+                var included = Enumerable.Range(0, row.Length).Where(i => i != plan.IdentityIndex).ToArray();
+                sql.Append("INSERT INTO ").Append(plan.SqlName).Append(" (")
+                    .Append(string.Join(",", included.Select(i => Quote(plan.Table.Columns[i].Name))
+                        .Concat(plan.NullColumns.Select(Quote)))).Append(")");
+                if (plan.IdentityIndex >= 0)
+                    sql.Append(" OUTPUT ").Append(parameters[plan.IdentityIndex]).Append(",INSERTED.")
+                        .Append(Quote(plan.IdentityColumn)).Append(" INTO ").Append(plan.MapName).Append(" (logical_id,actual_id)");
+                sql.Append(" VALUES (").Append(string.Join(",", included.Select(i => expressions[i])
+                    .Concat(plan.NullColumns.Select(name => "NULL"))))
+                    .Append("); SET @inserted=@inserted+1;");
+                if (plan.ReuseKey.Length > 0)
+                    sql.Append(" END ELSE INSERT INTO ").Append(plan.MapName).Append(" (logical_id,actual_id) VALUES (")
+                        .Append(parameters[plan.IdentityIndex]).Append(",@actual);");
+            }
+            sql.Append("SELECT @inserted;");
+            command.CommandText = sql.ToString();
+            return command;
+        }
+
+        private void InvalidateMarker(SqlTransaction transaction)
+        {
+            using (var command = Command(@"IF EXISTS (SELECT 1 FROM sys.extended_properties WHERE class=0 AND name=@marker)
+BEGIN
+ IF EXISTS (SELECT 1 FROM sys.extended_properties WHERE class=0 AND name=@state)
+  EXEC sys.sp_updateextendedproperty @name=@state, @value=N'modified-by-append';
+ IF EXISTS (SELECT 1 FROM sys.extended_properties WHERE class=0 AND name=@fingerprint)
+  EXEC sys.sp_updateextendedproperty @name=@fingerprint, @value=N'invalidated-by-append';
+END;", transaction))
+            {
+                command.Parameters.Add("@marker", SqlDbType.NVarChar, 128).Value = SqlDemoDatabase.Marker;
+                command.Parameters.Add("@state", SqlDbType.NVarChar, 128).Value = SqlDemoDatabase.StateMarker;
+                command.Parameters.Add("@fingerprint", SqlDbType.NVarChar, 128).Value = SqlDemoDatabase.FingerprintMarker;
+                Execute(command, command.ExecuteNonQuery);
+            }
+        }
+
+        private static string Quote(string identifier) => "[" + identifier.Replace("]", "]]") + "]";
+
+        private SqlCommand Command(string sql, SqlTransaction transaction = null) => new SqlCommand(sql, _connection, transaction)
+        { CommandTimeout = 120 };
+
+        private T Execute<T>(SqlCommand command, Func<T> execute)
+        {
+            _cancellation.ThrowIfCancellationRequested();
+            using (_cancellation.Register(command.Cancel))
+            {
+                try { return execute(); }
+                catch when (_cancellation.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException("Synthetic append cancelled." + FailureAdvice, _cancellation);
+                }
+            }
+        }
+
+        private void EnsureReady()
+        {
+            if (!_ready || _failed || _disposed)
+                throw new InvalidOperationException("No successful writable existing-target stream is open." + FailureAdvice);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _ready = false;
+            _sink?.Dispose();
+            _connection.Dispose();
+            _emailHash?.Dispose();
+        }
+
+        private sealed class SqlColumn
+        {
+            public string Type;
+            public int Length;
+            public bool Nullable, Identity, Computed, HasDefault, Generated, PrimaryKey;
+        }
+
+        private sealed class ForeignKey
+        {
+            public string Column, Schema, Table, TargetColumn;
+            public int Width;
+            public bool Disabled;
+        }
+
+        private sealed class TablePlan
+        {
+            public readonly DemoTable Table;
+            public readonly int Order;
+            public readonly string MapName;
+            public readonly Dictionary<string, SqlColumn> Columns = new Dictionary<string, SqlColumn>(StringComparer.OrdinalIgnoreCase);
+            public readonly List<ForeignKey> ForeignKeys = new List<ForeignKey>();
+            public readonly Dictionary<int, TablePlan> IdentityReferences = new Dictionary<int, TablePlan>();
+            public int IdentityIndex = -1;
+            public int[] ReuseKey = new int[0];
+            public string[] NullColumns = new string[0];
+            public long Received, Inserted, Reused, Skipped;
+            public string IdentityColumn => Table.Columns[IdentityIndex].Name;
+            public string SqlName => "dbo." + Quote(Table.Name);
+            public TablePlan(DemoTable table, int order) { Table = table; Order = order; MapName = "#ContosoDemoMap" + order; }
+        }
+
+        private sealed class ExistingSink : IDemoSink
+        {
+            private readonly SqlExistingDemoDatabase _owner;
+            private bool _disposed;
+            public readonly Dictionary<DemoTable, List<object[]>> Buffers = new Dictionary<DemoTable, List<object[]>>();
+            public int PendingRows { get; private set; }
+            public bool DiscardedRows { get; private set; }
+            public ExistingSink(SqlExistingDemoDatabase owner) { _owner = owner; }
+
+            public void Write(DemoTable table, params object[] values)
+            {
+                try
+                {
+                    if (_disposed) throw new ObjectDisposedException(nameof(ExistingSink));
+                    _owner.EnsureReady();
+                    _owner._cancellation.ThrowIfCancellationRequested();
+                    if (!_owner._plans.TryGetValue(table, out var plan))
+                        throw new InvalidOperationException("The table was not preflighted.");
+                    table.ValidateValues(values);
+                    var row = values.Select(_owner.NamespaceValue).ToArray();
+                    if (table == DemoTables.EngageGroups)
+                    {
+                        // Membership snapshots describe this run's population, not an existing group.
+                        int name = table.Columns.ToList().FindIndex(c => c.Name == "name");
+                        row[name] = row[name] + " (demo " + new Guid(_owner._runNamespace).ToString("N") + ")";
+                    }
+                    table.ValidateValues(row);
+                    for (int i = 0; i < row.Length; i++)
+                        if ((row[i] == null || row[i] == DBNull.Value) && !plan.Columns[table.Columns[i].Name].Nullable)
+                            throw new InvalidOperationException("Synthetic NULL in required column " + table.Name + "." + table.Columns[i].Name);
+                    if (plan.IdentityIndex >= 0 && (!(row[plan.IdentityIndex] is int key) || key <= 0))
+                        throw new InvalidOperationException("A positive logical integer identity is required.");
+                    plan.Received++;
+                    if (table == DemoTables.CopilotCounts) { plan.Skipped++; return; }
+                    if (!Buffers.TryGetValue(table, out var rows))
+                        Buffers.Add(table, rows = new List<object[]>(table.BatchLimit(_owner._options.BatchSize)));
+                    rows.Add(row);
+                    PendingRows++;
+                    if (rows.Count >= table.BatchLimit(_owner._options.BatchSize)) Flush();
+                }
+                catch
+                {
+                    _owner._failed = true;
+                    DiscardedRows |= PendingRows != 0;
+                    ClearBuffers();
+                    throw;
+                }
+            }
+
+            public void Flush()
+            {
+                try
+                {
+                    if (_disposed) throw new ObjectDisposedException(nameof(ExistingSink));
+                    _owner.Flush(this);
+                }
+                catch
+                {
+                    _owner._failed = true;
+                    DiscardedRows |= PendingRows != 0;
+                    ClearBuffers();
+                    throw;
+                }
+            }
+
+            public void ClearBuffers()
+            {
+                foreach (var rows in Buffers.Values) rows.Clear();
+                PendingRows = 0;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed) return;
+                _disposed = true;
+                DiscardedRows |= PendingRows != 0;
+                ClearBuffers();
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
@@ -23,20 +23,28 @@ namespace Tests.FakeDataGen
     internal class Program
     {
         // Menu options are registered up-front so the dispatcher stays in one place.
-        private static readonly List<MenuItem> MenuItems = new List<MenuItem>
+        private static readonly List<MenuItem> MenuItems = CreateMenuItems();
+
+        private static List<MenuItem> CreateMenuItems()
         {
-            // Data generation
-            new MenuItem(DemoInteractive.MenuTitle, MenuCategory.DataGeneration,
-                ctx => DemoInteractive.Run()),
-            new MenuItem("Generate fake Copilot activity", MenuCategory.DataGeneration,
+            var items = new List<MenuItem>
+            {
+                new MenuItem(DemoInteractive.MenuTitle, MenuCategory.DataGeneration, ctx => DemoInteractive.Run())
+            };
+            foreach (var area in DemoAreas.Catalogue)
+                items.Add(new MenuItem(area.Title + " (existing or new DB)", MenuCategory.DataGeneration,
+                    ctx => DemoInteractive.RunArea(area, ctx.ConnectionString)));
+            items.AddRange(new[]
+            {
+            new MenuItem("Generate fake Copilot activity", MenuCategory.LegacyGeneration,
                 ctx => RunCopilotActivityGenerator(ctx.RequireConnectionString())),
-            new MenuItem("Generate fake O365 audit activity", MenuCategory.DataGeneration,
+            new MenuItem("Generate fake O365 audit activity", MenuCategory.LegacyGeneration,
                 ctx => RunOffice365ActivityGenerator(ctx.RequireConnectionString())),
-            new MenuItem("Generate combined profiling data (O365 + Copilot)", MenuCategory.DataGeneration,
+            new MenuItem("Generate combined profiling data (O365 + Copilot)", MenuCategory.LegacyGeneration,
                 ctx => RunCombinedActivityGenerator(ctx.RequireConnectionString())),
-            new MenuItem("Generate fake Copilot prompt history (AI interaction history)", MenuCategory.DataGeneration,
+            new MenuItem("Generate fake Copilot prompt history (AI interaction history)", MenuCategory.LegacyGeneration,
                 ctx => RunCopilotInteractionHistoryGenerator(ctx.RequireConnectionString())),
-            new MenuItem("Generate fake DLP policy activity (Copilot + tenant-wide)", MenuCategory.DataGeneration,
+            new MenuItem("Generate fake DLP policy activity (Copilot + tenant-wide)", MenuCategory.LegacyGeneration,
                 ctx => RunDlpActivityGenerator(ctx.RequireConnectionString())),
 
             // Stress tests
@@ -54,7 +62,9 @@ namespace Tests.FakeDataGen
                 ctx => RunStressTest(new SentEmailImporterStressTest(), ctx)),
             new MenuItem("User activity data stress test (profiling SQL inputs)", MenuCategory.StressTest,
                 ctx => RunStressTest(new UserActivityStressTest(), ctx)),
-        };
+            });
+            return items;
+        }
 
         static void Main(string[] args)
         {
@@ -63,6 +73,16 @@ namespace Tests.FakeDataGen
             if (args.Length > 0 && args[0].Equals("demo", StringComparison.OrdinalIgnoreCase))
             {
                 Environment.ExitCode = DemoCommand.Run(args.Skip(1).ToArray());
+                return;
+            }
+            if (args.Length > 0 && args[0].Equals("append", StringComparison.OrdinalIgnoreCase))
+            {
+                if (args.Length < 2)
+                {
+                    Console.Error.WriteLine("append requires a TEST database connection string and --confirm-existing.");
+                    Environment.ExitCode = 2;
+                }
+                else Environment.ExitCode = DemoCommand.RunExisting(args.Skip(2).ToArray(), args[1]);
                 return;
             }
 
@@ -89,8 +109,8 @@ namespace Tests.FakeDataGen
             else
             {
                 Console.WriteLine("No SQL connection string provided.");
-                Console.WriteLine("The synthetic demo option (which creates its own new LocalDB database) and the");
-                Console.WriteLine("stress tests that don't need SQL will still run; everything else will be disabled.");
+                Console.WriteLine("The full demo and individual activity menus can create a new LocalDB database.");
+                Console.WriteLine("Existing-database appends and legacy generators need a startup connection string.");
                 Console.WriteLine("Usage: Tests.FakeDataGen.exe \"<SQL Connection String>\" [--run <copilot|copilotadoption|activityapi|activityapidb|powerplatform|sentemail|useractivity>]");
                 Console.WriteLine("Safe one-command demo: Tests.FakeDataGen.exe demo --help (or pick it from the menu below)");
             }
@@ -194,6 +214,13 @@ namespace Tests.FakeDataGen
                 index++;
             }
 
+            Console.WriteLine();
+            Console.WriteLine("LEGACY GENERATORS (existing DB only)");
+            foreach (var item in MenuItems.Where(m => m.Category == MenuCategory.LegacyGeneration))
+            {
+                Console.WriteLine($"  {index}. {item.Title}");
+                index++;
+            }
             Console.WriteLine();
             Console.WriteLine("STRESS TESTS");
             foreach (var item in MenuItems.Where(m => m.Category == MenuCategory.StressTest))
@@ -570,6 +597,7 @@ namespace Tests.FakeDataGen
         private enum MenuCategory
         {
             DataGeneration,
+            LegacyGeneration,
             StressTest
         }
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/README.md
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/README.md
@@ -18,8 +18,10 @@ Tests.FakeDataGen.exe demo --help
 This non-interactive command creates a **new LocalDB-only** target, applies the
 existing schema, and generates current overlapping licence assignments, daily
 workload coverage (including explicit zero rows), Copilot adoption and official
-D28 snapshots, metadata-only prompt/response pairs, SharePoint/web facts, and
-complete-week Power BI profiles. It never reads a configured production connection.
+D28 snapshots, metadata-only prompt/response pairs, SharePoint/web facts, detailed
+Teams activity, sent email, Power Platform activity, and complete-week Power BI
+profiles. Actual Power BI report views are separate from these profiling tables.
+It never reads a configured production connection.
 Exact completed reruns are read-only no-ops; other existing targets are refused.
 `--preview` runs the same generator without SQL. Fix `--as-of` and `--seed` for
 reproducibility. `--help` lists all flags and the deliberately unsupported datasets.
@@ -29,7 +31,9 @@ The same demo is the **first option on the interactive menu**, so it can be run
 without knowing any of the flags - see
 [Full synthetic demo](#full-synthetic-demo-contoso) below.
 
-The older, independent interactive generator/stress-test menu is still available:
+Each major area also has a menu entry offering a new database or additive
+generation into an existing **test/demo** database. Supply the existing connection
+when starting the menu:
 
 ```
 Tests.FakeDataGen.exe "<SQL Connection String>"
@@ -37,9 +41,11 @@ Tests.FakeDataGen.exe "<SQL Connection String>"
 
 The connection string is optional. Options that need SQL will refuse to run
 without one; stress tests that work in-memory still run. The synthetic demo
-option never uses it - it always creates its own new LocalDB database.
+option never uses it - it always creates its own new LocalDB database. The
+individual-area entries default to a new target and require explicit confirmation
+before appending to an existing one.
 
-The first time a menu option that needs the database runs in a session, the
+The first time a **legacy generator or database-backed stress test** runs, the
 host invokes `App.ControlPanel.Engine.DatabaseUpgrader.CheckDbUpgraded` against
 the supplied connection string. This applies the Entity Framework migrations
 and the custom SQL scripts under
@@ -48,27 +54,29 @@ stored procedures) so generators and stress tests never run against a stale
 schema. The upgrade is performed once per process; the in-memory
 `ActivityAPIStressTest` skips it because it does not touch SQL.
 
-When launched, an interactive menu is shown:
+The new existing-database path does **not** run that upgrader: it checks the
+schema before inserting, preserves existing users, remaps generated IDs and adds
+a separate synthetic population on each run. No deletes, resets or automatic
+cleanup are performed; committed batches remain after an interrupted append.
 
+The menu has three sections: **Data Generation** (full demo followed by each
+activity area, existing or new DB), **Legacy Generators**, and **Stress Tests**.
+Area keys and display labels come from `DemoAreas.Catalogue`, which also drives
+the command-line selector:
+
+```text
+Tests.FakeDataGen.exe demo --database ContosoDemo_Teams --areas teams
+Tests.FakeDataGen.exe demo --database ContosoDemo_PowerPlatform --areas powerapps,powerautomate,powerbi,copilot-studio
+Tests.FakeDataGen.exe append "<test-database-connection-string>" --areas powerbi --confirm-existing
 ```
-DATA GENERATION
-  1. Generate a complete synthetic demo database (Contoso, new LocalDB database)
-  2. Generate fake Copilot activity
-  3. Generate fake O365 audit activity
-  4. Generate combined profiling data (O365 + Copilot)
-  5. Generate fake Copilot prompt history (AI interaction history)
 
-STRESS TESTS
-  6. ActivityAPI import stress test
-  7. ActivityAPI import stress test (DB-backed, COLD+WARM)
-  8. Copilot event import stress test
-  9. Copilot Adoption page performance test (read-only, before/after)
-  10. Power Platform event import stress test
-  11. Sent email importer stress test
-  12. User activity data stress test (profiling SQL inputs)
-
-  0. Exit
-```
+`--areas all` is the default. Other keys are `directory`, `copilot`,
+`copilot-history`, `outlook`, `sent-email`, `sharepoint`, `web`, `onedrive`,
+`engage`, `office` and `dlp`. DLP includes prerequisite Copilot audit interactions
+and preserves the blocked-versus-audit-only policy scenarios. Shared users/licences and dependent dimensions accompany
+individual areas. Appends skip tenant-wide Copilot count snapshots and global
+profile compilation rather than publishing partial-population totals as tenant
+data. Use a full new demo for a self-contained profiled database.
 
 ## Folder layout
 
@@ -97,7 +105,7 @@ Tests.FakeDataGen/
 
 `Seeding` is intentionally shared: legacy generators and stress tests call
 `UserMetadataSeeder`; the new `demo` command uses the same `SeedDataCatalogue`
-through its new-target-only bounded sink. Users are made as
+through its new-target bounded sink or additive, identity-remapping existing-target sink. Users are made as
 realistic as a live tenant: `SeedDataCatalogue` assigns each user a coherent geo
 locale (country / state / city / office / usage location / postal code all agree,
 across 21 countries incl. non-Latin values), a job title that fits its department,
@@ -144,7 +152,7 @@ A finished run prints the two settings a web application needs:
 
 ```
   connectionStrings   SPOInsightsEntities = Server=(localdb)\MSSQLLocalDB;Database=ContosoDemo_X;Integrated Security=True
-  appSettings         ImportJobSettings = GraphUsersMetadata=True;GraphUsageReports=True;GraphCopilotUsageReports=True;Copilot=True;CopilotInteractionHistory=True;ActivityLog=True;WebTraffic=True
+  appSettings         ImportJobSettings = GraphUsersMetadata=True;GraphUsageReports=True;GraphCopilotUsageReports=True;Copilot=True;CopilotInteractionHistory=True;ActivityLog=True;WebTraffic=True;Calls=True;GraphTeams=True;SentEmails=True;ImportPowerPlatform=True;ImportDlp=True
 ```
 
 **The portal decides which workloads it can measure from `ImportJobSettings`, not
@@ -280,15 +288,15 @@ behaviour, verbosity) and reports:
 
 ### Available stress tests
 
-| # | Test | Purpose |
-| - | ---- | ------- |
-| 6 | `ActivityAPIStressTest` | Drives the ActivityAPI ingestion pipeline with fake loaders to detect leaks and benchmark the batch save path. |
-| 7 | `ActivityApiDbStressTest` | Drives the real SQL persistence path through repeatable cold and warm scenarios. |
-| 8 | `CopilotStressTest` | Exercises `CopilotAuditEventManager` at scale and validates the accessed-resources SQL path under load. |
-| 9 | `CopilotAdoptionPerfTest` | Read-only before/after timing of the Copilot Adoption page's analysis against an existing database. |
-| 10 | `PowerPlatformStressTest` | Exercises `PowerPlatformAuditEventManager` across the four Power Platform workloads (Power Apps, Power Automate, Power BI, Copilot Studio). |
-| 11 | `SentEmailImporterStressTest` | Exercises sent-email persistence and sentiment-scoring boundaries with synthetic messages. |
-| 12 | `UserActivityStressTest` | Bulk-loads the user + license + per-workload activity tables so the profiling SQL in `App.ControlPanel.Engine/SqlExtentions/Profiling-03-CreateSchema.sql` can be exercised against realistic volumes. After the seed, optionally invokes `[profiling].[usp_CompileWeekly]` to roll the daily rows into the weekly profiling tables straight away (the same proc that `WebJob.Office365ActivityImporter/AutomationPS/ProfilingJobs/Weekly.ps1` runs on schedule). |
+| Test | Purpose |
+| ---- | ------- |
+| `ActivityAPIStressTest` | Drives the ActivityAPI ingestion pipeline with fake loaders to detect leaks and benchmark the batch save path. |
+| `ActivityApiDbStressTest` | Drives the real SQL persistence path through repeatable cold and warm scenarios. |
+| `CopilotStressTest` | Exercises `CopilotAuditEventManager` at scale and validates the accessed-resources SQL path under load. |
+| `CopilotAdoptionPerfTest` | Read-only before/after timing of the Copilot Adoption page's analysis against an existing database. |
+| `PowerPlatformStressTest` | Exercises `PowerPlatformAuditEventManager` across Power Apps, Power Automate, Power BI and Copilot Studio. |
+| `SentEmailImporterStressTest` | Exercises sent-email persistence and sentiment-scoring boundaries with synthetic messages. |
+| `UserActivityStressTest` | Loads user/licence/daily workload rows and optionally compiles weekly profiling tables. |
 
 ### Adding a new stress test
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/README.md
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/README.md
@@ -75,7 +75,8 @@ Tests.FakeDataGen.exe append "<test-database-connection-string>" --areas powerbi
 `copilot-history`, `outlook`, `sent-email`, `sharepoint`, `web`, `onedrive`,
 `engage`, `office` and `dlp`. DLP includes prerequisite Copilot audit interactions
 and preserves the blocked-versus-audit-only policy scenarios. Shared users/licences and dependent dimensions accompany
-individual areas. Appends skip tenant-wide Copilot count snapshots and global
+individual areas. Appends skip tenant-wide Copilot count snapshots, agent costs
+(Copilot Studio credits, the capacity snapshot and Azure agent spend) and global
 profile compilation rather than publishing partial-population totals as tenant
 data. Use a full new demo for a self-contained profiled database.
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Copilot\CopilotResourceGenerator.cs" />
     <Compile Include="Copilot\CopilotUserManager.cs" />
     <Compile Include="Demo\DemoCalendar.cs" />
+    <Compile Include="Demo\DemoAreas.cs" />
     <Compile Include="Demo\DemoCommand.cs" />
     <Compile Include="Demo\DemoGenerator.cs" />
     <Compile Include="Demo\DemoInteractive.cs" />
@@ -63,8 +64,13 @@
     <Compile Include="Demo\DemoPopulation.cs" />
     <Compile Include="Demo\DemoPortalReadiness.cs" />
     <Compile Include="Demo\DemoTables.cs" />
+    <Compile Include="Demo\DemoCollaborationTables.cs" />
+    <Compile Include="Demo\DemoCollaborationGenerator.cs" />
+    <Compile Include="Demo\DemoPowerPlatformTables.cs" />
+    <Compile Include="Demo\DemoPowerPlatformGenerator.cs" />
     <Compile Include="Demo\DemoTimeline.cs" />
     <Compile Include="Demo\SqlDemoDatabase.cs" />
+    <Compile Include="Demo\SqlExistingDemoDatabase.cs" />
     <Compile Include="Generation\ActivityTimestampGenerator.cs" />
     <Compile Include="Office365\Office365ActivityGenerator.cs" />
     <Compile Include="Office365\Office365ActivityGeneratorConfig.cs" />

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Verify-DemoCommand.ps1
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Verify-DemoCommand.ps1
@@ -30,6 +30,10 @@ try {
     if ($generated.Status -ne 'Complete' -or $generated.CompletedProfileWeeks -le 0) {
         throw 'One-command generation did not complete its database and Power BI profiles.'
     }
+    foreach ($table in @('call_records', 'sent_emails', 'event_meta_power_app',
+        'event_meta_power_automate_flow', 'event_meta_power_bi', 'event_meta_copilot_studio')) {
+        if ($generated.Rows.$table -le 0) { throw "Full demo did not populate $table." }
+    }
     & $exe @arguments --output "$artifacts\repeat.json"
     Assert-CommandSucceeded
     $repeat = Get-Content "$artifacts\repeat.json" -Raw | ConvertFrom-Json
@@ -37,7 +41,22 @@ try {
 
     & $exe @arguments --seed 43
     if ($LASTEXITCODE -eq 0) { throw 'A changed generation was incorrectly accepted for an existing target.' }
-    Write-Output 'Demo CLI smoke passed: help, preview, new target, profiles, identical rerun and changed-input refusal.'
+
+    $connection = "Server=(localdb)\MSSQLLocalDB;Database=$database;Integrated Security=True;Pooling=False"
+    & $exe append $connection --areas powerbi --users 10 --days 35 --as-of 2026-09-01
+    if ($LASTEXITCODE -eq 0) { throw 'Append accepted an unconfirmed existing target.' }
+    & $exe append $connection --areas powerbi --users 10 --days 35 --as-of 2026-09-01 --confirm-existing --output "$artifacts\appended.json"
+    Assert-CommandSucceeded
+    $appended = Get-Content "$artifacts\appended.json" -Raw | ConvertFrom-Json
+    if ($appended.Status -ne 'Appended' -or $appended.Rows.event_meta_power_bi -le 0 -or $appended.CompletedProfileWeeks -ne 0) {
+        throw 'Individual-area append did not produce Power BI facts without global profiling.'
+    }
+    if ($appended.Rows.teams_user_activity_log -gt 0 -or $appended.Rows.copilot_chats -gt 0) {
+        throw 'Individual Power BI append generated unrelated workload facts.'
+    }
+    & $exe @arguments
+    if ($LASTEXITCODE -eq 0) { throw 'An appended-to demo was incorrectly treated as an unchanged completed target.' }
+    Write-Output 'Demo CLI smoke passed: full workload coverage, rerun safeguards and confirmed individual-area append.'
 }
 finally {
     # Only clean up this run's unpredictable name, and only with the generator's ownership marker.

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoAreaTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoAreaTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tests.FakeDataGen.Demo;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    [TestCategory("DemoGenerator")]
+    public class DemoAreaTests
+    {
+        [TestMethod]
+        public void Areas_AreStrictCanonicalAndIncludedInFingerprint()
+        {
+            foreach (var value in new[] { "", "teams,", "unknown", "teams,teams", "all,teams" })
+                Assert.ThrowsException<ArgumentException>(() => DemoAreas.Parse(value));
+            Assert.AreEqual(DemoArea.All, DemoAreas.Parse("all"));
+            Assert.AreEqual(DemoArea.Teams | DemoArea.PowerBI, DemoAreas.Parse(" POWERBI,Teams "));
+            var first = DemoGeneratorTests.Options("--areas", "powerbi,teams");
+            var second = DemoGeneratorTests.Options("--areas", "teams,powerbi");
+            Assert.AreEqual(first.Fingerprint, second.Fingerprint);
+            Assert.AreNotEqual(first.Fingerprint, DemoGeneratorTests.Options("--areas", "teams").Fingerprint);
+            Assert.IsFalse(first.HasAllDailyWorkloads);
+            Assert.IsTrue(DemoGeneratorTests.Options().HasAllDailyWorkloads);
+            Assert.AreEqual(DemoArea.All, DemoAreas.Catalogue.Aggregate((DemoArea)0, (flags, area) => flags | area.Area));
+            Assert.ThrowsException<ArgumentException>(() => DemoOptions.Parse(new[]
+                { "--preview", "--users", "1000000", "--days", "730", "--areas", "web" }, DateTime.UtcNow));
+        }
+
+        [TestMethod]
+        public void IndividualMenu_BuildsSelectedAreaForNewOrExistingDatabase()
+        {
+            var newArgs = DemoInteractive.BuildArgs(new Prompt(), new DateTime(2026, 9, 1), DemoArea.Teams);
+            var fresh = DemoOptions.Parse(newArgs, DateTime.UtcNow);
+            Assert.AreEqual(DemoArea.Teams, fresh.Areas);
+            Assert.IsNotNull(fresh.Database);
+            Assert.IsNull(DemoInteractive.BuildArgs(new Prompt(), DateTime.UtcNow, DemoArea.Teams, existing: true),
+                "End of input must never confirm an append.");
+            var existingArgs = DemoInteractive.BuildArgs(new Prompt("n", "n", "y"),
+                DateTime.UtcNow, DemoArea.PowerBI, existing: true);
+            var existing = DemoOptions.Parse(existingArgs, DateTime.UtcNow, existingTarget: true);
+            Assert.AreEqual(DemoArea.PowerBI, existing.Areas);
+            Assert.IsNull(existing.Database);
+            Assert.IsFalse(existing.CompileProfiles);
+            Assert.ThrowsException<ArgumentException>(() => DemoOptions.Parse(newArgs, DateTime.UtcNow, existingTarget: true));
+        }
+
+        [TestMethod]
+        public void AppendCommand_RequiresExplicitAcknowledgementBeforeAnyDatabaseAccess()
+        {
+            Assert.AreEqual(2, DemoCommand.RunExisting(new string[0], "Server=contoso.example;Database=Example"));
+            Assert.AreEqual(2, DemoCommand.RunExisting(new[] { "--confirm-existing" }, null));
+            Assert.AreEqual(2, DemoCommand.RunExisting(new[] { "--confirm-existing", "--confirm-existing" },
+                "Server=contoso.example;Database=Example"));
+        }
+
+        [DataTestMethod]
+        [DataRow("directory", "users")]
+        [DataRow("copilot", "copilot_chats")]
+        [DataRow("copilot-history", "copilot_interactions")]
+        [DataRow("teams", "call_records")]
+        [DataRow("outlook", "outlook_user_activity_log")]
+        [DataRow("sent-email", "sent_emails")]
+        [DataRow("sharepoint", "event_meta_sharepoint")]
+        [DataRow("web", "hits")]
+        [DataRow("onedrive", "onedrive_user_activity_log")]
+        [DataRow("engage", "yammer_user_activity_log")]
+        [DataRow("office", "platform_user_activity_log")]
+        [DataRow("powerapps", "event_meta_power_app")]
+        [DataRow("powerautomate", "event_meta_power_automate_flow")]
+        [DataRow("powerbi", "event_meta_power_bi")]
+        [DataRow("copilot-studio", "event_meta_copilot_studio")]
+        [DataRow("dlp", "copilot_dlp_events")]
+        public void EveryIndividualArea_ProducesReportFactsAndUsesSameRowsAsFullDemo(string key, string factTable)
+        {
+            var options = DemoGeneratorTests.Options("--areas", key);
+            var summary = DemoCommand.NewSummary(options);
+            var selected = new DemoGeneratorTests.RecordingSink(t => t.Name == factTable);
+            using (var sink = new CountingDemoSink(summary, selected))
+                new DemoGenerator(options).Generate(sink, summary, null);
+            Assert.IsTrue(summary.Rows.TryGetValue(factTable, out long rows) && rows > 0,
+                key + " must generate usable report facts, not just lookup tables.");
+
+            var full = new DemoGeneratorTests.RecordingSink(t => t.Name == factTable);
+            var allOptions = DemoGeneratorTests.Options();
+            var allSummary = DemoCommand.NewSummary(allOptions);
+            using (var sink = new CountingDemoSink(allSummary, full))
+                new DemoGenerator(allOptions).Generate(sink, allSummary, null);
+            Assert.AreEqual(Newtonsoft.Json.JsonConvert.SerializeObject(full.Rows),
+                Newtonsoft.Json.JsonConvert.SerializeObject(selected.Rows),
+                "Selecting an area must not use a separate, lower-quality generator.");
+        }
+
+        [TestMethod]
+        public void PortalSettings_AreLimitedToSelectedSources()
+        {
+            Assert.AreEqual("GraphUsersMetadata=True;ImportPowerPlatform=True",
+                DemoPortalReadiness.ImportSettings(DemoArea.PowerBI));
+            Assert.AreEqual("GraphUsersMetadata=True;GraphUsageReports=True;Calls=True;GraphTeams=True",
+                DemoPortalReadiness.ImportSettings(DemoArea.Teams));
+            Assert.AreEqual("GraphUsersMetadata=True;CopilotInteractionHistory=True",
+                DemoPortalReadiness.ImportSettings(DemoArea.CopilotHistory));
+            Assert.AreEqual("GraphUsersMetadata=True;Copilot=True;ImportDlp=True",
+                DemoPortalReadiness.ImportSettings(DemoArea.Dlp));
+        }
+
+        [TestMethod]
+        public void SelectingDailyWorkload_DoesNotInventOtherWorkloadFacts()
+        {
+            var mappings = new[]
+            {
+                (DemoArea.Teams, DemoTables.Teams), (DemoArea.Outlook, DemoTables.Outlook),
+                (DemoArea.SharePoint, DemoTables.SharePoint), (DemoArea.OneDrive, DemoTables.OneDrive),
+                (DemoArea.Engage, DemoTables.Engage), (DemoArea.Office, DemoTables.Platforms)
+            };
+            foreach (var mapping in mappings)
+            {
+                var options = DemoGeneratorTests.Options("--areas", DemoAreas.Format(mapping.Item1));
+                var summary = DemoCommand.NewSummary(options);
+                using (var sink = new CountingDemoSink(summary)) new DemoGenerator(options).Generate(sink, summary, null);
+                Assert.AreEqual(options.Users, summary.Rows[DemoTables.Users.Name]);
+                Assert.AreEqual(options.Users * (options.Days - 2), summary.Rows[mapping.Item2.Name]);
+                foreach (var other in mappings.Where(m => m.Item1 != mapping.Item1))
+                    Assert.IsFalse(summary.Rows.ContainsKey(other.Item2.Name), other.Item2.Name);
+                Assert.IsFalse(summary.Rows.ContainsKey(DemoTables.Chats.Name));
+                Assert.IsFalse(summary.Rows.ContainsKey(DemoTables.Interactions.Name));
+                Assert.IsFalse(summary.Rows.ContainsKey(DemoTables.CopilotUsage.Name));
+            }
+        }
+
+        private sealed class Prompt : IDemoPrompt
+        {
+            private readonly Queue<string> _answers;
+            public Prompt(params string[] answers) { _answers = new Queue<string>(answers); }
+            public void Write(string message) { }
+            public string Ask(string question) => _answers.Count == 0 ? null : _answers.Dequeue();
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoCollaborationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoCollaborationTests.cs
@@ -1,0 +1,366 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Tests.FakeDataGen.Demo;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    [TestCategory("DemoGenerator")]
+    public class DemoCollaborationTests
+    {
+        private static readonly DemoTable[] TeamsTables =
+        {
+            DemoTables.CallTypes, DemoTables.CallModalities, DemoTables.CallRecords, DemoTables.CallSessions,
+            DemoTables.CallSessionModalities, DemoTables.CallFeedback, DemoTables.CallFailures,
+            DemoTables.TeamDefinitions, DemoTables.TeamChannels, DemoTables.TeamMemberships, DemoTables.TeamOwners,
+            DemoTables.TeamTabs, DemoTables.TeamTabLogs, DemoTables.ChannelStats, DemoTables.ChannelKeywords,
+            DemoTables.ChannelLanguages, DemoTables.ReactionTypes, DemoTables.ChannelReactions, DemoTables.Keywords
+        };
+        private static readonly DemoTable[] EmailTables =
+            { DemoTables.EmailAddresses, DemoTables.SentEmails, DemoTables.EmailRecipients };
+        private static readonly DemoTable[] PageTables =
+            { DemoTables.PageFields, DemoTables.PageMetadata, DemoTables.PageComments, DemoTables.PageLikes };
+        private static readonly DemoTable[] WebTables =
+            { DemoTables.ClickTitles, DemoTables.ClickClasses, DemoTables.Clicks, DemoTables.SearchTerms, DemoTables.Searches };
+        private static readonly DemoTable[] OneDriveTables = { DemoTables.OneDriveStorage };
+        private static readonly DemoTable[] EngageTables = { DemoTables.EngageGroups, DemoTables.EngageGroupActivity };
+
+        private static DemoOptions Options(string areas = "all", string mix = "30,35,20,8,7", int users = 80) =>
+            DemoOptions.Parse(new[] { "--preview", "--users", users.ToString(CultureInfo.InvariantCulture),
+                "--days", "90", "--as-of", "2026-09-01", "--areas", areas, "--mix", mix }, DateTime.UtcNow);
+
+        [TestMethod]
+        public void Collaboration_AllImportedTablesHaveDeterministicRowsAndValidWidths()
+        {
+            var options = Options();
+            var first = Generate(options);
+            var second = Generate(options);
+            var expected = TeamsTables.Concat(EmailTables).Concat(PageTables).Concat(WebTables)
+                .Concat(OneDriveTables).Concat(EngageTables).Concat(new[] { DemoTables.Languages }).ToArray();
+            CollectionAssert.AreEquivalent(expected.Select(t => t.Name).ToArray(), first.Rows.Keys.Select(t => t.Name).ToArray());
+            foreach (var table in expected)
+            {
+                Assert.IsTrue(first.For(table).Count > 0, table.Name);
+                Assert.AreEqual(first.For(table).Count, second.For(table).Count, table.Name);
+                for (int i = 0; i < first.For(table).Count; i++)
+                    CollectionAssert.AreEqual(first.For(table)[i], second.For(table)[i], table.Name);
+            }
+            foreach (var table in new[] { DemoTables.ChannelStats, DemoTables.SentEmails, DemoTables.PageComments })
+            {
+                string score = table == DemoTables.SentEmails ? "cognitive_score" : "sentiment_score";
+                var scores = first.For(table).Select(r => first.Value(table, r, score)).ToArray();
+                Assert.IsTrue(scores.Any(s => s == null), table.Name + ": unknown cognitive results");
+                Assert.IsTrue(scores.Where(s => s != null).Select(Convert.ToDouble).Distinct().Count() >= 3,
+                    table.Name + ": varied sentiment");
+            }
+        }
+
+        [TestMethod]
+        public void Collaboration_EachAreaWritesOnlyItsOwnFactsAndRequiredLookups()
+        {
+            var full = Generate(Options());
+            var groups = new Dictionary<string, DemoTable[]>
+            {
+                ["teams"] = TeamsTables.Concat(new[] { DemoTables.Languages }).ToArray(),
+                ["sent-email"] = EmailTables,
+                ["sharepoint"] = new DemoTable[0],
+                ["web"] = WebTables.Concat(PageTables).Concat(new[] { DemoTables.Languages }).ToArray(),
+                ["onedrive"] = OneDriveTables,
+                ["engage"] = EngageTables,
+                ["copilot-history"] = new[] { DemoTables.Keywords, DemoTables.Languages }
+            };
+            foreach (var group in groups)
+            {
+                var capture = Generate(Options(group.Key));
+                CollectionAssert.AreEquivalent(group.Value.Select(t => t.Name).ToArray(),
+                    capture.Rows.Keys.Select(t => t.Name).ToArray(), group.Key);
+                foreach (var table in group.Value)
+                {
+                    Assert.AreEqual(full.For(table).Count, capture.For(table).Count, table.Name);
+                    for (int row = 0; row < full.For(table).Count; row++)
+                        CollectionAssert.AreEqual(full.For(table)[row], capture.For(table)[row],
+                            table.Name + ": selecting an area must preserve logical ids and row contents");
+                }
+            }
+            foreach (string unrelated in new[] { "directory", "outlook", "office", "copilot", "powerapps" })
+                Assert.AreEqual(0, Generate(Options(unrelated)).Rows.Count, unrelated);
+        }
+
+        [TestMethod]
+        public void Collaboration_NeverActiveUsersHaveNoActionsEvenWithOtherUsersReceivingMail()
+        {
+            var options = Options(mix: "0,0,0,100,0");
+            var capture = Generate(options);
+            foreach (var table in new[]
+            {
+                DemoTables.CallRecords, DemoTables.CallSessions, DemoTables.CallFeedback, DemoTables.CallFailures,
+                DemoTables.ChannelStats, DemoTables.ChannelKeywords, DemoTables.ChannelLanguages, DemoTables.ChannelReactions,
+                DemoTables.SentEmails, DemoTables.EmailRecipients, DemoTables.PageComments, DemoTables.PageLikes,
+                DemoTables.Clicks, DemoTables.Searches, DemoTables.OneDriveStorage, DemoTables.EngageGroupActivity
+            })
+                Assert.AreEqual(0, capture.For(table).Count, table.Name);
+        }
+
+        [TestMethod]
+        public void Collaboration_UserActionsFollowWorkdaysLeaveInactiveWindowsAndCommonWorkloads()
+        {
+            var options = Options();
+            var capture = Generate(options);
+            var population = new DemoPopulation(options);
+            var users = Enumerable.Range(1, options.Users).ToDictionary(i => i, population.User);
+            var timelines = users.ToDictionary(p => p.Key, p => new DemoTimeline(options, p.Value));
+            var mappings = new[]
+            {
+                Tuple.Create(DemoTables.CallRecords, "organizer_id", "start", "teams"),
+                Tuple.Create(DemoTables.CallSessions, "attendee_user_id", "start", "teams"),
+                Tuple.Create(DemoTables.ChannelReactions, "user_id", "date", "messages"),
+                Tuple.Create(DemoTables.SentEmails, "user_id", "sent_date", "email"),
+                Tuple.Create(DemoTables.PageComments, "user_id", "created", "sharepoint"),
+                Tuple.Create(DemoTables.PageLikes, "user_id", "created", "sharepoint"),
+                Tuple.Create(DemoTables.OneDriveStorage, "user_id", "date", "onedrive")
+            };
+            foreach (var map in mappings)
+                foreach (var row in capture.For(map.Item1))
+                {
+                    int id = (int)capture.Value(map.Item1, row, map.Item2);
+                    var time = (DateTime)capture.Value(map.Item1, row, map.Item3);
+                    var user = users[id];
+                    int day = (time.Date - options.Start).Days;
+                    Assert.IsTrue(time >= options.Start && time < options.AsOf, map.Item1.Name);
+                    Assert.IsTrue(DemoCalendar.IsWorkingDate(time), map.Item1.Name);
+                    Assert.IsFalse(DemoTimeline.IsOnLeave(id, day), map.Item1.Name);
+                    Assert.AreNotEqual(DemoCohort.Zero, user.Cohort);
+                    if (user.Cohort == DemoCohort.Inactive) Assert.IsTrue(options.Days - day > 60);
+                    var activity = timelines[id].Day(day);
+                    int count = map.Item4 == "teams" ? activity.Meetings : map.Item4 == "messages" ? activity.Messages
+                        : map.Item4 == "email" ? activity.Sent : map.Item4 == "onedrive" ? activity.OneDriveFiles : activity.SharePointFiles;
+                    Assert.IsTrue(count > 0, map.Item1.Name + ": no invented user activity");
+                }
+        }
+
+        [TestMethod]
+        public void Collaboration_CallsHaveDistinctAttendeesBoundedIntervalsAndValidModalities()
+        {
+            var capture = Generate(Options("teams"));
+            var calls = capture.For(DemoTables.CallRecords).ToDictionary(r => (int)r[0]);
+            var sessions = capture.For(DemoTables.CallSessions).ToDictionary(r => (int)r[0]);
+            var participants = new HashSet<string>();
+            foreach (var session in sessions.Values)
+            {
+                int user = (int)session[1], callId = (int)session[4];
+                var call = calls[callId];
+                Assert.AreNotEqual((int)call[1], user, "Importer stores the organizer on the call, not as their own attendee.");
+                Assert.IsTrue(participants.Add(callId + ":" + user), "Duplicate attendee");
+                Assert.IsTrue((DateTime)session[2] >= (DateTime)call[4]);
+                Assert.IsTrue((DateTime)session[3] <= (DateTime)call[5]);
+                Assert.IsTrue((DateTime)session[2] < (DateTime)session[3]);
+            }
+            foreach (var call in calls.Values) Assert.IsTrue((DateTime)call[4] < (DateTime)call[5]);
+            var links = capture.For(DemoTables.CallSessionModalities);
+            Assert.AreEqual(links.Count, links.Select(r => r[0] + ":" + r[1]).Distinct().Count());
+            foreach (var session in sessions)
+                Assert.IsTrue(links.Any(r => (int)r[0] == 1 && (int)r[1] == session.Key), "Every session carries audio.");
+            foreach (var row in capture.For(DemoTables.CallFeedback))
+                Assert.IsTrue(participants.Contains(row[3] + ":" + row[2]));
+            foreach (var row in capture.For(DemoTables.CallFailures)) Assert.IsTrue(calls.ContainsKey((int)row[2]));
+            CollectionAssert.AreEquivalent(new[] { "peerToPeer", "groupCall" },
+                capture.For(DemoTables.CallTypes).Select(r => (string)r[1]).ToArray());
+        }
+
+        [TestMethod]
+        public void Collaboration_ChannelAndGroupSummariesAreUniqueAndDerivedFromUserDays()
+        {
+            var options = Options();
+            var capture = Generate(options);
+            var population = new DemoPopulation(options);
+            var channels = new Dictionary<string, int>();
+            var groups = new Dictionary<string, int[]>();
+            for (int id = 1; id <= options.Users; id++)
+            {
+                var user = population.User(id);
+                var timeline = new DemoTimeline(options, user);
+                for (int day = 0; day < options.Days; day++)
+                {
+                    var activity = timeline.Day(day);
+                    if (activity.Messages > 0)
+                    {
+                        int channel = user.Department * 2 + (int)(DemoRandom.Value(options.Seed, id, day, 1020) % 2) + 1;
+                        string key = channel + ":" + day;
+                        channels.TryGetValue(key, out int count);
+                        channels[key] = count + Math.Max(1, activity.Messages / 4);
+                    }
+                    if (activity.EngageRead > 0 && options.Start.AddDays(day) <= options.ReportEnd)
+                    {
+                        string key = (user.Department + 1) + ":" + day;
+                        if (!groups.TryGetValue(key, out var counts)) groups.Add(key, counts = new int[3]);
+                        counts[0] += activity.EngageRead / 3;
+                        counts[1] += activity.EngageRead;
+                        counts[2] += activity.EngageRead / 2;
+                    }
+                }
+            }
+            var stats = capture.For(DemoTables.ChannelStats);
+            Assert.AreEqual(channels.Count, stats.Count);
+            var seen = new HashSet<string>();
+            foreach (var row in stats)
+            {
+                string key = row[4] + ":" + (((DateTime)row[3] - options.Start).Days);
+                Assert.IsTrue(seen.Add(key), "Only one channel/day row");
+                Assert.AreEqual(channels[key], (int)row[1]);
+            }
+            var groupRows = capture.For(DemoTables.EngageGroupActivity);
+            Assert.AreEqual(groups.Count, groupRows.Count);
+            seen.Clear();
+            foreach (var row in groupRows)
+            {
+                string key = row[4] + ":" + (((DateTime)row[5] - options.Start).Days);
+                Assert.IsTrue(seen.Add(key), "Only one group/day row");
+                CollectionAssert.AreEqual(groups[key], new[] { (int)row[0], (int)row[1], (int)row[2] });
+                Assert.IsTrue((int)row[3] > 0);
+                Assert.AreEqual(row[5], row[6]);
+            }
+        }
+
+        [TestMethod]
+        public void Collaboration_EmailRecipientBridgeAndPageMetadataHaveValidUniqueKeys()
+        {
+            var capture = Generate(Options());
+            var addresses = capture.For(DemoTables.EmailAddresses).ToDictionary(r => (int)r[0], r => (string)r[1]);
+            var emails = capture.For(DemoTables.SentEmails).ToDictionary(r => (int)r[0]);
+            var recipients = capture.For(DemoTables.EmailRecipients);
+            Assert.AreEqual(recipients.Count, recipients.Select(r => r[0] + ":" + r[1]).Distinct().Count());
+            foreach (var row in recipients)
+            {
+                Assert.IsTrue(emails.ContainsKey((int)row[0]));
+                Assert.IsTrue(addresses.ContainsKey((int)row[1]));
+            }
+            Assert.AreEqual(emails.Count, emails.Values.Select(r => r[3]).Distinct().Count(), "Graph message ids are unique.");
+            foreach (var row in emails.Values)
+            {
+                Assert.AreEqual(row[5], row[6], "Sender address and user identify the same synthetic person.");
+                Assert.IsTrue(recipients.Any(r => (int)r[0] == (int)row[0]));
+                Assert.IsTrue(addresses[(int)row[5]].All(c => c < 128), "UPNs are ASCII.");
+            }
+            var metadata = capture.For(DemoTables.PageMetadata);
+            Assert.AreEqual(metadata.Count, metadata.Select(r => r[0] + ":" + r[1]).Distinct().Count());
+            Assert.IsTrue(metadata.Any(r => r[3] is Guid), "Taxonomy ids are actually imported as tag_guid.");
+            Assert.IsTrue(metadata.Any(r => ((string)r[2]).Any(c => c > 127)), "Unicode in nvarchar fields");
+            var comments = capture.For(DemoTables.PageComments).ToDictionary(r => (int)r[0]);
+            Assert.IsTrue(comments.Values.Any(r => r[4] != null), "Include comment replies.");
+            foreach (var comment in comments.Values.Where(r => r[4] != null))
+            {
+                var parent = comments[(int)comment[4]];
+                Assert.AreEqual(parent[6], comment[6]);
+                Assert.IsTrue((DateTime)parent[7] < (DateTime)comment[7]);
+            }
+            var likes = capture.For(DemoTables.PageLikes);
+            Assert.AreEqual(likes.Count, likes.Select(r => r[0] + ":" + r[1]).Distinct().Count(), "One like/user/page");
+        }
+
+        [TestMethod]
+        public void Collaboration_WebClicksAndSearchesJoinTheBaseNavigationPath()
+        {
+            var options = Options("web");
+            var capture = new Capture();
+            new DemoGenerator(options).Generate(capture, new DemoSummary(), null);
+            Assert.IsTrue(DemoTables.Hits.SupplyIdentity, "Clicks require the base generator's logical hit ids.");
+            var hits = capture.For(DemoTables.Hits).ToDictionary(r => (int)capture.Value(DemoTables.Hits, r, "id"));
+            var sessions = capture.For(DemoTables.Sessions).ToDictionary(r => (int)r[0]);
+            foreach (var click in capture.For(DemoTables.Clicks))
+            {
+                var hit = hits[(int)click[3]];
+                var hitTime = (DateTime)capture.Value(DemoTables.Hits, hit, "hit_timestamp");
+                Assert.IsTrue((DateTime)click[4] > hitTime);
+                Assert.IsTrue(((DateTime)click[4] - hitTime).TotalSeconds
+                    < (double)capture.Value(DemoTables.Hits, hit, "seconds_on_page"));
+                int session = (int)capture.Value(DemoTables.Hits, hit, "session_id");
+                Assert.IsTrue(sessions.ContainsKey(session));
+                Assert.AreEqual((session - 1) * 3 + 1, (int)click[3], "Representative click joins the first hit.");
+            }
+            foreach (var search in capture.For(DemoTables.Searches))
+            {
+                int session = (int)search[0];
+                Assert.IsTrue(sessions.ContainsKey(session));
+                var hit = hits[(session - 1) * 3 + 1];
+                Assert.AreEqual(((DateTime)capture.Value(DemoTables.Hits, hit, "hit_timestamp")).Date, ((DateTime)search[2]).Date);
+            }
+        }
+
+        [TestMethod]
+        public void Collaboration_SchemaUsesImportedSpellingsAndDependencyOrder()
+        {
+            Assert.AreEqual("team_membership_log", DemoTables.TeamMemberships.Name);
+            Assert.AreEqual("teams_user_channel_reactions", DemoTables.ChannelReactions.Name);
+            Assert.AreEqual("teams_channel_stats_log_langs", DemoTables.ChannelLanguages.Name);
+            Assert.AreEqual("call_session_call_modalities", DemoTables.CallSessionModalities.Name);
+            Assert.AreEqual("onedrive_usage_activity_log", DemoTables.OneDriveStorage.Name);
+            Assert.AreEqual("yammer_group_activity_log", DemoTables.EngageGroupActivity.Name);
+            Assert.AreEqual("file_metadata_property_values", DemoTables.PageMetadata.Name);
+            Assert.AreEqual("searches", DemoTables.Searches.Name);
+            var all = DemoTables.All.ToList();
+            Assert.AreEqual(all.Count, all.Select(t => t.Name).Distinct().Count(), "No duplicate shared lookup registration.");
+            foreach (var pair in new[]
+            {
+                Tuple.Create(DemoTables.Users, DemoTables.CallRecords),
+                Tuple.Create(DemoTables.CallTypes, DemoTables.CallRecords),
+                Tuple.Create(DemoTables.CallRecords, DemoTables.CallSessions),
+                Tuple.Create(DemoTables.CallSessions, DemoTables.CallSessionModalities),
+                Tuple.Create(DemoTables.TeamDefinitions, DemoTables.TeamChannels),
+                Tuple.Create(DemoTables.TeamChannels, DemoTables.ChannelStats),
+                Tuple.Create(DemoTables.ChannelStats, DemoTables.ChannelKeywords),
+                Tuple.Create(DemoTables.EmailAddresses, DemoTables.SentEmails),
+                Tuple.Create(DemoTables.SentEmails, DemoTables.EmailRecipients),
+                Tuple.Create(DemoTables.Hits, DemoTables.Clicks),
+                Tuple.Create(DemoTables.Sessions, DemoTables.Searches)
+            }) Assert.IsTrue(all.IndexOf(pair.Item1) < all.IndexOf(pair.Item2), pair.Item2.Name);
+            Assert.IsFalse(all.Any(t => t.Name == "teams_channel_user_log"), "Unregistered entity has no production import.");
+            Assert.IsFalse(all.Any(t => t.Name.StartsWith("teams_addons", StringComparison.Ordinal)), "Deprecated add-on installs are not synthetic successes.");
+        }
+
+        [TestMethod]
+        public void Collaboration_SinglePersonNeverCreatesAnUnknownCallAttendee()
+        {
+            var options = Options("teams,sent-email", "100,0,0,0,0", 1);
+            var capture = Generate(options);
+            Assert.IsTrue(capture.For(DemoTables.CallRecords).Count > 0);
+            Assert.AreEqual(0, capture.For(DemoTables.CallSessions).Count, "Organizer is the only participant.");
+            Assert.IsTrue(capture.For(DemoTables.SentEmails).Count > 0);
+            Assert.IsTrue(capture.For(DemoTables.CallRecords).All(r => (int)r[1] == 1));
+        }
+
+        private static Capture Generate(DemoOptions options)
+        {
+            var capture = new Capture();
+            var population = new DemoPopulation(options);
+            var generator = new DemoCollaborationGenerator(options, population, new DemoCalendar(options), capture);
+            generator.WriteDimensions();
+            for (int id = 1; id <= options.Users; id++)
+            {
+                var user = population.User(id);
+                var timeline = new DemoTimeline(options, user);
+                for (int day = 0; day < options.Days; day++) generator.WriteDay(user, day, timeline.Day(day));
+            }
+            generator.WriteSummaries();
+            return capture;
+        }
+
+        private sealed class Capture : IDemoSink
+        {
+            public Dictionary<DemoTable, List<object[]>> Rows { get; } = new Dictionary<DemoTable, List<object[]>>();
+            public List<object[]> For(DemoTable table) => Rows.TryGetValue(table, out var rows) ? rows : new List<object[]>();
+            public object Value(DemoTable table, object[] row, string column) =>
+                row[table.Columns.Select(c => c.Name).ToList().IndexOf(column)];
+            public void Write(DemoTable table, params object[] values)
+            {
+                table.ValidateValues(values);
+                if (!Rows.TryGetValue(table, out var rows)) Rows.Add(table, rows = new List<object[]>());
+                rows.Add((object[])values.Clone());
+            }
+            public void Flush() { }
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoExistingDatabaseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoExistingDatabaseTests.cs
@@ -1,0 +1,508 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading;
+using Tests.FakeDataGen.Demo;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    [TestCategory("DemoGenerator")]
+    [TestCategory("Integration")]
+    [DoNotParallelize]
+    public class DemoExistingDatabaseTests
+    {
+        [TestMethod]
+        public void ExistingSchema_TextCompatibilityAllowsOnlyLosslessWidening()
+        {
+            var ascii = new DemoColumn("country_name", SqlDbType.VarChar, 250);
+            var unicode = new DemoColumn("name", SqlDbType.NVarChar, 250);
+            Assert.IsTrue(SqlExistingDemoDatabase.Compatible(ascii, "nvarchar", 500));
+            Assert.IsTrue(SqlExistingDemoDatabase.Compatible(ascii, "nvarchar", -1));
+            Assert.IsFalse(SqlExistingDemoDatabase.Compatible(ascii, "nvarchar", 498));
+            Assert.IsTrue(SqlExistingDemoDatabase.Compatible(ascii, "varchar", 250));
+            Assert.IsFalse(SqlExistingDemoDatabase.Compatible(unicode, "varchar", 1000));
+            Assert.IsFalse(SqlExistingDemoDatabase.Compatible(unicode, "varchar", -1));
+            Assert.IsTrue(SqlExistingDemoDatabase.Compatible(unicode, "nvarchar", 500));
+        }
+
+        [TestMethod]
+        public void ExistingFullDemo_AppendsTwicePreservingRowsAndRemappingThePopulation()
+        {
+            WithDatabase((name, options) =>
+            {
+                using (var database = new SqlDemoDatabase(options, CancellationToken.None))
+                {
+                    database.Open(null);
+                    var summary = DemoCommand.NewSummary(options);
+                    using (var sink = new CountingDemoSink(summary, database.CreateSink()))
+                        new DemoGenerator(options).Generate(sink, summary, null);
+                    database.ValidateAndComplete(summary, null);
+                }
+                using (var connection = Connect(name))
+                {
+                    int sentinel;
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = @"INSERT dbo.users (user_name,mail,azure_ad_id,account_enabled,last_updated)
+OUTPUT INSERTED.id VALUES ('sentinel@contoso.example',N'sentinel@contoso.example',
+N'00000000-0000-0000-0000-000000000000',0,'20020101');";
+                        sentinel = Convert.ToInt32(command.ExecuteScalar());
+                    }
+                    Execute(connection, @"INSERT dbo.audit_events (id,user_id,operation_id,time_stamp)
+SELECT '00000000-0000-0000-0000-000000000000',id,
+(SELECT TOP (1) id FROM dbo.event_operations ORDER BY id),'20020101'
+FROM dbo.users WHERE user_name='sentinel@contoso.example';");
+                    Execute(connection, @"UPDATE dbo.file_metadata_property_values
+SET field_value=N'Contoso sentinel metadata',tag_guid=NULL,updated='20020101'
+WHERE url_id=1 AND field_id=1;");
+                    long originalEvents = Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.audit_events;");
+                    long originalSessions = Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.sessions;");
+                    long originalInteractionSessions = Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.copilot_interaction_sessions;");
+                    long originalHits = Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.hits;");
+                    long originalCounts = Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.copilot_user_count_log;");
+                    long originalDepartments = Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.user_departments;");
+                    long originalLicences = Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.license_types;");
+                    const string unicodeUrlsSql = "SELECT COUNT_BIG(*) FROM dbo.urls WHERE full_url LIKE N'%\u039a\u03b1\u03bb\u03b7\u03bc\u03ad\u03c1\u03b1%';";
+                    long originalUnicodeUrls = Scalar(connection, unicodeUrlsSql);
+                    var originalRows = Counts(connection);
+                    var namespacedObjects = new[]
+                    {
+                        "power_app_environments", "power_apps", "power_automate_flows", "power_bi_workspaces",
+                        "power_bi_reports", "power_bi_dashboards", "copilot_studio_bots", "yammer_groups",
+                        "sites", "webs", "urls", "copilot_ai_system_plugins", "online_meetings"
+                    };
+                    Assert.IsTrue(originalEvents > 1 && originalSessions > 0 && originalInteractionSessions > 0);
+
+                    for (int run = 1; run <= 2; run++)
+                    {
+                        var before = Counts(connection);
+                        var messages = new List<string>();
+                        var appendOptions = Options(null, profiles: true);
+                        Assert.IsNull(appendOptions.Database, "The connection string, not --database, supplies an existing target.");
+                        var summary = DemoCommand.NewSummary(appendOptions);
+                        using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, appendOptions, CancellationToken.None))
+                        {
+                            database.Open(messages.Add);
+                            using (var sink = new CountingDemoSink(summary, database.CreateSink()))
+                                new DemoGenerator(appendOptions).Generate(sink, summary, null);
+                            database.Complete(summary, messages.Add);
+                            Assert.ThrowsException<InvalidOperationException>(() => database.CreateSink());
+                            Assert.ThrowsException<InvalidOperationException>(() => database.Complete(summary, null));
+                        }
+                        var after = Counts(connection);
+                        Assert.AreEqual(after.Sum(p => p.Value - before[p.Key]), summary.TotalRows,
+                            "Summary rows must count committed inserts, not reused dimensions or skipped tenant snapshots.");
+                        Assert.AreEqual(0, summary.CompletedProfileWeeks);
+                        Assert.AreEqual(0L, summary.Rows[DemoTables.CopilotCounts.Name]);
+                        Assert.IsTrue(messages.Any(m => m.Contains("Skipped") && m.Contains("tenant-wide")));
+                        Assert.IsTrue(messages.Any(m => m.Contains("reused dimension")));
+                        Assert.IsTrue(messages.Any(m => m.Contains("Global weekly profiling is skipped")));
+                        Assert.AreEqual(options.Users * (run + 1) + 1L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.users;"));
+                        Assert.AreEqual(originalCounts, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.copilot_user_count_log;"));
+                        Assert.AreEqual(originalDepartments, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.user_departments;"));
+                        Assert.AreEqual(originalLicences, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.license_types;"));
+                        foreach (string table in namespacedObjects)
+                        {
+                            Assert.IsTrue(originalRows[table] > 0, "The full demo must exercise " + table);
+                            Assert.AreEqual(originalRows[table] * (run + 1), after[table],
+                                "Each append needs fresh namespaced objects in " + table);
+                        }
+                        foreach (string table in new[] { "power_platform_connectors", "power_platform_client_types",
+                            "copilot_ai_models", "file_field_definitions" })
+                            Assert.AreEqual(originalRows[table], after[table], "Stable lookup names must be reused in " + table);
+                        Assert.AreEqual(originalRows["file_metadata_property_values"] * (run + 1),
+                            after["file_metadata_property_values"], "Each namespaced page must receive its own immutable metadata.");
+                        Assert.AreEqual(originalUnicodeUrls * (run + 1), Scalar(connection, unicodeUrlsSql),
+                            "Resource namespacing must retain the original Unicode paths, not inflate them with percent encoding.");
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM (
+SELECT url_id,field_id FROM dbo.file_metadata_property_values
+GROUP BY url_id,field_id HAVING COUNT_BIG(*)>1) duplicates;"));
+                        Assert.AreEqual(1L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.file_metadata_property_values
+WHERE url_id=1 AND field_id=1 AND field_value=N'Contoso sentinel metadata'
+AND tag_guid IS NULL AND updated='20020101';"), "Existing page metadata must not be reshaped.");
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM (
+SELECT yammer_group_id,[date] FROM dbo.yammer_group_activity_log
+GROUP BY yammer_group_id,[date] HAVING COUNT_BIG(*)>1) duplicates;"),
+                            "A new sample population must not masquerade as another snapshot of an existing group.");
+                        Assert.AreEqual((originalEvents - 1) * (run + 1) + 1,
+                            Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.audit_events;"));
+                        Assert.AreEqual(originalSessions * run, Scalar(connection,
+                            "SELECT COUNT_BIG(*) FROM dbo.sessions WHERE user_id>" + sentinel + ";"));
+                        Assert.AreEqual(originalInteractionSessions * run, Scalar(connection,
+                            "SELECT COUNT_BIG(*) FROM dbo.copilot_interaction_sessions WHERE user_id>" + sentinel + ";"));
+                        Assert.AreEqual(originalHits * run, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.hits h
+JOIN dbo.sessions s ON s.id=h.session_id WHERE s.user_id>" + sentinel + ";"));
+                        Assert.AreEqual(originalRows["hits_clicked_elements"] * run, Scalar(connection,
+                            @"SELECT COUNT_BIG(*) FROM dbo.hits_clicked_elements c
+JOIN dbo.hits h ON h.id=c.hit_id JOIN dbo.sessions s ON s.id=h.session_id WHERE s.user_id>" + sentinel + ";"),
+                            "Click references must remap the hit identity even when its projected column is last.");
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.users
+WHERE id>" + sentinel + " AND manager_id IS NOT NULL AND manager_id<=" + sentinel + ";"));
+                        Assert.IsTrue(Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.users
+WHERE id>" + sentinel + " AND manager_id IS NOT NULL;") > 0, "Exercise manager remapping, not just NULL managers.");
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.users u
+JOIN dbo.users manager ON manager.id=u.manager_id
+WHERE u.id>" + sentinel + " AND (u.department_id<>manager.department_id OR u.company_name_id<>manager.company_name_id);"));
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.copilot_interactions i
+JOIN dbo.copilot_interaction_sessions s ON s.id=i.session_id WHERE s.user_id<>i.user_id;"));
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.copilot_chats c
+JOIN dbo.audit_events a ON a.id=c.event_id WHERE a.user_id<>c.user_id OR a.time_stamp<>c.time_stamp;"));
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.event_meta_power_app e
+JOIN dbo.audit_events a ON a.id=e.event_id WHERE a.user_id>" + sentinel
+                            + " AND e.power_app_id<=" + originalRows["power_apps"] + ";"));
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.event_meta_power_app_share e
+JOIN dbo.audit_events a ON a.id=e.event_id WHERE a.user_id>" + sentinel
+                            + " AND e.shared_with_user_id<=" + sentinel + ";"));
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.copilot_interactions i
+WHERE LEFT(i.graph_interaction_id,32)<>i.request_id
+OR NOT EXISTS (SELECT 1 FROM dbo.audit_events a WHERE REPLACE(CONVERT(varchar(36),a.id),'-','')=i.request_id);"));
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.copilot_interaction_sessions s
+WHERE NOT EXISTS (SELECT 1 FROM dbo.copilot_chats c WHERE c.thread_id=s.session_ref AND c.user_id=s.user_id);"));
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.users WHERE id>" + sentinel
+                            + " AND (user_name NOT LIKE 'demo-%@contoso.example' OR mail<>user_name OR LEN(azure_ad_id)<>36);"));
+                        Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM (
+SELECT azure_ad_id FROM dbo.users GROUP BY azure_ad_id HAVING COUNT_BIG(*)>1) duplicates;"));
+                        Assert.AreEqual(1L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.users
+WHERE user_name='sentinel@contoso.example' AND mail=N'sentinel@contoso.example'
+AND azure_ad_id=N'00000000-0000-0000-0000-000000000000' AND account_enabled=0 AND last_updated='20020101';"));
+                        Assert.AreEqual(1L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.audit_events
+WHERE id='00000000-0000-0000-0000-000000000000' AND time_stamp='20020101' AND user_id=" + sentinel + ";"));
+                        Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM profiling.ActivitiesWeeklyColumns;"));
+                        Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM profiling.UsageWeekly;"));
+
+                        if (run == 1)
+                        {
+                            Assert.AreEqual(1L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM sys.extended_properties
+WHERE class=0 AND name=N'M365AnalyticsSyntheticDemoState' AND CONVERT(nvarchar(4000),value)=N'modified-by-append';"));
+                            using (var rerun = new SqlDemoDatabase(options, CancellationToken.None))
+                                Assert.ThrowsException<InvalidOperationException>(() => rerun.Open(null));
+                            // An ordinary current-schema application DB has no new-demo markers.
+                            // The second identical append must also support that state, without claiming it.
+                            Execute(connection, @"EXEC sys.sp_dropextendedproperty @name=N'M365AnalyticsSyntheticDemo';
+EXEC sys.sp_dropextendedproperty @name=N'M365AnalyticsSyntheticDemoState';
+EXEC sys.sp_dropextendedproperty @name=N'M365AnalyticsSyntheticDemoFingerprint';");
+                        }
+                        else
+                            Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM sys.extended_properties
+WHERE class=0 AND name LIKE N'M365AnalyticsSyntheticDemo%';"));
+                    }
+                }
+            });
+        }
+
+        [TestMethod]
+        public void ExistingAppend_NamespacesGuidFormatsAndMaximumLengthStringReferencesConsistently()
+        {
+            WithDatabase((name, schemaOptions) =>
+            {
+                CreateSchema(schemaOptions);
+                var options = DemoOptions.Parse(new[] { "--users", "1",
+                    "--days", "31", "--as-of", "2026-09-01", "--no-profiles" }, new DateTime(2026, 9, 1), existingTarget: true);
+                var id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+                string session = id.ToString("N") + new string('x', 18);
+                string thread = id.ToString("D") + "-" + new string('x', 413);
+                string graph = id.ToString("N") + "-" + new string('x', 167);
+                string upn = new string('a', 200) + "@contoso.example";
+                const string resourceBase = "https://contoso.example/";
+                string resource = resourceBase + new string('x', 850 - resourceBase.Length - "/contoso-demo-".Length - 32);
+                using (var connection = Connect(name))
+                {
+                    for (int run = 0; run < 2; run++)
+                    {
+                        var summary = DemoCommand.NewSummary(options);
+                        using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, options, CancellationToken.None))
+                        {
+                            database.Open(null);
+                            using (var sink = new CountingDemoSink(summary, database.CreateSink()))
+                            {
+                                sink.Write(DemoTables.Operations, 1, "Contoso boundary operation");
+                                sink.Write(DemoTables.InteractionTypes, 1, "userPrompt");
+                                sink.Write(DemoTables.InteractionApps, 1, "Contoso boundary app");
+                                sink.Write(DemoTables.ConversationTypes, 1, "bizchat");
+                                sink.Write(DemoTables.Urls, 1, resource);
+                                sink.Write(DemoTables.Users, 1, upn, upn, id.ToString(), true, options.AsOf,
+                                    "00000", null, null, null, null, null, null, null, null);
+                                sink.Write(DemoTables.Sessions, 1, session, 1);
+                                sink.Write(DemoTables.InteractionSessions, 1, thread, 1);
+                                sink.Write(DemoTables.Audit, id, 1, 1, options.AsOf);
+                                sink.Write(DemoTables.Chats, id, "Contoso", null, thread, "US", "1", 1, options.AsOf);
+                                sink.Write(DemoTables.Interactions, graph, 1, 1, id.ToString("N"), 1, 1, 1,
+                                    options.AsOf, 10, 2, 0, 0, 0, 0, null, null, null);
+                                sink.Flush();
+                            }
+                            database.Complete(summary, null);
+                        }
+                    }
+                    Assert.AreEqual(2L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.users;"));
+                    Assert.AreEqual(2L, Scalar(connection, "SELECT COUNT_BIG(DISTINCT user_name) FROM dbo.users;"));
+                    Assert.AreEqual(2L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.urls
+WHERE LEN(full_url)=850 AND full_url LIKE N'https://contoso.example/contoso-demo-%';"),
+                        "Exactly fitting namespaced URLs must persist without truncation.");
+                    Assert.AreEqual(2L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.users
+WHERE user_name LIKE 'demo-%@contoso.example' AND mail=user_name AND LEN(user_name)<=250;"));
+                    Assert.AreEqual(2L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM dbo.audit_events a
+JOIN dbo.users u ON u.id=a.user_id AND u.azure_ad_id=CONVERT(nvarchar(36),a.id)
+JOIN dbo.copilot_chats c ON c.event_id=a.id
+JOIN dbo.copilot_interaction_sessions s ON s.user_id=u.id AND s.session_ref=c.thread_id
+JOIN dbo.copilot_interactions i ON i.session_id=s.id AND i.user_id=u.id
+JOIN dbo.sessions web ON web.user_id=u.id
+WHERE i.request_id=REPLACE(CONVERT(varchar(36),a.id),'-','')
+AND LEFT(i.graph_interaction_id,32)=i.request_id AND LEN(i.graph_interaction_id)=200
+AND LEFT(s.session_ref,36)=CONVERT(varchar(36),a.id) AND LEN(s.session_ref)=450
+AND LEFT(web.ai_session_id,32)=i.request_id AND LEN(web.ai_session_id)=50;"));
+                }
+            });
+        }
+
+        [TestMethod]
+        public void ExistingSchema_PreflightRejectsRequiredColumnsMissingTablesAndUnsupportedForeignKeysBeforeWrites()
+        {
+            WithDatabase((name, options) =>
+            {
+                CreateSchema(options);
+                using (var connection = Connect(name))
+                {
+                    Execute(connection, "ALTER TABLE dbo.users ADD contoso_required int NOT NULL;");
+                    AssertPreflightRefused(connection, options, "contoso_required");
+                    Execute(connection, "ALTER TABLE dbo.users DROP COLUMN contoso_required;");
+
+                    Execute(connection, @"CREATE TABLE dbo.ContosoUnsupported (id int NOT NULL PRIMARY KEY);
+ALTER TABLE dbo.user_departments ADD CONSTRAINT FK_ContosoUnsupported
+FOREIGN KEY (id) REFERENCES dbo.ContosoUnsupported(id);");
+                    AssertPreflightRefused(connection, options, "foreign-key");
+                    Execute(connection, "ALTER TABLE dbo.user_departments DROP CONSTRAINT FK_ContosoUnsupported;");
+
+                    Execute(connection, @"DECLARE @name sysname = (
+SELECT f.name FROM sys.foreign_keys f JOIN sys.foreign_key_columns fc ON fc.constraint_object_id=f.object_id
+JOIN sys.columns c ON c.object_id=fc.parent_object_id AND c.column_id=fc.parent_column_id
+WHERE f.parent_object_id=OBJECT_ID('dbo.sessions') AND c.name='user_id');
+DECLARE @sql nvarchar(max)=N'ALTER TABLE dbo.sessions DROP CONSTRAINT ' + QUOTENAME(@name);
+EXEC sys.sp_executesql @sql;");
+                    AssertPreflightRefused(connection, options, "missing foreign-key metadata for user_id");
+                    Execute(connection, @"ALTER TABLE dbo.sessions ADD CONSTRAINT FK_ContosoSessionUser
+FOREIGN KEY (user_id) REFERENCES dbo.users(id);");
+
+                    Execute(connection, "ALTER TABLE dbo.copilot_user_count_log DROP COLUMN average_prompts_submitted;");
+                    AssertPreflightRefused(connection, options, "average_prompts_submitted");
+                    Execute(connection, "DROP TABLE dbo.copilot_user_count_log;");
+                    AssertPreflightRefused(connection, options, "missing table");
+                    Assert.AreEqual(1L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM sys.extended_properties
+WHERE class=0 AND name=N'M365AnalyticsSyntheticDemoState' AND CONVERT(nvarchar(4000),value)=N'building';"));
+                }
+            });
+        }
+
+        [TestMethod]
+        public void ExistingSchema_OmittedNullableForeignKeysStayNullAndRequiredDefaultsRemainSupported()
+        {
+            WithDatabase((name, options) =>
+            {
+                CreateSchema(options);
+                using (var connection = Connect(name))
+                {
+                    Execute(connection, @"CREATE TABLE dbo.ContosoUnusedLookup (id int NOT NULL PRIMARY KEY);
+INSERT dbo.ContosoUnusedLookup (id) VALUES (1);
+ALTER TABLE dbo.users ADD contoso_unused_id int NULL CONSTRAINT DF_ContosoUnused DEFAULT (1),
+contoso_required_default_id int NOT NULL CONSTRAINT DF_ContosoRequiredDefault DEFAULT (1);
+ALTER TABLE dbo.users ADD CONSTRAINT FK_ContosoUnused FOREIGN KEY (contoso_unused_id)
+REFERENCES dbo.ContosoUnusedLookup(id),
+CONSTRAINT FK_ContosoRequiredDefault FOREIGN KEY (contoso_required_default_id)
+REFERENCES dbo.ContosoUnusedLookup(id);");
+                    var summary = DemoCommand.NewSummary(options);
+                    using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, options, CancellationToken.None))
+                    {
+                        database.Open(null);
+                        using (var sink = new CountingDemoSink(summary, database.CreateSink()))
+                            new DemoGenerator(options).Generate(sink, summary, null);
+                        database.Complete(summary, null);
+                    }
+                    Assert.AreEqual((long)options.Users, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.users;"));
+                    Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.users WHERE contoso_unused_id IS NOT NULL;"));
+                    Assert.AreEqual((long)options.Users, Scalar(connection,
+                        "SELECT COUNT_BIG(*) FROM dbo.users WHERE contoso_required_default_id=1;"));
+                }
+            });
+        }
+
+        [TestMethod]
+        public void ExistingTarget_RejectsSystemImplicitAttachedAndAbsentCatalogsWithoutCreatingAnything()
+        {
+            string name = "ContosoDemo_Absent_" + Guid.NewGuid().ToString("N");
+            var options = Options(name);
+            foreach (var catalog in new[] { "master", "model", "msdb", "tempdb", "mssqlsystemresource", "" })
+                Assert.ThrowsException<ArgumentException>(() =>
+                    new SqlExistingDemoDatabase(SqlDemoDatabase.LocalConnection(catalog), options, CancellationToken.None));
+            var attached = new SqlConnectionStringBuilder(SqlDemoDatabase.LocalConnection(name)) { AttachDBFilename = "Contoso.mdf" };
+            Assert.ThrowsException<ArgumentException>(() =>
+                new SqlExistingDemoDatabase(attached.ConnectionString, options, CancellationToken.None));
+            using (var absent = new SqlExistingDemoDatabase(SqlDemoDatabase.LocalConnection(name), options, CancellationToken.None))
+            {
+                Assert.ThrowsException<SqlException>(() => absent.Open(null));
+                Assert.ThrowsException<InvalidOperationException>(() => absent.CreateSink());
+                Assert.ThrowsException<InvalidOperationException>(() => absent.Complete(DemoCommand.NewSummary(options), null));
+            }
+            using (var master = Connect("master"))
+            using (var command = master.CreateCommand())
+            {
+                command.CommandText = "SELECT CASE WHEN DB_ID(@name) IS NULL THEN 0 ELSE 1 END;";
+                command.Parameters.Add("@name", SqlDbType.NVarChar, 128).Value = name;
+                Assert.AreEqual(0, Convert.ToInt32(command.ExecuteScalar()));
+            }
+        }
+
+        [TestMethod]
+        public void ExistingAppend_ErrorCancellationAndAbandonedBuffersNeverFlushOrReportSuccess()
+        {
+            WithDatabase((name, options) =>
+            {
+                CreateSchema(options);
+                using (var connection = Connect(name))
+                {
+                    using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, options, CancellationToken.None))
+                    {
+                        database.Open(null);
+                        using (var sink = database.CreateSink())
+                        {
+                            sink.Write(DemoTables.Departments, 1, "Contoso committed department");
+                            sink.Flush();
+                            sink.Write(DemoTables.Jobs, 1, "Contoso rolled-back job");
+                            sink.Write(DemoTables.Users, 1, "failure@contoso.example", "failure@contoso.example",
+                                Guid.Empty.ToString(), true, options.AsOf, "00000", null, null, null, null, null, null, null, 999);
+                            var failure = Assert.ThrowsException<InvalidOperationException>(() => sink.Flush());
+                            StringAssert.Contains(failure.Message, "batch-committed");
+                            Assert.ThrowsException<InvalidOperationException>(() => sink.Flush());
+                        }
+                        Assert.ThrowsException<InvalidOperationException>(() => database.Complete(DemoCommand.NewSummary(options), null));
+                    }
+                    Assert.AreEqual(1L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.user_departments;"));
+                    Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.user_job_titles;"));
+                    Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.users;"));
+
+                    using (var cancellation = new CancellationTokenSource())
+                    using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, options, cancellation.Token))
+                    {
+                        database.Open(null);
+                        using (var sink = database.CreateSink())
+                        {
+                            sink.Write(DemoTables.Departments, 1, "Contoso cancellation department");
+                            sink.Flush();
+                            sink.Write(DemoTables.Jobs, 1, "Contoso abandoned job");
+                            cancellation.Cancel();
+                            Assert.ThrowsException<OperationCanceledException>(() => sink.Flush());
+                        }
+                        Assert.ThrowsException<InvalidOperationException>(() => database.Complete(DemoCommand.NewSummary(options), null));
+                    }
+                    using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, options, CancellationToken.None))
+                    {
+                        database.Open(null);
+                        using (var sink = database.CreateSink())
+                            sink.Write(DemoTables.Jobs, 1, "Contoso unflushed job");
+                        Assert.ThrowsException<InvalidOperationException>(() => database.Complete(DemoCommand.NewSummary(options), null));
+                    }
+                    using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, options, CancellationToken.None))
+                    {
+                        database.Open(null);
+                        using (var sink = database.CreateSink())
+                        {
+                            const string resourceBase = "https://contoso.example/";
+                            var tooWideAfterNamespacing = resourceBase + new string('x', 850 - resourceBase.Length);
+                            Assert.ThrowsException<InvalidOperationException>(() =>
+                                sink.Write(DemoTables.Urls, 1, tooWideAfterNamespacing));
+                        }
+                        Assert.ThrowsException<InvalidOperationException>(() => database.Complete(DemoCommand.NewSummary(options), null));
+                    }
+                    using (var cancellation = new CancellationTokenSource())
+                    {
+                        cancellation.Cancel();
+                        using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, options, cancellation.Token))
+                        {
+                            Assert.ThrowsException<OperationCanceledException>(() => database.Open(null));
+                            Assert.ThrowsException<InvalidOperationException>(() => database.CreateSink());
+                        }
+                    }
+                    Assert.AreEqual(2L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.user_departments;"));
+                    Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.user_job_titles;"));
+                    Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.users;"));
+                    Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.urls;"),
+                        "An over-width namespaced resource must be refused, never silently truncated.");
+                    Assert.AreEqual(0L, Scalar(connection, @"SELECT COUNT_BIG(*) FROM sys.extended_properties
+WHERE class=0 AND name=N'M365AnalyticsSyntheticDemoState' AND CONVERT(nvarchar(4000),value)=N'complete';"));
+                }
+            });
+        }
+
+        private static void AssertPreflightRefused(SqlConnection connection, DemoOptions options, string expected)
+        {
+            using (var database = new SqlExistingDemoDatabase(connection.ConnectionString, options, CancellationToken.None))
+            {
+                var exception = Assert.ThrowsException<InvalidOperationException>(() => database.Open(null));
+                StringAssert.Contains(exception.Message, expected);
+                Assert.ThrowsException<InvalidOperationException>(() => database.CreateSink());
+            }
+            Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.users;"));
+            Assert.AreEqual(0L, Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.user_departments;"));
+        }
+
+        private static Dictionary<string, long> Counts(SqlConnection connection) =>
+            DemoTables.All.ToDictionary(t => t.Name, t => Scalar(connection, "SELECT COUNT_BIG(*) FROM dbo.[" + t.Name + "];"));
+
+        private static DemoOptions Options(string name, bool profiles = false) => DemoOptions.Parse(new[]
+        {
+            "--users", "30", "--days", "31", "--as-of", "2026-09-01",
+            "--skus", "10", "--batch-size", "40"
+        }.Concat(name == null ? new string[0] : new[] { "--database", name })
+            .Concat(profiles ? new string[0] : new[] { "--no-profiles" }).ToArray(),
+            new DateTime(2026, 9, 1), existingTarget: name == null);
+
+        private static void CreateSchema(DemoOptions options)
+        {
+            using (var database = new SqlDemoDatabase(options, CancellationToken.None)) database.Open(null);
+        }
+
+        private static SqlConnection Connect(string name)
+        {
+            var connection = new SqlConnection(SqlDemoDatabase.LocalConnection(name));
+            connection.Open();
+            return connection;
+        }
+
+        private static long Scalar(SqlConnection connection, string sql)
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = sql;
+                return Convert.ToInt64(command.ExecuteScalar());
+            }
+        }
+
+        private static void Execute(SqlConnection connection, string sql)
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = sql;
+                command.ExecuteNonQuery();
+            }
+        }
+
+        private static void WithDatabase(Action<string, DemoOptions> test)
+        {
+            string name = "ContosoDemo_AppendTest_" + Guid.NewGuid().ToString("N");
+            try { test(name, Options(name)); }
+            finally
+            {
+                using (var master = Connect("master"))
+                using (var command = master.CreateCommand())
+                {
+                    command.CommandText = "IF DB_ID(@name) IS NOT NULL BEGIN ALTER DATABASE [" + name
+                        + "] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [" + name + "]; END;";
+                    command.Parameters.Add("@name", SqlDbType.NVarChar, 128).Value = name;
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoExistingDatabaseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoExistingDatabaseTests.cs
@@ -253,7 +253,7 @@ JOIN dbo.sessions web ON web.user_id=u.id
 WHERE i.request_id=REPLACE(CONVERT(varchar(36),a.id),'-','')
 AND LEFT(i.graph_interaction_id,32)=i.request_id AND LEN(i.graph_interaction_id)=200
 AND LEFT(s.session_ref,36)=CONVERT(varchar(36),a.id) AND LEN(s.session_ref)=450
-AND LEFT(web.ai_session_id,32)=i.request_id AND LEN(web.ai_session_id)=50;"));
+AND LEFT(web.ai_session_id,32) COLLATE DATABASE_DEFAULT=i.request_id AND LEN(web.ai_session_id)=50;"));
                 }
             });
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoPowerPlatformTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoPowerPlatformTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using Tests.FakeDataGen.Demo;
+
+namespace Tests.UnitTests
+{
+    [TestClass]
+    [TestCategory("DemoGenerator")]
+    public class DemoPowerPlatformTests
+    {
+        [TestMethod]
+        public void PowerPlatform_HasCoherentResourcesUsageSharingAndHistory()
+        {
+            var options = DemoGeneratorTests.Options("--areas", "powerapps,powerautomate,powerbi,copilot-studio");
+            var summary = DemoCommand.NewSummary(options);
+            var capture = new DemoGeneratorTests.RecordingSink(_ => true);
+            using (var sink = new CountingDemoSink(summary, capture))
+                new DemoGenerator(options).Generate(sink, summary, null);
+            var audit = capture.For(DemoTables.Audit).ToDictionary(r => (Guid)r[0]);
+            var operations = capture.For(DemoTables.Operations).ToDictionary(r => (int)r[0], r => (string)r[1]);
+            var reports = capture.For(DemoTables.PowerReports).ToDictionary(r => (int)r[0]);
+            var workspaces = capture.For(DemoTables.PowerWorkspaces).Select(r => (int)r[0]).ToList();
+            var environments = capture.For(DemoTables.PowerEnvironments).Select(r => (int)r[0]).ToList();
+            var apps = capture.For(DemoTables.PowerApps).ToDictionary(r => (int)r[0]);
+            var flows = capture.For(DemoTables.PowerFlows).ToDictionary(r => (int)r[0]);
+            var bots = capture.For(DemoTables.StudioBots).ToDictionary(r => (int)r[0]);
+            foreach (var row in apps.Values.Concat(flows.Values).Concat(bots.Values))
+                CollectionAssert.Contains(environments, (int)row[3]);
+            foreach (var row in capture.For(DemoTables.PowerAppEvents))
+            {
+                Assert.IsTrue(apps.ContainsKey((int)row[1]));
+                Assert.IsTrue(audit.ContainsKey((Guid)row[0]));
+            }
+            foreach (var row in capture.For(DemoTables.PowerFlowEvents))
+            {
+                Assert.IsTrue(flows.ContainsKey((int)row[1]));
+                Assert.IsNull(row[2], "Flow audit administration is not flow-run telemetry.");
+                Assert.IsTrue(audit.ContainsKey((Guid)row[0]));
+            }
+            foreach (var row in capture.For(DemoTables.PowerBIEvents))
+            {
+                CollectionAssert.Contains(workspaces, (int)row[1]);
+                Assert.AreEqual(reports[(int)row[2]][4], row[1]);
+                Assert.AreEqual("ViewReport", operations[(int)audit[(Guid)row[0]][2]],
+                    "Do not generate operations the production loader drops.");
+            }
+            foreach (var row in capture.For(DemoTables.StudioEvents))
+            {
+                Assert.IsTrue(bots.ContainsKey((int)row[1]));
+                StringAssert.StartsWith(operations[(int)audit[(Guid)row[0]][2]], "BotUpdateOperation-");
+            }
+            foreach (var table in new[] { DemoTables.PowerAppShares, DemoTables.PowerFlowShares })
+            {
+                var shares = capture.For(table);
+                Assert.IsTrue(shares.Count > 0, table.Name);
+                Assert.AreEqual(shares.Count, shares.Select(r => r[0] + "|" + r[2]).Distinct().Count());
+                Assert.IsTrue(shares.All(r => (int)r[2] >= 1 && (int)r[2] <= options.Users));
+            }
+            foreach (var table in new[] { DemoTables.PowerAppConnectors, DemoTables.PowerFlowConnectors })
+            {
+                var bridges = capture.For(table);
+                Assert.IsTrue(bridges.Count > 0);
+                Assert.AreEqual(bridges.Count, bridges.Select(r => r[0] + "|" + r[1]).Distinct().Count());
+            }
+            var times = audit.Values.Select(r => (DateTime)r[3]).ToList();
+            Assert.IsTrue(times.All(t => t >= options.Start && t < options.AsOf && DemoCalendar.IsWeekday(t)));
+            Assert.IsTrue((times.Max() - times.Min()).TotalDays >= 21, "Examples must span history, not only the last day.");
+            Assert.IsTrue(reports.Values.Select(r => r[3]).Distinct().Count() > 1);
+            Assert.IsFalse(summary.Rows.ContainsKey(DemoTables.Teams.Name));
+            Assert.IsFalse(summary.Rows.ContainsKey(DemoTables.Chats.Name));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -166,6 +166,13 @@
     <Compile Include="DemoGeneratorSqlTests.cs" />
     <Compile Include="DemoLicenceActivityCoverageTests.cs" />
     <Compile Include="DemoInteractiveTests.cs" />
+    <Compile Include="DemoAreaTests.cs" />
+    <Compile Include="DemoExistingDatabaseTests.cs" />
+    <Compile Include="DemoCollaborationTests.cs" />
+    <Compile Include="DemoPowerPlatformTests.cs" />
+    <Compile Include="..\Tests.FakeDataGen\Demo\DemoAreas.cs">
+      <Link>DemoGenerator\DemoAreas.cs</Link>
+    </Compile>
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoCalendar.cs">
       <Link>DemoGenerator\DemoCalendar.cs</Link>
     </Compile>
@@ -190,11 +197,26 @@
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoTables.cs">
       <Link>DemoGenerator\DemoTables.cs</Link>
     </Compile>
+    <Compile Include="..\Tests.FakeDataGen\Demo\DemoCollaborationTables.cs">
+      <Link>DemoGenerator\DemoCollaborationTables.cs</Link>
+    </Compile>
+    <Compile Include="..\Tests.FakeDataGen\Demo\DemoCollaborationGenerator.cs">
+      <Link>DemoGenerator\DemoCollaborationGenerator.cs</Link>
+    </Compile>
+    <Compile Include="..\Tests.FakeDataGen\Demo\DemoPowerPlatformTables.cs">
+      <Link>DemoGenerator\DemoPowerPlatformTables.cs</Link>
+    </Compile>
+    <Compile Include="..\Tests.FakeDataGen\Demo\DemoPowerPlatformGenerator.cs">
+      <Link>DemoGenerator\DemoPowerPlatformGenerator.cs</Link>
+    </Compile>
     <Compile Include="..\Tests.FakeDataGen\Demo\DemoTimeline.cs">
       <Link>DemoGenerator\DemoTimeline.cs</Link>
     </Compile>
     <Compile Include="..\Tests.FakeDataGen\Demo\SqlDemoDatabase.cs">
       <Link>DemoGenerator\SqlDemoDatabase.cs</Link>
+    </Compile>
+    <Compile Include="..\Tests.FakeDataGen\Demo\SqlExistingDemoDatabase.cs">
+      <Link>DemoGenerator\SqlExistingDemoDatabase.cs</Link>
     </Compile>
     <Compile Include="..\Tests.FakeDataGen\Copilot\CopilotAdoptionPersonas.cs">
       <Link>DemoGenerator\CopilotAdoptionPersonas.cs</Link>


### PR DESCRIPTION
## Summary

Expand `Tests.FakeDataGen` with a shared, deterministic generation path for full demos and individually selected activity areas. Target branch: **dev**. The branch is rebased onto current `dev`, preserving its DLP generation and schema changes.

## Implementation

- Add a 16-area catalogue and `--areas` selector: directory/licences, Copilot audit/usage, Copilot history, Teams, Outlook, sent email, SharePoint, web, OneDrive, Viva Engage, Office apps, Power Apps, Power Automate, Power BI, Copilot Studio and DLP.
- Give each area an interactive existing-or-new database option. Retain the existing generators, including DLP attachment to existing activity, in a separate legacy section; stress tests remain available.
- Add report-oriented Teams calls/sessions/modalities/feedback, memberships/tabs/channel statistics/reactions; sent-email recipients and synthetic sentiment; web page metadata/comments/likes/clicks/search; OneDrive storage and Engage group summaries.
- Add Power Platform resource dimensions, audit metadata, sharing and connector links. Power BI emits `ViewReport`; Power Automate examples represent audit administration rather than flow-run success telemetry.
- Enrich Copilot examples with file/meeting contexts, model/plugin metadata and synthetic history language/sentiment. Preserve DLP blocked-versus-audit-only scenarios and expose DLP through the shared selector with prerequisite Copilot audit facts.
- Keep generation streaming, with bounded SQL batches and department/day summary counters. Individual areas produce the same logical facts as the corresponding portion of a full demo.

## Database safety and compatibility

- `demo` retains new-LocalDB-only targeting, ownership/fingerprint checks, completed-run no-op semantics and refusal of changed/incomplete targets. Bump the synthetic format to `contoso-demo-v3`.
- Add `append`, requiring an explicit existing test database and `--confirm-existing`. Preflight the schema, allocate SQL identities, map logical foreign keys through connection-local temporary tables, and namespace synthetic users/resources per run. Preserve existing rows and reuse appropriate lookup catalogues.
- Account for the legacy unconstrained audit/SharePoint references, Unicode column widening and the current case-sensitive session-ID schema. Refuse missing required relationship metadata rather than using unmapped logical IDs.
- Appends do not create or upgrade application schema, delete existing rows, recompute global profiles, or publish partial-population Copilot tenant counts. Existing demo fingerprints are invalidated after a committed append. Committed batches remain on failure; disposal never flushes abandoned buffers.
- New-database weekly profiling runs only when the complete daily workload set is selected.

**No production importer, migration, database-schema or installer-config changes are introduced by this PR.**

## Validation

- Release build of `Tests.FakeDataGen` and referenced projects succeeds against current `dev`.
- **68 focused DemoGenerator tests pass**, including real-schema LocalDB generation, report coverage, per-area/full-demo equivalence, DLP scenarios, repeated additive appends, identifier remapping/widths, Unicode, schema refusals and cancellation/failure handling.
- `Verify-DemoCommand.ps1 -Configuration Release` passes: help/preview, full new database and profiles, workload coverage, exact-rerun no-op, changed-input refusal, unconfirmed-append refusal, confirmed Power BI-only append and invalidated-demo refusal.
- All database fixtures use synthetic data and are cleaned up.

## Documentation and reviewer notes

Update the repository README and CLI help. The companion synthetic-demo wiki guide and sidebar edits are in the separate wiki checkout and are **not published or included in this PR**.

Review hotspots are `SqlExistingDemoDatabase` (mapping, namespacing and failure semantics), the area catalogue/menu routing, and dependency-ordered table declarations. Detailed events are representative samples, not a reconstruction of every event behind daily aggregate counts. No live customer content or real prompt/message bodies are fetched.