### PR TITLE
Stop the portal nav pushing duplicate history entries

### DIFF
--- a/src/AnalyticsEngine/Web/Scripts/portal/src/App.test.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/App.test.tsx
@@ -1,18 +1,59 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { screen, within } from '@testing-library/react';
+import { useEffect } from 'react';
+import { screen, within, fireEvent, waitFor, configure, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { HashRouter, useLocation } from 'react-router-dom';
 import { renderWithProvider } from './test/renderWithProvider';
 import App from './App';
 import { routesForArea } from './navigation';
 import { fetchAvailability } from './api/licenceActivityApi';
 import { fetchReportAreas } from './api/reportsApi';
 
+// Every test here mounts the whole app shell (Fluent header, TabList and NavDrawer) and then waits
+// for a lazily-imported page chunk. In jsdom that is slow, and under a full parallel run it has
+// been measured over 6s, so the async matchers get well beyond LicenceActivityPage.test.tsx's
+// headroom - without it this file fails intermittently on timing alone.
+configure({ asyncUtilTimeout: 15000 });
+vi.setConfig({ testTimeout: 30000 });
+
 vi.mock('./api/licenceActivityApi', async (importOriginal) => ({
   ...await importOriginal<typeof import('./api/licenceActivityApi')>(),
   fetchAvailability: vi.fn(),
 }));
 vi.mock('./api/reportsApi', () => ({ fetchReportAreas: vi.fn(), fetchReportArea: vi.fn() }));
+
+/** Records each distinct location react-router lands on, including duplicate pushes. */
+function LocationLog({ log }: { log: string[] }) {
+  const location = useLocation();
+  useEffect(() => {
+    log.push(location.pathname);
+  }, [location, log]);
+  return null;
+}
+
+/**
+ * Renders the app at `path` under HashRouter - the router main.tsx uses in production.
+ *
+ * The shell decides whether to navigate by reading the live URL, so the router has to be a real
+ * one over jsdom's history: under MemoryRouter there is no URL to read, and because jsdom's
+ * history is shared by every test in the file, a stale hash left by an earlier test would be read
+ * as the current route. Replacing (not pushing) the entry also means a Back press in one test
+ * cannot walk into another test's history.
+ */
+const renderAt = (path: string) => {
+  window.history.replaceState(null, '', `#${path}`);
+  const log: string[] = [];
+  renderWithProvider(
+    <HashRouter>
+      <LocationLog log={log} />
+      <App />
+    </HashRouter>,
+  );
+  return log;
+};
+
+/** The browser Back button - the invariant the user actually feels. */
+const pressBack = () => window.history.back();
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -32,7 +73,7 @@ describe('Licence activity navigation', () => {
   });
 
   it('opens the standalone route directly without loading Reports or requiring its imports', async () => {
-    renderWithProvider(<MemoryRouter initialEntries={['/insights/licence-activity']}><App /></MemoryRouter>);
+    renderAt('/insights/licence-activity');
 
     expect(await screen.findByText(/Licence activity reporting is not available on this deployment/)).toBeVisible();
     expect(screen.getByText('Preview')).toBeVisible();
@@ -44,12 +85,136 @@ describe('Licence activity navigation', () => {
 
   it('navigates from Reports to Licence activity using the sidebar', async () => {
     const user = userEvent.setup();
-    renderWithProvider(<MemoryRouter initialEntries={['/insights/reports']}><App /></MemoryRouter>);
+    renderAt('/insights/reports');
 
     expect(await screen.findByText(/No built-in report charts are available yet/)).toBeVisible();
     expect(fetchAvailability).not.toHaveBeenCalled();
     await user.click(within(screen.getByLabelText('Insights navigation')).getByText('Licence activity'));
     expect(await screen.findByText(/Licence activity reporting is not available on this deployment/)).toBeVisible();
     expect(screen.queryByText(/No built-in report charts are available yet/)).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Every push adds a browser history entry, so re-selecting what is already selected leaves a
+ * duplicate the user has to Back through - the first press looks like a dead Back button.
+ * Verified against the deployed site: clicking one nav item three times needed three Backs to
+ * return to the previous page.
+ *
+ * These use HashRouter (what main.tsx renders) rather than MemoryRouter, because the shell decides
+ * whether to navigate by reading the live URL - jsdom's history is what makes that reachable, and
+ * MemoryRouter would leave the interesting logic untested.
+ */
+describe('History entries', () => {
+  it('does not push a history entry when the selected nav item is clicked again', async () => {
+    const user = userEvent.setup();
+    const log = renderAt('/insights/reports');
+    expect(await screen.findByText(/No built-in report charts are available yet/)).toBeVisible();
+    const initial = log.length;
+
+    const nav = screen.getByLabelText('Insights navigation');
+    await user.click(within(nav).getByText('Reports'));
+    await user.click(within(nav).getByText('Reports'));
+
+    expect(log.length).toBe(initial);
+    expect(await screen.findByText(/No built-in report charts are available yet/)).toBeVisible();
+  });
+
+  it('still navigates when a different nav item is clicked', async () => {
+    const user = userEvent.setup();
+    const log = renderAt('/insights/reports');
+    expect(await screen.findByText(/No built-in report charts are available yet/)).toBeVisible();
+
+    await user.click(within(screen.getByLabelText('Insights navigation')).getByText('Licence activity'));
+
+    expect(await screen.findByText(/Licence activity reporting is not available on this deployment/)).toBeVisible();
+    expect(log[log.length - 1]).toBe('/insights/licence-activity');
+  });
+
+  it('takes one Back press to undo a nav item that was double-clicked', async () => {
+    const log = renderAt('/insights/overview');
+    await screen.findByLabelText('Insights navigation');
+    const nav = screen.getByLabelText('Insights navigation');
+
+    // Both clicks must land before the first navigation commits. fireEvent flushes between calls,
+    // which would hide the race, so dispatch both inside one act. A duplicate push is invisible to
+    // LocationLog because React coalesces the two updates - pressing Back is what exposes it.
+    const reports = within(nav).getByText('Reports');
+    await act(async () => {
+      reports.click();
+      reports.click();
+    });
+    await waitFor(() => expect(log[log.length - 1]).toBe('/insights/reports'));
+
+    pressBack();
+
+    await waitFor(() => expect(log[log.length - 1]).toBe('/insights/overview'));
+  });
+
+  it('still navigates, and keeps the page behind it, when an interrupted navigation is retried', async () => {
+    const log = renderAt('/insights/overview');
+    await screen.findByLabelText('Insights navigation');
+    const reports = within(screen.getByLabelText('Insights navigation')).getByText('Reports');
+
+    // Stage the real interleaving: the retry has to happen after Back has changed the URL but
+    // before React commits it. Keeping one act open and awaiting popstate does that - jsdom queues
+    // history.back() to a later task, so clicking straight after it would still see the pre-Back
+    // URL and prove nothing.
+    await act(async () => {
+      reports.click();
+      const popped = new Promise<void>((resolve) =>
+        window.addEventListener('popstate', () => resolve(), { once: true }),
+      );
+      pressBack();
+      await popped;
+      reports.click();
+    });
+
+    // The retry must navigate...
+    await waitFor(() => expect(log[log.length - 1]).toBe('/insights/reports'));
+    // ...by pushing, not replacing: the page it was launched from must still be behind it.
+    pressBack();
+    await waitFor(() => expect(log[log.length - 1]).toBe('/insights/overview'));
+  });
+
+  it('honours a click on another item while a navigation is still in flight', async () => {
+    const log = renderAt('/insights/overview');
+    await screen.findByLabelText('Insights navigation');
+    const nav = screen.getByLabelText('Insights navigation');
+
+    // The second click targets the page we are visually still on, so comparing against the
+    // committed location would discard it and leave the user on Reports.
+    await act(async () => {
+      within(nav).getByText('Reports').click();
+      within(nav).getByText('Overview').click();
+    });
+
+    await waitFor(() => expect(log[log.length - 1]).toBe('/insights/overview'));
+  });
+
+  it('does not bounce you to the area home page when the area tab you are already in is clicked', async () => {
+    // Starting one page deep means a bounce is visible in the history stack rather than only in
+    // timing: with the bounce, Back returns to Licence activity; without it, Back reaches Reports.
+    const user = userEvent.setup();
+    const log = renderAt('/insights/reports');
+    expect(await screen.findByText(/No built-in report charts are available yet/)).toBeVisible();
+    await user.click(within(screen.getByLabelText('Insights navigation')).getByText('Licence activity'));
+    expect(await screen.findByText(/Licence activity reporting is not available on this deployment/)).toBeVisible();
+
+    // Fluent's TabList only responds to fireEvent here, as in the other page tests.
+    fireEvent.click(screen.getByRole('tab', { name: 'Insights' }));
+    pressBack();
+
+    await waitFor(() => expect(log[log.length - 1]).toBe('/insights/reports'));
+  });
+
+  it('switches area and lands on its home page when the other area tab is clicked', async () => {
+    const log = renderAt('/insights/licence-activity');
+    expect(await screen.findByText(/Licence activity reporting is not available on this deployment/)).toBeVisible();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Administration' }));
+
+    await waitFor(() => expect(log[log.length - 1]).toBe('/admin/health'));
+    expect(await screen.findByLabelText('Administration navigation')).toBeVisible();
   });
 });

--- a/src/AnalyticsEngine/Web/Scripts/portal/src/App.tsx
+++ b/src/AnalyticsEngine/Web/Scripts/portal/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from 'react';
+import { Suspense, useCallback, useState } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import {
   makeStyles,
@@ -69,6 +69,36 @@ const useStyles = makeStyles({
 });
 
 /**
+ * The route the browser's history is on *right now*.
+ *
+ * `useLocation` reports the last committed render, which lags a navigation that has been pushed
+ * but not yet rendered - pages load lazily, so that gap is real. It therefore cannot answer "are
+ * we already going there?" for a second click, and using it leads to both duplicate history
+ * entries and silently dropped clicks. pushState/replaceState update the URL synchronously, so
+ * under HashRouter the hash always can.
+ *
+ * Parsed the way HashRouter parses it, so a hand-typed `#insights/overview` reads the same as the
+ * canonical `#/insights/overview`. Falls back to the committed path only when there is no fragment
+ * at all - a host that is not hash-routed, where the committed path is the best available answer.
+ */
+function currentRoutePath(committedPath: string): string {
+  const hash = typeof window === 'undefined' ? '' : window.location.hash;
+  if (!hash.startsWith('#')) {
+    if (import.meta.env.DEV && typeof window !== 'undefined') {
+      // Not hash-routed: the committed path is all there is, which is the lagging value this
+      // function exists to avoid. Nav would go back to duplicating history entries and dropping
+      // clicks during an in-flight navigation, silently - so say so rather than degrade quietly.
+      console.warn('[portal] No hash route found - App expects HashRouter. Nav de-duplication is degraded.');
+    }
+    return committedPath;
+  }
+
+  const path = hash.slice(1).split(/[?#]/)[0];
+  if (!path) return '/';
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+/**
  * App shell: an Office 365-style brand header, an area switcher (Insights / Administration) and a
  * per-area left nav. Uses HashRouter so the whole SPA is served by a single MVC action (no IIS /
  * MVC route changes to add pages).
@@ -85,9 +115,24 @@ export default function App() {
   const currentArea = areaForPath(location.pathname);
   const navGroups = groupedRoutesForArea(currentArea);
 
+  const goTo = useCallback(
+    (target: string) => {
+      // Navigating to the entry history is already on would push an identical entry, so the
+      // browser's Back button would look like it is doing nothing. Anything else navigates: a
+      // click must never be silently dropped, however fast it follows the previous one.
+      if (target === currentRoutePath(location.pathname)) return;
+      navigate(target);
+    },
+    [navigate, location.pathname],
+  );
+
   const onAreaSelect: SelectTabEventHandler = (_event, data) => {
     const area = AREAS.find((a) => a.id === data.value);
-    if (area) navigate(area.homePath);
+    // TabList fires for the already-selected tab too, and re-navigating would bounce the user off
+    // the page they are reading back to the area's home page. Compare against where history
+    // actually is, so a tab click during an in-flight navigation is not discarded.
+    const liveArea = areaForPath(currentRoutePath(location.pathname));
+    if (area && area.id !== liveArea) goTo(area.homePath);
   };
 
   return (
@@ -129,7 +174,7 @@ export default function App() {
           type="inline"
           className={styles.nav}
           selectedValue={location.pathname}
-          onNavItemSelect={(_event, data) => navigate(String(data.value))}
+          onNavItemSelect={(_event, data) => goTo(String(data.value))}
           aria-label={`${AREAS.find((a) => a.id === currentArea)?.label} navigation`}
         >
           <NavDrawerBody>


### PR DESCRIPTION
## Summary

The portal's left nav and area switcher called `navigate(...)` unconditionally. Fluent v9's `NavItem` and `Tab` fire `onSelect` on **every** click — including on the already-selected item — and react-router does not de-duplicate identical pushes, so each click added another history entry.

Measured against a deployment before the fix:

```
click Reports #1   -> /insights/reports
click Reports #2   -> /insights/reports   (duplicate entry)
click Reports #3   -> /insights/reports   (duplicate entry)
back #1            -> /insights/reports   (Back looks dead)
back #2            -> /insights/reports   (Back looks dead)
back #3            -> /insights/overview
```

The area switcher had a second, more visible symptom: clicking the tab for the area you were **already in** navigated to that area's `homePath`, so it bounced you off the page you were reading (`/insights/agent-costs` → `/insights/overview`).

## Why the de-duplication reads the URL, not `useLocation()`

This is the non-obvious part, and it's why the first two attempts were wrong.

`HashRouter` schedules its state update inside `startTransition`, and every page is a `React.lazy` chunk. The committed location therefore **lags** a navigation that has already been pushed — that window is as long as the chunk takes to load. Comparing a click's target against `location.pathname` gets both failure modes:

- a double-click lands entirely inside the window, both handlers see the old path, and two entries are pushed;
- a click aimed at the page you are *visually still on* compares equal to the stale committed path and is **silently dropped**.

`pushState`/`replaceState` update the URL synchronously, so under `HashRouter` the hash is the one value that always answers "where is history right now?". `currentRoutePath()` parses it the way `HashRouter` does (so a hand-typed `#insights/overview` reads the same as `#/insights/overview`) and warns in dev if `App` is ever mounted without a hash route, rather than silently degrading to the old behaviour.

## Two rejected approaches, recorded so they aren't retried

Both were caught by review and then reproduced:

1. **A `requestedPath` ref used to suppress a duplicate click.** If a navigation is started and then interrupted (Back pressed before it commits), the committed pathname never changes, so the resync effect never runs and the ref is left pointing at a page that was never reached — making that nav item **permanently inert**. Reproduced in jsdom.
2. **The same ref used to downgrade the duplicate from push to `replace`.** This destroys the entry the user came from, so a later Back skips the page (or leaves the SPA), and it still dropped a click aimed at a different item during an in-flight navigation. Both reproduced in a real browser.

## Changes

- `App.tsx` — adds `currentRoutePath()` and routes both handlers through a single `goTo()`. The only case that does not navigate is a target equal to the route history is already on; **a click is never otherwise dropped**. The area guard compares against `liveArea` for the same reason.
- `App.test.tsx` — six new tests, and the file now renders under `HashRouter` instead of `MemoryRouter`.

## Test notes

The tests had to move to `HashRouter` because the shell now reads the live URL and `MemoryRouter` has none — under `MemoryRouter` the interesting logic would be untested. That also removed a latent **order-dependence**: jsdom's history is shared by the whole file, so a `MemoryRouter` test could read a stale hash left behind by a `HashRouter` one and drop its click. Confirmed order-independent with `--sequence.shuffle`.

Every new behavioural test was verified in both directions — it fails against the broken implementation it guards and passes against this one:

| Test | Fails against |
|---|---|
| `takes one Back press to undo a nav item that was double-clicked` | committed-location guard |
| `honours a click on another item while a navigation is still in flight` | committed-location guard |
| `still navigates, and keeps the page behind it, when an interrupted navigation is retried` | ref + `replace` variant |
| `does not bounce you to the area home page when the area tab you are already in is clicked` | unguarded `onAreaSelect` |

The interrupted-retry test stages the genuine pre-commit interleaving by holding one `act` open and awaiting `popstate` — jsdom queues `history.back()` to a later task, so clicking straight after it would still see the pre-Back URL and prove nothing.

`asyncUtilTimeout`/`testTimeout` are raised because this file now mounts the full app shell ten times; under a contended parallel run a lazy chunk was measured taking over 6s.

## Verification

Playwright against `npm run dev` with the `ReportsPage` chunk delayed by request interception — all pass:

```
repeated clicks=1/2/3 (1200ms delay) and 2 clicks (no delay): one Back always returns
interrupted (1500ms, 0ms):        re-click still navigates (nav item not inert)
interrupted-retry (1500ms, 800ms): second Back returns to Overview (entry preserved)
click-other-while-pending:         last click wins (not dropped)
```

Also swept the deployed site beforehand: all 12 routes, 30 sub-tabs, 6 viewports (1920→768), F5 on every route, nav collapse/expand and rapid clicking — no console errors, no failed requests. Routing itself was never broken; the defect was purely the history stack.

Full portal suite: 24/24 files, 170 tests, repeated clean runs. `npm run lint` (`tsc --noEmit`) clean.

## Reviewer hotspots

- `currentRoutePath()`'s fallback when there is no fragment. It is unreachable in production (`main.tsx` always mounts `HashRouter`) and now warns in dev, but it returns the lagging value this change exists to avoid, so it would quietly reinstate both bugs if the app ever moved to `BrowserRouter`.
- `<TabList selectedValue>` and `<NavDrawer selectedValue>` deliberately still use the **committed** location so the highlight does not flicker mid-transition. During an in-flight navigation the highlight can therefore briefly disagree with what the handler decides; "last click wins" is the intended resolution.
- One narrow theoretical window is **not** addressed: a click landing between the initial render and the `<Navigate replace>` redirect effect for `/` or `*` could be replaced by that redirect. It is sub-frame and not reachable by a user in practice.

## Risk

Front-end only, no schema/config/API change, no migrations. Worst case of a regression is a stray extra history entry, which is the behaviour being removed.
