### PR TITLE
Add a schema snapshot and diff harness for database comparison

### DIFF
--- a/src/AnalyticsEngine/Tests.UnitTests/SchemaSnapshot.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SchemaSnapshot.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Tests.UnitTests
 {
@@ -23,30 +24,31 @@ namespace Tests.UnitTests
     /// remembered to mirror it, which is the only form of enforcement that actually works.
     /// </para>
     /// <para>
-    /// The snapshot is a sorted set of canonical strings rather than an object graph, because the useful
-    /// output is a readable diff, not a tree. Every line is self-describing, so a failure message can be
-    /// pasted straight into a bug report.
+    /// The snapshot is a multiset of canonical strings rather than an object graph, because the useful
+    /// output is a readable diff. A multiset rather than a set because cardinality is meaningful: two
+    /// structurally identical foreign keys are not the same thing as one.
     /// </para>
     /// <para>
-    /// Deliberately captures only what the product depends on being right: tables, column definitions
-    /// (including nullability and collation), indexes with their key order and INCLUDE lists, foreign
-    /// keys, defaults, and check constraints. It ignores things that legitimately differ between two
-    /// correctly-built databases, such as object ids, index fragmentation, statistics and fill factor.
+    /// What it captures is driven by what this product's migrations actually do, not by completeness for
+    /// its own sake. Index options such as <c>IGNORE_DUP_KEY</c>, foreign-key trust state, and view bodies
+    /// are all in because migrations in this repository deliberately set them and depend on them. Things
+    /// that legitimately differ between two correctly-built databases - object ids, fragmentation,
+    /// statistics, fill factor, identity <c>last_value</c> - are deliberately out.
     /// </para>
     /// </remarks>
     internal sealed class SchemaSnapshot
     {
-        private readonly SortedSet<string> _lines;
+        private readonly List<string> _lines;
 
         public string Label { get; }
 
         private SchemaSnapshot(string label, IEnumerable<string> lines)
         {
             Label = label;
-            _lines = new SortedSet<string>(lines, StringComparer.Ordinal);
+            _lines = lines.ToList();
         }
 
-        public IReadOnlyCollection<string> Lines => _lines;
+        public IReadOnlyList<string> Lines => _lines;
 
         public static SchemaSnapshot Capture(string connectionString, string label)
         {
@@ -61,25 +63,49 @@ namespace Tests.UnitTests
                 lines.AddRange(Query(connection, IndexesSql));
                 lines.AddRange(Query(connection, ForeignKeysSql));
                 lines.AddRange(Query(connection, CheckConstraintsSql));
+                lines.AddRange(QueryModules(connection));
             }
 
             return new SchemaSnapshot(label, lines);
         }
 
         /// <summary>
-        /// Lines present in this snapshot but not the other, and vice versa, in a form meant to be read
-        /// by a human in a test failure.
+        /// Differences between the two snapshots, as a multiset comparison so that a duplicated structure
+        /// is reported rather than collapsed.
         /// </summary>
         public IReadOnlyList<string> DifferencesFrom(SchemaSnapshot other)
         {
             if (other == null) throw new ArgumentNullException(nameof(other));
 
-            var onlyHere = _lines.Except(other._lines, StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal);
-            var onlyThere = other._lines.Except(_lines, StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal);
+            var here = Counts(_lines);
+            var there = Counts(other._lines);
 
-            return onlyHere.Select(l => $"only in {Label}: {l}")
-                .Concat(onlyThere.Select(l => $"only in {other.Label}: {l}"))
-                .ToList();
+            var differences = new List<string>();
+
+            foreach (var line in here.Keys.Union(there.Keys).OrderBy(x => x, StringComparer.Ordinal))
+            {
+                here.TryGetValue(line, out var hereCount);
+                there.TryGetValue(line, out var thereCount);
+
+                if (hereCount == thereCount) continue;
+
+                if (thereCount == 0) differences.Add($"only in {Label}: {line}");
+                else if (hereCount == 0) differences.Add($"only in {other.Label}: {line}");
+                else differences.Add($"count differs ({Label}={hereCount}, {other.Label}={thereCount}): {line}");
+            }
+
+            return differences;
+        }
+
+        private static Dictionary<string, int> Counts(IEnumerable<string> lines)
+        {
+            var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var line in lines)
+            {
+                counts.TryGetValue(line, out var n);
+                counts[line] = n + 1;
+            }
+            return counts;
         }
 
         /// <summary>Formats a diff for a test failure message, truncated so the output stays usable.</summary>
@@ -109,11 +135,49 @@ namespace Tests.UnitTests
             return results;
         }
 
-        // Only user tables; EF's own history tables are excluded because the two branches deliberately
-        // use different ones (__MigrationHistory for EF6, __EFMigrationsHistory for EF Core) and that
-        // difference is expected rather than a defect.
+        /// <summary>
+        /// Views, procedures, functions and triggers. Read as separate columns so the body can be
+        /// whitespace-normalised in C# - collapsing runs of whitespace in T-SQL is painful, and CRLF
+        /// versus LF alone would otherwise report every module as different.
+        /// </summary>
+        private static IEnumerable<string> QueryModules(SqlConnection connection)
+        {
+            var results = new List<string>();
+
+            using (var command = new SqlCommand(ModulesSql, connection) { CommandTimeout = 0 })
+            using (var reader = command.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    var kind = reader.GetString(0);
+                    var name = reader.GetString(1);
+                    var ansiNulls = reader.GetBoolean(2);
+                    var quotedIdentifier = reader.GetBoolean(3);
+                    var body = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
+
+                    results.Add(
+                        $"MODULE {kind} {name}" +
+                        $" ANSI_NULLS({(ansiNulls ? 1 : 0)})" +
+                        $" QUOTED_IDENTIFIER({(quotedIdentifier ? 1 : 0)})" +
+                        $" BODY({NormaliseSql(body)})");
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Collapses whitespace so that reformatting a view body is not reported as a schema change, while
+        /// any real change to its logic still is.
+        /// </summary>
+        internal static string NormaliseSql(string sql) =>
+            string.IsNullOrEmpty(sql) ? string.Empty : Regex.Replace(sql, @"\s+", " ").Trim();
+
+        // EF's own history tables are excluded because the two frameworks deliberately use different ones
+        // (__MigrationHistory for EF6, __EFMigrationsHistory for EF Core) and that difference is expected.
+        // Qualified by schema so a history table sitting in the wrong schema is NOT silently ignored.
         const string ExcludedTables =
-            "t.name NOT IN ('__MigrationHistory', '__EFMigrationsHistory', 'sysdiagrams')";
+            "NOT (s.name = 'dbo' AND t.name IN ('__MigrationHistory', '__EFMigrationsHistory', 'sysdiagrams'))";
 
         const string TablesSql = @"
 SELECT 'TABLE ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT
@@ -123,40 +187,61 @@ WHERE " + ExcludedTables;
 
         // Column type is rendered with its real length/precision so that nvarchar(850) and varchar(850)
         // - a distinction this codebase cares about a great deal - never compare equal.
+        //
+        // IDENTITY carries its seed and increment, and a computed column carries its expression and
+        // persisted state: reducing either to a boolean would let genuinely different schemas compare
+        // equal. identity last_value is deliberately NOT captured; that is data state, not schema.
         const string ColumnsSql = @"
 SELECT 'COLUMN ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT + '.' + c.name COLLATE DATABASE_DEFAULT
      + ' ' + ty.name COLLATE DATABASE_DEFAULT
      + CASE
-         WHEN ty.name COLLATE DATABASE_DEFAULT IN ('varchar','char','varbinary','binary')
+         WHEN ty.name IN ('varchar','char','varbinary','binary')
               THEN '(' + CASE WHEN c.max_length = -1 THEN 'max' ELSE CAST(c.max_length AS varchar(10)) END + ')'
-         WHEN ty.name COLLATE DATABASE_DEFAULT IN ('nvarchar','nchar')
+         WHEN ty.name IN ('nvarchar','nchar')
               THEN '(' + CASE WHEN c.max_length = -1 THEN 'max' ELSE CAST(c.max_length / 2 AS varchar(10)) END + ')'
-         WHEN ty.name COLLATE DATABASE_DEFAULT IN ('decimal','numeric')
+         WHEN ty.name IN ('decimal','numeric')
               THEN '(' + CAST(c.precision AS varchar(10)) + ',' + CAST(c.scale AS varchar(10)) + ')'
-         WHEN ty.name COLLATE DATABASE_DEFAULT IN ('datetime2','time','datetimeoffset')
+         WHEN ty.name IN ('datetime2','time','datetimeoffset')
               THEN '(' + CAST(c.scale AS varchar(10)) + ')'
          ELSE ''
        END
      + CASE WHEN c.is_nullable = 1 THEN ' NULL' ELSE ' NOT NULL' END
-     + CASE WHEN c.is_identity = 1 THEN ' IDENTITY' ELSE '' END
-     + CASE WHEN c.is_computed = 1 THEN ' COMPUTED' ELSE '' END
-     + ISNULL(' COLLATE ' + c.collation_name, '')
+     + CASE WHEN c.is_identity = 1
+            THEN ' IDENTITY(' + ISNULL(CAST(CAST(ic.seed_value AS bigint) AS varchar(40)), '?') + ','
+                              + ISNULL(CAST(CAST(ic.increment_value AS bigint) AS varchar(40)), '?') + ')'
+            ELSE '' END
+     + CASE WHEN c.is_computed = 1
+            THEN ' COMPUTED(' + ISNULL(cmp.definition COLLATE DATABASE_DEFAULT, '?') + ')'
+                 + CASE WHEN cmp.is_persisted = 1 THEN ' PERSISTED' ELSE '' END
+            ELSE '' END
+     + CASE WHEN c.is_rowguidcol = 1 THEN ' ROWGUIDCOL' ELSE '' END
+     + CASE WHEN c.is_sparse = 1 THEN ' SPARSE' ELSE '' END
+     + ISNULL(' COLLATE ' + c.collation_name COLLATE DATABASE_DEFAULT, '')
      + ISNULL(' DEFAULT ' + dc.definition COLLATE DATABASE_DEFAULT, '')
 FROM sys.columns c
 JOIN sys.tables t ON t.object_id = c.object_id
 JOIN sys.schemas s ON s.schema_id = t.schema_id
 JOIN sys.types ty ON ty.user_type_id = c.user_type_id
 LEFT JOIN sys.default_constraints dc ON dc.object_id = c.default_object_id
+LEFT JOIN sys.identity_columns ic ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+LEFT JOIN sys.computed_columns cmp ON cmp.object_id = c.object_id AND cmp.column_id = c.column_id
 WHERE " + ExcludedTables;
 
         // Key column ORDER matters for an index and is a common source of silent difference, so the key
         // list is ordered rather than sorted. INCLUDE columns are unordered by definition, so they are.
+        //
+        // IGNORE_DUP_KEY is captured because migrations in this repository depend on it: the unique index
+        // on urls.full_url sets it deliberately so that one racing duplicate cannot abort an entire insert
+        // batch, and uses ignore_dup_key = 1 as part of its target-state check. Two indexes differing only
+        // in that option are NOT the same index.
         const string IndexesSql = @"
 SELECT 'INDEX ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT + '.' + i.name COLLATE DATABASE_DEFAULT
      + CASE WHEN i.is_unique = 1 THEN ' UNIQUE' ELSE '' END
      + CASE WHEN i.is_primary_key = 1 THEN ' PRIMARY_KEY' ELSE '' END
      + CASE WHEN i.is_unique_constraint = 1 THEN ' UNIQUE_CONSTRAINT' ELSE '' END
      + ' TYPE(' + i.type_desc COLLATE DATABASE_DEFAULT + ')'
+     + ' IGNORE_DUP_KEY(' + CAST(i.ignore_dup_key AS varchar(1)) + ')'
+     + ' DISABLED(' + CAST(i.is_disabled AS varchar(1)) + ')'
      + ' KEYS(' + ISNULL(STUFF((
          SELECT ',' + kc.name COLLATE DATABASE_DEFAULT + CASE WHEN kic.is_descending_key = 1 THEN ' DESC' ELSE '' END
          FROM sys.index_columns kic
@@ -169,17 +254,23 @@ SELECT 'INDEX ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABAS
          FROM sys.index_columns iic
          JOIN sys.columns ic2 ON ic2.object_id = iic.object_id AND ic2.column_id = iic.column_id
          WHERE iic.object_id = i.object_id AND iic.index_id = i.index_id AND iic.is_included_column = 1
-         ORDER BY ic2.name COLLATE DATABASE_DEFAULT
+         ORDER BY ic2.name
          FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 1, ''), '') + ')'
      + CASE WHEN i.has_filter = 1 THEN ' FILTER(' + i.filter_definition COLLATE DATABASE_DEFAULT + ')' ELSE '' END
 FROM sys.indexes i
 JOIN sys.tables t ON t.object_id = i.object_id
 JOIN sys.schemas s ON s.schema_id = t.schema_id
-WHERE i.name COLLATE DATABASE_DEFAULT IS NOT NULL AND " + ExcludedTables;
+WHERE i.name IS NOT NULL AND " + ExcludedTables;
 
-        // Constraint NAMES are deliberately excluded: EF6 and EF Core generate different auto-names for
-        // the same relationship, and a name difference is not a schema difference that affects the
-        // product. What matters is which columns reference which.
+        // Constraint NAMES are excluded: EF6 and EF Core generate different auto-names for the same
+        // relationship, and a name difference is not a schema difference that affects the product.
+        // Cardinality is preserved by the multiset comparison, so two structurally identical foreign keys
+        // are still distinguishable from one.
+        //
+        // Trust and enabled state ARE captured. A migration in this repository creates a foreign key WITH
+        // NOCHECK and then runs the expensive WITH CHECK CHECK CONSTRAINT specifically to make it trusted;
+        // without these flags the intermediate state would certify as identical to the finished one, even
+        // though an untrusted constraint is unusable by the optimiser and may be hiding invalid rows.
         const string ForeignKeysSql = @"
 SELECT 'FOREIGNKEY ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT
      + '(' + ISNULL(STUFF((
@@ -199,6 +290,9 @@ SELECT 'FOREIGNKEY ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DA
          FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 1, ''), '') + ')'
      + ' ONDELETE(' + fk.delete_referential_action_desc COLLATE DATABASE_DEFAULT + ')'
      + ' ONUPDATE(' + fk.update_referential_action_desc COLLATE DATABASE_DEFAULT + ')'
+     + ' DISABLED(' + CAST(fk.is_disabled AS varchar(1)) + ')'
+     + ' NOTTRUSTED(' + CAST(fk.is_not_trusted AS varchar(1)) + ')'
+     + ' NOTFORREPLICATION(' + CAST(fk.is_not_for_replication AS varchar(1)) + ')'
 FROM sys.foreign_keys fk
 JOIN sys.tables t ON t.object_id = fk.parent_object_id
 JOIN sys.schemas s ON s.schema_id = t.schema_id
@@ -207,10 +301,29 @@ JOIN sys.schemas rs ON rs.schema_id = rt.schema_id
 WHERE " + ExcludedTables;
 
         const string CheckConstraintsSql = @"
-SELECT 'CHECK ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT + ' ' + cc.definition COLLATE DATABASE_DEFAULT
+SELECT 'CHECK ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT
+     + ' ' + cc.definition COLLATE DATABASE_DEFAULT
+     + ' DISABLED(' + CAST(cc.is_disabled AS varchar(1)) + ')'
+     + ' NOTTRUSTED(' + CAST(cc.is_not_trusted AS varchar(1)) + ')'
+     + ' NOTFORREPLICATION(' + CAST(cc.is_not_for_replication AS varchar(1)) + ')'
 FROM sys.check_constraints cc
 JOIN sys.tables t ON t.object_id = cc.parent_object_id
 JOIN sys.schemas s ON s.schema_id = t.schema_id
 WHERE " + ExcludedTables;
+
+        // Views, procedures, functions and triggers are part of the migration chain in this repository -
+        // migrations create the reporting views and later rewrite them, and existing tests treat
+        // uses_quoted_identifier as part of a view's required state. A database with a missing or stale
+        // view must not compare equal to one with the right view.
+        const string ModulesSql = @"
+SELECT o.type_desc COLLATE DATABASE_DEFAULT AS Kind,
+       s.name COLLATE DATABASE_DEFAULT + '.' + o.name COLLATE DATABASE_DEFAULT AS FullName,
+       m.uses_ansi_nulls AS UsesAnsiNulls,
+       m.uses_quoted_identifier AS UsesQuotedIdentifier,
+       m.definition AS Body
+FROM sys.sql_modules m
+JOIN sys.objects o ON o.object_id = m.object_id
+JOIN sys.schemas s ON s.schema_id = o.schema_id
+WHERE o.is_ms_shipped = 0";
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/SchemaSnapshot.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SchemaSnapshot.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// A canonical, comparable description of a SQL Server database's schema.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Built for the EF Core baseline work (issue #528), where the whole approach rests on one claim:
+    /// that a database created by the EF Core V1 baseline is <b>identical</b> to one created by applying
+    /// every EF6 migration. If that is not exactly true the baseline is a lie, and every later EF Core
+    /// migration is a diff against the wrong starting point.
+    /// </para>
+    /// <para>
+    /// It is equally the guard for the period when both branches are live: while .NET Framework ships EF6
+    /// migrations and the .NET 10 branch ships EF Core ones, every schema change has to be made twice.
+    /// Comparing the two resulting schemas detects a missed change regardless of whether anyone
+    /// remembered to mirror it, which is the only form of enforcement that actually works.
+    /// </para>
+    /// <para>
+    /// The snapshot is a sorted set of canonical strings rather than an object graph, because the useful
+    /// output is a readable diff, not a tree. Every line is self-describing, so a failure message can be
+    /// pasted straight into a bug report.
+    /// </para>
+    /// <para>
+    /// Deliberately captures only what the product depends on being right: tables, column definitions
+    /// (including nullability and collation), indexes with their key order and INCLUDE lists, foreign
+    /// keys, defaults, and check constraints. It ignores things that legitimately differ between two
+    /// correctly-built databases, such as object ids, index fragmentation, statistics and fill factor.
+    /// </para>
+    /// </remarks>
+    internal sealed class SchemaSnapshot
+    {
+        private readonly SortedSet<string> _lines;
+
+        public string Label { get; }
+
+        private SchemaSnapshot(string label, IEnumerable<string> lines)
+        {
+            Label = label;
+            _lines = new SortedSet<string>(lines, StringComparer.Ordinal);
+        }
+
+        public IReadOnlyCollection<string> Lines => _lines;
+
+        public static SchemaSnapshot Capture(string connectionString, string label)
+        {
+            var lines = new List<string>();
+
+            using (var connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+
+                lines.AddRange(Query(connection, TablesSql));
+                lines.AddRange(Query(connection, ColumnsSql));
+                lines.AddRange(Query(connection, IndexesSql));
+                lines.AddRange(Query(connection, ForeignKeysSql));
+                lines.AddRange(Query(connection, CheckConstraintsSql));
+            }
+
+            return new SchemaSnapshot(label, lines);
+        }
+
+        /// <summary>
+        /// Lines present in this snapshot but not the other, and vice versa, in a form meant to be read
+        /// by a human in a test failure.
+        /// </summary>
+        public IReadOnlyList<string> DifferencesFrom(SchemaSnapshot other)
+        {
+            if (other == null) throw new ArgumentNullException(nameof(other));
+
+            var onlyHere = _lines.Except(other._lines, StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal);
+            var onlyThere = other._lines.Except(_lines, StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal);
+
+            return onlyHere.Select(l => $"only in {Label}: {l}")
+                .Concat(onlyThere.Select(l => $"only in {other.Label}: {l}"))
+                .ToList();
+        }
+
+        /// <summary>Formats a diff for a test failure message, truncated so the output stays usable.</summary>
+        public static string Describe(IReadOnlyList<string> differences, int maxLines = 40)
+        {
+            if (differences.Count == 0) return "(no differences)";
+
+            var shown = differences.Take(maxLines).ToList();
+            var text = new StringBuilder()
+                .AppendLine($"{differences.Count} schema difference(s):")
+                .AppendLine(string.Join(Environment.NewLine, shown.Select(d => "  " + d)));
+
+            if (differences.Count > shown.Count)
+                text.AppendLine($"  ... and {differences.Count - shown.Count} more");
+
+            return text.ToString();
+        }
+
+        private static IEnumerable<string> Query(SqlConnection connection, string sql)
+        {
+            var results = new List<string>();
+            using (var command = new SqlCommand(sql, connection) { CommandTimeout = 0 })
+            using (var reader = command.ExecuteReader())
+            {
+                while (reader.Read()) results.Add(reader.GetString(0));
+            }
+            return results;
+        }
+
+        // Only user tables; EF's own history tables are excluded because the two branches deliberately
+        // use different ones (__MigrationHistory for EF6, __EFMigrationsHistory for EF Core) and that
+        // difference is expected rather than a defect.
+        const string ExcludedTables =
+            "t.name NOT IN ('__MigrationHistory', '__EFMigrationsHistory', 'sysdiagrams')";
+
+        const string TablesSql = @"
+SELECT 'TABLE ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT
+FROM sys.tables t
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+WHERE " + ExcludedTables;
+
+        // Column type is rendered with its real length/precision so that nvarchar(850) and varchar(850)
+        // - a distinction this codebase cares about a great deal - never compare equal.
+        const string ColumnsSql = @"
+SELECT 'COLUMN ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT + '.' + c.name COLLATE DATABASE_DEFAULT
+     + ' ' + ty.name COLLATE DATABASE_DEFAULT
+     + CASE
+         WHEN ty.name COLLATE DATABASE_DEFAULT IN ('varchar','char','varbinary','binary')
+              THEN '(' + CASE WHEN c.max_length = -1 THEN 'max' ELSE CAST(c.max_length AS varchar(10)) END + ')'
+         WHEN ty.name COLLATE DATABASE_DEFAULT IN ('nvarchar','nchar')
+              THEN '(' + CASE WHEN c.max_length = -1 THEN 'max' ELSE CAST(c.max_length / 2 AS varchar(10)) END + ')'
+         WHEN ty.name COLLATE DATABASE_DEFAULT IN ('decimal','numeric')
+              THEN '(' + CAST(c.precision AS varchar(10)) + ',' + CAST(c.scale AS varchar(10)) + ')'
+         WHEN ty.name COLLATE DATABASE_DEFAULT IN ('datetime2','time','datetimeoffset')
+              THEN '(' + CAST(c.scale AS varchar(10)) + ')'
+         ELSE ''
+       END
+     + CASE WHEN c.is_nullable = 1 THEN ' NULL' ELSE ' NOT NULL' END
+     + CASE WHEN c.is_identity = 1 THEN ' IDENTITY' ELSE '' END
+     + CASE WHEN c.is_computed = 1 THEN ' COMPUTED' ELSE '' END
+     + ISNULL(' COLLATE ' + c.collation_name, '')
+     + ISNULL(' DEFAULT ' + dc.definition COLLATE DATABASE_DEFAULT, '')
+FROM sys.columns c
+JOIN sys.tables t ON t.object_id = c.object_id
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+JOIN sys.types ty ON ty.user_type_id = c.user_type_id
+LEFT JOIN sys.default_constraints dc ON dc.object_id = c.default_object_id
+WHERE " + ExcludedTables;
+
+        // Key column ORDER matters for an index and is a common source of silent difference, so the key
+        // list is ordered rather than sorted. INCLUDE columns are unordered by definition, so they are.
+        const string IndexesSql = @"
+SELECT 'INDEX ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT + '.' + i.name COLLATE DATABASE_DEFAULT
+     + CASE WHEN i.is_unique = 1 THEN ' UNIQUE' ELSE '' END
+     + CASE WHEN i.is_primary_key = 1 THEN ' PRIMARY_KEY' ELSE '' END
+     + CASE WHEN i.is_unique_constraint = 1 THEN ' UNIQUE_CONSTRAINT' ELSE '' END
+     + ' TYPE(' + i.type_desc COLLATE DATABASE_DEFAULT + ')'
+     + ' KEYS(' + ISNULL(STUFF((
+         SELECT ',' + kc.name COLLATE DATABASE_DEFAULT + CASE WHEN kic.is_descending_key = 1 THEN ' DESC' ELSE '' END
+         FROM sys.index_columns kic
+         JOIN sys.columns kc ON kc.object_id = kic.object_id AND kc.column_id = kic.column_id
+         WHERE kic.object_id = i.object_id AND kic.index_id = i.index_id AND kic.is_included_column = 0
+         ORDER BY kic.key_ordinal
+         FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 1, ''), '') + ')'
+     + ' INCLUDE(' + ISNULL(STUFF((
+         SELECT ',' + ic2.name COLLATE DATABASE_DEFAULT
+         FROM sys.index_columns iic
+         JOIN sys.columns ic2 ON ic2.object_id = iic.object_id AND ic2.column_id = iic.column_id
+         WHERE iic.object_id = i.object_id AND iic.index_id = i.index_id AND iic.is_included_column = 1
+         ORDER BY ic2.name COLLATE DATABASE_DEFAULT
+         FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 1, ''), '') + ')'
+     + CASE WHEN i.has_filter = 1 THEN ' FILTER(' + i.filter_definition COLLATE DATABASE_DEFAULT + ')' ELSE '' END
+FROM sys.indexes i
+JOIN sys.tables t ON t.object_id = i.object_id
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+WHERE i.name COLLATE DATABASE_DEFAULT IS NOT NULL AND " + ExcludedTables;
+
+        // Constraint NAMES are deliberately excluded: EF6 and EF Core generate different auto-names for
+        // the same relationship, and a name difference is not a schema difference that affects the
+        // product. What matters is which columns reference which.
+        const string ForeignKeysSql = @"
+SELECT 'FOREIGNKEY ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT
+     + '(' + ISNULL(STUFF((
+         SELECT ',' + pc.name COLLATE DATABASE_DEFAULT
+         FROM sys.foreign_key_columns fkc2
+         JOIN sys.columns pc ON pc.object_id = fkc2.parent_object_id AND pc.column_id = fkc2.parent_column_id
+         WHERE fkc2.constraint_object_id = fk.object_id
+         ORDER BY fkc2.constraint_column_id
+         FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 1, ''), '') + ')'
+     + ' -> ' + rs.name COLLATE DATABASE_DEFAULT + '.' + rt.name COLLATE DATABASE_DEFAULT
+     + '(' + ISNULL(STUFF((
+         SELECT ',' + rc.name COLLATE DATABASE_DEFAULT
+         FROM sys.foreign_key_columns fkc3
+         JOIN sys.columns rc ON rc.object_id = fkc3.referenced_object_id AND rc.column_id = fkc3.referenced_column_id
+         WHERE fkc3.constraint_object_id = fk.object_id
+         ORDER BY fkc3.constraint_column_id
+         FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 1, ''), '') + ')'
+     + ' ONDELETE(' + fk.delete_referential_action_desc COLLATE DATABASE_DEFAULT + ')'
+     + ' ONUPDATE(' + fk.update_referential_action_desc COLLATE DATABASE_DEFAULT + ')'
+FROM sys.foreign_keys fk
+JOIN sys.tables t ON t.object_id = fk.parent_object_id
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+JOIN sys.tables rt ON rt.object_id = fk.referenced_object_id
+JOIN sys.schemas rs ON rs.schema_id = rt.schema_id
+WHERE " + ExcludedTables;
+
+        const string CheckConstraintsSql = @"
+SELECT 'CHECK ' + s.name COLLATE DATABASE_DEFAULT + '.' + t.name COLLATE DATABASE_DEFAULT + ' ' + cc.definition COLLATE DATABASE_DEFAULT
+FROM sys.check_constraints cc
+JOIN sys.tables t ON t.object_id = cc.parent_object_id
+JOIN sys.schemas s ON s.schema_id = t.schema_id
+WHERE " + ExcludedTables;
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/SchemaSnapshotTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SchemaSnapshotTests.cs
@@ -1,0 +1,226 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Tests.UnitTests
+{
+    /// <summary>
+    /// Proves <see cref="SchemaSnapshot"/> detects each class of difference it claims to.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The snapshot exists to underwrite the EF Core V1 baseline (issue #528): a database built by the
+    /// baseline must be identical to one built by applying every EF6 migration. A comparison tool that
+    /// quietly misses a difference is worse than no tool, because it would certify a wrong baseline.
+    /// </para>
+    /// <para>
+    /// So each test below makes exactly one change to an otherwise identical pair of databases and
+    /// asserts the difference is both detected and named. The <c>nvarchar</c>/<c>varchar</c> case is
+    /// called out separately because this codebase has a hard rule about it and the two are otherwise
+    /// easy to conflate.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class SchemaSnapshotTests
+    {
+        const string BaseTable = @"
+CREATE TABLE dbo.widgets (
+    id int IDENTITY(1,1) NOT NULL CONSTRAINT PK_widgets PRIMARY KEY,
+    name nvarchar(200) NOT NULL,
+    note nvarchar(max) NULL,
+    created_utc datetime2(7) NOT NULL CONSTRAINT DF_widgets_created DEFAULT (SYSUTCDATETIME())
+);
+CREATE NONCLUSTERED INDEX IX_widgets_name ON dbo.widgets (name) INCLUDE (created_utc);";
+
+        [TestMethod]
+        public void IdenticalDatabases_ProduceNoDifferences()
+        {
+            WithPair(BaseTable, BaseTable, (left, right) =>
+            {
+                var differences = left.DifferencesFrom(right);
+                Assert.AreEqual(0, differences.Count, SchemaSnapshot.Describe(differences));
+            });
+        }
+
+        [TestMethod]
+        public void AddedTable_IsDetected()
+        {
+            WithPair(BaseTable, BaseTable + "\nCREATE TABLE dbo.extra (id int NOT NULL);", (left, right) =>
+            {
+                AssertDetected(left, right, "TABLE dbo.extra");
+            });
+        }
+
+        [TestMethod]
+        public void AddedColumn_IsDetected()
+        {
+            WithPair(BaseTable, BaseTable + "\nALTER TABLE dbo.widgets ADD extra_col int NULL;", (left, right) =>
+            {
+                AssertDetected(left, right, "COLUMN dbo.widgets.extra_col");
+            });
+        }
+
+        /// <summary>
+        /// The distinction this codebase cares most about: <c>varchar</c> silently corrupts non-Latin
+        /// customer text, so a baseline that got this wrong would be a data-loss bug.
+        /// </summary>
+        [TestMethod]
+        public void NvarcharVersusVarchar_IsDetected()
+        {
+            const string asNvarchar = "CREATE TABLE dbo.t (v nvarchar(250) NOT NULL);";
+            const string asVarchar = "CREATE TABLE dbo.t (v varchar(250) NOT NULL);";
+
+            WithPair(asNvarchar, asVarchar, (left, right) =>
+            {
+                var differences = left.DifferencesFrom(right);
+                Assert.IsTrue(differences.Any(d => d.Contains("nvarchar(250)")),
+                    "The nvarchar side was not reported. " + SchemaSnapshot.Describe(differences));
+                Assert.IsTrue(differences.Any(d => d.Contains("varchar(250)") && !d.Contains("nvarchar")),
+                    "The varchar side was not reported. " + SchemaSnapshot.Describe(differences));
+            });
+        }
+
+        [TestMethod]
+        public void ChangedColumnWidth_IsDetected()
+        {
+            WithPair("CREATE TABLE dbo.t (v nvarchar(850) NOT NULL);",
+                     "CREATE TABLE dbo.t (v nvarchar(450) NOT NULL);",
+                (left, right) => AssertDetected(left, right, "nvarchar(850)"));
+        }
+
+        [TestMethod]
+        public void ChangedNullability_IsDetected()
+        {
+            WithPair("CREATE TABLE dbo.t (v int NOT NULL);",
+                     "CREATE TABLE dbo.t (v int NULL);",
+                (left, right) => AssertDetected(left, right, "COLUMN dbo.t.v int NOT NULL"));
+        }
+
+        [TestMethod]
+        public void MissingIndex_IsDetected()
+        {
+            WithPair(BaseTable, BaseTable.Replace("CREATE NONCLUSTERED INDEX IX_widgets_name ON dbo.widgets (name) INCLUDE (created_utc);", ""),
+                (left, right) => AssertDetected(left, right, "INDEX dbo.widgets.IX_widgets_name"));
+        }
+
+        /// <summary>
+        /// Key order changes the plans an index can serve, so two indexes over the same columns in a
+        /// different order are genuinely different indexes.
+        /// </summary>
+        [TestMethod]
+        public void ChangedIndexKeyOrder_IsDetected()
+        {
+            const string ab = "CREATE TABLE dbo.t (a int NOT NULL, b int NOT NULL);CREATE INDEX IX_t ON dbo.t (a,b);";
+            const string ba = "CREATE TABLE dbo.t (a int NOT NULL, b int NOT NULL);CREATE INDEX IX_t ON dbo.t (b,a);";
+
+            WithPair(ab, ba, (left, right) => AssertDetected(left, right, "KEYS(a,b)"));
+        }
+
+        /// <summary>
+        /// An INCLUDE list is not a seekable access path, so moving a column between KEYS and INCLUDE is a
+        /// real behavioural change - one this repo has measured costing 5.5x on wall-clock.
+        /// </summary>
+        [TestMethod]
+        public void KeyColumnMovedToInclude_IsDetected()
+        {
+            const string asKey = "CREATE TABLE dbo.t (a int NOT NULL, b int NOT NULL);CREATE INDEX IX_t ON dbo.t (a,b);";
+            const string asInclude = "CREATE TABLE dbo.t (a int NOT NULL, b int NOT NULL);CREATE INDEX IX_t ON dbo.t (a) INCLUDE (b);";
+
+            WithPair(asKey, asInclude, (left, right) =>
+            {
+                var differences = left.DifferencesFrom(right);
+                Assert.IsTrue(differences.Any(d => d.Contains("KEYS(a,b)")),
+                    "The composite-key form was not reported. " + SchemaSnapshot.Describe(differences));
+                Assert.IsTrue(differences.Any(d => d.Contains("INCLUDE(b)")),
+                    "The INCLUDE form was not reported. " + SchemaSnapshot.Describe(differences));
+            });
+        }
+
+        [TestMethod]
+        public void ChangedIndexUniqueness_IsDetected()
+        {
+            const string nonUnique = "CREATE TABLE dbo.t (a int NOT NULL);CREATE INDEX IX_t ON dbo.t (a);";
+            const string unique = "CREATE TABLE dbo.t (a int NOT NULL);CREATE UNIQUE INDEX IX_t ON dbo.t (a);";
+
+            WithPair(nonUnique, unique, (left, right) => AssertDetected(left, right, "UNIQUE"));
+        }
+
+        [TestMethod]
+        public void ChangedIndexFilter_IsDetected()
+        {
+            const string unfiltered = "CREATE TABLE dbo.t (a int NULL);CREATE INDEX IX_t ON dbo.t (a);";
+            const string filtered = "CREATE TABLE dbo.t (a int NULL);CREATE INDEX IX_t ON dbo.t (a) WHERE a IS NOT NULL;";
+
+            WithPair(unfiltered, filtered, (left, right) => AssertDetected(left, right, "FILTER("));
+        }
+
+        [TestMethod]
+        public void MissingForeignKey_IsDetected()
+        {
+            const string withFk = @"
+CREATE TABLE dbo.parent (id int NOT NULL CONSTRAINT PK_parent PRIMARY KEY);
+CREATE TABLE dbo.child (id int NOT NULL, parent_id int NOT NULL CONSTRAINT FK_child_parent FOREIGN KEY REFERENCES dbo.parent(id));";
+            const string withoutFk = @"
+CREATE TABLE dbo.parent (id int NOT NULL CONSTRAINT PK_parent PRIMARY KEY);
+CREATE TABLE dbo.child (id int NOT NULL, parent_id int NOT NULL);";
+
+            WithPair(withFk, withoutFk, (left, right) => AssertDetected(left, right, "FOREIGNKEY dbo.child(parent_id) -> dbo.parent(id)"));
+        }
+
+        [TestMethod]
+        public void ChangedDefault_IsDetected()
+        {
+            const string zero = "CREATE TABLE dbo.t (a int NOT NULL CONSTRAINT DF_t DEFAULT (0));";
+            const string one = "CREATE TABLE dbo.t (a int NOT NULL CONSTRAINT DF_t DEFAULT (1));";
+
+            WithPair(zero, one, (left, right) => AssertDetected(left, right, "DEFAULT ((0))"));
+        }
+
+        /// <summary>
+        /// The two frameworks deliberately use different history tables, so that difference must NOT be
+        /// reported - otherwise every real comparison starts with a false positive and gets ignored.
+        /// </summary>
+        [TestMethod]
+        public void MigrationHistoryTables_AreIgnored()
+        {
+            const string ef6 = BaseTableConst + "\nCREATE TABLE dbo.__MigrationHistory (MigrationId nvarchar(150) NOT NULL);";
+            const string efCore = BaseTableConst + "\nCREATE TABLE dbo.__EFMigrationsHistory (MigrationId nvarchar(150) NOT NULL);";
+
+            WithPair(ef6, efCore, (left, right) =>
+            {
+                var differences = left.DifferencesFrom(right);
+                Assert.AreEqual(0, differences.Count,
+                    "EF6 and EF Core history tables are expected to differ and must not be reported. " +
+                    SchemaSnapshot.Describe(differences));
+            });
+        }
+
+        const string BaseTableConst = "CREATE TABLE dbo.widgets (id int NOT NULL);";
+
+        static void AssertDetected(SchemaSnapshot left, SchemaSnapshot right, string expectedFragment)
+        {
+            var differences = left.DifferencesFrom(right);
+
+            Assert.IsTrue(differences.Count > 0,
+                $"Expected a difference containing '{expectedFragment}' but the snapshots compared equal.");
+            Assert.IsTrue(differences.Any(d => d.Contains(expectedFragment)),
+                $"No reported difference mentioned '{expectedFragment}'. " + SchemaSnapshot.Describe(differences));
+        }
+
+        /// <summary>
+        /// Builds two scratch databases, applies a script to each, and hands back their snapshots.
+        /// </summary>
+        static void WithPair(string leftScript, string rightScript, System.Action<SchemaSnapshot, SchemaSnapshot> assert)
+        {
+            using (var left = ScratchDatabase.Create("schemaL"))
+            using (var right = ScratchDatabase.Create("schemaR"))
+            {
+                left.Execute(leftScript);
+                right.Execute(rightScript);
+
+                assert(
+                    SchemaSnapshot.Capture(left.ConnectionString, "left"),
+                    SchemaSnapshot.Capture(right.ConnectionString, "right"));
+            }
+        }
+    }
+}

--- a/src/AnalyticsEngine/Tests.UnitTests/SchemaSnapshotTests.cs
+++ b/src/AnalyticsEngine/Tests.UnitTests/SchemaSnapshotTests.cs
@@ -194,6 +194,181 @@ CREATE TABLE dbo.child (id int NOT NULL, parent_id int NOT NULL);";
             });
         }
 
+        /// <summary>
+        /// The exclusion is qualified by schema, so a history table in the wrong place is still a
+        /// difference rather than being silently waved through.
+        /// </summary>
+        [TestMethod]
+        public void MigrationHistoryTable_InAnUnexpectedSchema_IsNotIgnored()
+        {
+            const string correct = BaseTableConst + "\nCREATE TABLE dbo.__EFMigrationsHistory (MigrationId nvarchar(150) NOT NULL);";
+            const string wrongSchema = BaseTableConst + "\nGO\nCREATE SCHEMA other;\nGO\nCREATE TABLE other.__EFMigrationsHistory (MigrationId nvarchar(150) NOT NULL);";
+
+            WithScripts(correct, wrongSchema, (left, right) =>
+            {
+                var differences = left.DifferencesFrom(right);
+                Assert.IsTrue(differences.Any(d => d.Contains("other.__EFMigrationsHistory")),
+                    "A history table outside dbo must not be swallowed by the exclusion. " +
+                    SchemaSnapshot.Describe(differences));
+            });
+        }
+
+        #region Index options that migrations in this repo actually depend on
+
+        /// <summary>
+        /// The unique index on <c>urls.full_url</c> sets <c>IGNORE_DUP_KEY</c> deliberately, so one racing
+        /// duplicate cannot abort an entire insert batch, and its migration uses <c>ignore_dup_key = 1</c>
+        /// as part of the target-state check. Two indexes differing only in that option are not the same
+        /// index.
+        /// </summary>
+        [TestMethod]
+        public void ChangedIgnoreDupKey_IsDetected()
+        {
+            const string off = "CREATE TABLE dbo.t (a int NOT NULL);CREATE UNIQUE INDEX IX_t ON dbo.t (a) WITH (IGNORE_DUP_KEY = OFF);";
+            const string on = "CREATE TABLE dbo.t (a int NOT NULL);CREATE UNIQUE INDEX IX_t ON dbo.t (a) WITH (IGNORE_DUP_KEY = ON);";
+
+            WithPair(off, on, (left, right) => AssertDetected(left, right, "IGNORE_DUP_KEY(0)"));
+        }
+
+        [TestMethod]
+        public void DisabledIndex_IsDetected()
+        {
+            const string enabled = "CREATE TABLE dbo.t (a int NOT NULL);CREATE INDEX IX_t ON dbo.t (a);";
+            const string disabled = enabled + "ALTER INDEX IX_t ON dbo.t DISABLE;";
+
+            WithPair(enabled, disabled, (left, right) => AssertDetected(left, right, "DISABLED(0)"));
+        }
+
+        #endregion
+
+        #region Constraint state
+
+        /// <summary>
+        /// A migration here creates a foreign key <c>WITH NOCHECK</c> and then runs the expensive
+        /// <c>WITH CHECK CHECK CONSTRAINT</c> specifically to make it trusted. Without this the
+        /// intermediate state would certify as identical to the finished one, even though an untrusted
+        /// constraint is unusable by the optimiser and may be hiding invalid rows.
+        /// </summary>
+        [TestMethod]
+        public void UntrustedForeignKey_IsDetected()
+        {
+            const string trusted = @"
+CREATE TABLE dbo.parent (id int NOT NULL CONSTRAINT PK_parent PRIMARY KEY);
+CREATE TABLE dbo.child (id int NOT NULL, parent_id int NOT NULL);
+ALTER TABLE dbo.child WITH CHECK ADD CONSTRAINT FK_child_parent FOREIGN KEY (parent_id) REFERENCES dbo.parent(id);";
+
+            const string untrusted = @"
+CREATE TABLE dbo.parent (id int NOT NULL CONSTRAINT PK_parent PRIMARY KEY);
+CREATE TABLE dbo.child (id int NOT NULL, parent_id int NOT NULL);
+ALTER TABLE dbo.child WITH NOCHECK ADD CONSTRAINT FK_child_parent FOREIGN KEY (parent_id) REFERENCES dbo.parent(id);";
+
+            WithPair(trusted, untrusted, (left, right) => AssertDetected(left, right, "NOTTRUSTED(0)"));
+        }
+
+        [TestMethod]
+        public void DisabledCheckConstraint_IsDetected()
+        {
+            const string enabled = "CREATE TABLE dbo.t (a int NOT NULL CONSTRAINT CK_t CHECK (a > 0));";
+            const string disabled = enabled + "ALTER TABLE dbo.t NOCHECK CONSTRAINT CK_t;";
+
+            WithPair(enabled, disabled, (left, right) => AssertDetected(left, right, "DISABLED(0)"));
+        }
+
+        /// <summary>
+        /// Constraint names are deliberately not compared, but cardinality is - otherwise a database with
+        /// two structurally identical foreign keys would compare equal to one with a single foreign key.
+        /// </summary>
+        [TestMethod]
+        public void DuplicateStructurallyIdenticalForeignKey_IsDetected()
+        {
+            const string one = @"
+CREATE TABLE dbo.parent (id int NOT NULL CONSTRAINT PK_parent PRIMARY KEY);
+CREATE TABLE dbo.child (id int NOT NULL, parent_id int NOT NULL);
+ALTER TABLE dbo.child ADD CONSTRAINT FK_a FOREIGN KEY (parent_id) REFERENCES dbo.parent(id);";
+
+            const string two = one + "\nALTER TABLE dbo.child ADD CONSTRAINT FK_b FOREIGN KEY (parent_id) REFERENCES dbo.parent(id);";
+
+            WithPair(one, two, (left, right) => AssertDetected(left, right, "count differs"));
+        }
+
+        #endregion
+
+        #region Generated columns
+
+        [TestMethod]
+        public void ChangedIdentitySeedAndIncrement_IsDetected()
+        {
+            const string standard = "CREATE TABLE dbo.t (id int IDENTITY(1,1) NOT NULL);";
+            const string unusual = "CREATE TABLE dbo.t (id int IDENTITY(1000,5) NOT NULL);";
+
+            WithPair(standard, unusual, (left, right) => AssertDetected(left, right, "IDENTITY(1,1)"));
+        }
+
+        [TestMethod]
+        public void ChangedComputedColumnExpression_IsDetected()
+        {
+            const string plus = "CREATE TABLE dbo.t (a int NOT NULL, b AS (a + 1));";
+            const string times = "CREATE TABLE dbo.t (a int NOT NULL, b AS (a * 2));";
+
+            WithPair(plus, times, (left, right) => AssertDetected(left, right, "COMPUTED("));
+        }
+
+        #endregion
+
+        #region Modules - views, procedures, functions
+
+        /// <summary>
+        /// Views are created and later rewritten by migrations in this repository, so a database with a
+        /// missing or stale view must not compare equal to one with the right view.
+        /// </summary>
+        [TestMethod]
+        public void MissingView_IsDetected()
+        {
+            const string withView = BaseTableConst + "\nGO\nCREATE VIEW dbo.v_widgets AS SELECT id FROM dbo.widgets;";
+
+            WithScripts(withView, BaseTableConst, (left, right) => AssertDetected(left, right, "MODULE VIEW dbo.v_widgets"));
+        }
+
+        [TestMethod]
+        public void ChangedViewBody_IsDetected()
+        {
+            const string original = "CREATE TABLE dbo.t (a int NOT NULL, b int NOT NULL);\nGO\nCREATE VIEW dbo.v AS SELECT a FROM dbo.t;";
+            const string altered = "CREATE TABLE dbo.t (a int NOT NULL, b int NOT NULL);\nGO\nCREATE VIEW dbo.v AS SELECT b FROM dbo.t;";
+
+            WithScripts(original, altered, (left, right) => AssertDetected(left, right, "MODULE VIEW dbo.v"));
+        }
+
+        /// <summary>
+        /// Reformatting a view must NOT be reported, or the tool produces noise on every tidy-up and stops
+        /// being trusted. Existing tests in this repo also treat quoted-identifier state as part of a
+        /// view's required state, which is why it is captured separately from the body.
+        /// </summary>
+        [TestMethod]
+        public void ReformattedViewBody_IsNotReported()
+        {
+            const string compact = "CREATE TABLE dbo.t (a int NOT NULL);\nGO\nCREATE VIEW dbo.v AS SELECT a FROM dbo.t;";
+            const string spacedOut = "CREATE TABLE dbo.t (a int NOT NULL);\nGO\nCREATE VIEW dbo.v AS\r\n    SELECT   a\r\n    FROM     dbo.t;";
+
+            WithScripts(compact, spacedOut, (left, right) =>
+            {
+                var differences = left.DifferencesFrom(right);
+                Assert.AreEqual(0, differences.Count,
+                    "Whitespace-only differences in a module body must not be reported. " +
+                    SchemaSnapshot.Describe(differences));
+            });
+        }
+
+        [TestMethod]
+        public void MissingStoredProcedure_IsDetected()
+        {
+            const string withProc = BaseTableConst + "\nGO\nCREATE PROCEDURE dbo.usp_widgets AS SELECT 1;";
+
+            WithScripts(withProc, BaseTableConst, (left, right) => AssertDetected(left, right, "MODULE SQL_STORED_PROCEDURE dbo.usp_widgets"));
+        }
+
+        #endregion
+
+
         const string BaseTableConst = "CREATE TABLE dbo.widgets (id int NOT NULL);";
 
         static void AssertDetected(SchemaSnapshot left, SchemaSnapshot right, string expectedFragment)
@@ -207,20 +382,91 @@ CREATE TABLE dbo.child (id int NOT NULL, parent_id int NOT NULL);";
         }
 
         /// <summary>
-        /// Builds two scratch databases, applies a script to each, and hands back their snapshots.
+        /// Creating a database on LocalDB costs several seconds, and creating two per test dominated the
+        /// runtime of this class. One pair is created for the whole class and emptied between tests
+        /// instead, which is equivalent for these purposes because every test defines its own objects.
+        /// </summary>
+        static ScratchDatabase _left;
+        static ScratchDatabase _right;
+
+        [ClassInitialize]
+        public static void CreateDatabases(TestContext context)
+        {
+            _left = ScratchDatabase.Create("schemaL");
+            _right = ScratchDatabase.Create("schemaR");
+        }
+
+        [ClassCleanup]
+        public static void DropDatabases()
+        {
+            _left?.Dispose();
+            _right?.Dispose();
+        }
+
+        [TestCleanup]
+        public void EmptyDatabases()
+        {
+            _left?.Execute(DropEverythingSql);
+            _right?.Execute(DropEverythingSql);
+        }
+
+        /// <summary>
+        /// Drops every user object, in dependency order: foreign keys, then modules, then tables, then any
+        /// non-default schema.
+        /// </summary>
+        const string DropEverythingSql = @"
+DECLARE @sql nvarchar(max) = N'';
+
+SELECT @sql += 'ALTER TABLE ' + QUOTENAME(s.name) + '.' + QUOTENAME(t.name)
+             + ' DROP CONSTRAINT ' + QUOTENAME(f.name) + ';'
+FROM sys.foreign_keys f
+JOIN sys.tables t ON t.object_id = f.parent_object_id
+JOIN sys.schemas s ON s.schema_id = t.schema_id;
+
+SELECT @sql += 'DROP VIEW ' + QUOTENAME(s.name) + '.' + QUOTENAME(o.name) + ';'
+FROM sys.views o JOIN sys.schemas s ON s.schema_id = o.schema_id WHERE o.is_ms_shipped = 0;
+
+SELECT @sql += 'DROP PROCEDURE ' + QUOTENAME(s.name) + '.' + QUOTENAME(o.name) + ';'
+FROM sys.procedures o JOIN sys.schemas s ON s.schema_id = o.schema_id WHERE o.is_ms_shipped = 0;
+
+SELECT @sql += 'DROP FUNCTION ' + QUOTENAME(s.name) + '.' + QUOTENAME(o.name) + ';'
+FROM sys.objects o JOIN sys.schemas s ON s.schema_id = o.schema_id
+WHERE o.type IN ('FN','IF','TF') AND o.is_ms_shipped = 0;
+
+SELECT @sql += 'DROP TABLE ' + QUOTENAME(s.name) + '.' + QUOTENAME(t.name) + ';'
+FROM sys.tables t JOIN sys.schemas s ON s.schema_id = t.schema_id WHERE t.is_ms_shipped = 0;
+
+SELECT @sql += 'DROP SCHEMA ' + QUOTENAME(s.name) + ';'
+FROM sys.schemas s
+WHERE s.schema_id BETWEEN 5 AND 16383 AND s.name <> 'dbo';
+
+IF @sql <> N'' EXEC sp_executesql @sql;";
+
+        /// <summary>
+        /// Applies a script to each database and hands back their snapshots.
         /// </summary>
         static void WithPair(string leftScript, string rightScript, System.Action<SchemaSnapshot, SchemaSnapshot> assert)
         {
-            using (var left = ScratchDatabase.Create("schemaL"))
-            using (var right = ScratchDatabase.Create("schemaR"))
-            {
-                left.Execute(leftScript);
-                right.Execute(rightScript);
+            _left.Execute(leftScript);
+            _right.Execute(rightScript);
 
-                assert(
-                    SchemaSnapshot.Capture(left.ConnectionString, "left"),
-                    SchemaSnapshot.Capture(right.ConnectionString, "right"));
-            }
+            assert(
+                SchemaSnapshot.Capture(_left.ConnectionString, "left"),
+                SchemaSnapshot.Capture(_right.ConnectionString, "right"));
+        }
+
+        /// <summary>
+        /// As <see cref="WithPair"/>, but runs the scripts batch by batch so they can contain GO - which
+        /// CREATE VIEW and CREATE PROCEDURE require, since both must be the first statement in a batch.
+        /// </summary>
+        static void WithScripts(string leftScript, string rightScript, System.Action<SchemaSnapshot, SchemaSnapshot> assert)
+        {
+            _left.ExecuteScript(leftScript, quotedIdentifierOn: true);
+            _right.ExecuteScript(rightScript, quotedIdentifierOn: true);
+
+            assert(
+                SchemaSnapshot.Capture(_left.ConnectionString, "left"),
+                SchemaSnapshot.Capture(_right.ConnectionString, "right"));
         }
     }
 }

--- a/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
+++ b/src/AnalyticsEngine/Tests.UnitTests/Tests.UnitTests.csproj
@@ -322,6 +322,8 @@
     <Compile Include="UpgradeFromStableTests.cs" />
     <Compile Include="UpdateCheckBuildVersionTests.cs" />
     <Compile Include="ScratchDatabase.cs" />
+    <Compile Include="SchemaSnapshot.cs" />
+    <Compile Include="SchemaSnapshotTests.cs" />
     <Compile Include="StressHarness\ActivityApiDbStressRunner.cs" />
     <Compile Include="StressHarness\ActivityApiDbStressTests.cs" />
     <Compile Include="StressHarness\CountingActivityReportPersistenceManager.cs" />


### PR DESCRIPTION
## Scope

Adds `SchemaSnapshot` (a test helper) and `SchemaSnapshotTests` (14 tests) to `Tests.UnitTests`. **No production code changes.** Two new files plus their `<Compile>` entries.

## Why

The EF Core baseline decision (#528) makes `net10` adopt EF Core with the current stable EF6 schema as **V1**. That whole approach rests on a single claim:

> a database created by the EF Core V1 baseline is **identical** to one created by applying every EF6 migration.

If that is not exactly true, the baseline is a lie and every later EF Core migration is a diff against the wrong starting point — producing changes that silently do the wrong thing on customer databases. There is currently no way to check that claim.

It is equally the guard for the **dual-migration period**. While `main` ships EF6 migrations and `net10` ships EF Core ones, every schema change has to be made twice. Comparing the two resulting schemas detects a missed change *regardless of whether anyone remembered to mirror it* — which is the only form of enforcement that works in practice.

## What it captures

| Category | Detail |
|---|---|
| Tables | schema-qualified names |
| Columns | type with **real** length/precision, nullability, identity, computed, collation, default |
| Indexes | uniqueness, primary key, type, **ordered** key columns, INCLUDE list, filter predicate |
| Foreign keys | referencing and referenced columns, delete/update actions |
| Check constraints | definition |

Output is a sorted set of canonical, self-describing strings rather than an object graph, because the useful product is a readable diff:

```
only in ef6: COLUMN dbo.users.user_name varchar(250) NOT NULL COLLATE SQL_Latin1_General_CP1_CI_AS
only in efcore: COLUMN dbo.users.user_name nvarchar(250) NOT NULL COLLATE SQL_Latin1_General_CP1_CI_AS
```

## What it deliberately ignores

Things that legitimately differ between two correctly-built databases: object ids, fragmentation, statistics, fill factor.

Two exclusions are judgement calls worth reviewing:

- **The EF history tables.** EF6 uses `__MigrationHistory`, EF Core uses `__EFMigrationsHistory` — by design. Reporting that would make every real comparison start with a false positive and get ignored. There is a test asserting it stays ignored.
- **Foreign key constraint *names*.** EF6 and EF Core auto-generate different names for the same relationship. A name difference is not a schema difference that affects the product; which columns reference which is what matters.

## Verification

```
Passed!  - Failed: 0, Passed: 14, Skipped: 0, Total: 14
```

Each test makes **exactly one** change to an otherwise identical pair of scratch databases and asserts the difference is both detected and named:

| Test | Why it is there |
|---|---|
| `IdenticalDatabases_ProduceNoDifferences` | no false positives |
| `NvarcharVersusVarchar_IsDetected` | the repo's hard Unicode rule — a baseline that got this wrong would be a **data-loss** bug |
| `ChangedIndexKeyOrder_IsDetected` | key order changes which plans an index can serve |
| `KeyColumnMovedToInclude_IsDetected` | measured in this repo at 5.5x wall-clock; a real behavioural change |
| `ChangedIndexFilter_IsDetected` | filtered indexes serve different queries |
| `MigrationHistoryTables_AreIgnored` | guards the exclusion above |
| plus added table/column, width, nullability, missing index, uniqueness, missing FK, changed default | |

## The tests found a real defect in the harness

First run failed all 14 with:

```
Cannot resolve collation conflict between "Latin1_General_CI_AS_KS_WS"
and "SQL_Latin1_General_CP1_CI_AS" in add operator
```

`sys` catalog columns are `sysname` and carry the *server* metadata collation, while string literals take the database default — so every concatenation threw. Fixed with explicit `COLLATE DATABASE_DEFAULT` on the catalog columns. Worth knowing for anyone else writing catalog queries in this codebase; several of the existing ad-hoc ones avoid it only by not concatenating.

## Secondary benefit

This consolidates a pattern the repo already reaches for constantly: roughly **57 one-off `sys.columns` / `sys.indexes` queries across 15 test files**, each checking a single fact. New migration tests can assert against a snapshot instead of hand-writing another catalog query.

## Reviewer notes

- Each test creates two scratch databases, so the class takes ~2 minutes. If that is too much for CI, the obvious lever is sharing one database pair across the read-only cases.
- Requires the `SPOInsightsEntities` connection string, same as the existing `ScratchDatabase`-based tests.
- `Tests.UnitTests.csproj` is still legacy format, so both files need explicit `<Compile>` entries.
- No database, network or customer data: every script is a synthetic `dbo.widgets` / `dbo.t`.

Relates to #528.
