### PR TITLE
Fix SQL authentication detection for legacy installer upgrades

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
@@ -246,15 +246,32 @@ namespace App.ControlPanel.Engine
 
         void ReportSqlConnectionFailure(string connectionString, SqlException error)
         {
+            if (error == null) return; // Connection/token creation already reported its error.
+
             var dataSource = new SqlConnectionStringBuilder(connectionString).DataSource;
 
             _logger.LogError($"Error testing SQL connection to '{dataSource}': '{error?.Message}'. " +
-                $"Verify network connectivity to server.");
+                GetSqlConnectionFailureGuidance(connectionString, error.Number));
 
-            if (PrivateNetworkGuidance.IsPrivateNetworkOnly(Config))
+            if (error.Number != 18456 && PrivateNetworkGuidance.IsPrivateNetworkOnly(Config))
             {
                 _logger.LogError(PrivateNetworkGuidance.BuildVmOnVNetGuidance("the SQL connectivity test and database schema initialisation", Config.NetworkConfig?.VNetName));
             }
+        }
+
+        internal static string GetSqlConnectionFailureGuidance(string connectionString, int errorNumber)
+        {
+            if (errorNumber != 18456) return "Verify network connectivity to server.";
+
+            return AzureSqlTokenAuth.NeedsAccessToken(connectionString)
+                ? "SQL Server rejected the Microsoft Entra identity. The installer signs in as its app registration, " +
+                  "not the interactive Azure portal user or the App Service managed identity. An Entra administrator " +
+                  "must grant that installer principal access to the target database with schema-upgrade permissions. " +
+                  "If the server permits SQL logins, select SQL Server authentication and supply its administrator password; " +
+                  "SQL passwords cannot be used on an Entra-only server. This is a login failure, not a firewall rejection."
+                : "SQL Server rejected the SQL login. Verify the SQL administrator username/password and access to the " +
+                  "target database, and confirm Microsoft Entra-only authentication is disabled. This is a login failure, " +
+                  "not a firewall rejection.";
         }
 
         #region ExecuteAndReportFailure

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -67,9 +67,9 @@ namespace App.ControlPanel.Engine
             if (!sqlReachable && Config.TasksConfig.UpgradeSchema)
             {
                 throw new UnexpectedInstallException(
-                    "SQL Server is not reachable from this host, so the database upgrade cannot run. The App Service has " +
+                    "The SQL connection test failed, so the database upgrade cannot run. The App Service has " +
                     "deliberately NOT been stopped, so the existing deployment keeps running on its current schema. " +
-                    "Fix the connectivity problem reported above and re-run the installer.");
+                    "Fix the authentication or connectivity problem reported above and re-run the installer.");
             }
 
             // Give the App Service's managed identity access to the database. Only needed when the database

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -511,21 +511,8 @@ namespace App.ControlPanel.Engine.InstallerTasks
         /// </summary>
         async Task DetectSqlAuthMethod()
         {
-            var haveSqlCredentials = !string.IsNullOrWhiteSpace(_config.SQLServerAdminUsername)
-                && !string.IsNullOrWhiteSpace(_config.SQLServerAdminPassword);
-
-            SqlServerAuthState state = null;
-            try
-            {
-                state = await SqlServerAuthReader.ReadAsync(CreatedSqlServer, Logger);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning($"Could not read the SQL Server's authentication configuration: {ex.Message}");
-            }
-
-            _sqlAuthDecision = SqlServerAuthDetection.Decide(state, haveSqlCredentials, _config.SqlAuthMode);
-            Logger.LogInformation($"SQL authentication: {_sqlAuthDecision.Reason}");
+            _sqlAuthDecision = await SqlServerAuthReader.DetectAsync(
+                CreatedSqlServer, _config.SQLServerAdminPassword, _config.SqlAuthMode, Logger);
 
             await RepairAutomationSqlCredentialIfNeeded();
         }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
@@ -1,5 +1,7 @@
 using App.ControlPanel.Engine.Entities;
+using Azure;
 using Azure.ResourceManager.Sql;
+using Common.Entities.Installer;
 using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
@@ -17,6 +19,18 @@ namespace App.ControlPanel.Engine.InstallerTasks
     /// </summary>
     public static class SqlServerAuthReader
     {
+        public static async Task<SqlAuthDecision> DetectAsync(SqlServerResource sqlServer, string sqlPassword,
+            SqlServerAuthMode configuredMode, ILogger logger)
+        {
+            if (sqlServer == null) throw new ArgumentNullException(nameof(sqlServer));
+
+            var state = await ReadAsync(sqlServer, logger);
+            var decision = SqlServerAuthDetection.Decide(state,
+                state.HasSqlAdminLogin && !string.IsNullOrWhiteSpace(sqlPassword), configuredMode);
+            logger?.LogInformation($"SQL authentication: {decision.Reason}");
+            return decision;
+        }
+
         /// <summary>
         /// Inspects the server. Returns null when there is no server to inspect.
         /// </summary>
@@ -31,51 +45,43 @@ namespace App.ControlPanel.Engine.InstallerTasks
             var state = new SqlServerAuthState
             {
                 HasSqlAdminLogin = !string.IsNullOrWhiteSpace(data.AdministratorLogin),
-                HasEntraAdmin = data.Administrators != null && data.Administrators.Sid.HasValue,
-                EntraAdminLogin = data.Administrators?.Login,
-                EntraOnlyAuthEnabled = data.Administrators?.IsAzureADOnlyAuthenticationEnabled == true,
             };
 
-            // The server payload only reports Entra-only auth when the administrator was set through the
-            // server resource. The authoritative source is the azureADOnlyAuthentications child resource,
-            // which is also where a customer's own portal/CLI change shows up.
-            if (!state.EntraOnlyAuthEnabled)
+            // Always read the authoritative child, even when the embedded administrator says true:
+            // that value can disagree after authentication is changed through the portal/CLI.
+            try
             {
-                try
-                {
-                    foreach (var onlyAuth in sqlServer.GetSqlServerAzureADOnlyAuthentications())
-                    {
-                        if (onlyAuth.Data != null && onlyAuth.Data.IsAzureADOnlyAuthenticationEnabled == true)
-                        {
-                            state.EntraOnlyAuthEnabled = true;
-                            break;
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // A server that has never had it set returns 404/NotFound here. Not an error.
-                    logger?.LogInformation($"Could not read Microsoft Entra-only authentication state for SQL Server '{data.Name}': {ex.Message}");
-                }
+                var onlyAuth = await sqlServer.GetSqlServerAzureADOnlyAuthentications().GetAsync("Default");
+                state.EntraOnlyAuthEnabled = onlyAuth.Value.Data.IsAzureADOnlyAuthenticationEnabled
+                    ?? throw new InvalidOperationException("Azure did not return the SQL Server's Microsoft Entra-only authentication setting.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                logger?.LogInformation("No Microsoft Entra-only authentication resource exists for this SQL Server; SQL logins are not disabled.");
+            }
+            catch (RequestFailedException ex)
+            {
+                logger?.LogError($"Could not read the SQL Server's Microsoft Entra-only authentication setting (HTTP {ex.Status}). " +
+                    "Verify the installer can read Microsoft.Sql/servers/azureADOnlyAuthentications. Authentication will not be guessed.");
+                throw;
             }
 
-            // Likewise, an administrator assigned separately (portal, CLI, an older install) lives in the
-            // administrators child collection rather than on the server payload.
-            if (!state.HasEntraAdmin)
+            // A separately removed/replaced administrator must not be inferred from the embedded payload.
+            try
             {
-                try
-                {
-                    var admin = sqlServer.GetSqlServerAzureADAdministrators().FirstOrDefault();
-                    if (admin != null && admin.Data != null)
-                    {
-                        state.HasEntraAdmin = true;
-                        state.EntraAdminLogin = admin.Data.Login;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger?.LogInformation($"Could not read the Microsoft Entra administrator for SQL Server '{data.Name}': {ex.Message}");
-                }
+                var admin = await sqlServer.GetSqlServerAzureADAdministrators().GetAsync("ActiveDirectory");
+                state.HasEntraAdmin = admin.Value.Data.Sid.HasValue;
+                state.EntraAdminLogin = admin.Value.Data.Login;
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                logger?.LogInformation("No Microsoft Entra administrator is configured for this SQL Server.");
+            }
+            catch (RequestFailedException ex)
+            {
+                logger?.LogError($"Could not read the SQL Server's Microsoft Entra administrator (HTTP {ex.Status}). " +
+                    "Verify the installer can read Microsoft.Sql/servers/administrators. Authentication will not be guessed.");
+                throw;
             }
 
             logger?.LogInformation(

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/AppServicePublishInfo.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/AppServicePublishInfo.cs
@@ -16,6 +16,11 @@
             public string SqlFqdn { get; set; }
             public string SqlUsername { get; set; }
             public string SqlPassword { get; set; }
+            public Entities.SqlConnectionAuthMethod AuthMethod { get; set; }
+
+            public string ConnectionString => AuthMethod == Entities.SqlConnectionAuthMethod.EntraId
+                ? Entities.DatabasePaaSInfo.GetEntraIdConnectionString(SqlFqdn, null)
+                : Entities.DatabasePaaSInfo.GetConnectionString(SqlFqdn, null, SqlUsername, SqlPassword);
         }
     }
 }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -1,4 +1,5 @@
 using App.ControlPanel.Engine.Entities;
+using App.ControlPanel.Engine.InstallerTasks;
 using App.ControlPanel.Engine.Models;
 using Azure.Identity;
 using Azure.ResourceManager;
@@ -140,11 +141,6 @@ namespace App.ControlPanel.Engine
         /// </summary>
         public async Task<AutodetectedSqlDetails> GetSqlDetails(string sqlPassword)
         {
-            if (string.IsNullOrEmpty(sqlPassword) && Config.SqlAuthMode != SqlServerAuthMode.EntraId)
-            {
-                throw new ArgumentException($"'{nameof(sqlPassword)}' cannot be null or empty.", nameof(sqlPassword));
-            }
-
             var (testRg, _) = await GetResourceGroupIfValid();
             if (testRg != null)
             {
@@ -156,12 +152,16 @@ namespace App.ControlPanel.Engine
                 }
                 else
                 {
+                    var decision = await SqlServerAuthReader.DetectAsync(sqlServer, sqlPassword, Config.SqlAuthMode, _logger);
                     sqlInfo = new SqlDetails
                     {
                         SqlFqdn = sqlServer.Data.FullyQualifiedDomainName,
-                        SqlPassword = sqlPassword,
-                        SqlUsername = sqlServer.Data.AdministratorLogin
+                        AuthMethod = decision.Method,
+                        SqlPassword = decision.UsesEntraId ? null : sqlPassword,
+                        SqlUsername = decision.UsesEntraId ? null : sqlServer.Data.AdministratorLogin
                     };
+                    if (!decision.UsesEntraId)
+                        DatabasePaaSInfo.EnsureSqlLoginUsable(sqlInfo.SqlFqdn, sqlInfo.SqlUsername, sqlInfo.SqlPassword);
                 }
 
                 return new AutodetectedSqlDetails { Sql = sqlInfo };
@@ -180,16 +180,11 @@ namespace App.ControlPanel.Engine
         {
             if (config == null) return false;
 
-            // A Microsoft Entra ID deployment has no SQL login to supply, so requiring one here would make
-            // autodetection permanently unavailable for it. See issue #117.
-            var haveSqlCredentials = config.SqlAuthMode == SqlServerAuthMode.EntraId
-                || (!string.IsNullOrEmpty(config.SQLServerAdminPassword) && !string.IsNullOrEmpty(config.SQLServerAdminUsername));
-
             var installerAccErrors = config.InstallerAccount?.GetValidationErrors();
             return installerAccErrors != null && installerAccErrors.Count == 0
                 && !string.IsNullOrEmpty(config.ResourceGroupName)
-                && config.Subscription.IsValidSubscription
-                && haveSqlCredentials && !string.IsNullOrEmpty(config.SQLServerName);
+                && config.Subscription != null && config.Subscription.IsValidSubscription
+                && !string.IsNullOrEmpty(config.SQLServerName);
         }
 
         async Task<(ResourceGroupResource, bool)> GetResourceGroupIfValid()

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/SqlInstallerTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Utils/SqlInstallerTasks.cs
@@ -65,10 +65,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
         /// </summary>
         internal async Task InitDatabaseSchema(List<string> targetSites)
         {
-            // Create DB migration info
-            var upgradeInfo = new DatabaseUpgradeInfo();
-            upgradeInfo.ConnectionString = _dbInfo.ConnectionString;
-            upgradeInfo.OrgURLs = targetSites;
+            var upgradeInfo = CreateDatabaseUpgradeInfo(targetSites);
 
             // A connection string with no login means the SQL server has SQL authentication disabled, so
             // the downloaded app has to authenticate with Microsoft Entra ID. It cannot use a managed
@@ -77,10 +74,6 @@ namespace App.ControlPanel.Engine.InstallerTasks
             var needsEntraAuth = AzureSqlTokenAuth.NeedsAccessToken(upgradeInfo.ConnectionString);
             if (needsEntraAuth)
             {
-                upgradeInfo.EntraTenantId = _config.InstallerAccount?.DirectoryId;
-                upgradeInfo.EntraClientId = _config.InstallerAccount?.ClientId;
-                upgradeInfo.EntraClientSecret = _config.InstallerAccount?.Secret;
-
                 // Stop BEFORE running a build that cannot possibly succeed. Such a build opens the
                 // connection with no credentials and fails inside Entity Framework with an error about the
                 // 'master' database, naming neither Entra ID nor the real cause - and there is no way to
@@ -128,6 +121,22 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 _logger.LogInformation($"Database initialisation completed (exit 0)" + (lastLine != null ? $": {lastLine}" : ".") +
                     $" Full details in Windows application log (event ID {InstallerConstants.EVENT_LOG_CATEGORY_ID}).");
             }
+        }
+
+        internal DatabaseUpgradeInfo CreateDatabaseUpgradeInfo(List<string> targetSites)
+        {
+            var upgradeInfo = new DatabaseUpgradeInfo
+            {
+                ConnectionString = _dbInfo.ConnectionString,
+                OrgURLs = targetSites
+            };
+            if (AzureSqlTokenAuth.NeedsAccessToken(upgradeInfo.ConnectionString))
+            {
+                upgradeInfo.EntraTenantId = _config.InstallerAccount?.DirectoryId;
+                upgradeInfo.EntraClientId = _config.InstallerAccount?.ClientId;
+                upgradeInfo.EntraClientSecret = _config.InstallerAccount?.Secret;
+            }
+            return upgradeInfo;
         }
 
         internal async Task RegisterConfigAndStatus(List<InstallLogEventArgs> installLogEvents, string configPassword)
@@ -181,7 +190,8 @@ namespace App.ControlPanel.Engine.InstallerTasks
             bool sqlTestWorked = await _verifySqlCallback(_dbInfo.ConnectionString);
             if (!sqlTestWorked)
             {
-                _logger.LogInformation("Skipping control-panel app to init/update database due to failed connectivity test. Verify your current IP address is correct in the SQL Server firewall settings", true);
+                _logger.LogError("Skipping control-panel app to init/update database due to a failed SQL connection test. " +
+                    "Fix the authentication or connectivity problem reported above and re-run the installer.");
                 return new ChildResult { Success = false, ExitCode = -1 };
             }
 

--- a/src/AnalyticsEngine/App.ControlPanel/TestSettingsForm.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/TestSettingsForm.cs
@@ -9,6 +9,7 @@ namespace App.ControlPanel
     public partial class TestSettingsForm : Form
     {
         private InMemoryLogger _logger = new InMemoryLogger();
+        private bool _usesEntraSqlAuth;
         public TestSettingsForm()
         {
             InitializeComponent();
@@ -33,6 +34,11 @@ namespace App.ControlPanel
                 {
                     connectionString = DatabasePaaSInfo.GetConnectionString(txtSqlServer.Text, null, txtSqlUsername.Text, txtSqlPassword.Text);
                 }
+                else if (_usesEntraSqlAuth && txtSqlServer.Text.Length > 0
+                    && txtSqlUsername.Text.Length == 0 && txtSqlPassword.Text.Length == 0)
+                {
+                    connectionString = DatabasePaaSInfo.GetEntraIdConnectionString(txtSqlServer.Text, null);
+                }
                 return new TestConfiguration()
                 {
                     SQLConnectionString = connectionString
@@ -44,6 +50,7 @@ namespace App.ControlPanel
                 if (value != null) defaultConfig = value;
 
                 var sqlConnectionInfo = new System.Data.SqlClient.SqlConnectionStringBuilder(defaultConfig.SQLConnectionString);
+                _usesEntraSqlAuth = DataUtils.Sql.AzureSqlTokenAuth.NeedsAccessToken(defaultConfig.SQLConnectionString);
                 txtSqlServer.Text = sqlConnectionInfo?.DataSource;
                 txtSqlUsername.Text = sqlConnectionInfo?.UserID;
                 txtSqlPassword.Text = sqlConnectionInfo?.Password;
@@ -86,21 +93,9 @@ namespace App.ControlPanel
             if (e.Result is AutodetectedSqlDetails)
             {
                 var r = (AutodetectedSqlDetails)e.Result;
-                var connectionString = string.Empty;
-                if (!string.IsNullOrEmpty(r.Sql?.SqlUsername) && !string.IsNullOrEmpty(r.Sql?.SqlPassword) && !string.IsNullOrEmpty(r.Sql?.SqlFqdn))
-                {
-                    connectionString = DatabasePaaSInfo.GetConnectionString(r.Sql?.SqlFqdn, null, r.Sql?.SqlUsername, r.Sql?.SqlPassword);
-                }
-                else if (!string.IsNullOrEmpty(r.Sql?.SqlFqdn))
-                {
-                    // No SQL login: the server authenticates with Microsoft Entra ID, so the tests connect
-                    // with a token instead of credentials (issue #117).
-                    connectionString = DatabasePaaSInfo.GetEntraIdConnectionString(r.Sql.SqlFqdn, null);
-                }
-
                 this.TestConfiguration = new TestConfiguration
                 {
-                    SQLConnectionString = connectionString
+                    SQLConnectionString = r.Sql?.ConnectionString ?? string.Empty
                 };
 
                 if (r.Sql == null)

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/SqlAuthenticationDetectionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/SqlAuthenticationDetectionTests.cs
@@ -1,0 +1,281 @@
+using App.ControlPanel.Engine;
+using App.ControlPanel.Engine.Entities;
+using App.ControlPanel.Engine.InstallerTasks;
+using App.ControlPanel.Engine.Models;
+using Azure;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Sql;
+using Common.Entities.Installer;
+using Common.Entities.Sql;
+using DataUtils.Sql;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tests.UnitTests.InstallTests
+{
+    [TestClass]
+    public class SqlAuthenticationDetectionTests
+    {
+        [TestCleanup]
+        public void Cleanup() => AzureSqlTokenAuth.ResetCredential();
+
+        [DataTestMethod]
+        [DataRow(true, false)]
+        [DataRow(false, true)]
+        public async Task Reader_ChildSettingOverridesEmbeddedSettingInBothDirections(bool embedded, bool actual)
+        {
+            using (var arm = new SqlArmFixture { EmbeddedEntraOnly = embedded, EntraOnly = actual })
+            {
+                var decision = await SqlServerAuthReader.DetectAsync(arm.Server, "SyntheticPassword!", SqlServerAuthMode.SqlLogin, null);
+
+                Assert.AreEqual(actual, decision.UsesEntraId);
+                Assert.AreEqual(1, arm.AuthenticationReads);
+            }
+        }
+
+        [TestMethod]
+        public async Task Reader_LegacyServerWithoutAuthChildren_UsesSqlEvenWhenEntraSelected()
+        {
+            using (var arm = new SqlArmFixture { AuthenticationStatus = HttpStatusCode.NotFound })
+            {
+                var state = await SqlServerAuthReader.ReadAsync(arm.Server, null);
+                Assert.IsFalse(state.EntraOnlyAuthEnabled);
+                Assert.IsFalse(state.HasEntraAdmin);
+                Assert.IsTrue(state.HasSqlAdminLogin);
+
+                var decision = await SqlServerAuthReader.DetectAsync(arm.Server, "SyntheticPassword!", SqlServerAuthMode.EntraId, null);
+                Assert.AreEqual(SqlConnectionAuthMethod.SqlLogin, decision.Method);
+            }
+        }
+
+        [TestMethod]
+        public async Task Reader_SeparateEntraAdmin_EnablesExplicitEntraSelection()
+        {
+            using (var arm = new SqlArmFixture { AdministratorStatus = HttpStatusCode.OK })
+            {
+                var decision = await SqlServerAuthReader.DetectAsync(arm.Server, null, SqlServerAuthMode.EntraId, null);
+                Assert.IsTrue(decision.UsesEntraId);
+            }
+        }
+
+        [TestMethod]
+        public async Task Reader_RemovedEntraAdmin_DoesNotSelectEntraFromEmbeddedAdministrator()
+        {
+            using (var arm = new SqlArmFixture { EmbeddedEntraOnly = true, EntraOnly = false })
+            {
+                var decision = await SqlServerAuthReader.DetectAsync(arm.Server, "SyntheticPassword!", SqlServerAuthMode.EntraId, null);
+                Assert.AreEqual(SqlConnectionAuthMethod.SqlLogin, decision.Method);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(403, false)]
+        [DataRow(500, false)]
+        [DataRow(403, true)]
+        [DataRow(500, true)]
+        public async Task Reader_FailedMetadataRead_DoesNotGuessAuthentication(int status, bool administrator)
+        {
+            using (var arm = new SqlArmFixture())
+            {
+                if (administrator) arm.AdministratorStatus = (HttpStatusCode)status;
+                else arm.AuthenticationStatus = (HttpStatusCode)status;
+
+                var error = await Assert.ThrowsExceptionAsync<RequestFailedException>(() =>
+                    SqlServerAuthReader.DetectAsync(arm.Server, "SyntheticPassword!", SqlServerAuthMode.SqlLogin, null));
+                Assert.AreEqual(status, error.Status);
+            }
+        }
+
+        [TestMethod]
+        public async Task Reader_MissingBoolean_IsNotTreatedAsSqlAuthentication()
+        {
+            using (var arm = new SqlArmFixture { EntraOnly = null })
+            {
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                    SqlServerAuthReader.DetectAsync(arm.Server, "SyntheticPassword!", SqlServerAuthMode.SqlLogin, null));
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task DetectedAuthentication_SurvivesHeadlessPayloadAndEfConnection(bool entraOnly)
+        {
+            using (var arm = new SqlArmFixture { EntraOnly = entraOnly })
+            {
+                var config = new SolutionInstallConfig
+                {
+                    SQLServerAdminPassword = "SyntheticPassword!",
+                    InstallerAccount = new AppRegistrationCredentials("synthetic-client", "synthetic-secret", Guid.Empty.ToString())
+                };
+                var decision = await SqlServerAuthReader.DetectAsync(arm.Server, config.SQLServerAdminPassword, SqlServerAuthMode.SqlLogin, null);
+                var server = (await arm.Server.GetAsync()).Value;
+                var database = (await server.GetSqlDatabases().GetAsync("analytics")).Value;
+                var dbInfo = new DatabasePaaSInfo(server, database, config) { AuthMethod = decision.Method };
+                var tasks = new SqlInstallerTasks(config, null, dbInfo, null, "Synthetic operator", null, null);
+                var payload = tasks.CreateDatabaseUpgradeInfo(new List<string> { "https://contoso.sharepoint.com" });
+                var received = DatabaseUpgradeInfo.GetFromBase64String(payload.ToBase64());
+
+                Assert.AreEqual(dbInfo.ConnectionString, received.ConnectionString);
+                CollectionAssert.AreEqual(payload.OrgURLs, received.OrgURLs);
+                Assert.AreEqual(entraOnly, received.HasEntraCredential);
+                var builder = new SqlConnectionStringBuilder(received.ConnectionString);
+                Assert.AreEqual(entraOnly ? "" : "sqladmin", builder.UserID);
+                Assert.AreEqual(entraOnly ? "" : config.SQLServerAdminPassword, builder.Password);
+                if (entraOnly)
+                    Assert.AreEqual(config.InstallerAccount.Secret, received.EntraClientSecret);
+                else
+                {
+                    Assert.IsNull(received.EntraTenantId);
+                    Assert.IsNull(received.EntraClientId);
+                    Assert.IsNull(received.EntraClientSecret);
+                }
+
+                var credential = new FixedTokenCredential();
+                AzureSqlTokenAuth.SetCredential(credential);
+                using (var connection = AzureSqlTokenAuth.CreateConnection(received.ConnectionString))
+                {
+                    new AzureSqlAccessTokenInterceptor().Opening(connection, null);
+                    Assert.AreEqual(entraOnly, !string.IsNullOrEmpty(connection.AccessToken));
+                }
+                Assert.AreEqual(entraOnly ? 2 : 0, credential.TokenRequests);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(SqlConnectionAuthMethod.SqlLogin)]
+        [DataRow(SqlConnectionAuthMethod.EntraId)]
+        public void TestTarget_UsesDetectedAuthenticationNotPresenceOfOldPassword(SqlConnectionAuthMethod method)
+        {
+            var details = new AutodetectedSqlDetails.SqlDetails
+            {
+                SqlFqdn = "contoso-sql.database.windows.net",
+                SqlUsername = "sqladmin",
+                SqlPassword = "SyntheticPassword!",
+                AuthMethod = method
+            };
+            var connection = new SqlConnectionStringBuilder(details.ConnectionString);
+            Assert.AreEqual(method == SqlConnectionAuthMethod.EntraId, AzureSqlTokenAuth.NeedsAccessToken(details.ConnectionString));
+            Assert.AreEqual(method == SqlConnectionAuthMethod.SqlLogin ? "sqladmin" : "", connection.UserID);
+        }
+
+        [TestMethod]
+        public void Autodetection_DoesNotRequireSqlCredentialsBeforeReadingServer()
+        {
+            var config = new SolutionInstallConfig
+            {
+                InstallerAccount = new AppRegistrationCredentials("synthetic-client", "synthetic-secret", Guid.Empty.ToString()),
+                Subscription = new AzureSubscription(Guid.Empty.ToString(), "Synthetic subscription"),
+                ResourceGroupName = "contoso",
+                SQLServerName = "contoso-sql"
+            };
+            Assert.IsTrue(SolutionInstallVerifier.ConfigIsReadyForSqlAutodetection(config));
+            config.Subscription = null;
+            Assert.IsFalse(SolutionInstallVerifier.ConfigIsReadyForSqlAutodetection(config));
+        }
+
+        [TestMethod]
+        public void LoginFailure_ExplainsIdentityInsteadOfBlamingFirewall()
+        {
+            var entra = DatabasePaaSInfo.GetEntraIdConnectionString("contoso-sql.database.windows.net", "analytics");
+            var sql = DatabasePaaSInfo.GetConnectionString("contoso-sql.database.windows.net", "analytics", "sqladmin", "SyntheticPassword!");
+            StringAssert.Contains(BaseInstallProcess.GetSqlConnectionFailureGuidance(entra, 18456), "installer signs in as its app registration");
+            StringAssert.Contains(BaseInstallProcess.GetSqlConnectionFailureGuidance(sql, 18456), "username/password");
+            StringAssert.Contains(BaseInstallProcess.GetSqlConnectionFailureGuidance(sql, 40615), "network connectivity");
+        }
+
+        // Exercise the real SDK deserialisation and resource routes without any Azure calls.
+        sealed class SqlArmFixture : HttpMessageHandler
+        {
+            const string ServerId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso/providers/Microsoft.Sql/servers/contoso-sql";
+            readonly HttpClient _http;
+            public bool? EmbeddedEntraOnly { get; set; }
+            public bool? EntraOnly { get; set; } = false;
+            public HttpStatusCode AuthenticationStatus { get; set; } = HttpStatusCode.OK;
+            public HttpStatusCode AdministratorStatus { get; set; } = HttpStatusCode.NotFound;
+            public int AuthenticationReads { get; private set; }
+            public SqlServerResource Server { get; }
+
+            public SqlArmFixture()
+            {
+                _http = new HttpClient(this, disposeHandler: false);
+                var client = new ArmClient(new FixedTokenCredential(), Guid.Empty.ToString(), new ArmClientOptions
+                {
+                    Transport = new HttpClientTransport(_http),
+                    Retry = { MaxRetries = 0 }
+                });
+                Server = client.GetSqlServerResource(new ResourceIdentifier(ServerId));
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Assert.AreEqual(HttpMethod.Get, request.Method, "Detection must never change a server's authentication.");
+                var path = request.RequestUri.AbsolutePath;
+                var status = HttpStatusCode.OK;
+                var properties = new JObject();
+                if (path.EndsWith("/azureADOnlyAuthentications/Default", StringComparison.OrdinalIgnoreCase))
+                {
+                    AuthenticationReads++;
+                    status = AuthenticationStatus;
+                    if (EntraOnly.HasValue) properties["azureADOnlyAuthentication"] = EntraOnly.Value;
+                }
+                else if (path.EndsWith("/administrators/ActiveDirectory", StringComparison.OrdinalIgnoreCase))
+                {
+                    status = AdministratorStatus;
+                    properties["sid"] = Guid.Empty.ToString();
+                    properties["login"] = "Synthetic administrator";
+                }
+                else if (path.EndsWith("/databases/analytics", StringComparison.OrdinalIgnoreCase))
+                {
+                    properties["status"] = "Online";
+                }
+                else
+                {
+                    Assert.AreEqual(ServerId, path);
+                    properties["administratorLogin"] = "sqladmin";
+                    properties["fullyQualifiedDomainName"] = "contoso-sql.database.windows.net";
+                    if (EmbeddedEntraOnly.HasValue)
+                    {
+                        properties["administrators"] = new JObject
+                        {
+                            ["sid"] = Guid.Empty.ToString(),
+                            ["login"] = "Synthetic administrator",
+                            ["azureADOnlyAuthentication"] = EmbeddedEntraOnly.Value
+                        };
+                    }
+                }
+                var body = status == HttpStatusCode.OK
+                    ? new JObject { ["id"] = path, ["name"] = path.Substring(path.LastIndexOf('/') + 1), ["location"] = "westeurope", ["properties"] = properties }
+                    : new JObject { ["error"] = new JObject { ["code"] = status.ToString(), ["message"] = "Synthetic ARM error" } };
+                return Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body.ToString(), System.Text.Encoding.UTF8, "application/json") });
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing) _http.Dispose();
+                base.Dispose(disposing);
+            }
+        }
+
+        sealed class FixedTokenCredential : TokenCredential
+        {
+            public int TokenRequests { get; private set; }
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                TokenRequests++;
+                return new AccessToken("synthetic-token", DateTimeOffset.UtcNow.AddHours(1));
+            }
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+                => new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="AgentCostUserResolutionTests.cs" />
     <Compile Include="AgentCostSqlIntegrationTests.cs" />
     <Compile Include="AzureSqlEntraAuthTests.cs" />
+    <Compile Include="InstallTests\SqlAuthenticationDetectionTests.cs" />
     <Compile Include="ActivityReportLoaderTimeoutTests.cs" />
     <Compile Include="ActivityReportSetMinMaxTests.cs" />
     <Compile Include="ActivitySaveConcurrencyPolicyTests.cs" />
@@ -537,5 +538,4 @@
     <TransformXml Source="App.Template.config" Transform="App.$(Configuration).config" Destination="App.config" />
   </Target>
 </Project>
-
 


### PR DESCRIPTION
## Scope
Fix SQL authentication selection for existing/legacy Azure SQL servers in setup and solution-test autodetection, while preserving that selection through the downloaded installer's headless schema-upgrade hand-off. Target branch: **dev**.

## Implementation
- Always read `azureADOnlyAuthentications/Default` and `administrators/ActiveDirectory` asynchronously. Embedded server-administrator metadata no longer overrides the authoritative child settings.
- Share `SqlServerAuthReader.DetectAsync` between resource installation and solution-test autodetection. SQL-login availability is checked against the administrator login returned by Azure, matching the connection-string builder, plus the supplied password.
- Treat a missing authentication child (404) as absent. Surface permission/service failures rather than silently choosing an authentication method; reject a successful response that omits the authentication boolean.
- Preserve legacy SQL authentication when no Entra administrator exists, including when Entra was selected for provisioning. Retain Entra-only enforcement: a genuinely Entra-only server never falls back to a SQL password. Existing servers are not reconfigured.
- Carry the detected method into test settings and preserve login-free Entra connection strings when the dialog is saved; previously saving those settings cleared the connection string.
- Extract the actual `DatabaseUpgradeInfo` construction for regression coverage. The selected SQL connection string retains its login/password and carries no Entra credential; the Entra path retains the installer credential. No headless wire-format change.
- Diagnose SQL login error 18456 as an authentication failure, distinguishing the installer app registration from the portal user/App Service identity, instead of blaming the firewall. Preserve the pre-upgrade connection gate and the existing stop/restart workflow.

## Verification
- Release builds of `Tests.UnitTests` and `App.ControlPanel.WinForms` succeeded.
- **95 focused tests passed** across `SqlAuthenticationDetectionTests`, `AzureSqlEntraAuthTests`, `InstallFailureDiagnosisTests`, and `SqlFirewallRulesTests`.
- New tests exercise real Azure SDK deserialization/routes with an in-memory HTTP transport: contradictory embedded/child settings in both directions, absent legacy resources, separately assigned/removed administrators, 403/500 failures, and a missing boolean.
- Reproduced the stale-administrator regression before the final fix: expected `SqlLogin`, actual `EntraId`; the same test passes after using the administrator child resource.
- Round-trip the production headless payload through Base64 serialization and exercise both raw SqlClient and the EF access-token interceptor. SQL-login mode makes zero token requests.
- Separate smoke harness instantiated the built WinForms test-settings form without showing it and verified SQL → Entra → cleared → SQL save/load round trips.
- Tests use synthetic data only; no live Azure authentication or customer database/schema upgrade was performed. Source/tests and companion wiki edits were checked for identifiers from the supplied diagnostics; the commit secret scan was clean.

## Compatibility and reviewer notes
- **No database migrations, saved-config schema changes, or dependency changes.** The new autodetected authentication property is transient, not part of the saved installer schema; `CONFIG_VERSION` is unchanged.
- Metadata-read permissions are now enforced instead of swallowed. Reviewers should check the intentional fail-closed behavior for non-404 responses.
- A token-principal login failure alone does not prove SQL passwords are allowed. When the authoritative setting really is Entra-only, an administrator must grant the installer principal database/schema permissions; this change does not bypass that server policy.
- Companion operator guidance was updated in the local wiki checkout's `Updating the solution.md`; it is not published by this source PR.
- Does not change the draft release or address unrelated Key Vault/App Service warnings.