### PR TITLE
Fix installer against RBAC Key Vaults, keyless Azure AI Language and post-deploy 500s

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/InstallAppServiceContentsTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/InstallAppServiceContentsTask.cs
@@ -70,6 +70,30 @@ namespace App.ControlPanel.Engine.InstallerTasks
                 await PublishZipAsync(kuduDetails, deploymentPackage, _proxyConfig);
             }
 
+            // The zip deploy wrote new binaries underneath a running AppDomain, which leaves the old worker
+            // process holding shadow copies of the previous build. The first requests then fail with
+            // ConfigurationErrorsException "Cannot create/shadow copy '<assembly>' when that file already
+            // exists" and the site serves HTTP 500 until the app pool recycles on its own - which looks
+            // exactly like a failed install to the warm-up step that runs next. An explicit restart drops
+            // the old worker deterministically.
+            //
+            // synchronous: true matters. The default is asynchronous, where the await returns as soon as ARM
+            // accepts the request - the warm-up would then race the recycle and could even pass against the
+            // pre-restart worker. softRestart: false is the full restart ("by default the API always restarts
+            // and reprovisions the app"; true would restart only if it judged it necessary).
+            _logger.LogInformation("Restarting App Service so the newly deployed binaries load into a clean worker process...");
+            try
+            {
+                await webApp.Value.RestartAsync(softRestart: false, synchronous: true);
+            }
+            catch (Exception ex)
+            {
+                // Not fatal: the app pool will recycle eventually, and the warm-up that follows retries 5xx
+                // for three minutes. Warn so a 500 during warm-up is attributable rather than mysterious.
+                _logger.LogWarning($"Could not restart the App Service after deployment: {ex.Message}. " +
+                    "The site may return HTTP 500 'Cannot create/shadow copy' errors until its app pool recycles by itself.");
+            }
+
             var url = $"https://{webApp.Value.Data.HostNames.First()}/";
             _logger.LogInformation($"App Service configured & running selected release. URL: {url}");
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstaller.cs
@@ -220,14 +220,33 @@ namespace App.ControlPanel.Engine
                     {
                         var response = await httpClient.GetAsync(adminSiteUrl, ct);
                         lastStatus = response.StatusCode;
-                        if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Moved || response.StatusCode == HttpStatusCode.MovedPermanently)
+                        // Any redirect counts as "the app is serving" - the admin site 302s to the Entra
+                        // sign-in endpoint for an unauthenticated request. HttpClient follows redirects by
+                        // default so this normally sees the final 200, but a redirect it declines to follow
+                        // (e.g. an https -> http downgrade) must not be reported as an install failure.
+                        // The previous test listed Moved and MovedPermanently, which are both 301 and so
+                        // could never match the 302 this site actually returns.
+                        var statusCode = (int)response.StatusCode;
+                        if (response.StatusCode == HttpStatusCode.OK)
                         {
-                            log.LogInformation($"Web-app warmup OK ({(int)response.StatusCode} {response.StatusCode}) on attempt {attempt}.");
+                            log.LogInformation($"Web-app warmup OK ({statusCode} {response.StatusCode}) on attempt {attempt}.");
                             return true;
                         }
-                        if ((int)response.StatusCode < 500)
+                        if (statusCode >= 300 && statusCode < 400)
                         {
-                            log.LogError($"Web-app warmup got unexpected non-success response {(int)response.StatusCode} {response.StatusCode} — check manually that the App Service is started.");
+                            // The app is serving (IIS/ASP.NET started), which is all warm-up needs to prove.
+                            // HttpClient follows redirects by default, so a 3xx surfacing here means the chain
+                            // was NOT followed to completion - most likely the redirect limit was exhausted,
+                            // or it was a scheme downgrade. Accept it, because the old check tested Moved and
+                            // MovedPermanently (both 301) and so could never match the 302 this site returns -
+                            // but say so, since a redirect loop is worth a human look.
+                            log.LogWarning($"Web-app warmup got {statusCode} {response.StatusCode} on attempt {attempt} and the redirect was not followed to completion. " +
+                                $"Treating the App Service as started, but if the admin site is unusable check the app registration's Reply URLs / sign-in configuration for a redirect loop.");
+                            return true;
+                        }
+                        if (statusCode < 500)
+                        {
+                            log.LogError($"Web-app warmup got unexpected non-success response {statusCode} {response.StatusCode} — check manually that the App Service is started.");
                             return false;
                         }
                         // 5xx — keep retrying
@@ -255,8 +274,26 @@ namespace App.ControlPanel.Engine
                 }
 
                 var lastDetail = lastStatus.HasValue ? $"{(int)lastStatus.Value} {lastStatus.Value}" : lastError ?? "no response";
-                log.LogError($"Web-app warmup did not succeed within {totalWarmupSeconds}s — last response was {lastDetail}. " +
-                    $"If the installer is running off-VNet, the App Service's hostname resolves to its private endpoint and the warm-up request can't reach it — try browsing '{adminSiteUrl}' from a machine on the VNet, or temporarily enable Public Network Access on the App Service to verify it started.");
+
+                // Only offer the private-endpoint explanation when this install actually uses a VNet.
+                // Blaming it unconditionally sent operators of ordinary public deployments looking for a
+                // networking fault that did not exist. Equally, when nothing ever answered we cannot claim
+                // the site "is reachable but failing to start" - that is a different diagnosis entirely.
+                string guidance;
+                if (this.Config?.NetworkConfig?.Enabled == true)
+                {
+                    guidance = $"If the installer is running off-VNet, the App Service's hostname resolves to its private endpoint and the warm-up request can't reach it — try browsing '{adminSiteUrl}' from a machine on the VNet, or temporarily enable Public Network Access on the App Service to verify it started.";
+                }
+                else if (lastStatus.HasValue)
+                {
+                    guidance = $"The App Service answered, so it is reachable, but the application is failing to start. Check the startup errors in the App Service's LogFiles/eventlog.xml (Kudu / Advanced Tools), and browse '{adminSiteUrl}' to confirm.";
+                }
+                else
+                {
+                    guidance = $"Nothing answered the warm-up request, so this is a connectivity problem rather than a failed application start — check DNS resolution for '{adminSiteUrl}', any proxy in front of the installer, and that the App Service is started and allows public access.";
+                }
+
+                log.LogError($"Web-app warmup did not succeed within {totalWarmupSeconds}s — last response was {lastDetail}. {guidance}");
                 return false;
             }
         }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -2,6 +2,8 @@
 using Azure.Core;
 using Azure.Identity;
 using Azure.ResourceManager.AppService;
+using Azure.ResourceManager.Authorization;
+using Azure.ResourceManager.Authorization.Models;
 using Azure.ResourceManager.KeyVault;
 using Azure.ResourceManager.KeyVault.Models;
 using Azure.Security.KeyVault.Secrets;
@@ -10,6 +12,8 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace CloudInstallEngine.Azure.InstallTasks
@@ -136,12 +140,35 @@ namespace CloudInstallEngine.Azure.InstallTasks
         public const string CONFIG_KEY_SECRET = "secret";
         public const string CONFIG_KEY_WEB_APP_NAME = "webAppName";
 
+        // Built-in Key Vault data-plane roles, used when the vault has the RBAC permission model enabled.
+        public const string ROLE_SECRETS_OFFICER = "Key Vault Secrets Officer";
+        public const string ROLE_SECRETS_USER = "Key Vault Secrets User";
+        public const string ROLE_CERTIFICATE_USER = "Key Vault Certificate User";
+
+        /// <summary>
+        /// Access-policy secret permissions that imply write access, and therefore need
+        /// "Key Vault Secrets Officer" rather than the read-only "Key Vault Secrets User".
+        /// </summary>
+        private static readonly string[] SecretWritePermissions = { "set", "delete", "recover", "backup", "restore", "purge" };
+
         protected BaseKeyVaultAddPolicyTask(TaskConfig config, ILogger logger, AzureLocation azureLocation, Dictionary<string, string> tags) : base(config, logger, azureLocation, tags)
         {
         }
 
         protected async Task AddPolicyForConfiguredAccount(KeyVaultResource vaultResource, Guid tenantId, string objectId, IEnumerable<string> secretPerms, IEnumerable<string> certPerms)
         {
+            // A vault using the RBAC permission model ignores access policies completely. Azure still
+            // ACCEPTS the UpdateAccessPolicy call below and stores the entry, so this used to look like it
+            // worked while granting nothing at all - the first data-plane call then failed with
+            // 403 "ForbiddenByRbac" / "Assignment: (not found)". Note that even subscription Owner does not
+            // help: Key Vault secret get/set are dataActions, which Owner does not include. Assign the
+            // equivalent built-in role at the vault scope instead.
+            if (vaultResource.Data.Properties?.EnableRbacAuthorization == true)
+            {
+                await AssignVaultRbacRoles(vaultResource, objectId, secretPerms, certPerms);
+                return;
+            }
+
             var access = new IdentityAccessPermissions();
             foreach (var perm in secretPerms)
             {
@@ -156,6 +183,160 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 new KeyVaultAccessPolicy(tenantId, objectId, access)
             }));
             await vaultResource.UpdateAccessPolicyAsync(AccessPolicyUpdateKind.Add, pol);
+        }
+
+        /// <summary>
+        /// RBAC-permission-model equivalent of an access policy: translates the requested secret /
+        /// certificate permissions into the matching built-in roles and assigns them at the vault scope.
+        /// </summary>
+        private async Task AssignVaultRbacRoles(KeyVaultResource vaultResource, string objectId, IEnumerable<string> secretPerms, IEnumerable<string> certPerms)
+        {
+            if (!Guid.TryParse(objectId, out var principalId))
+            {
+                throw new InstallException($"Invalid object ID '{objectId}' for key vault '{vaultResource.Data.Name}' role assignment");
+            }
+
+            foreach (var roleName in MapPermissionsToRoles(secretPerms, certPerms))
+            {
+                await AssignVaultRole(vaultResource, principalId, roleName);
+            }
+        }
+
+        /// <summary>
+        /// Translates access-policy style permissions into the equivalent built-in Key Vault RBAC roles.
+        /// </summary>
+        /// <remarks>
+        /// "Key Vault Certificate User" is chosen for certificate access rather than a certificates-only role
+        /// because it also carries <c>secrets/getSecret</c>, which is what actually returns the certificate's
+        /// private key via <c>CertificateClient.DownloadCertificate</c> — a bare certificates/read is not
+        /// enough for <c>AuthHelper.RetrieveKeyVaultCertificate</c>.
+        /// </remarks>
+        public static IReadOnlyList<string> MapPermissionsToRoles(IEnumerable<string> secretPerms, IEnumerable<string> certPerms)
+        {
+            var roleNames = new List<string>();
+
+            var secrets = (secretPerms ?? Enumerable.Empty<string>()).ToList();
+            if (secrets.Count > 0)
+            {
+                var needsWrite = secrets.Any(p => SecretWritePermissions.Contains(p, StringComparer.OrdinalIgnoreCase));
+                roleNames.Add(needsWrite ? ROLE_SECRETS_OFFICER : ROLE_SECRETS_USER);
+            }
+
+            if ((certPerms ?? Enumerable.Empty<string>()).Any())
+            {
+                roleNames.Add(ROLE_CERTIFICATE_USER);
+            }
+
+            return roleNames;
+        }
+
+        private async Task AssignVaultRole(KeyVaultResource vaultResource, Guid principalId, string roleName)
+        {
+            // Ask ARM for just this role rather than enumerating the several-hundred built-in definitions
+            // once per role per task. Fall back to a full scan if the server-side filter returns nothing.
+            var roleDefinitions = vaultResource.GetAuthorizationRoleDefinitions();
+            var roleDefinition = roleDefinitions
+                .GetAll($"roleName eq '{roleName}'")
+                .FirstOrDefault(rd => string.Equals(rd.Data.RoleName, roleName, StringComparison.OrdinalIgnoreCase))
+                ?? roleDefinitions.FirstOrDefault(rd => string.Equals(rd.Data.RoleName, roleName, StringComparison.OrdinalIgnoreCase));
+
+            if (roleDefinition == null)
+            {
+                throw new InstallException($"Role definition '{roleName}' not found on scope '{vaultResource.Id}'");
+            }
+
+            var roleAssignments = vaultResource.GetRoleAssignments();
+            if (HasVaultScopedAssignment(roleAssignments, vaultResource, principalId, roleDefinition))
+            {
+                _logger.LogInformation($"Key vault '{vaultResource.Data.Name}' uses the RBAC permission model; role '{roleName}' already assigned to principal '{principalId}'.");
+                return;
+            }
+
+            _logger.LogInformation($"Key vault '{vaultResource.Data.Name}' uses the RBAC permission model (access policies are ignored) — assigning role '{roleName}' to principal '{principalId}' at vault scope...");
+
+            var content = new RoleAssignmentCreateOrUpdateContent(roleDefinition.Id, principalId)
+            {
+                // Tells ARM not to fail the create while a just-created service principal is still
+                // replicating through Entra ID.
+                PrincipalType = new RoleManagementPrincipalType("ServicePrincipal")
+            };
+
+            // Deterministic name, so re-running the installer PUTs the same assignment instead of trying to
+            // create a second one for the same (principal, role, scope) and getting 409 RoleAssignmentExists.
+            var assignmentName = DeterministicRoleAssignmentName(vaultResource.Id.ToString(), principalId, roleDefinition.Id.Name);
+
+            try
+            {
+                await roleAssignments.CreateOrUpdateAsync(WaitUntil.Completed, assignmentName, content);
+                _logger.LogInformation($"Assigned role '{roleName}' on key vault '{vaultResource.Data.Name}' to principal '{principalId}'. Note: data-plane role assignments can take a minute to propagate.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == 409 || string.Equals(ex.ErrorCode, "RoleAssignmentExists", StringComparison.OrdinalIgnoreCase))
+            {
+                // Someone (a previous install with a random name, or an admin in the portal) already granted
+                // this exact role at this scope under a different assignment name. That is the desired state.
+                _logger.LogInformation($"Role '{roleName}' was already assigned on key vault '{vaultResource.Data.Name}' to principal '{principalId}' under a different assignment name; nothing to do.");
+            }
+            catch (RequestFailedException ex) when (ex.Status == 403)
+            {
+                // The installer account can reach the vault but cannot hand out roles. This MUST be fatal:
+                // on an RBAC vault the access policies are ignored, so continuing would produce a deployment
+                // that looks installed but whose web app and importer cannot read the vault at all - exactly
+                // the silent failure this whole change exists to remove. Creating role assignments needs
+                // 'Microsoft.Authorization/roleAssignments/write' (User Access Administrator or Owner), which
+                // Contributor does NOT include.
+                throw new InstallException(
+                    $"Could not assign role '{roleName}' on key vault '{vaultResource.Data.Name}' to principal '{principalId}': " +
+                    $"the installer account is not permitted to create role assignments ({ex.ErrorCode}). " +
+                    $"This vault uses the RBAC permission model, so access policies will NOT work as a substitute. " +
+                    $"Grant the installer account 'User Access Administrator' (or Owner) on the vault — Contributor is not enough — " +
+                    $"or assign '{roleName}' to that principal by hand, then re-run.");
+            }
+        }
+
+        /// <summary>
+        /// True when the principal already holds the role at the vault itself (or an ancestor scope).
+        /// Deliberately ignores assignments scoped to an individual secret/certificate inside the vault, and
+        /// any assignment carrying an ABAC <c>Condition</c>: neither grants unconditional vault-wide access,
+        /// so treating them as equivalent would skip a grant the install actually needs.
+        /// </summary>
+        private static bool HasVaultScopedAssignment(RoleAssignmentCollection roleAssignments, KeyVaultResource vaultResource,
+            Guid principalId, AuthorizationRoleDefinitionResource roleDefinition)
+        {
+            var vaultScope = vaultResource.Id.ToString();
+
+            foreach (var existing in roleAssignments)
+            {
+                if (existing.Data.PrincipalId != principalId) continue;
+
+                // Compare the role definition GUID rather than the full resource id: the id returned when
+                // listing definitions at a resource scope is not guaranteed to be the same string as the one
+                // stored on an existing assignment (tenant-rooted vs subscription-rooted paths).
+                if (!string.Equals(existing.Data.RoleDefinitionId?.Name, roleDefinition.Id.Name, StringComparison.OrdinalIgnoreCase)) continue;
+
+                if (!string.IsNullOrEmpty(existing.Data.Condition)) continue;
+
+                var existingScope = existing.Data.Scope?.ToString();
+                if (string.IsNullOrEmpty(existingScope)) continue;
+
+                // The vault itself, or an ancestor (resource group / subscription) that already covers it.
+                if (vaultScope.StartsWith(existingScope, StringComparison.OrdinalIgnoreCase)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Stable GUID for a (scope, principal, role) triple so repeated installs are idempotent.
+        /// </summary>
+        private static string DeterministicRoleAssignmentName(string scope, Guid principalId, string roleDefinitionGuid)
+        {
+            using (var sha = SHA256.Create())
+            {
+                var hash = sha.ComputeHash(Encoding.UTF8.GetBytes($"{scope}|{principalId}|{roleDefinitionGuid}".ToLowerInvariant()));
+                var guidBytes = new byte[16];
+                Array.Copy(hash, guidBytes, 16);
+                return new Guid(guidBytes).ToString();
+            }
         }
         protected async Task AddPolicyForConfiguredRuntimeAccount(KeyVaultResource vaultResource, IEnumerable<string> secretPerms, IEnumerable<string> certPerms)
         {
@@ -172,7 +353,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 return;
             }
 
-            _logger.LogInformation($"Adding Azure AD application with client ID '{clientId}' to key vault {vaultResource.Data.Name} for secret read & list; certificate read");
+            _logger.LogInformation($"Granting Azure AD application with client ID '{clientId}' access to key vault {vaultResource.Data.Name} for {DescribePermissions(secretPerms, certPerms)}");
 
             // Extract object Id by getting a token from the credentials passed. Only log the
             // resolution on the first lookup; subsequent KV access-policy adds for the same SP would
@@ -184,6 +365,28 @@ namespace CloudInstallEngine.Azure.InstallTasks
             }
 
             await AddPolicyForConfiguredAccount(vaultResource, tenantId, objectIdValue, secretPerms, certPerms);
+        }
+
+        /// <summary>
+        /// Renders the requested permissions for logging, e.g. "secrets: Get, List; certificates: Get".
+        /// Previously every call logged a hard-coded "secret read &amp; list; certificate read", which was
+        /// actively misleading on the task that grants Set - the log claimed read-only access moments
+        /// before failing to write a secret.
+        /// </summary>
+        protected static string DescribePermissions(IEnumerable<string> secretPerms, IEnumerable<string> certPerms)
+        {
+            var parts = new List<string>();
+            var secrets = (secretPerms ?? Enumerable.Empty<string>()).ToList();
+            if (secrets.Count > 0)
+            {
+                parts.Add($"secrets: {string.Join(", ", secrets)}");
+            }
+            var certs = (certPerms ?? Enumerable.Empty<string>()).ToList();
+            if (certs.Count > 0)
+            {
+                parts.Add($"certificates: {string.Join(", ", certs)}");
+            }
+            return parts.Count > 0 ? string.Join("; ", parts) : "no permissions";
         }
 
         protected Guid TenantGuidFromConfig()
@@ -214,7 +417,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
                 throw new InstallException($"Can't find web-app with name '{webAppName}'");
 
             await AddPolicyForConfiguredAccount(vaultResource, tenantId, webAppWithManagedIdentity.Data.Identity.PrincipalId.ToString(), secretPerms, certPerms);
-            _logger.LogInformation($"Added web-app '{webAppName}' to key vault {vaultResource.Data.Name} for secret read & list; certificate read");
+            _logger.LogInformation($"Granted web-app '{webAppName}' access to key vault {vaultResource.Data.Name} for {DescribePermissions(secretPerms, certPerms)}");
         }
 
         public override async Task<KeyVaultResource> ExecuteTaskReturnResult(object contextArg)
@@ -269,8 +472,19 @@ namespace CloudInstallEngine.Azure.InstallTasks
         public const string CONFIG_KEY_CRED_CLIENT_ID = "clientId";
         public const string CONFIG_KEY_CRED_SECRET = "secret";
 
-        /// <summary>Backoff schedule (seconds) for retrying the secret write on a 403 — absorbs typical AAD policy propagation lag (~30–60s).</summary>
-        private static readonly int[] _retryDelaysSeconds = new[] { 10, 20, 30 };
+        /// <summary>Backoff schedule (seconds) for retrying the secret write on a 403 — absorbs typical access-policy propagation lag (~30–60s).</summary>
+        private static readonly int[] _accessPolicyRetryDelaysSeconds = new[] { 10, 20, 30 };
+
+        /// <summary>
+        /// Backoff schedule (seconds) for vaults using the RBAC permission model. Role assignments replicate
+        /// through Entra ID and the Key Vault data plane far more slowly than access policies — Azure documents
+        /// up to 5 minutes — and the installer will usually have created the assignment moments earlier, so the
+        /// first write lands squarely inside that window. The access-policy schedule (~60s total) is not enough.
+        /// </summary>
+        private static readonly int[] _rbacRetryDelaysSeconds = new[] { 10, 20, 30, 45, 60, 60, 60 };
+
+        private static int[] RetryDelaysFor(KeyVaultResource vault) =>
+            vault.Data.Properties?.EnableRbacAuthorization == true ? _rbacRetryDelaysSeconds : _accessPolicyRetryDelaysSeconds;
 
         public KeyVaultSecretAddTask(TaskConfig config, ILogger logger) : base(config, logger)
         {
@@ -353,11 +567,13 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
             _logger.LogInformation($"Updating secret '{name}' in key vault '{vault.Data.Name}'...");
 
-            // Retry on 403/Forbidden: the access policy granting the InstallerAccount Set permission was just
-            // added by KeyVaultAddSecretAllPermissionsForAppRegistrationTask in the same task batch, and AAD
-            // typically takes 30-60s to propagate before the policy is enforceable from the data plane.
+            // Retry on 403/Forbidden: the permission granting the InstallerAccount Set access was just added by
+            // KeyVaultAddSecretAllPermissionsForAppRegistrationTask in the same task batch, and Entra ID takes
+            // time to propagate before it is enforceable from the data plane — 30-60s for an access policy, and
+            // materially longer for a role assignment on an RBAC-model vault (hence the wider schedule).
+            var retryDelaysSeconds = RetryDelaysFor(vault);
             RequestFailedException lastForbidden = null;
-            for (var attempt = 0; attempt <= _retryDelaysSeconds.Length; attempt++)
+            for (var attempt = 0; attempt <= retryDelaysSeconds.Length; attempt++)
             {
                 try
                 {
@@ -384,11 +600,21 @@ namespace CloudInstallEngine.Azure.InstallTasks
                         _logger.LogInformation($"Key vault said: {KeyVaultForbiddenClassifier.FirstLine(ex.Message)}");
                     }
 
-                    if (attempt < _retryDelaysSeconds.Length)
+                    // A networking refusal (vault firewall, public access disabled) will still be a refusal
+                    // in five minutes - the installer's own address is not going to change mid-run. Only
+                    // permission/unknown 403s are worth waiting out for propagation, so stop retrying here
+                    // and let the classification below report it. Without this the RBAC schedule would sit
+                    // through its full backoff on a failure that could never succeed.
+                    if (KeyVaultForbiddenClassifier.Classify(ex) == KeyVaultForbiddenReason.NetworkBlocked)
                     {
-                        var delaySeconds = _retryDelaysSeconds[attempt];
-                        _logger.LogInformation($"Key vault secret write got 403/Forbidden (attempt {attempt + 1} of {_retryDelaysSeconds.Length + 1}). " +
-                            $"This usually means the access policy added moments earlier has not yet propagated through AAD. Waiting {delaySeconds}s and retrying...");
+                        break;
+                    }
+
+                    if (attempt < retryDelaysSeconds.Length)
+                    {
+                        var delaySeconds = retryDelaysSeconds[attempt];
+                        _logger.LogInformation($"Key vault secret write got 403/Forbidden (attempt {attempt + 1} of {retryDelaysSeconds.Length + 1}). " +
+                            $"This usually means the access policy or role assignment added moments earlier has not yet propagated through Entra ID. Waiting {delaySeconds}s and retrying...");
                         await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
                     }
                 }
@@ -415,10 +641,15 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
             if (reason == KeyVaultForbiddenReason.PermissionDenied)
             {
+                var usesRbac = vault.Data.Properties?.EnableRbacAuthorization == true;
                 _logger.LogError(
-                    $"Could not add secret '{name}' to key vault '{vault.Data.Name}' after {_retryDelaysSeconds.Length + 1} attempts: the installer reached the vault but is not permitted to write secrets. " +
+                    $"Could not add secret '{name}' to key vault '{vault.Data.Name}' after {retryDelaysSeconds.Length + 1} attempts: the installer reached the vault but is not permitted to write secrets. " +
                     $"Key vault said: {vaultSaid} " +
-                    $"Grant the installer's app registration 'Set' on secrets (vault Access policies blade, or the 'Key Vault Secrets Officer' role when the vault uses RBAC) and re-run. " +
+                    (usesRbac
+                        ? $"This vault uses the RBAC permission model, so the Access policies blade has no effect — and note that Owner/Contributor do NOT grant secret access either, because Key Vault secret operations are dataActions. " +
+                          $"Assign the installer's app registration the 'Key Vault Secrets Officer' role on the vault and re-run. " +
+                          $"(The installer tries to assign this automatically; if it could not, it needs 'User Access Administrator' or Owner on the vault.) "
+                        : $"Grant the installer's app registration 'Set' on secrets in the vault's Access policies blade and re-run. ") +
                     $"App-registration secrets in the vault may now be out of date.");
                 return vault;
             }
@@ -446,9 +677,9 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
             // Other 403 (policy lag past retry window, network ACL deny, etc.) — surface as Error.
             _logger.LogError(
-                $"Could not add secret '{name}' to key vault '{vault.Data.Name}' after {_retryDelaysSeconds.Length + 1} attempts (last error: 403 Forbidden, ErrorCode='{lastForbidden?.ErrorCode}'). " +
+                $"Could not add secret '{name}' to key vault '{vault.Data.Name}' after {retryDelaysSeconds.Length + 1} attempts (last error: 403 Forbidden, ErrorCode='{lastForbidden?.ErrorCode}'). " +
                 (vaultSaid != null ? $"Key vault said: {vaultSaid} " : string.Empty) +
-                $"Likely causes: access policy / RBAC propagation lag (longer than the {(_retryDelaysSeconds.Length + 1)}-attempt retry window) or a vault firewall rule rejecting the runner IP — check the vault's Networking blade. " +
+                $"Likely causes: access policy / RBAC propagation lag (longer than the {(retryDelaysSeconds.Length + 1)}-attempt retry window) or a vault firewall rule rejecting the runner IP — check the vault's Networking blade. " +
                 $"App-registration secrets in the vault may now be out of date — re-run the installer once the underlying cause is resolved.");
             return vault;
         }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/TextAnalyticsInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/TextAnalyticsInstallTask.cs
@@ -113,9 +113,32 @@ namespace CloudInstallEngine.Azure.InstallTasks
                     "role on this resource.");
             }
 
+            // Always prefer the resource's own endpoint - the custom-subdomain form,
+            // https://<name>.cognitiveservices.azure.com/. The regional endpoint
+            // (https://<region>.api.cognitive.microsoft.com/) supports API-key auth ONLY: Azure rejects
+            // Entra ID tokens against it with 400 "Please provide a custom subdomain for token
+            // authentication, otherwise API key is required". Hard-coding the regional form therefore
+            // broke the RBAC fallback taken just above when disableLocalAuth = true - the install
+            // succeeded and sentiment/key-phrase enrichment then failed silently at runtime. It also
+            // breaks private endpoints, because the privatelink.cognitiveservices.azure.com zone only
+            // ever resolves the custom-subdomain name.
+            var endpoint = ResolveEndpoint(
+                analytics.Data.Properties?.Endpoint,
+                analytics.Data.Properties?.CustomSubDomainName,
+                analytics.Data.Location.Name,
+                out var usedRegionalFallback);
+
+            if (usedRegionalFallback)
+            {
+                _logger.LogWarning($"Cognitive Service '{name}' reports neither an endpoint nor a custom subdomain, so the regional endpoint '{endpoint}' will be used. " +
+                    "Entra ID (RBAC) authentication does NOT work against regional endpoints — if account keys are disabled on this resource, " +
+                    "set a custom subdomain on it and re-run the installer, or sentiment/key-phrase enrichment will fail with " +
+                    "'Please provide a custom subdomain for token authentication'.");
+            }
+
             var cognitiveServicesInfo = new CognitiveServicesInfo
             {
-                Endpoint = $"https://{analytics.Data.Location.Name}.api.cognitive.microsoft.com/",
+                Endpoint = endpoint,
                 Key = accountKey ?? string.Empty
             };
 
@@ -123,6 +146,41 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
             _logger.LogInformation($"{logMsg}");
             return cognitiveServicesInfo;
+        }
+
+        /// <summary>
+        /// Chooses the Azure AI Language endpoint to hand to the runtime.
+        /// </summary>
+        /// <remarks>
+        /// Order matters. The regional endpoint <c>https://{region}.api.cognitive.microsoft.com/</c> supports
+        /// API-key authentication ONLY — Azure rejects Entra ID tokens against it with HTTP 400
+        /// "Please provide a custom subdomain for token authentication, otherwise API key is required". Since
+        /// the installer falls back to RBAC whenever the resource has <c>disableLocalAuth = true</c>, the
+        /// custom-subdomain endpoint is the only form that works in that configuration. It is also the only
+        /// form a <c>privatelink.cognitiveservices.azure.com</c> private DNS zone can resolve.
+        /// </remarks>
+        /// <param name="usedRegionalFallback">
+        /// True when neither an endpoint nor a custom subdomain was available and the regional form was used
+        /// as a last resort — the caller should warn, because RBAC auth cannot work against it.
+        /// </param>
+        public static string ResolveEndpoint(string reportedEndpoint, string customSubDomain, string location, out bool usedRegionalFallback)
+        {
+            usedRegionalFallback = false;
+
+            if (!string.IsNullOrWhiteSpace(reportedEndpoint))
+            {
+                return reportedEndpoint;
+            }
+
+            // Every path in this task sets CustomSubDomainName, so this is the normal fallback for a freshly
+            // created account whose Endpoint ARM has not populated yet.
+            if (!string.IsNullOrWhiteSpace(customSubDomain))
+            {
+                return $"https://{customSubDomain}.cognitiveservices.azure.com/";
+            }
+
+            usedRegionalFallback = true;
+            return $"https://{location}.api.cognitive.microsoft.com/";
         }
     }
 }

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/KeyVaultForbiddenClassifier.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/KeyVaultForbiddenClassifier.cs
@@ -61,6 +61,10 @@ namespace CloudInstallEngine.Azure
         static readonly string[] PermissionMarkers =
         {
             "forbiddenbypolicy",
+            // Key Vault's inner error code when the vault uses the RBAC permission model and the caller has
+            // no matching role assignment. Access policies are ignored on such vaults, so this specifically
+            // means "assign a Key Vault data-plane role" rather than "edit the access policies blade".
+            "forbiddenbyrbac",
             "does not have secrets",
             "does not have keys",
             "does not have certificates",

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallerAuthAndEndpointTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallerAuthAndEndpointTests.cs
@@ -1,0 +1,155 @@
+using CloudInstallEngine.Azure;
+using CloudInstallEngine.Azure.InstallTasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Tests.UnitTests.InstallTests
+{
+    /// <summary>
+    /// Azure-free tests for two installer decisions that used to be wrong in ways the install log did not
+    /// reveal: which Azure AI Language endpoint the runtime is given, and which Key Vault RBAC roles are
+    /// granted when the vault uses the RBAC permission model instead of access policies.
+    /// </summary>
+    [TestClass]
+    public class InstallerAuthAndEndpointTests
+    {
+        // ---------------------------------------------------------------------
+        // Azure AI Language endpoint selection
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// The regression this guards: the installer used to hard-code the REGIONAL endpoint, which only
+        /// supports API-key auth. When the resource has account keys disabled the installer falls back to
+        /// Entra ID, and Azure then rejects every call with 400 "Please provide a custom subdomain for token
+        /// authentication, otherwise API key is required" - an install that reports success but whose
+        /// sentiment/key-phrase enrichment never works.
+        /// </summary>
+        [TestMethod]
+        public void ResolveEndpoint_PrefersTheResourcesOwnEndpoint()
+        {
+            var endpoint = TextAnalyticsInstallTask.ResolveEndpoint(
+                reportedEndpoint: "https://contoso-language.cognitiveservices.azure.com/",
+                customSubDomain: "contoso-language",
+                location: "westeurope",
+                usedRegionalFallback: out var fellBack);
+
+            Assert.AreEqual("https://contoso-language.cognitiveservices.azure.com/", endpoint);
+            Assert.IsFalse(fellBack);
+            StringAssert.Contains(endpoint, "cognitiveservices.azure.com",
+                "Entra ID token auth only works against the custom-subdomain endpoint.");
+        }
+
+        [TestMethod]
+        public void ResolveEndpoint_BuildsCustomSubdomainWhenArmHasNotPopulatedTheEndpointYet()
+        {
+            var endpoint = TextAnalyticsInstallTask.ResolveEndpoint(
+                reportedEndpoint: null,
+                customSubDomain: "contoso-language",
+                location: "westeurope",
+                usedRegionalFallback: out var fellBack);
+
+            Assert.AreEqual("https://contoso-language.cognitiveservices.azure.com/", endpoint);
+            Assert.IsFalse(fellBack, "A custom subdomain is available, so this is not the regional fallback.");
+        }
+
+        [TestMethod]
+        public void ResolveEndpoint_FallsBackToRegionalOnlyAsALastResortAndFlagsIt()
+        {
+            var endpoint = TextAnalyticsInstallTask.ResolveEndpoint(
+                reportedEndpoint: "   ",
+                customSubDomain: null,
+                location: "westeurope",
+                usedRegionalFallback: out var fellBack);
+
+            Assert.AreEqual("https://westeurope.api.cognitive.microsoft.com/", endpoint);
+            Assert.IsTrue(fellBack, "The caller must warn: RBAC auth cannot work against a regional endpoint.");
+        }
+
+        // ---------------------------------------------------------------------
+        // Key Vault access-policy permissions -> RBAC roles
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// Read-only secret access must NOT be granted the Officer role - that would hand the web app's
+        /// managed identity the ability to overwrite and delete every secret in the vault.
+        /// </summary>
+        [TestMethod]
+        public void MapPermissionsToRoles_ReadOnlySecretsGetsSecretsUserNotOfficer()
+        {
+            var roles = BaseKeyVaultAddPolicyTask.MapPermissionsToRoles(
+                new[] { "Get", "List" }, new string[0]);
+
+            CollectionAssert.AreEqual(new[] { BaseKeyVaultAddPolicyTask.ROLE_SECRETS_USER }, roles.ToList());
+        }
+
+        [TestMethod]
+        public void MapPermissionsToRoles_WritePermissionsEscalateToSecretsOfficer()
+        {
+            // The permission set used by the task that writes the runtime app-registration secret.
+            var roles = BaseKeyVaultAddPolicyTask.MapPermissionsToRoles(
+                new[] { "Get", "List", "Set", "Delete", "Recover", "Backup", "Restore" }, new[] { "Get" });
+
+            CollectionAssert.AreEquivalent(
+                new[] { BaseKeyVaultAddPolicyTask.ROLE_SECRETS_OFFICER, BaseKeyVaultAddPolicyTask.ROLE_CERTIFICATE_USER },
+                roles.ToList());
+            CollectionAssert.DoesNotContain(roles.ToList(), BaseKeyVaultAddPolicyTask.ROLE_SECRETS_USER);
+        }
+
+        [TestMethod]
+        public void MapPermissionsToRoles_WriteDetectionIsCaseInsensitive()
+        {
+            var roles = BaseKeyVaultAddPolicyTask.MapPermissionsToRoles(
+                new[] { "get", "set" }, new string[0]);
+
+            CollectionAssert.AreEqual(new[] { BaseKeyVaultAddPolicyTask.ROLE_SECRETS_OFFICER }, roles.ToList());
+        }
+
+        /// <summary>
+        /// Certificate access needs "Key Vault Certificate User" specifically, because downloading a
+        /// certificate's private key also reads the backing secret.
+        /// </summary>
+        [TestMethod]
+        public void MapPermissionsToRoles_CertificateOnlyGrantsCertificateUser()
+        {
+            var roles = BaseKeyVaultAddPolicyTask.MapPermissionsToRoles(
+                new string[0], new[] { "Get" });
+
+            CollectionAssert.AreEqual(new[] { BaseKeyVaultAddPolicyTask.ROLE_CERTIFICATE_USER }, roles.ToList());
+        }
+
+        [TestMethod]
+        public void MapPermissionsToRoles_NoPermissionsGrantsNoRoles()
+        {
+            Assert.AreEqual(0, BaseKeyVaultAddPolicyTask.MapPermissionsToRoles(null, null).Count);
+            Assert.AreEqual(0, BaseKeyVaultAddPolicyTask.MapPermissionsToRoles(new string[0], new string[0]).Count);
+        }
+
+        // ---------------------------------------------------------------------
+        // 403 classification
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// An RBAC-model vault reports a missing role assignment with the inner error code
+        /// <c>ForbiddenByRbac</c>. That wording carries none of the phrases the other permission markers
+        /// match, so without an explicit marker it classified as Unknown and the operator got the generic
+        /// "could be networking, could be permissions" message instead of the RBAC remedy.
+        /// </summary>
+        [TestMethod]
+        public void Classify_ForbiddenByRbacInnerCode_IsPermissionDenied()
+        {
+            Assert.AreEqual(KeyVaultForbiddenReason.PermissionDenied,
+                KeyVaultForbiddenClassifier.Classify("Access denied. Inner error: {\"code\":\"ForbiddenByRbac\"}"));
+        }
+
+        /// <summary>
+        /// Ordering guard: the networking markers are tested first, so a firewall rejection must not be
+        /// reclassified as a permission problem by the new RBAC marker.
+        /// </summary>
+        [TestMethod]
+        public void Classify_FirewallStillWinsOverTheRbacMarker()
+        {
+            Assert.AreEqual(KeyVaultForbiddenReason.NetworkBlocked,
+                KeyVaultForbiddenClassifier.Classify("Client address is not authorized. Inner error: {\"code\":\"ForbiddenByFirewall\"}"));
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -334,6 +334,7 @@
     <Compile Include="InstallTests\ImportToggleVerificationCoverageTests.cs" />
     <Compile Include="InstallTests\InstallEngineTests.cs" />
     <Compile Include="InstallTests\InstallFailureDiagnosisTests.cs" />
+    <Compile Include="InstallTests\InstallerAuthAndEndpointTests.cs" />
     <Compile Include="InstallTests\KeyVaultFirewallConfigTaskTests.cs" />
     <Compile Include="InstallTests\ServiceBusNamespaceInstallTaskTests.cs" />
     <Compile Include="InstallTests\RbacPermissionProbeTests.cs" />


### PR DESCRIPTION
Three installer defects diagnosed from a failing install against a real subscription. All three share a failure mode: the installer reports success (or blames the wrong thing) while the deployment is broken.

## 1. Azure AI Language endpoint is incompatible with the auth the installer chooses

`TextAnalyticsInstallTask` hard-coded the **regional** endpoint:

```csharp
Endpoint = $"https://{analytics.Data.Location.Name}.api.cognitive.microsoft.com/",
```

The regional form supports **API-key auth only**. A few lines earlier the same method already falls back to Entra ID/RBAC when the resource has `disableLocalAuth = true`, and Azure rejects tokens against a regional endpoint with:

```
400 BadRequest - Please provide a custom subdomain for token authentication, otherwise API key is required.
```

So on any keyless Azure AI Language resource, sentiment/key-phrase enrichment fails on every call while the install reports success. The task already *ensures* a custom subdomain exists a few lines above, then ignored it. This also breaks private-endpoint deployments: `privatelink.cognitiveservices.azure.com` only ever resolves the custom-subdomain name, never the regional one.

Endpoint selection is now `TextAnalyticsInstallTask.ResolveEndpoint()`: resource `Properties.Endpoint` -> `CustomSubDomainName` -> regional as a flagged last resort that warns that RBAC cannot work against it.

## 2. Key Vault access policies are ignored on RBAC-model vaults

Permissions were granted with `UpdateAccessPolicyAsync`. On a vault with `enableRbacAuthorization = true`, Azure **accepts and stores** the access policy but ignores it for authorization, so the grant silently did nothing and the secret write failed with `403 ForbiddenByRbac` / `Assignment: (not found)`. Subscription **Owner** does not help either — Key Vault secret operations are `dataActions`, which Owner does not include.

`AddPolicyForConfiguredAccount` now detects the permission model and assigns built-in roles at **vault scope** instead. Strict no-op for access-policy vaults (`EnableRbacAuthorization == true` only; `null`/`false` take the original path).

| Requested permissions | Role assigned |
|---|---|
| secrets `Get`/`List` | Key Vault Secrets User |
| secrets incl. `Set`/`Delete`/`Recover`/`Backup`/`Restore`/`Purge` | Key Vault Secrets Officer |
| any certificate permission | Key Vault Certificate User |

Certificate User rather than a certificates-only role because it also carries `secrets/getSecret`, which is what actually returns the private key via `CertificateClient.DownloadCertificate` — `AuthHelper.RetrieveKeyVaultCertificate` needs both.

Also in this area:

- **Idempotency.** Assignment names are derived deterministically from scope/principal/role, so a re-run PUTs the same assignment rather than creating a second one and hitting `409 RoleAssignmentExists`. 409 is additionally caught and treated as already-granted. An existing assignment only counts as a match when it is unconditioned (no ABAC `Condition`) and scoped to the vault or a genuine ancestor — a role scoped to a single secret inside the vault must not suppress the vault-wide grant.
- **A 403 creating a role assignment is now fatal.** It was initially logged and swallowed; since these tasks are `IsCritical`, that reproduced the exact silent failure this PR exists to remove. Creating role assignments needs `Microsoft.Authorization/roleAssignments/write` (User Access Administrator or Owner) — Contributor is not enough, and the message now says so.
- **Retry backoff** for the secret write is widened for RBAC vaults, because role assignments replicate far more slowly than access policies and the installer creates them seconds earlier. The loop now **stops immediately on a networking refusal**, which can never succeed on retry — previously a firewall block sat through the whole schedule before being classified.
- `KeyVaultForbiddenClassifier` recognises the `ForbiddenByRbac` inner error code, so that case gets the RBAC remedy rather than the generic "could be networking, could be permissions" message.
- Log text: the permission lines printed a fixed `secret read & list` regardless of what was requested — actively misleading on the task that grants `Set`, which logged read-only access one line before failing to write.

## 3. Post-deploy HTTP 500s, misdiagnosed as a private-endpoint problem

The site returned 500 for ~3 minutes after deployment and failed warm-up. Cause, from the App Service's own `LogFiles/eventlog.xml`:

```
ConfigurationErrorsException: Cannot create/shadow copy 'Microsoft.ApplicationInsights, Version=...'
when that file already exists.
```

Classic ASP.NET shadow-copy collision from zip-deploying over a running site — the old AppDomain still holds shadow copies of the previous build. It self-heals once the app pool recycles, which is why the site was fine later.

- The deploy is now followed by `RestartAsync(softRestart: false, synchronous: true)`. `synchronous` matters: it defaults to false, so the await would otherwise return as soon as ARM accepts the request and the warm-up would race the recycle. `softRestart: false` is the full restart (per the SDK docs, `true` restarts only if it judges it necessary).
- **Warm-up accepted `OK`, `Moved` and `MovedPermanently`.** The latter two are both **301**, so the **302** the admin site returns for an unauthenticated request never matched. Any 3xx is now accepted — with a warning when the redirect chain was not followed to completion, so a genuine redirect loop stays visible rather than being silently treated as healthy.
- The failure message blamed private endpoints **unconditionally**, which sent operators of ordinary public deployments (no VNet, public access enabled) hunting a networking fault that did not exist, and made `InstallSummary` tag it `[PrivateEndpoint]`. It now distinguishes three cases: VNet deployments, an app that answered but failed to start (pointing at `eventlog.xml`), and nothing answering at all.

An `MSDEPLOY_RENAME_LOCKED_FILES=1` app setting was in an earlier revision of this branch and has been **removed**: the deploy goes to Kudu OneDeploy (`POST /api/publish?type=zip`, see `BuildKuduPublishUri`), and that setting is only honoured by MSDeploy/WebDeploy. It would have been dead configuration permanently written into every customer's App Service.

## Tests

New `Tests.UnitTests/InstallTests/InstallerAuthAndEndpointTests.cs` (10 tests, Azure-free):

- endpoint precedence, including that the regional fallback is flagged;
- the permission-to-role mapping, including the read-only/Officer boundary (read-only access must **not** get Officer, which would let the web app's managed identity overwrite and delete every secret) and case-insensitive write detection;
- `ForbiddenByRbac` classification, plus an ordering guard that a firewall refusal is still classified as networking rather than being captured by the new marker.

170 installer tests pass; the solution builds clean in Release.

## Reviewer notes

- **Schema/config:** no change to the installer's saved config schema, so `CONFIG_VERSION` is deliberately unchanged. No database migrations.
- **Hotspot:** `AssignVaultRole` / `HasVaultScopedAssignment` in `KeyVaultTasks.cs` is the riskiest code here — the scope-matching rule and the now-fatal 403 are the two decisions most worth a second opinion.
- **Behaviour on existing deployments:** vaults still using access policies take the original code path unchanged. RBAC vaults that previously "installed" with silently-ignored access policies will now either be granted properly or fail loudly.
- **Unrelated pre-existing issue spotted, not fixed here:** `VNetIntegrationTests` fails on a clean checkout because `Tests.UnitTests/InstallTests/TestConfigs/InstallerTestConfig.json` is tracked in git but has no copy rule in `Tests.UnitTests.csproj`, so it never reaches the output directory. Confirmed present on `dev` and untouched by this branch.
