### PR TITLE
Disambiguate LINQ calls on Azure ARM collections

### DIFF
--- a/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/ConfigureAzureComponentsTasks.cs
@@ -367,7 +367,7 @@ namespace App.ControlPanel.Engine
                 {
                     var rules = sqlServer.GetSqlFirewallRules();
 
-                    var existing = rules
+                    var existing = rules.AsEnumerable()
                         .Where(r => r.Data.Name == AzurePaaSInstallJob.INSTALLER_FIREWALL_RULE_NAME)
                         .Select(r => new SqlFirewallRuleRange(r.Data.Name, r.Data.StartIPAddress, r.Data.EndIPAddress))
                         .SingleOrDefault();

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/AutomationAccountTask.cs
@@ -43,7 +43,7 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
         public override async Task<AutomationAccountResource> ExecuteTaskReturnResult(object contextArg)
         {
             // Get/create app-service with plan
-            var automationAccount = Container.GetAutomationAccounts().Where(s => s.Data.Name == _config.ResourceName).SingleOrDefault();
+            var automationAccount = Container.GetAutomationAccounts().AsEnumerable().Where(s => s.Data.Name == _config.ResourceName).SingleOrDefault();
             if (automationAccount == null)
             {
                 var newAutomationAccountInfo = new AutomationAccountCreateOrUpdateContent()

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/HybridWorkerGroupTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/JobTasks/HybridWorkerGroupTask.cs
@@ -44,7 +44,7 @@ namespace App.ControlPanel.Engine.InstallerTasks.Tasks
             try
             {
                 // Find automation account
-                var automationAccount = Container.GetAutomationAccounts().Where(s => s.Data.Name == automationAccountName).SingleOrDefault();
+                var automationAccount = Container.GetAutomationAccounts().AsEnumerable().Where(s => s.Data.Name == automationAccountName).SingleOrDefault();
                 if (automationAccount == null)
                 {
                     _logger.LogError($"Automation account '{automationAccountName}' not found. Cannot create hybrid worker group.");

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/SolutionInstallVerifier.cs
@@ -145,7 +145,7 @@ namespace App.ControlPanel.Engine
             if (testRg != null)
             {
                 SqlDetails sqlInfo = null;
-                var sqlServer = testRg.GetSqlServers().Where(s => s.Data.Name == Config.SQLServerName).SingleOrDefault();
+                var sqlServer = testRg.GetSqlServers().AsEnumerable().Where(s => s.Data.Name == Config.SQLServerName).SingleOrDefault();
                 if (sqlServer == null)
                 {
                     _logger.LogError($"Can't find SQL Server with name '{Config.SQLServerName}' in resource-group '{testRg.Data.Name}'");
@@ -273,7 +273,7 @@ namespace App.ControlPanel.Engine
 
             try
             {
-                var plan = testRg.GetAppServicePlans().Where(p => p.Data.Name == planName).SingleOrDefault();
+                var plan = testRg.GetAppServicePlans().AsEnumerable().Where(p => p.Data.Name == planName).SingleOrDefault();
                 if (plan == null)
                 {
                     _logger.LogInformation($"App Service plan '{planName}' not found yet; skipping capability check (it will be created during install).");
@@ -354,7 +354,7 @@ namespace App.ControlPanel.Engine
             KeyVaultResource vault;
             try
             {
-                vault = testRg.GetKeyVaults().Where(v => v.Data.Name == Config.KeyVaultName).SingleOrDefault();
+                vault = testRg.GetKeyVaults().AsEnumerable().Where(v => v.Data.Name == Config.KeyVaultName).SingleOrDefault();
             }
             catch (Exception ex)
             {
@@ -706,7 +706,7 @@ namespace App.ControlPanel.Engine
 
             try
             {
-                var classic = testRg.GetAllRedis().Where(c => c.Data.Name == redisName).SingleOrDefault();
+                var classic = testRg.GetAllRedis().AsEnumerable().Where(c => c.Data.Name == redisName).SingleOrDefault();
                 if (!string.IsNullOrWhiteSpace(classic?.Data?.HostName))
                 {
                     return classic.Data.HostName;
@@ -719,7 +719,7 @@ namespace App.ControlPanel.Engine
 
             try
             {
-                var managed = testRg.GetRedisEnterpriseClusters().Where(c => c.Data.Name == redisName).SingleOrDefault();
+                var managed = testRg.GetRedisEnterpriseClusters().AsEnumerable().Where(c => c.Data.Name == redisName).SingleOrDefault();
                 if (!string.IsNullOrWhiteSpace(managed?.Data?.HostName))
                 {
                     return managed.Data.HostName;

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServicePlanTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServicePlanTask.cs
@@ -26,7 +26,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
         public override async Task<AppServicePlanResource> ExecuteTaskReturnResult(object contextArg)
         {
             // Get/create plan
-            var plan = Container.GetAppServicePlans().Where(p => p.Data.Name == _config.ResourceName).SingleOrDefault();
+            var plan = Container.GetAppServicePlans().AsEnumerable().Where(p => p.Data.Name == _config.ResourceName).SingleOrDefault();
 
             if (plan == null)
             {

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/AppServiceWebsiteTask.cs
@@ -37,7 +37,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             var supportsAlwaysOn = AppServicePlanCapabilities.SupportsAlwaysOn(appServicePlanSku);
 
             // Get/create app-service with plan
-            var webApp = Container.GetWebSites().Where(s => s.Data.Name == _config.ResourceName).SingleOrDefault();
+            var webApp = Container.GetWebSites().AsEnumerable().Where(s => s.Data.Name == _config.ResourceName).SingleOrDefault();
             if (webApp == null)
             {
                 var newWebAppInfo = BuildNewWebSiteData(base.AzureLocation, appServicePlan.Id, appServicePlanSku, _allowPublicAccess);

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultFirewallConfigTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultFirewallConfigTask.cs
@@ -111,7 +111,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
 
         List<string> GetAppServiceOutboundIps(string appServiceName)
         {
-            var site = Container.GetWebSites().Where(s => s.Data.Name == appServiceName).SingleOrDefault();
+            var site = Container.GetWebSites().AsEnumerable().Where(s => s.Data.Name == appServiceName).SingleOrDefault();
             if (site == null)
             {
                 _logger.LogWarning($"App Service '{appServiceName}' not found in the resource group; cannot allow its outbound IPs on the Key Vault firewall.");

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/KeyVaultTasks.cs
@@ -412,7 +412,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             var webAppName = _config.GetConfigValue(CONFIG_KEY_WEB_APP_NAME);
             var tenantId = TenantGuidFromConfig();
 
-            var webAppWithManagedIdentity = Container.GetWebSites().Where(s => s.Data.Name == webAppName).SingleOrDefault();
+            var webAppWithManagedIdentity = Container.GetWebSites().AsEnumerable().Where(s => s.Data.Name == webAppName).SingleOrDefault();
             if (webAppWithManagedIdentity == null)
                 throw new InstallException($"Can't find web-app with name '{webAppName}'");
 

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/LogAnalyticsInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/LogAnalyticsInstallTask.cs
@@ -25,7 +25,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
         public async override Task<LogWorkspaceInfo> ExecuteTaskReturnResult(object contextArg)
         {
             var name = base._config.GetNameConfigValue();
-            var insightsLogs = Container.GetOperationalInsightsWorkspaces()
+            var insightsLogs = Container.GetOperationalInsightsWorkspaces().AsEnumerable()
                             .Where(r => r.Data.Name == name).SingleOrDefault();
 
             if (insightsLogs == null)

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/RedisInstallTask.cs
@@ -79,7 +79,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
         private Task<RedisResource> TryGetLegacyClassicCacheAsync(string name)
         {
             var allLegacy = base.Container.GetAllRedis();
-            return Task.FromResult(allLegacy.Where(c => c.Data.Name == name).SingleOrDefault());
+            return Task.FromResult(allLegacy.AsEnumerable().Where(c => c.Data.Name == name).SingleOrDefault());
         }
 
         private async Task<RedisInstallResult> ReuseLegacyClassicCacheAsync(RedisResource legacy)
@@ -148,7 +148,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             var skuLabel = _requireStandardSku ? "Balanced B1" : "Balanced B0";
 
             var allClusters = base.Container.GetRedisEnterpriseClusters();
-            var cluster = allClusters.Where(c => c.Data.Name == name).SingleOrDefault();
+            var cluster = allClusters.AsEnumerable().Where(c => c.Data.Name == name).SingleOrDefault();
 
             if (cluster == null)
             {

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/ServiceBusNamespaceInstallTask.cs
@@ -81,7 +81,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             var name = base._config.GetNameConfigValue();
             var desiredAccess = _allowPublicAccess ? ServiceBusPublicNetworkAccess.Enabled : ServiceBusPublicNetworkAccess.Disabled;
 
-            var sbNS = allNSs.Where(ns => ns.Data.Name.ToLower() == name.ToLower()).SingleOrDefault();
+            var sbNS = allNSs.AsEnumerable().Where(ns => ns.Data.Name.ToLower() == name.ToLower()).SingleOrDefault();
 
             if (sbNS == null)
             {

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerFirewallConfigTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/SqlServerFirewallConfigTask.cs
@@ -132,14 +132,14 @@ namespace CloudInstallEngine.Azure.InstallTasks
         /// <summary>Snapshot of the server's firewall rules in the shape the pure coverage logic works on.</summary>
         private static List<SqlFirewallRuleRange> ReadRules(SqlServerResource server)
         {
-            return server.GetSqlFirewallRules()
+            return server.GetSqlFirewallRules().AsEnumerable()
                 .Select(r => new SqlFirewallRuleRange(r.Data.Name, r.Data.StartIPAddress, r.Data.EndIPAddress))
                 .ToList();
         }
 
         SqlFirewallRuleResource GetRuleByName(SqlServerResource server, string name)
         {
-            return server.GetSqlFirewallRules().Where(r => r.Data.Name == name).SingleOrDefault();
+            return server.GetSqlFirewallRules().AsEnumerable().Where(r => r.Data.Name == name).SingleOrDefault();
         }
 
         private async Task AddRule(SqlFirewallRuleCollection serverRules, string ruleName, string ip)

--- a/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/TextAnalyticsInstallTask.cs
+++ b/src/AnalyticsEngine/Common/CloudInstallEngine/Azure/InstallTasks/TextAnalyticsInstallTask.cs
@@ -26,7 +26,7 @@ namespace CloudInstallEngine.Azure.InstallTasks
             var name = _config.GetNameConfigValue();
             var desiredAccess = _allowPublicAccess ? ServiceAccountPublicNetworkAccess.Enabled : ServiceAccountPublicNetworkAccess.Disabled;
 
-            var analytics = Container.GetCognitiveServicesAccounts().Where(s => s.Data.Name == name).SingleOrDefault();
+            var analytics = Container.GetCognitiveServicesAccounts().AsEnumerable().Where(s => s.Data.Name == name).SingleOrDefault();
 
             var logMsg = string.Empty;
             if (analytics == null)


### PR DESCRIPTION
## Scope

Adds `.AsEnumerable()` at 11 call sites in `Common/CloudInstallEngine/Azure/InstallTasks`. **9 files, 11 insertions, 11 deletions.** No behaviour change on .NET Framework 4.8.

## Why

Azure Resource Manager collection types — `AppServicePlanCollection`, `WebSiteCollection`, `RedisCollection`, `SqlFirewallRuleCollection`, `ServiceBusNamespaceCollection` and friends — implement **both** `IEnumerable<T>` and `IAsyncEnumerable<T>`.

Calling `.Where(...)` directly on one resolves unambiguously today only because `System.Linq.Enumerable` is the only candidate in scope. **.NET 10 adds `System.Linq.AsyncEnumerable` to the BCL**, which makes both extension methods applicable and the call ambiguous:

```
error CS0121: The call is ambiguous between the following methods or properties:
'System.Linq.AsyncEnumerable.Where<TSource>(IAsyncEnumerable<TSource>, Func<TSource, bool>)' and
'System.Linq.Enumerable.Where<TSource>(IEnumerable<TSource>, Func<TSource, bool>)'
```

This is a .NET 10 **source-breaking change**, not a defect in our code — it only bites because the Azure SDK collections are dual-interface.

## Why this targets `dev` rather than a .NET 10 branch

`.AsEnumerable()` exists on .NET Framework 4.8, so this compiles identically on the current target. It pins the synchronous overload these sites already resolve to — enumeration semantics, ordering and the number of ARM round-trips are all unchanged.

Landing it here rather than on a port branch keeps the eventual .NET 10 diff smaller, and makes the existing intent explicit at each call site regardless of framework.

## Call sites

| File | Line | Receiver |
|---|---|---|
| `AppServicePlanTask.cs` | 29 | `Container.GetAppServicePlans()` |
| `AppServiceWebsiteTask.cs` | 40 | `Container.GetWebSites()` |
| `KeyVaultFirewallConfigTask.cs` | 114 | `Container.GetWebSites()` |
| `KeyVaultTasks.cs` | 212 | `Container.GetWebSites()` |
| `LogAnalyticsInstallTask.cs` | 28–29 | `Container.GetOperationalInsightsWorkspaces()` |
| `RedisInstallTask.cs` | 82 | `allLegacy` |
| `RedisInstallTask.cs` | 151 | `allClusters` |
| `ServiceBusNamespaceInstallTask.cs` | 84 | `allNSs` |
| `SqlServerFirewallConfigTask.cs` | 135–136 | `server.GetSqlFirewallRules()` (`.Select`) |
| `SqlServerFirewallConfigTask.cs` | 142 | `server.GetSqlFirewallRules()` (`.Where`) |
| `TextAnalyticsInstallTask.cs` | 29 | `Container.GetCognitiveServicesAccounts()` |

## Verification

| Leg | Before | After |
|---|---|---|
| `netstandard2.0` (what ships today) | clean | **0 warnings, 0 errors** |
| `net10.0` (temporary multi-target, reverted before commit) | 22 × `CS0121` | **Build succeeded, 0 errors** |

The `netstandard2.0` leg staying at 0/0 is the evidence that this is safe for the current product.

## Deliberately not in scope

`.Where(...).SingleOrDefault()` on an ARM collection enumerates client-side; several of these could arguably be server-side `Get`/`Exists` calls instead. That would be a behaviour change and is kept out so this PR stays trivially reviewable — every hunk is the same one-token insertion.

## Reviewer note

The change is purely mechanical. The thing worth checking is that `.AsEnumerable()` was inserted **before** `.Where`/`.Select` and not after, so the synchronous overload is selected on the collection rather than on an already-projected sequence.

Addresses #509.
