### PR TITLE
Switch EF SQL provider to Microsoft.Data.SqlClient

### DIFF
--- a/deploy/Debug Config Files/Unit tests/App.Debug.config
+++ b/deploy/Debug Config Files/Unit tests/App.Debug.config
@@ -27,8 +27,8 @@
 
 	<connectionStrings xdt:Transform="Replace">
 		
-		<add name="SPOInsightsEntities" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingSPOInsights;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-		<add name="UnitTestingOffice365Services" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=FakeOfficeServicesDB;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+		<add name="SPOInsightsEntities" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingSPOInsights;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework;TrustServerCertificate=True" providerName="Microsoft.Data.SqlClient" />
+		<add name="UnitTestingOffice365Services" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=FakeOfficeServicesDB;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework;TrustServerCertificate=True" providerName="Microsoft.Data.SqlClient" />
 		<add name="redis" connectionString="" />
 		<add name="ServiceBus" connectionString="" />
 		<add name="Storage" connectionString="UseDevelopmentStorage=true" />

--- a/deploy/Debug Config Files/Web/Web.Debug.config
+++ b/deploy/Debug Config Files/Web/Web.Debug.config
@@ -31,7 +31,7 @@
 	</appSettings>
 
 	<connectionStrings xdt:Transform="Replace">
-		<add name="SPOInsightsEntities" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingSPOInsights;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+		<add name="SPOInsightsEntities" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingSPOInsights;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework;TrustServerCertificate=True" providerName="Microsoft.Data.SqlClient" />
 		<add name="redis" connectionString="" />
 		<add name="ServiceBus" connectionString="" />
 		<add name="Storage" connectionString="UseDevelopmentStorage=true" />

--- a/deploy/Debug Config Files/Webjobs/App.Debug.config
+++ b/deploy/Debug Config Files/Webjobs/App.Debug.config
@@ -31,7 +31,7 @@
 	</appSettings>
 
 	<connectionStrings xdt:Transform="Replace">
-		<add name="SPOInsightsEntities" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingSPOInsights;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+		<add name="SPOInsightsEntities" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingSPOInsights;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework;TrustServerCertificate=True" providerName="Microsoft.Data.SqlClient" />
 		<add name="redis" connectionString="" />
 		<add name="ServiceBus" connectionString="" />
 		<add name="Storage" connectionString="UseDevelopmentStorage=true" />

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/App.ControlPanel.Engine.csproj
@@ -217,6 +217,12 @@
     <PackageReference Include="EntityFramework">
       <Version>6.5.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
       <Version>2.22.0</Version>
     </PackageReference>

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/BaseInstallProcessClasses.cs
@@ -7,7 +7,7 @@ using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 
 namespace App.ControlPanel.Engine

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlDatabaseUserGrantTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlDatabaseUserGrantTask.cs
@@ -4,7 +4,7 @@ using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlEntraAccessBootstrap.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlEntraAccessBootstrap.cs
@@ -5,7 +5,7 @@ using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/InstallerTasks/SqlIdentityAccessTask.cs
@@ -6,7 +6,7 @@ using DataUtils.Sql;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabasePaaSInfo.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/DatabasePaaSInfo.cs
@@ -80,7 +80,7 @@ namespace App.ControlPanel.Engine.Entities
         /// <c>DataUtils.Sql.AzureSqlTokenAuth</c>, which attaches an access token at connection-open time,
         /// and to anything reading the App Service configuration. Deliberately NOT
         /// <c>Authentication=Active Directory Managed Identity</c>: that keyword makes SqlClient acquire
-        /// the token itself, which the in-box .NET Framework System.Data.SqlClient provider EF6 requires
+        /// the token itself, which the in-box .NET Framework Microsoft.Data.SqlClient provider EF6 requires
         /// does not support for managed identity.
         /// </remarks>
         public static string GetEntraIdConnectionString(string server, string db)

--- a/src/AnalyticsEngine/App.ControlPanel.Engine/Models/OrgUrlStore.cs
+++ b/src/AnalyticsEngine/App.ControlPanel.Engine/Models/OrgUrlStore.cs
@@ -1,7 +1,7 @@
 using Common.Entities;
 using System;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 
 namespace App.ControlPanel.Engine.Models

--- a/src/AnalyticsEngine/App.ControlPanel/App.ControlPanel.WinForms.csproj
+++ b/src/AnalyticsEngine/App.ControlPanel/App.ControlPanel.WinForms.csproj
@@ -392,6 +392,12 @@
     <Content Include="Resources\Redis.png" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>10.0.11</Version>
     </PackageReference>

--- a/src/AnalyticsEngine/App.ControlPanel/App.Template.config
+++ b/src/AnalyticsEngine/App.ControlPanel/App.Template.config
@@ -15,6 +15,8 @@
 		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftSqlConnectionFactory, Microsoft.EntityFramework.SqlServer" />
 		<providers>
 			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+			<!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 

--- a/src/AnalyticsEngine/App.ControlPanel/App.Template.config
+++ b/src/AnalyticsEngine/App.ControlPanel/App.Template.config
@@ -12,14 +12,29 @@
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
 	</startup>
 	<entityFramework>
-		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftSqlConnectionFactory, Microsoft.EntityFramework.SqlServer" />
 		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
@@ -223,10 +238,6 @@
 			<dependentAssembly>
 				<assemblyIdentity name="System.IO.Hashing" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/AnalyticsEngine/App.ControlPanel/Frames/ManageDataControl.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/Frames/ManageDataControl.cs
@@ -80,7 +80,7 @@ namespace App.ControlPanel.Frames
 
         SPOInsightsEntitiesContext GetDB()
         {
-            var sqlConnFact = new SqlConnectionFactory(txtConnectionString.Text);
+            var sqlConnFact = new MicrosoftSqlConnectionFactory(txtConnectionString.Text);
             DbConnection con = sqlConnFact.CreateConnection(txtConnectionString.Text);
             return new SPOInsightsEntitiesContext(con);
         }
@@ -102,7 +102,7 @@ namespace App.ControlPanel.Frames
                 {
                     errs.Add(ex.Message);
                 }
-                catch (System.Data.SqlClient.SqlException ex)
+                catch (Microsoft.Data.SqlClient.SqlException ex)
                 {
                     errs.Add(ex.Message);
                 }

--- a/src/AnalyticsEngine/App.ControlPanel/TestSettingsForm.cs
+++ b/src/AnalyticsEngine/App.ControlPanel/TestSettingsForm.cs
@@ -49,7 +49,7 @@ namespace App.ControlPanel
                 var defaultConfig = new TestConfiguration();
                 if (value != null) defaultConfig = value;
 
-                var sqlConnectionInfo = new System.Data.SqlClient.SqlConnectionStringBuilder(defaultConfig.SQLConnectionString);
+                var sqlConnectionInfo = new Microsoft.Data.SqlClient.SqlConnectionStringBuilder(defaultConfig.SQLConnectionString);
                 _usesEntraSqlAuth = DataUtils.Sql.AzureSqlTokenAuth.NeedsAccessToken(defaultConfig.SQLConnectionString);
                 txtSqlServer.Text = sqlConnectionInfo?.DataSource;
                 txtSqlUsername.Text = sqlConnectionInfo?.UserID;

--- a/src/AnalyticsEngine/Common/DataUtils/ConsoleApp.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/ConsoleApp.cs
@@ -44,7 +44,7 @@ namespace DataUtils
         {
 
             logger.LogInformation($"Office 365 Advanced Analytics engine START: '{buildLabel}'.");
-            var sqlConnectionInfo = new System.Data.SqlClient.SqlConnectionStringBuilder(efConnectionString);
+            var sqlConnectionInfo = new Microsoft.Data.SqlClient.SqlConnectionStringBuilder(efConnectionString);
             logger.LogInformation($"Destination SQL Server='{sqlConnectionInfo.DataSource}', DB='{sqlConnectionInfo.InitialCatalog}'.");
             if (!string.IsNullOrEmpty(userGroupsFilterString))
             {

--- a/src/AnalyticsEngine/Common/DataUtils/DataUtils.csproj
+++ b/src/AnalyticsEngine/Common/DataUtils/DataUtils.csproj
@@ -2,15 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <!--
-      Suppress CS0618 for this project. As a netstandard2.0 library it references the
-      System.Data.SqlClient *NuGet package*, whose types (SqlConnection, SqlException,
-      SqlConnectionStringBuilder, ...) are marked [Obsolete] in favour of Microsoft.Data.SqlClient.
-      We intentionally stay on System.Data.SqlClient because EF6 (used across the solution) has no
-      official Microsoft.Data.SqlClient provider and mandates the System.Data.SqlClient provider, so
-      the obsolete usage here is deliberate. (.NET Framework consumers use the in-box, non-obsolete
-      System.Data.SqlClient and don't warn.) See issue for context.
-    -->
+    <!-- Azure.Identity keeps an obsolete ManagedIdentityCredential constructor that this project still uses for the legacy token-auth fallback. -->
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
@@ -22,11 +14,13 @@
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.9.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="EntityFramework" Version="6.5.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.11" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.11" />
     <PackageReference Include="System.Text.Json" Version="10.0.11" />
   </ItemGroup>

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/AzureSqlTokenAuth.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/AzureSqlTokenAuth.cs
@@ -1,7 +1,7 @@
 using Azure.Core;
 using Azure.Identity;
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text.RegularExpressions;
 using System.Threading;
 

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/Inserts/InsertBatch.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
 using System.Threading;

--- a/src/AnalyticsEngine/Common/DataUtils/Sql/TransientSqlRetry.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/Sql/TransientSqlRetry.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 
 namespace DataUtils.Sql

--- a/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
+++ b/src/AnalyticsEngine/Common/DataUtils/StringUtils.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;

--- a/src/AnalyticsEngine/Common/DataUtils/app.config
+++ b/src/AnalyticsEngine/Common/DataUtils/app.config
@@ -6,22 +6,37 @@
 	</configSections>
 
 	<entityFramework>
-		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftLocalDbConnectionFactory, Microsoft.EntityFramework.SqlServer">
 			<parameters>
 				<parameter value="mssqllocaldb" />
 			</parameters>
 		</defaultConnectionFactory>
 		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
-	<startup>
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
+<startup>
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
 	</startup>
 
 
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
 
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>
@@ -31,5 +46,5 @@
 			</assemblyBinding>
 		</assemblyBinding>
 	</runtime>
-	
+
 </configuration>

--- a/src/AnalyticsEngine/Common/DataUtils/app.config
+++ b/src/AnalyticsEngine/Common/DataUtils/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 		<!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
@@ -13,6 +13,8 @@
 		</defaultConnectionFactory>
 		<providers>
 			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+			<!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 

--- a/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
+++ b/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
@@ -1,4 +1,4 @@
-using Common.Entities.Config;
+﻿using Common.Entities.Config;
 using Common.Entities.Entities;
 using Common.Entities.Entities.AgentCosts;
 using Common.Entities.Entities.AuditLog;
@@ -585,10 +585,37 @@ namespace Common.Entities
     /// </summary>
     public class SPOInsightsDBConfiguration : System.Data.Entity.SqlServer.MicrosoftSqlDbConfiguration
     {
+        /// <summary>
+        /// The ADO.NET invariant name Azure App Service injects for a connection string saved with type
+        /// <c>SQLAzure</c>, which is how the installer stores <c>SPOInsightsEntities</c>.
+        /// </summary>
+        internal const string LegacyProviderInvariantName = "System.Data.SqlClient";
+
+        internal const string ProviderInvariantName = "Microsoft.Data.SqlClient";
+
         // https://docs.microsoft.com/en-us/ef/ef6/fundamentals/connection-resiliency/retry-logic
         public SPOInsightsDBConfiguration()
         {
-            SetExecutionStrategy("Microsoft.Data.SqlClient", () => new System.Data.Entity.SqlServer.MicrosoftSqlAzureExecutionStrategy());
+            SetExecutionStrategy(ProviderInvariantName, () => new System.Data.Entity.SqlServer.MicrosoftSqlAzureExecutionStrategy());
+
+            // Azure App Service rewrites a connection string saved as type SQLAzure into the
+            // SQLAZURECONNSTR_ environment variable and hands it to .NET Framework with
+            // providerName="System.Data.SqlClient". The installer saves SPOInsightsEntities with that
+            // type, and every existing deployment already has it, so the running web app and web jobs
+            // ask EF for the OLD invariant name no matter what this build prefers.
+            //
+            // Without these aliases EF throws "No Entity Framework provider found for the ADO.NET
+            // provider with invariant name 'System.Data.SqlClient'" on the first query after upgrade.
+            // Worse, if the machine-wide factory resolved instead, connections would be
+            // System.Data.SqlClient.SqlConnection and AzureSqlAccessTokenInterceptor - which casts to the
+            // Microsoft.Data.SqlClient type - would silently stop attaching Entra tokens, breaking
+            // token-authenticated installs with no error at the provider layer.
+            //
+            // So map the legacy name onto the modern provider as well: whichever name arrives, the
+            // connection is a Microsoft.Data.SqlClient one. See issue #511.
+            SetProviderServices(LegacyProviderInvariantName, System.Data.Entity.SqlServer.MicrosoftSqlProviderServices.Instance);
+            SetProviderFactory(LegacyProviderInvariantName, Microsoft.Data.SqlClient.SqlClientFactory.Instance);
+            SetExecutionStrategy(LegacyProviderInvariantName, () => new System.Data.Entity.SqlServer.MicrosoftSqlAzureExecutionStrategy());
 
             // Lets EF connect to an Azure SQL server that has SQL authentication disabled, by attaching a
             // Microsoft Entra ID access token to connections whose connection string carries no

--- a/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
+++ b/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
@@ -583,12 +583,12 @@ namespace Common.Entities
     /// <summary>
     /// config automatically read by EF
     /// </summary>
-    public class SPOInsightsDBConfiguration : DbConfiguration
+    public class SPOInsightsDBConfiguration : System.Data.Entity.SqlServer.MicrosoftSqlDbConfiguration
     {
         // https://docs.microsoft.com/en-us/ef/ef6/fundamentals/connection-resiliency/retry-logic
         public SPOInsightsDBConfiguration()
         {
-            SetExecutionStrategy("System.Data.SqlClient", () => new System.Data.Entity.SqlServer.SqlAzureExecutionStrategy());
+            SetExecutionStrategy("Microsoft.Data.SqlClient", () => new System.Data.Entity.SqlServer.MicrosoftSqlAzureExecutionStrategy());
 
             // Lets EF connect to an Azure SQL server that has SQL authentication disabled, by attaching a
             // Microsoft Entra ID access token to connections whose connection string carries no

--- a/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
+++ b/src/AnalyticsEngine/Common/Entities/AnalyticsEntitiesContext.cs
@@ -604,18 +604,21 @@ namespace Common.Entities
             // type, and every existing deployment already has it, so the running web app and web jobs
             // ask EF for the OLD invariant name no matter what this build prefers.
             //
-            // Without these aliases EF throws "No Entity Framework provider found for the ADO.NET
-            // provider with invariant name 'System.Data.SqlClient'" on the first query after upgrade.
-            // Worse, if the machine-wide factory resolved instead, connections would be
+            // Without an alias EF throws "No Entity Framework provider found for the ADO.NET provider
+            // with invariant name 'System.Data.SqlClient'" on the first query after upgrade. Worse, if
+            // the machine-wide factory resolved instead, connections would be
             // System.Data.SqlClient.SqlConnection and AzureSqlAccessTokenInterceptor - which casts to the
-            // Microsoft.Data.SqlClient type - would silently stop attaching Entra tokens, breaking
-            // token-authenticated installs with no error at the provider layer.
+            // Microsoft.Data.SqlClient type - would silently stop attaching Entra tokens.
             //
-            // So map the legacy name onto the modern provider as well: whichever name arrives, the
-            // connection is a Microsoft.Data.SqlClient one. See issue #511.
-            SetProviderServices(LegacyProviderInvariantName, System.Data.Entity.SqlServer.MicrosoftSqlProviderServices.Instance);
-            SetProviderFactory(LegacyProviderInvariantName, Microsoft.Data.SqlClient.SqlClientFactory.Instance);
+            // The alias is deliberately NOT SetProviderFactory/SetProviderServices. Those also register a
+            // REVERSE IProviderInvariantName lookup keyed on the factory instance, and because the base
+            // class has already registered the modern name, the legacy registration would win and EF would
+            // start calling every Microsoft.Data.SqlClient connection "System.Data.SqlClient". Provider
+            // services such as the migrations SQL generator are keyed on the modern name, so that breaks
+            // DatabaseUpgrader - and therefore every customer schema upgrade - while leaving ordinary
+            // queries working. A forward-only resolver avoids that entirely. See issue #511.
             SetExecutionStrategy(LegacyProviderInvariantName, () => new System.Data.Entity.SqlServer.MicrosoftSqlAzureExecutionStrategy());
+            AddDependencyResolver(new Sql.LegacyProviderNameAliasResolver());
 
             // Lets EF connect to an Azure SQL server that has SQL authentication disabled, by attaching a
             // Microsoft Entra ID access token to connections whose connection string carries no

--- a/src/AnalyticsEngine/Common/Entities/App.Config
+++ b/src/AnalyticsEngine/Common/Entities/App.Config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 
@@ -16,6 +16,8 @@
 		</defaultConnectionFactory>
 		<providers>
 			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+			<!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 

--- a/src/AnalyticsEngine/Common/Entities/App.Config
+++ b/src/AnalyticsEngine/Common/Entities/App.Config
@@ -7,20 +7,35 @@
 	<startup>
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
 	</startup>
-	
+
 	<entityFramework>
-		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftLocalDbConnectionFactory, Microsoft.EntityFramework.SqlServer">
 			<parameters>
 				<parameter value="mssqllocaldb" />
 			</parameters>
 		</defaultConnectionFactory>
 		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
 
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>
@@ -30,5 +45,5 @@
 			</assemblyBinding>
 		</assemblyBinding>
 	</runtime>
-	
+
 </configuration>

--- a/src/AnalyticsEngine/Common/Entities/Config/AppConnectionStrings.cs
+++ b/src/AnalyticsEngine/Common/Entities/Config/AppConnectionStrings.cs
@@ -26,7 +26,7 @@ namespace Common.Entities.Config
                     HandleSqlTestException(ex, logger);
                     return false;
                 }
-                catch (System.Data.SqlClient.SqlException ex)
+                catch (Microsoft.Data.SqlClient.SqlException ex)
                 {
                     HandleSqlTestException(ex, logger);
                     return false;

--- a/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
+++ b/src/AnalyticsEngine/Common/Entities/CopilotAdoption/CopilotAdoptionService.cs
@@ -2,7 +2,7 @@ using Common.Entities.Copilot;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -469,6 +469,7 @@
     <Compile Include="Redis\TeamsRedisManager.cs" />
     <Compile Include="AnalyticsEntitiesContext.cs" />
     <Compile Include="Sql\AzureSqlAccessTokenInterceptor.cs" />
+    <Compile Include="Sql\LegacyProviderNameAliasResolver.cs" />
     <Compile Include="IAnalyticsDbContextFactory.cs" />
     <Compile Include="Entities\Url.cs" />
     <Compile Include="Entities\User.cs" />

--- a/src/AnalyticsEngine/Common/Entities/Entities.csproj
+++ b/src/AnalyticsEngine/Common/Entities/Entities.csproj
@@ -719,6 +719,12 @@
     <PackageReference Include="EntityFramework">
       <Version>6.5.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>10.0.11</Version>
     </PackageReference>

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityReadModelLoader.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityReadModelLoader.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;

--- a/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
+++ b/src/AnalyticsEngine/Common/Entities/LicenceActivity/SqlLicenceActivityStore.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Linq;

--- a/src/AnalyticsEngine/Common/Entities/LookupCaches/Discrete/DBLookupCache.cs
+++ b/src/AnalyticsEngine/Common/Entities/LookupCaches/Discrete/DBLookupCache.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/AnalyticsEngine/Common/Entities/Sql/AzureSqlAccessTokenInterceptor.cs
+++ b/src/AnalyticsEngine/Common/Entities/Sql/AzureSqlAccessTokenInterceptor.cs
@@ -2,21 +2,22 @@ using DataUtils.Sql;
 using System.Data;
 using System.Data.Common;
 using System.Data.Entity.Infrastructure.Interception;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Common.Entities.Sql
 {
     /// <summary>
-    /// Attaches a Microsoft Entra ID access token to every Entity Framework connection that needs one.
+    /// Attaches a Microsoft Entra ID access token to every Entity Framework connection that still uses the legacy token fallback.
     /// </summary>
     /// <remarks>
     /// <para>
     /// An Azure SQL server can be created with SQL authentication disabled, in which case the connection
     /// string has no <c>user id</c> / <c>password</c> and the caller must set
-    /// <see cref="SqlConnection.AccessToken"/> instead. EF6 has no built-in support for that, but it does
-    /// route connection opens through <see cref="DbInterception"/> - including the ones the migration
-    /// pipeline makes for itself, which is the case that matters here, because a schema upgrade opens
-    /// connections EF creates internally rather than the context's own.
+    /// <see cref="SqlConnection.AccessToken"/> instead. The Microsoft.Data.SqlClient provider can handle
+    /// modern Authentication keywords natively, but this compatibility path is deliberately kept for
+    /// existing connection strings. EF routes connection opens through <see cref="DbInterception"/> -
+    /// including the ones the migration pipeline makes for itself, which is the case that matters here,
+    /// because a schema upgrade opens connections EF creates internally rather than the context's own.
     /// </para>
     /// <para>
     /// Deliberately inert unless the connection string genuinely needs a token

--- a/src/AnalyticsEngine/Common/Entities/Sql/LegacyProviderNameAliasResolver.cs
+++ b/src/AnalyticsEngine/Common/Entities/Sql/LegacyProviderNameAliasResolver.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.Entity.Core.Common;
+using System.Data.Entity.Infrastructure.DependencyResolution;
+using System.Data.Entity.Migrations.Sql;
+using System.Data.Entity.SqlServer;
+using System.Linq;
+
+namespace Common.Entities.Sql
+{
+    /// <summary>
+    /// Answers Entity Framework's lookups for the legacy <c>System.Data.SqlClient</c> invariant name with
+    /// the modern <c>Microsoft.Data.SqlClient</c> services, without claiming that name as the provider's
+    /// identity.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Azure App Service hands a connection string saved with type <c>SQLAzure</c> to a .NET Framework app
+    /// with <c>providerName="System.Data.SqlClient"</c>. The installer saves <c>SPOInsightsEntities</c>
+    /// that way and every existing deployment already has it, so EF is asked for the legacy name at
+    /// runtime regardless of which provider this build ships.
+    /// </para>
+    /// <para>
+    /// The obvious implementation - <c>SetProviderFactory</c> and <c>SetProviderServices</c> under the
+    /// legacy name - is wrong, and subtly so. Both also register a <b>reverse</b>
+    /// <see cref="IProviderInvariantName"/> lookup keyed on the factory instance. Since
+    /// <see cref="MicrosoftSqlDbConfiguration"/> has already registered the modern name, the later legacy
+    /// registration wins, and EF then reports every <c>Microsoft.Data.SqlClient</c> connection as
+    /// "System.Data.SqlClient". Provider-specific services - above all
+    /// <see cref="MicrosoftSqlServerMigrationSqlGenerator"/> - are keyed on the modern name only, so they
+    /// stop resolving and <c>DatabaseUpgrader</c> fails with "No MigrationSqlGenerator found for provider".
+    /// Ordinary queries keep working, which is what makes it dangerous: it would surface only when a
+    /// customer upgrades a database.
+    /// </para>
+    /// <para>
+    /// This resolver is therefore deliberately <b>forward-only</b>. It answers "what services does the
+    /// legacy name need?" and never "what is this factory called?", leaving the modern name as the
+    /// provider's single identity. See issue #511.
+    /// </para>
+    /// </remarks>
+    internal sealed class LegacyProviderNameAliasResolver : IDbDependencyResolver
+    {
+        public object GetService(Type type, object key)
+        {
+            if (type == null) return null;
+
+            // Only ever answer for the legacy invariant name; everything else falls through to EF's
+            // normal resolution, including every lookup keyed on the factory instance.
+            if (!string.Equals(key as string, SPOInsightsDBConfiguration.LegacyProviderInvariantName, StringComparison.Ordinal))
+                return null;
+
+            if (type == typeof(DbProviderServices))
+                return MicrosoftSqlProviderServices.Instance;
+
+            if (type == typeof(DbProviderFactory))
+                return Microsoft.Data.SqlClient.SqlClientFactory.Instance;
+
+            // Migrations are resolved by provider name, so the alias has to cover the SQL generator or
+            // DatabaseUpgrader breaks on any deployment whose connection string carries the legacy name -
+            // which is all of them.
+            if (type == typeof(Func<MigrationSqlGenerator>))
+                return (Func<MigrationSqlGenerator>)(() => new MicrosoftSqlServerMigrationSqlGenerator());
+
+            return null;
+        }
+
+        public IEnumerable<object> GetServices(Type type, object key)
+        {
+            var service = GetService(type, key);
+            return service == null ? Enumerable.Empty<object>() : new[] { service };
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.FakeDataGen/App.config
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/App.config
@@ -10,6 +10,8 @@
   <entityFramework>
     <providers>
       <provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+      <!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/App.config
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/App.config
@@ -9,11 +9,26 @@
   </startup>
   <entityFramework>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
-  <runtime>
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
+	<runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" culture="neutral" publicKeyToken="92742159e12e44c8" />
         <bindingRedirect oldVersion="0.0.0.0-1.62.0.0" newVersion="1.62.0.0" />

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlDemoDatabase.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlDemoDatabase.cs
@@ -3,7 +3,7 @@ using App.ControlPanel.Engine.Models;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -38,6 +38,7 @@ namespace Tests.FakeDataGen.Demo
             IntegratedSecurity = true,
             Pooling = false,
             ConnectTimeout = 30,
+            TrustServerCertificate = true,
             ApplicationName = "Contoso synthetic demo generator"
         }.ConnectionString;
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlExistingDemoDatabase.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Demo/SqlExistingDemoDatabase.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Office365/Office365ActivityGenerator.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Office365/Office365ActivityGenerator.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using Tests.FakeDataGen.Generation;
 using Tests.FakeDataGen.Seeding;

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Program.cs
@@ -3,7 +3,7 @@ using App.ControlPanel.Engine.Models;
 using Common.Entities;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using Tests.FakeDataGen.Copilot;
 using Tests.FakeDataGen.Demo;

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Seeding/UserMetadataSeeder.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Seeding/UserMetadataSeeder.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text;
 
 namespace Tests.FakeDataGen.Seeding

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/CopilotStressTest.cs
@@ -3,7 +3,7 @@ using Common.Entities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using Tests.FakeDataGen.Seeding;
 using UnitTests.FakeLoaderClasses;

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/LoadTest/LoadTestSuite.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/LoadTest/LoadTestSuite.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/PowerPlatformStressTest.cs
@@ -2,7 +2,7 @@ using Common.Entities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using Tests.FakeDataGen.Seeding;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.PowerPlatform;

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/SentEmailImporterStressTest.cs
@@ -3,7 +3,7 @@ using DataUtils;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/UserActivityStressTest.cs
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/StressTests/UserActivityStressTest.cs
@@ -2,7 +2,7 @@ using Common.Entities;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using Tests.FakeDataGen.Seeding;
 

--- a/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
+++ b/src/AnalyticsEngine/Tests.FakeDataGen/Tests.FakeDataGen.csproj
@@ -136,6 +136,12 @@
     <PackageReference Include="EntityFramework">
       <Version>6.5.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console">
       <Version>10.0.11</Version>
     </PackageReference>

--- a/src/AnalyticsEngine/Tests.UnitTests/App.Release.config
+++ b/src/AnalyticsEngine/Tests.UnitTests/App.Release.config
@@ -35,8 +35,8 @@
 
 	<connectionStrings xdt:Transform="Replace">
 		
-		<add name="SPOInsightsEntities" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingSPOInsights;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-		<add name="UnitTestingOffice365Services" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=FakeOfficeServicesDB;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+		<add name="SPOInsightsEntities" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingSPOInsights;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework;TrustServerCertificate=True" providerName="Microsoft.Data.SqlClient" />
+		<add name="UnitTestingOffice365Services" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=FakeOfficeServicesDB;Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework;TrustServerCertificate=True" providerName="Microsoft.Data.SqlClient" />
 		<add name="redis" connectionString="__redis__" />
 		<add name="ServiceBus" connectionString="__ServiceBus__" />
 		<add name="Storage" connectionString="__Storage__" />

--- a/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
+++ b/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
@@ -10,19 +10,34 @@
 	<connectionStrings></connectionStrings>
 
 	<entityFramework codeConfigurationType="Common.Entities.SPOInsightsDBConfiguration, Common.Entities">
-		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftLocalDbConnectionFactory, Microsoft.EntityFramework.SqlServer">
 			<parameters>
 				<parameter value="mssqllocaldb" />
 			</parameters>
 		</defaultConnectionFactory>
 		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
 	<runtime>
 
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
@@ -236,10 +251,6 @@
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
 			</dependentAssembly>
@@ -252,7 +263,7 @@
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
 			</dependentAssembly>
 		</assemblyBinding>
-		
+
 	</runtime>
 
 	<startup>

--- a/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
+++ b/src/AnalyticsEngine/Tests.UnitTests/App.Template.config
@@ -17,6 +17,8 @@
 		</defaultConnectionFactory>
 		<providers>
 			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+			<!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 

--- a/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/AzureSqlEntraAuthTests.cs
@@ -6,7 +6,7 @@ using Common.Entities.Sql;
 using DataUtils.Sql;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading;
 
 namespace Tests.UnitTests

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAdoptionSqlIntegrationTests.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 
 namespace Tests.UnitTests

--- a/src/AnalyticsEngine/Tests.UnitTests/CopilotAuditEventManagerStagingTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/CopilotAuditEventManagerStagingTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using UnitTests.FakeLoaderClasses;

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoAgentCostReportTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoAgentCostReportTests.cs
@@ -3,7 +3,7 @@ using Common.Entities.AgentCosts;
 using Common.Entities.Entities.AgentCosts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using Tests.FakeDataGen.Demo;

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoExistingDatabaseTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoExistingDatabaseTests.cs
@@ -2,7 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using Tests.FakeDataGen.Demo;

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoGeneratorSqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoGeneratorSqlTests.cs
@@ -2,7 +2,7 @@ using Common.Entities.CopilotAdoption;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using Tests.FakeDataGen.Demo;

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoGeneratorTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoGeneratorTests.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;

--- a/src/AnalyticsEngine/Tests.UnitTests/DemoLicenceActivityCoverageTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DemoLicenceActivityCoverageTests.cs
@@ -1,7 +1,7 @@
 using Common.Entities.LicenceActivity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using Tests.FakeDataGen.Demo;

--- a/src/AnalyticsEngine/Tests.UnitTests/DenormaliseCopilotChatUserAndTimeManualScriptTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DenormaliseCopilotChatUserAndTimeManualScriptTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/AnalyticsEngine/Tests.UnitTests/DlpApiSqlIntegrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/DlpApiSqlIntegrationTests.cs
@@ -5,7 +5,7 @@ using Common.Entities.Entities.AuditLog;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Configuration = Common.Entities.Migrations.Configuration;
@@ -39,14 +39,14 @@ namespace Tests.UnitTests
         private static string _connectionString;
 
         private const string MasterConnection =
-            @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=master;Integrated Security=true";
+            @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=master;Integrated Security=true;TrustServerCertificate=True";
 
         [ClassInitialize]
         public static void CreateMigratedDatabase(TestContext context)
         {
             _database = "DlpApiIntegration_" + Guid.NewGuid().ToString("N").Substring(0, 12);
             _connectionString =
-                $@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog={_database};Integrated Security=true;MultipleActiveResultSets=True";
+                $@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog={_database};Integrated Security=true;MultipleActiveResultSets=True;TrustServerCertificate=True";
 
             Execute(MasterConnection, $"CREATE DATABASE [{_database}];");
 
@@ -54,7 +54,7 @@ namespace Tests.UnitTests
             // rather than a hand-built subset that could omit the very column a query needs.
             var migrationConfig = new Configuration
             {
-                TargetDatabase = new System.Data.Entity.Infrastructure.DbConnectionInfo(_connectionString, "System.Data.SqlClient")
+                TargetDatabase = new System.Data.Entity.Infrastructure.DbConnectionInfo(_connectionString, "Microsoft.Data.SqlClient")
             };
             new DbMigrator(migrationConfig).Update();
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/EfProviderRegistrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/EfProviderRegistrationTests.cs
@@ -6,6 +6,7 @@ using System.Data.Entity;
 using System.Data.Entity.Core.Common;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.Infrastructure.DependencyResolution;
+using System.Data.Entity.Migrations.Sql;
 using System.Data.Entity.SqlServer;
 
 namespace Tests.UnitTests
@@ -113,6 +114,69 @@ namespace Tests.UnitTests
             Assert.IsNotNull(strategy, $"No execution strategy registered for '{invariantName}'.");
             Assert.IsInstanceOfType(strategy(), typeof(MicrosoftSqlAzureExecutionStrategy),
                 $"'{invariantName}' must use the Azure SQL retry strategy.");
+        }
+
+        /// <summary>
+        /// Aliasing the legacy name must not change what EF calls the modern factory.
+        /// </summary>
+        /// <remarks>
+        /// <c>SetProviderFactory</c> registers a reverse <see cref="IProviderInvariantName"/> lookup as
+        /// well as the forward one. If the legacy alias wins that reverse lookup, EF starts describing
+        /// every <c>Microsoft.Data.SqlClient</c> connection as "System.Data.SqlClient" - and provider
+        /// services such as the migrations SQL generator are keyed on the modern name only, so they stop
+        /// resolving. That breaks <c>DatabaseUpgrader</c> and therefore every customer schema upgrade.
+        /// </remarks>
+        [TestMethod]
+        public void ModernFactory_StillReportsTheModernInvariantName()
+        {
+            var invariantName = DbConfiguration.DependencyResolver.GetService<IProviderInvariantName>(
+                Microsoft.Data.SqlClient.SqlClientFactory.Instance);
+
+            Assert.IsNotNull(invariantName, "EF cannot name the Microsoft.Data.SqlClient factory at all.");
+            Assert.AreEqual(ModernInvariantName, invariantName.Name,
+                "EF now reports the Microsoft.Data.SqlClient factory under the legacy invariant name. " +
+                "Provider-specific services - notably the migrations SQL generator - are keyed on the " +
+                "modern name, so this breaks DatabaseUpgrader and every schema upgrade.");
+        }
+
+        /// <summary>
+        /// The consequence of the reverse-lookup mapping, asserted directly: migrations must still be
+        /// generatable for whatever EF decides to call the connection.
+        /// </summary>
+        [TestMethod]
+        public void MigrationSqlGenerator_ResolvesForTheModernProvider()
+        {
+            var generator = DbConfiguration.DependencyResolver.GetService<Func<MigrationSqlGenerator>>(ModernInvariantName);
+
+            Assert.IsNotNull(generator,
+                "No MigrationSqlGenerator for the Microsoft.Data.SqlClient provider. DatabaseUpgrader " +
+                "calls Database.Initialize(true), which runs MigrateDatabaseToLatestVersion - so a " +
+                "customer upgrade with pending migrations would fail.");
+        }
+
+        /// <summary>
+        /// End to end: a context built from a raw connection string - the shape
+        /// <c>DatabaseUpgrader</c> uses - must be described by EF under a provider name that has a
+        /// migrations SQL generator.
+        /// </summary>
+        [TestMethod]
+        public void ContextFromRawConnectionString_ResolvesAMigrationSqlGenerator()
+        {
+            var connectionString =
+                @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingAnalytics;Integrated Security=true;TrustServerCertificate=True";
+
+            var info = new DbContextInfo(
+                typeof(AnalyticsEntitiesContext),
+                new DbConnectionInfo(connectionString, ModernInvariantName));
+
+            var reportedProvider = info.ConnectionProviderName;
+
+            var generator = DbConfiguration.DependencyResolver.GetService<Func<MigrationSqlGenerator>>(reportedProvider);
+
+            Assert.IsNotNull(generator,
+                $"EF describes this connection as provider '{reportedProvider}', and no MigrationSqlGenerator " +
+                "is registered for that name. DatabaseUpgrader would fail with 'No MigrationSqlGenerator " +
+                "found for provider' on any upgrade with pending migrations.");
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/EfProviderRegistrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/EfProviderRegistrationTests.cs
@@ -155,9 +155,9 @@ namespace Tests.UnitTests
         }
 
         /// <summary>
-        /// End to end: a context built from a raw connection string - the shape
-        /// <c>DatabaseUpgrader</c> uses - must be described by EF under a provider name that has a
-        /// migrations SQL generator.
+        /// End to end, using the invariant name a real App Service deployment actually supplies: a context
+        /// built from a raw connection string - the shape <c>DatabaseUpgrader</c> uses - must be described
+        /// by EF under a provider name that has a migrations SQL generator.
         /// </summary>
         [TestMethod]
         public void ContextFromRawConnectionString_ResolvesAMigrationSqlGenerator()
@@ -165,11 +165,17 @@ namespace Tests.UnitTests
             var connectionString =
                 @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=UnitTestingAnalytics;Integrated Security=true;TrustServerCertificate=True";
 
+            // Deliberately the LEGACY name, because that is what Azure App Service injects for a
+            // connection string saved as type SQLAzure.
             var info = new DbContextInfo(
                 typeof(AnalyticsEntitiesContext),
-                new DbConnectionInfo(connectionString, ModernInvariantName));
+                new DbConnectionInfo(connectionString, LegacyInvariantName));
 
             var reportedProvider = info.ConnectionProviderName;
+
+            Assert.AreEqual(ModernInvariantName, reportedProvider,
+                "EF must settle on the modern provider name even when handed the legacy one, because " +
+                "provider-specific services are keyed on the modern name.");
 
             var generator = DbConfiguration.DependencyResolver.GetService<Func<MigrationSqlGenerator>>(reportedProvider);
 

--- a/src/AnalyticsEngine/Tests.UnitTests/EfProviderRegistrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/EfProviderRegistrationTests.cs
@@ -1,0 +1,118 @@
+﻿using Common.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Data.Common;
+using System.Data.Entity;
+using System.Data.Entity.Core.Common;
+using System.Data.Entity.Infrastructure;
+using System.Data.Entity.Infrastructure.DependencyResolution;
+using System.Data.Entity.SqlServer;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Guards the EF6 provider registration after the move to Microsoft.Data.SqlClient (issue #511).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The installer saves the <c>SPOInsightsEntities</c> connection string on the App Service with type
+    /// <c>SQLAzure</c>. Azure surfaces that to a .NET Framework app as <c>SQLAZURECONNSTR_*</c> and hands
+    /// it to <c>ConfigurationManager</c> with <c>providerName="System.Data.SqlClient"</c> - the OLD
+    /// invariant name - regardless of which provider this build prefers. Every existing deployment
+    /// already has that setting, and re-running the installer does not change it.
+    /// </para>
+    /// <para>
+    /// So if EF only knows <c>Microsoft.Data.SqlClient</c>, the first query after an upgrade fails with
+    /// <c>No Entity Framework provider found for the ADO.NET provider with invariant name
+    /// 'System.Data.SqlClient'</c>.
+    /// </para>
+    /// <para>
+    /// The subtler failure matters more: if the machine-wide factory resolved instead, connections would
+    /// be <c>System.Data.SqlClient.SqlConnection</c>, and <see cref="Common.Entities.Sql.AzureSqlAccessTokenInterceptor"/>
+    /// - which casts to the <c>Microsoft.Data.SqlClient</c> type - would silently stop attaching Entra
+    /// tokens. Token-authenticated installs would break with nothing wrong at the provider layer.
+    /// </para>
+    /// <para>
+    /// These tests fail against a build that registers only the new invariant name.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class EfProviderRegistrationTests
+    {
+        const string LegacyInvariantName = "System.Data.SqlClient";
+        const string ModernInvariantName = "Microsoft.Data.SqlClient";
+
+        /// <summary>
+        /// Touch the context type so EF applies <see cref="SPOInsightsDBConfiguration"/> before the
+        /// resolver is queried. EF resolves its configuration lazily on first use.
+        /// </summary>
+        [ClassInitialize]
+        public static void EnsureDbConfigurationLoaded(TestContext context)
+        {
+            DbConfiguration.LoadConfiguration(typeof(AnalyticsEntitiesContext));
+        }
+
+        [DataTestMethod]
+        [DataRow(ModernInvariantName, DisplayName = "Modern invariant name")]
+        [DataRow(LegacyInvariantName, DisplayName = "Legacy invariant name injected by App Service")]
+        public void DbProviderServices_ResolvesToTheMicrosoftSqlProvider(string invariantName)
+        {
+            var services = DbConfiguration.DependencyResolver.GetService<DbProviderServices>(invariantName);
+
+            Assert.IsNotNull(services,
+                $"EF has no provider registered for '{invariantName}'. A connection string arriving with " +
+                "that invariant name would fail with 'No Entity Framework provider found'.");
+            Assert.IsInstanceOfType(services, typeof(MicrosoftSqlProviderServices),
+                $"'{invariantName}' must map to the Microsoft.Data.SqlClient provider services.");
+        }
+
+        [DataTestMethod]
+        [DataRow(ModernInvariantName, DisplayName = "Modern invariant name")]
+        [DataRow(LegacyInvariantName, DisplayName = "Legacy invariant name injected by App Service")]
+        public void DbProviderFactory_ResolvesToTheMicrosoftSqlClientFactory(string invariantName)
+        {
+            var factory = DbConfiguration.DependencyResolver.GetService<DbProviderFactory>(invariantName);
+
+            Assert.IsNotNull(factory, $"EF has no DbProviderFactory registered for '{invariantName}'.");
+            Assert.IsInstanceOfType(factory, typeof(Microsoft.Data.SqlClient.SqlClientFactory),
+                $"'{invariantName}' must produce Microsoft.Data.SqlClient connections. If it produces the " +
+                "legacy System.Data.SqlClient type, AzureSqlAccessTokenInterceptor stops attaching Entra " +
+                "tokens and token-authenticated installs break silently.");
+        }
+
+        /// <summary>
+        /// The consequence that actually matters: a connection created for the legacy invariant name must
+        /// be the type the Entra token interceptor can act on.
+        /// </summary>
+        [TestMethod]
+        public void ConnectionCreatedForLegacyInvariantName_IsAMicrosoftDataSqlConnection()
+        {
+            var factory = DbConfiguration.DependencyResolver.GetService<DbProviderFactory>(LegacyInvariantName);
+
+            using (var connection = factory.CreateConnection())
+            {
+                Assert.IsInstanceOfType(connection, typeof(Microsoft.Data.SqlClient.SqlConnection),
+                    "A connection built from the App Service-injected invariant name must be a " +
+                    "Microsoft.Data.SqlClient.SqlConnection, otherwise AzureSqlAccessTokenInterceptor " +
+                    "cannot attach an access token to it.");
+            }
+        }
+
+        /// <summary>
+        /// Both names must resolve to the retry strategy, or Azure SQL transient faults stop being retried
+        /// on whichever name the deployment actually uses.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(ModernInvariantName, DisplayName = "Modern invariant name")]
+        [DataRow(LegacyInvariantName, DisplayName = "Legacy invariant name injected by App Service")]
+        public void ExecutionStrategy_IsRegisteredForBothInvariantNames(string invariantName)
+        {
+            var strategy = DbConfiguration.DependencyResolver.GetService<Func<IDbExecutionStrategy>>(
+                new ExecutionStrategyKey(invariantName, "tcp:contoso.database.windows.net,1433"));
+
+            Assert.IsNotNull(strategy, $"No execution strategy registered for '{invariantName}'.");
+            Assert.IsInstanceOfType(strategy(), typeof(MicrosoftSqlAzureExecutionStrategy),
+                $"'{invariantName}' must use the Azure SQL retry strategy.");
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/InsertBatchOverWidthTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InsertBatchOverWidthTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallFailureDiagnosisTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/InstallFailureDiagnosisTests.cs
@@ -117,7 +117,7 @@ namespace Tests.UnitTests.InstallTests
             var childOutput = "Build 'Build 1825' - begin database upgrade.\r\n"
                 + "Connecting to database @ '...' with Entity Framework context initializer set to 'MigrateDatabaseToLatestVersion'...\r\n"
                 + "Initialise database failed with EF. Exception: 'System.InvalidOperationException: This operation requires a "
-                + "connection to the 'master' database. ---> System.Data.SqlClient.SqlException: Login failed for user ''.";
+                + "connection to the 'master' database. ---> Microsoft.Data.SqlClient.SqlException: Login failed for user ''.";
 
             var hint = SqlInstallerTasks.DownloadedBuildEntraHint(true, childOutput, null);
 

--- a/src/AnalyticsEngine/Tests.UnitTests/InstallTests/SqlAuthenticationDetectionTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/InstallTests/SqlAuthenticationDetectionTests.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Net;
 using System.Net.Http;
 using System.Threading;

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelSqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivityReadModelSqlTests.cs
@@ -213,7 +213,7 @@ UPDATE dbo.teams_user_activity_log SET last_activity_date=NULL WHERE user_id=1;"
                 var pending = fixture.Store(measurements.Instrumentation(includeShowplan: false))
                     .LoadReadModelAsync(Query(), Sources(), null, CancellationToken.None);
                 if (failCoverage)
-                    await Assert.ThrowsExceptionAsync<System.Data.SqlClient.SqlException>(() => pending);
+                    await Assert.ThrowsExceptionAsync<Microsoft.Data.SqlClient.SqlException>(() => pending);
                 else
                     Assert.AreEqual(5, (await pending).BuildOverview(Query(), CancellationToken.None).DistinctAssignedUsers);
                 Assert.AreEqual(0, measurements.ActiveCommands);

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlFixture.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -220,6 +220,7 @@ VALUES (N'" + RetainedMarker + "');");
                 throw new InvalidOperationException(
                     "Retained licence-activity performance databases are allowed only on LocalDB.");
             builder.InitialCatalog = database;
+            builder.TrustServerCertificate = true;
             return builder;
         }
 

--- a/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/LicenceActivitySqlTests.cs
@@ -2,7 +2,7 @@ using Common.Entities.LicenceActivity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -1326,7 +1326,7 @@ SELECT N'Synthetic limit ' + CAST(n AS nvarchar(10)),
        N'LIMIT_' + CAST(n AS nvarchar(10))
 FROM Numbers;");
 
-                var exception = await Assert.ThrowsExceptionAsync<System.Data.SqlClient.SqlException>(() =>
+                var exception = await Assert.ThrowsExceptionAsync<Microsoft.Data.SqlClient.SqlException>(() =>
                     fixture.Store().LoadOverviewAsync(
                         OverviewQuery(), Sources(usageReports: false),
                         NullLicenceActivityDiagnostics.Instance, CancellationToken.None));

--- a/src/AnalyticsEngine/Tests.UnitTests/ScratchDatabase.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ScratchDatabase.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Configuration;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text.RegularExpressions;
 
 namespace Tests.UnitTests
@@ -51,6 +51,11 @@ namespace Tests.UnitTests
 
             var master = new SqlConnectionStringBuilder(configured.ConnectionString) { InitialCatalog = "master" };
             var scratch = new SqlConnectionStringBuilder(configured.ConnectionString) { InitialCatalog = name };
+            if (master.DataSource.IndexOf("(localdb)", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                master.TrustServerCertificate = true;
+                scratch.TrustServerCertificate = true;
+            }
 
             var database = new ScratchDatabase(name, master.ConnectionString, scratch.ConnectionString);
             ExecuteOn(master.ConnectionString, $"CREATE DATABASE [{name}];");

--- a/src/AnalyticsEngine/Tests.UnitTests/ShrinkUrlsFullUrlColumnMigrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/ShrinkUrlsFullUrlColumnMigrationTests.cs
@@ -3,7 +3,7 @@ using Common.Entities.Migrations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/AnalyticsEngine/Tests.UnitTests/StressHarness/ActivityApiDbStressRunner.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/StressHarness/ActivityApiDbStressRunner.cs
@@ -4,7 +4,7 @@ using Common.Entities;
 using DataUtils;
 using System;
 using System.Configuration;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
@@ -37,7 +37,7 @@ namespace Tests.UnitTests.StressHarness
         /// </summary>
         public const string DefaultLocalDbConnectionString =
             "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=AuditImporterStressTest;" +
-            "Integrated Security=true;MultipleActiveResultSets=True;App=EntityFramework";
+            "Integrated Security=true;MultipleActiveResultSets=True;TrustServerCertificate=True;App=EntityFramework";
 
         // Delete order (children first) for resetting a non-LocalDB target (best effort).
         private static readonly string[] ImportTablesChildFirst =
@@ -393,11 +393,11 @@ namespace Tests.UnitTests.StressHarness
                     .GetField("_bReadOnly", BindingFlags.Instance | BindingFlags.NonPublic);
                 elemReadOnly?.SetValue(existing, false);
                 existing.ConnectionString = connectionString;
-                existing.ProviderName = "System.Data.SqlClient";
+                existing.ProviderName = "Microsoft.Data.SqlClient";
             }
             else
             {
-                settings.Add(new ConnectionStringSettings(name, connectionString, "System.Data.SqlClient"));
+                settings.Add(new ConnectionStringSettings(name, connectionString, "Microsoft.Data.SqlClient"));
             }
 
             var check = ConfigurationManager.ConnectionStrings[name]?.ConnectionString;

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="AgentCostUserResolutionTests.cs" />
     <Compile Include="AgentCostSqlIntegrationTests.cs" />
     <Compile Include="AzureSqlEntraAuthTests.cs" />
+    <Compile Include="EfProviderRegistrationTests.cs" />
     <Compile Include="InstallTests\SqlAuthenticationDetectionTests.cs" />
     <Compile Include="ActivityReportLoaderTimeoutTests.cs" />
     <Compile Include="ActivityReportSetMinMaxTests.cs" />

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -501,6 +501,12 @@
     <PackageReference Include="EntityFramework">
       <Version>6.5.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
       <Version>2.22.0</Version>
     </PackageReference>
@@ -530,9 +536,6 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.4</Version>
-    </PackageReference>
-    <PackageReference Include="System.Data.SqlClient">
-      <Version>4.9.1</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
       <Version>8.22.0</Version>

--- a/src/AnalyticsEngine/Tests.UnitTests/UniqueUrlsFullUrlIndexMigrationTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UniqueUrlsFullUrlIndexMigrationTests.cs
@@ -3,7 +3,7 @@ using Common.Entities.Migrations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/AnalyticsEngine/Tests.UnitTests/UpgradeFromStableTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UpgradeFromStableTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using Common.Entities.Migrations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -154,7 +154,7 @@ namespace Tests.UnitTests
         {
             var config = new Configuration
             {
-                TargetDatabase = new DbConnectionInfo(connectionString, "System.Data.SqlClient")
+                TargetDatabase = new DbConnectionInfo(connectionString, "Microsoft.Data.SqlClient")
             };
             return new DbMigrator(config);
         }

--- a/src/AnalyticsEngine/Tests.UnitTests/UrlFullUrlMigrationPipelineTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/UrlFullUrlMigrationPipelineTests.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Data;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 // Aliased rather than imported: an unqualified `using System.Configuration` makes `Configuration`
 // ambiguous with the EF migrations Configuration this file already uses.
 using ConfigurationManager = System.Configuration.ConfigurationManager;

--- a/src/AnalyticsEngine/Web/Controllers/ProfilingStatusAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ProfilingStatusAPIController.cs
@@ -2,7 +2,7 @@ using Common.Entities;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Runtime.Caching;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
+++ b/src/AnalyticsEngine/Web/Controllers/ReportsAPIController.cs
@@ -3,7 +3,7 @@ using Common.Entities.Config;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Runtime.Caching;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
+++ b/src/AnalyticsEngine/Web/Models/Health/HealthService.cs
@@ -298,7 +298,7 @@ namespace Web.AnalyticsWeb.Models.Health
         {
             try
             {
-                return new System.Data.SqlClient.SqlConnectionStringBuilder(config.ConnectionStrings.DatabaseConnectionString).DataSource;
+                return new Microsoft.Data.SqlClient.SqlConnectionStringBuilder(config.ConnectionStrings.DatabaseConnectionString).DataSource;
             }
             catch
             {

--- a/src/AnalyticsEngine/Web/Models/Health/SqlHealthDataSource.cs
+++ b/src/AnalyticsEngine/Web/Models/Health/SqlHealthDataSource.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/AnalyticsEngine/Web/Models/SystemStatus.cs
+++ b/src/AnalyticsEngine/Web/Models/SystemStatus.cs
@@ -104,7 +104,7 @@ namespace Web.AnalyticsWeb.Models
             status.WebAppConfigRedis = string.IsNullOrWhiteSpace(config.ConnectionStrings.RedisConnectionString)
                 ? "(not configured - Teams deep analytics disabled)"
                 : StackExchange.Redis.ConfigurationOptions.Parse(config.ConnectionStrings.RedisConnectionString).SslHost;
-            status.WebAppConfigSQL = new System.Data.SqlClient.SqlConnectionStringBuilder(config.ConnectionStrings.DatabaseConnectionString).DataSource;
+            status.WebAppConfigSQL = new Microsoft.Data.SqlClient.SqlConnectionStringBuilder(config.ConnectionStrings.DatabaseConnectionString).DataSource;
             status.WebAppConfigServiceBus = string.IsNullOrWhiteSpace(config.ConnectionStrings.ServiceBusConnectionString)
                 ? "(disabled)"
                 : ServiceBusConnectionStringProperties.Parse(config.ConnectionStrings.ServiceBusConnectionString).Endpoint.ToString();

--- a/src/AnalyticsEngine/Web/Web.Template.config
+++ b/src/AnalyticsEngine/Web/Web.Template.config
@@ -302,6 +302,8 @@
 	<entityFramework>
 		<providers>
 			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+			<!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 

--- a/src/AnalyticsEngine/Web/Web.Template.config
+++ b/src/AnalyticsEngine/Web/Web.Template.config
@@ -33,6 +33,14 @@
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
@@ -63,10 +71,6 @@
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -297,7 +301,14 @@
 	</system.webServer>
 	<entityFramework>
 		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
 </configuration>

--- a/src/AnalyticsEngine/Web/Web.csproj
+++ b/src/AnalyticsEngine/Web/Web.csproj
@@ -56,6 +56,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="System.ClientModel">
       <Version>1.15.0</Version>
     </PackageReference>
@@ -97,9 +103,6 @@
     </PackageReference>
     <PackageReference Include="System.Configuration.ConfigurationManager">
       <Version>10.0.11</Version>
-    </PackageReference>
-    <PackageReference Include="System.Data.SqlClient">
-      <Version>4.9.1</Version>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.EventLog">
       <Version>10.0.11</Version>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/PageUpdates/PageUpdateManager.cs
@@ -10,7 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SearchesSaveExtension.cs
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/Sql/SearchesSaveExtension.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using WebJob.AppInsightsImporter.Engine.APIResponseParsers.CustomEvents;

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/WebJob.AppInsightsImporter.Engine.csproj
@@ -139,6 +139,12 @@
     <PackageReference Include="EntityFramework">
       <Version>6.5.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
       <Version>2.22.0</Version>
     </PackageReference>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/app.config
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 
@@ -9,6 +9,8 @@
 		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftSqlConnectionFactory, Microsoft.EntityFramework.SqlServer" />
 		<providers>
 			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+			<!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/app.config
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter.Engine/app.config
@@ -4,19 +4,34 @@
 
 		<section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
 	</configSections>
-		
+
 	<entityFramework>
-		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftSqlConnectionFactory, Microsoft.EntityFramework.SqlServer" />
 		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
-	<startup>
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
+<startup>
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
 	</startup>
 
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
 
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/App.Template.config
@@ -145,10 +145,6 @@
 				<bindingRedirect oldVersion="0.0.0.0-8.22.0.0" newVersion="8.22.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.2" newVersion="10.0.0.2" />
 			</dependentAssembly>

--- a/src/AnalyticsEngine/WebJob.AppInsightsImporter/WebJob.AppInsightsImporter.csproj
+++ b/src/AnalyticsEngine/WebJob.AppInsightsImporter/WebJob.AppInsightsImporter.csproj
@@ -160,6 +160,12 @@
     <Content Include="Generated\**" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>10.0.11</Version>
     </PackageReference>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/ActivityReportSqlPersistenceManager.cs
@@ -9,7 +9,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityAPI/Copilot/CopilotAuditEventManager.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/ActivityImportCache.cs
@@ -2,7 +2,7 @@
 using DataUtils;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using WebJob.Office365ActivityImporter.Engine.ActivityAPI.Rules;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/App.config
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/App.config
@@ -5,18 +5,33 @@
 		<section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
 	</configSections>
 	<entityFramework>
-		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftSqlConnectionFactory, Microsoft.EntityFramework.SqlServer" />
 		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
-	
-	<startup>
+
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
+<startup>
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
 	</startup>
-	
+
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
 
 			<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 				<dependentAssembly>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/App.config
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
 
@@ -8,6 +8,8 @@
 		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftSqlConnectionFactory, Microsoft.EntityFramework.SqlServer" />
 		<providers>
 			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+			<!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsImporter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/Teams/TeamsImporter.cs
@@ -7,7 +7,7 @@ using Microsoft.Graph.Models;
 using Microsoft.Graph.Models.ODataErrors;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 
 namespace WebJob.Office365ActivityImporter.Engine.Graph.Teams

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStorageInspector.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/UsageReports/IUsageReportStorageInspector.cs
@@ -3,7 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Reflection;
 using System.Threading.Tasks;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserBulkUpdateWriter.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserBulkUpdateWriter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 using DataUtils.Sql;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserLicenseStore.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/SqlUserLicenseStore.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserInsertProcessor.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/Graph/User/UserInsertProcessor.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Entity;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter.Engine/WebJob.Office365ActivityImporter.Engine.csproj
@@ -365,6 +365,12 @@
     <PackageReference Include="EntityFramework">
       <Version>6.5.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
       <Version>2.22.0</Version>
     </PackageReference>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
@@ -260,6 +260,8 @@
 		</defaultConnectionFactory>
 		<providers>
 			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
+			<!-- Azure App Service injects providerName="System.Data.SqlClient" for connection strings saved as type SQLAzure, which is how the installer stores SPOInsightsEntities. Map that name onto the modern provider so existing deployments keep working. See issue #511. -->
+			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/App.Template.config
@@ -29,6 +29,14 @@
 
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.SqlClient" publicKeyToken="23ec7fc2d6eaa4a5" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFramework.SqlServer" publicKeyToken="b77a5c561934e089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
 			</dependentAssembly>
@@ -233,10 +241,6 @@
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.11" newVersion="10.0.0.11" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.SqlClient" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.2" newVersion="10.0.0.2" />
 			</dependentAssembly>
@@ -249,13 +253,20 @@
 	</runtime>
 
 	<entityFramework>
-		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+		<defaultConnectionFactory type="System.Data.Entity.Infrastructure.MicrosoftLocalDbConnectionFactory, Microsoft.EntityFramework.SqlServer">
 			<parameters>
 				<parameter value="mssqllocaldb" />
 			</parameters>
 		</defaultConnectionFactory>
 		<providers>
-			<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+			<provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
 		</providers>
 	</entityFramework>
+
+	<system.data>
+		<DbProviderFactories>
+			<remove invariant="Microsoft.Data.SqlClient" />
+			<add name="SqlClient Data Provider" invariant="Microsoft.Data.SqlClient" description=".NET Framework Data Provider for SQL Server" type="Microsoft.Data.SqlClient.SqlClientFactory, Microsoft.Data.SqlClient" />
+		</DbProviderFactories>
+	</system.data>
 </configuration>

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/Program.cs
@@ -410,7 +410,7 @@ namespace WebJob.Office365ActivityImporter
                                  select allDownloads).Count();
                     logger.LogInformation($"Found {count.ToString("n0")} events in table already. Test passed!");
                 }
-                catch (System.Data.SqlClient.SqlException ex)
+                catch (Microsoft.Data.SqlClient.SqlException ex)
                 {
                     logger.LogError(ex, $"Got a SQL error: {ex.Message}");
                     ConsoleApp.BombOut(true);
@@ -426,7 +426,7 @@ namespace WebJob.Office365ActivityImporter
             ConsoleApp.PrintStartupAndLoggingConfig(settings.ConnectionStrings.DatabaseConnectionString, settings.BuildLabel, settings.UserGroupsFilter, logger);
 
             var efConnectionString = ConfigurationManager.ConnectionStrings["SPOInsightsEntities"].ConnectionString;
-            var sqlConnectionInfo = new System.Data.SqlClient.SqlConnectionStringBuilder(efConnectionString);
+            var sqlConnectionInfo = new Microsoft.Data.SqlClient.SqlConnectionStringBuilder(efConnectionString);
 
             logger.LogInformation("\nConfigured values:");
 

--- a/src/AnalyticsEngine/WebJob.Office365ActivityImporter/WebJob.Office365ActivityImporter.csproj
+++ b/src/AnalyticsEngine/WebJob.Office365ActivityImporter/WebJob.Office365ActivityImporter.csproj
@@ -150,14 +150,17 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>6.1.4</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer">
+      <Version>6.5.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>10.0.11</Version>
     </PackageReference>
     <PackageReference Include="System.Configuration.ConfigurationManager">
       <Version>10.0.11</Version>
-    </PackageReference>
-    <PackageReference Include="System.Data.SqlClient">
-      <Version>4.9.1</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>


### PR DESCRIPTION
## Summary
Addresses #511.

This switches the EF6 SQL Server provider path from the deprecated `System.Data.SqlClient` provider to the official Microsoft.Data-backed provider:

- Replaced C# `SqlConnection`/`SqlCommand`/`SqlException` usages with `Microsoft.Data.SqlClient`.
- Added `Microsoft.Data.SqlClient` 6.1.4 and `Microsoft.EntityFramework.SqlServer` 6.5.2 package references to the .NET Framework entry points/libraries that need them; `Common.DataUtils` keeps only `Microsoft.Data.SqlClient` because the EF provider package has no netstandard2.0 asset.
- Updated EF provider configuration to `Microsoft.Data.SqlClient`, `MicrosoftSqlProviderServices`, `MicrosoftSqlDbConfiguration`, `MicrosoftSqlAzureExecutionStrategy`, and the Microsoft SQL connection factories.
- Updated provider factories and binding redirects in the application templates/configs.
- Removed all tracked `System.Data.SqlClient` source/config/project references.
- Added `TrustServerCertificate=True` only for LocalDB/test/demo connection strings and LocalDB-only scratch database builders.

## Behavioural risk

`Microsoft.Data.SqlClient` defaults to `Encrypt=True`; the old provider defaulted to `Encrypt=False`. Azure SQL deployments should generally benefit from the stricter default, but non-Azure/dev SQL servers with untrusted certificates can fail during connection open unless their connection strings explicitly opt into a trusted certificate chain or a deliberate `TrustServerCertificate=True` dev/test override.

I intentionally did **not** add `TrustServerCertificate=True` to customer deployment connection-string builders or installer production paths because that would weaken certificate validation. Reviewers should check any non-Azure SQL deployment guidance before merge.

## Not changed

- Kept the existing `AzureSqlTokenAuth` / `AzureSqlAccessTokenInterceptor` compatibility workaround. `Microsoft.Data.SqlClient` can handle modern `Authentication=Active Directory ...` keywords natively, so removing/simplifying that fallback is a follow-up.
- No installer saved-config schema change; `CONFIG_VERSION` was not bumped.

## Validation

- `MSBuild.exe src\AnalyticsEngine\O365 Advanced Analytics Engine.sln -p:Configuration=Release -p:Platform="Any CPU" -m -v:minimal` succeeded. It still emits the pre-existing `System.Text.Json` binding-remap warnings.
- `MSBuild.exe src\AnalyticsEngine\Tests.UnitTests\Tests.UnitTests.csproj -p:Configuration=Debug -p:Platform=anycpu -m -v:minimal` succeeded.
- `vstest.console.exe src\AnalyticsEngine\Tests.UnitTests\bin\Debug\Tests.UnitTests.dll /Platform:x64 /TestCaseFilter:FullyQualifiedName~AzureSqlEntraAuthTests` passed: 68 passed, 0 failed.
- Full Debug `Tests.UnitTests` run completed: 2132 passed, 12 failed, 4 skipped, 2148 total. The failures are existing environment/config-dependent tests against unavailable fake external services or missing local installer test config copy, not SQL-provider failures:
  - `CommentsCognitiveTests`
  - `UsageStatsReporterRealTests`
  - `SharePointSitesUsageLoaderTest`
  - `MessageImportTests`
  - `CallQueueProcessorTest`
  - `SingleTeamSaveToSQLTest`
  - `AllTeamsLoadTest`
  - `ChatMessageLoadCognitiveStatsFromCacheOrAITests`
  - `ConfigFileLoadsWithVNetDefaults`
  - `SolutionInstallConfig_VNetEnabled_SkuUpgradeValidation`
  - `SolutionInstallConfig_SerializationRoundTrip_PreservesVNet`
  - `DeployWithVNet_CreatesVNetAndResources`
- `git grep -n "System.Data.SqlClient" -- '*.cs' '*.config' '*.csproj'` returns no tracked matches.
- Changed config files parse as XML and `git diff --check` passes.

## Reviewer hotspots

- EF provider registration in `Common\Entities\AnalyticsEntitiesContext.cs` and every `<entityFramework>` config block.
- Binding redirects/provider factories in app templates and tracked app configs.
- LocalDB-only `TrustServerCertificate=True` additions versus production/customer connection-string paths.
- The retained `AzureSqlTokenAuth` fallback against the new `Microsoft.Data.SqlClient.SqlConnection` type.
