### PR TITLE
Give people database access without locking the installer out of schema upgrades

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -83,6 +83,8 @@
     <Compile Include="InstallerTasks\JobTasks\RunbookCreateOrUpdateTasks.cs" />
     <Compile Include="InstallerTasks\ResourceSecurityInstallJob.cs" />
     <Compile Include="InstallerTasks\SqlIdentityAccessTask.cs" />
+    <Compile Include="InstallerTasks\SqlEntraAccessBootstrap.cs" />
+    <Compile Include="InstallerTasks\SqlDatabaseUserGrantTask.cs" />
     <Compile Include="InstallerTasks\RunbooksInstallJob.cs" />
     <Compile Include="Models\AzStorageConnectionInfo.cs" />
     <Compile Include="SolutionUninstaller.cs" />

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
@@ -1,4 +1,5 @@
 ﻿using App.ControlPanel.Engine.Entities;
+using App.ControlPanel.Engine.InstallerTasks;
 using App.ControlPanel.Engine.Models;
 using Azure.Identity;
 using CloudInstallEngine.Azure;
@@ -101,7 +102,17 @@ namespace App.ControlPanel.Engine
         /// correct behind NAT, proxies and split-tunnel VPNs. Retries are bounded so a permanently broken
         /// environment cannot loop. See issue #326.
         /// </remarks>
-        public async Task<bool> VerifySqlWithFirewallSelfHeal(string connectionString, Func<string, Task<bool>> repairFirewallForIp)
+        /// <param name="repairEntraAccess">
+        /// Repairs the installer's own Microsoft Entra access to the database - by signing an administrator
+        /// in and creating the contained user it needs - returning whether it succeeded. Null disables that
+        /// self-healing (a headless run, or a SQL-authentication deployment where it makes no sense).
+        /// </param>
+        /// <param name="entraLockoutRemedy">
+        /// Explanation of the login rejection in terms of this server's actual administrator assignment,
+        /// logged before attempting the repair. Optional.
+        /// </param>
+        public async Task<bool> VerifySqlWithFirewallSelfHeal(string connectionString, Func<string, Task<bool>> repairFirewallForIp,
+            Func<Task<bool>> repairEntraAccess = null, string entraLockoutRemedy = null)
         {
             if (string.IsNullOrEmpty(connectionString))
             {
@@ -110,8 +121,10 @@ namespace App.ControlPanel.Engine
             if (_sqlTestDoneAlready) return true;
 
             string repairedForIp = null;
+            var attempt = 0;
+            var entraRepairAttempted = false;
 
-            for (var attempt = 0; ; attempt++)
+            while (true)
             {
                 var (ok, error) = await TrySqlConnection(connectionString);
                 if (ok)
@@ -123,6 +136,44 @@ namespace App.ControlPanel.Engine
                     }
                     _sqlTestDoneAlready = true;
                     return true;
+                }
+
+                // A token-authenticated login rejection is self-healable too, but by a completely different
+                // route to a firewall block: nothing about the network is wrong, the installer's service
+                // principal simply has no user in the database. Attempted once only - a second go would just
+                // ask the operator to sign in again for the same reason.
+                var entraLockout = error != null
+                    && error.Number == SqlEntraAccessBootstrap.SqlLoginFailedErrorNumber
+                    && AzureSqlTokenAuth.NeedsAccessToken(connectionString);
+
+                if (entraLockout && !entraRepairAttempted)
+                {
+                    entraRepairAttempted = true;
+
+                    var repaired = false;
+                    if (repairEntraAccess != null)
+                    {
+                        try
+                        {
+                            repaired = await repairEntraAccess();
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError($"Could not repair the installer's database access: {ex.Message}");
+                        }
+                    }
+
+                    // A contained user takes effect immediately, so retry straight away rather than
+                    // spending one of the firewall backoff waits on it. Nothing is logged as an error on
+                    // this path: the install recovered, so the summary must not report a failure.
+                    if (repaired) continue;
+
+                    // Only now is this genuinely unrecoverable, so explain it in terms of the server's
+                    // actual administrator assignment before the generic connection-failure guidance.
+                    if (!string.IsNullOrEmpty(entraLockoutRemedy)) _logger.LogError(entraLockoutRemedy);
+
+                    ReportSqlConnectionFailure(connectionString, error);
+                    return false;
                 }
 
                 // Only a firewall rejection is self-healable, and only while retries remain.
@@ -201,6 +252,7 @@ namespace App.ControlPanel.Engine
                 var wait = _firewallRepairRetryBackoff[attempt];
                 _logger.LogInformation($"Waiting {wait.TotalSeconds:0}s for the SQL Server firewall change to propagate, then retrying...");
                 await Task.Delay(wait);
+                attempt++;
             }
         }
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -300,10 +300,17 @@ namespace App.ControlPanel.Engine
         private Func<Task<bool>> BuildEntraAccessRepairCallback(DatabasePaaSInfo dbInfo, Guid installerObjectId)
         {
             if (dbInfo == null || dbInfo.AuthMethod != SqlConnectionAuthMethod.EntraId) return null;
-            if (installerObjectId == Guid.Empty) return null;
 
             var account = Config.InstallerAccount;
-            if (account == null || string.IsNullOrWhiteSpace(account.ClientId)) return null;
+
+            // Azure SQL matches a service principal on its APPLICATION (client) ID, not its object ID, so
+            // the client ID is what the repair actually needs - the object ID is only used to diagnose
+            // whether we are the server's administrator.
+            Guid installerClientId;
+            if (account == null || !Guid.TryParse((account.ClientId ?? string.Empty).Trim(), out installerClientId) || installerClientId == Guid.Empty)
+            {
+                return null;
+            }
 
             if (!SqlEntraAccessBootstrap.CanPromptForSignIn())
             {
@@ -314,7 +321,7 @@ namespace App.ControlPanel.Engine
             }
 
             return () => SqlEntraAccessBootstrap.TryRepairInstallerAccessAsync(
-                dbInfo.ConnectionString, account.DirectoryId, installerObjectId, account.ClientId, _logger);
+                dbInfo.ConnectionString, account.DirectoryId, installerClientId, _logger);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -207,7 +207,7 @@ namespace App.ControlPanel.Engine
                 return;
             }
 
-            var task = new SqlIdentityAccessTask(_logger);
+            var task = new SqlIdentityAccessTask(_logger, BuildPrincipalResolver());
             await task.GrantDatabaseAccessAsync(
                 dbInfo.ConnectionString,
                 current.Data.Name,
@@ -249,12 +249,26 @@ namespace App.ControlPanel.Engine
                 return;
             }
 
-            var task = new SqlIdentityAccessTask(_logger);
+            var task = new SqlIdentityAccessTask(_logger, BuildPrincipalResolver());
             await task.GrantDatabaseAccessAsync(
                 dbInfo.ConnectionString,
                 current.Data.Name,
                 principalId.Value,
                 new[] { "db_owner" });
+        }
+
+        /// <summary>
+        /// Builds the Microsoft Graph resolver used to turn Entra principals into the identifiers Azure SQL
+        /// needs.
+        /// </summary>
+        /// <remarks>
+        /// Both app registrations are offered because neither is guaranteed to hold a directory-read
+        /// permission: the installer account is an Azure Resource Manager identity and often has none,
+        /// while the runtime account already reads user metadata. Whichever works is used.
+        /// </remarks>
+        private GraphEntraPrincipalResolver BuildPrincipalResolver()
+        {
+            return new GraphEntraPrincipalResolver(_logger, Config.InstallerAccount, Config.RuntimeAccountOffice365);
         }
 
         /// <summary>
@@ -280,7 +294,7 @@ namespace App.ControlPanel.Engine
             var configured = Config.SQLEntraDatabaseUsers;
             if (configured == null || configured.Count == 0) return;
 
-            var resolver = new GraphEntraPrincipalResolver(_logger, Config.InstallerAccount, Config.RuntimeAccountOffice365);
+            var resolver = BuildPrincipalResolver();
             var task = new SqlDatabaseUserGrantTask(_logger, resolver);
 
             await task.GrantConfiguredUsersAsync(dbInfo.ConnectionString, configured);

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -44,7 +44,7 @@ namespace App.ControlPanel.Engine
             AppInsightsInfo appInsights,
             RedisInstallResult redis, CognitiveServicesInfo cognitiveServicesInfo,
             KeyVaultResource keyVault, string serviceBusConnectionString, SubscriptionResource subscription,
-            SqlServerResource sqlServer = null)
+            SqlServerResource sqlServer = null, SqlAuthDecision sqlAuthDecision = null, Guid installerObjectId = default(Guid))
         {
             // Configure app-service connection-strings, etc
             await ConfigureWebApp(webApp, appServicePlan, dbInfo, storage, redis, cognitiveServicesInfo, appInsights, serviceBusConnectionString, keyVault);
@@ -59,7 +59,13 @@ namespace App.ControlPanel.Engine
             // attempt to restart it (issue #326). VerifySQL caches success, so the test inside the database
             // step below becomes a no-op.
             var repairFirewall = BuildFirewallRepairCallback(sqlServer);
-            var sqlReachable = await VerifySqlWithFirewallSelfHeal(dbInfo.ConnectionString, repairFirewall);
+            var repairEntraAccess = BuildEntraAccessRepairCallback(dbInfo, installerObjectId);
+
+            // Computed even when no repair is possible: a headless run cannot self-heal, but it still needs
+            // to be told which administrator assignment locked the installer out.
+            var entraLockoutRemedy = SqlServerAuthDetection.GetInstallerLockoutRemedy(sqlAuthDecision?.ServerState, installerObjectId);
+
+            var sqlReachable = await VerifySqlWithFirewallSelfHeal(dbInfo.ConnectionString, repairFirewall, repairEntraAccess, entraLockoutRemedy);
 
             // Terminate here rather than carrying a "SQL is broken" flag through the rest of the method. The
             // database step would fail anyway, but only after more work had been done, and the App Service
@@ -80,6 +86,7 @@ namespace App.ControlPanel.Engine
             {
                 await GrantAppServiceDatabaseAccess(webApp, dbInfo);
                 await GrantAutomationAccountDatabaseAccess(automationAccount, dbInfo);
+                await GrantConfiguredDatabaseUsers(dbInfo);
             }
 
             // Find downloaded installer app
@@ -248,6 +255,66 @@ namespace App.ControlPanel.Engine
                 current.Data.Name,
                 principalId.Value,
                 new[] { "db_owner" });
+        }
+
+        /// <summary>
+        /// Grants the Microsoft Entra users and groups configured in the installer their own access to the
+        /// analytics database.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Only reached on a database that authenticates with Microsoft Entra ID, and that is a hard
+        /// requirement rather than tidiness: SQL Server refuses to create an external (<c>TYPE = E</c>) user
+        /// unless the connection creating it is itself Entra-authenticated. Over a SQL login the statement
+        /// fails with "Only connections established with Active Directory accounts can create other Active
+        /// Directory users" - and on such a server nobody is locked out anyway, because the SQL
+        /// administrator login still works.
+        /// </para>
+        /// <para>
+        /// This is the supported alternative to reassigning the server's Entra administrator, which Azure
+        /// permits only one of and which would evict the installer's service principal. See issue #117.
+        /// </para>
+        /// </remarks>
+        private async Task GrantConfiguredDatabaseUsers(DatabasePaaSInfo dbInfo)
+        {
+            var configured = Config.SQLEntraDatabaseUsers;
+            if (configured == null || configured.Count == 0) return;
+
+            var resolver = new GraphEntraPrincipalResolver(_logger, Config.InstallerAccount, Config.RuntimeAccountOffice365);
+            var task = new SqlDatabaseUserGrantTask(_logger, resolver);
+
+            await task.GrantConfiguredUsersAsync(dbInfo.ConnectionString, configured);
+        }
+
+        /// <summary>
+        /// Builds the delegate that repairs the installer's own database access after SQL rejects its
+        /// service principal, or null when that self-healing must not be attempted.
+        /// </summary>
+        /// <remarks>
+        /// Null in three cases, each of which would otherwise make things worse rather than better: a
+        /// SQL-authentication deployment (there is no token principal to grant, and the login/password in
+        /// the connection string is the thing to fix); an unresolvable installer object ID (there is no SID
+        /// to create a user for); and a non-interactive process, where prompting for a sign-in nobody can
+        /// complete would hang a scripted install instead of failing it cleanly.
+        /// </remarks>
+        private Func<Task<bool>> BuildEntraAccessRepairCallback(DatabasePaaSInfo dbInfo, Guid installerObjectId)
+        {
+            if (dbInfo == null || dbInfo.AuthMethod != SqlConnectionAuthMethod.EntraId) return null;
+            if (installerObjectId == Guid.Empty) return null;
+
+            var account = Config.InstallerAccount;
+            if (account == null || string.IsNullOrWhiteSpace(account.ClientId)) return null;
+
+            if (!SqlEntraAccessBootstrap.CanPromptForSignIn())
+            {
+                _logger.LogInformation(
+                    "This process cannot prompt for an interactive sign-in, so the installer will not try to repair its own " +
+                    "database access if SQL Server rejects it.");
+                return null;
+            }
+
+            return () => SqlEntraAccessBootstrap.TryRepairInstallerAccessAsync(
+                dbInfo.ConnectionString, account.DirectoryId, installerObjectId, account.ClientId, _logger);
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/AzurePaaSInstallJob.cs
@@ -41,6 +41,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
         private TaskConfig _sqlServerConfig;
         private TaskConfig _automationAccountConfig;
         private SqlAuthDecision _sqlAuthDecision;
+        private Guid _installerObjectId = Guid.Empty;
         private readonly KeyVaultTask _keyVaultTask;
 
         private readonly AppServicePlanTask _appServicePlanTask;
@@ -511,10 +512,48 @@ namespace App.ControlPanel.Engine.InstallerTasks
         /// </summary>
         async Task DetectSqlAuthMethod()
         {
+            _installerObjectId = await ResolveInstallerObjectId();
+
             _sqlAuthDecision = await SqlServerAuthReader.DetectAsync(
-                CreatedSqlServer, _config.SQLServerAdminPassword, _config.SqlAuthMode, Logger);
+                CreatedSqlServer, _config.SQLServerAdminPassword, _config.SqlAuthMode, Logger,
+                _installerObjectId,
+                _config.SQLEntraDatabaseUsers != null && _config.SQLEntraDatabaseUsers.Count > 0);
 
             await RepairAutomationSqlCredentialIfNeeded();
+        }
+
+        /// <summary>
+        /// Object ID of the installer's own service principal, or <see cref="Guid.Empty"/> when it cannot be
+        /// resolved.
+        /// </summary>
+        /// <remarks>
+        /// Needed to answer "is the installer this server's Microsoft Entra administrator?" before anything
+        /// tries to sign in. Never fatal: not knowing simply means the question goes unanswered and the
+        /// install proceeds exactly as it did before, rather than blocking on a diagnostic.
+        /// </remarks>
+        async Task<Guid> ResolveInstallerObjectId()
+        {
+            var account = _config.InstallerAccount;
+            if (account == null
+                || string.IsNullOrWhiteSpace(account.DirectoryId)
+                || string.IsNullOrWhiteSpace(account.ClientId)
+                || string.IsNullOrWhiteSpace(account.Secret))
+            {
+                return Guid.Empty;
+            }
+
+            try
+            {
+                var raw = await ServicePrincipalResolver.GetObjectIdFromClientCredentials(
+                    account.DirectoryId, account.ClientId, account.Secret);
+
+                Guid parsed;
+                return Guid.TryParse(raw, out parsed) ? parsed : Guid.Empty;
+            }
+            catch (Exception)
+            {
+                return Guid.Empty;
+            }
         }
 
         /// <summary>
@@ -613,6 +652,12 @@ namespace App.ControlPanel.Engine.InstallerTasks
         /// run. See issue #117.
         /// </summary>
         public SqlAuthDecision SqlAuthDecision => _sqlAuthDecision;
+
+        /// <summary>
+        /// Object ID of the installer's own service principal, or <see cref="Guid.Empty"/> when it could not
+        /// be resolved. Used to explain - and repair - a SQL login rejection. See issue #117.
+        /// </summary>
+        public Guid InstallerObjectId => _installerObjectId;
 
         public DatabasePaaSInfo DatabasePaaSInfo => new DatabasePaaSInfo(CreatedSqlServer, CreatedSqlDatabase, _config)
         {

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlDatabaseUserGrantTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlDatabaseUserGrantTask.cs
@@ -25,6 +25,17 @@ namespace App.ControlPanel.Engine.InstallerTasks
         /// why rather than throwing, so one unresolvable entry does not abandon the rest.
         /// </summary>
         Task<Guid?> ResolveObjectIdAsync(SqlDatabaseUser user, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Resolves a service principal's application (client) ID from its object ID, or null when it
+        /// cannot be read.
+        /// </summary>
+        /// <remarks>
+        /// Needed because Azure SQL identifies a service principal - including a managed identity - by its
+        /// application ID, while ARM only reports the object ID of a system-assigned identity. The two are
+        /// different GUIDs, and using the wrong one creates a database user that can never sign in.
+        /// </remarks>
+        Task<Guid?> ResolveApplicationIdAsync(Guid servicePrincipalObjectId, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -154,7 +165,8 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
                     foreach (var entry in resolved)
                     {
-                        var sql = SqlContainedUserScript.CreateUserAndGrantRoles(entry.Key.Login, entry.Value, DatabaseUserRoles);
+                        var sql = SqlContainedUserScript.CreateUserAndGrantRoles(
+                            entry.Key.Login, entry.Value, DatabaseUserRoles, entry.Key.IsGroup);
 
                         try
                         {
@@ -306,6 +318,50 @@ namespace App.ControlPanel.Engine.InstallerTasks
         {
             Guid parsed;
             if (!string.IsNullOrWhiteSpace(id) && Guid.TryParse(id, out parsed) && parsed != Guid.Empty) return parsed;
+            return null;
+        }
+
+        /// <summary>
+        /// Reads a service principal's application (client) ID from its object ID.
+        /// </summary>
+        /// <remarks>
+        /// Needs <c>Application.Read.All</c> or <c>Directory.Read.All</c> on one of the candidate app
+        /// registrations. Returns null rather than throwing when neither has it, so the caller can fall
+        /// back to letting SQL Server resolve the name itself.
+        /// </remarks>
+        public async Task<Guid?> ResolveApplicationIdAsync(Guid servicePrincipalObjectId, CancellationToken cancellationToken)
+        {
+            if (servicePrincipalObjectId == Guid.Empty) return null;
+            if (_candidates.Count == 0) return null;
+
+            Exception lastFailure = null;
+
+            foreach (var account in _candidates)
+            {
+                try
+                {
+                    var credential = new Azure.Identity.ClientSecretCredential(account.DirectoryId, account.ClientId, account.Secret);
+                    var graph = new Microsoft.Graph.GraphServiceClient(credential);
+
+                    var sp = await graph.ServicePrincipals[servicePrincipalObjectId.ToString()]
+                        .GetAsync(rc => rc.QueryParameters.Select = new[] { "id", "appId", "displayName" }, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    var appId = ParseId(sp?.AppId);
+                    if (appId != null) return appId;
+                }
+                catch (Exception ex)
+                {
+                    lastFailure = ex;
+                }
+            }
+
+            if (lastFailure != null)
+            {
+                _logger?.LogInformation(
+                    $"Could not read the managed identity's application ID from Microsoft Graph: {lastFailure.Message}");
+            }
+
             return null;
         }
     }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlDatabaseUserGrantTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlDatabaseUserGrantTask.cs
@@ -1,0 +1,312 @@
+using App.ControlPanel.Engine.Entities;
+using Common.Entities.Installer;
+using DataUtils.Sql;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace App.ControlPanel.Engine.InstallerTasks
+{
+    /// <summary>
+    /// Turns a configured Microsoft Entra principal into the object ID SQL Server needs as a SID.
+    /// </summary>
+    /// <remarks>
+    /// An interface so the grant logic can be unit tested without Microsoft Graph, and so a tenant that
+    /// supplies object IDs directly never needs a directory-read permission at all.
+    /// </remarks>
+    public interface IEntraPrincipalResolver
+    {
+        /// <summary>
+        /// Resolves the principal's object ID, or null when it cannot be found. Implementations report
+        /// why rather than throwing, so one unresolvable entry does not abandon the rest.
+        /// </summary>
+        Task<Guid?> ResolveObjectIdAsync(SqlDatabaseUser user, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Grants the Microsoft Entra users and groups named in the installer config access to the analytics
+    /// database, as contained database users.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is how people get to query the data on an Entra-authenticated server. The obvious-looking
+    /// alternative - making yourself the server's Microsoft Entra administrator in the Azure portal - is a
+    /// trap: Azure permits exactly ONE administrator per server and it is the installer's own service
+    /// principal, so "Set admin" removes the identity that applies schema upgrades and the next upgrade
+    /// fails with <c>Login failed for user '&lt;token-identified principal&gt;'</c>.
+    /// </para>
+    /// <para>
+    /// The installer performs the grants because on an Entra-only server it is the only thing that can
+    /// authenticate as the administrator; a person cannot sign in to run the <c>CREATE USER</c> themselves.
+    /// </para>
+    /// <para>
+    /// Best-effort and idempotent, like the managed-identity grant it sits next to: a failure is reported
+    /// but never aborts the install, because losing an operator's convenience access is not a reason to
+    /// leave a deployment half-upgraded. See issue #117.
+    /// </para>
+    /// </remarks>
+    public class SqlDatabaseUserGrantTask
+    {
+        /// <summary>
+        /// Roles granted to a configured database user. <c>db_owner</c> because these are the deployment's
+        /// own administrators: as well as reading data they are expected to be able to run the shipped
+        /// stored procedures and maintain the database by hand.
+        /// </summary>
+        public static readonly IReadOnlyList<string> DatabaseUserRoles = new[] { "db_owner" };
+
+        private readonly ILogger _logger;
+        private readonly IEntraPrincipalResolver _resolver;
+
+        public SqlDatabaseUserGrantTask(ILogger logger, IEntraPrincipalResolver resolver)
+        {
+            _logger = logger;
+            _resolver = resolver;
+        }
+
+        /// <summary>
+        /// Works out the Entra object ID for each configured principal, dropping the ones that cannot be
+        /// used and saying why.
+        /// </summary>
+        /// <remarks>
+        /// Separate from the grant so the decision logic - what is skipped, and what the operator is told
+        /// about it - is unit testable without a database. A bad or unresolvable entry only ever costs
+        /// itself: the rest of the list is still granted, because one mistyped name is not a reason to
+        /// leave everybody else locked out.
+        /// </remarks>
+        public async Task<List<KeyValuePair<SqlDatabaseUser, Guid>>> ResolveUsersAsync(IList<SqlDatabaseUser> users,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var resolved = new List<KeyValuePair<SqlDatabaseUser, Guid>>();
+            if (users == null || users.Count == 0) return resolved;
+
+            foreach (var user in users)
+            {
+                if (user == null) continue;
+
+                var validationError = user.GetValidationError();
+                if (validationError != null)
+                {
+                    _logger.LogWarning($"Skipping a configured database user: {validationError}");
+                    continue;
+                }
+
+                Guid objectId;
+                if (!user.TryGetObjectId(out objectId))
+                {
+                    Guid? looked;
+                    try
+                    {
+                        looked = _resolver == null
+                            ? null
+                            : await _resolver.ResolveObjectIdAsync(user, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning($"Could not look up database user '{user.Login}' in Microsoft Entra ID: {ex.Message}");
+                        looked = null;
+                    }
+
+                    if (looked == null || looked.Value == Guid.Empty)
+                    {
+                        _logger.LogWarning(
+                            $"Skipping database user '{user.Login}': its Microsoft Entra object ID could not be resolved. " +
+                            "Either grant the installer's app registration permission to read the directory, or paste the " +
+                            "principal's Object ID into the installer next to the name - it is on the principal's overview " +
+                            "blade in the Azure portal, and with it no directory lookup is needed.");
+                        continue;
+                    }
+
+                    objectId = looked.Value;
+                }
+
+                resolved.Add(new KeyValuePair<SqlDatabaseUser, Guid>(user, objectId));
+            }
+
+            return resolved;
+        }
+
+        /// <summary>
+        /// Creates or repairs a contained database user for each configured principal. Returns how many
+        /// were granted successfully.
+        /// </summary>
+        public async Task<int> GrantConfiguredUsersAsync(string connectionString, IList<SqlDatabaseUser> users,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (string.IsNullOrWhiteSpace(connectionString)) return 0;
+
+            var resolved = await ResolveUsersAsync(users, cancellationToken).ConfigureAwait(false);
+            if (resolved.Count == 0) return 0;
+
+            _logger.LogInformation(
+                $"Granting {resolved.Count} configured database user(s) access to the database " +
+                $"({string.Join(", ", DatabaseUserRoles)}): {string.Join(", ", resolved.Select(r => r.Key.Login))}...");
+
+            var granted = 0;
+            try
+            {
+                using (var connection = AzureSqlTokenAuth.CreateConnection(connectionString))
+                {
+                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                    foreach (var entry in resolved)
+                    {
+                        var sql = SqlContainedUserScript.CreateUserAndGrantRoles(entry.Key.Login, entry.Value, DatabaseUserRoles);
+
+                        try
+                        {
+                            using (var cmd = connection.CreateCommand())
+                            {
+                                cmd.CommandText = sql;
+                                cmd.CommandTimeout = 120;
+                                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                            }
+                            granted++;
+                        }
+                        catch (SqlException ex)
+                        {
+                            // One bad entry must not cost the others their access.
+                            _logger.LogWarning($"Could not grant database access to '{entry.Key.Login}': {ex.Message}");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    $"Could not grant the configured database users access: {ex.Message}. The people listed in the installer " +
+                    "will not be able to query the database until this is fixed.");
+                return granted;
+            }
+
+            if (granted > 0)
+            {
+                _logger.LogInformation(
+                    $"{granted} database user(s) can now sign in to the database with their own Microsoft Entra account. " +
+                    "The SQL Server's Microsoft Entra administrator was not changed.");
+            }
+
+            return granted;
+        }
+    }
+
+    /// <summary>
+    /// Resolves Microsoft Entra principals with Microsoft Graph, trying each app registration the
+    /// installer knows about until one has enough directory permission.
+    /// </summary>
+    /// <remarks>
+    /// Two credentials are tried because neither is guaranteed to work. The installer's own app
+    /// registration is an Azure Resource Manager identity and often has no Graph directory permission at
+    /// all; the runtime account does read user metadata (<c>User.Read.All</c>) and so usually can resolve a
+    /// UPN. Falling back rather than picking one keeps this working on tenants that granted either.
+    /// </remarks>
+    public class GraphEntraPrincipalResolver : IEntraPrincipalResolver
+    {
+        private readonly ILogger _logger;
+        private readonly List<AppRegistrationCredentials> _candidates;
+
+        public GraphEntraPrincipalResolver(ILogger logger, params AppRegistrationCredentials[] candidateAccounts)
+        {
+            _logger = logger;
+            _candidates = (candidateAccounts ?? new AppRegistrationCredentials[0])
+                .Where(IsUsable)
+                .ToList();
+        }
+
+        static bool IsUsable(AppRegistrationCredentials account)
+        {
+            return account != null
+                && !string.IsNullOrWhiteSpace(account.DirectoryId)
+                && !string.IsNullOrWhiteSpace(account.ClientId)
+                && !string.IsNullOrWhiteSpace(account.Secret);
+        }
+
+        public async Task<Guid?> ResolveObjectIdAsync(SqlDatabaseUser user, CancellationToken cancellationToken)
+        {
+            if (user == null || string.IsNullOrWhiteSpace(user.Login)) return null;
+
+            if (_candidates.Count == 0)
+            {
+                _logger?.LogWarning(
+                    $"No app registration with a client secret is configured, so '{user.Login}' cannot be looked up in " +
+                    "Microsoft Entra ID. Supply the principal's Object ID in the installer instead.");
+                return null;
+            }
+
+            Exception lastFailure = null;
+
+            foreach (var account in _candidates)
+            {
+                try
+                {
+                    var credential = new Azure.Identity.ClientSecretCredential(account.DirectoryId, account.ClientId, account.Secret);
+                    var graph = new Microsoft.Graph.GraphServiceClient(credential);
+
+                    var objectId = user.IsGroup
+                        ? await ResolveGroupAsync(graph, user.Login, cancellationToken).ConfigureAwait(false)
+                        : await ResolveUserAsync(graph, user.Login, cancellationToken).ConfigureAwait(false);
+
+                    if (objectId != null) return objectId;
+                }
+                catch (Exception ex)
+                {
+                    // Typically a missing directory-read grant on this particular app registration. Keep the
+                    // reason for the final message, but try the other one before giving up.
+                    lastFailure = ex;
+                }
+            }
+
+            if (lastFailure != null)
+            {
+                _logger?.LogWarning($"Microsoft Graph could not resolve '{user.Login}': {lastFailure.Message}");
+            }
+
+            return null;
+        }
+
+        static async Task<Guid?> ResolveUserAsync(Microsoft.Graph.GraphServiceClient graph, string login, CancellationToken cancellationToken)
+        {
+            // A UPN is a valid key for the users collection, so this needs no filter and no ConsistencyLevel.
+            var found = await graph.Users[login.Trim()]
+                .GetAsync(rc => rc.QueryParameters.Select = new[] { "id", "userPrincipalName" }, cancellationToken)
+                .ConfigureAwait(false);
+
+            return ParseId(found?.Id);
+        }
+
+        static async Task<Guid?> ResolveGroupAsync(Microsoft.Graph.GraphServiceClient graph, string login, CancellationToken cancellationToken)
+        {
+            var escaped = login.Trim().Replace("'", "''");
+
+            var found = await graph.Groups
+                .GetAsync(rc =>
+                {
+                    rc.QueryParameters.Filter = $"displayName eq '{escaped}'";
+                    rc.QueryParameters.Select = new[] { "id", "displayName" };
+                }, cancellationToken)
+                .ConfigureAwait(false);
+
+            var matches = found?.Value;
+            if (matches == null || matches.Count == 0) return null;
+
+            if (matches.Count > 1)
+            {
+                // Display names are not unique, so guessing could grant the wrong group access to the data.
+                throw new InvalidOperationException(
+                    $"more than one group is named '{login}'. Supply the group's Object ID in the installer instead.");
+            }
+
+            return ParseId(matches[0].Id);
+        }
+
+        static Guid? ParseId(string id)
+        {
+            Guid parsed;
+            if (!string.IsNullOrWhiteSpace(id) && Guid.TryParse(id, out parsed) && parsed != Guid.Empty) return parsed;
+            return null;
+        }
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlEntraAccessBootstrap.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlEntraAccessBootstrap.cs
@@ -1,0 +1,243 @@
+using App.ControlPanel.Engine.Entities;
+using Azure.Core;
+using Azure.Identity;
+using DataUtils.Sql;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace App.ControlPanel.Engine.InstallerTasks
+{
+    /// <summary>
+    /// Repairs the installer's own access to an Azure SQL database by signing a human Microsoft Entra
+    /// administrator in interactively and creating the contained database user the installer needs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Exists to break a genuine chicken-and-egg. On a server with Microsoft Entra-only authentication the
+    /// installer signs in as its own service principal. If that principal is not the server's Entra
+    /// administrator - typically because somebody assigned a named user as administrator afterwards, which
+    /// Azure treats as <em>replacing</em> the previous one because it permits exactly one - then it cannot
+    /// sign in, and the only identity that could grant it access is an administrator nobody is currently
+    /// authenticated as. There is no SQL password to fall back on, because the server rejects SQL logins
+    /// outright.
+    /// </para>
+    /// <para>
+    /// The way out is the person sitting in front of the installer: they can sign in interactively as the
+    /// administrator, which the installer cannot. So we ask them to, use their token for exactly one
+    /// statement batch - creating the contained user - and then go back to the service principal for the
+    /// rest of the install. Deliberately NOT done by reassigning the server's administrator over ARM: that
+    /// would mutate a live customer server and could strand the assignment if the installer died halfway.
+    /// </para>
+    /// <para>
+    /// Never runs unattended. A headless process has nobody to sign in, so prompting there would hang a
+    /// scripted install until it timed out, which is worse than the clear failure it replaces.
+    /// </para>
+    /// <para>See issue #117.</para>
+    /// </remarks>
+    public static class SqlEntraAccessBootstrap
+    {
+        /// <summary>
+        /// Roles the installer's own principal needs. It applies Entity Framework migrations, so it
+        /// creates, alters and drops tables and stored procedures - <c>db_owner</c> is what actually
+        /// covers that, and it is the access the principal had when it was the server administrator.
+        /// </summary>
+        public static readonly IReadOnlyList<string> InstallerRoles = new[] { "db_owner" };
+
+        /// <summary>
+        /// How long to wait for the operator to complete the sign-in before giving up. Long enough to find
+        /// a password and satisfy MFA, short enough that an install left running against an empty desk
+        /// still finishes with a real error instead of hanging.
+        /// </summary>
+        public static readonly TimeSpan SignInTimeout = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Whether this process can ask a human to sign in. False for the headless child processes the
+        /// installer launches (<c>--initdb</c> / <c>--registerconfig</c>) and for any scripted run.
+        /// </summary>
+        public static bool CanPromptForSignIn()
+        {
+            try
+            {
+                return Environment.UserInteractive;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Signs an administrator in and grants the installer's service principal a contained database
+        /// user. Returns whether the database now has that user.
+        /// </summary>
+        /// <remarks>
+        /// Best-effort and non-throwing: every failure is reported and returns false, so the caller falls
+        /// back to its normal "could not connect" diagnosis rather than replacing one confusing error with
+        /// another.
+        /// </remarks>
+        /// <param name="connectionString">Connection string for the target database. Must be a token-auth one.</param>
+        /// <param name="tenantId">Directory the administrator lives in - the installer's own tenant.</param>
+        /// <param name="installerObjectId">Object ID of the installer's service principal.</param>
+        /// <param name="installerLogin">Name to give the contained user; the installer's client ID or app name.</param>
+        public static async Task<bool> TryRepairInstallerAccessAsync(string connectionString, string tenantId,
+            Guid installerObjectId, string installerLogin, ILogger logger, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (string.IsNullOrWhiteSpace(connectionString)) return false;
+
+            if (installerObjectId == Guid.Empty)
+            {
+                logger?.LogWarning(
+                    "Cannot repair the installer's database access: its service principal object ID could not be resolved.");
+                return false;
+            }
+
+            if (!AzureSqlTokenAuth.NeedsAccessToken(connectionString))
+            {
+                // A SQL-authentication connection string has a login of its own; there is nothing here to repair.
+                return false;
+            }
+
+            if (!CanPromptForSignIn())
+            {
+                logger?.LogError(
+                    "The installer's service principal has no access to this database, and this process cannot prompt anyone to " +
+                    "sign in to repair it. Re-run the installer interactively, or make the installer's service principal the " +
+                    "SQL Server's Microsoft Entra administrator again.");
+                return false;
+            }
+
+            logger?.LogWarning(
+                "The installer's service principal cannot sign in to the database, so it will ask you to sign in as a Microsoft " +
+                "Entra administrator of this SQL Server and repair its own access. A browser window will open. Sign in with an " +
+                "account that is the server's Microsoft Entra administrator - the same one shown in the authentication line " +
+                "above. Nothing is stored: the sign-in is used once, to create the database user the installer needs.");
+
+            AccessToken adminToken;
+            try
+            {
+                adminToken = await AcquireAdminTokenAsync(tenantId, logger, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                logger?.LogError(
+                    $"The administrator sign-in was cancelled or did not complete within {SignInTimeout.TotalMinutes:0} minutes, " +
+                    "so the installer could not repair its database access.");
+                return false;
+            }
+            catch (AuthenticationFailedException ex)
+            {
+                logger?.LogError($"The administrator sign-in failed, so the installer could not repair its database access: {ex.Message}");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError($"Could not sign in to repair the installer's database access: {ex.Message}");
+                return false;
+            }
+
+            var script = SqlContainedUserScript.CreateUserAndGrantRoles(installerLogin, installerObjectId, InstallerRoles);
+
+            try
+            {
+                using (var connection = new SqlConnection(connectionString))
+                {
+                    connection.AccessToken = adminToken.Token;
+                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                    using (var cmd = connection.CreateCommand())
+                    {
+                        cmd.CommandText = script;
+                        cmd.CommandTimeout = 120;
+                        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (SqlException ex)
+            {
+                // 18456 here means the person who signed in is not an administrator of this server either,
+                // which is a different problem from the one we set out to fix - so name it rather than
+                // letting it read as "the repair does not work".
+                if (ex.Number == SqlLoginFailedErrorNumber)
+                {
+                    logger?.LogError(
+                        "The account you signed in with was rejected by SQL Server, so it is not this server's Microsoft Entra " +
+                        "administrator and cannot grant database access. Check SQL Server > Settings > Microsoft Entra ID in the " +
+                        "Azure portal to see which account is the administrator, and re-run the installer signing in as that one.");
+                }
+                else
+                {
+                    logger?.LogError($"Could not create the installer's database user: {ex.Message}");
+                }
+                return false;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError($"Could not create the installer's database user: {ex.Message}");
+                return false;
+            }
+
+            logger?.LogInformation(
+                $"Created contained database user '{installerLogin}' ({string.Join(", ", InstallerRoles)}) for the installer's " +
+                "service principal. The installer can now sign in to apply the schema upgrade, and future runs will not need " +
+                "this sign-in. The SQL Server's Microsoft Entra administrator was NOT changed.");
+
+            return true;
+        }
+
+        /// <summary>SQL Server's "Login failed for user" error.</summary>
+        public const int SqlLoginFailedErrorNumber = 18456;
+
+        /// <summary>
+        /// Gets a SQL access token for a human administrator, preferring the system browser and falling
+        /// back to a device code when no browser can be opened (Server Core, a locked-down jump box, or a
+        /// remote session with no default browser registered).
+        /// </summary>
+        static async Task<AccessToken> AcquireAdminTokenAsync(string tenantId, ILogger logger, CancellationToken cancellationToken)
+        {
+            var request = new TokenRequestContext(new[] { AzureSqlTokenAuth.SqlTokenScope });
+
+            using (var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                timeout.CancelAfter(SignInTimeout);
+
+                try
+                {
+                    // TenantId is pinned to the installer's own directory: the administrator of a SQL server
+                    // in this subscription lives there, and leaving it unset would let the browser's existing
+                    // session sign in against some other tenant the operator happens to be signed in to.
+                    var browser = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
+                    {
+                        TenantId = string.IsNullOrWhiteSpace(tenantId) ? null : tenantId,
+                    });
+
+                    return await browser.GetTokenAsync(request, timeout.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(
+                        $"Could not sign in with a browser ({ex.Message}). Falling back to device-code sign-in.");
+                }
+
+                var deviceCode = new DeviceCodeCredential(new DeviceCodeCredentialOptions
+                {
+                    TenantId = string.IsNullOrWhiteSpace(tenantId) ? null : tenantId,
+                    DeviceCodeCallback = (info, ct) =>
+                    {
+                        logger?.LogWarning($"To repair the installer's database access: {info.Message}");
+                        return Task.CompletedTask;
+                    },
+                });
+
+                return await deviceCode.GetTokenAsync(request, timeout.Token).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlEntraAccessBootstrap.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlEntraAccessBootstrap.cs
@@ -81,17 +81,19 @@ namespace App.ControlPanel.Engine.InstallerTasks
         /// </remarks>
         /// <param name="connectionString">Connection string for the target database. Must be a token-auth one.</param>
         /// <param name="tenantId">Directory the administrator lives in - the installer's own tenant.</param>
-        /// <param name="installerObjectId">Object ID of the installer's service principal.</param>
-        /// <param name="installerLogin">Name to give the contained user; the installer's client ID or app name.</param>
+        /// <param name="installerClientId">
+        /// Application (client) ID of the installer's app registration. This - NOT its object ID - is what
+        /// Azure SQL matches a service principal on.
+        /// </param>
         public static async Task<bool> TryRepairInstallerAccessAsync(string connectionString, string tenantId,
-            Guid installerObjectId, string installerLogin, ILogger logger, CancellationToken cancellationToken = default(CancellationToken))
+            Guid installerClientId, ILogger logger, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrWhiteSpace(connectionString)) return false;
 
-            if (installerObjectId == Guid.Empty)
+            if (installerClientId == Guid.Empty)
             {
                 logger?.LogWarning(
-                    "Cannot repair the installer's database access: its service principal object ID could not be resolved.");
+                    "Cannot repair the installer's database access: its application (client) ID is not a valid GUID.");
                 return false;
             }
 
@@ -139,7 +141,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 return false;
             }
 
-            var script = SqlContainedUserScript.CreateUserAndGrantRoles(installerLogin, installerObjectId, InstallerRoles);
+            var script = BuildInstallerUserScript(installerClientId);
 
             try
             {
@@ -181,7 +183,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
             }
 
             logger?.LogInformation(
-                $"Created contained database user '{installerLogin}' ({string.Join(", ", InstallerRoles)}) for the installer's " +
+                $"Created contained database user '{installerClientId}' ({string.Join(", ", InstallerRoles)}) for the installer's " +
                 "service principal. The installer can now sign in to apply the schema upgrade, and future runs will not need " +
                 "this sign-in. The SQL Server's Microsoft Entra administrator was NOT changed.");
 
@@ -190,6 +192,24 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
         /// <summary>SQL Server's "Login failed for user" error.</summary>
         public const int SqlLoginFailedErrorNumber = 18456;
+
+        /// <summary>
+        /// Builds the contained-user script for the installer's own service principal.
+        /// </summary>
+        /// <remarks>
+        /// The application (client) ID is deliberately used as BOTH the database user name and the SID.
+        /// The SID part is the one that matters and the one that is easy to get wrong: Azure SQL matches a
+        /// user or group on its object ID, but a service principal - including any managed identity - on
+        /// its <b>application (client) ID</b>. SQL Server does not validate the SID against Entra ID, so
+        /// supplying the object ID instead creates the user successfully and only fails later, at sign-in,
+        /// with <c>Login failed for user '&lt;token-identified principal&gt;'</c>. Separated out so that
+        /// rule is directly testable.
+        /// </remarks>
+        public static string BuildInstallerUserScript(Guid installerClientId)
+        {
+            return SqlContainedUserScript.CreateUserAndGrantRoles(
+                installerClientId.ToString(), installerClientId, InstallerRoles);
+        }
 
         /// <summary>
         /// Gets a SQL access token for a human administrator, preferring the system browser and falling

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
@@ -52,9 +52,11 @@ namespace App.ControlPanel.Engine.InstallerTasks
             };
 
             // The principal type is only carried on the server payload's embedded administrator, not on the
-            // authoritative child resource read below. Keep it, but discard it if the two disagree about who
-            // the administrator is - that means the embedded copy is stale and its type cannot be trusted.
-            var embeddedAdminLogin = data.Administrators?.Login;
+            // authoritative child resource read below. Correlate the two by object ID (SID) rather than by
+            // login: a login is a display name, so it is neither stable nor unique, and two administrators
+            // that merely share one are not the same principal. Requiring both SIDs to be present and equal
+            // also stops a pair of absent values matching each other.
+            var embeddedAdminSid = data.Administrators?.Sid;
             var embeddedPrincipalType = data.Administrators?.PrincipalType?.ToString();
 
             // Always read the authoritative child, even when the embedded administrator says true:
@@ -80,11 +82,11 @@ namespace App.ControlPanel.Engine.InstallerTasks
             try
             {
                 var admin = await sqlServer.GetSqlServerAzureADAdministrators().GetAsync("ActiveDirectory");
-                state.HasEntraAdmin = admin.Value.Data.Sid.HasValue;
+                var childSid = admin.Value.Data.Sid;
+                state.HasEntraAdmin = childSid.HasValue;
                 state.EntraAdminLogin = admin.Value.Data.Login;
 
-                if (state.HasEntraAdmin
-                    && string.Equals(state.EntraAdminLogin, embeddedAdminLogin, StringComparison.OrdinalIgnoreCase))
+                if (childSid.HasValue && embeddedAdminSid.HasValue && embeddedAdminSid.Value == childSid.Value)
                 {
                     state.EntraAdminPrincipalType = embeddedPrincipalType;
                 }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace App.ControlPanel.Engine.InstallerTasks
@@ -128,10 +129,12 @@ namespace App.ControlPanel.Engine.InstallerTasks
     public class SqlIdentityAccessTask
     {
         private readonly ILogger _logger;
+        private readonly IEntraPrincipalResolver _resolver;
 
-        public SqlIdentityAccessTask(ILogger logger)
+        public SqlIdentityAccessTask(ILogger logger, IEntraPrincipalResolver resolver = null)
         {
             _logger = logger;
+            _resolver = resolver;
         }
 
         /// <summary>
@@ -139,9 +142,20 @@ namespace App.ControlPanel.Engine.InstallerTasks
         /// database roles the runtime needs.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Best-effort by design: it returns false rather than throwing, because a failure here does not
         /// invalidate the rest of the install and the operator can grant access by hand. It is also
         /// idempotent, so re-running the installer is safe.
+        /// </para>
+        /// <para>
+        /// <paramref name="principalObjectId"/> is what ARM reports for a system-assigned managed identity,
+        /// but it is NOT what Azure SQL matches the sign-in against: a service principal - which a managed
+        /// identity is - is identified by its <b>application (client) ID</b>. The two are different GUIDs,
+        /// and SQL Server does not validate either, so using the object ID produces a user that exists, sits
+        /// in the right roles, and is refused at every sign-in. So the application ID is resolved from
+        /// Microsoft Graph, and when that is not permitted we let SQL Server resolve the name itself with
+        /// <c>FROM EXTERNAL PROVIDER</c> instead of writing an identifier we know to be wrong.
+        /// </para>
         /// </remarks>
         public async Task<bool> GrantDatabaseAccessAsync(string connectionString, string principalName, Guid principalObjectId, IEnumerable<string> roles)
         {
@@ -159,7 +173,30 @@ namespace App.ControlPanel.Engine.InstallerTasks
             }
 
             var roleList = roles == null ? new List<string>() : roles.ToList();
-            var sql = SqlContainedUserScript.CreateUserAndGrantRoles(principalName, principalObjectId, roleList);
+
+            Guid? applicationId = null;
+            if (_resolver != null)
+            {
+                try
+                {
+                    applicationId = await _resolver.ResolveApplicationIdAsync(principalObjectId, CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogInformation($"Could not resolve the application ID for '{principalName}': {ex.Message}");
+                }
+            }
+
+            string sql = BuildGrantScript(principalName, applicationId, roleList);
+            if (applicationId == null)
+            {
+                _logger.LogInformation(
+                    $"Could not read the application ID of managed identity '{principalName}' from Microsoft Graph, so SQL Server " +
+                    "will be asked to resolve the name itself. That needs the SQL Server's own identity to hold the Microsoft " +
+                    "Entra 'Directory Readers' role; if it does not, the grant fails with \"Principal could not be found\" and " +
+                    "you should instead grant the installer's app registration 'Application.Read.All' (or 'Directory.Read.All') " +
+                    "and re-run.");
+            }
 
             _logger.LogInformation(
                 $"Granting the App Service managed identity '{principalName}' access to the database " +
@@ -195,6 +232,22 @@ namespace App.ControlPanel.Engine.InstallerTasks
 
             _logger.LogInformation($"App Service managed identity '{principalName}' now has database access.");
             return true;
+        }
+
+        /// <summary>
+        /// Chooses how to declare the managed identity's contained user: by its application ID when we
+        /// could read one, otherwise by asking SQL Server to resolve the name itself.
+        /// </summary>
+        /// <remarks>
+        /// Split out so the choice is testable without a database. The object ID is deliberately never a
+        /// candidate - writing it would create a user that exists, holds the right roles, and is refused at
+        /// every sign-in.
+        /// </remarks>
+        public static string BuildGrantScript(string principalName, Guid? applicationId, IEnumerable<string> roles)
+        {
+            return applicationId != null
+                ? SqlContainedUserScript.CreateUserAndGrantRoles(principalName, applicationId.Value, roles)
+                : SqlContainedUserScript.CreateUserFromExternalProviderAndGrantRoles(principalName, roles);
         }
     }
 }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
@@ -28,6 +28,10 @@ namespace App.ControlPanel.Engine.InstallerTasks
             var decision = SqlServerAuthDetection.Decide(state,
                 state.HasSqlAdminLogin && !string.IsNullOrWhiteSpace(sqlPassword), configuredMode);
             logger?.LogInformation($"SQL authentication: {decision.Reason}");
+
+            var noInteractiveAdmin = SqlServerAuthDetection.GetInteractiveAdminWarning(state, decision);
+            if (!string.IsNullOrEmpty(noInteractiveAdmin)) logger?.LogWarning(noInteractiveAdmin);
+
             return decision;
         }
 
@@ -46,6 +50,12 @@ namespace App.ControlPanel.Engine.InstallerTasks
             {
                 HasSqlAdminLogin = !string.IsNullOrWhiteSpace(data.AdministratorLogin),
             };
+
+            // The principal type is only carried on the server payload's embedded administrator, not on the
+            // authoritative child resource read below. Keep it, but discard it if the two disagree about who
+            // the administrator is - that means the embedded copy is stale and its type cannot be trusted.
+            var embeddedAdminLogin = data.Administrators?.Login;
+            var embeddedPrincipalType = data.Administrators?.PrincipalType?.ToString();
 
             // Always read the authoritative child, even when the embedded administrator says true:
             // that value can disagree after authentication is changed through the portal/CLI.
@@ -72,6 +82,12 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 var admin = await sqlServer.GetSqlServerAzureADAdministrators().GetAsync("ActiveDirectory");
                 state.HasEntraAdmin = admin.Value.Data.Sid.HasValue;
                 state.EntraAdminLogin = admin.Value.Data.Login;
+
+                if (state.HasEntraAdmin
+                    && string.Equals(state.EntraAdminLogin, embeddedAdminLogin, StringComparison.OrdinalIgnoreCase))
+                {
+                    state.EntraAdminPrincipalType = embeddedPrincipalType;
+                }
             }
             catch (RequestFailedException ex) when (ex.Status == 404)
             {

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
@@ -20,16 +20,24 @@ namespace App.ControlPanel.Engine.InstallerTasks
     public static class SqlServerAuthReader
     {
         public static async Task<SqlAuthDecision> DetectAsync(SqlServerResource sqlServer, string sqlPassword,
-            SqlServerAuthMode configuredMode, ILogger logger)
+            SqlServerAuthMode configuredMode, ILogger logger, Guid installerObjectId = default(Guid),
+            bool hasConfiguredDatabaseUsers = false)
         {
             if (sqlServer == null) throw new ArgumentNullException(nameof(sqlServer));
 
             var state = await ReadAsync(sqlServer, logger);
             var decision = SqlServerAuthDetection.Decide(state,
                 state.HasSqlAdminLogin && !string.IsNullOrWhiteSpace(sqlPassword), configuredMode);
+            decision.ServerState = state;
             logger?.LogInformation($"SQL authentication: {decision.Reason}");
 
-            var noInteractiveAdmin = SqlServerAuthDetection.GetInteractiveAdminWarning(state, decision);
+            // Said BEFORE anything tries to connect: without it, a server whose administrator was reassigned
+            // to a person looks completely healthy for several minutes and then fails with a login error
+            // that names no principal at all.
+            var lockout = SqlServerAuthDetection.GetInstallerLockoutWarning(state, decision, installerObjectId);
+            if (!string.IsNullOrEmpty(lockout)) logger?.LogWarning(lockout);
+
+            var noInteractiveAdmin = SqlServerAuthDetection.GetInteractiveAdminWarning(state, decision, hasConfiguredDatabaseUsers);
             if (!string.IsNullOrEmpty(noInteractiveAdmin)) logger?.LogWarning(noInteractiveAdmin);
 
             return decision;
@@ -85,6 +93,7 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 var childSid = admin.Value.Data.Sid;
                 state.HasEntraAdmin = childSid.HasValue;
                 state.EntraAdminLogin = admin.Value.Data.Login;
+                state.EntraAdminSid = childSid;
 
                 if (childSid.HasValue && embeddedAdminSid.HasValue && embeddedAdminSid.Value == childSid.Value)
                 {

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
@@ -385,23 +385,36 @@ namespace App.ControlPanel.Engine.Entities
         /// The database user name. For a system-assigned managed identity this is the Azure resource name
         /// (e.g. the App Service name), which is also the identity's display name in Entra ID.
         /// </param>
-        /// <param name="principalObjectId">The Entra object (principal) ID of the identity.</param>
+        /// <param name="principalSid">
+        /// The value Azure SQL matches the sign-in against, and it is NOT the same kind of ID for every
+        /// principal:
+        /// <list type="bullet">
+        /// <item><description>a <b>user</b> or <b>group</b> - its Entra <b>object ID</b>;</description></item>
+        /// <item><description>a <b>service principal</b>, which includes an app registration and any
+        /// managed identity - its <b>application (client) ID</b>.</description></item>
+        /// </list>
+        /// Getting this wrong fails silently: SQL Server does not validate the value against Entra ID, so
+        /// <c>CREATE USER</c> succeeds and only the subsequent sign-in is rejected, with
+        /// <c>Login failed for user '&lt;token-identified principal&gt;'</c> - an error that names no
+        /// principal and looks nothing like a bad SID. See the remarks on
+        /// <see cref="CreateUserAndGrantRoles"/>'s caller and the CREATE USER documentation.
+        /// </param>
         /// <param name="roles">Database roles to add the user to.</param>
-        public static string CreateUserAndGrantRoles(string principalName, Guid principalObjectId, IEnumerable<string> roles)
+        public static string CreateUserAndGrantRoles(string principalName, Guid principalSid, IEnumerable<string> roles)
         {
             if (string.IsNullOrWhiteSpace(principalName))
             {
                 throw new ArgumentException($"'{nameof(principalName)}' cannot be null or empty.", nameof(principalName));
             }
-            if (principalObjectId == Guid.Empty)
+            if (principalSid == Guid.Empty)
             {
-                throw new ArgumentException($"'{nameof(principalObjectId)}' cannot be an empty GUID.", nameof(principalObjectId));
+                throw new ArgumentException($"'{nameof(principalSid)}' cannot be an empty GUID.", nameof(principalSid));
             }
             if (roles == null) throw new ArgumentNullException(nameof(roles));
 
             var quotedName = QuoteIdentifier(principalName);
             var literalName = QuoteLiteral(principalName);
-            var sid = ToSqlSid(principalObjectId);
+            var sid = ToSqlSid(principalSid);
 
             var sql = new System.Text.StringBuilder();
             sql.AppendLine($"IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE [name] = N'{literalName}')");

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
@@ -172,22 +172,33 @@ namespace App.ControlPanel.Engine.Entities
             }
 
             var opening = serverState.HasEntraAdmin
-                ? "This SQL Server's only Microsoft Entra administrator is an application (the installer's own service " +
-                  $"principal{FormatAdminLogin(serverState.EntraAdminLogin)}), which nobody can sign in as."
+                ? "This SQL Server's only Microsoft Entra administrator is an application" +
+                  $"{FormatAdminLogin(serverState.EntraAdminLogin)}, which nobody can sign in as. On a new install this is " +
+                  "normally the installer's own service principal, which must keep access so it can apply future schema upgrades."
                 : "This SQL Server has no Microsoft Entra administrator assigned.";
+
+            // Only a server with SQL authentication actually disabled leaves an operator with no way in at
+            // all. On a mixed-auth server the SQL administrator login still works, so say so rather than
+            // overstate the problem.
+            var consequence = serverState.EntraOnlyAuthEnabled
+                ? " Because SQL authentication is disabled on this server, no person can sign in to the database, so " +
+                  "querying it by hand - for example with the Azure portal's Query Editor, SSMS or Azure Data Studio - " +
+                  "will be refused with \"You don't have access to this database\". That message reports a successful " +
+                  "sign-in and blames database permissions, which is misleading: the real cause is that you are not an " +
+                  "administrator of the server."
+                : " SQL authentication is still enabled on this server, so the SQL administrator login continues to work. " +
+                  "Signing in with Microsoft Entra ID will be refused with \"You don't have access to this database\" - a " +
+                  "misleading message, because the real cause is that you are not a Microsoft Entra administrator of the " +
+                  "server rather than anything to do with database permissions.";
 
             return opening +
                 " The solution itself is unaffected and will keep importing: the App Service and Automation account " +
-                "authenticate as themselves. But because SQL authentication is disabled, no person can sign in to the " +
-                "database, so querying it by hand - for example with the Azure portal's Query Editor, SSMS or Azure Data " +
-                "Studio - will be refused with \"You don't have access to this database\". That message reports a " +
-                "successful sign-in and blames database permissions, which is misleading: the real cause is that you are " +
-                "not an administrator of the server. " +
-                "If you want to browse or query the data yourself, assign a Microsoft Entra administrator in the Azure " +
-                "portal: SQL Server > Settings > Microsoft Entra ID > Set admin, and pick a user or a security group. " +
-                "Azure permits only ONE Entra administrator per server, so prefer a group - replacing this application " +
-                "administrator with a single user would leave the installer unable to apply future schema upgrades unless " +
-                "that service principal is a member of it.";
+                "authenticate as themselves." + consequence +
+                " If you want to browse or query the data with your own Microsoft Entra account, assign a Microsoft Entra " +
+                "administrator in the Azure portal: SQL Server > Settings > Microsoft Entra ID > Set admin, and pick a user " +
+                "or a security group. Azure permits only ONE Entra administrator per server, so prefer a group - replacing " +
+                "an application administrator with a single user would leave the installer unable to apply future schema " +
+                "upgrades unless that service principal is a member of it.";
         }
 
         static string FormatAdminLogin(string login)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
@@ -37,6 +37,18 @@ namespace App.ControlPanel.Engine.Entities
         public string EntraAdminLogin { get; set; }
 
         /// <summary>
+        /// Object (principal) ID of the Entra administrator, read from the authoritative
+        /// <c>administrators/ActiveDirectory</c> child resource. Null when the server has no Entra
+        /// administrator.
+        /// </summary>
+        /// <remarks>
+        /// This is what makes "can the installer actually sign in?" answerable before trying: the installer
+        /// knows its own service principal's object ID, so it can compare the two. A login name cannot be
+        /// used for that - it is a display name, so it is neither stable nor unique.
+        /// </remarks>
+        public Guid? EntraAdminSid { get; set; }
+
+        /// <summary>
         /// Principal type of the Entra administrator - "User", "Group" or "Application". An
         /// <c>Application</c> administrator is a service principal, which no person can sign in as.
         /// Null when the server has no Entra administrator or Azure did not report the type.
@@ -159,7 +171,12 @@ namespace App.ControlPanel.Engine.Entities
         /// say nothing rather than guess.
         /// </param>
         /// <param name="decision">The authentication method chosen for this run.</param>
-        public static string GetInteractiveAdminWarning(SqlServerAuthState serverState, SqlAuthDecision decision)
+        /// <param name="hasConfiguredDatabaseUsers">
+        /// Whether the installer config already lists people to grant database access to. When it does, the
+        /// install is about to fix this by itself, so the warning says so instead of asking for action.
+        /// </param>
+        public static string GetInteractiveAdminWarning(SqlServerAuthState serverState, SqlAuthDecision decision,
+            bool hasConfiguredDatabaseUsers = false)
         {
             if (decision == null || !decision.UsesEntraId) return null;
             if (serverState == null) return null;
@@ -194,14 +211,112 @@ namespace App.ControlPanel.Engine.Entities
                       : " SQL authentication is still enabled on this server, but Azure reports no SQL administrator login, " +
                         "so there is no alternative way in either.");
 
+            // Deliberately does NOT tell anyone to reassign the server's Entra administrator. Azure permits
+            // only one, so "Set admin" to a named user silently evicts the installer's service principal and
+            // breaks every future schema upgrade - which is exactly what happened to the deployment this
+            // guidance was rewritten for. Data access for people is a contained-user grant, which leaves the
+            // administrator alone, and the installer performs it because it is the only identity that can
+            // sign in as that administrator.
+            var remedy = hasConfiguredDatabaseUsers
+                ? " The database users configured in this installer will be granted access during this run, so the people " +
+                  "listed there will be able to query the database with their own Microsoft Entra account once it finishes."
+                : $" To give people access, add them to '{DatabaseUsersConfigUiName}' in the installer and re-run it: the " +
+                  "installer signs in as the administrator and creates a contained database user for each one. " +
+                  "Do NOT reassign the server's Microsoft Entra administrator to do this. Azure permits only ONE " +
+                  "administrator per server, so replacing this service principal - for example via SQL Server > Settings > " +
+                  "Microsoft Entra ID > Set admin - removes the identity that applies schema upgrades, and your next upgrade " +
+                  "will fail with \"Login failed for user '<token-identified principal>'\".";
+
             return opening +
                 " This does not affect the solution's own database access: the App Service and Automation account " +
-                "authenticate as themselves." + consequence +
-                " If you want to browse or query the data with your own Microsoft Entra account, assign a Microsoft Entra " +
-                "administrator in the Azure portal: SQL Server > Settings > Microsoft Entra ID > Set admin, and pick a user " +
-                "or a security group. Azure permits only ONE Entra administrator per server, so prefer a group - replacing " +
-                "an application administrator with a single user would leave the installer unable to apply future schema " +
-                "upgrades unless that service principal is a member of it.";
+                "authenticate as themselves." + consequence + remedy;
+        }
+
+        /// <summary>
+        /// Name of the installer setting that lists the people to grant database access to. Kept in one
+        /// place so the warning text and the UI cannot drift apart.
+        /// </summary>
+        public const string DatabaseUsersConfigUiName = "Azure Config > SQL database users";
+
+        /// <summary>
+        /// Warns, before anything tries to connect, that this run will authenticate to SQL as the installer's
+        /// service principal but that principal is not the server's Microsoft Entra administrator.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Deliberately a warning rather than a hard stop, because a mismatch is not proof of lockout: the
+        /// administrator may be a security <em>group</em> that contains the installer principal, and the
+        /// principal may already have a contained user in the database from an earlier run. Only an actual
+        /// login failure proves it, which is what <see cref="GetInstallerLockoutRemedy"/> is for.
+        /// </para>
+        /// <para>
+        /// Worth saying up front all the same: without it the operator gets several minutes of apparently
+        /// healthy install followed by a bare <c>Login failed for user '&lt;token-identified principal&gt;'</c>,
+        /// which names no principal and suggests nothing actionable.
+        /// </para>
+        /// </remarks>
+        /// <param name="installerObjectId">
+        /// Object ID of the installer's own service principal, or <see cref="Guid.Empty"/> when it could not
+        /// be resolved - in which case nothing is said rather than guessed.
+        /// </param>
+        public static string GetInstallerLockoutWarning(SqlServerAuthState serverState, SqlAuthDecision decision, Guid installerObjectId)
+        {
+            if (decision == null || !decision.UsesEntraId) return null;
+            if (serverState == null) return null;
+            if (installerObjectId == Guid.Empty) return null;
+
+            // We are the administrator, so there is nothing to worry about.
+            if (serverState.EntraAdminSid.HasValue && serverState.EntraAdminSid.Value == installerObjectId) return null;
+
+            if (!serverState.HasEntraAdmin)
+            {
+                return "This run will authenticate to SQL Server with Microsoft Entra ID, but the server has no Microsoft Entra " +
+                       "administrator assigned at all. Unless the installer's service principal already has a contained user in " +
+                       "the database, it will not be able to sign in and the schema upgrade cannot run.";
+            }
+
+            var isGroup = string.Equals(serverState.EntraAdminPrincipalType, "Group", StringComparison.OrdinalIgnoreCase);
+
+            return "This run will authenticate to SQL Server with Microsoft Entra ID as the installer's service principal " +
+                   $"(object ID '{installerObjectId}'), which is NOT this server's Microsoft Entra administrator" +
+                   $"{FormatAdminLogin(serverState.EntraAdminLogin)}. " +
+                   (isGroup
+                       ? "The administrator is a security group, so this is fine as long as the installer's service principal is " +
+                         "a member of it - which cannot be verified from here."
+                       : "That normally means the administrator was reassigned to a named user after the install, which Azure " +
+                         "treats as replacing the previous one because it permits only ONE administrator per server. Unless the " +
+                         "installer's service principal already has a contained user in the database, the schema upgrade will " +
+                         "fail with \"Login failed for user '<token-identified principal>'\".");
+        }
+
+        /// <summary>
+        /// The actionable explanation for a login failure that has already happened, once SQL has actually
+        /// rejected the installer's service principal.
+        /// </summary>
+        /// <remarks>
+        /// Separate from <see cref="GetInstallerLockoutWarning"/> because by this point the ambiguity is
+        /// gone - the principal demonstrably cannot sign in - so this states the cause outright and names
+        /// both routes back: let the installer repair it with an administrator sign-in, or restore the
+        /// administrator assignment it expects.
+        /// </remarks>
+        public static string GetInstallerLockoutRemedy(SqlServerAuthState serverState, Guid installerObjectId)
+        {
+            var adminDescription = serverState != null && serverState.HasEntraAdmin
+                ? $"This server's Microsoft Entra administrator is{FormatAdminLogin(serverState.EntraAdminLogin)}"
+                : "This server has no Microsoft Entra administrator assigned";
+
+            var identity = installerObjectId == Guid.Empty
+                ? "the installer's service principal"
+                : $"the installer's service principal (object ID '{installerObjectId}')";
+
+            return $"SQL Server rejected {identity}, so it has no access to this database. {adminDescription}, which is a " +
+                   "different principal. Azure permits only ONE Microsoft Entra administrator per SQL server, so assigning a " +
+                   "named user as administrator removes the installer's principal and with it the ability to apply schema " +
+                   "upgrades. Fix it either by letting the installer repair its own access - sign in when prompted as a " +
+                   "Microsoft Entra administrator of this server and it will create the contained database user it needs - or " +
+                   "by making the installer's service principal the server's Microsoft Entra administrator again. To give " +
+                   $"people access to query the data, use '{DatabaseUsersConfigUiName}' rather than reassigning the " +
+                   "administrator.";
         }
 
         static string FormatAdminLogin(string login)
@@ -221,6 +336,13 @@ namespace App.ControlPanel.Engine.Entities
 
         public SqlConnectionAuthMethod Method { get; }
         public string Reason { get; }
+
+        /// <summary>
+        /// What Azure reported about the server this decision was made from, or null when it could not be
+        /// inspected. Carried along so a later failure can be explained in terms of the actual server
+        /// configuration - which administrator is assigned - instead of a bare login error.
+        /// </summary>
+        public SqlServerAuthState ServerState { get; set; }
 
         public bool UsesEntraId => Method == SqlConnectionAuthMethod.EntraId;
     }

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
@@ -186,13 +186,16 @@ namespace App.ControlPanel.Engine.Entities
                   "will be refused with \"You don't have access to this database\". That message reports a successful " +
                   "sign-in and blames database permissions, which is misleading: the real cause is that you are not an " +
                   "administrator of the server."
-                : " SQL authentication is still enabled on this server, so the SQL administrator login continues to work. " +
-                  "Signing in with Microsoft Entra ID will be refused with \"You don't have access to this database\" - a " +
+                : " Signing in with Microsoft Entra ID will be refused with \"You don't have access to this database\" - a " +
                   "misleading message, because the real cause is that you are not a Microsoft Entra administrator of the " +
-                  "server rather than anything to do with database permissions.";
+                  "server rather than anything to do with database permissions." +
+                  (serverState.HasSqlAdminLogin
+                      ? " SQL authentication is still enabled on this server, so its SQL administrator login remains an option."
+                      : " SQL authentication is still enabled on this server, but Azure reports no SQL administrator login, " +
+                        "so there is no alternative way in either.");
 
             return opening +
-                " The solution itself is unaffected and will keep importing: the App Service and Automation account " +
+                " This does not affect the solution's own database access: the App Service and Automation account " +
                 "authenticate as themselves." + consequence +
                 " If you want to browse or query the data with your own Microsoft Entra account, assign a Microsoft Entra " +
                 "administrator in the Azure portal: SQL Server > Settings > Microsoft Entra ID > Set admin, and pick a user " +

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
@@ -400,7 +400,13 @@ namespace App.ControlPanel.Engine.Entities
         /// <see cref="CreateUserAndGrantRoles"/>'s caller and the CREATE USER documentation.
         /// </param>
         /// <param name="roles">Database roles to add the user to.</param>
-        public static string CreateUserAndGrantRoles(string principalName, Guid principalSid, IEnumerable<string> roles)
+        /// <param name="isGroup">
+        /// Whether the principal is a Microsoft Entra <b>group</b>, which SQL Server declares as
+        /// <c>TYPE = X</c>. <c>TYPE = E</c> covers a user and a service principal (an application or a
+        /// managed identity).
+        /// </param>
+        public static string CreateUserAndGrantRoles(string principalName, Guid principalSid, IEnumerable<string> roles,
+            bool isGroup = false)
         {
             if (string.IsNullOrWhiteSpace(principalName))
             {
@@ -415,13 +421,74 @@ namespace App.ControlPanel.Engine.Entities
             var quotedName = QuoteIdentifier(principalName);
             var literalName = QuoteLiteral(principalName);
             var sid = ToSqlSid(principalSid);
+            var externalType = isGroup ? "X" : "E";
+
+            var sql = new System.Text.StringBuilder();
+
+            // Repair a user an earlier release created with the wrong identifier. Such a user looks
+            // completely healthy - it exists, it is in the right roles - but its SID corresponds to no
+            // identity that will ever present a token, so every sign-in is refused. Without this the
+            // IF NOT EXISTS below would see it and skip, leaving it broken forever. Only external
+            // principals are touched, so a SQL user that happens to share the name is left alone.
+            sql.AppendLine($"IF EXISTS (SELECT 1 FROM sys.database_principals WHERE [name] = N'{literalName}'");
+            sql.AppendLine($"    AND [type] IN ('E', 'X') AND ([sid] IS NULL OR [sid] <> {sid}))");
+            sql.AppendLine("BEGIN");
+            sql.AppendLine($"    DROP USER {quotedName};");
+            sql.AppendLine("END");
+
+            sql.AppendLine($"IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE [name] = N'{literalName}')");
+            sql.AppendLine("BEGIN");
+            sql.AppendLine($"    CREATE USER {quotedName} WITH SID = {sid}, TYPE = {externalType};");
+            sql.AppendLine("END");
+
+            AppendRoleGrants(sql, quotedName, literalName, roles);
+
+            return sql.ToString();
+        }
+
+        /// <summary>
+        /// Emits an idempotent script that creates the contained user by asking SQL Server to resolve the
+        /// name in Microsoft Entra ID, for when the caller could not determine the principal's identifier
+        /// itself.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The fallback for a managed identity whose application (client) ID could not be read from
+        /// Microsoft Graph. SQL Server resolves the name itself, so the right identifier is guaranteed -
+        /// but only if the server's own identity holds the tenant-wide <b>Directory Readers</b> role,
+        /// which needs a Global Administrator to grant. Without it this fails with
+        /// <c>Principal '...' could not be found</c>.
+        /// </para>
+        /// <para>
+        /// Deliberately does NOT repair an existing user the way the SID form does: with no known-correct
+        /// identifier there is nothing to compare against, and dropping a working user to re-create it
+        /// would interrupt a running App Service for no proven reason.
+        /// </para>
+        /// </remarks>
+        public static string CreateUserFromExternalProviderAndGrantRoles(string principalName, IEnumerable<string> roles)
+        {
+            if (string.IsNullOrWhiteSpace(principalName))
+            {
+                throw new ArgumentException($"'{nameof(principalName)}' cannot be null or empty.", nameof(principalName));
+            }
+            if (roles == null) throw new ArgumentNullException(nameof(roles));
+
+            var quotedName = QuoteIdentifier(principalName);
+            var literalName = QuoteLiteral(principalName);
 
             var sql = new System.Text.StringBuilder();
             sql.AppendLine($"IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE [name] = N'{literalName}')");
             sql.AppendLine("BEGIN");
-            sql.AppendLine($"    CREATE USER {quotedName} WITH SID = {sid}, TYPE = E;");
+            sql.AppendLine($"    CREATE USER {quotedName} FROM EXTERNAL PROVIDER;");
             sql.AppendLine("END");
 
+            AppendRoleGrants(sql, quotedName, literalName, roles);
+
+            return sql.ToString();
+        }
+
+        static void AppendRoleGrants(System.Text.StringBuilder sql, string quotedName, string literalName, IEnumerable<string> roles)
+        {
             foreach (var role in roles)
             {
                 if (string.IsNullOrWhiteSpace(role)) continue;
@@ -440,8 +507,6 @@ namespace App.ControlPanel.Engine.Entities
             // db_datareader/db_datawriter cover tables but not EXECUTE, and the solution ships stored
             // procedures (sp_CreateDimTables and the Power BI refresh procs).
             sql.AppendLine($"GRANT EXECUTE TO {quotedName};");
-
-            return sql.ToString();
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/SqlServerAuthDetection.cs
@@ -35,6 +35,13 @@ namespace App.ControlPanel.Engine.Entities
 
         /// <summary>Login name of the Entra administrator, for logging. Never a secret.</summary>
         public string EntraAdminLogin { get; set; }
+
+        /// <summary>
+        /// Principal type of the Entra administrator - "User", "Group" or "Application". An
+        /// <c>Application</c> administrator is a service principal, which no person can sign in as.
+        /// Null when the server has no Entra administrator or Azure did not report the type.
+        /// </summary>
+        public string EntraAdminPrincipalType { get; set; }
     }
 
     /// <summary>
@@ -120,6 +127,72 @@ namespace App.ControlPanel.Engine.Entities
         public static bool ShouldProvisionWithEntraAuth(bool serverAlreadyExists, SqlServerAuthMode configuredMode)
         {
             return !serverAlreadyExists && configuredMode == SqlServerAuthMode.EntraId;
+        }
+
+        /// <summary>
+        /// Warns when Microsoft Entra ID authentication is in use but no <em>person</em> can sign in to the
+        /// database, so an operator who tries to browse the data by hand is refused.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the normal outcome of a default install, not a failure. Azure allows exactly one Entra
+        /// administrator per SQL server, and the installer makes itself that administrator because it is the
+        /// identity that has to sign in to apply the schema upgrade. The solution therefore works perfectly -
+        /// but the administrator is a service principal, and nobody can authenticate interactively as one.
+        /// </para>
+        /// <para>
+        /// The symptom is unhelpfully worded: the Azure portal's Query Editor reports
+        /// <c>"You don't have access to this database"</c> and says the account "was authenticated
+        /// successfully, but it doesn't have permission to access this database", which reads like a missing
+        /// database role rather than a missing server administrator.
+        /// </para>
+        /// <para>Returns null when there is nothing to warn about. Pure, so it is unit testable.</para>
+        /// <para>
+        /// An administrator whose principal type Azure did not report is assumed to be a principal that can
+        /// sign in, consistent with the "authentication will not be guessed" rule this class follows: the
+        /// case the warning exists for - a server the installer created and made itself the administrator of -
+        /// always reports <c>Application</c>, because the installer is what set it.
+        /// </para>
+        /// </remarks>
+        /// <param name="serverState">
+        /// What Azure reports about the server, or null when it could not be inspected - in which case we
+        /// say nothing rather than guess.
+        /// </param>
+        /// <param name="decision">The authentication method chosen for this run.</param>
+        public static string GetInteractiveAdminWarning(SqlServerAuthState serverState, SqlAuthDecision decision)
+        {
+            if (decision == null || !decision.UsesEntraId) return null;
+            if (serverState == null) return null;
+
+            // A human or a group containing humans can sign in, so there is nothing to say.
+            if (serverState.HasEntraAdmin
+                && !string.Equals(serverState.EntraAdminPrincipalType, "Application", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var opening = serverState.HasEntraAdmin
+                ? "This SQL Server's only Microsoft Entra administrator is an application (the installer's own service " +
+                  $"principal{FormatAdminLogin(serverState.EntraAdminLogin)}), which nobody can sign in as."
+                : "This SQL Server has no Microsoft Entra administrator assigned.";
+
+            return opening +
+                " The solution itself is unaffected and will keep importing: the App Service and Automation account " +
+                "authenticate as themselves. But because SQL authentication is disabled, no person can sign in to the " +
+                "database, so querying it by hand - for example with the Azure portal's Query Editor, SSMS or Azure Data " +
+                "Studio - will be refused with \"You don't have access to this database\". That message reports a " +
+                "successful sign-in and blames database permissions, which is misleading: the real cause is that you are " +
+                "not an administrator of the server. " +
+                "If you want to browse or query the data yourself, assign a Microsoft Entra administrator in the Azure " +
+                "portal: SQL Server > Settings > Microsoft Entra ID > Set admin, and pick a user or a security group. " +
+                "Azure permits only ONE Entra administrator per server, so prefer a group - replacing this application " +
+                "administrator with a single user would leave the installer unable to apply future schema upgrades unless " +
+                "that service principal is a member of it.";
+        }
+
+        static string FormatAdminLogin(string login)
+        {
+            return string.IsNullOrWhiteSpace(login) ? string.Empty : $", '{login}'";
         }
     }
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -152,7 +152,9 @@ namespace App.ControlPanel.Engine
                 }
                 else
                 {
-                    var decision = await SqlServerAuthReader.DetectAsync(sqlServer, sqlPassword, Config.SqlAuthMode, _logger);
+                    var decision = await SqlServerAuthReader.DetectAsync(sqlServer, sqlPassword, Config.SqlAuthMode, _logger,
+                        await ResolveInstallerObjectIdForDiagnostics(),
+                        Config.SQLEntraDatabaseUsers != null && Config.SQLEntraDatabaseUsers.Count > 0);
                     sqlInfo = new SqlDetails
                     {
                         SqlFqdn = sqlServer.Data.FullyQualifiedDomainName,
@@ -174,10 +176,43 @@ namespace App.ControlPanel.Engine
         }
 
         /// <summary>
+        /// Object ID of the installer's own service principal, for diagnostics only.
+        /// </summary>
+        /// <remarks>
+        /// Lets the SQL authentication report say whether the installer is actually this server's Microsoft
+        /// Entra administrator, which is the difference between "will connect" and "will be rejected with a
+        /// login error naming no principal". Never fatal - a failure here just means the question goes
+        /// unanswered, so a configuration test is not broken by a diagnostic.
+        /// </remarks>
+        async Task<Guid> ResolveInstallerObjectIdForDiagnostics()
+        {
+            var account = Config?.InstallerAccount;
+            if (account == null
+                || string.IsNullOrWhiteSpace(account.DirectoryId)
+                || string.IsNullOrWhiteSpace(account.ClientId)
+                || string.IsNullOrWhiteSpace(account.Secret))
+            {
+                return Guid.Empty;
+            }
+
+            try
+            {
+                var raw = await ServicePrincipalResolver.GetObjectIdFromClientCredentials(
+                    account.DirectoryId, account.ClientId, account.Secret);
+
+                Guid parsed;
+                return Guid.TryParse(raw, out parsed) ? parsed : Guid.Empty;
+            }
+            catch (Exception)
+            {
+                return Guid.Empty;
+            }
+        }
+
+        /// <summary>
         /// Do we have enough config to autodetect SQL connectivity details?
         /// </summary>
-        public static bool ConfigIsReadyForSqlAutodetection(SolutionInstallConfig config)
-        {
+        public static bool ConfigIsReadyForSqlAutodetection(SolutionInstallConfig config)        {
             if (config == null) return false;
 
             var installerAccErrors = config.InstallerAccount?.GetValidationErrors();

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
@@ -93,7 +93,9 @@ namespace App.ControlPanel.Engine
                     azureBackeEndCreationJob.CognitiveServicesInfo,
                     azureBackeEndCreationJob.KeyVault,
                     azureBackeEndCreationJob.SBQueueWithConnectionString?.ConnectionString, azureBackeEndCreationJob.Subscription,
-                    azureBackeEndCreationJob.CreatedSqlServer
+                    azureBackeEndCreationJob.CreatedSqlServer,
+                    azureBackeEndCreationJob.SqlAuthDecision,
+                    azureBackeEndCreationJob.InstallerObjectId
                 );
 
                 ct.ThrowIfCancellationRequested();

--- a/src/AnalyticsEngine/App.ControlPanel/App.ControlPanel.WinForms.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel/App.ControlPanel.WinForms.csproj
@@ -197,6 +197,12 @@
       <DependentUpon>ProxyConfigForm.cs</DependentUpon>
     </Compile>
     <Compile Include="SolutionInstallerLogger.cs" />
+    <Compile Include="SqlDatabaseUsersForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="SqlDatabaseUsersForm.Designer.cs">
+      <DependentUpon>SqlDatabaseUsersForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="TestSettingsForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -266,6 +272,9 @@
     </Compile>
     <EmbeddedResource Include="ProxyConfigForm.resx">
       <DependentUpon>ProxyConfigForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SqlDatabaseUsersForm.resx">
+      <DependentUpon>SqlDatabaseUsersForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="TestSettingsForm.resx">
       <DependentUpon>TestSettingsForm.cs</DependentUpon>

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallSPOSitesControl.cs
@@ -104,6 +104,7 @@ namespace App.ControlPanel.Frames
                 SQLServerAdminUsername = azureStorageConfigControl1.SQLServerUsername,
                 SQLServerAdminPassword = azureStorageConfigControl1.SQLServerPassword,
                 SqlAuthMode = azureStorageConfigControl1.SqlAuthMode,
+                SQLEntraDatabaseUsers = azureStorageConfigControl1.SqlDatabaseUsers,
                 ServiceBusName = azureStorageConfigControl1.ServiceBusName,
                 ServiceBusEnabled = azureStorageConfigControl1.ServiceBusEnabled,
                 RedisName = azureStorageConfigControl1.RedisName,
@@ -191,6 +192,7 @@ namespace App.ControlPanel.Frames
             azureStorageConfigControl1.SQLServerPassword = config.SQLServerAdminPassword;
             azureStorageConfigControl1.SQLServerUsername = config.SQLServerAdminUsername;
             azureStorageConfigControl1.SqlAuthMode = config.SqlAuthMode;
+            azureStorageConfigControl1.SqlDatabaseUsers = config.SQLEntraDatabaseUsers;
             azureStorageConfigControl1.StorageAccount = config.StorageAccountName;
             // Take the region from the picker rather than the raw config: the picker rejects a value that is
             // not a known Azure region (it falls back to its "no region" placeholder), and the preview label

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
@@ -178,7 +178,7 @@
             // chkSqlEntraAuth
             // 
             this.chkSqlEntraAuth.AutoSize = true;
-            this.chkSqlEntraAuth.Location = new System.Drawing.Point(64, 359);
+            this.chkSqlEntraAuth.Location = new System.Drawing.Point(64, 377);
             this.chkSqlEntraAuth.Name = "chkSqlEntraAuth";
             this.chkSqlEntraAuth.Size = new System.Drawing.Size(520, 17);
             this.chkSqlEntraAuth.TabIndex = 178;
@@ -189,7 +189,7 @@
             // 
             // btnSqlDatabaseUsers
             // 
-            this.btnSqlDatabaseUsers.Location = new System.Drawing.Point(64, 412);
+            this.btnSqlDatabaseUsers.Location = new System.Drawing.Point(64, 434);
             this.btnSqlDatabaseUsers.Name = "btnSqlDatabaseUsers";
             this.btnSqlDatabaseUsers.Size = new System.Drawing.Size(170, 23);
             this.btnSqlDatabaseUsers.TabIndex = 179;
@@ -200,14 +200,14 @@
             // lblSqlDatabaseUsers
             // 
             this.lblSqlDatabaseUsers.AutoSize = true;
-            this.lblSqlDatabaseUsers.Location = new System.Drawing.Point(240, 417);
+            this.lblSqlDatabaseUsers.Location = new System.Drawing.Point(240, 439);
             this.lblSqlDatabaseUsers.Name = "lblSqlDatabaseUsers";
             this.lblSqlDatabaseUsers.Size = new System.Drawing.Size(0, 13);
             this.lblSqlDatabaseUsers.TabIndex = 180;
             // 
             // txtSQLServerPassword
             // 
-            this.txtSQLServerPassword.Location = new System.Drawing.Point(438, 382);
+            this.txtSQLServerPassword.Location = new System.Drawing.Point(438, 400);
             this.txtSQLServerPassword.Name = "txtSQLServerPassword";
             this.txtSQLServerPassword.PasswordChar = '*';
             this.txtSQLServerPassword.Size = new System.Drawing.Size(150, 20);
@@ -217,7 +217,7 @@
             // lblGUIAzureSQLPassword
             // 
             this.lblGUIAzureSQLPassword.AutoSize = true;
-            this.lblGUIAzureSQLPassword.Location = new System.Drawing.Point(352, 385);
+            this.lblGUIAzureSQLPassword.Location = new System.Drawing.Point(352, 403);
             this.lblGUIAzureSQLPassword.Name = "lblGUIAzureSQLPassword";
             this.lblGUIAzureSQLPassword.Size = new System.Drawing.Size(56, 13);
             this.lblGUIAzureSQLPassword.TabIndex = 165;
@@ -225,7 +225,7 @@
             // 
             // txtSQLServerUsername
             // 
-            this.txtSQLServerUsername.Location = new System.Drawing.Point(156, 382);
+            this.txtSQLServerUsername.Location = new System.Drawing.Point(156, 400);
             this.txtSQLServerUsername.Name = "txtSQLServerUsername";
             this.txtSQLServerUsername.Size = new System.Drawing.Size(150, 20);
             this.txtSQLServerUsername.TabIndex = 153;
@@ -234,7 +234,7 @@
             // lblGUIAzureSQLUsername
             // 
             this.lblGUIAzureSQLUsername.AutoSize = true;
-            this.lblGUIAzureSQLUsername.Location = new System.Drawing.Point(62, 385);
+            this.lblGUIAzureSQLUsername.Location = new System.Drawing.Point(62, 403);
             this.lblGUIAzureSQLUsername.Name = "lblGUIAzureSQLUsername";
             this.lblGUIAzureSQLUsername.Size = new System.Drawing.Size(90, 13);
             this.lblGUIAzureSQLUsername.TabIndex = 164;
@@ -407,7 +407,7 @@
             this.Controls.Add(this.picRedis);
             this.Controls.Add(this.picStorage);
             this.Name = "AzureStorageConfigControl";
-            this.Size = new System.Drawing.Size(606, 445);
+            this.Size = new System.Drawing.Size(606, 470);
             ((System.ComponentModel.ISupportInitialize)(this.picServiceBus)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.picSQL)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.picRedis)).EndInit();

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.Designer.cs
@@ -41,6 +41,8 @@
             this.chkServiceBusEnabled = new System.Windows.Forms.CheckBox();
             this.lblGUIAzureHeaderSQL = new System.Windows.Forms.Label();
             this.chkSqlEntraAuth = new System.Windows.Forms.CheckBox();
+            this.btnSqlDatabaseUsers = new System.Windows.Forms.Button();
+            this.lblSqlDatabaseUsers = new System.Windows.Forms.Label();
             this.txtSQLServerPassword = new System.Windows.Forms.TextBox();
             this.lblGUIAzureSQLPassword = new System.Windows.Forms.Label();
             this.txtSQLServerUsername = new System.Windows.Forms.TextBox();
@@ -184,6 +186,24 @@
     "cated";
             this.chkSqlEntraAuth.UseVisualStyleBackColor = true;
             this.chkSqlEntraAuth.CheckedChanged += new System.EventHandler(this.chkSqlEntraAuth_CheckedChanged);
+            // 
+            // btnSqlDatabaseUsers
+            // 
+            this.btnSqlDatabaseUsers.Location = new System.Drawing.Point(64, 412);
+            this.btnSqlDatabaseUsers.Name = "btnSqlDatabaseUsers";
+            this.btnSqlDatabaseUsers.Size = new System.Drawing.Size(170, 23);
+            this.btnSqlDatabaseUsers.TabIndex = 179;
+            this.btnSqlDatabaseUsers.Text = "SQL database users...";
+            this.btnSqlDatabaseUsers.UseVisualStyleBackColor = true;
+            this.btnSqlDatabaseUsers.Click += new System.EventHandler(this.btnSqlDatabaseUsers_Click);
+            // 
+            // lblSqlDatabaseUsers
+            // 
+            this.lblSqlDatabaseUsers.AutoSize = true;
+            this.lblSqlDatabaseUsers.Location = new System.Drawing.Point(240, 417);
+            this.lblSqlDatabaseUsers.Name = "lblSqlDatabaseUsers";
+            this.lblSqlDatabaseUsers.Size = new System.Drawing.Size(0, 13);
+            this.lblSqlDatabaseUsers.TabIndex = 180;
             // 
             // txtSQLServerPassword
             // 
@@ -366,6 +386,8 @@
             this.Controls.Add(this.lblGUIAzureServiceBusName);
             this.Controls.Add(this.lblGUIAzureHeaderSQL);
             this.Controls.Add(this.chkSqlEntraAuth);
+            this.Controls.Add(this.btnSqlDatabaseUsers);
+            this.Controls.Add(this.lblSqlDatabaseUsers);
             this.Controls.Add(this.txtSQLServerPassword);
             this.Controls.Add(this.lblGUIAzureSQLPassword);
             this.Controls.Add(this.txtSQLServerUsername);
@@ -385,7 +407,7 @@
             this.Controls.Add(this.picRedis);
             this.Controls.Add(this.picStorage);
             this.Name = "AzureStorageConfigControl";
-            this.Size = new System.Drawing.Size(606, 409);
+            this.Size = new System.Drawing.Size(606, 445);
             ((System.ComponentModel.ISupportInitialize)(this.picServiceBus)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.picSQL)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.picRedis)).EndInit();
@@ -410,6 +432,8 @@
         private System.Windows.Forms.Label lblGUIAzureHeaderSQL;
         private System.Windows.Forms.TextBox txtSQLServerPassword;
         private System.Windows.Forms.CheckBox chkSqlEntraAuth;
+        private System.Windows.Forms.Button btnSqlDatabaseUsers;
+        private System.Windows.Forms.Label lblSqlDatabaseUsers;
         private System.Windows.Forms.Label lblGUIAzureSQLPassword;
         private System.Windows.Forms.TextBox txtSQLServerUsername;
         private System.Windows.Forms.Label lblGUIAzureSQLUsername;

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/InstallWizardPages/AzureStorageConfigControl.cs
@@ -1,6 +1,8 @@
 ﻿using App.ControlPanel.Engine;
 using Common.Entities.Installer;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace App.ControlPanel.Frames.InstallWizard
@@ -8,10 +10,30 @@ namespace App.ControlPanel.Frames.InstallWizard
     public partial class AzureStorageConfigControl : UserControl
     {
         private string _azureRegion;
+        private List<SqlDatabaseUser> _sqlDatabaseUsers = new List<SqlDatabaseUser>();
 
         public AzureStorageConfigControl()
         {
             InitializeComponent();
+        }
+
+        /// <summary>
+        /// Microsoft Entra users and groups the installer gives their own access to the database.
+        /// </summary>
+        /// <remarks>
+        /// Edited in its own dialog rather than inline, because the alternative an admin would otherwise
+        /// reach for - reassigning the SQL Server's Microsoft Entra administrator - silently locks the
+        /// installer out of future schema upgrades, and that warning needs more room than a tab affords.
+        /// See issue #117.
+        /// </remarks>
+        public List<SqlDatabaseUser> SqlDatabaseUsers
+        {
+            get { return _sqlDatabaseUsers; }
+            set
+            {
+                _sqlDatabaseUsers = value ?? new List<SqlDatabaseUser>();
+                UpdateResponsiveUIControls();
+            }
         }
 
         public string SQLDb { get { return txtSQLDb.Text; } set { txtSQLDb.Text = value; } }
@@ -33,8 +55,7 @@ namespace App.ControlPanel.Frames.InstallWizard
                 UpdateResponsiveUIControls();
             }
         }
-        public string StorageAccount { get { return txtStorageAccount.Text; } set { txtStorageAccount.Text = value; } }
-        public string RedisName { get { return txtRedisName.Text; } set { txtRedisName.Text = value; } }
+        public string StorageAccount { get { return txtStorageAccount.Text; } set { txtStorageAccount.Text = value; } }        public string RedisName { get { return txtRedisName.Text; } set { txtRedisName.Text = value; } }
         public string ServiceBusName { get { return txtServiceBusName.Text; } set { txtServiceBusName.Text = value; } }
 
         /// <summary>
@@ -80,6 +101,51 @@ namespace App.ControlPanel.Frames.InstallWizard
             txtSQLServerPassword.Enabled = sqlLoginInUse;
             lblGUIAzureSQLUsername.Enabled = sqlLoginInUse;
             lblGUIAzureSQLPassword.Enabled = sqlLoginInUse;
+
+            UpdateSqlDatabaseUsersLabel();
+        }
+
+        /// <summary>
+        /// Summarises who will be granted database access, and says plainly what to do when that is nobody.
+        /// </summary>
+        /// <remarks>
+        /// The "nobody" case is not cosmetic. On a server using Microsoft Entra ID authentication the only
+        /// administrator is the installer's service principal, so with an empty list no person can query the
+        /// database at all - and the obvious-looking fix in the Azure portal breaks the next upgrade.
+        /// </remarks>
+        private void UpdateSqlDatabaseUsersLabel()
+        {
+            var count = _sqlDatabaseUsers?.Count ?? 0;
+
+            if (count == 0)
+            {
+                lblSqlDatabaseUsers.Text = chkSqlEntraAuth.Checked
+                    ? "Nobody can query the database directly. Add people here - don't change the server's Entra admin."
+                    : "Nobody is granted direct database access.";
+                return;
+            }
+
+            var names = _sqlDatabaseUsers
+                .Where(u => u != null)
+                .Select(u => u.ToString())
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToList();
+
+            var shown = string.Join(", ", names.Take(3));
+            if (names.Count > 3) shown += $" (+{names.Count - 3} more)";
+
+            lblSqlDatabaseUsers.Text = $"{count} database user(s): {shown}";
+        }
+
+        private void btnSqlDatabaseUsers_Click(object sender, EventArgs e)
+        {
+            using (var form = new SqlDatabaseUsersForm(_sqlDatabaseUsers))
+            {
+                if (form.ShowDialog(this) != DialogResult.OK) return;
+
+                _sqlDatabaseUsers = form.DatabaseUsers;
+                UpdateResponsiveUIControls();
+            }
         }
 
         private void chkSqlEntraAuth_CheckedChanged(object sender, EventArgs e)

--- a/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.Designer.cs
@@ -1,0 +1,155 @@
+namespace App.ControlPanel
+{
+    partial class SqlDatabaseUsersForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.lblIntro = new System.Windows.Forms.Label();
+            this.gridUsers = new System.Windows.Forms.DataGridView();
+            this.colLogin = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colObjectId = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colPrincipalType = new System.Windows.Forms.DataGridViewComboBoxColumn();
+            this.btnOk = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.lblHint = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.gridUsers)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // lblIntro
+            // 
+            this.lblIntro.Location = new System.Drawing.Point(12, 9);
+            this.lblIntro.Name = "lblIntro";
+            this.lblIntro.Size = new System.Drawing.Size(660, 60);
+            this.lblIntro.TabIndex = 0;
+            this.lblIntro.Text = "People listed here get their own access to the analytics database, as contained da" +
+                "tabase users granted db_owner. The installer creates them on every run.\r\n\r\nDo NOT" +
+                " give people access by changing the SQL Server\'s Microsoft Entra administrator ins" +
+                "tead. Azure allows only ONE administrator per server and it is the installer\'s ser" +
+                "vice principal, so replacing it breaks the next database upgrade.";
+            // 
+            // gridUsers
+            // 
+            this.gridUsers.AllowUserToResizeRows = false;
+            this.gridUsers.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.gridUsers.AutoGenerateColumns = false;
+            this.gridUsers.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.gridUsers.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.colLogin,
+            this.colObjectId,
+            this.colPrincipalType});
+            this.gridUsers.Location = new System.Drawing.Point(12, 75);
+            this.gridUsers.Name = "gridUsers";
+            this.gridUsers.RowHeadersWidth = 25;
+            this.gridUsers.Size = new System.Drawing.Size(660, 250);
+            this.gridUsers.TabIndex = 1;
+            // 
+            // colLogin
+            // 
+            this.colLogin.DataPropertyName = "Login";
+            this.colLogin.HeaderText = "Login (UPN or group name)";
+            this.colLogin.Name = "colLogin";
+            this.colLogin.Width = 240;
+            // 
+            // colObjectId
+            // 
+            this.colObjectId.DataPropertyName = "ObjectId";
+            this.colObjectId.HeaderText = "Object ID (optional)";
+            this.colObjectId.Name = "colObjectId";
+            this.colObjectId.Width = 260;
+            // 
+            // colPrincipalType
+            // 
+            this.colPrincipalType.DataPropertyName = "PrincipalType";
+            this.colPrincipalType.HeaderText = "Type";
+            this.colPrincipalType.Name = "colPrincipalType";
+            this.colPrincipalType.Width = 90;
+            // 
+            // btnOk
+            // 
+            this.btnOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOk.Location = new System.Drawing.Point(516, 375);
+            this.btnOk.Name = "btnOk";
+            this.btnOk.Size = new System.Drawing.Size(75, 23);
+            this.btnOk.TabIndex = 2;
+            this.btnOk.Text = "OK";
+            this.btnOk.UseVisualStyleBackColor = true;
+            this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(597, 375);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 3;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            // 
+            // lblHint
+            // 
+            this.lblHint.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblHint.Location = new System.Drawing.Point(12, 332);
+            this.lblHint.Name = "lblHint";
+            this.lblHint.Size = new System.Drawing.Size(660, 36);
+            this.lblHint.TabIndex = 4;
+            this.lblHint.Text = "Object ID is only needed if the installer cannot look the name up in Microsoft Ent" +
+                "ra ID. Find it on the user\'s or group\'s overview page in the Azure portal.";
+            // 
+            // SqlDatabaseUsersForm
+            // 
+            this.AcceptButton = this.btnOk;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(684, 410);
+            this.Controls.Add(this.lblHint);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnOk);
+            this.Controls.Add(this.gridUsers);
+            this.Controls.Add(this.lblIntro);
+            this.MinimizeBox = false;
+            this.MaximizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(560, 340);
+            this.Name = "SqlDatabaseUsersForm";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "SQL database users";
+            ((System.ComponentModel.ISupportInitialize)(this.gridUsers)).EndInit();
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblIntro;
+        private System.Windows.Forms.DataGridView gridUsers;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colLogin;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colObjectId;
+        private System.Windows.Forms.DataGridViewComboBoxColumn colPrincipalType;
+        private System.Windows.Forms.Button btnOk;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Label lblHint;
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.Designer.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.Designer.cs
@@ -38,7 +38,7 @@ namespace App.ControlPanel
             // 
             this.lblIntro.Location = new System.Drawing.Point(12, 9);
             this.lblIntro.Name = "lblIntro";
-            this.lblIntro.Size = new System.Drawing.Size(660, 60);
+            this.lblIntro.Size = new System.Drawing.Size(660, 88);
             this.lblIntro.TabIndex = 0;
             this.lblIntro.Text = "People listed here get their own access to the analytics database, as contained da" +
                 "tabase users granted db_owner. The installer creates them on every run.\r\n\r\nDo NOT" +
@@ -58,10 +58,10 @@ namespace App.ControlPanel
             this.colLogin,
             this.colObjectId,
             this.colPrincipalType});
-            this.gridUsers.Location = new System.Drawing.Point(12, 75);
+            this.gridUsers.Location = new System.Drawing.Point(12, 105);
             this.gridUsers.Name = "gridUsers";
             this.gridUsers.RowHeadersWidth = 25;
-            this.gridUsers.Size = new System.Drawing.Size(660, 250);
+            this.gridUsers.Size = new System.Drawing.Size(660, 255);
             this.gridUsers.TabIndex = 1;
             // 
             // colLogin
@@ -88,7 +88,7 @@ namespace App.ControlPanel
             // btnOk
             // 
             this.btnOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOk.Location = new System.Drawing.Point(516, 375);
+            this.btnOk.Location = new System.Drawing.Point(516, 425);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(75, 23);
             this.btnOk.TabIndex = 2;
@@ -100,7 +100,7 @@ namespace App.ControlPanel
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(597, 375);
+            this.btnCancel.Location = new System.Drawing.Point(597, 425);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 3;
@@ -111,7 +111,7 @@ namespace App.ControlPanel
             // 
             this.lblHint.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblHint.Location = new System.Drawing.Point(12, 332);
+            this.lblHint.Location = new System.Drawing.Point(12, 370);
             this.lblHint.Name = "lblHint";
             this.lblHint.Size = new System.Drawing.Size(660, 36);
             this.lblHint.TabIndex = 4;
@@ -124,7 +124,7 @@ namespace App.ControlPanel
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(684, 410);
+            this.ClientSize = new System.Drawing.Size(684, 460);
             this.Controls.Add(this.lblHint);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOk);
@@ -132,7 +132,7 @@ namespace App.ControlPanel
             this.Controls.Add(this.lblIntro);
             this.MinimizeBox = false;
             this.MaximizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(560, 340);
+            this.MinimumSize = new System.Drawing.Size(600, 430);
             this.Name = "SqlDatabaseUsersForm";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.cs
@@ -23,6 +23,7 @@ namespace App.ControlPanel
         public SqlDatabaseUsersForm(IEnumerable<SqlDatabaseUser> users)
         {
             InitializeComponent();
+            UseApplicationIcon();
 
             // Copied, not referenced: Cancel has to leave the caller's list untouched.
             _users = new BindingList<SqlDatabaseUser>((users ?? Enumerable.Empty<SqlDatabaseUser>())
@@ -51,6 +52,32 @@ namespace App.ControlPanel
 
         /// <summary>The edited list. Only meaningful once the dialog returns <see cref="DialogResult.OK"/>.</summary>
         public List<SqlDatabaseUser> DatabaseUsers { get; private set; } = new List<SqlDatabaseUser>();
+
+        /// <summary>
+        /// Shows the installer's own icon in the title bar instead of the default WinForms one.
+        /// </summary>
+        /// <remarks>
+        /// Read from the assembly that defines this form rather than a file next to it, so it cannot break
+        /// if <c>office_icon.ico</c> is not copied to the output directory - and rather than
+        /// <c>Application.ExecutablePath</c>, which returns whatever process is hosting the form and so
+        /// picks up the wrong icon under a test harness. Best-effort: a failure just leaves the default
+        /// icon, which is not worth failing a dialog over.
+        /// </remarks>
+        private void UseApplicationIcon()
+        {
+            try
+            {
+                var installerExe = System.Reflection.Assembly.GetExecutingAssembly().Location;
+                if (!string.IsNullOrEmpty(installerExe))
+                {
+                    Icon = System.Drawing.Icon.ExtractAssociatedIcon(installerExe);
+                }
+            }
+            catch (Exception)
+            {
+                // Keep the default icon.
+            }
+        }
 
         private void btnOk_Click(object sender, EventArgs e)
         {

--- a/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.cs
@@ -1,0 +1,93 @@
+using Common.Entities.Installer;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace App.ControlPanel
+{
+    /// <summary>
+    /// Edits the list of Microsoft Entra principals the installer grants their own database access to.
+    /// </summary>
+    /// <remarks>
+    /// Exists so giving someone access to the data does not require reassigning the SQL Server's Microsoft
+    /// Entra administrator. Azure permits exactly one administrator per server and it is the installer's
+    /// service principal, so replacing it locks the installer out of future schema upgrades - the failure
+    /// this dialog is designed to stop people walking into. See issue #117.
+    /// </remarks>
+    public partial class SqlDatabaseUsersForm : Form
+    {
+        private readonly BindingList<SqlDatabaseUser> _users;
+
+        public SqlDatabaseUsersForm(IEnumerable<SqlDatabaseUser> users)
+        {
+            InitializeComponent();
+
+            // Copied, not referenced: Cancel has to leave the caller's list untouched.
+            _users = new BindingList<SqlDatabaseUser>((users ?? Enumerable.Empty<SqlDatabaseUser>())
+                .Where(u => u != null)
+                .Select(u => new SqlDatabaseUser
+                {
+                    Login = u.Login,
+                    ObjectId = u.ObjectId,
+                    PrincipalType = string.IsNullOrWhiteSpace(u.PrincipalType) ? SqlDatabaseUser.PrincipalTypeUser : u.PrincipalType,
+                })
+                .ToList());
+
+            colPrincipalType.Items.Add(SqlDatabaseUser.PrincipalTypeUser);
+            colPrincipalType.Items.Add(SqlDatabaseUser.PrincipalTypeGroup);
+
+            gridUsers.DataSource = _users;
+
+            // A new row starts with no principal type, which the combo column rejects with a
+            // DataError dialog the moment the cell is painted. Default it instead.
+            gridUsers.DefaultValuesNeeded += (s, e) =>
+                e.Row.Cells[colPrincipalType.Index].Value = SqlDatabaseUser.PrincipalTypeUser;
+
+            // Never let a malformed cell throw a modal exception dialog out of the grid.
+            gridUsers.DataError += (s, e) => e.ThrowException = false;
+        }
+
+        /// <summary>The edited list. Only meaningful once the dialog returns <see cref="DialogResult.OK"/>.</summary>
+        public List<SqlDatabaseUser> DatabaseUsers { get; private set; } = new List<SqlDatabaseUser>();
+
+        private void btnOk_Click(object sender, EventArgs e)
+        {
+            // Commit the cell being edited, or the last thing typed is silently dropped.
+            gridUsers.EndEdit();
+            var currency = gridUsers.BindingContext[_users] as CurrencyManager;
+            currency?.EndCurrentEdit();
+
+            var cleaned = _users
+                .Where(u => u != null && (!string.IsNullOrWhiteSpace(u.Login) || !string.IsNullOrWhiteSpace(u.ObjectId)))
+                .Select(u => new SqlDatabaseUser
+                {
+                    Login = (u.Login ?? string.Empty).Trim(),
+                    ObjectId = (u.ObjectId ?? string.Empty).Trim(),
+                    PrincipalType = string.IsNullOrWhiteSpace(u.PrincipalType) ? SqlDatabaseUser.PrincipalTypeUser : u.PrincipalType.Trim(),
+                })
+                .ToList();
+
+            var problems = cleaned
+                .Select(u => u.GetValidationError())
+                .Where(err => err != null)
+                .ToList();
+
+            if (problems.Count > 0)
+            {
+                // Refuse to save something the install would only reject later, when the operator has
+                // stopped watching.
+                MessageBox.Show(this,
+                    "These database users cannot be used:" + Environment.NewLine + Environment.NewLine +
+                    string.Join(Environment.NewLine, problems),
+                    "SQL database users", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            DatabaseUsers = cleaned;
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.resx
+++ b/src/AnalyticsEngine/App.ControlPanel/SqlDatabaseUsersForm.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="colLogin.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="colObjectId.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="colPrincipalType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Entities\UsageReports\SharePointSitesFileWeeklyStats.cs" />
     <Compile Include="Installer\BaseConfig.cs" />
     <Compile Include="Installer\BaseSolutionInstallConfig.cs" />
+    <Compile Include="Installer\SqlDatabaseUser.cs" />
     <Compile Include="Installer\TargetSolutionConfig.cs" />
     <Compile Include="LookupCaches\Discrete\CallModalityCache.cs" />
     <Compile Include="LookupCaches\Discrete\CallTypeCache.cs" />

--- a/src/AnalyticsEngine/Common/Entities/Installer/BaseSolutionInstallConfig.cs
+++ b/src/AnalyticsEngine/Common/Entities/Installer/BaseSolutionInstallConfig.cs
@@ -33,7 +33,13 @@ namespace Common.Entities.Installer
         //          Copilot Credits, and daily Azure spend from Microsoft Cost Management).
         //          2.4.0 -> 2.5.0 added ImportTaskSettings.ImportDlp (opt-in Microsoft Purview DLP import
         //          from the DLP.All content type; needs the separate ActivityFeed.ReadDlp permission).
-        const string CONFIG_VERSION = "2.5.0";
+        //          2.5.0 -> 2.6.0 added SQLEntraDatabaseUsers (Microsoft Entra users/groups the installer
+        //          grants a contained database user). Additive: an older config with no such property
+        //          grants nobody, exactly as before. Exists because Azure permits only ONE Entra
+        //          administrator per SQL server, so handing out data access by reassigning the
+        //          administrator evicts the installer's service principal and breaks the next schema
+        //          upgrade. See issue #117.
+        const string CONFIG_VERSION = "2.6.0";
 
         public BaseSolutionInstallConfig()
         {
@@ -113,6 +119,27 @@ namespace Common.Entities.Installer
         /// Principal type of the configured Entra administrator - "User", "Group" or "Application".
         /// </summary>
         public string SQLEntraAdminPrincipalType { get; set; } = "User";
+
+        /// <summary>
+        /// Microsoft Entra users and groups to give direct query access to the analytics database, as
+        /// contained database users.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the supported way to let people read the data on a server that uses Microsoft Entra ID
+        /// authentication. The tempting alternative - assigning yourself as the server's Entra administrator
+        /// in the portal - does not work here: Azure permits exactly ONE administrator per server, and it is
+        /// the installer's own service principal, so replacing it removes the identity that applies schema
+        /// upgrades and the next upgrade fails with
+        /// <c>Login failed for user '&lt;token-identified principal&gt;'</c>.
+        /// </para>
+        /// <para>
+        /// The installer applies these grants itself on every run, because on an Entra-only server it is the
+        /// only thing that can authenticate as the administrator. Empty by default, which grants nobody and
+        /// matches the behaviour of every config written before this property existed.
+        /// </para>
+        /// </remarks>
+        public List<SqlDatabaseUser> SQLEntraDatabaseUsers { get; set; } = new List<SqlDatabaseUser>();
 
         public bool CognitiveServicesEnabled { get; set; } = true;
         public string CognitiveServiceName { get; set; } = string.Empty;

--- a/src/AnalyticsEngine/Common/Entities/Installer/SqlDatabaseUser.cs
+++ b/src/AnalyticsEngine/Common/Entities/Installer/SqlDatabaseUser.cs
@@ -1,0 +1,95 @@
+using System;
+
+namespace Common.Entities.Installer
+{
+    /// <summary>
+    /// A Microsoft Entra principal that should be able to query the analytics database directly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Exists because Azure permits exactly ONE Microsoft Entra administrator per SQL server, and that
+    /// administrator is the installer's own service principal - it is the identity that signs in to apply
+    /// schema upgrades. Reassigning the administrator to a named person is therefore not a way to hand out
+    /// data access: it silently evicts the installer and breaks the next upgrade with
+    /// <c>Login failed for user '&lt;token-identified principal&gt;'</c>.
+    /// </para>
+    /// <para>
+    /// The supported way is a contained database user per person, which leaves the administrator
+    /// assignment alone. Nobody can create one by hand on an Entra-only server - that too requires signing
+    /// in as the administrator, which is a service principal - so the installer creates them, because it is
+    /// the one thing that CAN authenticate as that principal.
+    /// </para>
+    /// </remarks>
+    public class SqlDatabaseUser
+    {
+        /// <summary>
+        /// UPN, group name or display name of the principal. Also used verbatim as the contained database
+        /// user's name, so it is what shows up in <c>sys.database_principals</c>.
+        /// </summary>
+        public string Login { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Entra object (principal) ID. Optional: when blank the installer resolves it from
+        /// <see cref="Login"/> via Microsoft Graph.
+        /// </summary>
+        /// <remarks>
+        /// Supplying it explicitly is the escape hatch for a tenant whose app registrations have no
+        /// directory-read permission - the object ID is on the principal's overview blade in the Azure
+        /// portal, and with it no Graph call is needed at all.
+        /// </remarks>
+        public string ObjectId { get; set; } = string.Empty;
+
+        /// <summary>"User" or "Group". Decides which Graph collection <see cref="Login"/> is resolved against.</summary>
+        public string PrincipalType { get; set; } = PrincipalTypeUser;
+
+        public const string PrincipalTypeUser = "User";
+        public const string PrincipalTypeGroup = "Group";
+
+        /// <summary>Whether this entry carries an explicit, usable object ID.</summary>
+        [Newtonsoft.Json.JsonIgnore]
+        public bool HasObjectId
+        {
+            get
+            {
+                Guid ignored;
+                return TryGetObjectId(out ignored);
+            }
+        }
+
+        /// <summary>Whether <see cref="ObjectId"/> parses as a real (non-empty) GUID.</summary>
+        public bool TryGetObjectId(out Guid objectId)
+        {
+            objectId = Guid.Empty;
+            if (string.IsNullOrWhiteSpace(ObjectId)) return false;
+            return Guid.TryParse(ObjectId.Trim(), out objectId) && objectId != Guid.Empty;
+        }
+
+        /// <summary>Whether this entry identifies a group rather than an individual.</summary>
+        [Newtonsoft.Json.JsonIgnore]
+        public bool IsGroup => string.Equals((PrincipalType ?? string.Empty).Trim(), PrincipalTypeGroup, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Why this entry cannot be used, or null when it is usable. An entry needs a login - it becomes the
+        /// database user name - and either an object ID or a login Graph can look up.
+        /// </summary>
+        public string GetValidationError()
+        {
+            if (!string.IsNullOrWhiteSpace(ObjectId) && !HasObjectId)
+            {
+                return $"'{ObjectId}' is not a valid Microsoft Entra object ID for database user '{Login}'.";
+            }
+
+            if (string.IsNullOrWhiteSpace(Login))
+            {
+                return "A database user needs a login (UPN or group name) to use as the database user name.";
+            }
+
+            return null;
+        }
+
+        public override string ToString()
+        {
+            return string.IsNullOrWhiteSpace(Login) ? (ObjectId ?? string.Empty) : Login;
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -394,8 +394,33 @@ namespace Tests.UnitTests
 
             Assert.IsNotNull(warning);
             StringAssert.Contains(warning, "SQL authentication is still enabled");
+            StringAssert.Contains(warning, "remains an option");
             Assert.IsFalse(warning.Contains("Because SQL authentication is disabled"),
                 "A mixed-authentication server still accepts the SQL administrator login.");
+        }
+
+        /// <summary>
+        /// Decide picks Entra whenever it is configured and the server has an Entra administrator, without
+        /// checking for a SQL administrator login. So a mixed-auth server with no SQL login is reachable, and
+        /// the warning must not offer a login that Azure says does not exist.
+        /// </summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_MixedAuthWithNoSqlLogin_DoesNotOfferOne()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = false,
+                HasSqlAdminLogin = false,
+                HasEntraAdmin = true,
+                EntraAdminPrincipalType = "Application",
+            };
+
+            var warning = SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision);
+
+            Assert.IsNotNull(warning);
+            StringAssert.Contains(warning, "no SQL administrator login");
+            Assert.IsFalse(warning.Contains("remains an option"),
+                "There is no SQL administrator login to fall back on.");
         }
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -811,6 +811,12 @@ namespace Tests.UnitTests
 
                 return System.Threading.Tasks.Task.FromResult(answer);
             }
+
+            /// <summary>Application ID lookups are not what these tests exercise.</summary>
+            public System.Threading.Tasks.Task<Guid?> ResolveApplicationIdAsync(Guid servicePrincipalObjectId, CancellationToken cancellationToken)
+            {
+                return System.Threading.Tasks.Task.FromResult<Guid?>(null);
+            }
         }
 
         /// <summary>
@@ -933,6 +939,78 @@ namespace Tests.UnitTests
             Assert.AreEqual(1, resolved.Count);
             Assert.AreEqual(SomebodyElse, resolved[0].Value,
                 "A user or group is identified by its Entra object ID, unlike a service principal.");
+        }
+
+        /// <summary>
+        /// A managed identity is a service principal, so its contained user must carry its application
+        /// (client) ID. ARM only reports the object ID of a system-assigned identity, which is a different
+        /// GUID - writing that one produces a user that can never sign in.
+        /// </summary>
+        [TestMethod]
+        public void ManagedIdentityGrant_UsesTheApplicationId_NotTheObjectId()
+        {
+            var objectId = new Guid("55555555-5555-5555-5555-555555555555");
+            var appId = new Guid("66666666-6666-6666-6666-666666666666");
+
+            var script = App.ControlPanel.Engine.InstallerTasks.SqlIdentityAccessTask.BuildGrantScript(
+                "contosoanalytics", appId, SqlContainedUserScript.AppServiceRoles);
+
+            StringAssert.Contains(script, SqlContainedUserScript.ToSqlSid(appId));
+            Assert.IsFalse(script.Contains(SqlContainedUserScript.ToSqlSid(objectId)),
+                "The managed identity's object ID must never be written as the SID.");
+            StringAssert.Contains(script, "TYPE = E");
+            StringAssert.Contains(script, "db_ddladmin");
+        }
+
+        /// <summary>
+        /// When the application ID cannot be read from Graph, fall back to letting SQL Server resolve the
+        /// name - rather than writing an identifier known to be wrong.
+        /// </summary>
+        [TestMethod]
+        public void ManagedIdentityGrant_WithoutAnApplicationId_FallsBackToExternalProvider()
+        {
+            var script = App.ControlPanel.Engine.InstallerTasks.SqlIdentityAccessTask.BuildGrantScript(
+                "contosoanalytics", null, SqlContainedUserScript.AppServiceRoles);
+
+            StringAssert.Contains(script, "FROM EXTERNAL PROVIDER");
+            Assert.IsFalse(script.Contains("WITH SID"),
+                "With no known-correct identifier, none must be guessed.");
+            StringAssert.Contains(script, "db_ddladmin");
+        }
+
+        /// <summary>
+        /// An earlier release wrote object IDs as SIDs, so upgrades inherit users that exist, hold the right
+        /// roles, and are refused at every sign-in. A plain IF NOT EXISTS would see them and skip forever,
+        /// so the script must replace a mismatched one.
+        /// </summary>
+        [TestMethod]
+        public void ContainedUserScript_ReplacesAUserWhoseSidIsWrong()
+        {
+            var appId = new Guid("66666666-6666-6666-6666-666666666666");
+
+            var script = SqlContainedUserScript.CreateUserAndGrantRoles("contosoanalytics", appId, new[] { "db_owner" });
+
+            StringAssert.Contains(script, "DROP USER [contosoanalytics];");
+            StringAssert.Contains(script, $"[sid] <> {SqlContainedUserScript.ToSqlSid(appId)}");
+
+            // Only external principals may be dropped - a SQL user that happens to share the name is not ours.
+            StringAssert.Contains(script, "[type] IN ('E', 'X')");
+        }
+
+        /// <summary>
+        /// SQL Server declares an Entra group as TYPE = X; TYPE = E is a user or service principal. A group
+        /// created as E does not resolve to the group's members.
+        /// </summary>
+        [TestMethod]
+        public void ContainedUserScript_DeclaresGroupsAsTypeX()
+        {
+            var sid = new Guid("77777777-7777-7777-7777-777777777777");
+
+            var group = SqlContainedUserScript.CreateUserAndGrantRoles("Contoso DBAs", sid, new[] { "db_owner" }, isGroup: true);
+            var user = SqlContainedUserScript.CreateUserAndGrantRoles("dba@contoso.com", sid, new[] { "db_owner" }, isGroup: false);
+
+            StringAssert.Contains(group, "TYPE = X");
+            StringAssert.Contains(user, "TYPE = E");
         }
 
         #endregion

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -345,6 +345,108 @@ namespace Tests.UnitTests
 
         #endregion
 
+        #region No interactive administrator warning
+
+        static SqlAuthDecision EntraDecision => new SqlAuthDecision(SqlConnectionAuthMethod.EntraId, "test");
+        static SqlAuthDecision SqlLoginDecision => new SqlAuthDecision(SqlConnectionAuthMethod.SqlLogin, "test");
+
+        /// <summary>
+        /// The default install: the installer makes its own service principal the Entra administrator, so the
+        /// solution works but no person can sign in to query the database by hand.
+        /// </summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_ApplicationAdministrator_Warns()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = true,
+                HasEntraAdmin = true,
+                EntraAdminPrincipalType = "Application",
+                EntraAdminLogin = "00000000-0000-0000-0000-000000000000",
+            };
+
+            var warning = SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision);
+
+            Assert.IsNotNull(warning);
+            StringAssert.Contains(warning, "Set admin");
+            StringAssert.Contains(warning, "You don't have access to this database");
+        }
+
+        [TestMethod]
+        public void InteractiveAdminWarning_NoAdministratorAtAll_Warns()
+        {
+            var state = new SqlServerAuthState { EntraOnlyAuthEnabled = true, HasEntraAdmin = false };
+
+            var warning = SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision);
+
+            Assert.IsNotNull(warning);
+            StringAssert.Contains(warning, "no Microsoft Entra administrator");
+        }
+
+        /// <summary>
+        /// A user or a group administrator can sign in, so there is nothing to warn about. A group is the
+        /// shape we actually recommend, so it must not warn either.
+        /// </summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_UserOrGroupAdministrator_IsSilent()
+        {
+            foreach (var principalType in new[] { "User", "Group", "group" })
+            {
+                var state = new SqlServerAuthState
+                {
+                    EntraOnlyAuthEnabled = true,
+                    HasEntraAdmin = true,
+                    EntraAdminPrincipalType = principalType,
+                    EntraAdminLogin = "dba-team@contoso.com",
+                };
+
+                Assert.IsNull(SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision),
+                    $"A '{principalType}' administrator can sign in, so no warning should be produced.");
+            }
+        }
+
+        /// <summary>
+        /// On the SQL-login path the operator already has a username and password, so none of this applies.
+        /// </summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_SqlLoginPath_IsSilent()
+        {
+            var state = new SqlServerAuthState { HasEntraAdmin = false, HasSqlAdminLogin = true };
+
+            Assert.IsNull(SqlServerAuthDetection.GetInteractiveAdminWarning(state, SqlLoginDecision));
+        }
+
+        /// <summary>Never guess: an uninspectable server produces no claim either way.</summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_UnknownServerState_IsSilent()
+        {
+            Assert.IsNull(SqlServerAuthDetection.GetInteractiveAdminWarning(null, EntraDecision));
+            Assert.IsNull(SqlServerAuthDetection.GetInteractiveAdminWarning(new SqlServerAuthState(), null));
+        }
+
+        /// <summary>
+        /// Azure does not always report a principal type. Consistent with the "authentication will not be
+        /// guessed" rule elsewhere in this reader, an administrator of unknown type is assumed to be a real
+        /// principal that can sign in, so we stay silent rather than tell an operator who already has a
+        /// working administrator to go and set one. The case this warning exists for - a server the
+        /// installer itself created - always reports the type, because the installer sets it.
+        /// </summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_UnknownPrincipalType_IsSilent()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = true,
+                HasEntraAdmin = true,
+                EntraAdminPrincipalType = null,
+                EntraAdminLogin = "someone@contoso.com",
+            };
+
+            Assert.IsNull(SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision));
+        }
+
+        #endregion
+
         #region Contained-user T-SQL
 
         /// <summary>

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -370,6 +370,54 @@ namespace Tests.UnitTests
             Assert.IsNotNull(warning);
             StringAssert.Contains(warning, "Set admin");
             StringAssert.Contains(warning, "You don't have access to this database");
+            StringAssert.Contains(warning, "Because SQL authentication is disabled");
+        }
+
+        /// <summary>
+        /// A mixed-authentication server is reachable: Decide picks Entra whenever it is configured and the
+        /// server has an Entra administrator, even though SQL logins still work. The warning must not claim
+        /// SQL authentication is disabled there, because it is not.
+        /// </summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_MixedAuthServer_DoesNotClaimSqlAuthIsDisabled()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = false,
+                HasSqlAdminLogin = true,
+                HasEntraAdmin = true,
+                EntraAdminPrincipalType = "Application",
+                EntraAdminLogin = "some-other-app",
+            };
+
+            var warning = SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision);
+
+            Assert.IsNotNull(warning);
+            StringAssert.Contains(warning, "SQL authentication is still enabled");
+            Assert.IsFalse(warning.Contains("Because SQL authentication is disabled"),
+                "A mixed-authentication server still accepts the SQL administrator login.");
+        }
+
+        /// <summary>
+        /// The administrator is only known to be an application, not known to be OUR application - an
+        /// operator can configure a different one, and an existing server may already have its own.
+        /// </summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_DoesNotAssertWhichApplicationIsAdministrator()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = true,
+                HasEntraAdmin = true,
+                EntraAdminPrincipalType = "Application",
+                EntraAdminLogin = "some-unrelated-automation-app",
+            };
+
+            var warning = SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision);
+
+            StringAssert.Contains(warning, "some-unrelated-automation-app");
+            Assert.IsFalse(warning.Contains("is the installer's own service principal"),
+                "The warning must not assert an identity it has not verified.");
         }
 
         [TestMethod]

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -354,8 +354,14 @@ namespace Tests.UnitTests
         /// The default install: the installer makes its own service principal the Entra administrator, so the
         /// solution works but no person can sign in to query the database by hand.
         /// </summary>
+        /// <remarks>
+        /// The remedy must NOT be "assign yourself as the Entra administrator". Azure permits exactly one,
+        /// so doing that evicts the installer's principal and breaks the next schema upgrade - which is
+        /// precisely the failure this guidance was rewritten to stop causing. "Set admin" may still appear,
+        /// but only as the thing not to do.
+        /// </remarks>
         [TestMethod]
-        public void InteractiveAdminWarning_ApplicationAdministrator_Warns()
+        public void InteractiveAdminWarning_ApplicationAdministrator_WarnsAndDoesNotRecommendReassigningTheAdmin()
         {
             var state = new SqlServerAuthState
             {
@@ -368,9 +374,40 @@ namespace Tests.UnitTests
             var warning = SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision);
 
             Assert.IsNotNull(warning);
-            StringAssert.Contains(warning, "Set admin");
             StringAssert.Contains(warning, "You don't have access to this database");
             StringAssert.Contains(warning, "Because SQL authentication is disabled");
+
+            // The supported route: contained database users, configured in the installer.
+            StringAssert.Contains(warning, SqlServerAuthDetection.DatabaseUsersConfigUiName);
+            StringAssert.Contains(warning, "contained database user");
+
+            // And an explicit prohibition on the thing that breaks the next upgrade.
+            StringAssert.Contains(warning, "Do NOT reassign");
+            StringAssert.Contains(warning, "only ONE");
+            Assert.IsFalse(warning.Contains("so prefer a group"),
+                "Recommending a group administrator was the old guidance; the fix is a contained user, not a different administrator.");
+        }
+
+        /// <summary>
+        /// When people are already configured the install is about to grant them itself, so the warning must
+        /// report that rather than ask an operator to go and do something.
+        /// </summary>
+        [TestMethod]
+        public void InteractiveAdminWarning_WithConfiguredDatabaseUsers_SaysTheInstallWillGrantThem()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = true,
+                HasEntraAdmin = true,
+                EntraAdminPrincipalType = "Application",
+            };
+
+            var warning = SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision, hasConfiguredDatabaseUsers: true);
+
+            Assert.IsNotNull(warning);
+            StringAssert.Contains(warning, "will be granted access during this run");
+            Assert.IsFalse(warning.Contains("Do NOT reassign"),
+                "Nothing is being asked of the operator, so the prohibition is noise here.");
         }
 
         /// <summary>
@@ -516,6 +553,339 @@ namespace Tests.UnitTests
             };
 
             Assert.IsNull(SqlServerAuthDetection.GetInteractiveAdminWarning(state, EntraDecision));
+        }
+
+        #endregion
+
+        #region Installer lockout diagnosis
+
+        static readonly Guid InstallerSp = new Guid("11111111-1111-1111-1111-111111111111");
+        static readonly Guid SomebodyElse = new Guid("22222222-2222-2222-2222-222222222222");
+
+        /// <summary>
+        /// The healthy shape: the installer IS the administrator, so it can sign in and there is nothing to
+        /// say. Matching on the object ID rather than the login is the point - a login is a display name.
+        /// </summary>
+        [TestMethod]
+        public void InstallerLockoutWarning_InstallerIsTheAdministrator_IsSilent()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = true,
+                HasEntraAdmin = true,
+                EntraAdminSid = InstallerSp,
+                EntraAdminPrincipalType = "Application",
+                EntraAdminLogin = "the-installer-app",
+            };
+
+            Assert.IsNull(SqlServerAuthDetection.GetInstallerLockoutWarning(state, EntraDecision, InstallerSp));
+        }
+
+        /// <summary>
+        /// The failure this whole change exists for: somebody assigned a named user as the server's Entra
+        /// administrator, which Azure treats as replacing the installer's service principal, and the next
+        /// upgrade fails with a login error naming no principal at all.
+        /// </summary>
+        [TestMethod]
+        public void InstallerLockoutWarning_AdministratorReassignedToAPerson_Warns()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = true,
+                HasEntraAdmin = true,
+                EntraAdminSid = SomebodyElse,
+                EntraAdminPrincipalType = "User",
+                EntraAdminLogin = "dba@contoso.com",
+            };
+
+            var warning = SqlServerAuthDetection.GetInstallerLockoutWarning(state, EntraDecision, InstallerSp);
+
+            Assert.IsNotNull(warning);
+            StringAssert.Contains(warning, "dba@contoso.com");
+            StringAssert.Contains(warning, InstallerSp.ToString());
+            StringAssert.Contains(warning, "only ONE administrator per server");
+            StringAssert.Contains(warning, "<token-identified principal>");
+        }
+
+        /// <summary>
+        /// A group administrator may well contain the installer principal, which cannot be checked from ARM.
+        /// The warning must say so rather than predict a failure that will probably not happen.
+        /// </summary>
+        [TestMethod]
+        public void InstallerLockoutWarning_GroupAdministrator_IsHedged()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = true,
+                HasEntraAdmin = true,
+                EntraAdminSid = SomebodyElse,
+                EntraAdminPrincipalType = "Group",
+                EntraAdminLogin = "sql-admins",
+            };
+
+            var warning = SqlServerAuthDetection.GetInstallerLockoutWarning(state, EntraDecision, InstallerSp);
+
+            Assert.IsNotNull(warning);
+            StringAssert.Contains(warning, "security group");
+            StringAssert.Contains(warning, "member of it");
+            Assert.IsFalse(warning.Contains("will fail with"),
+                "A group administrator may contain the installer principal, so failure must not be asserted.");
+        }
+
+        [TestMethod]
+        public void InstallerLockoutWarning_NoAdministratorAtAll_Warns()
+        {
+            var state = new SqlServerAuthState { EntraOnlyAuthEnabled = true, HasEntraAdmin = false };
+
+            var warning = SqlServerAuthDetection.GetInstallerLockoutWarning(state, EntraDecision, InstallerSp);
+
+            Assert.IsNotNull(warning);
+            StringAssert.Contains(warning, "no Microsoft Entra administrator assigned at all");
+        }
+
+        /// <summary>
+        /// Never guess. Without the installer's own object ID the comparison is meaningless, and on the SQL
+        /// login path there is no token principal involved at all.
+        /// </summary>
+        [TestMethod]
+        public void InstallerLockoutWarning_UnknowableOrIrrelevant_IsSilent()
+        {
+            var mismatched = new SqlServerAuthState
+            {
+                HasEntraAdmin = true,
+                EntraAdminSid = SomebodyElse,
+                EntraAdminPrincipalType = "User",
+            };
+
+            Assert.IsNull(SqlServerAuthDetection.GetInstallerLockoutWarning(mismatched, EntraDecision, Guid.Empty),
+                "Without the installer's object ID there is nothing to compare.");
+            Assert.IsNull(SqlServerAuthDetection.GetInstallerLockoutWarning(mismatched, SqlLoginDecision, InstallerSp),
+                "A SQL login does not authenticate as the installer's service principal.");
+            Assert.IsNull(SqlServerAuthDetection.GetInstallerLockoutWarning(null, EntraDecision, InstallerSp),
+                "An uninspectable server produces no claim either way.");
+        }
+
+        /// <summary>
+        /// After SQL has actually rejected the principal the ambiguity is gone, so the remedy states the
+        /// cause outright and offers both routes back - without ever recommending the admin reassignment
+        /// that caused it.
+        /// </summary>
+        [TestMethod]
+        public void InstallerLockoutRemedy_NamesBothRoutesBack()
+        {
+            var state = new SqlServerAuthState
+            {
+                EntraOnlyAuthEnabled = true,
+                HasEntraAdmin = true,
+                EntraAdminSid = SomebodyElse,
+                EntraAdminPrincipalType = "User",
+                EntraAdminLogin = "dba@contoso.com",
+            };
+
+            var remedy = SqlServerAuthDetection.GetInstallerLockoutRemedy(state, InstallerSp);
+
+            StringAssert.Contains(remedy, "dba@contoso.com");
+            StringAssert.Contains(remedy, InstallerSp.ToString());
+            StringAssert.Contains(remedy, "sign in when prompted");
+            StringAssert.Contains(remedy, "administrator again");
+            StringAssert.Contains(remedy, SqlServerAuthDetection.DatabaseUsersConfigUiName);
+        }
+
+        /// <summary>Still useful when the server could not be inspected or the object ID is unknown.</summary>
+        [TestMethod]
+        public void InstallerLockoutRemedy_WithoutServerState_StillExplainsItself()
+        {
+            var remedy = SqlServerAuthDetection.GetInstallerLockoutRemedy(null, Guid.Empty);
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(remedy));
+            StringAssert.Contains(remedy, "no Microsoft Entra administrator assigned");
+            Assert.IsFalse(remedy.Contains("()"), "An unresolved object ID must not leave empty brackets in the text.");
+        }
+
+        #endregion
+
+        #region Configured database users
+
+        [TestMethod]
+        public void SqlDatabaseUser_ValidatesLoginAndObjectId()
+        {
+            Assert.IsNull(new SqlDatabaseUser { Login = "dba@contoso.com" }.GetValidationError(),
+                "A login alone is enough - the object ID is resolved from it.");
+
+            Assert.IsNull(new SqlDatabaseUser
+            {
+                Login = "dba@contoso.com",
+                ObjectId = "22222222-2222-2222-2222-222222222222",
+            }.GetValidationError());
+
+            StringAssert.Contains(new SqlDatabaseUser { Login = "dba@contoso.com", ObjectId = "not-a-guid" }.GetValidationError(),
+                "not a valid Microsoft Entra object ID");
+
+            StringAssert.Contains(new SqlDatabaseUser { Login = " " }.GetValidationError(),
+                "needs a login");
+
+            // An all-zero GUID is what an unpopulated field serialises to, and it is not a real principal.
+            StringAssert.Contains(new SqlDatabaseUser
+            {
+                Login = "dba@contoso.com",
+                ObjectId = "00000000-0000-0000-0000-000000000000",
+            }.GetValidationError(), "not a valid Microsoft Entra object ID");
+        }
+
+        [TestMethod]
+        public void SqlDatabaseUser_ParsesObjectIdAndPrincipalType()
+        {
+            Guid parsed;
+
+            Assert.IsTrue(new SqlDatabaseUser { ObjectId = " 22222222-2222-2222-2222-222222222222 " }.TryGetObjectId(out parsed));
+            Assert.AreEqual(SomebodyElse, parsed);
+
+            Assert.IsFalse(new SqlDatabaseUser().TryGetObjectId(out parsed));
+            Assert.AreEqual(Guid.Empty, parsed);
+
+            Assert.IsTrue(new SqlDatabaseUser { PrincipalType = "group" }.IsGroup, "Principal type is compared case-insensitively.");
+            Assert.IsFalse(new SqlDatabaseUser { PrincipalType = "User" }.IsGroup);
+            Assert.IsFalse(new SqlDatabaseUser { PrincipalType = null }.IsGroup);
+        }
+
+        /// <summary>
+        /// The list is persisted in the saved installer config, so it has to survive a JSON round trip - and
+        /// a config written before the property existed must still load, granting nobody.
+        /// </summary>
+        [TestMethod]
+        public void SqlDatabaseUsers_RoundTripThroughConfigJson()
+        {
+            var config = new BaseSolutionInstallConfig();
+            config.SQLEntraDatabaseUsers.Add(new SqlDatabaseUser
+            {
+                Login = "Καλημέρα κόσμε",
+                ObjectId = "22222222-2222-2222-2222-222222222222",
+                PrincipalType = SqlDatabaseUser.PrincipalTypeGroup,
+            });
+
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(config);
+            var loaded = Newtonsoft.Json.JsonConvert.DeserializeObject<BaseSolutionInstallConfig>(json);
+
+            Assert.AreEqual(1, loaded.SQLEntraDatabaseUsers.Count);
+            Assert.AreEqual("Καλημέρα κόσμε", loaded.SQLEntraDatabaseUsers[0].Login,
+                "A group display name is customer text and can be non-Latin.");
+            Assert.IsTrue(loaded.SQLEntraDatabaseUsers[0].IsGroup);
+
+            var legacy = Newtonsoft.Json.JsonConvert.DeserializeObject<BaseSolutionInstallConfig>("{}");
+            Assert.IsNotNull(legacy.SQLEntraDatabaseUsers);
+            Assert.AreEqual(0, legacy.SQLEntraDatabaseUsers.Count,
+                "A config written before this property existed must load and grant nobody.");
+        }
+
+        /// <summary>
+        /// Adding a persisted property to the saved config schema requires the schema version to move, or
+        /// config compatibility cannot be reasoned about across upgrades.
+        /// </summary>
+        [TestMethod]
+        public void ConfigSchemaVersion_WasBumpedForTheDatabaseUsersList()
+        {
+            Assert.IsTrue(new BaseSolutionInstallConfig().ConfigSchemaVersion >= new Version(2, 6, 0),
+                "SQLEntraDatabaseUsers is a new persisted property, so CONFIG_VERSION must be at least 2.6.0.");
+        }
+
+        class StubPrincipalResolver : App.ControlPanel.Engine.InstallerTasks.IEntraPrincipalResolver
+        {
+            private readonly System.Collections.Generic.Dictionary<string, Guid?> _answers;
+
+            public StubPrincipalResolver(System.Collections.Generic.Dictionary<string, Guid?> answers)
+            {
+                _answers = answers;
+            }
+
+            public int Calls { get; private set; }
+
+            public System.Threading.Tasks.Task<Guid?> ResolveObjectIdAsync(SqlDatabaseUser user, CancellationToken cancellationToken)
+            {
+                Calls++;
+
+                Guid? answer;
+                if (!_answers.TryGetValue(user.Login ?? string.Empty, out answer))
+                {
+                    throw new InvalidOperationException("directory read denied");
+                }
+
+                return System.Threading.Tasks.Task.FromResult(answer);
+            }
+        }
+
+        /// <summary>
+        /// An explicit object ID must be used as-is. That is the escape hatch for a tenant whose app
+        /// registrations have no directory-read permission, so it has to work without Graph being consulted
+        /// at all.
+        /// </summary>
+        [TestMethod]
+        public async System.Threading.Tasks.Task ResolveUsers_ExplicitObjectId_SkipsTheDirectoryLookup()
+        {
+            var resolver = new StubPrincipalResolver(new System.Collections.Generic.Dictionary<string, Guid?>());
+            var task = new App.ControlPanel.Engine.InstallerTasks.SqlDatabaseUserGrantTask(
+                Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance, resolver);
+
+            var resolved = await task.ResolveUsersAsync(new[]
+            {
+                new SqlDatabaseUser { Login = "dba@contoso.com", ObjectId = "22222222-2222-2222-2222-222222222222" },
+            });
+
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual(SomebodyElse, resolved[0].Value);
+            Assert.AreEqual(0, resolver.Calls, "A supplied object ID must not trigger a Graph call.");
+        }
+
+        /// <summary>
+        /// One unusable entry - malformed, unresolvable, or a directory read the app registration is not
+        /// permitted to make - must not cost everybody else their access.
+        /// </summary>
+        [TestMethod]
+        public async System.Threading.Tasks.Task ResolveUsers_BadEntriesAreSkippedWithoutLosingTheGoodOnes()
+        {
+            var resolver = new StubPrincipalResolver(new System.Collections.Generic.Dictionary<string, Guid?>
+            {
+                { "found@contoso.com", SomebodyElse },
+                { "missing@contoso.com", null },
+            });
+
+            var task = new App.ControlPanel.Engine.InstallerTasks.SqlDatabaseUserGrantTask(
+                Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance, resolver);
+
+            var resolved = await task.ResolveUsersAsync(new[]
+            {
+                null,
+                new SqlDatabaseUser { Login = "   " },                                             // no login at all
+                new SqlDatabaseUser { Login = "bad@contoso.com", ObjectId = "not-a-guid" },        // malformed object ID
+                new SqlDatabaseUser { Login = "missing@contoso.com" },                             // not in the directory
+                new SqlDatabaseUser { Login = "denied@contoso.com" },                              // lookup throws
+                new SqlDatabaseUser { Login = "found@contoso.com" },                               // fine
+            });
+
+            Assert.AreEqual(1, resolved.Count, "Only the resolvable entry should survive.");
+            Assert.AreEqual("found@contoso.com", resolved[0].Key.Login);
+            Assert.AreEqual(SomebodyElse, resolved[0].Value);
+        }
+
+        /// <summary>Nothing configured is the default, and must be a silent no-op rather than an error.</summary>
+        [TestMethod]
+        public async System.Threading.Tasks.Task ResolveUsers_EmptyList_IsANoOp()
+        {
+            var task = new App.ControlPanel.Engine.InstallerTasks.SqlDatabaseUserGrantTask(
+                Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance, null);
+
+            Assert.AreEqual(0, (await task.ResolveUsersAsync(null)).Count);
+            Assert.AreEqual(0, (await task.ResolveUsersAsync(new SqlDatabaseUser[0])).Count);
+        }
+
+        /// <summary>
+        /// Humans are granted db_owner: they are the deployment's own administrators, and read-only access
+        /// would not let them run the shipped reporting procedures.
+        /// </summary>
+        [TestMethod]
+        public void DatabaseUserRoles_AreDbOwner()
+        {
+            CollectionAssert.AreEqual(new[] { "db_owner" },
+                System.Linq.Enumerable.ToArray(App.ControlPanel.Engine.InstallerTasks.SqlDatabaseUserGrantTask.DatabaseUserRoles));
         }
 
         #endregion

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -888,6 +888,53 @@ namespace Tests.UnitTests
                 System.Linq.Enumerable.ToArray(App.ControlPanel.Engine.InstallerTasks.SqlDatabaseUserGrantTask.DatabaseUserRoles));
         }
 
+        /// <summary>
+        /// Azure SQL matches a <em>service principal</em> on its application (client) ID, not its object
+        /// ID - unlike a user or group, which it matches on the object ID.
+        /// </summary>
+        /// <remarks>
+        /// Regression test for a failure that looked like a success. SQL Server does not validate the SID
+        /// against Entra ID, so creating the installer's contained user with its object ID reported
+        /// "Created contained database user ..." and the very next connection was still rejected with
+        /// <c>Login failed for user '&lt;token-identified principal&gt;'</c> - an error naming no principal
+        /// and reading like a firewall or password problem.
+        /// </remarks>
+        [TestMethod]
+        public void InstallerContainedUser_UsesTheClientIdAsTheSid_NotTheObjectId()
+        {
+            var clientId = new Guid("33333333-3333-3333-3333-333333333333");
+            var objectId = new Guid("44444444-4444-4444-4444-444444444444");
+
+            var script = App.ControlPanel.Engine.InstallerTasks.SqlEntraAccessBootstrap.BuildInstallerUserScript(clientId);
+
+            StringAssert.Contains(script, SqlContainedUserScript.ToSqlSid(clientId),
+                "Azure SQL identifies a service principal by its application (client) ID.");
+            Assert.IsFalse(script.Contains(SqlContainedUserScript.ToSqlSid(objectId)),
+                "The object ID must never be used as the SID for a service principal - it fails silently at sign-in.");
+            StringAssert.Contains(script, "TYPE = E");
+            StringAssert.Contains(script, "db_owner");
+        }
+
+        /// <summary>
+        /// A configured human or group is the other half of the rule: those ARE matched on the object ID,
+        /// so the resolver must keep passing it straight through.
+        /// </summary>
+        [TestMethod]
+        public async System.Threading.Tasks.Task ConfiguredUsers_KeepUsingTheObjectIdAsTheSid()
+        {
+            var task = new App.ControlPanel.Engine.InstallerTasks.SqlDatabaseUserGrantTask(
+                Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance, null);
+
+            var resolved = await task.ResolveUsersAsync(new[]
+            {
+                new SqlDatabaseUser { Login = "dba@contoso.com", ObjectId = SomebodyElse.ToString() },
+            });
+
+            Assert.AreEqual(1, resolved.Count);
+            Assert.AreEqual(SomebodyElse, resolved[0].Value,
+                "A user or group is identified by its Entra object ID, unlike a service principal.");
+        }
+
         #endregion
 
         #region Contained-user T-SQL


### PR DESCRIPTION
## Summary

Follow-up to #482, and a correction to this PR''s own original guidance.

Azure permits exactly **one** Microsoft Entra administrator per SQL server, and #482 makes that administrator the **installer''s own service principal** - deliberately, because it is the identity that signs in to apply schema upgrades. Nobody can authenticate interactively as a service principal, so after a default install no *person* has database access.

This PR originally warned about that and told operators to fix it by reassigning the administrator to a user or security group. **That advice is wrong, and it broke a real deployment while this PR was open.** Reassigning the single permitted administrator *replaces* the installer''s principal, so the next upgrade aborts at the SQL connectivity test with:

```
Login failed for user '<token-identified principal>'.
```

The error names no principal and reads like a firewall or password problem. It is neither. On an Entra-only server the SQL administrator password is ignored outright, so the `SQL administrator login = present` on the authentication line above it is a red herring - a SQL-login probe against such a server returns `Reason: Azure Active Directory only authentication is enabled.`

So the warning stays, and the remedy changes: people get **contained database users**, and the administrator assignment is left alone.

## Changes

### 1. Warn that nobody can query the database (original scope, unchanged)

`SqlServerAuthState.EntraAdminPrincipalType` (`User`/`Group`/`Application`), populated in `SqlServerAuthReader.ReadAsync`. The principal type only exists on the server payload''s **embedded** administrator, not the authoritative child resource, so it is kept only when both agree on the administrator''s SID - a disagreement means the embedded copy is stale and is discarded rather than believed.

`SqlServerAuthDetection.GetInteractiveAdminWarning` is pure and unit tested. Silent for a `User`/`Group` administrator, on the SQL-login path, for an uninspectable server, and for an administrator whose type Azure did not report.

### 2. Contained database users instead of reassigning the administrator

- **New `SQLEntraDatabaseUsers`** on `BaseSolutionInstallConfig`: a list of Entra principals granted `db_owner` contained users on every run. Each entry is a login (also the database user name), an optional object ID, and `User`/`Group`.
- **`SqlDatabaseUserGrantTask`** performs the grants; **`GraphEntraPrincipalResolver`** turns a login into an object ID, trying the installer account then the runtime account, because neither is guaranteed to hold a directory-read permission. An explicit object ID bypasses Graph entirely - the escape hatch for tenants that granted neither.
- **Applied only when `dbInfo.AuthMethod == EntraId`.** This is a hard requirement, not tidiness: SQL Server rejects `TYPE = E` user creation over a SQL login with *"Only connections established with Active Directory accounts can create other Active Directory users"*, and on a SQL-auth server nobody is locked out anyway.
- Resolution is split into `ResolveUsersAsync` so the skip/report decisions are testable without a database. One unusable entry only ever costs itself.
- UI: **Azure Config > SQL database users...** opens `SqlDatabaseUsersForm` (a `DataGridView` over a `BindingList`), with the summary label on the tab naming who will be granted. A separate dialog rather than inline because the "do not reassign the admin" warning needs more room than the tab has.
- `GetInteractiveAdminWarning` no longer recommends `Set admin`; it names the new list, and states the prohibition with the exact error the old advice produces.

### 3. Diagnose and repair deployments the old advice already broke

- `SqlServerAuthState.EntraAdminSid` carries the administrator''s object ID, so `GetInstallerLockoutWarning` can compare it against the installer''s own principal **before anything connects**, instead of a healthy-looking install failing minutes later. Matching on SID, not login - a login is a display name, so it is neither stable nor unique. A **group** administrator may contain the principal, which ARM cannot confirm from here, so that case is hedged rather than asserted.
- `SqlEntraAccessBootstrap` repairs it: on a token login rejection an interactive installer asks for an administrator sign-in (`InteractiveBrowserCredential`, device-code fallback, 5-minute timeout), creates the contained user for its own principal, and retries. Wired into `VerifySqlWithFirewallSelfHeal` alongside the existing firewall self-heal, attempted once.
- Deliberately **not** done by reassigning the administrator over ARM: that mutates a live customer server and could strand the assignment if the installer died halfway.
- `GetInstallerLockoutRemedy` is computed even when no repair is possible, so a headless run still learns which administrator assignment locked it out.

## Database, configuration and dependencies

- **`CONFIG_VERSION` 2.5.0 -> 2.6.0** with a `// History:` entry - `SQLEntraDatabaseUsers` is a new persisted property. Additive: a config written before it loads and grants nobody.
- **No database migrations, no `Create DB.sql` change, no dependency changes.** `Azure.Identity` 1.21.0 was already referenced; `InteractiveBrowserCredential`/`DeviceCodeCredential` need no new package and no new app registration (the credential defaults to the pre-consented Azure developer sign-on client).

## Tests

`Failed: 0, Passed: 123` across `AzureSqlEntraAuthTests`, `SqlAuthenticationDetectionTests`, `SqlFirewallSelfHealTests`, `SqlFirewallRulesTests`, `InstallFailureDiagnosisTests`, `UrlFullUrlMigrationPipelineTests`, after merging latest `dev`. Release builds of `Tests.UnitTests` and `App.ControlPanel.WinForms` both succeed.

New coverage: SID-based administrator matching in both directions; hedged group administrator; no administrator; unknowable/irrelevant cases silent; the remedy naming both routes back; `SqlDatabaseUser` validation and object-ID parsing; config JSON round trip including a non-Latin group display name and a pre-property config; the `CONFIG_VERSION` floor; resolver behaviour for explicit IDs, unresolvable entries and directory-read failures; `db_owner` roles.

The rewritten guidance is asserted by intent, not just presence - `InteractiveAdminWarning_ApplicationAdministrator_WarnsAndDoesNotRecommendReassigningTheAdmin` requires the contained-user remedy and the prohibition, and asserts the old `"so prefer a group"` advice is **absent**.

Note the full suite cannot run locally in Release: `Tests.UnitTests/App.Release.config` ships the literal `__TenantGUID__` token that CI substitutes, so every `AppConfig`-dependent test fails with `Guid should contain 32 digits`. Unrelated to this change.

## Risks and reviewer hotspots

- **The interactive sign-in.** Gated on `Environment.UserInteractive`, an Entra auth method, a resolvable installer object ID and a configured client ID - any of which being absent disables it. Worth checking it can never fire in the headless `--initdb`/`--registerconfig` child processes (it is only invoked from `ConfigureAzureComponentsTasks`, in the parent).
- **Error vs warning on the self-heal path.** The lockout remedy is logged as an error only when the repair did *not* succeed, so a recovered install does not report a spurious error in its summary.
- **The retry loop** in `VerifySqlWithFirewallSelfHeal` changed from `for` to `while` with an explicit counter, so the Entra retry does not consume a firewall backoff slot or skip `_firewallRepairRetryBackoff[0]`.
- **Graph dependency.** A tenant where neither app registration can read the directory gets a clear skip message pointing at the object-ID column, not a failure.

## Docs

Wiki updated (separate repo, already pushed): *Security Model > Give yourself access to query the database* rewritten around the new list with a warning against `Set admin`; a new *Troubleshooting* entry keyed on the `<token-identified principal>` error text explaining the `SQL administrator login = present` red herring; `SQLEntraDatabaseUsers` documented in *Configuration Reference*.

## Tracking

Addresses #117.
